### PR TITLE
CHECKOUT-4223: Add custom Formik connector which shallow-checks injected props

### DIFF
--- a/src/app/common/form/ConnectFormikProps.ts
+++ b/src/app/common/form/ConnectFormikProps.ts
@@ -1,0 +1,5 @@
+import { FormikContext } from 'formik';
+
+export default interface ConnectFormikProps<TValues> {
+    formik: FormikContext<TValues>;
+}

--- a/src/app/common/form/connectFormik.spec.tsx
+++ b/src/app/common/form/connectFormik.spec.tsx
@@ -1,0 +1,76 @@
+import { mount } from 'enzyme';
+import { Field, Formik, FormikActions } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import connectFormik from './connectFormik';
+import ConnectFormikProps from './ConnectFormikProps';
+
+describe('connectFormik()', () => {
+    it('only re-renders connected component if Formik props have changed', () => {
+        const TestComponent: FunctionComponent = jest.fn(() => <div />);
+        const ConnectedTestComponent = connectFormik(TestComponent);
+        let setFieldValue: FormikActions<{ message: string }>['setFieldValue'] = noop;
+
+        mount(
+            <Formik
+                initialValues={ { message: 'foobar' } }
+                onSubmit={ jest.fn() }
+                render={ formik => {
+                    setFieldValue = formik.setFieldValue;
+
+                    return <>
+                        <ConnectedTestComponent />
+                        <Field name="message" />
+                    </>;
+                } }
+            />
+        );
+
+        expect(TestComponent)
+            .toHaveBeenCalledTimes(1);
+
+        // Setting the same value as the initial value
+        setFieldValue('message', 'foobar');
+
+        expect(TestComponent)
+            .toHaveBeenCalledTimes(1);
+
+        // Setting a value different to the initial value
+        setFieldValue('message', 'hello');
+
+        expect(TestComponent)
+            .toHaveBeenCalledTimes(2);
+    });
+
+    it('also re-renders connected component if non-Formik props have changed', () => {
+        const TestComponent: FunctionComponent<{ count: number } & ConnectFormikProps<{ message: string }>> = jest.fn(() => <div />);
+        const ConnectedTestComponent = connectFormik(TestComponent);
+        const initialValues = { message: 'foobar' };
+        const handleSubmit = jest.fn();
+        const Container: FunctionComponent<{ count: number }> = props => (
+            <Formik
+                initialValues={ initialValues }
+                onSubmit={ handleSubmit }
+                render={ () => {
+                    return <>
+                        <ConnectedTestComponent { ...props } />
+                        <Field name="message" />
+                    </>;
+                } }
+            />
+        );
+
+        const container = mount(<Container count={ 1 } />);
+
+        expect(TestComponent)
+            .toHaveBeenCalledTimes(1);
+
+        // Changing the value of `count`, which is passed to
+        // `ConnectedTestComponent`, should re-render that component.
+        container.setProps({ count: 2 });
+
+        expect(TestComponent)
+            .toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/app/common/form/connectFormik.tsx
+++ b/src/app/common/form/connectFormik.tsx
@@ -1,0 +1,25 @@
+import { connect } from 'formik';
+import React, { memo, ComponentType, FunctionComponent } from 'react';
+import shallowEqual from 'shallowequal';
+
+import ConnectFormikProps from './ConnectFormikProps';
+
+export default function connectFormik<
+    TProps extends ConnectFormikProps<TValues>,
+    TValues = any
+>(
+    OriginalComponent: ComponentType<TProps>
+): ComponentType<Omit<TProps, keyof ConnectFormikProps<TValues>>> {
+    const InnerComponent: FunctionComponent<TProps> = memo(
+        props => <OriginalComponent { ...props } />,
+        ({ formik: prevFormik, ...prevProps }, { formik: nextFormik, ...nextProps }) => (
+            shallowEqual(prevFormik, nextFormik) && shallowEqual(prevProps, nextProps)
+        )
+    );
+
+    const DecoratedComponent = connect<TProps, TValues>(InnerComponent) as ComponentType<Omit<TProps, keyof ConnectFormikProps<TValues>>>;
+
+    DecoratedComponent.displayName = `ConnectFormik(${OriginalComponent.displayName || OriginalComponent.name})`;
+
+    return DecoratedComponent;
+}

--- a/src/app/common/form/index.ts
+++ b/src/app/common/form/index.ts
@@ -1,0 +1,2 @@
+export { default as connectFormik } from './connectFormik';
+export { default as ConnectFormikProps } from './ConnectFormikProps';


### PR DESCRIPTION
## What?
Add custom Formik connector which shallow-checks injected props

## Why?
Formik's default `connect` always provides a new `formik` object, which doesn't work well with `PureComponent` and `memo`.

## Testing / Proof
CircleCI

@bigcommerce/checkout
