### PR TITLE
CHECKOUT-4223 Add commit validation scopes

### DIFF
--- a/commit-validation.json
+++ b/commit-validation.json
@@ -1,5 +1,13 @@
 {
     "scopes": [
-        "common"
+        "billing",
+        "cart",
+        "checkout",
+        "common",
+        "customer",
+        "embedded-checkout",
+        "order",
+        "payment",
+        "shipping"
     ]
 }


### PR DESCRIPTION
## What?
* Add commit validation scopes

## Why?
* To restrict the scopes we allow for commit validation

## Testing / Proof
* n/a

@bigcommerce/checkout
