### PR TITLE
CHECKOUT-4223 Add analytics module

### DIFF
--- a/src/app/analytics/AnalyticsStepTracker.spec.ts
+++ b/src/app/analytics/AnalyticsStepTracker.spec.ts
@@ -1,0 +1,406 @@
+import { createCheckoutService, CheckoutService, Order, ShopperCurrency } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout } from '../checkout/checkouts.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getOrder } from '../order/orders.mock';
+import { getPaymentMethod } from '../payment/payment-methods.mock';
+import { getShippingOption } from '../shipping/shippingOption/shippingMethod.mock';
+
+import AnalyticsStepTracker, { ANALYTIC_STEP_TYPE } from './AnalyticsStepTracker';
+
+describe('AnalyticsStepTracker', () => {
+    let checkoutService: CheckoutService;
+    let analyticsStepTracker: AnalyticsStepTracker;
+    let sessionStorage: any;
+    let legacyStorage: any;
+    let analytics: any;
+
+    const VIEWED_EVENT_NAME = 'Checkout Step Viewed';
+    const COMPLETED_EVENT_NAME = 'Checkout Step Completed';
+    const storedData = {
+        103: {
+            brand: 'OFS',
+            category: 'Cat 1',
+        },
+        104: {
+            brand: 'Digitalia',
+            category: 'Ebooks, Audio Books',
+        },
+    };
+
+    beforeEach(() => {
+        analytics = { track: jest.fn() };
+        sessionStorage = {
+            getItem: jest.fn(() => JSON.stringify(storedData)),
+            setItem: jest.fn(),
+            removeItem: jest.fn(),
+        };
+
+        legacyStorage = {
+            getItem: jest.fn(() => null),
+        };
+
+        checkoutService = createCheckoutService();
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout')
+            .mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig')
+            .mockReturnValue({
+                ...getStoreConfig(),
+                shopperCurrency: {
+                    code: 'JPY',
+                    exchangeRate: 1.01,
+                } as ShopperCurrency,
+            });
+
+        analyticsStepTracker = new AnalyticsStepTracker(
+            checkoutService,
+            sessionStorage,
+            legacyStorage,
+            analytics
+        );
+    });
+
+    describe('#trackCheckoutStarted()', () => {
+        beforeEach(() => {
+            analyticsStepTracker.trackCheckoutStarted();
+        });
+
+        it('saves the category and brand data to the storage', () => {
+            expect(sessionStorage.setItem)
+                .toHaveBeenCalledWith(
+                    'ORDER_ITEMS_b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                    JSON.stringify(storedData)
+                );
+        });
+
+        it('only tracks analytics once', () => {
+            analyticsStepTracker.trackCheckoutStarted();
+            analyticsStepTracker.trackCheckoutStarted();
+
+            expect(analytics.track).toBeCalledTimes(1);
+        });
+
+        it('tracks the affiliation', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    affiliation: 's1504098821',
+                })
+            );
+        });
+
+        it('tracks the currency', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    currency: 'JPY',
+                })
+            );
+        });
+
+        it('tracks the expected tax', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    tax: 3.03,
+                })
+            );
+        });
+
+        it('tracks the expected revenue', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    revenue: 191.9,
+                })
+            );
+        });
+
+        it('tracks the expected shipping cost', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    shipping: 15.15,
+                })
+            );
+        });
+
+        it('tracks the coupons', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    coupon: 'savebig2015',
+                })
+            );
+        });
+
+        it('tracks the products', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    products: [{
+                        product_id: 103,
+                        sku: 'CLC',
+                        name: 'Canvas Laundry Cart',
+                        price: 200,
+                        quantity: 1,
+                        image_url: '/images/canvas-laundry-cart.jpg',
+                        brand: 'OFS',
+                        category: 'Cat 1',
+                        variant: 'n:v',
+                    }, {
+                        product_id: 104,
+                        sku: 'CLX',
+                        name: 'Digital Book',
+                        price: 100,
+                        quantity: 1,
+                        image_url: '/images/digital-book.jpg',
+                        brand: 'Digitalia',
+                        category: 'Ebooks, Audio Books',
+                        variant: 'm:l',
+                    }],
+                })
+            );
+        });
+    });
+
+    describe('#trackOrderComplete()', () => {
+        describe('when order is not complete', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getOrder').mockReturnValue({
+                    isComplete: false,
+                } as Order);
+                analyticsStepTracker.trackOrderComplete();
+            });
+
+            it('does not send any data', () => {
+                expect(analytics.track).not.toHaveBeenCalled();
+            });
+
+            it('doest not remove the category and brand data from the storage', () => {
+                expect(sessionStorage.removeItem).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when there are no saved items', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getOrder')
+                    .mockReturnValue(getOrder());
+
+                sessionStorage.getItem = jest.fn(() => null);
+                analyticsStepTracker.trackOrderComplete();
+            });
+
+            it('does not send any data', () => {
+                expect(analytics.track).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when there is a complete order', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getOrder')
+                    .mockReturnValue(getOrder());
+
+                analyticsStepTracker.trackOrderComplete();
+            });
+
+            it('tracks the order id', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        orderId: 295,
+                    })
+                );
+            });
+
+            it('tracks the order affiliation', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        affiliation: 's1504098821',
+                    })
+                );
+            });
+
+            it('tracks the order grand total', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        revenue: 191.9,
+                    })
+                );
+            });
+
+            it('tracks the order shipping cost', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        shipping: 15.15,
+                    })
+                );
+            });
+
+            it('tracks the order discount amount', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        discount: 10.1,
+                    })
+                );
+            });
+
+            it('tracks the order coupons as a single, comma-separated string', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        coupon: 'savebig2015,279F507D817E3E7',
+                    })
+                );
+            });
+
+            it('tracks the order currency', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        currency: 'JPY',
+                    })
+                );
+            });
+
+            it('tracks the tax total value', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        tax: 3.03,
+                    })
+                );
+            });
+
+            it('tracks the product list', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        products: [{
+                            product_id: 103,
+                            sku: 'CLC',
+                            name: 'Canvas Laundry Cart',
+                            price: 200,
+                            quantity: 1,
+                            image_url: '/images/canvas-laundry-cart.jpg',
+                            brand: 'OFS',
+                            category: 'Cat 1',
+                            variant: 'n:v',
+                        }, {
+                            product_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                            name: '$100 Gift Certificate',
+                            price: 101,
+                            quantity: 1,
+                        }],
+                    })
+                );
+            });
+
+            it('reads data from session storage', () => {
+                expect(sessionStorage.getItem)
+                    .toHaveBeenCalledWith('ORDER_ITEMS_b20deef40f9699e48671bbc3fef6ca44dc80e3c7');
+            });
+
+            it('removes the category and brand data to the storage', () => {
+                expect(sessionStorage.removeItem)
+                    .toHaveBeenCalledWith('ORDER_ITEMS_b20deef40f9699e48671bbc3fef6ca44dc80e3c7');
+            });
+        });
+    });
+
+    describe('#trackStepViewed()', () => {
+        beforeEach(() => {
+            analyticsStepTracker.trackStepViewed('payment.something');
+        });
+
+        it('sends step viewed tracking data to GA for the given step with current currency', () => {
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: ANALYTIC_STEP_TYPE.PAYMENT, currency: 'JPY' });
+        });
+
+        it('sends step completed & viewed tracking data to GA for all the steps before given step (including current step)', () => {
+            expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(ANALYTIC_STEP_TYPE.CUSTOMER));
+            expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(ANALYTIC_STEP_TYPE.BILLING));
+            expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(ANALYTIC_STEP_TYPE.SHIPPING));
+
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: ANALYTIC_STEP_TYPE.PAYMENT, currency: 'JPY' });
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: ANALYTIC_STEP_TYPE.CUSTOMER, currency: 'JPY' });
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: ANALYTIC_STEP_TYPE.BILLING, currency: 'JPY' });
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: ANALYTIC_STEP_TYPE.SHIPPING, currency: 'JPY' });
+        });
+    });
+
+    describe('#trackStepCompleted()', () => {
+        describe('when no information is available', () => {
+            beforeEach(() => {
+                analyticsStepTracker.trackStepCompleted('payment.something');
+            });
+
+            it('sends an empty shippingMethod property when neither paymentMethod nor shippingMethod are specified', () => {
+                expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(ANALYTIC_STEP_TYPE.PAYMENT));
+            });
+        });
+
+        describe('when there is information available', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getSelectedShippingOption')
+                    .mockReturnValue(getShippingOption());
+
+                jest.spyOn(checkoutService.getState().data, 'getSelectedPaymentMethod')
+                    .mockReturnValue(getPaymentMethod());
+
+                analyticsStepTracker.trackStepCompleted('payment.something');
+            });
+
+            it('sends the shippingMethod and payment data', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    COMPLETED_EVENT_NAME,
+                    {
+                        step: ANALYTIC_STEP_TYPE.PAYMENT,
+                        shippingMethod: 'Flat Rate',
+                        paymentMethod: 'Authorizenet',
+                        currency: 'JPY',
+                    }
+                );
+            });
+
+            it('calls track only once per step', () => {
+                analytics.track.mockReset();
+                analyticsStepTracker.trackStepCompleted('payment.something');
+                expect(analytics.track).toHaveBeenCalledTimes(0);
+            });
+
+            it('sends step complete event again if different shippingMethod method is selected', () => {
+                jest.spyOn(checkoutService.getState().data, 'getSelectedShippingOption')
+                        .mockReturnValue({
+                            ...getShippingOption(),
+                            id: 'id-foo',
+                            description: 'foo',
+                        });
+
+                jest.spyOn(checkoutService.getState().data, 'getSelectedPaymentMethod')
+                    .mockReturnValue(undefined);
+
+                analyticsStepTracker.trackStepCompleted('shipping');
+
+                expect(analytics.track).toHaveBeenLastCalledWith(
+                    COMPLETED_EVENT_NAME,
+                    {
+                        step: ANALYTIC_STEP_TYPE.SHIPPING,
+                        shippingMethod: 'foo',
+                        currency: 'JPY',
+                    }
+                );
+            });
+        });
+    });
+
+    function buildCompletedPayload(step: ANALYTIC_STEP_TYPE) {
+        return { step, shippingMethod: ' ', currency: 'JPY' };
+    }
+});

--- a/src/app/analytics/AnalyticsStepTracker.ts
+++ b/src/app/analytics/AnalyticsStepTracker.ts
@@ -1,0 +1,449 @@
+import { Checkout, CheckoutService, Coupon, LineItemMap, Order, ShippingOption, ShopperCurrency, StoreProfile } from '@bigcommerce/checkout-sdk';
+
+import StepTracker from './StepTracker';
+
+export const ORDER_ITEMS_STORAGE_KEY = 'ORDER_ITEMS';
+
+export enum ANALYTIC_STEP_TYPE {
+    CUSTOMER = 1,
+    SHIPPING,
+    BILLING,
+    PAYMENT,
+}
+
+export const ANALYTIC_STEPS: { [key: string]: ANALYTIC_STEP_TYPE } = {
+    customer: ANALYTIC_STEP_TYPE.CUSTOMER,
+    shipping: ANALYTIC_STEP_TYPE.SHIPPING,
+    billing: ANALYTIC_STEP_TYPE.BILLING,
+    payment: ANALYTIC_STEP_TYPE.PAYMENT,
+};
+
+export const ANALYTIC_STEP_ORDER = [
+    ANALYTIC_STEPS.customer,
+    ANALYTIC_STEPS.shipping,
+    ANALYTIC_STEPS.billing,
+    ANALYTIC_STEPS.payment,
+];
+
+export default class AnalyticsStepTracker implements StepTracker {
+    private checkoutStarted: boolean = false;
+    private completedSteps: { [key: string]: boolean } = {};
+    private viewedSteps: { [key in ANALYTIC_STEP_TYPE]?: boolean; } = {};
+
+    constructor(
+        private checkoutService: CheckoutService,
+        private storage: StorageFallback,
+        private legacyStorage: Storage,
+        private analytics: AnalyticsTracker
+    ) {}
+
+    trackCheckoutStarted(): void {
+        if (this.checkoutStarted) {
+            return;
+        }
+
+        const checkout = this.getCheckout();
+
+        if (!checkout) {
+            return;
+        }
+
+        const {
+            coupons,
+            grandTotal,
+            shippingCostTotal,
+            taxTotal,
+            cart: {
+                lineItems,
+                discountAmount,
+                id,
+            },
+        } = checkout;
+
+        const extraItemsData = this.saveExtraItemsData(id, lineItems);
+
+        this.analytics.track('Checkout Started', this.getTrackingPayload({
+            revenue: grandTotal,
+            shipping: shippingCostTotal,
+            tax: taxTotal,
+            discount: discountAmount,
+            coupons,
+            lineItems,
+            extraItemsData,
+        }));
+
+        this.checkoutStarted = true;
+    }
+
+    trackOrderComplete(): void {
+        const order = this.getOrder();
+
+        if (!order) {
+            return;
+        }
+
+        const {
+            isComplete,
+            orderId,
+            orderAmount,
+            shippingCostTotal,
+            taxTotal,
+            discountAmount,
+            coupons,
+            lineItems,
+            cartId,
+        } = order;
+
+        if (!isComplete) {
+            return;
+        }
+
+        const extraItemsData = this.readExtraItemsData(cartId);
+
+        if (extraItemsData === null) {
+            return;
+        }
+
+        this.analytics.track('Order Completed', this.getTrackingPayload({
+            orderId,
+            revenue: orderAmount,
+            shipping: shippingCostTotal,
+            tax: taxTotal,
+            discount: discountAmount,
+            coupons,
+            extraItemsData,
+            lineItems,
+        }));
+
+        this.clearExtraItemData(cartId);
+    }
+
+    trackStepViewed(step: string): void {
+        const stepId = this.getIdFromStep(step);
+
+        if (!stepId || this.hasStepViewed(stepId)) {
+            return;
+        }
+
+        this.trackViewed(stepId);
+        this.backfill(stepId);
+    }
+
+    trackStepCompleted(step: string): void {
+        const stepId = this.getIdFromStep(step);
+
+        if (!stepId || this.hasStepCompleted(stepId)) {
+            return;
+        }
+
+        this.backfill(stepId);
+        this.trackCompleted(stepId);
+    }
+
+    private trackCompleted(stepId: ANALYTIC_STEP_TYPE): void {
+        const shippingMethod = this.getSelectedShippingOption();
+        const { code: currency = '' } = this.getShopperCurrency() || {};
+        const paymentMethod = this.getPaymentMethodName();
+
+        const payload: {
+            step: number;
+            currency: string;
+            shippingMethod?: string;
+            paymentMethod?: string;
+        } = {
+            step: stepId,
+            currency,
+        };
+
+        if (shippingMethod) {
+            payload.shippingMethod = shippingMethod.description;
+        }
+
+        if (paymentMethod) {
+            payload.paymentMethod = paymentMethod;
+        }
+
+        // due to an issue with the way the segment library works, we must send at least one of the two
+        // options--otherwise it rejects the track call with no diagnostic messages. however, if we blindly
+        // include both options, it sends a single comma for the value, which is undesireable. by only adding
+        // one of the two (shippingMethod here being arbitrarily chosen), we always have at least one value, but
+        // never send two empty values.
+        if (!payload.shippingMethod && !payload.paymentMethod) {
+            payload.shippingMethod = ' ';
+        }
+
+        this.analytics.track('Checkout Step Completed', payload);
+
+        const shippingMethodId = shippingMethod ? shippingMethod.id : '';
+        const completedStepId = stepId === ANALYTIC_STEP_TYPE.SHIPPING ?
+            `${stepId}-${shippingMethodId}` :
+            stepId;
+
+        this.completedSteps[completedStepId] = true;
+    }
+
+    private getTrackingPayload({
+        orderId,
+        revenue,
+        shipping,
+        tax,
+        discount,
+        coupons,
+        extraItemsData,
+        lineItems,
+    }: {
+        orderId?: number;
+        revenue: number;
+        shipping: number;
+        tax: number;
+        discount: number;
+        coupons: Coupon[];
+        extraItemsData: ExtraItemsData;
+        lineItems: LineItemMap;
+    }) {
+        const { code = '' } = this.getShopperCurrency() || {};
+        const { storeName = '' } = this.getStoreProfile() || {};
+
+        return {
+            orderId,
+            affiliation: storeName,
+            revenue: this.toShopperCurrency(revenue),
+            shipping: this.toShopperCurrency(shipping),
+            tax: this.toShopperCurrency(tax),
+            discount: this.toShopperCurrency(discount),
+            coupon: (coupons || []).map(coupon => coupon.code).join(','),
+            currency: code,
+            products: this.getProducts(extraItemsData, lineItems),
+        };
+    }
+
+    private hasStepCompleted(stepId: ANALYTIC_STEP_TYPE): boolean {
+        const shippingOption = this.getSelectedShippingOption();
+        const shippingMethodId = shippingOption ? shippingOption.id : '';
+
+        return this.completedSteps.hasOwnProperty(stepId) ||
+            (
+                stepId === ANALYTIC_STEP_TYPE.SHIPPING &&
+                this.completedSteps.hasOwnProperty(`${stepId}-${shippingMethodId}`)
+            );
+    }
+
+    private hasStepViewed(stepId: ANALYTIC_STEP_TYPE): boolean {
+        return !!this.viewedSteps[stepId];
+    }
+
+    private getIdFromStep(step: string): ANALYTIC_STEP_TYPE | null {
+        const name = step.split('.');
+
+        return ANALYTIC_STEPS[name[0]] || null;
+    }
+
+    private backfill(stepId: ANALYTIC_STEP_TYPE): void {
+        for (const i of ANALYTIC_STEP_ORDER) {
+            if (!this.hasStepViewed(i)) {
+                this.trackViewed(i);
+            }
+            if (i === stepId) {
+                break;
+            }
+            if (!this.hasStepCompleted(i)) {
+                this.trackCompleted(i);
+            }
+        }
+    }
+
+    private trackViewed(stepId: ANALYTIC_STEP_TYPE): void {
+        const currency = this.getShopperCurrency();
+
+        this.analytics.track('Checkout Step Viewed', {
+            step: stepId,
+            currency: currency ? currency.code : '',
+        });
+
+        this.viewedSteps[stepId] = true;
+    }
+
+    private getOrder(): Order | undefined {
+        const { data: { getOrder } } = this.checkoutService.getState();
+
+        return getOrder();
+    }
+
+    private getCheckout(): Checkout | undefined {
+        const { data: { getCheckout } } = this.checkoutService.getState();
+
+        return getCheckout();
+    }
+
+    private getShopperCurrency(): ShopperCurrency | undefined {
+        const { data: { getConfig } } = this.checkoutService.getState();
+        const config = getConfig();
+
+        return config && config.shopperCurrency;
+    }
+
+    private getStoreProfile(): StoreProfile | undefined {
+        const { data: { getConfig } } = this.checkoutService.getState();
+        const config = getConfig();
+
+        return config && config.storeProfile;
+    }
+
+    private toShopperCurrency(amount: number): number {
+        const { exchangeRate = 1 } = this.getShopperCurrency() || {};
+
+        return Math.round(amount * exchangeRate * 100) / 100;
+    }
+
+    private saveExtraItemsData(id: string, lineItems: LineItemMap): ExtraItemsData {
+        const data = [
+            ...lineItems.physicalItems,
+            ...lineItems.digitalItems,
+        ].reduce((result, item) => {
+            result[item.productId] = {
+                brand: item.brand ? item.brand : '',
+                category: item.categoryNames ? item.categoryNames.join(', ') : '',
+            };
+
+            return result;
+        }, {} as ExtraItemsData);
+
+        try {
+            this.storage.setItem(this.getStorageKey(id), JSON.stringify(data));
+
+            return data;
+        } catch (err) {
+            return {};
+        }
+    }
+
+    private getStorageKey(id: string): string {
+        return id ? `${ORDER_ITEMS_STORAGE_KEY}_${id}` : '';
+    }
+
+    private readExtraItemsData(id: string): ExtraItemsData | null {
+        try {
+            let item = this.storage.getItem(this.getStorageKey(id));
+
+            // @todo: this is a fall back while we transition to the new storage key. If we cant find anything
+            // with the new key, just try with the previous key to see if there's anything there.
+            // remove this fallback once it's safe to assume there are no sessions left with the old key
+            if (!item) {
+                item = this.legacyStorage.getItem(ORDER_ITEMS_STORAGE_KEY);
+            }
+
+            return item ? JSON.parse(item) : null;
+        } catch (err) {
+            return null;
+        }
+    }
+
+    private clearExtraItemData(id: string): void {
+        try {
+            this.storage.removeItem(this.getStorageKey(id));
+
+            // @todo: remove this once it's safe to assume there are no sessions left with the old key
+            this.legacyStorage.removeItem(ORDER_ITEMS_STORAGE_KEY);
+        } catch (err) {
+            // silently ignore the failure
+        }
+    }
+
+    private getSelectedShippingOption(): ShippingOption | null {
+        const { data } = this.checkoutService.getState();
+        const shippingOption = data.getSelectedShippingOption();
+
+        return (shippingOption && shippingOption.id && shippingOption.description) ?
+            shippingOption :
+            null;
+    }
+
+    private getPaymentMethodName(): string {
+        const { data } = this.checkoutService.getState();
+        const paymentMethod = data.getSelectedPaymentMethod();
+
+        return (paymentMethod && paymentMethod.config) ?
+            paymentMethod.config.displayName || '' :
+            '';
+    }
+
+    private getProducts(itemsData: ExtraItemsData, lineItems: LineItemMap): AnalyticsProduct[] {
+        const customItems: AnalyticsProduct[] = (lineItems.customItems || []).map(item => ({
+            product_id: item.id,
+            sku: item.sku,
+            price: item.listPrice,
+            quantity: item.quantity,
+            name: item.name,
+        }));
+
+        const giftCertificateItems: AnalyticsProduct[] = lineItems.giftCertificates.map(item => {
+            return {
+                product_id: item.id,
+                price: this.toShopperCurrency(item.amount),
+                name: item.name,
+                quantity: 1,
+            };
+        });
+
+        const physicalAndDigitalItems: AnalyticsProduct[] = [
+            ...lineItems.physicalItems,
+            ...lineItems.digitalItems,
+        ].map(item => {
+            let itemAttributes;
+
+            if (item.options && item.options.length) {
+                itemAttributes = item.options.map(option => `${option.name}:${option.value}`);
+                itemAttributes.sort();
+            }
+
+            return {
+                product_id: item.productId,
+                sku: item.sku,
+                price: item.listPrice,
+                image_url: item.imageUrl,
+                name: item.name,
+                quantity: item.quantity,
+                brand: itemsData[item.productId] ? itemsData[item.productId].brand : '',
+                category: itemsData[item.productId] ? itemsData[item.productId].category : '',
+                variant: (itemAttributes || []).join(', '),
+            };
+        });
+
+        return [
+            ...customItems,
+            ...physicalAndDigitalItems,
+            ...giftCertificateItems,
+        ];
+    }
+}
+
+export interface AnalyticsProduct {
+    product_id: string | number;
+    price: number;
+    quantity: number;
+    name: string;
+    sku?: string;
+    image_url?: string;
+    category?: string;
+    variant?: string;
+    brand?: string;
+}
+
+export interface ExtraItemsData {
+    [productId: string]: {
+        brand: string;
+        category: string;
+    };
+}
+
+export interface AnalyticsTracker {
+    track(step: string, data: any): void;
+}
+
+export interface AnalyticsTrackerWindow extends Window {
+    analytics: AnalyticsTracker;
+}
+
+export function isAnalyticsTrackerWindow(window: Window): window is AnalyticsTrackerWindow {
+    return Boolean((window as AnalyticsTrackerWindow).analytics);
+}

--- a/src/app/analytics/NoopStepTracker.ts
+++ b/src/app/analytics/NoopStepTracker.ts
@@ -1,0 +1,19 @@
+import StepTracker from './StepTracker';
+
+export default class NoopStepTracker implements StepTracker {
+    trackCheckoutStarted(): void {
+        return;
+    }
+
+    trackOrderComplete(): void {
+        return;
+    }
+
+    trackStepViewed(step: string): void {
+        return;
+    }
+
+    trackStepCompleted(step: string): void {
+        return;
+    }
+}

--- a/src/app/analytics/StepTracker.ts
+++ b/src/app/analytics/StepTracker.ts
@@ -1,0 +1,6 @@
+export default interface StepTracker {
+    trackOrderComplete(): void;
+    trackCheckoutStarted(): void;
+    trackStepViewed(step: string): void;
+    trackStepCompleted(step: string): void;
+}

--- a/src/app/analytics/StepTrackerFactory.spec.ts
+++ b/src/app/analytics/StepTrackerFactory.spec.ts
@@ -1,0 +1,65 @@
+import { createCheckoutService, CheckoutService, StoreConfig } from '@bigcommerce/checkout-sdk';
+
+import AnalyticsStepTracker, { AnalyticsTracker, AnalyticsTrackerWindow } from './AnalyticsStepTracker';
+import NoopStepTracker from './NoopStepTracker';
+import StepTrackerFactory from './StepTrackerFactory';
+
+declare let window: AnalyticsTrackerWindow;
+
+describe('ErrorLoggerFactory', () => {
+    let factory: StepTrackerFactory;
+    let checkoutService: CheckoutService;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        factory = new StepTrackerFactory(checkoutService);
+    });
+
+    describe('#createTracker()', () => {
+        describe('when window.analytics is undefined', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                    checkoutSettings: {
+                        isAnalyticsEnabled: true,
+                    },
+                } as StoreConfig);
+            });
+
+            it('returns instance of noop logger', () => {
+                expect(factory.createTracker()).toBeInstanceOf(NoopStepTracker);
+            });
+        });
+
+        describe('when analytics settings is disabled', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                    checkoutSettings: {
+                        isAnalyticsEnabled: false,
+                    },
+                } as StoreConfig);
+
+                window.analytics = {} as AnalyticsTracker;
+            });
+
+            it('returns instance of noop logger', () => {
+                expect(factory.createTracker()).toBeInstanceOf(NoopStepTracker);
+            });
+        });
+
+        describe('when window.analytics is defined and analytics setting enabled', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                    checkoutSettings: {
+                        isAnalyticsEnabled: true,
+                    },
+                } as StoreConfig);
+
+                window.analytics = {} as AnalyticsTracker;
+            });
+
+            it('returns instance of AnalyticsStepTracker', () => {
+                expect(factory.createTracker()).toBeInstanceOf(AnalyticsStepTracker);
+            });
+        });
+    });
+});

--- a/src/app/analytics/StepTrackerFactory.ts
+++ b/src/app/analytics/StepTrackerFactory.ts
@@ -1,0 +1,34 @@
+import { CheckoutService } from '@bigcommerce/checkout-sdk';
+import localStorageFallback from 'local-storage-fallback';
+
+import AnalyticsStepTracker, { isAnalyticsTrackerWindow } from './AnalyticsStepTracker';
+import NoopStepTracker from './NoopStepTracker';
+import StepTracker from './StepTracker';
+
+export default class StepTrackerFactory {
+    constructor(
+        private checkoutService: CheckoutService
+    ) {}
+
+    createTracker(): StepTracker {
+        const { data } = this.checkoutService.getState();
+        const config = data.getConfig();
+
+        if (!config) {
+            throw new Error('Missing configuration data');
+        }
+
+        const { isAnalyticsEnabled } = config.checkoutSettings;
+
+        if (isAnalyticsEnabled && isAnalyticsTrackerWindow(window)) {
+            return new AnalyticsStepTracker(
+                this.checkoutService,
+                localStorageFallback,
+                window.sessionStorage,
+                window.analytics
+            );
+        }
+
+        return new NoopStepTracker();
+    }
+}

--- a/src/app/analytics/createTracker.ts
+++ b/src/app/analytics/createTracker.ts
@@ -1,0 +1,8 @@
+import { CheckoutService } from '@bigcommerce/checkout-sdk';
+
+import StepTracker from './StepTracker';
+import StepTrackerFactory from './StepTrackerFactory';
+
+export default function createTracker(checkoutService: CheckoutService): StepTracker {
+    return new StepTrackerFactory(checkoutService).createTracker();
+}

--- a/src/app/analytics/index.ts
+++ b/src/app/analytics/index.ts
@@ -1,0 +1,5 @@
+export { default as StepTrackerFactory } from './StepTrackerFactory';
+export { default as StepTracker } from './StepTracker';
+export { default as createTracker } from './createTracker';
+export { ANALYTIC_STEP_TYPE } from './AnalyticsStepTracker';
+export { default as NoopStepTracker } from './NoopStepTracker';


### PR DESCRIPTION
## What?
Adds analytics module

## Why?
This module is used to track customers journey throughout the checkout process, using Google Analytics. A Noop step tracker is provided if store does not have analytics enabled.

## Testing / Proof
unit

@bigcommerce/checkout
