### PR TITLE
CHECKOUT-4223: Add credit card payment form

### DIFF
--- a/src/app/common/cardValidator/index.ts
+++ b/src/app/common/cardValidator/index.ts
@@ -1,0 +1,16 @@
+import 'card-validator';
+import { CreditCardType as OriginalCreditCardType, CreditCardTypeInfo as OriginalCreditCardTypeInfo } from 'credit-card-type';
+
+// Merge @types/card-validator with missing methods
+declare module 'card-validator' {
+    interface CreditCardTypeInfo extends OriginalCreditCardTypeInfo {
+        patterns?: Array<number | [number, number]>;
+    }
+
+    interface CreditCardType extends OriginalCreditCardType {
+        getTypeInfo(type: string): CreditCardTypeInfo;
+        updateCard(type: string, updates: Partial<CreditCardTypeInfo>): void;
+    }
+
+    export const creditCardType: CreditCardType;
+}

--- a/src/app/payment/creditCard/CreditCardCodeField.tsx
+++ b/src/app/payment/creditCard/CreditCardCodeField.tsx
@@ -1,0 +1,48 @@
+import React, { Fragment, FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { FormField, TextInput } from '../../ui/form';
+import { IconHelp, IconLock } from '../../ui/icon';
+import TooltipTrigger from '../../ui/tooltip/TooltipTrigger';
+
+import CreditCardCodeTooltip from './CreditCardCodeTooltip';
+
+export interface CreditCardCodeFieldProps {
+    name: string;
+}
+
+const CreditCardCodeField: FunctionComponent<CreditCardCodeFieldProps> = ({ name }) => (
+    <FormField
+        additionalClassName="form-ccFields-field--ccCvv"
+        labelContent={
+            <Fragment>
+                <TranslatedString id="payment.credit_card_cvv_label" />
+
+                <TooltipTrigger
+                    placement="top-start"
+                    tooltip={ <CreditCardCodeTooltip /> }
+                >
+                    <span className="has-tip">
+                        <IconHelp />
+                    </span>
+                </TooltipTrigger>
+            </Fragment>
+        }
+        input={ ({ field }) =>
+            <Fragment>
+                <TextInput
+                    { ...field }
+                    additionalClassName="has-icon"
+                    autoComplete="cc-csc"
+                    id={ field.name }
+                    type="tel"
+                />
+
+                <IconLock />
+            </Fragment>
+        }
+        name={ name }
+    />
+);
+
+export default CreditCardCodeField;

--- a/src/app/payment/creditCard/CreditCardCodeTooltip.scss
+++ b/src/app/payment/creditCard/CreditCardCodeTooltip.scss
@@ -1,0 +1,7 @@
+.dropdown-menu--card-code {
+    display: block;
+    left: 0;
+    position: relative;
+    visibility: visible;
+    width: 200px;
+}

--- a/src/app/payment/creditCard/CreditCardCodeTooltip.tsx
+++ b/src/app/payment/creditCard/CreditCardCodeTooltip.tsx
@@ -1,0 +1,30 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { IconCardCodeAmex, IconCardCodeVisa, IconSize } from '../../ui/icon';
+
+import './CreditCardCodeTooltip.scss';
+
+const CreditCardCodeTooltip: FunctionComponent = () => (
+    <div className="dropdown-menu dropdown-menu--content dropdown-menu--card-code" >
+        <div className="form-ccFields-cvvExample">
+            <div className="form-ccFields-cvvExampleDescription">
+                <p>
+                    <TranslatedString id="payment.credit_card_cvv_help_text" />
+                </p>
+            </div>
+
+            <div className="form-ccFields-cvvExampleFigures">
+                <figure>
+                    <IconCardCodeVisa size={ IconSize.Large } />
+                </figure>
+
+                <figure>
+                    <IconCardCodeAmex size={ IconSize.Large } />
+                </figure>
+            </div>
+        </div>
+    </div>
+);
+
+export default CreditCardCodeTooltip;

--- a/src/app/payment/creditCard/CreditCardCustomerCodeField.tsx
+++ b/src/app/payment/creditCard/CreditCardCustomerCodeField.tsx
@@ -1,0 +1,33 @@
+import React, { Fragment, FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { FormField, TextInput } from '../../ui/form';
+
+export interface CreditCardCustomerCodeFieldProps {
+    name: string;
+}
+
+const CreditCardCustomerCodeField: FunctionComponent<CreditCardCustomerCodeFieldProps> = ({ name }) => (
+    <FormField
+        labelContent={
+            <Fragment>
+                <TranslatedString id="payment.credit_card_customer_code_label" />
+
+                { ' ' }
+
+                <small className="optimizedCheckout-contentSecondary">
+                    <TranslatedString id="common.optional_text" />
+                </small>
+            </Fragment>
+        }
+        input={ ({ field }) => (
+            <TextInput
+                { ...field }
+                id={ field.name }
+            />
+        ) }
+        name={ name }
+    />
+);
+
+export default CreditCardCustomerCodeField;

--- a/src/app/payment/creditCard/CreditCardExpiryField.tsx
+++ b/src/app/payment/creditCard/CreditCardExpiryField.tsx
@@ -1,0 +1,34 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { FormField, TextInput } from '../../ui/form';
+
+import formatCreditCardExpiryDate from './formatCreditCardExpiryDate';
+
+export interface CreditCardExpiryFieldProps {
+    name: string;
+}
+
+const CreditCardExpiryField: FunctionComponent<CreditCardExpiryFieldProps> = ({ name }) => (
+    <FormField
+        additionalClassName="form-field--ccExpiry"
+        labelContent={
+            <TranslatedString id="payment.credit_card_expiration_label" />
+        }
+        input={ ({ field, form }) => (
+            <TextInput
+                { ...field }
+                autoComplete="cc-exp"
+                id={ field.name }
+                onChange={ event => {
+                    form.setFieldValue(field.name, formatCreditCardExpiryDate(event.target.value));
+                } }
+                placeholder="MM / YY"
+                type="tel"
+            />
+        ) }
+        name={ name }
+    />
+);
+
+export default CreditCardExpiryField;

--- a/src/app/payment/creditCard/CreditCardFieldset.spec.tsx
+++ b/src/app/payment/creditCard/CreditCardFieldset.spec.tsx
@@ -1,0 +1,91 @@
+import { mount, render } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+
+import CreditCardFieldset, { CreditCardFieldsetValues } from './CreditCardFieldset';
+
+describe('CreditCardFieldset', () => {
+    let initialValues: CreditCardFieldsetValues;
+    let localeContext: LocaleContextType;
+
+    beforeEach(() => {
+        initialValues = {
+            ccCustomerCode: '',
+            ccCvv: '',
+            ccExpiry: '',
+            ccName: '',
+            ccNumber: '',
+        };
+
+        localeContext = createLocaleContext(getStoreConfig());
+    });
+
+    it('matches snapshot', () => {
+        expect(render(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardFieldset />
+                </Formik>
+            </LocaleContext.Provider>
+        ))
+            .toMatchSnapshot();
+    });
+
+    it('shows card code field when configured', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardFieldset shouldShowCardCodeField={ true } />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find('input[name="ccCvv"]').exists())
+            .toEqual(true);
+    });
+
+    it('shows customer code field when configured', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardFieldset shouldShowCustomerCodeField={ true } />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find('input[name="ccCustomerCode"]').exists())
+            .toEqual(true);
+    });
+
+    it('does not show card code field or customer code field by default', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardFieldset />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find('input[name="ccCvv"]').exists())
+            .toEqual(false);
+
+        expect(component.find('input[name="ccCustomerCode"]').exists())
+            .toEqual(false);
+    });
+});

--- a/src/app/payment/creditCard/CreditCardFieldset.tsx
+++ b/src/app/payment/creditCard/CreditCardFieldset.tsx
@@ -1,0 +1,57 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { Fieldset, Legend } from '../../ui/form';
+
+import CreditCardCodeField from './CreditCardCodeField';
+import CreditCardCustomerCodeField from './CreditCardCustomerCodeField';
+import CreditCardExpiryField from './CreditCardExpiryField';
+import CreditCardNameField from './CreditCardNameField';
+import CreditCardNumberField from './CreditCardNumberField';
+import CreditCardStorageField from './CreditCardStorageField';
+
+export interface CreditCardFieldsetProps {
+    shouldShowCardCodeField?: boolean;
+    shouldShowCustomerCodeField?: boolean;
+    shouldShowSaveCardField?: boolean;
+}
+
+export interface CreditCardFieldsetValues {
+    ccCustomerCode?: string;
+    ccCvv?: string;
+    ccExpiry: string;
+    ccName: string;
+    ccNumber: string;
+    shouldSaveInstrument?: boolean;
+}
+
+const CreditCardFieldset: FunctionComponent<CreditCardFieldsetProps> = ({
+    shouldShowCardCodeField,
+    shouldShowCustomerCodeField,
+    shouldShowSaveCardField,
+}) => (
+    <Fieldset
+        additionalClassName="creditCardFieldset"
+        legend={
+            <Legend hidden>
+                <TranslatedString id="payment.credit_card_text" />
+            </Legend>
+        }
+    >
+        <div className="form-ccFields">
+            <CreditCardNumberField name="ccNumber" />
+
+            <CreditCardExpiryField name="ccExpiry" />
+
+            <CreditCardNameField name="ccName" />
+
+            { shouldShowCardCodeField && <CreditCardCodeField name="ccCvv" /> }
+
+            { shouldShowCustomerCodeField && <CreditCardCustomerCodeField name="ccCustomerCode" /> }
+
+            { shouldShowSaveCardField && <CreditCardStorageField name="shouldSaveInstrument" /> }
+        </div>
+    </Fieldset>
+);
+
+export default CreditCardFieldset;

--- a/src/app/payment/creditCard/CreditCardIcon.spec.tsx
+++ b/src/app/payment/creditCard/CreditCardIcon.spec.tsx
@@ -1,0 +1,62 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { IconCardAmex, IconCardDinersClub, IconCardDiscover, IconCardJCB, IconCardMaestro, IconCardMastercard, IconCardUnionPay, IconCardVisa } from '../../ui/icon';
+
+import CreditCardIcon from './CreditCardIcon';
+
+describe('CreditCardIcon', () => {
+    it('returns American Express card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="american-express" />).find(IconCardAmex))
+            .toHaveLength(1);
+    });
+
+    it('returns Diners Club card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="diners-club" />).find(IconCardDinersClub))
+            .toHaveLength(1);
+    });
+
+    it('returns Discover card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="discover" />).find(IconCardDiscover))
+            .toHaveLength(1);
+    });
+
+    it('returns JCB card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="jcb" />).find(IconCardJCB))
+            .toHaveLength(1);
+    });
+
+    it('returns Maestro card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="maestro" />).find(IconCardMaestro))
+            .toHaveLength(1);
+    });
+
+    it('returns Mastercard card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="mastercard" />).find(IconCardMastercard))
+            .toHaveLength(1);
+    });
+
+    it('returns Union Pay card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="unionpay" />).find(IconCardUnionPay))
+            .toHaveLength(1);
+    });
+
+    it('returns Visa card icon', () => {
+        expect(shallow(<CreditCardIcon cardType="visa" />).find(IconCardVisa))
+            .toHaveLength(1);
+    });
+
+    it('returns default card icon if nothing matches', () => {
+        expect(shallow(<CreditCardIcon cardType="foobar" />).hasClass('cardIcon-icon--default'))
+            .toEqual(true);
+    });
+
+    it('configures icon component with test ID', () => {
+        const component = shallow(
+            <CreditCardIcon cardType="american-express" />
+        );
+
+        expect(component.find(IconCardAmex).prop('testId'))
+            .toEqual('credit-card-icon-american-express');
+    });
+});

--- a/src/app/payment/creditCard/CreditCardIcon.tsx
+++ b/src/app/payment/creditCard/CreditCardIcon.tsx
@@ -1,0 +1,58 @@
+import React, { FunctionComponent } from 'react';
+
+import {
+    IconCardAmex,
+    IconCardDinersClub,
+    IconCardDiscover,
+    IconCardJCB,
+    IconCardMaestro,
+    IconCardMastercard,
+    IconCardUnionPay,
+    IconCardVisa,
+    IconSize
+} from '../../ui/icon';
+
+export interface CreditCardIconProps {
+    cardType?: string;
+}
+
+const CreditCardIcon: FunctionComponent<CreditCardIconProps> = ({
+    cardType,
+}) => {
+    const iconProps = {
+        additionalClassName: 'cardIcon-icon',
+        size: IconSize.Medium,
+        testId: `credit-card-icon-${cardType || 'default'}`,
+    };
+
+    switch (cardType) {
+    case 'american-express':
+        return <IconCardAmex { ...iconProps } />;
+
+    case 'diners-club':
+        return <IconCardDinersClub { ...iconProps } />;
+
+    case 'discover':
+        return <IconCardDiscover { ...iconProps } />;
+
+    case 'jcb':
+        return <IconCardJCB { ...iconProps } />;
+
+    case 'maestro':
+        return <IconCardMaestro { ...iconProps } />;
+
+    case 'mastercard':
+        return <IconCardMastercard { ...iconProps } />;
+
+    case 'unionpay':
+        return <IconCardUnionPay { ...iconProps } />;
+
+    case 'visa':
+        return <IconCardVisa { ...iconProps } />;
+
+    default:
+        return <div className="cardIcon-icon cardIcon-icon--default icon icon--medium" />;
+    }
+};
+
+export default CreditCardIcon;

--- a/src/app/payment/creditCard/CreditCardIconList.spec.tsx
+++ b/src/app/payment/creditCard/CreditCardIconList.spec.tsx
@@ -1,0 +1,62 @@
+import { shallow, ShallowWrapper } from 'enzyme';
+import React from 'react';
+
+import CreditCardIcon from './CreditCardIcon';
+import CreditCardIconList from './CreditCardIconList';
+
+describe('CreditCardIconList', () => {
+    it('filters out card types without icon', () => {
+        const component = shallow(
+            <CreditCardIconList cardTypes={ ['visa', 'mastercard', 'foo'] } />
+        );
+
+        expect(component.find(CreditCardIcon))
+            .toHaveLength(2);
+
+        expect(component.find(CreditCardIcon).at(0).prop('cardType'))
+            .toEqual('visa');
+
+        expect(component.find(CreditCardIcon).at(1).prop('cardType'))
+            .toEqual('mastercard');
+    });
+
+    it('renders nothing if no cards have icon', () => {
+        const component = shallow(
+            <CreditCardIconList cardTypes={ ['foo', 'bar'] } />
+        );
+
+        expect(component.html())
+            .toEqual(null);
+    });
+
+    describe('when a credit card is selected', () => {
+        let component: ShallowWrapper;
+
+        beforeEach(() => {
+            component = shallow(
+                <CreditCardIconList
+                    cardTypes={ ['visa', 'mastercard', 'foo', 'diners-club'] }
+                    selectedCardType={ 'mastercard' }
+                />
+            );
+        });
+
+        it('renders all supported cards', () => {
+            expect(component.find(CreditCardIcon))
+                .toHaveLength(3);
+        });
+
+        it('applies active class to selected card', () => {
+            expect(component.find('.creditCardTypes-list-item').at(1).prop('className'))
+                .toMatch('is-active');
+        });
+
+        it('applies inactive class to unselected cards', () => {
+            expect(component.find('.creditCardTypes-list-item').at(0).prop('className'))
+                .toMatch('not-active');
+
+            expect(component.find('.creditCardTypes-list-item').at(2).prop('className'))
+                .toMatch('not-active');
+        });
+    });
+});

--- a/src/app/payment/creditCard/CreditCardIconList.tsx
+++ b/src/app/payment/creditCard/CreditCardIconList.tsx
@@ -1,0 +1,53 @@
+import classNames from 'classnames';
+import React, { FunctionComponent } from 'react';
+
+import CreditCardIcon from './CreditCardIcon';
+
+export const SUPPORTED_CARD_TYPES = [
+    'american-express',
+    'diners-club',
+    'discover',
+    'jcb',
+    'maestro',
+    'mastercard',
+    'unionpay',
+    'visa',
+];
+
+export interface CreditCardIconListProps {
+    selectedCardType?: string;
+    cardTypes: string[];
+}
+
+const CreditCardIconList: FunctionComponent<CreditCardIconListProps> = ({
+    selectedCardType,
+    cardTypes,
+}) => {
+    const filteredCardTypes = cardTypes
+        .filter(type => SUPPORTED_CARD_TYPES.indexOf(type) !== -1);
+
+    if (!filteredCardTypes.length) {
+        return null;
+    }
+
+    return (
+        <ul className="creditCardTypes-list">
+            { filteredCardTypes.map(type => (
+                <li
+                    key={ type }
+                    className={ classNames(
+                        'creditCardTypes-list-item',
+                        { 'is-active': selectedCardType === type },
+                        { 'not-active': selectedCardType && selectedCardType !== type}
+                    )}
+                >
+                    <span className="cardIcon">
+                        <CreditCardIcon cardType={ type } />
+                    </span>
+                </li>
+            )) }
+        </ul>
+    );
+};
+
+export default CreditCardIconList;

--- a/src/app/payment/creditCard/CreditCardNameField.tsx
+++ b/src/app/payment/creditCard/CreditCardNameField.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { FormField, TextInput } from '../../ui/form';
+
+export interface CreditCardNameFieldProps {
+    name: string;
+}
+
+const CreditCardNameField: FunctionComponent<CreditCardNameFieldProps> = ({ name }) => (
+    <FormField
+        additionalClassName="form-field--ccName"
+        labelContent={
+            <TranslatedString id="payment.credit_card_name_label" />
+        }
+        input={ ({ field }) => (
+            <TextInput
+                { ...field }
+                autoComplete="cc-name"
+                id={ field.name }
+            />
+        ) }
+        name={ name }
+    />
+);
+
+export default CreditCardNameField;

--- a/src/app/payment/creditCard/CreditCardNumberField.spec.tsx
+++ b/src/app/payment/creditCard/CreditCardNumberField.spec.tsx
@@ -1,0 +1,146 @@
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+
+import { CreditCardFieldsetValues } from './CreditCardFieldset';
+import CreditCardNumberField from './CreditCardNumberField';
+
+describe('CreditCardNumberField', () => {
+    let initialValues: Pick<CreditCardFieldsetValues, 'ccNumber'>;
+    let localeContext: LocaleContextType;
+
+    beforeEach(() => {
+        initialValues = {
+            ccNumber: '',
+        };
+
+        localeContext = createLocaleContext(getStoreConfig());
+    });
+
+    it('allows user to type in potentially valid number', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardNumberField name="ccNumber" />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        component.find('input[name="ccNumber"]')
+            .simulate('change', { target: { value: '4111', name: 'ccNumber' } })
+            .update();
+
+        expect(component.find('input[name="ccNumber"]').prop('value'))
+            .toEqual('4111');
+    });
+
+    it('prevents user from typing invalid number', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardNumberField name="ccNumber" />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        component.find('input[name="ccNumber"]')
+            .simulate('change', { target: { value: 'xxxx', name: 'ccNumber' } })
+            .update();
+
+        expect(component.find('input[name="ccNumber"]').prop('value'))
+            .toEqual('');
+    });
+
+    it('limits number of digits based on card type', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardNumberField name="ccNumber" />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        // The number of digits for Visa card should not exceed 19 digits (plus 3 gaps)
+        component.find('input[name="ccNumber"]')
+            .simulate('change', { target: { value: '4111 1111 1111 1111111 999999', name: 'ccNumber' } })
+            .update();
+
+        expect(component.find('input[name="ccNumber"]').prop('value'))
+            .toHaveLength(22);
+
+        // The number of digits for Amex card should not exceed 15 digits (plus 2 gaps)
+        component.find('input[name="ccNumber"]')
+            .simulate('change', { target: { value: '3782 822463 10005 999999', name: 'ccNumber' } })
+            .update();
+
+        expect(component.find('input[name="ccNumber"]').prop('value'))
+            .toHaveLength(17);
+    });
+
+    it('formats card number based on type', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <CreditCardNumberField name="ccNumber" />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        component.find('input[name="ccNumber"]')
+            .simulate('change', { target: { value: '411111111111', name: 'ccNumber' } })
+            .update();
+
+        expect(component.find('input[name="ccNumber"]').prop('value'))
+            .toEqual('4111 1111 1111');
+
+        component.find('input[name="ccNumber"]')
+            .simulate('change', { target: { value: '378282246310005', name: 'ccNumber' } })
+            .update();
+
+        expect(component.find('input[name="ccNumber"]').prop('value'))
+            .toEqual('3782 822463 10005');
+    });
+
+    it('only sets selection range if it has changed', () => {
+        const ccNumber = '4111';
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ { ...initialValues, ccNumber } }
+                    onSubmit={ noop }
+                >
+                    <CreditCardNumberField name="ccNumber" />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        const input = component.find('input[name="ccNumber"]');
+        const inputNode = input.getDOMNode<HTMLInputElement>();
+
+        inputNode.setSelectionRange(4, 4);
+        jest.spyOn(inputNode, 'setSelectionRange');
+
+        // Trigger a change event with the same value
+        input
+            .simulate('change', { target: { value: ccNumber, name: 'ccNumber' } })
+            .update();
+
+        expect(inputNode.setSelectionRange).toHaveBeenCalledTimes(0);
+    });
+});

--- a/src/app/payment/creditCard/CreditCardNumberField.tsx
+++ b/src/app/payment/creditCard/CreditCardNumberField.tsx
@@ -1,0 +1,94 @@
+import creditCardType from 'credit-card-type';
+import { FieldProps } from 'formik';
+import { max } from 'lodash';
+import React, { createRef, ChangeEventHandler, Component, Fragment, FunctionComponent, ReactNode, RefObject } from 'react';
+
+import { TranslatedString } from '../../language';
+import { FormField, TextInput } from '../../ui/form';
+import { IconLock } from '../../ui/icon';
+
+import formatCreditCardNumber from './formatCreditCardNumber';
+
+export interface CreditCardNumberFieldProps {
+    name: string;
+}
+
+const CreditCardNumberField: FunctionComponent<CreditCardNumberFieldProps> = ({ name }) => (
+    <FormField
+        additionalClassName="form-field--ccNumber"
+        labelContent={
+            <TranslatedString id="payment.credit_card_number_label" />
+        }
+        input={ ({ field, form }) => (
+            <CreditCardNumberInput
+                field={ field }
+                form={ form }
+            />
+        ) }
+        name={ name }
+    />
+);
+
+class CreditCardNumberInput extends Component<FieldProps<string>> {
+    private inputRef: RefObject<HTMLInputElement> = createRef();
+    private nextSelectionEnd: number = 0;
+
+    componentDidUpdate(): void {
+        if (this.inputRef.current && this.inputRef.current.selectionEnd !== this.nextSelectionEnd) {
+            this.inputRef.current.setSelectionRange(this.nextSelectionEnd, this.nextSelectionEnd);
+        }
+    }
+
+    render(): ReactNode {
+        const { field } = this.props;
+
+        return (
+            <Fragment>
+                <TextInput
+                    { ...field }
+                    additionalClassName="has-icon"
+                    autoComplete="cc-number"
+                    ref={ this.inputRef }
+                    id={ field.name }
+                    onChange={ this.handleChange }
+                    type="tel"
+                />
+
+                <IconLock />
+            </Fragment>
+        );
+    }
+
+    private handleChange: ChangeEventHandler<HTMLInputElement> = event => {
+        const separator = ' ';
+        const { value = '' } = event.target;
+        const { field, form } = this.props;
+        const { name, value: previousValue = '' } = field;
+        const selectionEnd = this.inputRef.current && this.inputRef.current.selectionEnd;
+
+        // Only allow digits and spaces
+        if (new RegExp(`[^\\d${separator}]`).test(value)) {
+            return form.setFieldValue(name, previousValue);
+        }
+
+        const maxLength = max(
+            creditCardType(value)
+                .map(info => max(info.lengths))
+        );
+
+        const formattedValue = formatCreditCardNumber(
+            value.replace(new RegExp(separator, 'g'), '').slice(0, maxLength),
+            separator
+        );
+
+        if (selectionEnd === value.length && value.length < formattedValue.length) {
+            this.nextSelectionEnd = formattedValue.length;
+        } else {
+            this.nextSelectionEnd = selectionEnd || 0;
+        }
+
+        form.setFieldValue(name, formattedValue);
+    };
+}
+
+export default CreditCardNumberField;

--- a/src/app/payment/creditCard/CreditCardStorageField.tsx
+++ b/src/app/payment/creditCard/CreditCardStorageField.tsx
@@ -1,0 +1,18 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { CheckboxFormField } from '../../ui/form';
+
+export interface CreditCardStorageFieldProps {
+    name: string;
+}
+
+const CreditCardStorageField: FunctionComponent<CreditCardStorageFieldProps> = ({ name }) => (
+    <CheckboxFormField
+        additionalClassName="form-field--saveInstrument"
+        name={ name }
+        labelContent={ <TranslatedString id="payment.instrument_save_payment_method_label" /> }
+    />
+);
+
+export default CreditCardStorageField;

--- a/src/app/payment/creditCard/__snapshots__/CreditCardFieldset.spec.tsx.snap
+++ b/src/app/payment/creditCard/__snapshots__/CreditCardFieldset.spec.tsx.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CreditCardFieldset matches snapshot 1`] = `
+<fieldset
+  class="form-fieldset creditCardFieldset"
+>
+  <legend
+    class="form-legend is-srOnly"
+  >
+    Credit card
+  </legend>
+  <div
+    class="form-body"
+  >
+    <div
+      class="form-ccFields"
+    >
+      <div
+        class="form-field form-field--ccNumber"
+      >
+        <label
+          class="form-label optimizedCheckout-form-label"
+          for="ccNumber"
+        >
+          Credit Card Number
+        </label>
+        <input
+          autocomplete="cc-number"
+          class="form-input optimizedCheckout-form-input has-icon"
+          id="ccNumber"
+          name="ccNumber"
+          type="tel"
+          value=""
+        />
+        <div
+          class="icon"
+        >
+          <svg
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        class="form-field form-field--ccExpiry"
+      >
+        <label
+          class="form-label optimizedCheckout-form-label"
+          for="ccExpiry"
+        >
+          Expiration
+        </label>
+        <input
+          autocomplete="cc-exp"
+          class="form-input optimizedCheckout-form-input"
+          id="ccExpiry"
+          name="ccExpiry"
+          placeholder="MM / YY"
+          type="tel"
+          value=""
+        />
+      </div>
+      <div
+        class="form-field form-field--ccName"
+      >
+        <label
+          class="form-label optimizedCheckout-form-label"
+          for="ccName"
+        >
+          Name on Card
+        </label>
+        <input
+          autocomplete="cc-name"
+          class="form-input optimizedCheckout-form-input"
+          id="ccName"
+          name="ccName"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+</fieldset>
+`;

--- a/src/app/payment/creditCard/configureCardValidator.ts
+++ b/src/app/payment/creditCard/configureCardValidator.ts
@@ -1,0 +1,23 @@
+// tslint:disable-next-line:no-reference
+// <reference path="../../common/cardValidator/index.d.ts" />
+import { creditCardType } from 'card-validator';
+
+import '../../common/cardValidator';
+
+export default function configureCardValidator(): void {
+    const discoverInfo = creditCardType.getTypeInfo('discover');
+    const visaInfo = creditCardType.getTypeInfo('visa');
+
+    // Need to support 13 digit PAN because some gateways only provide test credit card numbers in this format.
+    creditCardType.updateCard('visa', {
+        lengths: [13, ...(visaInfo.lengths || [])],
+    });
+
+    // Add support for 8-BIN Discover Cards.
+    creditCardType.updateCard('discover', {
+        patterns: [
+            ...(discoverInfo.patterns || []),
+            [810, 817],
+        ],
+    });
+}

--- a/src/app/payment/creditCard/formatCreditCardExpiryDate.spec.ts
+++ b/src/app/payment/creditCard/formatCreditCardExpiryDate.spec.ts
@@ -1,0 +1,23 @@
+import formatCreditCardExpiryDate from './formatCreditCardExpiryDate';
+
+describe('formatCreditCardExpiryDate()', () => {
+    it('converts date into MM/YY date format', () => {
+        expect(formatCreditCardExpiryDate('10/2019'))
+            .toEqual('10 / 19');
+    });
+
+    it('formats partial date value', () => {
+        expect(formatCreditCardExpiryDate('10'))
+            .toEqual('10 / ');
+    });
+
+    it('returns month only if there is no year and separator has no trailing space', () => {
+        expect(formatCreditCardExpiryDate('10 /'))
+            .toEqual('10');
+    });
+
+    it('surrounds separator with whitespaces', () => {
+        expect(formatCreditCardExpiryDate('10/19'))
+            .toEqual('10 / 19');
+    });
+});

--- a/src/app/payment/creditCard/formatCreditCardExpiryDate.ts
+++ b/src/app/payment/creditCard/formatCreditCardExpiryDate.ts
@@ -1,0 +1,18 @@
+export default function formatCreditCardExpiryDate(value: string): string {
+    const separator = '/';
+    const [month = '', year = ''] = value.split(new RegExp(`\\s*${separator}\\s*`));
+    const trimmedMonth = month.slice(0, 2);
+    const trimmedYear = year.length === 4 ? year.slice(-2) : (year ? year.slice(0, 2) : month.slice(2));
+
+    // i.e.: '1'
+    if (value.length < 2) {
+        return month;
+    }
+
+    // ie.: '10 /' (without trailing space)
+    if (value.length > 3 && !trimmedYear) {
+        return trimmedMonth;
+    }
+
+    return `${trimmedMonth} / ${trimmedYear}`;
+}

--- a/src/app/payment/creditCard/formatCreditCardNumber.spec.ts
+++ b/src/app/payment/creditCard/formatCreditCardNumber.spec.ts
@@ -1,0 +1,50 @@
+import formatCreditCardNumber from './formatCreditCardNumber';
+
+describe('formatCreditCardNumber()', () => {
+    it('formats Visa credit card number', () => {
+        expect(formatCreditCardNumber('4111111111111111'))
+            .toEqual('4111 1111 1111 1111');
+
+        expect(formatCreditCardNumber('4111 1111 1111 1111234'))
+            .toEqual('4111 1111 1111 1111234');
+    });
+
+    it('formats Mastercard credit card number', () => {
+        expect(formatCreditCardNumber('5555555555554444'))
+            .toEqual('5555 5555 5555 4444');
+    });
+
+    it('formats Amex credit card number', () => {
+        expect(formatCreditCardNumber('378282246310005'))
+            .toEqual('3782 822463 10005');
+    });
+
+    it('formats Diners Club credit card number', () => {
+        expect(formatCreditCardNumber('36259600000004'))
+            .toEqual('3625 960000 0004');
+    });
+
+    it('formats Discover credit card number', () => {
+        expect(formatCreditCardNumber('6011111111111117'))
+            .toEqual('6011 1111 1111 1117');
+    });
+
+    it('formats potentially invalid credit card number', () => {
+        expect(formatCreditCardNumber('41111'))
+            .toEqual('4111 1');
+
+        expect(formatCreditCardNumber('5555'))
+            .toEqual('5555');
+
+        expect(formatCreditCardNumber('37828224631'))
+            .toEqual('3782 822463 1');
+    });
+
+    it('does not format if credit card number cannot be recognized', () => {
+        expect(formatCreditCardNumber('99999999'))
+            .toEqual('99999999');
+
+        expect(formatCreditCardNumber('4111 1111 1111 11112345'))
+            .toEqual('4111 1111 1111 11112345');
+    });
+});

--- a/src/app/payment/creditCard/formatCreditCardNumber.ts
+++ b/src/app/payment/creditCard/formatCreditCardNumber.ts
@@ -1,0 +1,22 @@
+import { number } from 'card-validator';
+
+import unformatCreditCardNumber from './unformatCreditCardNumber';
+
+export default function formatCreditCardNumber(value: string, separator: string = ' '): string {
+    const { card } = number(value);
+
+    if (!card) {
+        return value;
+    }
+
+    const unformattedValue = unformatCreditCardNumber(value, separator);
+
+    return card.gaps
+        .filter(gapIndex => unformattedValue.length > gapIndex)
+        .reduce((output, gapIndex, index) => (
+            [
+                output.slice(0, gapIndex + index),
+                output.slice(gapIndex + index),
+            ].join(separator)
+        ), unformattedValue);
+}

--- a/src/app/payment/creditCard/getCreditCardValidationSchema.spec.ts
+++ b/src/app/payment/creditCard/getCreditCardValidationSchema.spec.ts
@@ -1,0 +1,102 @@
+import { createLanguageService, LanguageService } from '@bigcommerce/checkout-sdk';
+
+import getCreditCardValidationSchema from './getCreditCardValidationSchema';
+import { CreditCardFieldsetValues } from './CreditCardFieldset';
+
+describe('getCreditCardValidationSchema()', () => {
+    let language: LanguageService;
+    let validData: CreditCardFieldsetValues;
+
+    beforeEach(() => {
+        language = createLanguageService();
+
+        jest.spyOn(language, 'translate')
+            .mockImplementation(key => key);
+
+        validData = {
+            ccCustomerCode: '123',
+            ccCvv: '123',
+            ccExpiry: '10 / 25',
+            ccName: 'BC',
+            ccNumber: '4111 1111 1111 1111',
+        };
+    });
+
+    it('does not throw error if data is valid', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(schema.validateSync(validData))
+            .toEqual(validData);
+    });
+
+    it('returns error if card number is missing', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(() => schema.validateSync({ ...validData, ccNumber: '' }))
+            .toThrowError('payment.credit_card_number_required_error');
+    });
+
+    it('returns error if card number is invalid', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(() => schema.validateSync({ ...validData, ccNumber: '9999 9999 9999 9999' }))
+            .toThrowError('payment.credit_card_number_invalid_error');
+    });
+
+    it('returns error if card name is missing', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(() => schema.validateSync({ ...validData, ccName: '' }))
+            .toThrowError('payment.credit_card_name_required_error');
+    });
+
+    it('returns error if expiry date is missing', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(() => schema.validateSync({ ...validData, ccExpiry: '' }))
+            .toThrowError('payment.credit_card_expiration_required_error');
+    });
+
+    it('returns error if expiry date is invalid', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(() => schema.validateSync({ ...validData, ccExpiry: '2030 / 12' }))
+            .toThrowError('payment.credit_card_expiration_invalid_error');
+    });
+
+    it('returns error if expiry date is in past', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(() => schema.validateSync({ ...validData, ccExpiry: '12 / 10' }))
+            .toThrowError('payment.credit_card_expiration_invalid_error');
+    });
+
+    it('returns error if card code is missing when required', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: true, language });
+
+        expect(() => schema.validateSync({ ...validData, ccCvv: '' }))
+            .toThrowError('payment.credit_card_cvv_required_error');
+    });
+
+    it('returns error if card code is invalid when required', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: true, language });
+
+        expect(() => schema.validateSync({ ...validData, ccCvv: '99999' }))
+            .toThrowError('payment.credit_card_cvv_invalid_error');
+    });
+
+    it('returns error if card code is invalid for given card number', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: true, language });
+
+        // Card code for American Express should have 4 digts
+        expect(() => schema.validateSync({ ...validData, ccCvv: '123', ccNumber: '378282246310005' }))
+            .toThrowError('payment.credit_card_cvv_invalid_error');
+    });
+
+    it('does not return error if card code is not required', () => {
+        const schema = getCreditCardValidationSchema({ isCardCodeRequired: false, language });
+
+        expect(() => schema.validateSync({ ...validData, ccCvv: '' }))
+            .not.toThrow();
+    });
+});

--- a/src/app/payment/creditCard/getCreditCardValidationSchema.ts
+++ b/src/app/payment/creditCard/getCreditCardValidationSchema.ts
@@ -1,0 +1,51 @@
+import { LanguageService } from '@bigcommerce/checkout-sdk';
+import { cvv, expirationDate, number } from 'card-validator';
+import { memoize } from 'lodash';
+import { object, string, ObjectSchema } from 'yup';
+
+import { CreditCardFieldsetValues } from './CreditCardFieldset';
+
+export interface CreditCardValidationSchemaOptions {
+    isCardCodeRequired: boolean;
+    language: LanguageService;
+}
+
+export default memoize(function getCreditCardValidationSchema({
+    isCardCodeRequired,
+    language,
+}: CreditCardValidationSchemaOptions): ObjectSchema<CreditCardFieldsetValues> {
+    const schema = {
+        ccCustomerCode: string(),
+        ccCvv: string(),
+        ccExpiry: string()
+            .required(language.translate('payment.credit_card_expiration_required_error'))
+            .test({
+                message: language.translate('payment.credit_card_expiration_invalid_error'),
+                test: value => expirationDate(value).isValid,
+            }),
+        ccName: string()
+            .max(200)
+            .required(language.translate('payment.credit_card_name_required_error')),
+        ccNumber: string()
+            .required(language.translate('payment.credit_card_number_required_error'))
+            .test({
+                message: language.translate('payment.credit_card_number_invalid_error'),
+                test: value => number(value).isValid,
+            }),
+    };
+
+    if (isCardCodeRequired) {
+        schema.ccCvv = string()
+            .required(language.translate('payment.credit_card_cvv_required_error'))
+            .test({
+                message: language.translate('payment.credit_card_cvv_invalid_error'),
+                test(value) {
+                    const { card } = number(this.parent.ccNumber);
+
+                    return cvv(value, card && card.code ? card.code.size : undefined).isValid;
+                },
+            });
+    }
+
+    return object(schema);
+}, (...args) => JSON.stringify(args));

--- a/src/app/payment/creditCard/index.ts
+++ b/src/app/payment/creditCard/index.ts
@@ -1,0 +1,16 @@
+import { CreditCardFieldsetProps, CreditCardFieldsetValues } from './CreditCardFieldset';
+
+export type CreditCardFieldsetProps = CreditCardFieldsetProps;
+export type CreditCardFieldsetValues = CreditCardFieldsetValues;
+
+export { default as configureCardValidator } from './configureCardValidator';
+export { default as CreditCardFieldset } from './CreditCardFieldset';
+export { default as CreditCardIcon } from './CreditCardIcon';
+export { default as CreditCardIconList } from './CreditCardIconList';
+export { default as CreditCardCodeField } from './CreditCardCodeField';
+export { default as CreditCardNumberField } from './CreditCardNumberField';
+export { default as CreditCardStorageField } from './CreditCardStorageField';
+export { default as getCreditCardValidationSchema } from './getCreditCardValidationSchema';
+export { default as mapFromPaymentMethodCardType } from './mapFromPaymentMethodCardType';
+export { default as unformatCreditCardNumber } from './unformatCreditCardNumber';
+export { default as unformatCreditCardExpiryDate } from './unformatCreditCardExpiryDate';

--- a/src/app/payment/creditCard/mapFromPaymentMethodCardType.spec.ts
+++ b/src/app/payment/creditCard/mapFromPaymentMethodCardType.spec.ts
@@ -1,0 +1,34 @@
+import mapFromPaymentMethodCardType from './mapFromPaymentMethodCardType';
+
+describe('mapFromPaymentMethodCardType()', () => {
+    it('maps from payment method card type', () => {
+        expect(mapFromPaymentMethodCardType('AMEX'))
+            .toEqual('american-express');
+
+        expect(mapFromPaymentMethodCardType('DINERS'))
+            .toEqual('diners-club');
+
+        expect(mapFromPaymentMethodCardType('DISCOVER'))
+            .toEqual('discover');
+
+        expect(mapFromPaymentMethodCardType('JCB'))
+            .toEqual('jcb');
+
+        expect(mapFromPaymentMethodCardType('MAESTRO'))
+            .toEqual('maestro');
+
+        expect(mapFromPaymentMethodCardType('MC'))
+            .toEqual('mastercard');
+
+        expect(mapFromPaymentMethodCardType('CUP'))
+            .toEqual('unionpay');
+
+        expect(mapFromPaymentMethodCardType('VISA'))
+            .toEqual('visa');
+    });
+
+    it('returns undefined if unable to map type', () => {
+        expect(mapFromPaymentMethodCardType('FOOBAR'))
+            .toEqual(undefined);
+    });
+});

--- a/src/app/payment/creditCard/mapFromPaymentMethodCardType.ts
+++ b/src/app/payment/creditCard/mapFromPaymentMethodCardType.ts
@@ -1,0 +1,30 @@
+export default function mapFromPaymentMethodCardType(type: string): string | undefined {
+    switch (type) {
+    case 'AMEX':
+        return 'american-express';
+
+    case 'DINERS':
+        return 'diners-club';
+
+    case 'DISCOVER':
+        return 'discover';
+
+    case 'JCB':
+        return 'jcb';
+
+    case 'MAESTRO':
+        return 'maestro';
+
+    case 'MC':
+        return 'mastercard';
+
+    case 'CUP':
+        return 'unionpay';
+
+    case 'VISA':
+        return 'visa';
+
+    default:
+        return undefined;
+    }
+}

--- a/src/app/payment/creditCard/unformatCreditCardExpiryDate.spec.ts
+++ b/src/app/payment/creditCard/unformatCreditCardExpiryDate.spec.ts
@@ -1,0 +1,29 @@
+import unformatCreditCardExpiryDate from './unformatCreditCardExpiryDate';
+
+describe('unformatCreditCardExpiryDate()', () => {
+    it('converts MM / YY date format into expiry date object', () => {
+        expect(unformatCreditCardExpiryDate('01 / 30'))
+            .toEqual({ month: '01', year: '2030' });
+
+        expect(unformatCreditCardExpiryDate('12 / 30'))
+            .toEqual({ month: '12', year: '2030' });
+    });
+
+    it('converts MM / YYYY date format into expiry date object', () => {
+        expect(unformatCreditCardExpiryDate('01 / 2030'))
+            .toEqual({ month: '01', year: '2030' });
+
+        expect(unformatCreditCardExpiryDate('12 / 2030'))
+            .toEqual({ month: '12', year: '2030' });
+    });
+
+    it('converts M / YY date format into expiry date object', () => {
+        expect(unformatCreditCardExpiryDate('1 / 30'))
+            .toEqual({ month: '01', year: '2030' });
+    });
+
+    it('returns empty expiry date object if date format is invalid', () => {
+        expect(unformatCreditCardExpiryDate('fo / ba'))
+            .toEqual({ month: '', year: '' });
+    });
+});

--- a/src/app/payment/creditCard/unformatCreditCardExpiryDate.ts
+++ b/src/app/payment/creditCard/unformatCreditCardExpiryDate.ts
@@ -1,0 +1,18 @@
+export interface ExpiryDate {
+    month: string;
+    year: string;
+}
+
+export default function unformatCreditCardExpiryDate(value: string): ExpiryDate {
+    const separator = '/';
+    const [month = '', year = ''] = value.split(new RegExp(`\\s*${separator}\\s*`));
+
+    if (!/^\d+$/.test(month) || !/^\d+$/.test(year)) {
+        return { month: '', year: '' };
+    }
+
+    return {
+        month: month.length === 1 ? `0${month}` : month.slice(0, 2),
+        year: year.length === 2 ? `20${year}` : year.slice(0, 4),
+    };
+}

--- a/src/app/payment/creditCard/unformatCreditCardNumber.spec.ts
+++ b/src/app/payment/creditCard/unformatCreditCardNumber.spec.ts
@@ -1,0 +1,21 @@
+import unformatCreditCardNumber from './unformatCreditCardNumber';
+
+describe('unformatCreditCardNumber()', () => {
+    it('removes credit card number formatting', () => {
+        expect(unformatCreditCardNumber('4111 1111 1111 1111'))
+            .toEqual('4111111111111111');
+
+        expect(unformatCreditCardNumber('3782 822463 10005'))
+            .toEqual('378282246310005');
+    });
+
+    it('unformats credit card number that is partially complete', () => {
+        expect(unformatCreditCardNumber('4111 1111'))
+            .toEqual('41111111');
+    });
+
+    it('does not do anything if credit card number is invalid', () => {
+        expect(unformatCreditCardNumber('xxxx xxxx 1111 1111'))
+            .toEqual('xxxx xxxx 1111 1111');
+    });
+});

--- a/src/app/payment/creditCard/unformatCreditCardNumber.ts
+++ b/src/app/payment/creditCard/unformatCreditCardNumber.ts
@@ -1,0 +1,11 @@
+import { number } from 'card-validator';
+
+export default function unformatCreditCardNumber(value: string, separator: string = ' '): string {
+    const { card } = number(value);
+
+    if (!card) {
+        return value;
+    }
+
+    return value.replace(new RegExp(separator, 'g'), '');
+}


### PR DESCRIPTION
## What?
Add a credit card payment form. It can format credit card number based on its card type. Also, it can show the card type to the shopper as they enter their card details

## Why?
To collect credit card details.

## Testing / Proof
Unit

@bigcommerce/checkout
