### PR TITLE
CHECKOUT-4223 Add GoogleAddressAutocomplete component

### DIFF
--- a/src/app/address/googleAutocomplete/AddressSelector.spec.ts
+++ b/src/app/address/googleAutocomplete/AddressSelector.spec.ts
@@ -1,0 +1,78 @@
+import { getGoogleAutocompletePlaceMock } from './__mocks__/googleAutocompleteResult';
+import AddressSelector from './AddressSelector';
+
+describe('AddressSelector', () => {
+    let googleAutoCompleteResponseMock: google.maps.places.PlaceResult;
+
+    beforeEach(() => {
+        googleAutoCompleteResponseMock = getGoogleAutocompletePlaceMock();
+    });
+
+    describe('constructor', () => {
+        it('returns an instance of generic country accessor', () => {
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+            expect(accessor).toBeInstanceOf(AddressSelector);
+        });
+    });
+
+    describe('#getState()', () => {
+        it('returns the correct state', () => {
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+            expect(accessor.getState()).toBe('NSW');
+        });
+    });
+
+    describe('#getStreet()', () => {
+        it('returns the correct street', () => {
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+            expect(accessor.getStreet()).toBe('1-3 Smail St');
+        });
+    });
+
+    describe('#getCountry()', () => {
+        it('returns the correct country', () => {
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+            expect(accessor.getCountry()).toBe('AU');
+        });
+    });
+
+    describe('#getPostCode()', () => {
+        it('returns the correct post code', () => {
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+            expect(accessor.getPostCode()).toBe('2007');
+        });
+    });
+
+    describe('#getCity()', () => {
+        it('returns the postal town as city if present', () => {
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+            expect(accessor.getCity()).toBe('Ultimo PT (l)');
+        });
+
+        it('returns the locality as city if no postal town', () => {
+            // tslint:disable-next-line:no-non-null-assertion
+            const addressComponents = googleAutoCompleteResponseMock.address_components!
+                .filter(address => !address.types.includes('postal_town'));
+
+            const accessor = new AddressSelector({
+                ...googleAutoCompleteResponseMock,
+                address_components: addressComponents,
+            });
+
+            expect(accessor.getCity()).toBe('Ultimo (l)');
+        });
+
+        it('returns the neighborhood as city if nothing else is present', () => {
+            // tslint:disable-next-line:no-non-null-assertion
+            const addressComponents = googleAutoCompleteResponseMock.address_components!
+                .filter(address => !address.types.includes('postal_town') && !address.types.includes('locality'));
+
+            const accessor = new AddressSelector({
+                ...googleAutoCompleteResponseMock,
+                address_components: addressComponents,
+            });
+
+            expect(accessor.getCity()).toBe('Ultimo N');
+        });
+    });
+});

--- a/src/app/address/googleAutocomplete/AddressSelector.ts
+++ b/src/app/address/googleAutocomplete/AddressSelector.ts
@@ -1,0 +1,54 @@
+import { GoogleAddressFieldType } from './googleAutocompleteTypes';
+
+export default class AddressSelector {
+    protected _address: google.maps.GeocoderAddressComponent[] | undefined;
+    protected _name: string;
+
+    constructor(
+        googlePlace: google.maps.places.PlaceResult
+    ) {
+        const { address_components, name } = googlePlace;
+
+        this._name = name;
+        this._address = address_components;
+    }
+
+    getState(): string {
+        return this._get('administrative_area_level_1', 'short_name');
+    }
+
+    getStreet(): string {
+        return this._name;
+    }
+
+    getStreet2(): string {
+        return '';
+    }
+
+    getCity(): string {
+        return this._get('postal_town', 'long_name') ||
+            this._get('locality', 'long_name') ||
+            this._get('neighborhood', 'short_name');
+    }
+
+    getCountry(): string {
+        return this._get('country', 'short_name');
+    }
+
+    getPostCode(): string {
+        return this._get('postal_code', 'short_name');
+    }
+
+    protected _get(
+        type: GoogleAddressFieldType,
+        access: Exclude<keyof google.maps.GeocoderAddressComponent, 'types'>
+    ): string {
+        const element = this._address && this._address.find(field => field.types.indexOf(type) !== -1);
+
+        if (element) {
+            return element[access];
+        }
+
+        return '';
+    }
+}

--- a/src/app/address/googleAutocomplete/AddressSelectorFactory.ts
+++ b/src/app/address/googleAutocomplete/AddressSelectorFactory.ts
@@ -1,0 +1,15 @@
+import AddressSelector from './AddressSelector';
+import AddressSelectorUK from './AddressSelectorUk';
+
+export default class AddressSelectorFactory {
+    static create(autocompleteData: google.maps.places.PlaceResult): AddressSelector {
+        const addressSelector = new AddressSelector(autocompleteData);
+
+        switch (addressSelector.getCountry()) {
+        case 'GB':
+            return new AddressSelectorUK(autocompleteData);
+        }
+
+        return addressSelector;
+    }
+}

--- a/src/app/address/googleAutocomplete/AddressSelectorUk.ts
+++ b/src/app/address/googleAutocomplete/AddressSelectorUk.ts
@@ -1,0 +1,11 @@
+import AddressSelector from './AddressSelector';
+
+export default class AddressSelectorUK extends AddressSelector {
+    getState(): string {
+        return this._get('administrative_area_level_2', 'long_name');
+    }
+
+    getStreet2(): string {
+        return this._get('locality', 'long_name');
+    }
+}

--- a/src/app/address/googleAutocomplete/GoogleAutocomplete.scss
+++ b/src/app/address/googleAutocomplete/GoogleAutocomplete.scss
@@ -1,0 +1,16 @@
+@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+
+$googleLogoHeight: 18px;
+
+.co-googleAutocomplete-footer {
+    background-color: color("greys", "lightest");
+    background-image: url("../../../static/img/powered_by_google_on_white.png");
+    background-position-x: spacing("half");
+    background-position-y: center;
+    background-repeat: no-repeat;
+    border-top: container("border");
+    box-sizing: content-box;
+    color: color("greys", "dark");
+    height: $googleLogoHeight;
+    padding: spacing("half");
+}

--- a/src/app/address/googleAutocomplete/GoogleAutocomplete.spec.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocomplete.spec.tsx
@@ -1,0 +1,16 @@
+import { render } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+
+import GoogleAutocomplete from './GoogleAutocomplete';
+
+describe('GoogleAutocomplete Component', () => {
+    // @todo: add more tests when we can successfully mock "GoogleAutocompleteService"
+    // At the moment, jest.mock('...') doesn't seem to do the trick.
+
+    it('renders input with initial value', () => {
+        const tree = render(<GoogleAutocomplete apiKey="bar" initialValue="fo"/>);
+
+        expect(toJson(tree)).toMatchSnapshot();
+    });
+});

--- a/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -1,0 +1,146 @@
+import { noop } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+
+import { Autocomplete, AutocompleteItem } from '../../ui/autocomplete';
+
+import { GoogleAutocompleteOptionTypes } from './googleAutocompleteTypes';
+import './GoogleAutocomplete.scss';
+import GoogleAutocompleteService from './GoogleAutocompleteService';
+
+interface GoogleAutocompleteProps {
+    initialValue?: string;
+    componentRestrictions?: google.maps.places.ComponentRestrictions;
+    fields?: string[];
+    apiKey: string;
+    nextElement?: HTMLElement;
+    inputProps?: any;
+    isAutocompleteEnabled?: boolean;
+    types?: GoogleAutocompleteOptionTypes[];
+    onSelect?(place: google.maps.places.PlaceResult, item: AutocompleteItem): void;
+    onToggleOpen?(state: { inputValue: string; isOpen: boolean }): void;
+    onChange?(value: string, isOpen: boolean): void;
+}
+
+interface GoogleAutocompleteState {
+    items: AutocompleteItem[];
+    autoComplete: string;
+}
+
+class GoogleAutocomplete extends Component<GoogleAutocompleteProps, GoogleAutocompleteState> {
+    googleAutocompleteService: GoogleAutocompleteService;
+
+    constructor(props: GoogleAutocompleteProps) {
+        super(props);
+        this.googleAutocompleteService = new GoogleAutocompleteService(props.apiKey);
+        this.state = {
+            items: [],
+            autoComplete: 'off',
+        };
+    }
+
+    render(): ReactNode {
+        const {
+            initialValue,
+            onToggleOpen = noop,
+            inputProps = {},
+        } = this.props;
+        const { items } = this.state;
+
+        return (
+            <Autocomplete
+                listTestId="address-autocomplete-suggestions"
+                items={ items }
+                initialHighlightedIndex={ 0 }
+                inputProps={ {
+                    ...inputProps,
+                    autoComplete: this.state.autoComplete,
+                } }
+                initialValue={ initialValue }
+                onSelect={ this.onSelect }
+                onChange={ this.onChange }
+                onToggleOpen={ onToggleOpen }
+            >
+                <div className="co-googleAutocomplete-footer"></div>
+            </Autocomplete>
+        );
+    }
+
+    private onSelect: (item: AutocompleteItem) => void = item => {
+        const {
+            onSelect = noop,
+            nextElement,
+        } = this.props;
+
+        this.googleAutocompleteService.getPlacesServices().then(service => {
+            service.getDetails({
+                placeId: item.id,
+                fields: this.props.fields || ['address_components', 'name'],
+            }, result => {
+                if (nextElement) {
+                    nextElement.focus();
+                }
+
+                onSelect(result, item);
+            });
+        });
+    };
+
+    private onChange: (input: string) => void = input => {
+        const {
+            isAutocompleteEnabled,
+            onChange = noop,
+        } = this.props;
+
+        onChange(input);
+
+        if (!isAutocompleteEnabled) {
+            return this.resetAutocomplete();
+        }
+
+        this.setAutocomplete(input);
+        this.setItems(input);
+    };
+
+    private setItems(input: string): void {
+        if (!input) {
+            this.setState({ items: [] });
+
+            return;
+        }
+
+        this.googleAutocompleteService.getAutocompleteService().then(service => {
+            service.getPlacePredictions({
+                input,
+                types: this.props.types || ['geocode'],
+                componentRestrictions: this.props.componentRestrictions,
+            }, results =>
+                this.setState({ items: this.toAutocompleteItems(results) })
+            );
+        });
+    }
+
+    private resetAutocomplete(): void {
+        this.setState({
+            items: [],
+            autoComplete: 'off',
+        });
+    }
+
+    private setAutocomplete(input: string): void {
+        this.setState({
+            ...this.state,
+            autoComplete: input && input.length ? 'nope' : 'off',
+        });
+    }
+
+    private toAutocompleteItems(results?: google.maps.places.AutocompletePrediction[]): AutocompleteItem[] {
+        return (results || []).map(result => ({
+            label: result.description,
+            value: result.structured_formatting.main_text,
+            highlightedSlices: result.matched_substrings,
+            id: result.place_id,
+        }));
+    }
+}
+
+export default GoogleAutocomplete;

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
@@ -1,0 +1,70 @@
+import { FormField as FormFieldType } from '@bigcommerce/checkout-sdk';
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { AutocompleteItem } from '../../ui/autocomplete';
+import { FormField } from '../../ui/form';
+import { getFormFieldInputId } from '../util/getFormFieldInputId';
+
+import GoogleAutocomplete from './GoogleAutocomplete';
+
+export interface GoogleAutocompleteFormFieldProps {
+    apiKey: string;
+    field: FormFieldType;
+    countryCode?: string;
+    supportedCountries: string[];
+    nextElement?: HTMLElement;
+    parentFieldName?: string;
+    onSelect(place: google.maps.places.PlaceResult, item: AutocompleteItem): void;
+    onToggleOpen?(state: { inputValue: string; isOpen: boolean }): void;
+    onChange(value: string, isOpen: boolean): void;
+}
+
+const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormFieldProps>  = ({
+    field: {
+        name,
+    },
+    countryCode,
+    supportedCountries,
+    parentFieldName,
+    nextElement,
+    apiKey,
+    onSelect,
+    onChange,
+    onToggleOpen,
+}) => {
+    const fieldName = parentFieldName ? `${parentFieldName}.${name}` : name;
+
+    return (
+        <div className={ `dynamic-form-field dynamic-form-field--addressLineAutocomplete` }>
+            <FormField
+                name={ fieldName }
+                labelContent={ <TranslatedString id="address.address_line_1_label" />}
+                input={ ({ field }) =>
+                    <GoogleAutocomplete
+                        apiKey={ apiKey }
+                        onSelect={ onSelect }
+                        onChange={ onChange }
+                        initialValue={ field.value }
+                        nextElement={ nextElement }
+                        onToggleOpen={ onToggleOpen }
+                        isAutocompleteEnabled={ countryCode ?
+                            supportedCountries.indexOf(countryCode) > -1 :
+                            false
+                        }
+                        inputProps={ {
+                            className: 'form-input optimizedCheckout-form-input',
+                            id: getFormFieldInputId(name),
+                        } }
+                        componentRestrictions={ countryCode ?
+                            { country: countryCode } :
+                            undefined
+                        }
+                    />
+                }
+            />
+        </div>
+    );
+};
+
+export default GoogleAutocompleteFormField;

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteScriptLoader.ts
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteScriptLoader.ts
@@ -1,0 +1,59 @@
+import { getScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    GoogleAutocompleteWindow,
+    GoogleMapsSdk,
+} from './googleAutocompleteTypes';
+
+export default class GoogleAutocompleteScriptLoader {
+    private _scriptLoader: ScriptLoader;
+    private _googleAutoComplete?: Promise<GoogleMapsSdk>;
+
+    constructor() {
+        this._scriptLoader = getScriptLoader();
+    }
+
+    loadMapsSdk(apiKey: string): Promise<GoogleMapsSdk> {
+        if (this._googleAutoComplete) {
+            return this._googleAutoComplete;
+        }
+
+        this._googleAutoComplete = new Promise((resolve, reject) => {
+            const callbackName = 'initAutoComplete';
+            const params = [
+                'language=en',
+                `key=${apiKey}`,
+                'libraries=places',
+                `callback=${callbackName}`,
+            ].join('&');
+
+            (window as GoogleCallbackWindow)[callbackName] = () => {
+                if (isAutocompleteWindow(window)) {
+                    resolve(window.google.maps);
+                }
+
+                reject();
+            };
+
+            this._scriptLoader.loadScript(`//maps.googleapis.com/maps/api/js?${params}`)
+                .catch(e => {
+                    this._googleAutoComplete = undefined;
+                    throw e;
+                });
+        });
+
+        return this._googleAutoComplete;
+    }
+}
+
+function isAutocompleteWindow(window: Window): window is GoogleAutocompleteWindow {
+    const autocompleteWindow = window as GoogleAutocompleteWindow;
+
+    return Boolean(autocompleteWindow.google &&
+        autocompleteWindow.google.maps &&
+        autocompleteWindow.google.maps.places);
+}
+
+export interface GoogleCallbackWindow extends Window {
+    initAutoComplete?(): void;
+}

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteService.ts
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteService.ts
@@ -1,0 +1,44 @@
+import getGoogleAutocompleteScriptLoader from './getGoogleAutocompleteScriptLoader';
+import GoogleAutocompleteScriptLoader from './GoogleAutocompleteScriptLoader';
+
+export default class GoogleAutocompleteService {
+    private _autocompletePromise?: Promise<google.maps.places.AutocompleteService>;
+    private _placesPromise?: Promise<google.maps.places.PlacesService>;
+
+    constructor(
+        private _apiKey: string,
+        private _scriptLoader: GoogleAutocompleteScriptLoader = getGoogleAutocompleteScriptLoader()
+    ) {}
+
+    getAutocompleteService(): Promise<google.maps.places.AutocompleteService> {
+        if (!this._autocompletePromise) {
+            this._autocompletePromise = this._scriptLoader.loadMapsSdk(this._apiKey)
+                .then(googleMapsSdk => {
+                    if (!googleMapsSdk.places.AutocompleteService) {
+                        throw new Error('`AutocompleteService` is undefined');
+                    }
+
+                    return new googleMapsSdk.places.AutocompleteService();
+                });
+        }
+
+        return this._autocompletePromise;
+    }
+
+    getPlacesServices(): Promise<google.maps.places.PlacesService> {
+        const node = document.createElement('div');
+
+        if (!this._placesPromise) {
+            this._placesPromise = this._scriptLoader.loadMapsSdk(this._apiKey)
+                .then(googleMapsSdk => {
+                    if (!googleMapsSdk.places.PlacesService) {
+                        throw new Error('`PlacesService` is undefined');
+                    }
+
+                    return new googleMapsSdk.places.PlacesService(node);
+                });
+        }
+
+        return this._placesPromise;
+    }
+}

--- a/src/app/address/googleAutocomplete/__mocks__/googleAutocompleteResult.ts
+++ b/src/app/address/googleAutocomplete/__mocks__/googleAutocompleteResult.ts
@@ -1,0 +1,74 @@
+export function getGoogleAutocompletePlaceMock(): google.maps.places.PlaceResult {
+    return {
+        name: '1-3 Smail St',
+        address_components: [
+            {
+                long_name: '1-3 (l)',
+                short_name: '1-3 (s)',
+                types: [
+                    'street_number',
+                ],
+            },
+            {
+                long_name: 'Smail Street',
+                short_name: 'Smail St',
+                types: [
+                    'route',
+                ],
+            },
+            {
+                long_name: 'Ultimo PT (l)',
+                short_name: 'Ultimo PT',
+                types: [
+                    'postal_town',
+                ],
+            },
+            {
+                long_name: 'Ultimo (l)',
+                short_name: 'Ultimo',
+                types: [
+                    'locality',
+                    'political',
+                ],
+            },
+            {
+                long_name: 'Ultimo N (l)',
+                short_name: 'Ultimo N',
+                types: [
+                    'neighborhood',
+                ],
+            },
+            {
+                long_name: 'Council of the City of Sydney',
+                short_name: 'Sydney',
+                types: [
+                    'administrative_area_level_2',
+                    'political',
+                ],
+            },
+            {
+                long_name: 'New South Wales',
+                short_name: 'NSW',
+                types: [
+                    'administrative_area_level_1',
+                    'political',
+                ],
+            },
+            {
+                long_name: 'Australia',
+                short_name: 'AU',
+                types: [
+                    'country',
+                    'political',
+                ],
+            },
+            {
+                long_name: '2007  (l)',
+                short_name: '2007',
+                types: [
+                    'postal_code',
+                ],
+            },
+        ],
+    } as google.maps.places.PlaceResult;
+}

--- a/src/app/address/googleAutocomplete/__snapshots__/GoogleAutocomplete.spec.tsx.snap
+++ b/src/app/address/googleAutocomplete/__snapshots__/GoogleAutocomplete.spec.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GoogleAutocomplete Component renders input with initial value 1`] = `
+<div
+  aria-expanded="false"
+  aria-haspopup="listbox"
+  aria-labelledby="downshift-0-label"
+  role="combobox"
+>
+  <input
+    aria-autocomplete="list"
+    aria-labelledby="downshift-0-label"
+    autocomplete="off"
+    id="downshift-0-input"
+    value="fo"
+  />
+</div>
+`;

--- a/src/app/address/googleAutocomplete/getGoogleAutocompleteScriptLoader.spec.ts
+++ b/src/app/address/googleAutocomplete/getGoogleAutocompleteScriptLoader.spec.ts
@@ -1,0 +1,54 @@
+import { getScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
+
+import { GoogleAutocompleteWindow } from './googleAutocompleteTypes';
+import GoogleAutocompleteScriptLoader, { GoogleCallbackWindow } from './GoogleAutocompleteScriptLoader';
+
+describe('GoogleAutocompleteScriptLoader', () => {
+    const scriptLoader: ScriptLoader = getScriptLoader();
+    let googleScriptLoader: GoogleAutocompleteScriptLoader;
+
+    describe('#loadMapsSdk()', () => {
+        let spiedLoadScript: any;
+
+        beforeEach(async () => {
+            spiedLoadScript = jest.spyOn(scriptLoader, 'loadScript');
+
+            spiedLoadScript.mockImplementation(() => {
+                (window as GoogleAutocompleteWindow).google = {
+                    maps: {
+                        places: {},
+                    } as any,
+                };
+
+                // tslint:disable-next-line:no-non-null-assertion
+                (window as GoogleCallbackWindow).initAutoComplete!();
+            });
+
+            googleScriptLoader = new GoogleAutocompleteScriptLoader();
+            await googleScriptLoader.loadMapsSdk('foo');
+        });
+
+        afterEach(() => {
+            spiedLoadScript.mockReset();
+        });
+
+        it('calls loadScript with the right parameters', () => {
+            expect(scriptLoader.loadScript)
+                .toHaveBeenCalledWith([
+                    '//maps.googleapis.com/maps/api/js?language=en',
+                    'key=foo',
+                    'libraries=places',
+                    'callback=initAutoComplete',
+                ].join('&'));
+        });
+
+        it('calls loadScript once', async () => {
+            await googleScriptLoader.loadMapsSdk('x');
+            await googleScriptLoader.loadMapsSdk('y');
+            await googleScriptLoader.loadMapsSdk('z');
+
+            expect(scriptLoader.loadScript)
+                .toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/app/address/googleAutocomplete/getGoogleAutocompleteScriptLoader.ts
+++ b/src/app/address/googleAutocomplete/getGoogleAutocompleteScriptLoader.ts
@@ -1,0 +1,11 @@
+import GoogleAutocompleteScriptLoader from './GoogleAutocompleteScriptLoader';
+
+let instance: GoogleAutocompleteScriptLoader;
+
+export default function getGoogleAutocompleteScriptLoader(): GoogleAutocompleteScriptLoader {
+    if (!instance) {
+        instance = new GoogleAutocompleteScriptLoader();
+    }
+
+    return instance;
+}

--- a/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
+++ b/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
@@ -1,0 +1,52 @@
+export type GoogleAutocompleteOptionTypes =  'establishment' | 'geocode' | 'address';
+
+export type GoogleAutocompleteFields =
+    'address_components' |
+    'adr_address' |
+    'aspects' |
+    'formatted_address' |
+    'formatted_phone_number' |
+    'geometry' |
+    'html_attributions' |
+    'icon' |
+    'international_phone_number' |
+    'name' |
+    'opening_hours' |
+    'photos' |
+    'place_id' |
+    'plus_code' |
+    'price_level' |
+    'rating' |
+    'reviews' |
+    'types' |
+    'url' |
+    'utc_offset' |
+    'vicinity' |
+    'website';
+
+export type GoogleAutocompleteEvent = 'place_changed';
+
+export interface GoogleMapsSdk {
+    places: {
+        AutocompleteService?: new () => google.maps.places.AutocompleteService;
+        PlacesService?: new (attrContainer: HTMLDivElement) => google.maps.places.PlacesService;
+    };
+}
+
+export interface GoogleAutocompleteWindow extends Window {
+    google: {
+        maps: GoogleMapsSdk;
+    };
+}
+
+export type GoogleAddressFieldType =
+    'postal_town' |
+    'administrative_area_level_1' |
+    'administrative_area_level_2' |
+    'locality' |
+    'neighborhood' |
+    'postal_code' |
+    'street_number' |
+    'route' |
+    'political' |
+    'country';

--- a/src/app/address/googleAutocomplete/index.ts
+++ b/src/app/address/googleAutocomplete/index.ts
@@ -1,0 +1,5 @@
+export * from './googleAutocompleteTypes';
+export { default as mapToAddress } from './mapToAddress';
+export { default as GoogleAutocompleteScriptLoader } from './GoogleAutocompleteScriptLoader';
+export { default as GoogleAutocomplete } from './GoogleAutocomplete';
+export { default as GoogleAutocompleteFormField } from './GoogleAutocompleteFormField';

--- a/src/app/address/googleAutocomplete/mapToAddress.spec.ts
+++ b/src/app/address/googleAutocomplete/mapToAddress.spec.ts
@@ -1,0 +1,35 @@
+import { getCountries } from '../../geography/countries.mock';
+
+import mapToAddress from './mapToAddress';
+import { getGoogleAutocompletePlaceMock } from './__mocks__/googleAutocompleteResult';
+
+describe('mapToAddress()', () => {
+    it('returns a partial address with hydrated province', () => {
+        const googlePlace = getGoogleAutocompletePlaceMock();
+        const countries = getCountries();
+
+        const address = mapToAddress(googlePlace, countries);
+
+        expect(address).toMatchObject({
+            city: 'Ultimo PT (l)',
+            countryCode: 'AU',
+            postalCode: '2007',
+            stateOrProvince: 'New South Wales',
+            stateOrProvinceCode: 'NSW',
+        });
+    });
+
+    it('returns a partial address with province code when no countries are passed', () => {
+        const googlePlace = getGoogleAutocompletePlaceMock();
+
+        const address = mapToAddress(googlePlace);
+
+        expect(address).toMatchObject({
+            city: 'Ultimo PT (l)',
+            countryCode: 'AU',
+            postalCode: '2007',
+            stateOrProvince: 'NSW',
+            stateOrProvinceCode: '',
+        });
+    });
+});

--- a/src/app/address/googleAutocomplete/mapToAddress.ts
+++ b/src/app/address/googleAutocomplete/mapToAddress.ts
@@ -1,0 +1,49 @@
+import { Address } from '@bigcommerce/checkout-sdk';
+
+import { Country, Region } from '../../geography';
+
+import AddressSelectorFactory from './AddressSelectorFactory';
+
+export default function mapToAddress(
+    autocompleteData: google.maps.places.PlaceResult,
+    countries: Country[] = []
+): Partial<Address> {
+    if (!autocompleteData || !autocompleteData.address_components) {
+        return {};
+    }
+
+    const accessor = AddressSelectorFactory.create(autocompleteData);
+    const state = accessor.getState();
+    const countryCode = accessor.getCountry();
+    const country = countries && countries.find(c => countryCode === c.code);
+    const street2 = accessor.getStreet2();
+
+    return {
+        address2: street2,
+        city: accessor.getCity(),
+        countryCode,
+        postalCode: accessor.getPostCode(),
+        ...state ? getState(state, country && country.subdivisions) : {},
+    };
+}
+
+function getState(
+    stateName: string,
+    states: Region[] = []
+): Partial<Address> {
+    const state = states.find(({ code, name }: Region) =>
+        code === stateName || name === stateName
+    );
+
+    if (!state) {
+        return {
+            stateOrProvince: !states.length ? stateName : '',
+            stateOrProvinceCode: '',
+        };
+    }
+
+    return {
+        stateOrProvince: state.name,
+        stateOrProvinceCode: state.code,
+    };
+}


### PR DESCRIPTION
## What?
Add `GoogleAddressAutocomplete` component

## Why?
To support prefilling address form automatically from a list of suggestions while customer starts typing an address, using Google Maps API.

## Testing / Proof
unit

@bigcommerce/checkout
