### PR TITLE
CHECKOUT-4223: Add checkout steps

### DIFF
--- a/src/app/checkout/CheckoutStep.spec.tsx
+++ b/src/app/checkout/CheckoutStep.spec.tsx
@@ -1,0 +1,152 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import CheckoutStep, { CheckoutStepProps } from './CheckoutStep';
+import CheckoutStepHeader from './CheckoutStepHeader';
+import CheckoutStepType from './CheckoutStepType';
+
+jest.useFakeTimers();
+
+describe('CheckoutStep', () => {
+    let defaultProps: CheckoutStepProps;
+
+    beforeEach(() => {
+        defaultProps = {
+            isActive: true,
+            type: CheckoutStepType.Customer,
+            onExpanded: jest.fn(),
+        };
+
+        // JSDOM does not support `scrollTo`
+        window.scrollTo = jest.fn();
+    });
+
+    afterEach(() => {
+        delete window.scrollTo;
+
+        // Reset the focused element after each test
+        if (document.activeElement) {
+            (document.activeElement as HTMLElement).blur();
+        }
+    });
+
+    it('focuses on first form input when step is active', () => {
+        const component = mount(
+            <CheckoutStep { ...defaultProps }>
+                <input type="text" />
+                <input type="number" />
+            </CheckoutStep>
+        );
+
+        jest.runAllTimers();
+
+        expect(component.getDOMNode().querySelector('input'))
+            .toEqual(document.activeElement);
+    });
+
+    it('calls onExpanded when step is active', () => {
+        mount(<CheckoutStep { ...defaultProps } />);
+
+        jest.runAllTimers();
+
+        expect(defaultProps.onExpanded)
+            .toHaveBeenCalledWith('customer');
+    });
+
+    it('scrolls to container when step is active', () => {
+        const component = mount(
+            <CheckoutStep { ...defaultProps } />
+        );
+
+        jest.runAllTimers();
+
+        const expectedPosition = component.getDOMNode().getBoundingClientRect().top + window.scrollY - window.innerHeight / 5;
+
+        expect(window.scrollTo)
+            .toHaveBeenCalledWith(0, expectedPosition);
+    });
+
+    it('scrolls to container after timeout', () => {
+        mount(<CheckoutStep { ...defaultProps } />);
+
+        expect(window.scrollTo)
+            .not.toHaveBeenCalled();
+
+        jest.runAllTimers();
+
+        expect(window.scrollTo)
+            .toHaveBeenCalled();
+    });
+
+    it('does not focus or scroll to element if step is not active', () => {
+        const component = mount(
+            <CheckoutStep
+                { ...defaultProps }
+                isActive={ false }
+            >
+                <input type="text" />
+                <input type="number" />
+            </CheckoutStep>
+        );
+
+        jest.runAllTimers();
+
+        expect(component.getDOMNode().querySelector('input'))
+            .not.toEqual(document.activeElement);
+
+        expect(window.scrollTo)
+            .not.toHaveBeenCalled();
+    });
+
+    it('renders step header with required props', () => {
+        const headerProps = {
+            heading: 'Billing',
+            summary: 'Billing summary',
+            type: CheckoutStepType.Billing,
+            isComplete: true,
+            isEditable: true,
+            isActive: true,
+        };
+
+        const component = mount(
+            <CheckoutStep
+                { ...defaultProps }
+                { ...headerProps }
+            />
+        );
+
+        expect(component.find(CheckoutStepHeader))
+            .toHaveLength(1);
+
+        expect(component.find(CheckoutStepHeader).props())
+            .toEqual(headerProps);
+    });
+
+    it('renders content if step is active', () => {
+        const component = mount(
+            <CheckoutStep { ...defaultProps }>
+                Hello world
+            </CheckoutStep>
+        );
+
+        expect(component.exists('.checkout-view-content'))
+            .toEqual(true);
+
+        expect(component.find('.checkout-view-content').text())
+            .toEqual('Hello world');
+    });
+
+    it('does not render content if step is not active', () => {
+        const component = mount(
+            <CheckoutStep
+                { ...defaultProps }
+                isActive={ false }
+            >
+                Hello world
+            </CheckoutStep>
+        );
+
+        expect(component.exists('.checkout-view-content'))
+            .toEqual(false);
+    });
+});

--- a/src/app/checkout/CheckoutStep.tsx
+++ b/src/app/checkout/CheckoutStep.tsx
@@ -1,0 +1,196 @@
+import classNames from 'classnames';
+import { noop } from 'lodash';
+import React, { createRef, Component, ReactNode, RefObject } from 'react';
+import { CSSTransition } from 'react-transition-group';
+
+import CheckoutStepHeader from './CheckoutStepHeader';
+import CheckoutStepType from './CheckoutStepType';
+
+export interface CheckoutStepProps {
+    heading?: ReactNode;
+    isActive?: boolean;
+    isComplete?: boolean;
+    isEditable?: boolean;
+    shouldRenderEmptyContainer?: false; // TODO: Remove this once we are fully transitioned to React
+    summary?: ReactNode;
+    type: CheckoutStepType;
+    onExpanded?(step: CheckoutStepType): void;
+    onEdit?(step: CheckoutStepType): void;
+}
+
+// TODO: Remove this once we are fully transitioned to React
+export interface EmptyCheckoutStepProps {
+    isActive?: boolean;
+    isComplete?: boolean;
+    shouldRenderEmptyContainer: true;
+}
+
+const LARGE_SCREEN_BREAKPOINT = 968;
+const LARGE_SCREEN_ANIMATION_DELAY = 610;
+
+// TODO: Remove this once we are fully transitioned to React
+function isEmptyCheckoutStepProps(props: CheckoutStepProps | EmptyCheckoutStepProps): props is EmptyCheckoutStepProps {
+    return (props as EmptyCheckoutStepProps).shouldRenderEmptyContainer === true;
+}
+
+export default class CheckoutStep extends Component<CheckoutStepProps | EmptyCheckoutStepProps> {
+    private containerRef: RefObject<HTMLElement> = createRef();
+    private timeoutRef?: number;
+
+    componentDidMount(): void {
+        const { isActive } = this.props;
+
+        if (isActive) {
+            this.focusStep();
+        }
+    }
+
+    componentDidUpdate(prevProps: Readonly<CheckoutStepProps>): void {
+        const { isActive } = this.props;
+
+        if (isActive && isActive !== prevProps.isActive) {
+            this.focusStep();
+        }
+    }
+
+    componentWillUnmount(): void {
+        if (this.timeoutRef) {
+            window.clearTimeout(this.timeoutRef);
+
+            this.timeoutRef = undefined;
+        }
+    }
+
+    render(): ReactNode {
+        const { children } = this.props;
+
+        // TODO: Remove this once we are fully transitioned to React
+        if (isEmptyCheckoutStepProps(this.props)) {
+            return (
+                <div ref={ this.containerRef as RefObject<HTMLDivElement> }>
+                    { children }
+                </div>
+            );
+        }
+
+        const {
+            heading,
+            isActive,
+            isComplete,
+            isEditable,
+            onEdit,
+            summary,
+            type,
+        } = this.props;
+
+        return (
+            <li
+                className={ classNames(
+                    'checkout-step',
+                    'optimizedCheckout-checkoutStep',
+                    { [`checkout-step--${type}`]: !!type }
+                ) }
+                ref={ this.containerRef as RefObject<HTMLLIElement> }
+            >
+                <div className="checkout-view-header">
+                    <CheckoutStepHeader
+                        heading={ heading }
+                        isActive={ isActive }
+                        isEditable={ isEditable }
+                        isComplete={ isComplete }
+                        onEdit={ onEdit }
+                        summary={ summary }
+                        type={ type }
+                    />
+                </div>
+
+                <CSSTransition
+                    addEndListener={ (node, done) => {
+                        node.addEventListener('transitionend', ({ target }) => {
+                            if (target === node) {
+                                done();
+                            }
+                        });
+                    } }
+                    classNames="checkout-view-content"
+                    timeout={ {} }
+                    in={ isActive }
+                    unmountOnExit
+                    mountOnEnter
+                >
+                    <div className="checkout-view-content">
+                        { children }
+                    </div>
+                </CSSTransition>
+            </li>
+        );
+    }
+
+    private focusStep(): void {
+        const delay = window.innerWidth > LARGE_SCREEN_BREAKPOINT ? LARGE_SCREEN_ANIMATION_DELAY : 0;
+
+        this.timeoutRef = window.setTimeout(() => {
+            const input = this.getChildInput();
+            const position = this.getScrollPosition();
+
+            if (input) {
+                input.focus();
+            }
+
+            if (position !== undefined && !isNaN(position)) {
+                window.scrollTo(0, position);
+            }
+
+            if (!isEmptyCheckoutStepProps(this.props)) {
+                const { type, onExpanded = noop } = this.props;
+
+                onExpanded(type);
+            }
+
+            this.timeoutRef = undefined;
+        }, delay);
+    }
+
+    private getChildInput(): HTMLElement | undefined {
+        const container = this.containerRef.current;
+
+        if (!container) {
+            return;
+        }
+
+        const input = container.querySelector<HTMLElement>('input, select, textarea');
+
+        return input ? input : undefined;
+    }
+
+    private getScrollPosition(): number | undefined {
+        const container = this.getParentContainer();
+        const { isComplete } = this.props;
+
+        if (!container || window !== window.top) {
+            return;
+        }
+
+        const topOffset = isComplete ? 0 : window.innerHeight / 5;
+        const containerOffset = container.getBoundingClientRect().top + (window.scrollY || window.pageYOffset);
+
+        return containerOffset - topOffset;
+    }
+
+    // For now, we need to find the parent container because `CheckoutStep`
+    // isn't the outer container yet. Once both the header and body are
+    // moved inside this component, we can remove the lookup.
+    private getParentContainer(): HTMLElement | undefined {
+        let container: HTMLElement | null = this.containerRef.current;
+
+        while (container && container.parentElement) {
+            if (container.parentElement.classList.contains('checkout-step')) {
+                return container.parentElement;
+            }
+
+            container = container.parentElement;
+        }
+
+        return this.containerRef.current ? this.containerRef.current : undefined;
+    }
+}

--- a/src/app/checkout/CheckoutStepHeader.spec.tsx
+++ b/src/app/checkout/CheckoutStepHeader.spec.tsx
@@ -1,0 +1,140 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { Button } from '../ui/button';
+import { IconCheck } from '../ui/icon';
+
+import CheckoutStepHeader, { CheckoutStepHeaderProps } from './CheckoutStepHeader';
+import CheckoutStepType from './CheckoutStepType';
+
+describe('CheckoutStepHeader', () => {
+    let defaultProps: CheckoutStepHeaderProps;
+
+    beforeEach(() => {
+        defaultProps = {
+            heading: 'Billing',
+            summary: 'Billing summary',
+            type: CheckoutStepType.Billing,
+        };
+    });
+
+    it('renders summary if it is inactive and complete', () => {
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isComplete
+            />
+        );
+
+        expect(component.find('[data-test="step-info"]').text())
+            .toEqual('Billing summary');
+    });
+
+    it('does not render summary if it is active', () => {
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isActive
+            />
+        );
+
+        expect(component.find('[data-test="step-info"]').text())
+            .toEqual('');
+    });
+
+    it('does not render summary if it is inactive or incomplete', () => {
+        const component = shallow(
+            <CheckoutStepHeader { ...defaultProps } />
+        );
+
+        expect(component.find('[data-test="step-info"]').text())
+            .toEqual('');
+    });
+
+    it('renders edit button if it is editable', () => {
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isEditable
+            />
+        );
+
+        expect(component.find(Button).prop('testId'))
+            .toEqual('step-edit-button');
+
+        expect(component.prop('className'))
+            .not.toContain('is-readonly');
+    });
+
+    it('does not render edit button if it is not editable', () => {
+        const component = shallow(
+            <CheckoutStepHeader { ...defaultProps } />
+        );
+
+        expect(component.exists('[data-test="step-edit-button"]'))
+            .toEqual(false);
+
+        expect(component.prop('className'))
+            .toContain('is-readonly');
+    });
+
+    it('triggers callback when clicked', () => {
+        const handleEdit = jest.fn();
+        const event = { preventDefault: jest.fn() };
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isEditable
+                onEdit={ handleEdit }
+            />
+        );
+
+        component.simulate('click', event);
+
+        expect(handleEdit)
+            .toHaveBeenCalledWith(defaultProps.type);
+
+        expect(event.preventDefault)
+            .toHaveBeenCalled();
+    });
+
+    it('does not trigger callback when clicked if step is not editable', () => {
+        const handleEdit = jest.fn();
+        const event = { preventDefault: jest.fn() };
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                onEdit={ handleEdit }
+            />
+        );
+
+        component.simulate('click', event);
+
+        expect(handleEdit)
+            .not.toHaveBeenCalled();
+
+        expect(event.preventDefault)
+            .toHaveBeenCalled();
+    });
+
+    it('renders "complete" icon if step is complete', () => {
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isComplete
+            />
+        );
+
+        expect(component.find(IconCheck).prop('additionalClassName'))
+            .toContain('stepHeader-counter--complete');
+    });
+
+    it('does not render "complete" icon if step is incomplete', () => {
+        const component = shallow(
+            <CheckoutStepHeader { ...defaultProps } />
+        );
+
+        expect(component.find(IconCheck).prop('additionalClassName'))
+            .not.toContain('stepHeader-counter--complete');
+    });
+});

--- a/src/app/checkout/CheckoutStepHeader.tsx
+++ b/src/app/checkout/CheckoutStepHeader.tsx
@@ -1,0 +1,71 @@
+import classNames from 'classnames';
+import { noop } from 'lodash';
+import React, { FunctionComponent, ReactNode } from 'react';
+
+import { preventDefault } from '../common/dom';
+import { TranslatedString } from '../language';
+import { Button, ButtonSize, ButtonVariant } from '../ui/button';
+import { IconCheck } from '../ui/icon';
+
+import CheckoutStepType from './CheckoutStepType';
+
+export interface CheckoutStepHeaderProps {
+    heading: ReactNode;
+    isActive?: boolean;
+    isComplete?: boolean;
+    isEditable?: boolean;
+    summary?: ReactNode;
+    type: CheckoutStepType;
+    onEdit?(type: CheckoutStepType): void;
+}
+
+const CheckoutStepHeader: FunctionComponent<CheckoutStepHeaderProps> = ({
+    heading,
+    isActive,
+    isComplete,
+    isEditable,
+    onEdit,
+    summary,
+    type,
+}) => {
+    return (
+        <a
+            className={ classNames(
+                'stepHeader',
+                { 'is-readonly': !isEditable }
+            ) }
+            onClick={ preventDefault(isEditable && onEdit ? () => onEdit(type) : noop) }
+        >
+            <div className="stepHeader-figure stepHeader-column">
+                <IconCheck additionalClassName={ classNames(
+                    'stepHeader-counter',
+                    'optimizedCheckout-step',
+                    { 'stepHeader-counter--complete': isComplete }
+                ) } />
+
+                <h2 className="stepHeader-title optimizedCheckout-headingPrimary">
+                    { heading }
+                </h2>
+            </div>
+
+            <div
+                data-test="step-info"
+                className="stepHeader-body stepHeader-column optimizedCheckout-contentPrimary"
+            >
+                { !isActive && isComplete && summary }
+            </div>
+
+            { isEditable && !isActive && <div className="stepHeader-actions stepHeader-column">
+                <Button
+                    testId="step-edit-button"
+                    size={ ButtonSize.Tiny }
+                    variant={ ButtonVariant.Secondary }
+                >
+                    <TranslatedString id="common.edit_action" />
+                </Button>
+            </div> }
+        </a>
+    );
+};
+
+export default CheckoutStepHeader;

--- a/src/app/checkout/CheckoutStepStatus.ts
+++ b/src/app/checkout/CheckoutStepStatus.ts
@@ -1,0 +1,9 @@
+import CheckoutStepType from './CheckoutStepType';
+
+export default interface CheckoutStepStatus {
+    isActive: boolean;
+    isComplete: boolean;
+    isEditable: boolean;
+    isRequired: boolean;
+    type: CheckoutStepType;
+}

--- a/src/app/checkout/CheckoutStepType.ts
+++ b/src/app/checkout/CheckoutStepType.ts
@@ -1,0 +1,8 @@
+enum CheckoutStepType {
+    Billing = 'billing',
+    Customer = 'customer',
+    Payment = 'payment',
+    Shipping = 'shipping',
+}
+
+export default CheckoutStepType;

--- a/src/app/checkout/getCheckoutStepStatuses.spec.ts
+++ b/src/app/checkout/getCheckoutStepStatuses.spec.ts
@@ -1,0 +1,413 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { find } from 'lodash';
+
+import { getBillingAddress } from '../billing/billingAddresses.mock';
+import { getCart } from '../cart/carts.mock';
+import { getCustomer, getGuestCustomer } from '../customer/customers.mock';
+import { getOrder } from '../order/orders.mock';
+import { getConsignment } from '../shipping/consignment.mock';
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+
+import { getCheckoutWithPayments } from './checkouts.mock';
+import getCheckoutStepStatuses from './getCheckoutStepStatuses';
+import CheckoutStepType from './CheckoutStepType';
+
+describe('getCheckoutStepStatuses()', () => {
+    let service: CheckoutService;
+    let state: CheckoutSelectors;
+
+    beforeEach(() => {
+        service = createCheckoutService();
+        state = service.getState();
+    });
+
+    describe('customer step', () => {
+        it('is marked as complete if email is provided by guest shopper', () => {
+            jest.spyOn(state.data, 'getBillingAddress')
+                .mockReturnValue(getBillingAddress());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Customer })!.isComplete)
+                .toEqual(true);
+        });
+
+        it('is marked as complete if email is provided by returning shopper', () => {
+            jest.spyOn(state.data, 'getCustomer')
+                .mockReturnValue(getCustomer());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Customer })!.isComplete)
+                .toEqual(true);
+        });
+
+        it('is marked as complete if email is provided by digital wallet', () => {
+            jest.spyOn(state.data, 'getCheckout')
+                .mockReturnValue(getCheckoutWithPayments());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Customer })!.isComplete)
+                .toEqual(true);
+        });
+
+        it('is marked as incomplete if email is not provided', () => {
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Customer })!.isComplete)
+                .toEqual(false);
+        });
+
+        it('is marked as editable if email is provided by guest shopper directly', () => {
+            jest.spyOn(state.data, 'getCustomer')
+                .mockReturnValue(getGuestCustomer());
+
+            // Email address is surfaced through billing address for guest shoppers
+            jest.spyOn(state.data, 'getBillingAddress')
+                .mockReturnValue(getBillingAddress());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Customer })!.isEditable)
+                .toEqual(true);
+        });
+
+        it('is marked as non-editable if email is provided by digital wallet', () => {
+            jest.spyOn(state.data, 'getCheckout')
+                .mockReturnValue(getCheckoutWithPayments());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Customer })!.isEditable)
+                .toEqual(false);
+        });
+
+        it('is marked as non-editable if step is incomplete', () => {
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Customer })!.isEditable)
+                .toEqual(false);
+        });
+    });
+
+    describe('billing step', () => {
+        it('is marked as complete if billing address is provided', () => {
+            jest.spyOn(state.data, 'getBillingAddress')
+                .mockReturnValue(getBillingAddress());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Billing })!.isComplete)
+                .toEqual(true);
+        });
+
+        it('is marked as complete if billing address is provided by digital wallet', () => {
+            jest.spyOn(state.data, 'getCheckout')
+                .mockReturnValue(getCheckoutWithPayments());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Billing })!.isComplete)
+                .toEqual(true);
+        });
+
+        it('is marked as incomplete if billing address is not provided', () => {
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Billing })!.isComplete)
+                .toEqual(false);
+        });
+
+        it('is marked as non-editable if step is incomplete', () => {
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Billing })!.isEditable)
+                .toEqual(false);
+        });
+    });
+
+    describe('shipping step', () => {
+        it('is marked as complete if shipping address and option are provided and there are no unassigned line items', () => {
+            jest.spyOn(state.data, 'getShippingAddress')
+                .mockReturnValue(getShippingAddress());
+
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue(getCart());
+
+            jest.spyOn(state.data, 'getConsignments')
+                .mockReturnValue([getConsignment()]);
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isComplete)
+                .toEqual(true);
+        });
+
+        it('is marked as incomplete if shipping address is not provided', () => {
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue(getCart());
+
+            jest.spyOn(state.data, 'getConsignments')
+                .mockReturnValue([getConsignment()]);
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isComplete)
+                .toEqual(false);
+        });
+
+        it('is marked as incomplete if shipping option is not provided', () => {
+            jest.spyOn(state.data, 'getShippingAddress')
+                .mockReturnValue(getShippingAddress());
+
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue(getCart());
+
+            jest.spyOn(state.data, 'getConsignments')
+                .mockReturnValue([{
+                    ...getConsignment(),
+                    selectedShippingOption: undefined,
+                }]);
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isComplete)
+                .toEqual(false);
+        });
+
+        it('is marked as incomplete if there are unassigned line items', () => {
+            jest.spyOn(state.data, 'getShippingAddress')
+                .mockReturnValue(getShippingAddress());
+
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue(getCart());
+
+            jest.spyOn(state.data, 'getConsignments')
+                .mockReturnValue([{
+                    ...getConsignment(),
+                    lineItemIds: [],
+                }]);
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isComplete)
+                .toEqual(false);
+        });
+
+        it('is marked as required if cart contains physical items', () => {
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue(getCart());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isRequired)
+                .toEqual(true);
+        });
+
+        it('is marked as not required if cart does not contain physical items', () => {
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue({
+                    ...getCart(),
+                    lineItems: {
+                        ...getCart().lineItems,
+                        physicalItems: [],
+                    },
+                });
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isRequired)
+                .toEqual(false);
+        });
+
+        it('is marked as not editable if cart does not contain physical items', () => {
+            jest.spyOn(state.data, 'getCustomer')
+                .mockReturnValue(getCustomer());
+
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue(getCart());
+
+            jest.spyOn(state.data, 'getConsignments')
+                .mockReturnValue([getConsignment()]);
+
+            jest.spyOn(state.data, 'getShippingAddress')
+                .mockReturnValue(getShippingAddress());
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Shipping })!.isEditable)
+                .toEqual(true);
+
+            // Mock new state
+            state = { ...state };
+
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue({
+                    ...getCart(),
+                    lineItems: {
+                        ...getCart().lineItems,
+                        physicalItems: [],
+                    },
+                });
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Shipping })!.isEditable)
+                .toEqual(false);
+        });
+
+        it('is marked as non-editable if step is incomplete', () => {
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isEditable)
+                .toEqual(false);
+        });
+    });
+
+    describe('payment step', () => {
+        it('is marked as complete if order is complete', () => {
+            jest.spyOn(state.data, 'getOrder')
+                .mockReturnValue(getOrder());
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Payment })!.isComplete)
+                .toEqual(true);
+        });
+
+        it('is marked as incomplete if order is incomplete', () => {
+            jest.spyOn(state.data, 'getOrder')
+                .mockReturnValue({
+                    ...getOrder(),
+                    isComplete: false,
+                });
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Payment })!.isComplete)
+                .toEqual(false);
+        });
+
+        it('is marked as non-editable if step is incomplete', () => {
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Payment })!.isEditable)
+                .toEqual(false);
+        });
+    });
+
+    it('returns steps in order', () => {
+        const steps = getCheckoutStepStatuses(state);
+
+        expect(steps.map(step => step.type))
+            .toEqual([
+                CheckoutStepType.Customer,
+                CheckoutStepType.Shipping,
+                CheckoutStepType.Billing,
+                CheckoutStepType.Payment,
+            ]);
+    });
+
+    it('marks latter steps as non-editable if earlier steps are incomplete', () => {
+        jest.spyOn(state.data, 'getShippingAddress')
+            .mockReturnValue(undefined);
+
+        jest.spyOn(state.data, 'getCart')
+            .mockReturnValue(getCart());
+
+        jest.spyOn(state.data, 'getConsignments')
+            .mockReturnValue([getConsignment()]);
+
+        const steps = getCheckoutStepStatuses(state);
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(find(steps, { type: CheckoutStepType.Billing })!.isEditable)
+            .toEqual(false);
+    });
+
+    it('does not mark latter steps as non-editable if earlier steps are complete', () => {
+        jest.spyOn(state.data, 'getBillingAddress')
+            .mockReturnValue(getBillingAddress());
+
+        jest.spyOn(state.data, 'getShippingAddress')
+            .mockReturnValue(getShippingAddress());
+
+        jest.spyOn(state.data, 'getCart')
+            .mockReturnValue(getCart());
+
+        jest.spyOn(state.data, 'getConsignments')
+            .mockReturnValue([getConsignment()]);
+
+        const steps = getCheckoutStepStatuses(state);
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(find(steps, { type: CheckoutStepType.Billing })!.isEditable)
+            .toEqual(true);
+    });
+
+    it('marks first incomplete step as active', () => {
+        const steps = getCheckoutStepStatuses(state);
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(find(steps, { type: CheckoutStepType.Customer })!.isActive)
+            .toEqual(true);
+    });
+
+    it('does not mark incomplete step as active if it is not required', () => {
+        jest.spyOn(state.data, 'getCustomer')
+            .mockReturnValue(getCustomer());
+
+        // If cart has physical items, shipping step should be active
+        jest.spyOn(state.data, 'getCart')
+            .mockReturnValue(getCart());
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Shipping })!.isActive)
+            .toEqual(true);
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Billing })!.isActive)
+            .toEqual(false);
+
+        // Mock a new state
+        state = { ...state };
+
+        // If cart has no physical item, shipping step shouldn't be active
+        jest.spyOn(state.data, 'getCart')
+            .mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [],
+                },
+            });
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Shipping })!.isActive)
+            .toEqual(false);
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Billing })!.isActive)
+            .toEqual(true);
+    });
+});

--- a/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/src/app/checkout/getCheckoutStepStatuses.ts
@@ -1,0 +1,124 @@
+import { CheckoutSelectors } from '@bigcommerce/checkout-sdk';
+import { compact } from 'lodash';
+import { createSelector } from 'reselect';
+
+import { isValidAddress } from '../address';
+import { EMPTY_ARRAY } from '../common/utility';
+import { SUPPORTED_METHODS } from '../customer/CheckoutButtonList';
+import { hasSelectedShippingOptions, hasUnassignedLineItems } from '../shipping';
+
+import CheckoutStepType from './CheckoutStepType';
+
+const getCustomerStepStatus = createSelector(
+    ({ data }: CheckoutSelectors) => data.getCheckout(),
+    ({ data }: CheckoutSelectors) => data.getCustomer(),
+    ({ data }: CheckoutSelectors) => data.getBillingAddress(),
+    (checkout, customer, billingAddress) => {
+        const hasEmail = !!(customer && customer.email || billingAddress && billingAddress.email);
+        const isUsingWallet = checkout && checkout.payments ? checkout.payments.some(payment => SUPPORTED_METHODS.indexOf(payment.providerId) >= 0) : false;
+        const isGuest = !!(customer && customer.isGuest);
+        const isComplete = hasEmail || isUsingWallet;
+
+        return {
+            type: CheckoutStepType.Customer,
+            isActive: false,
+            isComplete,
+            isEditable: isComplete && !isUsingWallet && isGuest,
+            isRequired: true,
+        };
+    }
+);
+
+const getBillingStepStatus = createSelector(
+    ({ data }: CheckoutSelectors) => data.getCheckout(),
+    ({ data }: CheckoutSelectors) => data.getBillingAddress(),
+    ({ data }: CheckoutSelectors) => {
+        const billingAddress = data.getBillingAddress();
+
+        return billingAddress ? data.getBillingAddressFields(billingAddress.countryCode) : EMPTY_ARRAY;
+    },
+    (checkout, billingAddress, billingAddressFields) => {
+        const hasAddress = billingAddress ? isValidAddress(billingAddress, billingAddressFields) : false;
+        const isUsingWallet = checkout && checkout.payments ? checkout.payments.some(payment => SUPPORTED_METHODS.indexOf(payment.providerId) >= 0) : false;
+        const isComplete = hasAddress || isUsingWallet;
+
+        return {
+            type: CheckoutStepType.Billing,
+            isActive: false,
+            isComplete,
+            isEditable: isComplete && !isUsingWallet,
+            isRequired: true,
+        };
+    }
+);
+
+const getShippingStepStatus = createSelector(
+    ({ data }: CheckoutSelectors) => data.getShippingAddress(),
+    ({ data }: CheckoutSelectors) => data.getConsignments(),
+    ({ data }: CheckoutSelectors) => data.getCart(),
+    ({ data }: CheckoutSelectors) => {
+        const shippingAddress = data.getShippingAddress();
+
+        return shippingAddress ? data.getShippingAddressFields(shippingAddress.countryCode) : EMPTY_ARRAY;
+    },
+    (shippingAddress, consignments, cart, shippingAddressFields) => {
+        const hasAddress = shippingAddress ? isValidAddress(shippingAddress, shippingAddressFields) : false;
+        const hasOptions = consignments ? hasSelectedShippingOptions(consignments) : false;
+        const hasUnassignedItems = cart && consignments ? hasUnassignedLineItems(consignments, cart.lineItems) : true;
+        const isComplete = hasAddress && hasOptions && !hasUnassignedItems;
+        const isRequired = cart ? cart.lineItems.physicalItems.some(lineItem => lineItem.isShippingRequired) : false;
+
+        return {
+            type: CheckoutStepType.Shipping,
+            isActive: false,
+            isComplete,
+            isEditable: isComplete && isRequired,
+            isRequired,
+        };
+    }
+);
+
+const getPaymentStepStatus = createSelector(
+    ({ data }: CheckoutSelectors) => data.getOrder(),
+    order => {
+        const isComplete = order ? order.isComplete : false;
+
+        return {
+            type: CheckoutStepType.Payment,
+            isActive: false,
+            isComplete,
+            isEditable: isComplete,
+            isRequired: true,
+        };
+    }
+);
+
+const getCheckoutStepStatuses = createSelector(
+    getCustomerStepStatus,
+    getShippingStepStatus,
+    getBillingStepStatus,
+    getPaymentStepStatus,
+    (customerStep, shippingStep, billingStep, paymentStep) => {
+        const steps = compact([
+            customerStep,
+            shippingStep,
+            billingStep,
+            paymentStep,
+        ]);
+
+        const defaultActiveStep = steps.find(step => !step.isComplete && step.isRequired) || steps[steps.length - 1];
+
+        return steps.map((step, index) => {
+            const isPrevStepComplete = steps.slice(0, index).every(prevStep => prevStep.isComplete || !prevStep.isRequired);
+
+            return {
+                ...step,
+                isActive: defaultActiveStep.type === step.type,
+                // A step is only editable if its previous step is complete or not required
+                isEditable: isPrevStepComplete && step.isEditable,
+            };
+        });
+    }
+);
+
+export default getCheckoutStepStatuses;


### PR DESCRIPTION
## What?
* Add `CheckoutStep` component, which is a container holding various controller components of checkout, i.e.: `Customer`, `Shipping`, `Billing`, and `Payment`. It is responsible for revealing and collapsing its content depending if it should be active or not.
* Add `getCheckoutStepStatuses` function, which is a selector function for determining the current status of a checkout step - whether it is complete or not etc... The result is used to determine how the steps should be rendered.

## Why?
These components and functions can help us build the checkout UI as a multi-step form.

## Testing / Proof
Unit

@bigcommerce/checkout
