### PR TITLE
CHECKOUT-4223 Add Billing components

### DIFF
--- a/src/app/billing/Billing.spec.tsx
+++ b/src/app/billing/Billing.spec.tsx
@@ -1,0 +1,190 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService, LineItemMap } from '@bigcommerce/checkout-sdk';
+import { mount, ReactWrapper } from 'enzyme';
+import React, { FunctionComponent } from 'react';
+
+import { getFormFields } from '../address/formField.mock';
+import { getCart } from '../cart/carts.mock';
+import { CheckoutProvider } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getCountries } from '../geography/countries.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+import { OrderComments } from '../orderComments';
+
+import { getBillingAddress } from './billingAddresses.mock';
+import Billing, { BillingProps } from './Billing';
+import BillingForm from './BillingForm';
+
+describe('Billing Component', () => {
+    let component: ReactWrapper;
+    let checkoutService: CheckoutService;
+    let localeContext: LocaleContextType;
+    let defaultProps: BillingProps;
+    let ComponentTest: FunctionComponent<BillingProps>;
+    const billingAddress = {
+        ...getBillingAddress(),
+        firstName: 'foo',
+    };
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        checkoutService = createCheckoutService();
+        defaultProps = {
+            navigateNextStep: jest.fn(),
+            onReady: jest.fn(),
+            onUnhandledError: jest.fn(),
+        };
+
+        jest.spyOn(checkoutService.getState().data, 'getBillingAddressFields')
+            .mockReturnValue(getFormFields());
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutService.getState().data, 'getCart')
+            .mockReturnValue(getCart());
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout')
+            .mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutService.getState().data, 'getCustomer')
+            .mockReturnValue(getCustomer());
+
+        jest.spyOn(checkoutService.getState().data, 'getBillingCountries')
+            .mockReturnValue(getCountries());
+
+        jest.spyOn(checkoutService.getState().statuses, 'isUpdatingBillingAddress')
+            .mockReturnValue(false);
+
+        jest.spyOn(checkoutService.getState().data, 'getBillingAddress')
+            .mockReturnValue(billingAddress);
+
+        jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue({} as CheckoutSelectors);
+        jest.spyOn(checkoutService, 'updateCheckout').mockResolvedValue({} as CheckoutSelectors);
+        jest.spyOn(checkoutService, 'loadBillingAddressFields').mockResolvedValue({} as CheckoutSelectors);
+
+        ComponentTest = props => (
+            <CheckoutProvider checkoutService={ checkoutService } >
+                <LocaleContext.Provider value={ localeContext }>
+                    <Billing { ...props } />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    beforeEach(async () => {
+        component = mount(<ComponentTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+    });
+
+    it('loads billing fields', () => {
+        expect(checkoutService.loadBillingAddressFields).toHaveBeenCalled();
+    });
+
+    it('triggers callback when billing fields are loaded', () => {
+        expect(defaultProps.onReady).toHaveBeenCalled();
+    });
+
+    it('renders header', () => {
+        expect(component.find('[data-test="billing-address-heading"]').text())
+            .toEqual('Billing Address');
+    });
+
+    it('does not render order comments when there are physical items', () => {
+        expect(component.find(OrderComments).length)
+            .toEqual(0);
+    });
+
+    it('renders order comments when there are no physical items', () => {
+        jest.spyOn(checkoutService.getState().data, 'getCart')
+            .mockReturnValue({
+                ...getCart(),
+                lineItems: { physicalItems: [] } as unknown as LineItemMap,
+            });
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+
+        expect(component.find(OrderComments).length)
+            .toEqual(1);
+    });
+
+    it('updates order comment when input value does not match state value', async () => {
+        jest.spyOn(checkoutService.getState().data, 'getCart')
+            .mockReturnValue({
+                ...getCart(),
+                lineItems: { physicalItems: [] } as unknown as LineItemMap,
+            });
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+
+        component.find('input[name="orderComment"]')
+                .simulate('change', { target: { value: 'foo', name: 'orderComment' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.updateCheckout).toHaveBeenCalledWith({ customerMessage: 'foo' });
+        expect(defaultProps.navigateNextStep).toHaveBeenCalled();
+    });
+
+    it('does not render BillingForm while loading billing countries', () => {
+        jest.spyOn(checkoutService.getState().statuses, 'isLoadingBillingCountries')
+            .mockReturnValue(true);
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+
+        expect(component.find(BillingForm).length)
+            .toEqual(0);
+    });
+
+    it('renders BillingForm with expected props', () => {
+        expect(component.find(BillingForm).props())
+            .toEqual(expect.objectContaining({
+                billingAddress,
+                customer: getCustomer(),
+                countries: getCountries(),
+            }));
+    });
+
+    it('calls updateBillingAddress and navigateNextStep when form is submitted and valid', async () => {
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.updateBillingAddress).toHaveBeenCalledWith({
+            address1: '12345 Testing Way',
+            address2: '',
+            customFields: [
+                { fieldId: 'field_25', fieldValue: '' },
+                { fieldId: 'field_27', fieldValue: '' },
+                { fieldId: 'field_31', fieldValue: '' },
+            ],
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+            firstName: 'foo',
+            lastName: 'Tester',
+        });
+
+        expect(defaultProps.navigateNextStep).toHaveBeenCalled();
+    });
+
+    it('calls unhandled error handler when there is error that is not handled by component', async () => {
+        const error = new Error();
+
+        jest.spyOn(checkoutService, 'updateBillingAddress')
+            .mockRejectedValue(error);
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(defaultProps.onUnhandledError)
+            .toHaveBeenCalledWith(error);
+    });
+});

--- a/src/app/billing/Billing.tsx
+++ b/src/app/billing/Billing.tsx
@@ -1,0 +1,171 @@
+import { Address, CheckoutRequestBody, CheckoutSelectors, Country, Customer, FormField } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+
+import { isEqualAddress, mapAddressFromFormValues } from '../address';
+import { withCheckout, CheckoutContextProps } from '../checkout';
+import { EMPTY_ARRAY } from '../common/utility';
+import { TranslatedString } from '../language';
+import { getShippableItemsCount } from '../shipping';
+import { Legend } from '../ui/form';
+import { LoadingOverlay } from '../ui/loading';
+
+import BillingForm, { BillingFormValues } from './BillingForm';
+
+export interface BillingProps {
+    navigateNextStep(): void;
+    onReady?(): void;
+    onUnhandledError(error: Error): void;
+}
+
+export interface WithCheckoutBillingProps {
+    billingAddress?: Address;
+    countries: Country[];
+    countriesWithAutocomplete: string[];
+    customer: Customer;
+    customerMessage: string;
+    googleMapsApiKey: string;
+    isInitializing: boolean;
+    shouldShowOrderComments: boolean;
+    getFields(countryCode?: string): FormField[];
+    initialize(): Promise<CheckoutSelectors>;
+    updateAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+    updateCheckout(payload: CheckoutRequestBody): Promise<CheckoutSelectors>;
+}
+
+class Billing extends Component<BillingProps & WithCheckoutBillingProps> {
+    async componentDidMount(): Promise<void> {
+        const {
+            initialize,
+            onReady = noop,
+            onUnhandledError,
+        } = this.props;
+
+        try {
+            await initialize();
+            onReady();
+        } catch (e) {
+            onUnhandledError(e);
+        }
+    }
+
+    render(): ReactNode {
+        const {
+            updateAddress,
+            isInitializing,
+            ...props
+        } = this.props;
+
+        return (
+            <div className="checkout-form">
+                <div className="form-legend-container">
+                    <Legend testId="billing-address-heading">
+                        <TranslatedString id="billing.billing_address_heading" />
+                    </Legend>
+                </div>
+
+                <LoadingOverlay
+                    unmountContentWhenLoading
+                    isLoading={ isInitializing }
+                >
+                    <BillingForm
+                        { ...props }
+                        updateAddress={ updateAddress }
+                        onSubmit={ this.handleSubmit }
+                    />
+                </LoadingOverlay>
+            </div>
+        );
+    }
+
+    private handleSubmit: (values: BillingFormValues) => void = async ({
+        orderComment,
+        ...addressValues
+    }) => {
+        const {
+            updateAddress,
+            updateCheckout,
+            customerMessage,
+            billingAddress,
+            navigateNextStep,
+            onUnhandledError,
+        } = this.props;
+
+        const promises: Array<Promise<CheckoutSelectors>> = [];
+        const address = mapAddressFromFormValues(addressValues);
+
+        if (address && !isEqualAddress(address, billingAddress)) {
+            promises.push(updateAddress(address));
+        }
+
+        if (customerMessage !== orderComment) {
+            promises.push(updateCheckout({ customerMessage: orderComment }));
+        }
+
+        try {
+            await Promise.all(promises);
+
+            navigateNextStep();
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    };
+}
+
+function mapToBillingProps({
+    checkoutService,
+    checkoutState,
+}: CheckoutContextProps): WithCheckoutBillingProps | null {
+    const {
+        data: {
+            getCheckout,
+            getConfig,
+            getCart,
+            getCustomer,
+            getBillingAddress,
+            getBillingAddressFields,
+            getBillingCountries,
+        },
+        statuses: {
+            isLoadingBillingCountries,
+        },
+    } = checkoutState;
+
+    const config = getConfig();
+    const customer = getCustomer();
+    const checkout = getCheckout();
+    const cart = getCart();
+
+    if (!config || !customer || !checkout || !cart) {
+        return null;
+    }
+
+    const {
+        enableOrderComments,
+        googleMapsApiKey,
+        features,
+    } = config.checkoutSettings;
+
+    const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ'];
+
+    if (features['CHECKOUT-4183.checkout_google_address_autocomplete_uk']) {
+        countriesWithAutocomplete.push('GB');
+    }
+
+    return {
+        billingAddress: getBillingAddress(),
+        countries: getBillingCountries() || EMPTY_ARRAY,
+        countriesWithAutocomplete,
+        customer,
+        customerMessage: checkout.customerMessage,
+        getFields: getBillingAddressFields,
+        googleMapsApiKey,
+        initialize: checkoutService.loadBillingAddressFields,
+        isInitializing: isLoadingBillingCountries(),
+        shouldShowOrderComments: enableOrderComments && getShippableItemsCount(cart) < 1,
+        updateAddress: checkoutService.updateBillingAddress,
+        updateCheckout: checkoutService.updateCheckout,
+    };
+}
+
+export default withCheckout(mapToBillingProps)(Billing);

--- a/src/app/billing/BillingForm.spec.tsx
+++ b/src/app/billing/BillingForm.spec.tsx
@@ -1,0 +1,125 @@
+import { mount, ReactWrapper } from 'enzyme';
+import React from 'react';
+
+import { AddressForm, AddressSelect } from '../address';
+import { getFormFields } from '../address/formField.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getCountries } from '../geography/countries.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+
+import { getBillingAddress } from './billingAddresses.mock';
+import BillingForm, { BillingFormProps } from './BillingForm';
+
+describe('BillingForm Component', () => {
+    let component: ReactWrapper;
+    let localeContext: LocaleContextType;
+    let defaultProps: BillingFormProps;
+    const billingAddress = {
+        ...getBillingAddress(),
+        firstName: 'foo',
+    };
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        defaultProps = {
+            billingAddress,
+            countriesWithAutocomplete: [],
+            shouldShowOrderComments: false,
+            customerMessage: '',
+            customer: getCustomer(),
+            countries: getCountries(),
+            googleMapsApiKey: 'key',
+            getFields: () => getFormFields(),
+            onUnhandledError: jest.fn(),
+            updateAddress: jest.fn(),
+            onSubmit: jest.fn(),
+        };
+    });
+
+    beforeEach(() => {
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <BillingForm { ...defaultProps } />
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('renders form with expected id', () => {
+        expect(component.find('fieldset#checkoutBillingAddress').length).toEqual(1);
+    });
+
+    it('renders addresses', () => {
+        expect(component.find('fieldset#billingAddresses').length).toEqual(1);
+        expect(component.find(AddressSelect).props()).toEqual(expect.objectContaining({
+            addresses: getCustomer().addresses,
+        }));
+    });
+
+    it('does not render address form when selected customer address is valid', () => {
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <BillingForm { ...defaultProps }
+                    billingAddress={ defaultProps.customer.addresses[0] }
+                />
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find(AddressForm).length).toEqual(0);
+    });
+
+    it('renders address form when selected customer address is not valid', () => {
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <BillingForm { ...defaultProps }
+                    billingAddress={ {
+                        ...defaultProps.customer.addresses[0],
+                        address1: '',
+                    } }
+                />
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find(AddressForm).length).toEqual(1);
+    });
+
+    it('renders address form', () => {
+        expect(component.find(AddressForm).props()).toEqual(expect.objectContaining({
+            countries: getCountries(),
+        }));
+    });
+
+    it('calls handle submit when form is submitted and valid', async () => {
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(defaultProps.onSubmit).toHaveBeenCalledWith({
+            address1: '12345 Testing Way',
+            address2: '',
+            customFields: {
+                field_25: '',
+                field_27: '',
+                field_31: '',
+            },
+            orderComment: '',
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+            firstName: 'foo',
+            lastName: 'Tester',
+        });
+    });
+
+    it('calls does not call handle submit when form is submitted and invalid', async () => {
+        component.find('input#firstNameInput')
+            .simulate('change', { target: { value: '', name: 'firstName' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    });
+});

--- a/src/app/billing/BillingForm.tsx
+++ b/src/app/billing/BillingForm.tsx
@@ -1,0 +1,158 @@
+import { Address, CheckoutSelectors, Country, Customer, FormField } from '@bigcommerce/checkout-sdk';
+import { withFormik, FormikProps } from 'formik';
+import React, { createRef, Component, ReactNode, RefObject } from 'react';
+import { lazy } from 'yup';
+
+import { getAddressValidationSchema, isValidCustomerAddress, mapAddressToFormValues, AddressForm, AddressFormValues, AddressSelect } from '../address';
+import { TranslatedString } from '../language';
+import { withLanguage, WithLanguageProps } from '../locale';
+import { OrderComments } from '../orderComments';
+import { Button, ButtonVariant } from '../ui/button';
+import { Fieldset, Form } from '../ui/form';
+import { LoadingOverlay } from '../ui/loading';
+
+export type BillingFormValues = AddressFormValues & { orderComment: string };
+
+export interface BillingFormProps {
+    billingAddress?: Address;
+    customer: Customer;
+    customerMessage: string;
+    countries: Country[];
+    countriesWithAutocomplete: string[];
+    googleMapsApiKey: string;
+    shouldShowOrderComments: boolean;
+    getFields(countryCode?: string): FormField[];
+    onUnhandledError(error: Error): void;
+    updateAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+    onSubmit(values: BillingFormValues): void;
+}
+
+interface BillingFormState {
+    isResettingAddress: boolean;
+}
+
+class BillingForm extends Component<BillingFormProps & WithLanguageProps & FormikProps<BillingFormValues>, BillingFormState> {
+    state: BillingFormState = {
+        isResettingAddress: false,
+    };
+
+    private addressFormRef: RefObject<HTMLFieldSetElement> = createRef();
+
+    render(): ReactNode {
+        const {
+            googleMapsApiKey,
+            billingAddress,
+            countriesWithAutocomplete,
+            customer: { addresses },
+            getFields,
+            countries,
+            setFieldValue,
+            shouldShowOrderComments,
+            values,
+        } = this.props;
+
+        const { isResettingAddress } = this.state;
+        const hasAddresses = addresses && addresses.length > 0;
+        const hasValidCustomerAddress = billingAddress &&
+            isValidCustomerAddress(billingAddress, addresses, getFields(billingAddress.countryCode));
+
+        return (
+            <Form autoComplete="on">
+                <Fieldset ref={ this.addressFormRef } id="checkoutBillingAddress">
+                    { hasAddresses &&
+                        <Fieldset id="billingAddresses">
+                            <LoadingOverlay isLoading={ isResettingAddress }>
+                                <AddressSelect
+                                    addresses={ addresses }
+                                    selectedAddress={ hasValidCustomerAddress ? billingAddress : undefined }
+                                    onUseNewAddress={ () => this.onSelectAddress({}) }
+                                    onSelectAddress={ this.onSelectAddress }
+                                />
+                            </LoadingOverlay>
+                        </Fieldset>
+                    }
+
+                    { !hasValidCustomerAddress &&
+                        <LoadingOverlay isLoading={ isResettingAddress }>
+                            <AddressForm
+                                countries={ countries }
+                                countriesWithAutocomplete={ countriesWithAutocomplete }
+                                setFieldValue={ setFieldValue }
+                                googleMapsApiKey={ googleMapsApiKey }
+                                countryCode={ values.countryCode }
+                                formFields={ getFields(values.countryCode) }
+                            />
+                        </LoadingOverlay>
+                    }
+                </Fieldset>
+
+                { shouldShowOrderComments &&
+                    <OrderComments />
+                }
+
+                <div className="form-actions">
+                    <Button
+                        variant={ ButtonVariant.Primary }
+                        isLoading={ isResettingAddress }
+                        disabled={ isResettingAddress }
+                        id="checkout-billing-continue"
+                        type="submit"
+                    >
+                        <TranslatedString id="common.continue_action" />
+                    </Button>
+                </div>
+            </Form>
+        );
+    }
+
+    private onSelectAddress: (address: Partial<Address>) => void = async address => {
+        const {
+            updateAddress,
+            onUnhandledError,
+        } = this.props;
+
+        this.setState({ isResettingAddress: true });
+
+        try {
+            await updateAddress(address);
+        } catch (e) {
+            onUnhandledError(e);
+        } finally {
+            this.setState({ isResettingAddress: false });
+        }
+    };
+}
+
+export default withLanguage(withFormik<BillingFormProps & WithLanguageProps, BillingFormValues>({
+    handleSubmit: (values, { props: { onSubmit } }) => {
+        onSubmit(values);
+    },
+    mapPropsToValues: ({ getFields, customerMessage, billingAddress }) => (
+        {
+        ...mapAddressToFormValues(
+            getFields(billingAddress && billingAddress.countryCode),
+            billingAddress
+        ),
+        orderComment: customerMessage,
+    }),
+    isInitialValid: ({
+        billingAddress,
+        getFields,
+        language,
+    }) => (
+        !!billingAddress && getAddressValidationSchema({
+            language,
+            formFields: getFields(billingAddress.countryCode),
+        }).isValidSync(billingAddress)
+    ),
+    validationSchema: ({
+        language,
+        getFields,
+    }: BillingFormProps & WithLanguageProps) => (
+        lazy<Partial<AddressFormValues>>(values => getAddressValidationSchema({
+            language,
+            formFields: getFields(values && values.countryCode),
+        }))
+    ),
+    enableReinitialize: true,
+})(BillingForm));

--- a/src/app/billing/index.ts
+++ b/src/app/billing/index.ts
@@ -1,0 +1,5 @@
+import { BillingProps } from './Billing';
+
+export type BillingProps = BillingProps;
+
+export { default as Billing } from './Billing';


### PR DESCRIPTION
## What?
Adds `Billing` component

## Why?
In order to capture billing information during checkout

## Testing / Proof
unit

requires https://github.com/bigcommerce/checkout-js/pull/49 https://github.com/bigcommerce/checkout-js/pull/50

@bigcommerce/checkout
