### PR TITLE
CHECKOUT-4223 Add OrderComments component

### DIFF
--- a/src/app/orderComments/OrderComments.tsx
+++ b/src/app/orderComments/OrderComments.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../language';
+import { Fieldset, FormField, Label, Legend, TextInput } from '../ui/form';
+
+const OrderComments: FunctionComponent = () => (
+    <Fieldset testId="checkout-shipping-comments"
+        legend={
+            <Legend>
+                <TranslatedString id="shipping.order_comment_label" />
+            </Legend>
+        }
+    >
+        <FormField
+            name="orderComment"
+            label={ name => (
+                <Label hidden htmlFor={ name }>
+                    <TranslatedString id="shipping.order_comment_label" />
+                </Label>
+            ) }
+            input={ ({ field }) => (
+                <TextInput
+                    { ...field }
+                    maxLength={ 2000 }
+                    autoComplete={'off'}
+                />
+            )}
+        />
+    </Fieldset>
+);
+
+export default OrderComments;

--- a/src/app/orderComments/index.ts
+++ b/src/app/orderComments/index.ts
@@ -1,0 +1,1 @@
+export { default as OrderComments } from './OrderComments';


### PR DESCRIPTION
## What?
Adds `OrderComments` component

## Why?
So customers can enter additional order comments.

## Testing / Proof
To be tested as part of billing and shipping form

@bigcommerce/checkout
