### PR TITLE
CHECKOUT-4223: Add Jest transformer to handle stylesheet and file imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,10 @@ module.exports = {
     setupFilesAfterEnv: [
         '<rootDir>/jest-setup.ts',
     ],
+    transform: {
+        '\\.(gif|png|jpe?g|svg)$': '<rootDir>/scripts/jest/file-transformer',
+        '\\.scss$': '<rootDir>/scripts/jest/style-transformer',
+    },
     snapshotSerializers: [
         'enzyme-to-json/serializer',
     ],

--- a/scripts/jest/file-transformer.js
+++ b/scripts/jest/file-transformer.js
@@ -1,0 +1,4 @@
+module.exports = {
+    process: () => 'module.exports = {};',
+};
+

--- a/scripts/jest/style-transformer.js
+++ b/scripts/jest/style-transformer.js
@@ -1,0 +1,6 @@
+const cwd = `${process.cwd()}/`;
+
+module.exports = {
+    process: (src, filename) => `module.exports = '${filename.replace(cwd, '')}';`,
+};
+


### PR DESCRIPTION
## What?
Add Jest transformers to handle stylesheet and file imports

## Why?
Jest doesn't run Webpack so it doesn't recognise these imports. As we don't really need to import stylesheets and images in our unit tests, we can safely mock them out.

For more information, please see https://jestjs.io/docs/en/webpack

## Testing / Proof
Manual

@bigcommerce/checkout
