### PR TITLE
CHECKOUT-4223 Add address components

### DIFF
--- a/src/app/address/AddressSelect.spec.tsx
+++ b/src/app/address/AddressSelect.spec.tsx
@@ -1,0 +1,130 @@
+import { createCheckoutService, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount, ReactWrapper } from 'enzyme';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { CheckoutProvider } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+
+import { getAddress } from './address.mock';
+import StaticAddress from './staticAddress/StaticAddress';
+import AddressSelect from './AddressSelect';
+
+describe('AddressSelect Component', () => {
+    let checkoutService: CheckoutService;
+    let localeContext: LocaleContextType;
+    let component: ReactWrapper;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        localeContext = createLocaleContext(getStoreConfig());
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(getCheckout());
+        jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
+    });
+
+    it('renders `Enter Address` when there is no selected address ', () => {
+        component = mount(
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleContext.Provider value={ localeContext }>
+                    <AddressSelect
+                        addresses={ getCustomer().addresses }
+                        onSelectAddress={ noop }
+                        onUseNewAddress={ noop }
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        expect(component.find('#addressToggle').text()).toEqual('Enter a new address');
+    });
+
+    it('renders static address when there is a selected address', () => {
+        component = mount(
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleContext.Provider value={ localeContext }>
+                    <AddressSelect
+                        addresses={ getCustomer().addresses }
+                        selectedAddress={ getAddress() }
+                        onSelectAddress={ noop }
+                        onUseNewAddress={ noop }
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        expect(component.find(StaticAddress).prop('address')).toEqual(getAddress());
+    });
+
+    it('renders addresses menu when select component is clicked', () => {
+        component = mount(
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleContext.Provider value={ localeContext }>
+                    <AddressSelect
+                        addresses={ getCustomer().addresses }
+                        selectedAddress={ getAddress() }
+                        onSelectAddress={ noop }
+                        onUseNewAddress={ noop }
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        component.find('#addressToggle').simulate('click');
+        const options = component.find('#addressDropdown li');
+
+        expect(options.first().text()).toEqual('Enter a new address');
+        expect(options.find(StaticAddress).prop('address')).toEqual(getCustomer().addresses[0]);
+    });
+
+    it('triggers appropriate callbacks when an item is selected', () => {
+        const onSelectAddress = jest.fn();
+        const onUseNewAddress = jest.fn();
+
+        component = mount(
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleContext.Provider value={ localeContext }>
+                    <AddressSelect
+                        addresses={ getCustomer().addresses }
+                        onSelectAddress={ onSelectAddress }
+                        onUseNewAddress={ onUseNewAddress }
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        component.find('#addressToggle').simulate('click');
+        component.find('#addressDropdown li:first-child a').simulate('click');
+
+        expect(onUseNewAddress).toHaveBeenCalled();
+
+        component.find('#addressDropdown li:last-child a').simulate('click');
+
+        expect(onSelectAddress).toHaveBeenCalledWith(getCustomer().addresses[0]);
+    });
+
+    it('doest not trigger onSelectAddress callback if same address is selected', () => {
+        const onSelectAddress = jest.fn();
+
+        component = mount(
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleContext.Provider value={ localeContext }>
+                    <AddressSelect
+                        addresses={ getCustomer().addresses }
+                        onSelectAddress={ onSelectAddress }
+                        selectedAddress={ getAddress() }
+                        onUseNewAddress={ noop }
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        component.find('#addressToggle').simulate('click');
+        component.find('#addressDropdown li:last-child a').simulate('click');
+
+        expect(onSelectAddress).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/address/AddressSelect.tsx
+++ b/src/app/address/AddressSelect.tsx
@@ -1,0 +1,107 @@
+import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
+import { some } from 'lodash';
+import React, { Component, FunctionComponent, ReactNode } from 'react';
+
+import { preventDefault } from '../common/dom';
+import { TranslatedString } from '../language';
+import { DropdownTrigger } from '../ui/dropdown';
+
+import StaticAddress from './staticAddress/StaticAddress';
+import isEqualAddress from './util/isEqualAddress';
+
+export interface AddressSelectProps {
+    addresses: CustomerAddress[];
+    selectedAddress?: Address;
+    onSelectAddress(address: Address): void;
+    onUseNewAddress(currentAddress?: Address): void;
+}
+
+class AddressSelect extends Component<AddressSelectProps> {
+    render(): ReactNode {
+        const {
+            addresses,
+            selectedAddress,
+            onUseNewAddress,
+        } = this.props;
+
+        return (
+            <div className="form-field">
+                <div className="dropdown--select" role="combobox">
+                    <DropdownTrigger dropdown={
+                        <AddressSelectMenu
+                            addresses={ addresses }
+                            onSelectAddress={ this.onSelectAddress }
+                            onUseNewAddress={ () => onUseNewAddress(selectedAddress) }
+                            selectedAddress={ selectedAddress }
+                        />
+                    }>
+                        <AddressSelectButton
+                            addresses={ addresses }
+                            selectedAddress={ selectedAddress }
+                        />
+                    </DropdownTrigger>
+                </div>
+            </div>
+        );
+    }
+
+    private onSelectAddress: (newAddress: Address) => void = (newAddress: Address) => {
+        const {
+            onSelectAddress,
+            selectedAddress,
+        } = this.props;
+
+        if (!isEqualAddress(selectedAddress, newAddress)) {
+            onSelectAddress(newAddress);
+        }
+    };
+}
+
+const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({
+    addresses,
+    onSelectAddress,
+    onUseNewAddress,
+    selectedAddress,
+}) => (
+    <ul
+        className="dropdown-menu instrumentSelect-dropdownMenu"
+        id="addressDropdown"
+    >
+        <li className="dropdown-menu-item dropdown-menu-item--select">
+            <a href="#" onClick={ preventDefault(() => onUseNewAddress(selectedAddress)) }>
+                <TranslatedString id="address.enter_address_action" />
+            </a>
+        </li>
+        { addresses.map(address => (
+            <li
+                className="dropdown-menu-item dropdown-menu-item--select"
+                key={ address.id }
+            >
+                <a href="#" onClick={ preventDefault(() => onSelectAddress(address)) }>
+                    <StaticAddress address={ address } />
+                </a>
+            </li>
+        )) }
+    </ul>
+);
+
+type AddressSelectButtonProps = Pick<AddressSelectProps, 'selectedAddress' | 'addresses'>;
+
+const AddressSelectButton: FunctionComponent<AddressSelectButtonProps> = ({
+    selectedAddress,
+    addresses,
+}) => (
+    <a
+        className="button dropdown-button dropdown-toggle--select"
+        href="#"
+        id="addressToggle"
+        onClick={ preventDefault() }
+    >
+        { selectedAddress ?
+            <StaticAddress address={ selectedAddress } /> :
+            <TranslatedString id="address.enter_address_action" />
+        }
+    </a>
+);
+
+export default AddressSelect;

--- a/src/app/address/CheckboxGroupFormField.tsx
+++ b/src/app/address/CheckboxGroupFormField.tsx
@@ -1,0 +1,75 @@
+import { FormFieldItem } from '@bigcommerce/checkout-sdk';
+import { getIn, FieldArray } from 'formik';
+import { difference, kebabCase, noop } from 'lodash';
+import React, { FunctionComponent, ReactNode } from 'react';
+
+import { FormFieldContainer, FormFieldError } from '../ui/form';
+
+import { DynamicFormFieldType } from './DynamicFormField';
+import DynamicInput from './DynamicInput';
+import MultiCheckboxControl from './MultiCheckboxControl';
+
+export interface CheckboxGroupFormFieldProps {
+    name: string;
+    id: string;
+    label: ReactNode;
+    options: FormFieldItem[];
+    onChange?(values: string[]): void;
+}
+
+const CheckboxGroupFormField: FunctionComponent<CheckboxGroupFormFieldProps> = ({
+    label,
+    name,
+    id,
+    options,
+    onChange = noop,
+}) => (
+    <FieldArray
+        name={ name }
+        render={ ({ push, remove, pop, form: { values, errors } }) => (
+            <FormFieldContainer hasError={ getIn(errors, name) && getIn(errors, name).length }>
+                { label }
+                <MultiCheckboxControl
+                    testId={ id }
+                    onSelectedAll={ () => {
+                        const checkedValues: string[] = getIn(values, name) || [];
+                        difference(options.map(({ value }) => value), checkedValues)
+                            .forEach(val => push(val));
+
+                        onChange(getIn(values, name));
+                    }}
+                    onSelectedNone={ () => {
+                        const checkedValues: string[] = getIn(values, name) || [];
+                        checkedValues.forEach(() => pop());
+                        onChange(getIn(values, name));
+                    }}
+                />
+                <DynamicInput
+                    name={ name }
+                    value={ getIn(values, name) || [] }
+                    onChange={e => {
+                        const checkedValues: string[] = getIn(values, name) || [];
+                        const { value, checked } = e.target;
+
+                        if (checked) {
+                            push(value);
+                        } else {
+                            remove(checkedValues.indexOf(value));
+                        }
+
+                        onChange(getIn(values, name));
+                    } }
+                    fieldType={ DynamicFormFieldType.checkbox }
+                    options={ options }
+                    id={ id }
+                />
+                <FormFieldError
+                    name={ name }
+                    testId={ `${kebabCase(name)}-field-error-message` }
+                />
+            </FormFieldContainer>
+        )}
+    />
+);
+
+export default CheckboxGroupFormField;

--- a/src/app/address/DynamicFormField.spec.tsx
+++ b/src/app/address/DynamicFormField.spec.tsx
@@ -1,0 +1,106 @@
+import { FormField as FormFieldType } from '@bigcommerce/checkout-sdk';
+import { mount, shallow } from 'enzyme';
+import { Formik } from 'formik';
+import React from 'react';
+
+import { TranslatedString } from '../language';
+import { FormField } from '../ui/form';
+
+import { getFormFields } from './formField.mock';
+import CheckboxGroupFormField from './CheckboxGroupFormField';
+import DynamicFormField, { DynamicFormFieldType } from './DynamicFormField';
+import DynamicInput from './DynamicInput';
+
+describe('DynamicFormField Component', () => {
+    const formFields = getFormFields();
+    const onChange = jest.fn();
+
+    it('renders legacy class name', () => {
+        const component = shallow(
+            <DynamicFormField
+                field={ formFields.find(({ name }) => name === 'address1') as FormFieldType }
+            />
+        );
+
+        expect(component.find('.dynamic-form-field').prop('className'))
+            .toContain('dynamic-form-field--addressLine1');
+    });
+
+    it('renders FormField with expected props', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ jest.fn() }>
+                <DynamicFormField
+                    onChange={ onChange }
+                    field={ formFields.find(({ name }) => name === 'address1') as FormFieldType }
+                />
+            </Formik>
+        );
+
+        expect(component.find(FormField).props())
+            .toEqual(expect.objectContaining({
+                onChange,
+                name: 'address1',
+            }));
+    });
+
+    it('renders DynamicInput with expected props', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ jest.fn() }>
+                <DynamicFormField
+                    onChange={ onChange }
+                    field={ formFields.find(({ name }) => name === 'address1') as FormFieldType }
+                />
+            </Formik>
+        );
+
+        expect(component.find('.dynamic-form-field').prop('className'))
+            .toContain('dynamic-form-field--addressLine1');
+
+        expect(component.find(DynamicInput).props())
+            .toEqual(expect.objectContaining({
+                autoComplete: 'address-line1',
+                id: 'addressLine1Input',
+            }));
+    });
+
+    it('renders CheckboxGroupFormField if fieldType is checkbox', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ jest.fn() }>
+                <DynamicFormField
+                    field={ formFields.find(({ name }) => name === 'field_27') as FormFieldType }
+                    fieldType={ DynamicFormFieldType.checkbox }
+                />
+            </Formik>
+        );
+
+        expect(component.find(CheckboxGroupFormField).length).toEqual(1);
+    });
+
+    it('renders label', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ jest.fn() }>
+                <DynamicFormField
+                    field={ formFields.find(({ name }) => name === 'address1') as FormFieldType }
+                />
+            </Formik>
+        );
+
+        expect(component.find(TranslatedString).prop('id'))
+            .toEqual('address.address_line_1_label');
+
+        expect(component.find('.optimizedCheckout-contentSecondary').length).toEqual(0);
+    });
+
+    it('renders `optional` label when field is not required', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ jest.fn() }>
+                <DynamicFormField
+                    field={ formFields.find(({ name }) => name === 'address2') as FormFieldType }
+                />
+            </Formik>
+        );
+
+        expect(component.find('.optimizedCheckout-contentSecondary').find(TranslatedString).prop('id'))
+            .toEqual('common.optional_text');
+    });
+});

--- a/src/app/address/DynamicFormField.tsx
+++ b/src/app/address/DynamicFormField.tsx
@@ -1,0 +1,138 @@
+import { FormField as FormFieldType } from '@bigcommerce/checkout-sdk';
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../language';
+import { FormField, Label } from '../ui/form';
+
+import { getFormFieldInputId, getFormFieldLegacyName } from './util/getFormFieldInputId';
+import CheckboxGroupFormField from './CheckboxGroupFormField';
+import DynamicInput from './DynamicInput';
+
+export enum DynamicFormFieldType {
+    telephone = 'tel',
+    dropdown = 'dropdown',
+    number = 'number',
+    password = 'password',
+    checkbox = 'checkbox',
+    multiline = 'multiline',
+    date = 'date',
+    radio = 'radio',
+    text = 'text',
+}
+
+export interface AddressKeyMap<T = string> {
+    [fieldName: string]: T;
+}
+
+const LABEL: AddressKeyMap = {
+    address1: 'address.address_line_1_label',
+    address2: 'address.address_line_2_label',
+    city: 'address.city_label',
+    company: 'address.company_name_label',
+    countryCode: 'address.country_label',
+    firstName: 'address.first_name_label',
+    lastName: 'address.last_name_label',
+    phone: 'address.phone_number_label',
+    postalCode: 'address.postal_code_label',
+    stateOrProvince: 'address.state_label',
+    stateOrProvinceCode: 'address.state_label',
+};
+
+const AUTOCOMPLETE: AddressKeyMap = {
+    address1: 'address-line1',
+    address2: 'address-line2',
+    city: 'address-level2',
+    company: 'organization',
+    countryCode: 'country',
+    firstName: 'given-name',
+    lastName: 'family-name',
+    phone: 'tel',
+    postalCode: 'postal-code',
+    stateOrProvince: 'address-level1',
+    stateOrProvinceCode: 'address-level1',
+};
+
+export interface DynamicFormFieldOption {
+    code: string;
+    name: string;
+}
+
+export interface DynamicFormFieldProps {
+    field: FormFieldType;
+    parentFieldName?: string;
+    placeholder?: string;
+    fieldType?: DynamicFormFieldType;
+    onChange?(value: string | string[]): void;
+}
+
+const DynamicFormField: FunctionComponent<DynamicFormFieldProps>  = ({
+    field: {
+        name,
+        label: fieldLabel,
+        custom,
+        required,
+        options,
+        max,
+        min,
+        maxLength,
+    },
+    fieldType,
+    parentFieldName,
+    onChange,
+    placeholder,
+}) => {
+    const addressFieldName = name;
+    const fieldInputId = getFormFieldInputId(addressFieldName);
+    const fieldName = parentFieldName ? `${parentFieldName}.${name}` : name;
+    const translatedLabelString = LABEL[name];
+    const label = (
+        <Label htmlFor={ fieldInputId }>
+            { custom ?
+                fieldLabel :
+                translatedLabelString && <TranslatedString id={ translatedLabelString } />
+            }
+            { !required &&
+                <> { '' }
+                    <small className="optimizedCheckout-contentSecondary">
+                        <TranslatedString id="common.optional_text" />
+                    </small>
+                </>
+            }
+        </Label>
+    );
+
+    return (
+        <div className={ `dynamic-form-field dynamic-form-field--${getFormFieldLegacyName(addressFieldName)}` }>
+            { fieldType === DynamicFormFieldType.checkbox ?
+                <CheckboxGroupFormField
+                    onChange={ onChange }
+                    name={ fieldName }
+                    id={ fieldInputId }
+                    label={ label }
+                    options={ (options && options.items) || [] }
+                /> :
+                <FormField
+                    name={ fieldName }
+                    onChange={ onChange }
+                    label={ () => label }
+                    input={ props =>
+                        <DynamicInput
+                            { ...props.field }
+                            maxLength={ maxLength || undefined }
+                            max={ max }
+                            min={ min }
+                            placeholder={ placeholder || (options && options.helperLabel) }
+                            fieldType={ fieldType }
+                            rows={ options && (options as any).rows }
+                            options={ options && options.items }
+                            autoComplete={ AUTOCOMPLETE[addressFieldName] }
+                            id={ fieldInputId }
+                        />
+                    }
+                />
+            }
+        </div>
+    );
+};
+
+export default DynamicFormField;

--- a/src/app/address/DynamicInput.spec.tsx
+++ b/src/app/address/DynamicInput.spec.tsx
@@ -1,0 +1,137 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import ReactDatePicker from 'react-datepicker';
+
+import { CheckboxInput, RadioInput, TextArea, TextInput } from '../ui/form';
+
+import { DynamicFormFieldType } from './DynamicFormField';
+import DynamicInput from './DynamicInput';
+
+describe('DynamicInput', () => {
+    it('renders text input for default input with passed props', () => {
+        expect(shallow(<DynamicInput id="field_33" name="x" />).html())
+            .toMatchSnapshot();
+    });
+
+    it('renders textarea for multiline type', () => {
+        expect(shallow(
+            <DynamicInput
+                id="field_33"
+                fieldType={ DynamicFormFieldType.multiline }
+                rows={ 4 }
+            />)
+            .find(TextArea)
+            .prop('rows'))
+            .toEqual(4);
+    });
+
+    it('renders date picker for date type', () => {
+        expect(shallow(
+            <DynamicInput
+                id="field_33"
+                fieldType={ DynamicFormFieldType.date }
+            />)
+            .find(ReactDatePicker)
+            .length).toEqual(1);
+    });
+
+    it('renders checkbox input for checbox type', () => {
+        const component = shallow(
+            <DynamicInput
+                fieldType={ DynamicFormFieldType.checkbox }
+                id="id"
+                value={ ['y'] }
+                options={ [
+                    { value: 'x', label: 'X' },
+                    { value: 'y', label: 'Y' },
+                ] }
+            />);
+
+        expect(component.find(CheckboxInput).at(0).props())
+            .toEqual(expect.objectContaining({
+                id: 'id-x',
+                checked: false,
+            }));
+
+        expect(component.find(CheckboxInput).at(1).props())
+            .toEqual(expect.objectContaining({
+                id: 'id-y',
+                checked: true,
+            }));
+    });
+
+    it('renders radio type input for radio type', () => {
+        const component = shallow(
+            <DynamicInput
+                fieldType={ DynamicFormFieldType.radio }
+                id="id"
+                value="y"
+                onChange={ jest.fn() }
+                options={ [
+                    { value: 'x', label: 'X' },
+                    { value: 'y', label: 'Y' },
+                ] }
+            />);
+
+        expect(component.find(RadioInput).at(0).props())
+            .toEqual(expect.objectContaining({
+                id: 'id-x',
+                checked: false,
+            }));
+
+        expect(component.find(RadioInput).at(1).props())
+            .toEqual(expect.objectContaining({
+                id: 'id-y',
+                checked: true,
+            }));
+    });
+
+    it('renders number type input for number type', () => {
+        expect(shallow(
+            <DynamicInput
+                id="field_33"
+                fieldType={ DynamicFormFieldType.number }
+            />)
+            .find(TextInput)
+            .prop('type'))
+            .toEqual('number');
+    });
+
+    it('renders password type input for password type', () => {
+        expect(shallow(
+            <DynamicInput
+                id="field_33"
+                fieldType={ DynamicFormFieldType.password }
+            />)
+            .find(TextInput)
+            .prop('type'))
+            .toEqual('password');
+    });
+
+    it('renders tel type input for phone type', () => {
+        expect(shallow(
+            <DynamicInput
+                id="field_33"
+                fieldType={ DynamicFormFieldType.telephone }
+            />)
+            .find(TextInput)
+            .prop('type'))
+            .toEqual('tel');
+    });
+
+    it('renders select input with passed props', () => {
+        expect(shallow(
+            <DynamicInput
+                id="field_33"
+                fieldType={ DynamicFormFieldType.dropdown }
+                options={ [
+                    { label: 'Foo', value: 'foo'},
+                    { label: 'Foo1', value: 'foo1'},
+                ] }
+                defaultValue="foo"
+                placeholder="Select an option"
+                name="select"
+            />).html())
+            .toMatchSnapshot();
+    });
+});

--- a/src/app/address/DynamicInput.tsx
+++ b/src/app/address/DynamicInput.tsx
@@ -1,0 +1,140 @@
+import { FormFieldItem } from '@bigcommerce/checkout-sdk';
+import { isDate } from 'lodash';
+import React, { FunctionComponent } from 'react';
+import ReactDatePicker from 'react-datepicker';
+
+import { CheckboxInput, InputProps, RadioInput, TextArea, TextInput } from '../ui/form';
+
+import { DynamicFormFieldType } from './DynamicFormField';
+
+export interface DynamicInputProps extends InputProps {
+    id: string;
+    additionalClassName?: string;
+    value?: string | string[];
+    rows?: number;
+    fieldType?: DynamicFormFieldType;
+    options?: FormFieldItem[];
+}
+
+const DynamicInput: FunctionComponent<DynamicInputProps> = ({
+    additionalClassName,
+    fieldType,
+    options,
+    placeholder,
+    value,
+    id,
+    ...rest
+}) => {
+    switch (fieldType) {
+    case DynamicFormFieldType.dropdown:
+        return (
+            <select
+                { ...rest as any }
+                id={ id }
+                data-test={ `${id}-select` }
+                className="form-select optimizedCheckout-form-select"
+                value={ value === null ? '' : value }
+            >
+                { placeholder &&
+                    <option value="">
+                        { placeholder }
+                    </option>
+                }
+                { options && options.map(({ label, value: optionValue }) =>
+                    <option
+                        key={ optionValue }
+                        value={ optionValue }
+                    >
+                        { label }
+                    </option>
+                )}
+            </select>
+        );
+
+    case DynamicFormFieldType.radio:
+        if (!options || !options.length) {
+            return null;
+        }
+
+        return <>{ options.map(({ label, value: optionValue }) =>
+            <RadioInput
+                { ...rest }
+                id={ `${id}-${optionValue}` }
+                testId={ `${id}-${optionValue}-radio` }
+                key={ optionValue }
+                label={ label }
+                value={ optionValue }
+                checked={ optionValue === value }
+            />) }</>;
+
+    case DynamicFormFieldType.checkbox:
+        if (!options || !options.length) {
+            return null;
+        }
+
+        return <>{ options.map(({ label, value: optionValue }) =>
+            <CheckboxInput
+                { ...rest }
+                id={ `${id}-${optionValue}` }
+                testId={ `${id}-${optionValue}-checkbox` }
+                key={ optionValue }
+                label={ label }
+                value={ optionValue }
+                checked={ Array.isArray(value) ? value.includes(optionValue) : false }
+            />) }</>;
+
+    case DynamicFormFieldType.date:
+        return (
+            <ReactDatePicker
+                { ...rest as any }
+                // FIXME: we can avoid this by simply using onChangeRaw, but it's not being triggered properly
+                // https://github.com/Hacker0x01/react-datepicker/issues/1357
+                // onChangeRaw={ rest.onChange }
+                onChange={
+                    (date, event) => rest.onChange && rest.onChange({
+                        ...event,
+                        target: {
+                            name: rest.name,
+                            value: date,
+                        },
+                    } as any)
+                }
+                autoComplete="off"
+                placeholderText="MM/DD/YYYY"
+                minDate={ rest.min ? new Date(rest.min) : undefined }
+                maxDate={ rest.max ? new Date(rest.max) : undefined }
+                className="form-input optimizedCheckout-form-input"
+                popperClassName="optimizedCheckout-contentPrimary"
+                calendarClassName="optimizedCheckout-contentPrimary"
+                selected={ isDate(value) ? value : undefined }
+            />
+        );
+
+    case DynamicFormFieldType.multiline:
+        return (
+            <TextArea
+                { ...rest as any }
+                id={ id }
+                testId={ `${id}-text` }
+                type={ fieldType }
+                value={ value }
+            />
+        );
+
+    default:
+        return (
+            <TextInput
+                { ...rest }
+                id={ id }
+                testId={ `${id}-${ fieldType === DynamicFormFieldType.password ?
+                    'password' :
+                    'text' }`
+                }
+                type={ fieldType }
+                value={ value }
+            />
+        );
+    }
+};
+
+export default DynamicInput;

--- a/src/app/address/MultiCheckboxControl.tsx
+++ b/src/app/address/MultiCheckboxControl.tsx
@@ -1,0 +1,48 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../language';
+
+export interface MultiCheckboxControlProps {
+    testId?: string;
+    onSelectedAll(): void;
+    onSelectedNone(): void;
+}
+
+const MultiCheckboxControl: FunctionComponent<MultiCheckboxControlProps> = ({
+    testId,
+    onSelectedAll,
+    onSelectedNone,
+}) => (
+    <ul className="multiCheckbox--controls">
+        <li className="multiCheckbox--control">
+            <TranslatedString id="address.select" />
+        </li>
+        <li className="multiCheckbox--control">
+            <a
+                data-test={ `${testId}Checkbox-all-button` }
+                href="#"
+                onClick={ e => {
+                    e.preventDefault();
+                    onSelectedAll();
+                }
+            }>
+                <TranslatedString id="address.select_all" />
+            </a>
+        </li>
+
+        <li className="multiCheckbox--control">
+            <a
+                data-test={ `${testId}Checkbox-none-button` }
+                href="#"
+                onClick={ e => {
+                    e.preventDefault();
+                    onSelectedNone();
+                }
+            }>
+                <TranslatedString id="address.select_none" />
+            </a>
+        </li>
+    </ul>
+);
+
+export default MultiCheckboxControl;

--- a/src/app/address/__snapshots__/DynamicInput.spec.tsx.snap
+++ b/src/app/address/__snapshots__/DynamicInput.spec.tsx.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DynamicInput renders select input with passed props 1`] = `"<select name=\\"select\\" id=\\"field_33\\" data-test=\\"field_33-select\\" class=\\"form-select optimizedCheckout-form-select\\"><option value=\\"\\">Select an option</option><option selected=\\"\\" value=\\"foo\\">Foo</option><option value=\\"foo1\\">Foo1</option></select>"`;
+
+exports[`DynamicInput renders text input for default input with passed props 1`] = `"<input type=\\"text\\" name=\\"x\\" id=\\"field_33\\" class=\\"form-input optimizedCheckout-form-input\\" data-test=\\"field_33-text\\"/>"`;

--- a/src/app/address/getAddressValidationSchema.spec.tsx
+++ b/src/app/address/getAddressValidationSchema.spec.tsx
@@ -1,0 +1,134 @@
+import { createLanguageService, LanguageService } from '@bigcommerce/checkout-sdk';
+import { ObjectSchema, ValidationError } from 'yup';
+
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+
+import { getFormFields } from './formField.mock';
+import getAddressValidationSchema from './getAddressValidationSchema';
+import { AddressFormValues } from './mapAddressToFormValues';
+
+describe('getAddressValidationSchema', () => {
+    const formFields = getFormFields();
+    let language: LanguageService;
+
+    beforeEach(() => {
+        language = createLanguageService();
+        jest.spyOn(language, 'translate').mockImplementation(id => id);
+    });
+
+    it('resolves for a valid address', async () => {
+        const schema = getAddressValidationSchema({ formFields, language });
+        const spy = jest.fn();
+
+        await schema.validate(getShippingAddress()).then(spy);
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('throws if missing required field with translated error', async () => {
+        const schema = getAddressValidationSchema({ formFields, language });
+
+        const errors = await schema.validate({
+            ...getShippingAddress(),
+            firstName: undefined,
+        }).catch((error: ValidationError) => error.message);
+
+        expect(errors).toEqual('address.first_name_required_error');
+    });
+
+    describe('when custom integer field is present', () => {
+        let schema: ObjectSchema<Partial<AddressFormValues>>;
+
+        beforeEach(() => {
+            schema = getAddressValidationSchema({ formFields: [
+                ...formFields,
+                {
+                    custom: true,
+                    min: 3,
+                    max: 5,
+                    fieldType: 'text',
+                    id: 'field_100',
+                    name: 'field_100',
+                    required: false,
+                    type: 'integer',
+                } as any,
+            ], language });
+        });
+
+        it('throws if min validation fails', async () => {
+            const errors = await schema.validate({
+                ...getShippingAddress(),
+                customFields: {
+                    field_100: 2,
+                },
+            }).catch((error: ValidationError) => error.message);
+
+            expect(errors).toEqual('address.custom_min_error');
+        });
+
+        it('throws if max validation fails', async () => {
+            const errors = await schema.validate({
+                ...getShippingAddress(),
+                customFields: {
+                    field_100: 6,
+                },
+            }).catch((error: ValidationError) => error.message);
+
+            expect(errors).toEqual('address.custom_max_error');
+        });
+
+        it('resolves if min/max validation pass', async () => {
+            const spy = jest.fn();
+            await schema.validate({
+                ...getShippingAddress(),
+                customFields: {
+                    field_100: 4,
+                },
+            }).then(spy);
+
+            expect(spy).toHaveBeenCalled();
+        });
+    });
+
+    describe('when custom radio field is present', () => {
+        let schema: ObjectSchema<Partial<AddressFormValues>>;
+
+        beforeEach(() => {
+            schema = getAddressValidationSchema({ formFields: [
+                ...formFields,
+                {
+                    options: { items: [{ value: 'x' }, { value: 'y' }] },
+                    fieldType: 'dropdown',
+                    id: 'field_100',
+                    name: 'field_100',
+                    required: true,
+                    type: 'string',
+                    custom: true,
+                } as any,
+            ], language });
+        });
+
+        it('throws if value empty', async () => {
+            const errors = await schema.validate({
+                ...getShippingAddress(),
+                customFields: {
+                    field_100: '',
+                },
+            }).catch((error: ValidationError) => error.message);
+
+            expect(errors).toEqual('address.custom_required_error');
+        });
+
+        it('resolves if valid value', async () => {
+            const spy = jest.fn();
+            await schema.validate({
+                ...getShippingAddress(),
+                customFields: {
+                    field_100: 'x',
+                },
+            }).then(spy);
+
+            expect(spy).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/app/address/getAddressValidationSchema.ts
+++ b/src/app/address/getAddressValidationSchema.ts
@@ -1,0 +1,106 @@
+import { FormField, LanguageService } from '@bigcommerce/checkout-sdk';
+import { memoize } from 'lodash';
+import { array, date, number, object, string, ArraySchema, NumberSchema, ObjectSchema, Schema, StringSchema } from 'yup';
+
+import { AddressFormValues } from './mapAddressToFormValues';
+import { DynamicFormFieldType } from './DynamicFormField';
+
+export interface AddressValidationSchemaOptions {
+    formFields: FormField[];
+    language?: LanguageService;
+}
+
+const ERROR_KEYS: { [fieldName: string]: string } = {
+    custom: 'address.custom',
+    countryCode: 'address.country',
+    firstName: 'address.first_name',
+    lastName: 'address.last_name',
+    company: 'address.company_name',
+    address1: 'address.address_line_1',
+    address2: 'address.address_line_1',
+    city: 'address.city',
+    stateOrProvince: 'address.state',
+    stateOrProvinceCode: 'address.state',
+    postalCode: 'address.postal_code',
+    phone: 'address.phone_number',
+};
+
+export default memoize(function getAddressValidationSchema({
+    formFields,
+    language,
+}: AddressValidationSchemaOptions): ObjectSchema<Partial<AddressFormValues>> {
+    const translate: (
+        key: string,
+        data?: any
+    ) => string | undefined = (key, data) => language && language.translate(key, data);
+
+    return object({
+        ...formFields
+            .filter(({ custom }) => !custom)
+            .reduce((schema, { name, required }) => {
+                schema[name] = string();
+
+                if (required) {
+                    schema[name] = schema[name].required(
+                        translate(`${ERROR_KEYS[name]}_required_error`)
+                    );
+                }
+
+                return schema;
+            },
+            {} as { [key: string]: StringSchema }
+        ),
+        customFields: object(
+            formFields
+                .filter(({ custom }) => !!custom)
+                .reduce((schema, { name, label, required, fieldType, type, min, max }) => {
+                    const requiredErrorMessage = translate(`${ERROR_KEYS.custom}_required_error`, { label });
+                    let maxValue: number | undefined;
+                    let minValue: number | undefined;
+
+                    if (type === 'date') {
+                        schema[name] = date()
+                            // Transform NaN values to undefined to avoid empty string (empty input) to fail date
+                            // validation when it's optional
+                            .strict(true)
+                            .transform(value => value === '' ? undefined : value);
+                    } else if (type === 'integer') {
+                        schema[name] = number()
+                            // Transform NaN values to undefined to avoid empty string (empty input) to fail number
+                            // validation when it's optional
+                            .strict(true)
+                            .transform(value => isNaN(value) ? undefined : value);
+
+                        maxValue = typeof max === 'number' ? max : undefined;
+                        minValue = typeof min === 'number' ? min : undefined;
+                    } else if (fieldType === DynamicFormFieldType.checkbox) {
+                        schema[name] = array();
+                    } else {
+                        schema[name] = string();
+                    }
+
+                    if (maxValue !== undefined) {
+                        schema[name] = (schema[name] as NumberSchema).max(maxValue,
+                            translate(`${ERROR_KEYS.custom}_max_error`, { label, max: maxValue + 1 })
+                        );
+                    }
+
+                    if (minValue !== undefined) {
+                        schema[name] = (schema[name] as NumberSchema).min(minValue,
+                            translate(`${ERROR_KEYS.custom}_min_error`, { label, min: minValue - 1 })
+                        );
+                    }
+
+                    if (required) {
+                        schema[name] = fieldType === DynamicFormFieldType.checkbox ?
+                            (schema[name] as ArraySchema<string>).min(1, requiredErrorMessage) :
+                            (schema[name] as ArraySchema<string>).required(requiredErrorMessage);
+                    }
+
+                    return schema;
+                },
+                {} as { [key: string]: Schema<any> }
+            )
+        ).nullable(true),
+    }) as ObjectSchema<Partial<AddressFormValues>> ;
+}, (...args) => JSON.stringify(args));

--- a/src/app/address/index.ts
+++ b/src/app/address/index.ts
@@ -1,0 +1,13 @@
+import { AddressFormValues } from './mapAddressToFormValues';
+
+export type AddressFormValues = AddressFormValues;
+
+export { default as mapAddressToFormValues } from './mapAddressToFormValues';
+export { default as mapAddressFromFormValues } from './mapAddressFromFormValues';
+export { default as AddressSelect } from './AddressSelect';
+export { default as getAddressValidationSchema } from './getAddressValidationSchema';
+export { default as StaticAddress } from './staticAddress/StaticAddress';
+export { default as localizeAddress } from './util/localizeAddress';
+export { default as isValidAddress } from './util/isValidAddress';
+export { default as isValidCustomerAddress } from './util/isValidCustomerAddress';
+export { default as isEqualAddress } from './util/isEqualAddress';

--- a/src/app/address/mapAddressFromFormValues.ts
+++ b/src/app/address/mapAddressFromFormValues.ts
@@ -1,0 +1,21 @@
+import { Address } from '@bigcommerce/checkout-sdk';
+import { forIn, isDate } from 'lodash';
+
+import { AddressFormValues } from './mapAddressToFormValues';
+
+export default function mapAddressFromFormValues(formValues: AddressFormValues): Address {
+    const { customFields: customFieldsObject, ...address } = formValues;
+    const customFields: Array<{fieldId: string; fieldValue: string}> = [];
+
+    forIn(customFieldsObject, (value, key) =>
+        customFields.push({
+            fieldId: key,
+            fieldValue: isDate(value) ? value.toISOString().slice(0, 10) : value,
+        })
+    );
+
+    return {
+        ...address,
+        customFields,
+    };
+}

--- a/src/app/address/mapAddressToFormValues.ts
+++ b/src/app/address/mapAddressToFormValues.ts
@@ -1,0 +1,77 @@
+import { Address, AddressKey, FormField } from '@bigcommerce/checkout-sdk';
+
+import { DynamicFormFieldType } from './DynamicFormField';
+
+export type AddressFormValues = Pick<Address, Exclude<AddressKey, 'customFields'>> & {
+    customFields: { [id: string]: any };
+};
+
+export default function mapAddressToFormValues(fields: FormField[], address?: Address): AddressFormValues {
+    const values = ({
+        ...fields.reduce(
+            (addressFormValues, { name, custom, fieldType, default: defaultValue }) => {
+                if (custom) {
+                    if (!addressFormValues.customFields) {
+                        addressFormValues.customFields = {};
+                    }
+
+                    const field = address &&
+                        address.customFields &&
+                        address.customFields.find(({ fieldId }) => fieldId === name);
+
+                    const fieldValue = (field && field.fieldValue);
+
+                    addressFormValues.customFields[name] = getValue(fieldType, fieldValue, defaultValue);
+
+                    return addressFormValues;
+                }
+
+                if (isSystemAddressFieldName(name)) {
+                    addressFormValues[name] = (address && address[name]) || '';
+                }
+
+                return addressFormValues;
+            },
+            {} as AddressFormValues
+        ),
+    });
+
+    // Manually backfill stateOrProvince to avoid Formik warning (uncontrolled to controlled input)
+    if (values.stateOrProvince === undefined) {
+        values.stateOrProvince = '';
+    }
+
+    if (values.stateOrProvinceCode === undefined) {
+        values.stateOrProvinceCode = '';
+    }
+
+    return values;
+}
+
+function getValue(fieldType?: string, fieldValue?: string | string[] | number, defaultValue?: string): string | string[] | number | Date {
+    if (fieldValue === undefined || fieldValue === null) {
+        return getDefaultValue(fieldType, defaultValue);
+    }
+
+    if (fieldType === DynamicFormFieldType.date && typeof fieldValue === 'string') {
+        return new Date(fieldValue);
+    }
+
+    return fieldValue;
+}
+
+function getDefaultValue(fieldType?: string, defaultValue?: string): string | string[] | Date {
+    if (defaultValue && fieldType === DynamicFormFieldType.date) {
+        return new Date(defaultValue);
+    }
+
+    if (fieldType === DynamicFormFieldType.checkbox) {
+        return [];
+    }
+
+    return defaultValue || '';
+}
+
+function isSystemAddressFieldName(fieldName: string): fieldName is Exclude<keyof Address, 'customFields'> {
+    return fieldName !== 'customFields';
+}

--- a/src/app/address/staticAddress/StaticAddress.scss
+++ b/src/app/address/staticAddress/StaticAddress.scss
@@ -1,0 +1,5 @@
+.checkout-address--static {
+    .address-entry {
+        margin: 0;
+    }
+}

--- a/src/app/address/staticAddress/StaticAddress.spec.tsx
+++ b/src/app/address/staticAddress/StaticAddress.spec.tsx
@@ -1,0 +1,46 @@
+import { createCheckoutService, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { CheckoutProvider } from '../../checkout';
+import { getCountries } from '../../geography/countries.mock';
+import { getAddress } from '../address.mock';
+
+import StaticAddress from './StaticAddress';
+
+describe('StaticAddress Component', () => {
+    const address = getAddress();
+    let checkoutService: CheckoutService;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        jest.spyOn(checkoutService.getState().data, 'getBillingCountries')
+            .mockReturnValue(getCountries());
+    });
+
+    it('renders component with supplied props', () => {
+        const tree = mount(
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <StaticAddress address={ address } />
+            </CheckoutProvider>
+        );
+
+        expect(tree.find(StaticAddress).getDOMNode()).toMatchSnapshot();
+    });
+
+    it('renders component when props are missing', () => {
+        const tree = mount(
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <StaticAddress
+                    address={ {
+                        ...address,
+                        phone: '',
+                        address2: '',
+                    } }
+                />
+            </CheckoutProvider>
+        );
+
+        expect(tree.find(StaticAddress).getDOMNode()).toMatchSnapshot();
+    });
+});

--- a/src/app/address/staticAddress/StaticAddress.tsx
+++ b/src/app/address/staticAddress/StaticAddress.tsx
@@ -1,0 +1,76 @@
+import { Address } from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { withCheckout, CheckoutContextProps } from '../../checkout';
+import { LocalizedGeography } from '../../geography';
+import localizeAddress from '../util/localizeAddress';
+
+import './StaticAddress.scss';
+
+interface StaticAddressProps {
+    address: Address;
+}
+
+interface WithCheckoutStaticAddressProps {
+    localizedAddress: Address & LocalizedGeography;
+}
+
+const StaticAddress: React.FunctionComponent<StaticAddressProps & WithCheckoutStaticAddressProps> = ({ localizedAddress: address }) => (
+    <div className="vcard checkout-address--static">
+        <p className="fn address-entry">
+            <span className="first-name">{ address.firstName } </span>
+            <span className="family-name">{ address.lastName }</span>
+        </p>
+
+        {
+            (address.phone || address.company) &&
+            <p className="address-entry">
+                <span className="company-name">{ address.company } </span>
+                <span className="tel">{ address.phone }</span>
+            </p>
+        }
+
+        <div className="adr">
+            <p className="street-address address-entry">
+                <span className="address-line-1">{ address.address1 } </span>
+                {
+                    address.address2 &&
+                    <span className="address-line-2">
+                        / { address.address2 }
+                    </span>
+                }
+            </p>
+            <p className="address-entry">
+                <span className="locality">{ address.city }, </span>
+                {
+                    address.localizedProvince &&
+                    <span className="region">{ address.localizedProvince }, </span>
+                }
+                <span className="postal-code">{ address.postalCode } / </span>
+                <span className="country-name">{ address.localizedCountry } </span>
+            </p>
+        </div>
+    </div>
+);
+
+export function mapToStaticAddressProps(
+    context: CheckoutContextProps,
+    { address }: StaticAddressProps
+): WithCheckoutStaticAddressProps | null {
+    const {
+        checkoutState: {
+            data: {
+                getBillingCountries,
+            },
+        },
+    } = context;
+
+    return {
+        localizedAddress: localizeAddress(
+            address,
+            getBillingCountries()
+        ),
+    };
+}
+
+export default withCheckout(mapToStaticAddressProps)(StaticAddress);

--- a/src/app/address/staticAddress/__snapshots__/StaticAddress.spec.tsx.snap
+++ b/src/app/address/staticAddress/__snapshots__/StaticAddress.spec.tsx.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StaticAddress Component renders component when props are missing 1`] = `
+<div
+  class="vcard checkout-address--static"
+>
+  <p
+    class="fn address-entry"
+  >
+    <span
+      class="first-name"
+    >
+      Test
+       
+    </span>
+    <span
+      class="family-name"
+    >
+      Tester
+    </span>
+  </p>
+  <p
+    class="address-entry"
+  >
+    <span
+      class="company-name"
+    >
+      Bigcommerce
+       
+    </span>
+    <span
+      class="tel"
+    />
+  </p>
+  <div
+    class="adr"
+  >
+    <p
+      class="street-address address-entry"
+    >
+      <span
+        class="address-line-1"
+      >
+        12345 Testing Way
+         
+      </span>
+      
+    </p>
+    <p
+      class="address-entry"
+    >
+      <span
+        class="locality"
+      >
+        Some City
+        , 
+      </span>
+      <span
+        class="region"
+      >
+        California
+        , 
+      </span>
+      <span
+        class="postal-code"
+      >
+        95555
+         / 
+      </span>
+      <span
+        class="country-name"
+      >
+        United States
+         
+      </span>
+    </p>
+  </div>
+</div>
+`;
+
+exports[`StaticAddress Component renders component with supplied props 1`] = `
+<div
+  class="vcard checkout-address--static"
+>
+  <p
+    class="fn address-entry"
+  >
+    <span
+      class="first-name"
+    >
+      Test
+       
+    </span>
+    <span
+      class="family-name"
+    >
+      Tester
+    </span>
+  </p>
+  <p
+    class="address-entry"
+  >
+    <span
+      class="company-name"
+    >
+      Bigcommerce
+       
+    </span>
+    <span
+      class="tel"
+    >
+      555-555-5555
+    </span>
+  </p>
+  <div
+    class="adr"
+  >
+    <p
+      class="street-address address-entry"
+    >
+      <span
+        class="address-line-1"
+      >
+        12345 Testing Way
+         
+      </span>
+      
+    </p>
+    <p
+      class="address-entry"
+    >
+      <span
+        class="locality"
+      >
+        Some City
+        , 
+      </span>
+      <span
+        class="region"
+      >
+        California
+        , 
+      </span>
+      <span
+        class="postal-code"
+      >
+        95555
+         / 
+      </span>
+      <span
+        class="country-name"
+      >
+        United States
+         
+      </span>
+    </p>
+  </div>
+</div>
+`;

--- a/src/app/address/util/getFormFieldInputId.ts
+++ b/src/app/address/util/getFormFieldInputId.ts
@@ -1,0 +1,17 @@
+import { AddressKeyMap } from '../DynamicFormField';
+
+export const ADDRESS_FIELD_IDS: AddressKeyMap = {
+    address1: 'addressLine1',
+    address2: 'addressLine2',
+    postalCode: 'postCode',
+    stateOrProvince: 'province',
+    stateOrProvinceCode: 'provinceCode',
+};
+
+export function getFormFieldLegacyName(name: string): string {
+    return `${ADDRESS_FIELD_IDS[name] || name}`;
+}
+
+export function getFormFieldInputId(name: string): string {
+    return `${getFormFieldLegacyName(name)}Input`;
+}

--- a/src/app/address/util/isEqualAddress.spec.ts
+++ b/src/app/address/util/isEqualAddress.spec.ts
@@ -1,0 +1,41 @@
+import { getAddress } from '../address.mock';
+import { getAddressFormFields } from '../formField.mock';
+import mapAddressFromFormValues from '../mapAddressFromFormValues';
+import mapAddressToFormValues from '../mapAddressToFormValues';
+
+import isEqualAddress from './isEqualAddress';
+
+describe('isEqualAddress', () => {
+    it('returns true when ignored values are different', () => {
+        expect(isEqualAddress(getAddress(), {
+            ...getAddress(),
+            stateOrProvinceCode: 'w',
+            id: 'x',
+            email: 'y',
+            type: 'z',
+        })).toBeTruthy();
+    });
+
+    it('returns false when values are different', () => {
+        expect(isEqualAddress(getAddress(), {
+            ...getAddress(),
+            stateOrProvince: 'Foo',
+        })).toBeFalsy();
+    });
+
+    it('returns true for transformed address', () => {
+        const address = getAddress();
+        const transformedAddress = mapAddressFromFormValues(
+            mapAddressToFormValues(getAddressFormFields(), address)
+        );
+
+        expect(isEqualAddress(address, transformedAddress)).toBeTruthy();
+    });
+
+    it('returns true when when custom fields are empty', () => {
+        expect(isEqualAddress(getAddress(), {
+            ...getAddress(),
+            customFields: [{ fieldId: 'foo', fieldValue: '' }],
+        })).toBeTruthy();
+    });
+});

--- a/src/app/address/util/isEqualAddress.ts
+++ b/src/app/address/util/isEqualAddress.ts
@@ -1,0 +1,28 @@
+import { Address, AddressRequestBody, BillingAddress, CustomerAddress } from '@bigcommerce/checkout-sdk';
+import { isEqual, omit } from 'lodash';
+
+type ComparableAddress = CustomerAddress | Address | BillingAddress | AddressRequestBody;
+type ComparableAddressFields = keyof CustomerAddress | keyof Address | keyof BillingAddress;
+
+export default function isEqualAddress(address1?: ComparableAddress, address2?: ComparableAddress): boolean {
+    if (!address1 || !address2) {
+        return false;
+    }
+
+    return isEqual(
+        normalizeAddress(address1),
+        normalizeAddress(address2)
+    );
+}
+
+function normalizeAddress(address: ComparableAddress) {
+    const ignoredFields: ComparableAddressFields[] = ['id', 'stateOrProvinceCode', 'type', 'email'];
+
+    return omit(
+        {
+            ...address,
+            customFields: (address.customFields || []).filter(({ fieldValue }) => !!fieldValue),
+        },
+        ignoredFields
+    );
+}

--- a/src/app/address/util/isValidAddress.spec.ts
+++ b/src/app/address/util/isValidAddress.spec.ts
@@ -1,0 +1,86 @@
+import { getAddress } from '../address.mock';
+import { getFormFields } from '../formField.mock';
+
+import isValidAddress from './isValidAddress';
+
+describe('isValidAddress()', () => {
+    it('returns true if all required fields are defined', () => {
+        expect(isValidAddress(getAddress(), getFormFields()))
+            .toEqual(true);
+    });
+
+    it('returns false if some required fields are not defined', () => {
+        expect(isValidAddress({ ...getAddress(), address1: '' }, getFormFields()))
+            .toEqual(false);
+    });
+
+    describe('when field is dropdown', () => {
+        it('returns false if dropdown is required but not defined', () => {
+            const output = isValidAddress(
+                getAddress(),
+                getFormFields().map(field => (
+                    field.fieldType === 'dropdown' ?
+                        { ...field, required: true } :
+                        field
+                ))
+            );
+
+            expect(output)
+                .toEqual(false);
+        });
+
+        it('returns true if dropdown is required and defined', () => {
+            const output = isValidAddress(
+                {
+                    ...getAddress(),
+                    customFields: [
+                        { fieldId: 'field_27', fieldValue: '0' },
+                    ],
+                },
+                getFormFields().map(field => (
+                    field.type === 'array' ?
+                        { ...field, required: true } :
+                        field
+                ))
+            );
+
+            expect(output)
+                .toEqual(true);
+        });
+    });
+
+    describe('when field is number', () => {
+        it('returns true if field is required and defined as 0', () => {
+            const output = isValidAddress(
+                {
+                    ...getAddress(),
+                    customFields: [
+                        { fieldId: 'field_31', fieldValue: 0 },
+                    ],
+                },
+                getFormFields().map(field => (
+                    field.type === 'integer' ?
+                        { ...field, required: true } :
+                        field
+                ))
+            );
+
+            expect(output)
+                .toEqual(true);
+        });
+
+        it('returns false if field is required and not defined', () => {
+            const output = isValidAddress(
+                getAddress(),
+                getFormFields().map(field => (
+                    (typeof field.type !== undefined && field.type === 'integer') ?
+                        { ...field, required: true } :
+                        field
+                ))
+            );
+
+            expect(output)
+                .toEqual(false);
+        });
+    });
+});

--- a/src/app/address/util/isValidAddress.ts
+++ b/src/app/address/util/isValidAddress.ts
@@ -1,0 +1,10 @@
+import { Address, FormField } from '@bigcommerce/checkout-sdk';
+
+import getAddressValidationSchema from '../getAddressValidationSchema';
+import mapAddressToFormValues from '../mapAddressToFormValues';
+
+export default function isValidAddress(address: Address, formFields: FormField[]): boolean {
+    const addressSchema = getAddressValidationSchema({ formFields });
+
+    return addressSchema.isValidSync(mapAddressToFormValues(formFields, address));
+}

--- a/src/app/address/util/isValidCustomerAddress.ts
+++ b/src/app/address/util/isValidCustomerAddress.ts
@@ -1,0 +1,17 @@
+import { Address, CustomerAddress, FormField } from '@bigcommerce/checkout-sdk';
+import { some } from 'lodash';
+
+import isEqualAddress from './isEqualAddress';
+import isValidAddress from './isValidAddress';
+
+export default function isValidCustomerAddress(
+    address: Address | undefined,
+    addresses: CustomerAddress[],
+    formFields: FormField[]
+): boolean {
+    if (!address || !isValidAddress(address, formFields)) {
+        return false;
+    }
+
+    return some(addresses, customerAddress => isEqualAddress(customerAddress, address));
+}

--- a/src/app/address/util/localizeAddress.spec.ts
+++ b/src/app/address/util/localizeAddress.spec.ts
@@ -1,0 +1,43 @@
+import { Address } from '@bigcommerce/checkout-sdk';
+
+import { getCountries } from '../../geography/countries.mock';
+import { getAddress } from '../address.mock';
+
+import localizeAddress from './localizeAddress';
+
+describe('localizeAddress', () => {
+    let address: Address;
+
+    beforeEach(() => {
+        address = getAddress();
+    });
+
+    it('localizes address with provided countries', () => {
+        expect(localizeAddress(address, getCountries())).toMatchObject({
+            ...address,
+            localizedCountry: 'United States',
+            localizedProvince: 'California',
+        });
+    });
+
+    it('keeps same value if unable match countryCode', () => {
+        expect(localizeAddress(address, [])).toMatchObject({
+            ...address,
+            localizedCountry: 'United States',
+            localizedProvince: 'California',
+        });
+    });
+
+    it('keeps same value if unable to provinceCode', () => {
+        const countries = getCountries().map(country => ({
+            ...country,
+            subdivisions: [],
+        }));
+
+        expect(localizeAddress(address, countries)).toMatchObject({
+            ...address,
+            localizedCountry: 'United States',
+            localizedProvince: 'California',
+        });
+    });
+});

--- a/src/app/address/util/localizeAddress.ts
+++ b/src/app/address/util/localizeAddress.ts
@@ -1,0 +1,22 @@
+import { Address } from '@bigcommerce/checkout-sdk';
+import { find, isEmpty } from 'lodash';
+
+import { memoize } from '../../common/utility';
+import { Country, LocalizedGeography } from '../../geography';
+
+const localizeAddress = <T1 extends Address>(
+    address: T1,
+    countries?: Country[]
+): T1 & LocalizedGeography => {
+    const country =  find(countries, { code: address.countryCode });
+    const states = !country || isEmpty(country.subdivisions) ? [] : country.subdivisions;
+    const state = find(states, { code:  address.stateOrProvinceCode });
+
+    return {
+        ...address,
+        localizedCountry: country ? country.name : address.country,
+        localizedProvince: state ? state.name : address.stateOrProvince,
+    };
+};
+
+export default memoize(localizeAddress);

--- a/src/app/ui/form/index.ts
+++ b/src/app/ui/form/index.ts
@@ -41,6 +41,8 @@ export { default as FormFieldContainer } from './FormFieldContainer';
 export { default as Input } from './Input';
 export { default as TextArea } from './TextArea';
 export { default as TextInput } from './TextInput';
+export { default as RadioInput } from './RadioInput';
+export { default as CheckboxInput } from './CheckboxInput';
 export { default as Label } from './Label';
 export { default as Legend } from './Legend';
 export { default as ChecklistItemInput } from './ChecklistItemInput';


### PR DESCRIPTION
## What?
Add address components required for address form, and address utilities.

## Why?
`StaticAddress` is used to render a confirmed address.
`Dynamic*` components used to render custom address form fields.
`AddressSelect` to choose a specific address given a list of addresses

## Testing / Proof
unit

@bigcommerce/checkout
