### PR TITLE
CHECKOUT-4223: Add component for rendering list of promotion banners

### DIFF
--- a/src/app/promotion/PromotionBanner.spec.tsx
+++ b/src/app/promotion/PromotionBanner.spec.tsx
@@ -1,0 +1,29 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { Alert, AlertType } from '../ui/alert';
+
+import PromotionBanner from './PromotionBanner';
+
+describe('PromotionBanner', () => {
+    it('renders message as info alert', () => {
+        const component = shallow(
+            <PromotionBanner message="Hello world" />
+        );
+
+        expect(component.find(Alert))
+            .toHaveLength(1);
+
+        expect(component.find(Alert).prop('type'))
+            .toEqual(AlertType.Info);
+    });
+
+    it('renders alert message as HTML', () => {
+        const component = shallow(
+            <PromotionBanner message="<strong>Hello world</strong>" />
+        );
+
+        expect(component.find('[data-test="promotion-banner-message"]').html())
+            .toContain('<strong>Hello world</strong>');
+    });
+});

--- a/src/app/promotion/PromotionBanner.tsx
+++ b/src/app/promotion/PromotionBanner.tsx
@@ -1,0 +1,28 @@
+import DOMPurify from 'dompurify';
+import React, { FunctionComponent } from 'react';
+
+import { Alert, AlertType } from '../ui/alert';
+import { IconTag } from '../ui/icon';
+
+export interface PromotionBannerProps {
+    message: string;
+}
+
+const PromotionBanner: FunctionComponent<PromotionBannerProps> = ({
+    message,
+}) => (
+    <Alert
+        additionalClassName="optimizedCheckout-discountBanner"
+        icon={ <IconTag /> }
+        type={ AlertType.Info }
+    >
+        <span
+            data-test="promotion-banner-message"
+            dangerouslySetInnerHTML={ {
+                __html: DOMPurify.sanitize(message),
+            } }
+        />
+    </Alert>
+);
+
+export default PromotionBanner;

--- a/src/app/promotion/PromotionBannerList.spec.tsx
+++ b/src/app/promotion/PromotionBannerList.spec.tsx
@@ -1,0 +1,55 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { getPromotion } from './promotions.mock';
+import PromotionBanner from './PromotionBanner';
+import PromotionBannerList from './PromotionBannerList';
+
+describe('PromotionBannerList', () => {
+    it('renders list of promotion banners', () => {
+        const promotions = [getPromotion()];
+        const component = shallow(
+            <PromotionBannerList promotions={ promotions } />
+        );
+
+        expect(component.find(PromotionBanner))
+            .toHaveLength(2);
+
+        expect(component.find(PromotionBanner).at(0).prop('message'))
+            .toEqual(promotions[0].banners[0].text);
+
+        expect(component.find(PromotionBanner).at(1).prop('message'))
+            .toEqual(promotions[0].banners[1].text);
+    });
+
+    it('renders nested promotion banners as flat list', () => {
+        const promotions = [getPromotion(), getPromotion()];
+        const component = shallow(
+            <PromotionBannerList promotions={ promotions } />
+        );
+
+        expect(component.find(PromotionBanner))
+            .toHaveLength(4);
+
+        expect(component.find(PromotionBanner).at(0).prop('message'))
+            .toEqual(promotions[0].banners[0].text);
+
+        expect(component.find(PromotionBanner).at(1).prop('message'))
+            .toEqual(promotions[0].banners[1].text);
+
+        expect(component.find(PromotionBanner).at(2).prop('message'))
+            .toEqual(promotions[1].banners[0].text);
+
+        expect(component.find(PromotionBanner).at(3).prop('message'))
+            .toEqual(promotions[1].banners[1].text);
+    });
+
+    it('renders nothing if there are no banners', () => {
+        const component = shallow(
+            <PromotionBannerList promotions={ [] }/>
+        );
+
+        expect(component.html())
+            .toEqual(null);
+    });
+});

--- a/src/app/promotion/PromotionBannerList.tsx
+++ b/src/app/promotion/PromotionBannerList.tsx
@@ -1,0 +1,36 @@
+import { Banner, Promotion } from '@bigcommerce/checkout-sdk';
+import React, { FunctionComponent } from 'react';
+
+import PromotionBanner from './PromotionBanner';
+
+export interface PromotionBannerListProps {
+    promotions: Promotion[];
+}
+
+const PromotionBannerList: FunctionComponent<PromotionBannerListProps> = ({
+    promotions,
+}) => {
+    const banners = (promotions || []).reduce((result, promotion) => ([
+        ...result,
+        ...promotion.banners,
+    ]), [] as Banner[]);
+
+    if (!banners.length) {
+        return null;
+    }
+
+    return (
+        <div className="discountBanner">
+            <ul className="discountBannerList">
+                { banners.map((banner, index) => (
+                    <PromotionBanner
+                        message={ banner.text }
+                        key={ index }
+                    />
+                )) }
+            </ul>
+        </div>
+    );
+};
+
+export default PromotionBannerList;

--- a/src/app/promotion/index.ts
+++ b/src/app/promotion/index.ts
@@ -1,0 +1,1 @@
+export { default as PromotionBannerList } from './PromotionBannerList';


### PR DESCRIPTION
## What?
Add components responsible for rendering a list of promotion banners.

## Why?
We need it in order to display promotion banners on the checkout page.

## Testing / Proof
Unit

@bigcommerce/checkout
