### PR TITLE
CHECKOUT-4223 Add currency UI components

### DIFF
--- a/src/app/currency/ShopperCurrency.spec.tsx
+++ b/src/app/currency/ShopperCurrency.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import testRenderer from 'react-test-renderer';
+
+import { LocaleContext } from '../locale';
+import { getLocaleContext } from '../locale/localeContext.mock';
+
+import ShopperCurrency from './ShopperCurrency';
+
+describe('ShopperCurrency Component', () => {
+    const localeContext = getLocaleContext();
+
+    it('renders formatted amount in shopper currency', () => {
+        const currency = localeContext.currency;
+
+        jest.spyOn(currency, 'toCustomerCurrency');
+
+        const tree = testRenderer
+            .create(
+                <LocaleContext.Provider value={ localeContext }>
+                    <ShopperCurrency amount={ 10 } />
+                </LocaleContext.Provider>
+            )
+            .toJSON();
+
+        expect(currency.toCustomerCurrency).toHaveBeenCalledWith(10);
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/src/app/currency/ShopperCurrency.tsx
+++ b/src/app/currency/ShopperCurrency.tsx
@@ -1,0 +1,18 @@
+import React, { Fragment, FunctionComponent } from 'react';
+
+import { withCurrency, WithCurrencyProps } from '../locale';
+
+export interface ShopperCurrencyProps {
+    amount: number;
+}
+
+const ShopperCurrency: FunctionComponent<ShopperCurrencyProps & WithCurrencyProps> = ({
+    amount,
+    currency,
+}) => (
+    <Fragment>
+        { currency.toCustomerCurrency(amount) }
+    </Fragment>
+);
+
+export default withCurrency(ShopperCurrency);

--- a/src/app/currency/StoreCurrency.spec.tsx
+++ b/src/app/currency/StoreCurrency.spec.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import testRenderer from 'react-test-renderer';
+
+import { LocaleContext } from '../locale';
+import { getLocaleContext } from '../locale/localeContext.mock';
+
+import StoreCurrency from './StoreCurrency';
+
+describe('ShopperCurrency Component', () => {
+    const localeContext = getLocaleContext();
+
+    it('renders formatted amount in shopper currency', () => {
+        jest.spyOn(localeContext.currency, 'toStoreCurrency');
+
+        const tree = testRenderer
+            .create(
+                <LocaleContext.Provider value={ localeContext }>
+                    <StoreCurrency amount={ 10 } />
+                </LocaleContext.Provider>
+            )
+            .toJSON();
+
+        expect(localeContext.currency.toStoreCurrency).toHaveBeenCalledWith(10);
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/src/app/currency/StoreCurrency.tsx
+++ b/src/app/currency/StoreCurrency.tsx
@@ -1,0 +1,18 @@
+import React, { Fragment, FunctionComponent } from 'react';
+
+import { withCurrency, WithCurrencyProps } from '../locale';
+
+export interface StoreCurrencyProps {
+    amount: number;
+}
+
+const StoreCurrency: FunctionComponent<StoreCurrencyProps & WithCurrencyProps> = ({
+    amount,
+    currency,
+}) => (
+    <Fragment>
+        { currency.toStoreCurrency(amount) }
+    </Fragment>
+);
+
+export default withCurrency(StoreCurrency);

--- a/src/app/currency/__snapshots__/ShopperCurrency.spec.tsx.snap
+++ b/src/app/currency/__snapshots__/ShopperCurrency.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ShopperCurrency Component renders formatted amount in shopper currency 1`] = `"$11.20"`;

--- a/src/app/currency/__snapshots__/StoreCurrency.spec.tsx.snap
+++ b/src/app/currency/__snapshots__/StoreCurrency.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ShopperCurrency Component renders formatted amount in shopper currency 1`] = `"$10.00"`;

--- a/src/app/currency/index.ts
+++ b/src/app/currency/index.ts
@@ -1,0 +1,2 @@
+export { default as ShopperCurrency } from './ShopperCurrency';
+export { default as StoreCurrency } from './StoreCurrency';


### PR DESCRIPTION
## What?
Add currency UI components

## Why?
So we can easily display amounts either in "store currency" or "shopper currency".

## Testing / Proof
Unit

@bigcommerce/checkout
