### PR TITLE
 CHECKOUT-4223 Add shipping util functions

### DIFF
--- a/src/app/shipping/ShippableItem.ts
+++ b/src/app/shipping/ShippableItem.ts
@@ -1,0 +1,6 @@
+import { Consignment, PhysicalItem } from '@bigcommerce/checkout-sdk';
+
+export default interface ShippableItem extends PhysicalItem {
+    consignment?: Consignment;
+    key: string;
+}

--- a/src/app/shipping/index.ts
+++ b/src/app/shipping/index.ts
@@ -1,3 +1,5 @@
 export { default as hasUnassignedLineItems } from './util/hasUnassignedLineItems';
 export { default as isUsingMultiShipping } from './util/isUsingMultiShipping';
 export { default as hasSelectedShippingOptions } from './util/hasSelectedShippingOptions';
+export { default as getShippableLineItems } from './util/getShippableLineItems';
+export { default as getShippableItemsCount } from './util/getShippableItemsCount';

--- a/src/app/shipping/util/findConsignment.spec.ts
+++ b/src/app/shipping/util/findConsignment.spec.ts
@@ -1,0 +1,15 @@
+import { getConsignment } from '../consignment.mock';
+
+import findConsignment from './findConsignment';
+
+describe('findConsignment()', () => {
+    it('returns none if no match', () => {
+        expect(findConsignment([ getConsignment() ], '666'))
+            .toBeFalsy();
+    });
+
+    it('returns consignment if there is a match', () => {
+        expect(findConsignment([ getConsignment() ], getConsignment().lineItemIds[0]))
+            .toEqual(getConsignment());
+    });
+});

--- a/src/app/shipping/util/findConsignment.ts
+++ b/src/app/shipping/util/findConsignment.ts
@@ -1,0 +1,9 @@
+import { Consignment } from '@bigcommerce/checkout-sdk';
+import { find, includes } from 'lodash';
+
+export default function findConsignment(
+    consignments: Consignment[],
+    itemId: string
+): Consignment | undefined {
+    return find(consignments, consignment => includes(consignment.lineItemIds, itemId));
+}

--- a/src/app/shipping/util/findLineItems.spec.ts
+++ b/src/app/shipping/util/findLineItems.spec.ts
@@ -1,0 +1,26 @@
+import { getCart } from '../../cart/carts.mock';
+import { getPhysicalItem } from '../../cart/lineItem.mock';
+import { getConsignment } from '../consignment.mock';
+
+import findLineItems from './findLineItems';
+
+describe('findLineItems()', () => {
+    it('returns empty if couldnt find item', () => {
+        expect(findLineItems(
+            getCart(),
+            getConsignment()
+        ))
+            .toHaveLength(0);
+    });
+
+    it('returns physical item from cart when consignment line item id matches', () => {
+        expect(findLineItems(
+            getCart(),
+            {
+                ...getConsignment(),
+                lineItemIds: [ getPhysicalItem().id as string ],
+            }
+        ))
+            .toEqual([ getPhysicalItem() ]);
+    });
+});

--- a/src/app/shipping/util/findLineItems.ts
+++ b/src/app/shipping/util/findLineItems.ts
@@ -1,0 +1,14 @@
+import { Cart, Consignment, PhysicalItem } from '@bigcommerce/checkout-sdk';
+import { compact, find, map } from 'lodash';
+
+export default function findLineItems(
+    cart: Cart,
+    consignment: Consignment
+): PhysicalItem[] {
+    return compact(
+        map(
+            consignment.lineItemIds,
+            itemId => find(cart.lineItems.physicalItems , { id: itemId })
+        )
+    );
+}

--- a/src/app/shipping/util/getLineItemsCount.spec.ts
+++ b/src/app/shipping/util/getLineItemsCount.spec.ts
@@ -1,0 +1,18 @@
+import { getPhysicalItem } from '../../cart/lineItem.mock';
+
+import getLineItemsCount from './getLineItemsCount';
+
+describe('getLineItemsCount()', () => {
+    it('returns zero if empty array', () => {
+        expect(getLineItemsCount([]))
+            .toEqual(0);
+    });
+
+    it('returns the sum of quantities', () => {
+        expect(getLineItemsCount([
+            getPhysicalItem(),
+            getPhysicalItem(),
+        ]))
+            .toEqual(2);
+    });
+});

--- a/src/app/shipping/util/getLineItemsCount.ts
+++ b/src/app/shipping/util/getLineItemsCount.ts
@@ -1,0 +1,6 @@
+import { LineItem } from '@bigcommerce/checkout-sdk';
+import { reduce } from 'lodash';
+
+export default function getLineItemsCount(lineItems: LineItem[]): number {
+    return reduce(lineItems, (total, item) => total + item.quantity, 0);
+}

--- a/src/app/shipping/util/getRecommendedShippingOption.spec.ts
+++ b/src/app/shipping/util/getRecommendedShippingOption.spec.ts
@@ -1,0 +1,30 @@
+import { getConsignment } from '../consignment.mock';
+import { getShippingOption, getShippingOptionPickUpStore } from '../shippingOption/shippingMethod.mock';
+
+import getRecommendedShippingOption from './getRecommendedShippingOption';
+
+describe('getShippabgetRecommendedShippingOptioneLineItems()', () => {
+    it('returns falsy if it has a selected shipping option', () => {
+        expect(getRecommendedShippingOption(getConsignment()))
+            .toBeFalsy();
+    });
+
+    it('returns falsy if it has no recommended shipping options', () => {
+        expect(getRecommendedShippingOption({
+            ...getConsignment(),
+            availableShippingOptions: [
+                getShippingOptionPickUpStore(),
+            ],
+            selectedShippingOption: undefined,
+        }))
+            .toBeFalsy();
+    });
+
+    it('returns recommended shipping option when has no shipping option', () => {
+        expect(getRecommendedShippingOption({
+            ...getConsignment(),
+            selectedShippingOption: undefined,
+        }))
+            .toEqual(getShippingOption());
+    });
+});

--- a/src/app/shipping/util/getRecommendedShippingOption.ts
+++ b/src/app/shipping/util/getRecommendedShippingOption.ts
@@ -1,0 +1,12 @@
+import { Consignment, ShippingOption } from '@bigcommerce/checkout-sdk';
+
+export default function getRecommendedShippingOption(consignment: Consignment): ShippingOption | undefined {
+    if (consignment.selectedShippingOption ||
+        !consignment.availableShippingOptions ||
+        !consignment.availableShippingOptions.length
+    ) {
+        return;
+    }
+
+    return consignment.availableShippingOptions.find((option: { isRecommended: any }) => option.isRecommended);
+}

--- a/src/app/shipping/util/getShippableItemsCount.ts
+++ b/src/app/shipping/util/getShippableItemsCount.ts
@@ -1,0 +1,7 @@
+import { Cart } from '@bigcommerce/checkout-sdk';
+
+import getLineItemsCount from './getLineItemsCount';
+
+export default function getShippableItemsCount(cart: Cart): number {
+    return getLineItemsCount(cart.lineItems.physicalItems.filter(item => !item.addedByPromotion));
+}

--- a/src/app/shipping/util/getShippableLineItems.spec.ts
+++ b/src/app/shipping/util/getShippableLineItems.spec.ts
@@ -1,0 +1,91 @@
+import { getCart } from '../../cart/carts.mock';
+import { getDigitalItem, getGiftCertificateItem, getPhysicalItem } from '../../cart/lineItem.mock';
+import { getConsignment } from '../consignment.mock';
+
+import getShippableLineItems from './getShippableLineItems';
+
+describe('getShippableLineItems()', () => {
+    it('returns empty if only digital items', () => {
+        expect(getShippableLineItems({
+                ...getCart(),
+                lineItems: {
+                    digitalItems: [ getDigitalItem() ],
+                    physicalItems: [],
+                    giftCertificates: [],
+                },
+            }, []))
+            .toHaveLength(0);
+    });
+
+    it('returns empty if only gift certificates items', () => {
+        expect(getShippableLineItems({
+                ...getCart(),
+                lineItems: {
+                    digitalItems: [],
+                    physicalItems: [],
+                    giftCertificates: [ getGiftCertificateItem() ],
+                },
+            }, []))
+            .toHaveLength(0);
+    });
+
+    it('returns empty if only phyisical items added by promotions', () => {
+        expect(getShippableLineItems({
+                ...getCart(),
+                lineItems: {
+                    digitalItems: [],
+                    physicalItems: [ {
+                        ...getPhysicalItem(),
+                        addedByPromotion: true,
+                    }],
+                    giftCertificates: [],
+                },
+            }, []))
+            .toHaveLength(0);
+    });
+
+    it('splits physical items quantities', () => {
+        const items = getShippableLineItems({
+                ...getCart(),
+                lineItems: {
+                    digitalItems: [],
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 2,
+                        },
+                    ],
+                    giftCertificates: [],
+                },
+            }, []);
+
+        expect(items).toHaveLength(2);
+        expect(items[0]).toMatchObject(expect.objectContaining(getPhysicalItem()));
+        expect(items[1]).toMatchObject(expect.objectContaining(getPhysicalItem()));
+    });
+
+    it('adds consignment information when available', () => {
+        const consignment = {
+            ...getConsignment(),
+            lineItemIds: [ getPhysicalItem().id as string ],
+        };
+
+        const items = getShippableLineItems({
+                ...getCart(),
+                lineItems: {
+                    digitalItems: [],
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 2,
+                        },
+                    ],
+                    giftCertificates: [],
+                },
+            }, [
+                consignment,
+            ]);
+
+        expect(items[0].consignment).toMatchObject(expect.objectContaining(consignment));
+    });
+});

--- a/src/app/shipping/util/getShippableLineItems.ts
+++ b/src/app/shipping/util/getShippableLineItems.ts
@@ -1,0 +1,41 @@
+import { Cart, Consignment, PhysicalItem } from '@bigcommerce/checkout-sdk';
+import { reduce } from 'lodash';
+
+import ShippableItem from '../ShippableItem';
+
+import findConsignment from './findConsignment';
+
+export default function getShippableLineItems(
+    cart: Cart,
+    consignments: Consignment[]
+): ShippableItem[] {
+    return reduce(
+        (cart && cart.lineItems.physicalItems) || [],
+        (result, item, i) => (
+            !item.addedByPromotion ?
+                result.concat(...splitItem(item, consignments, i)) :
+                result
+        ),
+        [] as ShippableItem[]
+    );
+}
+
+function splitItem(
+    item: PhysicalItem,
+    consignments: Consignment[],
+    lineItemIndex: number
+): ShippableItem[] {
+    let splitItems: ShippableItem[] = [];
+    const consignment = findConsignment(consignments, item.id as string);
+
+    for (let i = 0; i < item.quantity; i++) {
+        splitItems = splitItems.concat({
+            ...item,
+            key: `${item.variantId}-${item.productId}-${lineItemIndex}-${i}`,
+            consignment,
+            quantity: 1,
+        });
+    }
+
+    return splitItems;
+}

--- a/src/app/shipping/util/updateShippableItems.spec.ts
+++ b/src/app/shipping/util/updateShippableItems.spec.ts
@@ -1,0 +1,313 @@
+import { Cart, Consignment } from '@bigcommerce/checkout-sdk';
+
+import { getAddress } from '../../address/address.mock';
+import { getCart } from '../../cart/carts.mock';
+import { getPhysicalItem } from '../../cart/lineItem.mock';
+import { getConsignment } from '../consignment.mock';
+
+import getShippableLineItems from './getShippableLineItems';
+import updateShippableItems from './updateShippableItems';
+
+describe('updateShippableItems()', () => {
+    let cart: Cart = {
+        ...getCart(),
+        lineItems: {
+            ...getCart().lineItems,
+            physicalItems: [
+                {
+                    ...getPhysicalItem(),
+                    quantity: 3,
+                    id: 'foo',
+                },
+            ],
+        },
+    };
+
+    let consignments: Consignment[];
+
+    it('returns undefined when invalid index', () => {
+        expect(updateShippableItems(
+            getShippableLineItems(cart, []),
+            { address: getAddress(), updatedItemIndex: -1 },
+            { cart: undefined, consignments: [] }
+        )).toBeFalsy();
+
+        expect(updateShippableItems(
+            getShippableLineItems(cart, []),
+            { address: getAddress(), updatedItemIndex: 3 },
+            { cart: undefined, consignments: [] }
+        )).toBeFalsy();
+    });
+
+    it('returns undefined when no cart index', () => {
+        expect(updateShippableItems(
+            getShippableLineItems(cart, []),
+            { address: getAddress(), updatedItemIndex: 0 },
+            { cart: undefined, consignments: [] }
+        )).toBeFalsy();
+    });
+
+    it('updates all items when no consignments', () => {
+        const shippableItems = getShippableLineItems(cart, []);
+        const updatedShippableItems = updateShippableItems(
+            shippableItems,
+            { address: getAddress(), updatedItemIndex: 1 },
+            { cart, consignments: [] }
+        );
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(updatedShippableItems![0].consignment).toBeFalsy();
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(updatedShippableItems![1].consignment).toBeFalsy();
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(updatedShippableItems![2].consignment).toBeFalsy();
+    });
+
+    describe('when item is not split', () => {
+        beforeEach(() => {
+            consignments = [{
+                ...getConsignment(),
+                shippingAddress: getAddress(),
+                lineItemIds: ['bar'],
+            }];
+        });
+
+        it('updates all items when no consignments', () => {
+            const shippableItems = getShippableLineItems(cart, []);
+            const updatedShippableItems = updateShippableItems(
+                shippableItems,
+                { address: getAddress(), updatedItemIndex: 1 },
+                { cart, consignments: [] }
+            );
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![0].consignment).toBeFalsy();
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![1].consignment).toBeFalsy();
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![2].consignment).toBeFalsy();
+        });
+
+        it('updates specific item when a line item gets split', () => {
+            const shippableItems = getShippableLineItems(cart, []);
+            const updatedShippableItems = updateShippableItems(
+                shippableItems,
+                {
+                    address: getAddress(),
+                    updatedItemIndex: 1,
+                },
+                {
+                    cart: {
+                        ...cart,
+                        lineItems: {
+                            ...cart.lineItems,
+                            physicalItems: [
+                                {
+                                    ...cart.lineItems.physicalItems[0],
+                                    id: 'foo',
+                                    quantity: 1,
+                                },
+                                {
+                                    ...cart.lineItems.physicalItems[0],
+                                    id: 'bar',
+                                    quantity: 1,
+                                },
+                            ],
+                        },
+                    },
+                    consignments,
+                }
+            );
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![0]).toEqual(shippableItems[0]);
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![0]).not.toBe(shippableItems[0]);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![2]).toEqual(shippableItems[2]);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![1]).toMatchObject({
+                consignment: consignments[0],
+                id: 'bar',
+            });
+        });
+    });
+
+    describe('when item is split', () => {
+        beforeEach(() => {
+            cart = {
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 2,
+                            id: 'foo',
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 1,
+                            id: 'bar',
+                        },
+                    ],
+                },
+            };
+
+            consignments = [
+                {
+                    ...getConsignment(),
+                    shippingAddress: getAddress(),
+                    lineItemIds: ['foo'],
+                },
+                {
+                    ...getConsignment(),
+                    shippingAddress: {
+                        ...getAddress(),
+                        address1: 'x',
+                    },
+                    lineItemIds: ['bar'],
+                },
+            ];
+        });
+
+        it('updates other item when a line item gets merged back keeping its id', () => {
+            cart.lineItems.physicalItems[0].quantity = 1;
+            const shippableItems = getShippableLineItems(cart, consignments);
+            const updatedItemIndex = shippableItems.findIndex(item => item.id === 'bar');
+
+            const updatedShippableItems = updateShippableItems(
+                shippableItems,
+                {
+                    address: getAddress(),
+                    updatedItemIndex,
+                },
+                {
+                    cart: {
+                        ...cart,
+                        lineItems: {
+                            ...cart.lineItems,
+                            physicalItems: [
+                                {
+                                    ...cart.lineItems.physicalItems[0],
+                                    id: 'bar',
+                                    quantity: 2,
+                                },
+                            ],
+                        },
+                    },
+                    consignments: [
+                        {
+                            ...getConsignment(),
+                            shippingAddress: getAddress(),
+                            lineItemIds: ['bar'],
+                        },
+                    ],
+                }
+            );
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![0]).toMatchObject({
+                consignment: {
+                    ...consignments[0],
+                    lineItemIds: ['bar'],
+                },
+                id: 'bar',
+            });
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![1]).toMatchObject({
+                consignment: {
+                    ...consignments[0],
+                    lineItemIds: ['bar'],
+                },
+                id: 'bar',
+            });
+        });
+
+        it('updates specific item when a line item gets merged back', () => {
+            const shippableItems = getShippableLineItems(cart, consignments);
+            const updatedItemIndex = shippableItems.findIndex(item => item.id === 'bar');
+
+            const updatedShippableItems = updateShippableItems(
+                shippableItems,
+                {
+                    address: getAddress(),
+                    updatedItemIndex,
+                },
+                {
+                    cart: {
+                        ...cart,
+                        lineItems: {
+                            ...cart.lineItems,
+                            physicalItems: [
+                                {
+                                    ...cart.lineItems.physicalItems[0],
+                                    id: 'foo',
+                                    quantity: 3,
+                                },
+                            ],
+                        },
+                    },
+                    consignments: [
+                        {
+                            ...getConsignment(),
+                            shippingAddress: getAddress(),
+                            lineItemIds: ['foo'],
+                        },
+                    ],
+                }
+            );
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![updatedItemIndex]).toMatchObject({
+                consignment: consignments[0],
+                id: 'foo',
+            });
+        });
+
+        it('updates specific item id and consignment when a line item gets moved', () => {
+            const shippableItems = getShippableLineItems(cart, consignments);
+            const updatedItemIndex = shippableItems.findIndex(item => item.id === 'foo');
+            const updatedShippableItems = updateShippableItems(
+                shippableItems,
+                {
+                    address: {
+                        ...getAddress(),
+                        address1: 'x',
+                    },
+                    updatedItemIndex,
+                },
+                {
+                    cart: {
+                        ...cart,
+                        lineItems: {
+                            ...cart.lineItems,
+                            physicalItems: [
+                                {
+                                    ...cart.lineItems.physicalItems[0],
+                                    id: 'foo',
+                                    quantity: 1,
+                                },
+                                {
+                                    ...cart.lineItems.physicalItems[0],
+                                    id: 'bar',
+                                    quantity: 2,
+                                },
+                            ],
+                        },
+                    },
+                    consignments,
+                }
+            );
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(updatedShippableItems![updatedItemIndex]).toMatchObject({
+                consignment: consignments[1],
+                id: 'bar',
+            });
+        });
+    });
+});

--- a/src/app/shipping/util/updateShippableItems.ts
+++ b/src/app/shipping/util/updateShippableItems.ts
@@ -1,0 +1,58 @@
+import { Address, Cart, Consignment } from '@bigcommerce/checkout-sdk';
+
+import { isEqualAddress } from '../../address';
+import ShippableItem from '../ShippableItem';
+
+import findConsignment from './findConsignment';
+
+export interface UpdateItemParams {
+    updatedItemIndex: number;
+    address: Address;
+}
+
+export default function updateShippableItems(
+    items: ShippableItem[],
+    { updatedItemIndex, address }: UpdateItemParams,
+    { cart, consignments }: { cart?: Cart; consignments?: Consignment[] }
+): ShippableItem[] | undefined {
+    if (updatedItemIndex < 0 || updatedItemIndex >= items.length || !cart) {
+        return;
+    }
+
+    const cartItemIds = cart.lineItems.physicalItems.map(({ id }) => id);
+
+    const updatedConsignment = (consignments || []).find(consignment =>
+        isEqualAddress(consignment.shippingAddress, address)
+    );
+
+    const newId = findNewItemId(items[updatedItemIndex], cart, updatedConsignment);
+    const updatedItems: ShippableItem[] = [];
+
+    items.forEach((item, i) => {
+        const id = newId && (i === updatedItemIndex || !cartItemIds.includes(item.id)) ?
+            newId : item.id;
+
+        updatedItems[i] = {
+            ...item,
+            id,
+            consignment: findConsignment(consignments || [], id  as string),
+        };
+    });
+
+    return updatedItems;
+}
+
+function findNewItemId(item: ShippableItem, cart?: Cart, consignment?: Consignment): string | undefined {
+    if (!cart || !consignment) {
+        return;
+    }
+
+    const { physicalItems } = cart.lineItems;
+    const matchingCartItems = physicalItems.filter(
+        ({ productId, variantId }) => productId === item.productId && variantId === item.variantId
+    );
+
+    const matchingCartItemIds = matchingCartItems.map(({ id }) => id);
+
+    return consignment.lineItemIds.find(id => matchingCartItemIds.includes(id));
+}


### PR DESCRIPTION
## What?
Add shipping util functions.

## Why?
So we know if they are shippable items in a cart, and find consignments given item ids.

## Testing / Proof
unit

@bigcommerce/checkout
