### PR TITLE
CHECKOUT-4223 Add Shipping form

### DIFF
--- a/src/app/common/hoc/createMappableInjectHoc.tsx
+++ b/src/app/common/hoc/createMappableInjectHoc.tsx
@@ -36,7 +36,7 @@ export default function createMappableInjectHoc<TContextProps>(
                 </ContextComponent.Consumer>
             );
 
-            if (options && options.displayNamePrefix) {
+            if (options && options.displayNamePrefix && OriginalComponent) {
                 DecoratedComponent.displayName = `${options.displayNamePrefix}(${OriginalComponent.displayName || OriginalComponent.name})`;
             }
 

--- a/src/app/shipping/ItemAddressSelect.spec.tsx
+++ b/src/app/shipping/ItemAddressSelect.spec.tsx
@@ -1,0 +1,39 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { AddressSelect } from '../address';
+import { getPhysicalItem } from '../cart/lineItem.mock';
+import { getCustomer } from '../customer/customers.mock';
+
+import { getConsignment } from './consignment.mock';
+import ItemAddressSelect, { ItemAddressSelectProps } from './ItemAddressSelect';
+
+describe('ItemAddressSelect Component', () => {
+    const defaultProps: ItemAddressSelectProps = {
+        item: {
+            ...getPhysicalItem(),
+            consignment: getConsignment(),
+            key: 'x',
+        },
+        addresses: getCustomer().addresses,
+        onSelectAddress: jest.fn(),
+        onUseNewAddress: jest.fn(),
+    };
+
+    it('renders product options', () => {
+        const component = shallow(<ItemAddressSelect { ...defaultProps } />);
+
+        expect(component.find('[data-test="consigment-item-product-options"]').length)
+            .toEqual(1);
+    });
+
+    it('renders address select with expected props', () => {
+        const component = shallow(<ItemAddressSelect { ...defaultProps } />);
+
+        expect(component.find(AddressSelect).prop('addresses'))
+            .toEqual(getCustomer().addresses);
+
+        expect(component.find(AddressSelect).prop('selectedAddress'))
+            .toEqual(getConsignment().shippingAddress);
+    });
+});

--- a/src/app/shipping/ItemAddressSelect.tsx
+++ b/src/app/shipping/ItemAddressSelect.tsx
@@ -1,0 +1,62 @@
+import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
+import React, { FunctionComponent } from 'react';
+
+import { AddressSelect } from '../address';
+
+import ShippableItem from './ShippableItem';
+
+export interface ItemAddressSelectProps {
+    item: ShippableItem;
+    addresses: CustomerAddress[];
+    onSelectAddress(address: Address, itemId: string): void;
+    onUseNewAddress(address: Address | undefined, itemId: string): void;
+}
+
+const ItemAddressSelect: FunctionComponent<ItemAddressSelectProps> = ({
+    item: {
+        id,
+        imageUrl,
+        quantity,
+        name,
+        options,
+        consignment,
+    },
+    addresses,
+    onSelectAddress,
+    onUseNewAddress,
+}) => (
+    <div className="consignment">
+        <figure className="consignment-product-figure">
+            { imageUrl &&
+                <img src={ imageUrl } alt={ name } />
+            }
+        </figure>
+
+        <div className="consignment-product-body">
+            <h5 className="optimizedCheckout-contentPrimary">
+                { quantity } x { name }
+            </h5>
+
+            { (options || []).map(({ name: optionName, value, nameId }) =>
+                <ul
+                    key={ nameId }
+                    data-test="consigment-item-product-options"
+                    className="product-options optimizedCheckout-contentSecondary"
+                >
+                    <li className="product-option">
+                        { optionName } { value }
+                    </li>
+                </ul>
+            )}
+
+            <AddressSelect
+                addresses={ addresses }
+                selectedAddress={ consignment && consignment.shippingAddress }
+                onUseNewAddress={ address => onUseNewAddress(address, id as string) }
+                onSelectAddress={ address => onSelectAddress(address, id as string) }
+            />
+        </div>
+    </div>
+);
+
+export default ItemAddressSelect;

--- a/src/app/shipping/MultiShippingForm.spec.tsx
+++ b/src/app/shipping/MultiShippingForm.spec.tsx
@@ -1,0 +1,96 @@
+import { mount, ReactWrapper } from 'enzyme';
+import React from 'react';
+
+import { getAddressFormFields } from '../address/formField.mock';
+import { getCart } from '../cart/carts.mock';
+import { getPhysicalItem } from '../cart/lineItem.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+
+import { getConsignment } from './consignment.mock';
+import ItemAddressSelect from './ItemAddressSelect';
+import MultiShippingForm, { MultiShippingFormProps } from './MultiShippingForm';
+
+describe('MultiShippingForm Component', () => {
+    let component: ReactWrapper;
+    let localeContext: LocaleContextType;
+    let defaultProps: MultiShippingFormProps;
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+
+        defaultProps = {
+            cart: {
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [
+                        {  ...getPhysicalItem(), quantity: 3 },
+                    ],
+                    giftCertificates: [],
+                    digitalItems: [],
+                },
+            },
+            getFields: jest.fn(() => getAddressFormFields()),
+            isGuest: false,
+            createAccountUrl: 'create-account',
+            onSignIn: jest.fn(),
+            addresses: getCustomer().addresses,
+            shouldShowOrderComments: true,
+            cartHasChanged: false,
+            customerMessage: 'x',
+            isLoading: false,
+            consignments: [
+                { ...getConsignment(), id: 'foo' },
+                { ...getConsignment(), id: 'bar' },
+            ],
+            onSubmit: jest.fn(),
+            assignItem: jest.fn(),
+            onUnhandledError: jest.fn(),
+            onUseNewAddress: jest.fn(),
+        };
+    });
+
+    describe('when user is guest', () => {
+        beforeEach(() => {
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <MultiShippingForm
+                        { ...defaultProps }
+                        isGuest={ true }
+                    />
+                </LocaleContext.Provider>
+            );
+        });
+
+        it('renders sign in message', () => {
+            component.find('[data-test="shipping-sign-in-link"]').simulate('click');
+
+            expect(defaultProps.onSignIn)
+                .toHaveBeenCalled();
+        });
+    });
+
+    describe('when user is signed in', () => {
+        beforeEach(() => {
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <MultiShippingForm
+                        { ...defaultProps }
+                    />
+                </LocaleContext.Provider>
+            );
+        });
+
+        it('renders shippable items list', () => {
+            expect(component.find('.consignmentList > li').length)
+                .toEqual(3);
+
+            expect(component.find(ItemAddressSelect).at(0).props()).toEqual(
+                expect.objectContaining({
+                    addresses: defaultProps.addresses,
+                })
+            );
+        });
+    });
+});

--- a/src/app/shipping/MultiShippingForm.tsx
+++ b/src/app/shipping/MultiShippingForm.tsx
@@ -1,0 +1,186 @@
+import { Address, Cart, CheckoutSelectors, CheckoutStoreSelector, Consignment, ConsignmentAssignmentRequestBody, FormField } from '@bigcommerce/checkout-sdk';
+import { CustomerAddress } from '@bigcommerce/checkout-sdk/dist/internal-mappers';
+import { withFormik, FormikProps } from 'formik';
+import React, { Component, ReactNode } from 'react';
+
+import { isValidAddress } from '../address';
+import { preventDefault } from '../common/dom';
+import { TranslatedHtml, TranslatedString } from '../language';
+import withLanguage, { WithLanguageProps } from '../locale/withLanguage';
+import { Form } from '../ui/form';
+
+import { AssignItemFailedError } from './errors/AssignItemFailedError';
+import { AssignItemInvalidAddressError } from './errors/AssignItemInvalidAddressError';
+import getShippableItemsCount from './util/getShippableItemsCount';
+import getShippableLineItems from './util/getShippableLineItems';
+import hasSelectedShippingOptions from './util/hasSelectedShippingOptions';
+import hasUnassignedLineItems from './util/hasUnassignedLineItems';
+import updateShippableItems from './util/updateShippableItems';
+import ItemAddressSelect from './ItemAddressSelect';
+import ShippableItem from './ShippableItem';
+import ShippingFormFooter from './ShippingFormFooter';
+
+export interface MultiShippingFormProps {
+    addresses: CustomerAddress[];
+    cart: Cart;
+    cartHasChanged: boolean;
+    consignments: Consignment[];
+    createAccountUrl: string;
+    customerMessage: string;
+    isGuest: boolean;
+    isLoading: boolean;
+    shouldShowOrderComments: boolean;
+    assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
+    onSignIn(): void;
+    getFields(countryCode?: string): FormField[];
+    onSubmit(values: MultiShippingFormValues): void;
+    onUnhandledError(error: Error): void;
+    onUseNewAddress(address: Address, itemId: string): void;
+}
+
+export interface MultiShippingFormState {
+    items: ShippableItem[];
+}
+
+class MultiShippingForm extends Component<MultiShippingFormProps & WithLanguageProps & FormikProps<MultiShippingFormValues>, MultiShippingFormState> {
+    static getDerivedStateFromProps(
+        { cart, consignments }: MultiShippingFormProps,
+        state: MultiShippingFormState
+    ) {
+        if (!state || !state.items || getShippableItemsCount(cart) !== state.items.length) {
+            return { items: getShippableLineItems(cart, consignments) };
+        }
+
+        return null;
+    }
+
+    state: MultiShippingFormState = { items: [] };
+
+    render(): ReactNode {
+        const {
+            addresses,
+            consignments,
+            cart,
+            isGuest,
+            onUseNewAddress,
+            onSignIn,
+            createAccountUrl,
+            cartHasChanged,
+            shouldShowOrderComments,
+            isLoading,
+        } = this.props;
+
+        const { items } = this.state;
+
+        if (isGuest) {
+            return (
+                <div className="checkout-step-info">
+                    <TranslatedString id="shipping.multishipping_guest_intro" />
+                    { ' ' }
+                    <a href="#" onClick={ preventDefault(onSignIn) } data-test="shipping-sign-in-link">
+                        <TranslatedString id="shipping.multishipping_guest_sign_in" />
+                    </a>
+                    { ' ' }
+                    <TranslatedHtml
+                        id="shipping.multishipping_guest_create"
+                        data={ { url: createAccountUrl } }
+                    />
+                </div>
+            );
+        }
+
+        return (
+            <Form>
+                <ul className="consignmentList">
+                    { items.map(item => (
+                        <li key={ item.key }>
+                            <ItemAddressSelect
+                                item={ item }
+                                addresses={ addresses }
+                                onSelectAddress={ (address, itemId) => this.handleSelectAddress(address, itemId, item.key)}
+                                onUseNewAddress={ onUseNewAddress }
+                            />
+                        </li>
+                    ))}
+                </ul>
+
+                <ShippingFormFooter
+                    isMultiShippingMode={ true }
+                    cartHasChanged={ cartHasChanged }
+                    shouldShowOrderComments={ shouldShowOrderComments }
+                    shouldShowShippingOptions={ !hasUnassignedLineItems(consignments, cart.lineItems) }
+                    shouldDisableSubmit={ this.shouldDisableSubmit() }
+                    isLoading={ isLoading }
+                />
+            </Form>
+        );
+    }
+
+    private handleSelectAddress: (address: Address, itemId: string, itemKey: string) => Promise<void> = async (address, itemId, itemKey) => {
+        const {
+            assignItem,
+            onUnhandledError,
+            getFields,
+        } = this.props;
+
+        if (!isValidAddress(address, getFields(address.countryCode))) {
+            return onUnhandledError(new AssignItemInvalidAddressError());
+        }
+
+        try {
+            const { data } = await assignItem({
+                shippingAddress: address,
+                lineItems: [{
+                    itemId,
+                    quantity: 1,
+                }],
+            });
+
+            this.syncItems(itemKey, address, data);
+        } catch (e) {
+            onUnhandledError(new AssignItemFailedError(e));
+        }
+    };
+
+    private shouldDisableSubmit: () => boolean = () => {
+        const { isLoading, consignments } = this.props;
+
+        return isLoading || !hasSelectedShippingOptions(consignments);
+    };
+
+    private syncItems: (
+        key: string,
+        address: Address,
+        data: CheckoutStoreSelector
+    ) => void = (key, address, data) => {
+        const items = updateShippableItems(
+            this.state.items,
+            {
+                updatedItemIndex: this.state.items.findIndex(item => item.key === key),
+                address,
+            },
+            {
+                cart: data.getCart(),
+                consignments: data.getConsignments(),
+            }
+        );
+
+        if (items) {
+            this.setState({ items });
+        }
+    };
+}
+
+export interface MultiShippingFormValues {
+    orderComment: string;
+}
+
+export default withLanguage(withFormik<MultiShippingFormProps & WithLanguageProps, MultiShippingFormValues>({
+    handleSubmit: (values, { props: { onSubmit } }) => {
+        onSubmit(values);
+    },
+    mapPropsToValues: ({ customerMessage }) => ({
+        orderComment: customerMessage,
+    }),
+    enableReinitialize: true,
+})(MultiShippingForm));

--- a/src/app/shipping/RemoteShippingAddress.spec.tsx
+++ b/src/app/shipping/RemoteShippingAddress.spec.tsx
@@ -1,0 +1,43 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+
+import { SignOutLink } from '../payment';
+
+import RemoteShippingAddress, { RemoteShippingAddressProps } from './RemoteShippingAddress';
+
+describe('RemoteShippingAddress Component', () => {
+    const defaultProps: RemoteShippingAddressProps = {
+        containerId: 'container',
+        methodId: 'amazon',
+        onSignOut: jest.fn(),
+        initialize: jest.fn(),
+        deinitialize: jest.fn(),
+    };
+
+    it('renders widget', () => {
+        const component = shallow(<RemoteShippingAddress { ...defaultProps } />);
+
+        expect(component.find('#container').hasClass('widget--amazon')).toBeTruthy();
+    });
+
+    it('renders SignOutLink', () => {
+        const component = shallow(<RemoteShippingAddress { ...defaultProps } />);
+
+        expect(component.find(SignOutLink).props()).toEqual(expect.objectContaining({
+            onSignOut: defaultProps.onSignOut,
+            method: { id: defaultProps.methodId },
+        }));
+    });
+
+    it('calls initialize prop on mount', () => {
+        mount(<RemoteShippingAddress { ...defaultProps } />);
+
+        expect(defaultProps.initialize).toHaveBeenCalled();
+    });
+
+    it('calls deinitialize prop on unmount', () => {
+        mount(<RemoteShippingAddress { ...defaultProps } />).unmount();
+
+        expect(defaultProps.initialize).toHaveBeenCalled();
+    });
+});

--- a/src/app/shipping/RemoteShippingAddress.tsx
+++ b/src/app/shipping/RemoteShippingAddress.tsx
@@ -1,0 +1,66 @@
+import { CheckoutSelectors, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+
+import { SignOutLink } from '../payment';
+
+export interface RemoteShippingAddressProps {
+    containerId: string;
+    methodId: string;
+    deinitialize(options?: ShippingRequestOptions): Promise<CheckoutSelectors>;
+    initialize(options?: ShippingInitializeOptions): Promise<CheckoutSelectors>;
+    onSignOut(): void;
+    onUnhandledError?(error: Error): void;
+}
+
+class RemoteShippingAddress extends Component<RemoteShippingAddressProps> {
+    async componentDidMount(): Promise<void> {
+        const {
+            initialize,
+            methodId,
+            onUnhandledError = noop,
+        } = this.props;
+
+        try {
+            await initialize({ methodId });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    async componentWillUnmount(): Promise<void> {
+        const {
+            deinitialize,
+            methodId,
+            onUnhandledError = noop,
+        } = this.props;
+
+        try {
+            await deinitialize({ methodId });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    render(): ReactNode {
+        const {
+            containerId,
+            methodId,
+            onSignOut,
+        } = this.props;
+
+        return (
+            <>
+                <div
+                    id={ containerId }
+                    className={ `widget address-widget widget--${methodId}` }
+                    tabIndex={ -1 }
+                />
+
+                <SignOutLink method={ { id: methodId } } onSignOut={ onSignOut } />
+            </>
+        );
+    }
+}
+
+export default RemoteShippingAddress;

--- a/src/app/shipping/Shipping.spec.tsx
+++ b/src/app/shipping/Shipping.spec.tsx
@@ -1,0 +1,301 @@
+import { createCheckoutService, BillingAddress, Cart, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount, ReactWrapper } from 'enzyme';
+import React, { FunctionComponent } from 'react';
+
+import { getAddressFormFields } from '../address/formField.mock';
+import { getCart } from '../cart/carts.mock';
+import { getPhysicalItem } from '../cart/lineItem.mock';
+import { CheckoutProvider } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+
+import { getConsignment } from './consignment.mock';
+import { getShippingAddress } from './shipping-addresses.mock';
+import Shipping, { ShippingProps } from './Shipping';
+import ShippingForm from './ShippingForm';
+
+describe('Shipping Component', () => {
+    let component: ReactWrapper;
+    let localeContext: LocaleContextType;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: ShippingProps;
+    let ComponentTest: FunctionComponent<ShippingProps>;
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        checkoutService = createCheckoutService();
+
+        checkoutState = checkoutService.getState();
+
+        defaultProps = {
+            isMultiShippingMode: false,
+            onToggleMultiShipping: jest.fn(),
+            cartHasChanged: false,
+            onSignIn: jest.fn(),
+            navigateNextStep: jest.fn(),
+            onUnhandledError: jest.fn(),
+        };
+
+        jest.spyOn(checkoutService, 'loadShippingAddressFields')
+            .mockResolvedValue({} as CheckoutSelectors);
+
+        jest.spyOn(checkoutService, 'loadShippingOptions')
+            .mockResolvedValue({} as CheckoutSelectors);
+
+        jest.spyOn(checkoutState.data, 'getCart')
+            .mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [ {
+                        ...getPhysicalItem(),
+                        quantity: 3,
+                    }],
+                },
+            } as Cart);
+
+        jest.spyOn(checkoutService.getState().data, 'getShippingAddress')
+            .mockReturnValue(getShippingAddress());
+
+        jest.spyOn(checkoutService.getState().data, 'getBillingAddress')
+            .mockReturnValue(undefined);
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getShippingAddressFields')
+            .mockReturnValue(getAddressFormFields());
+
+        jest.spyOn(checkoutState.data, 'getCustomer')
+            .mockReturnValue({ ...getCustomer(), addresses: [] });
+
+        jest.spyOn(checkoutState.data, 'getConsignments')
+            .mockReturnValue([getConsignment()]);
+
+        jest.spyOn(checkoutState.data, 'getCheckout')
+            .mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue({} as CheckoutSelectors);
+        jest.spyOn(checkoutService, 'updateCheckout').mockResolvedValue({} as CheckoutSelectors);
+        jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue({} as CheckoutSelectors);
+
+        ComponentTest = props => (
+            <CheckoutProvider checkoutService={ checkoutService } >
+                <LocaleContext.Provider value={ localeContext }>
+                    <Shipping { ...props } />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('loads shipping data  when component is mounted', () => {
+        mount(<ComponentTest { ...defaultProps } />);
+
+        expect(checkoutService.loadShippingAddressFields)
+            .toHaveBeenCalled();
+
+        expect(checkoutService.loadShippingOptions)
+            .toHaveBeenCalled();
+    });
+
+    it('triggers callback when shipping data is loaded', async () => {
+        const handleReady = jest.fn();
+
+        mount(<ComponentTest { ...defaultProps } onReady={ handleReady } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(handleReady).toHaveBeenCalled();
+    });
+
+    it('does not render ShippingForm while initializing', () => {
+        jest.spyOn(checkoutService.getState().statuses, 'isLoadingShippingCountries')
+            .mockReturnValue(true);
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+
+        expect(component.find(ShippingForm).length)
+            .toEqual(0);
+    });
+
+    it('updates shipping and billing if shipping address is changed and billingSameAsShipping', async () => {
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        component.find('input[name="shippingAddress.firstName"]')
+            .simulate('change', { target: { value: 'bar', name: 'shippingAddress.firstName' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.updateBillingAddress).toHaveBeenCalledWith(expect.objectContaining({
+            firstName: 'bar',
+        }));
+        expect(checkoutService.updateShippingAddress).toHaveBeenCalledWith(expect.objectContaining({
+            firstName: 'bar',
+        }));
+    });
+
+    it('updates only shipping if shipping address is changed and billingSameAsShipping is false', async () => {
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        component.find('input[name="shippingAddress.firstName"]')
+            .simulate('change', { target: { value: 'bar', name: 'shippingAddress.firstName' } });
+
+        component.find('input[name="billingSameAsShipping"]')
+                .simulate('change', { target: { checked: false, name: 'billingSameAsShipping' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.updateBillingAddress).not.toHaveBeenCalled();
+        expect(checkoutService.updateShippingAddress).toHaveBeenCalledWith(expect.objectContaining({
+            firstName: 'bar',
+        }));
+    });
+
+    it('calls updateCheckout if comment changes', async () => {
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        component.find('input[name="orderComment"]')
+            .simulate('change', { target: { value: 'foo', name: 'orderComment' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.updateCheckout).toHaveBeenCalledWith({ customerMessage: 'foo' });
+    });
+
+    it('calls onUnhandledError if failures', async () => {
+        jest.spyOn(checkoutService, 'updateShippingAddress').mockRejectedValue(new Error());
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        component.find('input[name="shippingAddress.firstName"]')
+            .simulate('change', { target: { value: 'bar', name: 'shippingAddress.firstName' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(defaultProps.navigateNextStep).not.toHaveBeenCalled();
+        expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+    });
+
+    it('calls navigateNextStep if no failures', async () => {
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        component.find('input[name="shippingAddress.firstName"]')
+            .simulate('change', { target: { value: 'bar', name: 'shippingAddress.firstName' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(defaultProps.navigateNextStep).toHaveBeenCalledWith(true);
+    });
+
+    it('calls only navigateNextStep when no changes', async () => {
+        jest.spyOn(checkoutService.getState().data, 'getShippingAddress')
+            .mockReturnValue(getShippingAddress());
+
+        jest.spyOn(checkoutService.getState().data, 'getBillingAddress')
+            .mockReturnValue(getShippingAddress() as BillingAddress);
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.updateBillingAddress).not.toHaveBeenCalled();
+        expect(checkoutService.updateShippingAddress).not.toHaveBeenCalled();
+        expect(checkoutService.updateCheckout).not.toHaveBeenCalled();
+        expect(defaultProps.navigateNextStep).toHaveBeenCalledWith(true);
+    });
+
+    describe('when multishipping mode is on', () => {
+        describe('when shopper is signed', () => {
+            beforeEach(async () => {
+                component = mount(<ComponentTest { ...defaultProps } isMultiShippingMode={ true } />);
+                await new Promise(resolve => process.nextTick(resolve));
+                component.update();
+            });
+
+            it('calls updateCheckout and navigateNextStep', async () => {
+                component.find('input[name="orderComment"]')
+                    .simulate('change', { target: { value: 'foo', name: 'orderComment' } });
+
+                component.find('form')
+                    .simulate('submit');
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(checkoutService.updateCheckout).toHaveBeenCalledWith({ customerMessage: 'foo' });
+                expect(defaultProps.navigateNextStep).toHaveBeenCalledWith(false);
+            });
+
+            it('calls onToggleMultiShipping when link is clicked', () => {
+                expect(component.find('[data-test="shipping-mode-toggle"]').text())
+                    .toEqual('Ship to a single address');
+
+                component.find('[data-test="shipping-mode-toggle"]').simulate('click');
+
+                expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
+            });
+
+            it('renders multishipping header', () => {
+                expect(component.find('[data-test="shipping-address-heading"]').text())
+                    .toEqual('Choose where to ship each item');
+            });
+
+            it('renders shipping form', () => {
+                expect(component.find(ShippingForm).length).toEqual(1);
+            });
+        });
+
+        describe('when is guest user', () => {
+            beforeEach(async () => {
+                jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+                    ...getCustomer(),
+                    isGuest: true,
+                });
+
+                component = mount(<ComponentTest { ...defaultProps } isMultiShippingMode={ true } />);
+                await new Promise(resolve => process.nextTick(resolve));
+                component.update();
+            });
+
+            it('renders multishipping header', () => {
+                expect(component.find('[data-test="shipping-address-heading"]').text())
+                    .toEqual('Please sign in first');
+            });
+
+            it('doest render shipping form', () => {
+                expect(component.find(ShippingForm).length).toEqual(1);
+            });
+        });
+    });
+});

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -1,0 +1,340 @@
+import { Address, Cart, CheckoutRequestBody, CheckoutSelectors, Consignment, ConsignmentAssignmentRequestBody, Country, Customer, CustomerRequestOptions, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+import { createSelector } from 'reselect';
+
+import { isEqualAddress, mapAddressFromFormValues } from '../address';
+import { withCheckout, CheckoutContextProps } from '../checkout';
+import { EMPTY_ARRAY } from '../common/utility';
+import { LoadingOverlay } from '../ui/loading';
+
+import { UnassignItemError } from './errors/UnassignItemError';
+import getShippingMethodId from './getShippingMethodId';
+import getShippableItemsCount from './util/getShippableItemsCount';
+import { MultiShippingFormValues } from './MultiShippingForm';
+import ShippingForm from './ShippingForm';
+import ShippingHeader from './ShippingHeader';
+import { SingleShippingFormValues } from './SingleShippingForm';
+
+export interface ShippingProps {
+    cartHasChanged: boolean;
+    isMultiShippingMode: boolean;
+    onToggleMultiShipping(): void;
+    onReady?(): void;
+    onUnhandledError(error: Error): void;
+    onSignIn(): void;
+    navigateNextStep(billingSameAsShipping: boolean): void;
+}
+
+export interface WithCheckoutShippingProps {
+    billingAddress?: Address;
+    cart: Cart;
+    consignments: Consignment[];
+    countries: Country[];
+    countriesWithAutocomplete: string[];
+    createAccountUrl: string;
+    customer: Customer;
+    customerMessage: string;
+    googleMapsApiKey: string;
+    isGuest: boolean;
+    isInitializing: boolean;
+    isLoading: boolean;
+    methodId?: string;
+    shippingAddress?: Address;
+    shouldShowMultiShipping: boolean;
+    shouldShowOrderComments: boolean;
+    assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
+    deinitializeShippingMethod(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
+    deleteConsignments(): Promise<Address | undefined>;
+    getFields(countryCode?: string): FormField[];
+    initializeShippingMethod(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
+    loadShippingAddressFields(): Promise<CheckoutSelectors>;
+    loadShippingOptions(): Promise<CheckoutSelectors>;
+    signOut(options?: CustomerRequestOptions): void;
+    unassignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
+    updateBillingAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+    updateCheckout(payload: CheckoutRequestBody): Promise<CheckoutSelectors>;
+    updateShippingAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+}
+
+interface ShippingState {
+    isInitializing: boolean;
+}
+
+class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, ShippingState> {
+    constructor(props: ShippingProps & WithCheckoutShippingProps) {
+        super(props);
+
+        this.state = {
+            isInitializing: true,
+        };
+    }
+
+    async componentDidMount(): Promise<void> {
+        const {
+            loadShippingAddressFields,
+            loadShippingOptions,
+            onReady = noop,
+            onUnhandledError = noop,
+        } = this.props;
+
+        try {
+            await Promise.all([
+                loadShippingAddressFields(),
+                loadShippingOptions(),
+            ]);
+
+            onReady();
+        } catch (error) {
+            onUnhandledError(error);
+        } finally {
+            this.setState({ isInitializing: false });
+        }
+    }
+
+    render(): ReactNode {
+        const {
+            isGuest,
+            shouldShowMultiShipping,
+            customer,
+            unassignItem,
+            updateShippingAddress,
+            initializeShippingMethod,
+            deinitializeShippingMethod,
+            isMultiShippingMode,
+            onToggleMultiShipping,
+            ...shippingFormProps
+        } = this.props;
+
+        const {
+            isInitializing,
+        } = this.state;
+
+        return (
+            <div className="checkout-form">
+                <ShippingHeader
+                    isMultiShippingMode={ isMultiShippingMode }
+                    isGuest={ isGuest }
+                    shouldShowMultiShipping={ shouldShowMultiShipping }
+                    onMultiShippingChange={ onToggleMultiShipping }
+                />
+
+                <LoadingOverlay
+                    isLoading={ isInitializing }
+                    unmountContentWhenLoading
+                >
+                    <ShippingForm
+                        { ...shippingFormProps }
+                        isGuest={ isGuest }
+                        addresses={ customer.addresses }
+                        updateAddress={ updateShippingAddress }
+                        initialize={ initializeShippingMethod }
+                        deinitialize={ deinitializeShippingMethod }
+                        onUseNewAddress={ this.handleUseNewAddress }
+                        onSingleShippingSubmit={ this.handleSingleShippingSubmit }
+                        onMultiShippingSubmit={ this.handleMultiShippingSubmit }
+                        isMultiShippingMode={ isMultiShippingMode }
+                    />
+                </LoadingOverlay>
+            </div>
+        );
+    }
+
+    private handleSingleShippingSubmit: (values: SingleShippingFormValues) => void = async ({
+        billingSameAsShipping,
+        shippingAddress: addressValues,
+        orderComment,
+    }) => {
+        const {
+            customerMessage,
+            updateCheckout,
+            updateShippingAddress,
+            updateBillingAddress,
+            navigateNextStep,
+            onUnhandledError,
+            shippingAddress,
+            billingAddress,
+        } = this.props;
+
+        const updatedShippingAddress = addressValues && mapAddressFromFormValues(addressValues);
+        const promises: Array<Promise<CheckoutSelectors>> = [];
+
+        if (!isEqualAddress(updatedShippingAddress, shippingAddress)) {
+            promises.push(updateShippingAddress(updatedShippingAddress || {}));
+        }
+
+        if (billingSameAsShipping &&
+            updatedShippingAddress &&
+            !isEqualAddress(updatedShippingAddress, billingAddress)
+        ) {
+            promises.push(updateBillingAddress(updatedShippingAddress));
+        }
+
+        if (customerMessage !== orderComment) {
+            promises.push(updateCheckout({ customerMessage: orderComment }));
+        }
+
+        try {
+            await Promise.all(promises);
+
+            navigateNextStep(billingSameAsShipping);
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    };
+
+    private handleUseNewAddress: (address: Address, itemId: string) => void = async (address, itemId) => {
+        const { unassignItem, onUnhandledError } = this.props;
+
+        try {
+            await unassignItem({
+                shippingAddress: address,
+                lineItems: [{
+                    quantity: 1,
+                    itemId,
+                }],
+            });
+
+            location.href = '/account.php?action=add_shipping_address&from=checkout';
+        } catch (e) {
+            onUnhandledError(new UnassignItemError(e));
+        }
+    };
+
+    private handleMultiShippingSubmit: (values: MultiShippingFormValues) => void = async ({ orderComment }) => {
+        const {
+            customerMessage,
+            updateCheckout,
+            navigateNextStep,
+            onUnhandledError,
+        } = this.props;
+
+        try {
+            if (customerMessage !== orderComment) {
+                await updateCheckout({ customerMessage: orderComment });
+            }
+
+            navigateNextStep(false);
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    };
+}
+
+const deleteConsignmentsSelector = createSelector(
+    ({ checkoutService: { deleteConsignment } }: CheckoutContextProps) => deleteConsignment,
+    ({ checkoutState: { data } }: CheckoutContextProps) => data.getConsignments(),
+    (deleteConsignment, consignments) => async () => {
+        const [{ data }] = await Promise.all((consignments || []).map(({ id }) =>
+            deleteConsignment(id)
+        ));
+
+        return data.getShippingAddress();
+    }
+);
+
+const updateOrderCommentSelector = createSelector(
+    ({ checkoutService: { updateCheckout } }: CheckoutContextProps) => updateCheckout,
+    updateCheckout => (comment: string) => {
+        return updateCheckout({ customerMessage: comment });
+    }
+);
+
+export function mapToShippingProps({
+    checkoutService,
+    checkoutState,
+}: CheckoutContextProps): WithCheckoutShippingProps | null {
+    const {
+        data: {
+            getCart,
+            getCheckout,
+            getConfig,
+            getCustomer,
+            getConsignments,
+            getShippingAddress,
+            getBillingAddress,
+            getShippingAddressFields,
+            getShippingCountries,
+        },
+        statuses: {
+            isSelectingShippingOption,
+            isLoadingShippingOptions,
+            isUpdatingConsignment,
+            isCreatingConsignments,
+            isLoadingShippingCountries,
+        },
+    } = checkoutState;
+
+    const checkout = getCheckout();
+    const config = getConfig();
+    const consignments = getConsignments() || [];
+    const customer = getCustomer();
+    const cart = getCart();
+
+    if (!checkout || !config || !customer || !cart) {
+        return null;
+    }
+
+    const {
+        checkoutSettings: {
+            enableOrderComments,
+            features,
+            hasMultiShippingEnabled,
+            googleMapsApiKey,
+        },
+        links,
+    } = config;
+
+    const methodId = getShippingMethodId(checkout);
+    const shippableItemsCount = getShippableItemsCount(cart);
+    const isLoading = (
+        isLoadingShippingOptions() ||
+        isSelectingShippingOption() ||
+        isUpdatingConsignment() ||
+        isCreatingConsignments()
+    );
+    const shouldShowMultiShipping = (
+        hasMultiShippingEnabled &&
+        !methodId &&
+        shippableItemsCount > 1 &&
+        shippableItemsCount < 50
+    );
+    const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ'];
+
+    if (features['CHECKOUT-4183.checkout_google_address_autocomplete_uk']) {
+        countriesWithAutocomplete.push('GB');
+    }
+
+    return {
+        assignItem: checkoutService.assignItemsToAddress,
+        billingAddress: getBillingAddress(),
+        cart,
+        consignments,
+        countries: getShippingCountries() || EMPTY_ARRAY,
+        countriesWithAutocomplete,
+        createAccountUrl: links.createAccountLink,
+        customer,
+        customerMessage: checkout.customerMessage,
+        deinitializeShippingMethod: checkoutService.deinitializeShipping,
+        deleteConsignments: deleteConsignmentsSelector({ checkoutService, checkoutState }),
+        getFields: getShippingAddressFields,
+        googleMapsApiKey,
+        initializeShippingMethod: checkoutService.initializeShipping,
+        isGuest: customer.isGuest,
+        isInitializing: isLoadingShippingCountries() || isLoadingShippingOptions(),
+        isLoading,
+        loadShippingAddressFields: checkoutService.loadShippingAddressFields,
+        loadShippingOptions: checkoutService.loadShippingOptions,
+        methodId,
+        shippingAddress: getShippingAddress(),
+        shouldShowMultiShipping,
+        shouldShowOrderComments: enableOrderComments,
+        signOut: checkoutService.signOutCustomer,
+        unassignItem: checkoutService.unassignItemsToAddress,
+        updateBillingAddress: checkoutService.updateBillingAddress,
+        updateCheckout: checkoutService.updateCheckout,
+        updateShippingAddress: checkoutService.updateShippingAddress,
+    };
+}
+
+export default withCheckout(mapToShippingProps)(Shipping);

--- a/src/app/shipping/ShippingAddress.spec.tsx
+++ b/src/app/shipping/ShippingAddress.spec.tsx
@@ -1,0 +1,108 @@
+import { mount, shallow } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { getFormFields } from '../address/formField.mock';
+import { getCustomer } from '../customer/customers.mock';
+
+import { getConsignment } from './consignment.mock';
+import { getShippingAddress } from './shipping-addresses.mock';
+import RemoteShippingAddress from './RemoteShippingAddress';
+import ShippingAddress, { ShippingAddressProps } from './ShippingAddress';
+import ShippingAddressForm from './ShippingAddressForm';
+
+describe('ShippingAddress Component', () => {
+    const defaultProps: ShippingAddressProps = {
+        consignments: [ getConsignment() ],
+        addresses: getCustomer().addresses,
+        shippingAddress: {
+            ...getShippingAddress(),
+            address1: 'x',
+        },
+        countriesWithAutocomplete: [],
+        isLoading: false,
+        formFields: getFormFields(),
+        onAddressSelect: jest.fn(),
+        onFieldChange: jest.fn(),
+        initialize: jest.fn(),
+        deinitialize: jest.fn(),
+        signOut: jest.fn(),
+        onUnhandledError: jest.fn(),
+        onUseNewAddress: jest.fn(),
+    };
+
+    describe('when no method id is provided', () => {
+        it('renders ShippingAddressForm with expected props', () => {
+            const component = shallow(<ShippingAddress { ...defaultProps } />);
+
+            expect(component.find(ShippingAddressForm).props()).toEqual(
+                expect.objectContaining({
+                    formFields: defaultProps.formFields,
+                    addresses: defaultProps.addresses,
+                    onUseNewAddress: defaultProps.onUseNewAddress,
+                    address: defaultProps.shippingAddress,
+                })
+            );
+        });
+
+        it('calls onAddressSelect when an address is selected', async () => {
+            const component = mount(
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <ShippingAddress { ...defaultProps } />
+                </Formik>
+            );
+
+            component.find('#addressToggle').simulate('click');
+            component.find('#addressDropdown li').at(1).find('a').simulate('click');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(defaultProps.onAddressSelect).toHaveBeenCalled();
+        });
+
+        it('does not render RemoteShippingAddress', () => {
+            const component = mount(
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <ShippingAddress { ...defaultProps } />
+                </Formik>
+            );
+
+            expect(component.find(RemoteShippingAddress).length).toEqual(0);
+        });
+    });
+
+    describe('when method id is provided', () => {
+        it('renders RemoteShippingAddress with expected props', () => {
+            const component = mount(<ShippingAddress { ...defaultProps } methodId="amazon" />);
+
+            expect(component.find(RemoteShippingAddress).props()).toEqual(
+                expect.objectContaining({
+                    containerId: 'addressWidget',
+                    methodId: 'amazon',
+                    deinitialize: defaultProps.deinitialize,
+                })
+            );
+
+            expect(defaultProps.initialize).toHaveBeenCalledWith({
+                methodId: 'amazon',
+                amazon: {
+                    container: 'addressWidget',
+                    onError: defaultProps.onUnhandledError,
+                },
+            });
+        });
+
+        it('does not render ShippingAddressForm', () => {
+            const component = mount(<ShippingAddress { ...defaultProps } methodId="amazon" />);
+
+            expect(component.find(ShippingAddressForm).length).toEqual(0);
+        });
+    });
+});

--- a/src/app/shipping/ShippingAddress.tsx
+++ b/src/app/shipping/ShippingAddress.tsx
@@ -1,0 +1,98 @@
+import { Address, CheckoutSelectors, Consignment, Country, CustomerAddress, CustomerRequestOptions, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import RemoteShippingAddress from './RemoteShippingAddress';
+import ShippingAddressForm from './ShippingAddressForm';
+
+export interface ShippingAddressProps {
+    addresses: CustomerAddress[];
+    consignments: Consignment[];
+    countries?: Country[];
+    countriesWithAutocomplete: string[];
+    formFields: FormField[];
+    googleMapsApiKey?: string;
+    isLoading: boolean;
+    methodId?: string;
+    shippingAddress?: Address;
+    deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
+    initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
+    onAddressSelect(address: Address): void;
+    onFieldChange(name: string, value: string): void;
+    onUnhandledError?(error: Error): void;
+    onUseNewAddress(): void;
+    signOut(options?: CustomerRequestOptions): void;
+}
+
+const ShippingAddress: FunctionComponent<ShippingAddressProps> = props => {
+    const {
+        methodId,
+        formFields,
+        countries,
+        countriesWithAutocomplete,
+        consignments,
+        googleMapsApiKey,
+        onAddressSelect,
+        onFieldChange,
+        onUseNewAddress,
+        initialize,
+        deinitialize,
+        signOut,
+        isLoading,
+        shippingAddress,
+        addresses,
+        onUnhandledError = noop,
+    } = props;
+
+    if (methodId) {
+        const containerId = 'addressWidget';
+        let options: ShippingInitializeOptions;
+
+        if (methodId === 'amazon') {
+            options = {
+                amazon: {
+                    container: containerId,
+                    onError: onUnhandledError,
+                },
+            };
+        }
+
+        return (
+            <RemoteShippingAddress
+                containerId={ containerId }
+                methodId={ methodId }
+                onSignOut={ async () => {
+                    try {
+                        await signOut({ methodId });
+                        window.location.reload();
+                    } catch (error) {
+                        onUnhandledError(error);
+                    }
+                } }
+                deinitialize={ deinitialize }
+                initialize={ defaultOptions => initialize({
+                    ...defaultOptions,
+                    ...options,
+                }) }
+            />
+        );
+    }
+
+    return (
+        <ShippingAddressForm
+            isLoading={ isLoading }
+            countries={ countries }
+            countriesWithAutocomplete={ countriesWithAutocomplete }
+            consignments={ consignments }
+            googleMapsApiKey={ googleMapsApiKey }
+            formFields={ formFields }
+            address={ shippingAddress }
+            addresses={ addresses }
+            onFieldChange={ onFieldChange }
+            onAddressSelect={ onAddressSelect }
+            onUseNewAddress={ onUseNewAddress }
+        />
+    );
+};
+
+export default ShippingAddress;

--- a/src/app/shipping/ShippingAddressFields.ts
+++ b/src/app/shipping/ShippingAddressFields.ts
@@ -1,0 +1,8 @@
+export const SHIPPING_ADDRESS_FIELDS = [
+    'address1',
+    'postalCode',
+    'countryCode',
+    'city',
+    'stateOrProvince',
+    'stateOrProvinceCode',
+];

--- a/src/app/shipping/ShippingAddressForm.spec.tsx
+++ b/src/app/shipping/ShippingAddressForm.spec.tsx
@@ -1,0 +1,162 @@
+import { createCheckoutService, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount, ReactWrapper } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { AddressForm, AddressSelect } from '../address';
+import { getFormFields } from '../address/formField.mock';
+import { getCheckout } from '../checkout/checkouts.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+
+import { getConsignment } from './consignment.mock';
+import { getShippingAddress } from './shipping-addresses.mock';
+import ShippingAddressForm, { ShippingAddressFormProps } from './ShippingAddressForm';
+
+describe('ShippingAddressForm Component', () => {
+    let component: ReactWrapper;
+    let defaultProps: ShippingAddressFormProps;
+
+    beforeEach(() => {
+        defaultProps = {
+            consignments: [ getConsignment() ],
+            countriesWithAutocomplete: [],
+            addresses: getCustomer().addresses,
+            address: getCustomer().addresses[0],
+            formFields: getFormFields(),
+            onAddressSelect: jest.fn(),
+            onFieldChange: jest.fn(),
+            onUseNewAddress: jest.fn(),
+            isLoading: false,
+        };
+    });
+
+    describe('when there are addresses (signed-in user)', () => {
+        beforeEach(() => {
+            component = mount(
+                <Formik initialValues={ {} } onSubmit={ noop }>
+                    <ShippingAddressForm { ...defaultProps } />
+                </Formik>
+            );
+        });
+
+        it('doest not render address form', () => {
+            expect(component.find(AddressForm).length)
+                .toEqual(0);
+        });
+
+        it('renders address select', () => {
+            expect(component.find(AddressSelect).props())
+                .toMatchObject({
+                    addresses: defaultProps.addresses,
+                    selectedAddress: defaultProps.address,
+                });
+        });
+
+        it('renders address form when selected address is not in the address list', () => {
+            component = mount(
+                <Formik initialValues={ {} } onSubmit={ noop }>
+                    <ShippingAddressForm
+                        { ...defaultProps }
+                        address={ {
+                            ...getShippingAddress(),
+                            firstName: 'foo',
+                        } }
+                    />
+                </Formik>
+            );
+
+            expect(component.find(AddressForm).props())
+                .toMatchObject({
+                    formFields: defaultProps.formFields,
+                });
+        });
+
+        it('renders address form when selected address is not valid even when in the list', () => {
+            component = mount(
+                <Formik initialValues={ {} } onSubmit={ noop }>
+                    <ShippingAddressForm
+                        { ...defaultProps }
+                        formFields={ [
+                            ...defaultProps.formFields,
+                            {
+                                ...defaultProps.formFields[1],
+                                name: 'newRequiredField',
+                                required: true,
+                            },
+                        ]}
+                    />
+                </Formik>
+            );
+
+            expect(component.find(AddressSelect).prop('selectedAddress'))
+                .toBeFalsy();
+
+            expect(component.find(AddressForm).length)
+                .toEqual(1);
+        });
+
+        it('renders address form when there is no selected address', () => {
+            component = mount(
+                <Formik initialValues={ {} } onSubmit={ noop }>
+                    <ShippingAddressForm { ...defaultProps }  address={ undefined } />
+                </Formik>
+            );
+
+            expect(component.find(AddressForm).props())
+                .toMatchObject({
+                    formFields: defaultProps.formFields,
+                });
+        });
+    });
+
+    describe('when there are no addresses (guest user)', () => {
+        beforeEach(() => {
+            component = mount(
+                <Formik initialValues={ {} } onSubmit={ noop }>
+                    <ShippingAddressForm { ...defaultProps }
+                        addresses={ [] }
+                    />
+                </Formik>
+            );
+        });
+
+        it('renders address form', () => {
+            expect(component.find(AddressForm).props())
+                .toMatchObject({
+                    formFields: defaultProps.formFields,
+                });
+        });
+    });
+
+    describe('when address is updated', () => {
+        let checkoutService: CheckoutService;
+        let localeContext: LocaleContextType;
+
+        beforeEach(() => {
+            checkoutService = createCheckoutService();
+            localeContext = createLocaleContext(getStoreConfig());
+
+            jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(getCheckout());
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
+
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <Formik
+                        initialValues={ {
+                            shippingAddress: getShippingAddress(),
+                        } }
+                        onSubmit={ noop }
+                    >
+                        <ShippingAddressForm { ...defaultProps }
+                            address={ getShippingAddress() }
+                            addresses={ [] }
+                        />
+                    </Formik>
+                </LocaleContext.Provider>
+            );
+        });
+    });
+});

--- a/src/app/shipping/ShippingAddressForm.tsx
+++ b/src/app/shipping/ShippingAddressForm.tsx
@@ -1,0 +1,115 @@
+import { Address, Consignment, Country, FormField } from '@bigcommerce/checkout-sdk';
+import { CustomerAddress } from '@bigcommerce/checkout-sdk/dist/internal-mappers';
+import React, { Component, ReactNode } from 'react';
+
+import {  isValidCustomerAddress, AddressForm, AddressSelect } from '../address';
+import { connectFormik, ConnectFormikProps } from '../common/form';
+import { Fieldset } from '../ui/form';
+import { LoadingOverlay } from '../ui/loading';
+
+import { SingleShippingFormValues } from './SingleShippingForm';
+
+export interface ShippingAddressFormProps {
+    addresses: CustomerAddress[];
+    address?: Address;
+    consignments: Consignment[];
+    countries?: Country[];
+    countriesWithAutocomplete: string[];
+    googleMapsApiKey?: string;
+    isLoading: boolean;
+    formFields: FormField[];
+    onUseNewAddress(): void;
+    onFieldChange(fieldName: string, value: string): void;
+    onAddressSelect(address: Address): void;
+}
+
+const addressFieldName = 'shippingAddress';
+
+class ShippingAddressForm extends Component<ShippingAddressFormProps & ConnectFormikProps<SingleShippingFormValues>> {
+    render(): ReactNode {
+        const {
+            addresses,
+            address: shippingAddress,
+            onAddressSelect,
+            onUseNewAddress,
+            countries,
+            countriesWithAutocomplete,
+            formFields,
+            isLoading,
+            googleMapsApiKey,
+            onFieldChange,
+            formik: {
+                values: {
+                    shippingAddress: formAddress,
+                },
+            },
+        } = this.props;
+
+        const hasAddresses = addresses && addresses.length > 0;
+        const hasValidCustomerAddress = isValidCustomerAddress(shippingAddress, addresses, formFields);
+
+        return (
+            <Fieldset id="checkoutShippingAddress">
+                { hasAddresses &&
+                    <Fieldset id="shippingAddresses">
+                        <LoadingOverlay isLoading={ isLoading }>
+                            <AddressSelect
+                                addresses={ addresses }
+                                onUseNewAddress={ onUseNewAddress }
+                                selectedAddress={ hasValidCustomerAddress ? shippingAddress : undefined }
+                                onSelectAddress={ address => onAddressSelect(address) }
+                            />
+                        </LoadingOverlay>
+                    </Fieldset>
+                }
+
+                { !hasValidCustomerAddress &&
+                    <LoadingOverlay isLoading={ isLoading } unmountContentWhenLoading>
+                        <AddressForm
+                            countries={ countries }
+                            countriesWithAutocomplete={ countriesWithAutocomplete }
+                            setFieldValue={ this.setFieldValue }
+                            googleMapsApiKey={ googleMapsApiKey }
+                            countryCode={ formAddress && formAddress.countryCode }
+                            onChange={ this.onChange }
+                            onAutocompleteToggle={ ({ isOpen, inputValue }) => {
+                                if (!isOpen) {
+                                    onFieldChange('address1', inputValue);
+                                }
+                            } }
+                            fieldName={ addressFieldName }
+                            formFields={ formFields }
+                        />
+                    </LoadingOverlay>
+                }
+            </Fieldset>
+        );
+    }
+
+    private setFieldValue: (fieldName: string, fieldValue: string) => void = (fieldName, fieldValue) => {
+        const {
+            formik: { setFieldValue },
+            formFields,
+        } = this.props;
+
+        const customFormFieldNames = formFields
+            .filter(field => field.custom)
+            .map(field => field.name);
+
+        const formFieldName = customFormFieldNames.includes(fieldName) ?
+            `customFields.${fieldName}` :
+            fieldName;
+
+        setFieldValue(`${addressFieldName}.${formFieldName}`, fieldValue);
+    };
+
+    private onChange: (fieldName: string, value: string) => void = (fieldName, value) => {
+        const {
+            onFieldChange,
+        } = this.props;
+
+        onFieldChange(fieldName, value);
+    };
+}
+
+export default connectFormik(ShippingAddressForm);

--- a/src/app/shipping/ShippingForm.spec.tsx
+++ b/src/app/shipping/ShippingForm.spec.tsx
@@ -1,0 +1,326 @@
+import { mount, ReactWrapper } from 'enzyme';
+import React from 'react';
+
+import { getCart } from '../cart/carts.mock';
+import { getPhysicalItem } from '../cart/lineItem.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getCountries } from '../geography/countries.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+import { OrderComments } from '../orderComments';
+
+import { getConsignment } from './consignment.mock';
+import { getShippingAddress } from './shipping-addresses.mock';
+import BillingSameAsShippingField from './shippingOption/BillingSameAsShippingField';
+import ShippingOptions from './shippingOption/ShippingOptions';
+import MultiShippingForm from './MultiShippingForm';
+import ShippingAddress from './ShippingAddress';
+import ShippingForm, { ShippingFormProps } from './ShippingForm';
+
+describe('ShippingForm Component', () => {
+    let component: ReactWrapper;
+    let localeContext: LocaleContextType;
+    let defaultProps: ShippingFormProps;
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+
+        defaultProps = {
+            cart: {
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [
+                        {  ...getPhysicalItem(), quantity: 3 },
+                    ],
+                    giftCertificates: [],
+                    digitalItems: [],
+                },
+            },
+            isGuest: false,
+            createAccountUrl: 'create-account',
+            onSignIn: jest.fn(),
+            assignItem: jest.fn(),
+            addresses: getCustomer().addresses,
+            cartHasChanged: false,
+            countries: getCountries(),
+            countriesWithAutocomplete: [],
+            consignments: [
+                { ...getConsignment(), id: 'foo' },
+                { ...getConsignment(), id: 'bar' },
+             ],
+            customerMessage: 'comment',
+            shippingAddress: getShippingAddress(),
+            isMultiShippingMode: false,
+            shouldShowOrderComments: true,
+            onMultiShippingSubmit: jest.fn(),
+            onSingleShippingSubmit: jest.fn(),
+            isLoading: false,
+            deleteConsignments: jest.fn(),
+            updateAddress: jest.fn(),
+            onUseNewAddress: jest.fn(),
+            getFields: jest.fn(() => []),
+            onUnhandledError: jest.fn(),
+            initialize: jest.fn(),
+            deinitialize: jest.fn(),
+            signOut: jest.fn(),
+        };
+    });
+
+    describe('when multishipping mode is off', () => {
+        beforeEach(() => {
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <ShippingForm
+                        { ...defaultProps }
+                    />
+                </LocaleContext.Provider>
+            );
+        });
+
+        it('renders ShippingAddress with expected props', () => {
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <ShippingForm
+                        { ...defaultProps }
+                        methodId="amazon"
+                    />
+                </LocaleContext.Provider>
+            );
+
+            expect(component.find(ShippingAddress).props()).toEqual(
+                expect.objectContaining({
+                    methodId: 'amazon',
+                })
+            );
+        });
+
+        it('renders BillingSameAsShippping component', () => {
+            expect(component.find(BillingSameAsShippingField).length)
+                .toEqual(1);
+        });
+
+        it('renders disabled continue button when valid address and no shipping option', () => {
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <ShippingForm
+                        { ...defaultProps }
+                        consignments={ [] }
+                    />
+                </LocaleContext.Provider>
+            );
+
+            expect(component.find('Button#checkout-shipping-continue').props())
+                .toEqual(expect.objectContaining({
+                    isLoading: false,
+                    disabled: true,
+                }));
+        });
+
+        it('renders enabled continue button when invalid address', () => {
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <ShippingForm
+                        { ...defaultProps }
+                        shippingAddress={ {
+                            ...getShippingAddress(),
+                            address1: '',
+                        } }
+                    />
+                </LocaleContext.Provider>
+            );
+
+            expect(component.find('Button#checkout-shipping-continue').props())
+                .toEqual(expect.objectContaining({
+                    isLoading: false,
+                    disabled: false,
+                }));
+        });
+
+        it('renders enabled continue button when no address', () => {
+            component = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <ShippingForm
+                        { ...defaultProps }
+                        shippingAddress={ undefined }
+                    />
+                </LocaleContext.Provider>
+            );
+
+            expect(component.find('Button#checkout-shipping-continue').props())
+                .toEqual(expect.objectContaining({
+                    isLoading: false,
+                    disabled: false,
+                }));
+        });
+
+        it('renders ShippingAddress', () => {
+            expect(component.find(ShippingAddress).props()).toEqual(
+                expect.objectContaining({
+                    methodId: undefined,
+                    shippingAddress: defaultProps.shippingAddress,
+                    addresses: defaultProps.addresses,
+                    formFields: [],
+                })
+            );
+
+            expect(defaultProps.getFields).toHaveBeenCalledWith('US');
+            expect(component.find(MultiShippingForm).length).toEqual(0);
+        });
+
+        it('renders shipping options', () => {
+            expect(component.find(ShippingOptions).prop('isMultiShippingMode'))
+                .toEqual(false);
+        });
+
+        it('renders order comments', () => {
+            expect(component.find(OrderComments).length)
+                .toEqual(1);
+        });
+
+        it('calls onSingleShippingSubmit when form is submitted', async () => {
+            component.find('form')
+                .simulate('submit');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(defaultProps.onSingleShippingSubmit).toHaveBeenCalledWith(expect.objectContaining({
+                billingSameAsShipping: true,
+                orderComment: 'comment',
+            }));
+        });
+    });
+
+    describe('when multishipping mode is on', () => {
+        describe('when user is guest', () => {
+            beforeEach(() => {
+                component = mount(
+                    <LocaleContext.Provider value={ localeContext }>
+                        <ShippingForm
+                            { ...defaultProps }
+                            isGuest={ true }
+                            isMultiShippingMode={ true }
+                        />
+                    </LocaleContext.Provider>
+                );
+            });
+
+            it('doest not render shipping options', () => {
+                expect(component.find(ShippingOptions).length).toEqual(0);
+            });
+
+            it('does not render order comments', () => {
+                expect(component.find(OrderComments).length)
+                    .toEqual(0);
+            });
+
+            it('renders MultiShippingForm', () => {
+                expect(component.find(ShippingAddress).length).toEqual(0);
+                expect(component.find(MultiShippingForm).length).toEqual(1);
+            });
+        });
+
+        describe('when user is signed in', () => {
+            beforeEach(() => {
+                component = mount(
+                    <LocaleContext.Provider value={ localeContext }>
+                        <ShippingForm
+                            { ...defaultProps }
+                            isMultiShippingMode={ true }
+                        />
+                    </LocaleContext.Provider>
+                );
+            });
+
+            it('renders disabled button when loading', () => {
+                component = mount(
+                    <LocaleContext.Provider value={ localeContext }>
+                        <ShippingForm
+                            { ...defaultProps }
+                            isLoading={ true }
+                            isMultiShippingMode={ true }
+                        />
+                    </LocaleContext.Provider>
+                );
+
+                expect(component.find('Button#checkout-shipping-continue').props())
+                    .toEqual(expect.objectContaining({
+                        isLoading: true,
+                        disabled: true,
+                    }));
+            });
+
+            it('renders disabled button when no shipping option selected', () => {
+                component = mount(
+                    <LocaleContext.Provider value={ localeContext }>
+                        <ShippingForm
+                            { ...defaultProps }
+                            consignments={ [{
+                                ...getConsignment(),
+                                selectedShippingOption: undefined,
+                            }] }
+                            isMultiShippingMode={ true }
+                        />
+                    </LocaleContext.Provider>
+                );
+
+                expect(component.find('Button#checkout-shipping-continue').props())
+                    .toEqual(expect.objectContaining({
+                        isLoading: false,
+                        disabled: true,
+                    }));
+            });
+
+            it('renders disabled button when unassigned items', () => {
+                component = mount(
+                    <LocaleContext.Provider value={ localeContext }>
+                        <ShippingForm
+                            { ...defaultProps }
+                            consignments={ [] }
+                            isMultiShippingMode={ true }
+                        />
+                    </LocaleContext.Provider>
+                );
+
+                expect(component.find('Button#checkout-shipping-continue').props())
+                    .toEqual(expect.objectContaining({
+                        isLoading: false,
+                        disabled: true,
+                    }));
+            });
+
+            it('renders submit button', () => {
+                expect(component.find('Button#checkout-shipping-continue').props())
+                    .toEqual(expect.objectContaining({
+                        isLoading: false,
+                        disabled: false,
+                    }));
+            });
+
+            it('renders MultiShippingForm', () => {
+                expect(component.find(ShippingAddress).length).toEqual(0);
+                expect(component.find(MultiShippingForm).length).toEqual(1);
+            });
+
+            it('renders shipping options', () => {
+                expect(component.find(ShippingOptions).prop('isMultiShippingMode'))
+                    .toEqual(true);
+            });
+
+            it('renders order comments', () => {
+                expect(component.find(OrderComments).length)
+                    .toEqual(1);
+            });
+
+            it('calls onMultiShippingSubmit when form is submitted', async () => {
+                component.find('form')
+                    .simulate('submit');
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(defaultProps.onMultiShippingSubmit).toHaveBeenCalledWith(expect.objectContaining({
+                    orderComment: 'comment',
+                }));
+            });
+        });
+    });
+});

--- a/src/app/shipping/ShippingForm.tsx
+++ b/src/app/shipping/ShippingForm.tsx
@@ -1,0 +1,114 @@
+import { Address, Cart, CheckoutSelectors, Consignment, ConsignmentAssignmentRequestBody, Country, CustomerAddress, CustomerRequestOptions, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+import React, { Component, ReactNode } from 'react';
+
+import { withLanguage, WithLanguageProps } from '../locale';
+
+import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm';
+import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
+
+export interface ShippingFormProps {
+    addresses: CustomerAddress[];
+    cart: Cart;
+    cartHasChanged: boolean;
+    consignments: Consignment[];
+    countries: Country[];
+    countriesWithAutocomplete: string[];
+    createAccountUrl: string;
+    customerMessage: string;
+    googleMapsApiKey?: string;
+    isGuest: boolean;
+    isLoading: boolean;
+    isMultiShippingMode: boolean;
+    methodId?: string;
+    shippingAddress?: Address;
+    shouldShowOrderComments: boolean;
+    assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
+    deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
+    deleteConsignments(): Promise<Address | undefined>;
+    getFields(countryCode?: string): FormField[];
+    initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
+    onMultiShippingSubmit(values: MultiShippingFormValues): void;
+    onSignIn(): void;
+    onSingleShippingSubmit(values: SingleShippingFormValues): void;
+    onUnhandledError(error: Error): void;
+    onUseNewAddress(address: Address, itemId: string): void;
+    signOut(options?: CustomerRequestOptions): void;
+    updateAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+}
+
+class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
+    render(): ReactNode {
+        const {
+            addresses,
+            assignItem,
+            cart,
+            cartHasChanged,
+            consignments,
+            countries,
+            countriesWithAutocomplete,
+            createAccountUrl,
+            customerMessage,
+            deinitialize,
+            deleteConsignments,
+            getFields,
+            googleMapsApiKey,
+            initialize,
+            isGuest,
+            isLoading,
+            isMultiShippingMode,
+            methodId,
+            onMultiShippingSubmit,
+            onSignIn,
+            onSingleShippingSubmit,
+            onUnhandledError,
+            onUseNewAddress,
+            shippingAddress,
+            shouldShowOrderComments,
+            signOut,
+            updateAddress,
+        } = this.props;
+
+        return isMultiShippingMode ?
+            <MultiShippingForm
+                cart={ cart }
+                consignments={ consignments }
+                customerMessage={ customerMessage }
+                isGuest={ isGuest }
+                addresses={ addresses }
+                assignItem={ assignItem }
+                onUnhandledError={ onUnhandledError }
+                onUseNewAddress={ onUseNewAddress }
+                onSignIn={ onSignIn }
+                createAccountUrl={ createAccountUrl }
+                isLoading={ isLoading }
+                getFields={ getFields }
+                cartHasChanged={ cartHasChanged }
+                shouldShowOrderComments={ shouldShowOrderComments }
+                onSubmit={ onMultiShippingSubmit }
+            /> :
+            <SingleShippingForm
+                countriesWithAutocomplete={ countriesWithAutocomplete }
+                customerMessage={ customerMessage }
+                cartHasChanged={ cartHasChanged }
+                isMultiShippingMode={ isMultiShippingMode }
+                shouldShowOrderComments={ shouldShowOrderComments }
+                shippingAddress={ shippingAddress }
+                onSubmit={ onSingleShippingSubmit }
+                updateAddress={ updateAddress }
+                deleteConsignments={ deleteConsignments }
+                getFields={ getFields }
+                onUnhandledError={ onUnhandledError }
+                consignments={ consignments }
+                methodId={ methodId }
+                isLoading={ isLoading }
+                googleMapsApiKey={ googleMapsApiKey }
+                countries={ countries }
+                addresses={ addresses }
+                initialize={ initialize }
+                deinitialize={ deinitialize }
+                signOut={ signOut }
+            />;
+    }
+}
+
+export default withLanguage(ShippingForm);

--- a/src/app/shipping/ShippingFormFooter.tsx
+++ b/src/app/shipping/ShippingFormFooter.tsx
@@ -1,0 +1,76 @@
+import React, { Component, ReactNode } from 'react';
+
+import { TranslatedString } from '../language';
+import { OrderComments } from '../orderComments';
+import { Alert, AlertType } from '../ui/alert';
+import { Button, ButtonVariant } from '../ui/button';
+import { Fieldset, Legend } from '../ui/form';
+
+import ShippingOptions from './shippingOption/ShippingOptions';
+
+export interface ShippingFormFooterProps {
+    cartHasChanged: boolean;
+    isMultiShippingMode: boolean;
+    shouldShowOrderComments: boolean;
+    shouldShowShippingOptions?: boolean;
+    shouldDisableSubmit: boolean;
+    isLoading: boolean;
+}
+
+class ShippingFormFooter extends Component<ShippingFormFooterProps> {
+    render(): ReactNode {
+        const {
+            cartHasChanged,
+            isMultiShippingMode,
+            shouldShowOrderComments,
+            shouldShowShippingOptions = true,
+            shouldDisableSubmit,
+            isLoading,
+        } = this.props;
+
+        return <>
+            <Fieldset
+                id="checkout-shipping-options"
+                legend={
+                    <>
+                        <Legend>
+                            <TranslatedString id="shipping.shipping_method_label" />
+                        </Legend>
+
+                        { cartHasChanged &&
+                            <Alert type={ AlertType.Error }>
+                                <strong>
+                                    <TranslatedString id="shipping.cart_change_error" />
+                                </strong>
+                            </Alert>
+                        }
+                    </>
+                }
+            >
+                <ShippingOptions
+                    isUpdatingAddress={ isLoading }
+                    shouldShowShippingOptions={ shouldShowShippingOptions }
+                    isMultiShippingMode={ isMultiShippingMode }
+                />
+            </Fieldset>
+
+            { shouldShowOrderComments &&
+                <OrderComments />
+            }
+
+            <div className="form-actions">
+                <Button
+                    variant={ ButtonVariant.Primary }
+                    isLoading={ isLoading }
+                    disabled={ shouldDisableSubmit }
+                    id="checkout-shipping-continue"
+                    type="submit"
+                >
+                    <TranslatedString id="common.continue_action" />
+                </Button>
+            </div>
+        </>;
+    }
+}
+
+export default ShippingFormFooter;

--- a/src/app/shipping/ShippingHeader.tsx
+++ b/src/app/shipping/ShippingHeader.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent } from 'react';
+
+import { preventDefault } from '../common/dom';
+import { TranslatedString } from '../language';
+import { Legend } from '../ui/form';
+
+interface ShippingHeaderProps {
+    isMultiShippingMode: boolean;
+    isGuest: boolean;
+    shouldShowMultiShipping: boolean;
+    onMultiShippingChange(): void;
+}
+
+const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
+    isMultiShippingMode,
+    isGuest,
+    onMultiShippingChange,
+    shouldShowMultiShipping,
+}) => (
+    <div className="form-legend-container">
+        <Legend testId="shipping-address-heading">
+            <TranslatedString id={ isMultiShippingMode ?
+                (isGuest ?
+                    'shipping.multishipping_address_heading_guest' :
+                    'shipping.multishipping_address_heading') :
+                'shipping.shipping_address_heading'
+            } />
+        </Legend>
+
+        { shouldShowMultiShipping &&
+            <a
+                href="#"
+                data-test="shipping-mode-toggle"
+                onClick={ preventDefault(onMultiShippingChange) }>
+                <TranslatedString id={ isMultiShippingMode ?
+                    'shipping.ship_to_single' :
+                    'shipping.ship_to_multi'
+                } />
+            </a>
+        }
+    </div>
+);
+
+export default ShippingHeader;

--- a/src/app/shipping/SingleShippingForm.spec.tsx
+++ b/src/app/shipping/SingleShippingForm.spec.tsx
@@ -1,0 +1,127 @@
+import { mount, ReactWrapper } from 'enzyme';
+import React from 'react';
+
+import { getAddressFormFields } from '../address/formField.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+
+import { getShippingAddress } from './shipping-addresses.mock';
+import SingleShippingForm, { SingleShippingFormProps, SHIPPING_AUTOSAVE_DELAY } from './SingleShippingForm';
+
+describe('SingleShippingForm', () => {
+    const addressFormFields = getAddressFormFields().filter(({ custom }) => !custom );
+    let localeContext: LocaleContextType;
+    let component: ReactWrapper;
+    let defaultProps: SingleShippingFormProps;
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        defaultProps = {
+            isMultiShippingMode: false,
+            countries: [],
+            countriesWithAutocomplete: [],
+            shippingAddress: getShippingAddress(),
+            customerMessage: '',
+            addresses: [],
+            shouldShowOrderComments: true,
+            consignments: [],
+            cartHasChanged: false,
+            isLoading: false,
+            onSubmit: jest.fn(),
+            getFields: jest.fn(() => addressFormFields),
+            onUnhandledError: jest.fn(),
+            deinitialize: jest.fn(),
+            signOut: jest.fn(),
+            initialize: jest.fn(),
+            updateAddress: jest.fn(),
+            deleteConsignments: jest.fn(),
+        };
+
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <SingleShippingForm { ...defaultProps } />
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('calls updateAddress with last event during a given timeframe', done => {
+        component.find('input[name="shippingAddress.address1"]')
+            .simulate('change', { target: { value: 'foo 1', name: 'shippingAddress.address1' } });
+
+        component.find('input[name="shippingAddress.address1"]')
+            .simulate('change', { target: { value: 'foo 2', name: 'shippingAddress.address1' } });
+
+        setTimeout(() => {
+            expect(defaultProps.updateAddress).toHaveBeenCalledTimes(1);
+            expect(defaultProps.updateAddress).toHaveBeenCalledWith({
+                ...getShippingAddress(),
+                address1: 'foo 2',
+            });
+            done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+
+    it('calls updateAddress if modified field does not affect shipping but makes form valid', done => {
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <SingleShippingForm
+                    { ...defaultProps }
+                    getFields={ () => [
+                        ...addressFormFields.map(field => ({ ...field, required: true })),
+                    ]}
+                />
+            </LocaleContext.Provider>
+        );
+
+        component.find('input[name="shippingAddress.address2"]')
+            .simulate('change', { target: { value: '', name: 'shippingAddress.address2' } });
+
+        component.find('input[name="shippingAddress.address2"]')
+            .simulate('change', { target: { value: 'foo 1', name: 'shippingAddress.address2' } });
+
+        setTimeout(() => {
+            expect(defaultProps.updateAddress).toHaveBeenCalledTimes(1);
+            done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+
+    it('does not call updateAddress if modified field does not affect shipping', done => {
+        component.find('input[name="shippingAddress.address2"]')
+            .simulate('change', { target: { value: 'foo 1', name: 'shippingAddress.address2' } });
+
+        setTimeout(() => {
+            expect(defaultProps.updateAddress).not.toHaveBeenCalled();
+            done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+
+    it('does not call updateAddress if modified field produces invalid address', done => {
+        component.find('input[name="shippingAddress.address1"]')
+            .simulate('change', { target: { value: '', name: 'shippingAddress.address1' } });
+
+        setTimeout(() => {
+            expect(defaultProps.updateAddress).not.toHaveBeenCalled();
+            done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+
+    it('does not call updateAddress if not valid address', done => {
+        component.find('input[name="shippingAddress.address1"]')
+            .simulate('change', { target: { value: '', name: 'shippingAddress.address1' } });
+
+        setTimeout(() => {
+            expect(defaultProps.updateAddress).not.toHaveBeenCalled();
+            done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+
+    it('does not call updateAddress if same address', done => {
+        component.find('input[name="shippingAddress.address1"]')
+            .simulate('change', { target: { value: '', name: getShippingAddress().address1 } });
+
+        setTimeout(() => {
+            expect(defaultProps.updateAddress).not.toHaveBeenCalled();
+            done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+});

--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -1,0 +1,310 @@
+import { Address, CheckoutSelectors, Consignment, Country, CustomerAddress, CustomerRequestOptions, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+import { withFormik, FormikProps } from 'formik';
+import { debounce, noop } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+import { lazy, object } from 'yup';
+
+import { getAddressValidationSchema, isEqualAddress, mapAddressFromFormValues, mapAddressToFormValues, AddressFormValues } from '../address';
+import { withLanguage, WithLanguageProps } from '../locale';
+import { Fieldset, Form } from '../ui/form';
+
+import BillingSameAsShippingField from './shippingOption/BillingSameAsShippingField';
+import hasSelectedShippingOptions from './util/hasSelectedShippingOptions';
+import ShippingAddress from './ShippingAddress';
+import { SHIPPING_ADDRESS_FIELDS } from './ShippingAddressFields';
+import ShippingFormFooter from './ShippingFormFooter';
+
+export interface SingleShippingFormProps {
+    addresses: CustomerAddress[];
+    cartHasChanged: boolean;
+    consignments: Consignment[];
+    countries: Country[];
+    countriesWithAutocomplete: string[];
+    customerMessage: string;
+    googleMapsApiKey?: string;
+    isLoading: boolean;
+    isMultiShippingMode: boolean;
+    methodId?: string;
+    shippingAddress?: Address;
+    shouldShowOrderComments: boolean;
+    deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
+    deleteConsignments(): Promise<Address | undefined>;
+    getFields(countryCode?: string): FormField[];
+    initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
+    onSubmit(values: SingleShippingFormValues): void;
+    onUnhandledError?(error: Error): void;
+    signOut(options?: CustomerRequestOptions): void;
+    updateAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+}
+
+export interface SingleShippingFormValues {
+    billingSameAsShipping: boolean;
+    shippingAddress?: AddressFormValues;
+    orderComment: string;
+}
+
+interface SingleShippingFormState {
+    isResettingAddress: boolean;
+    isUpdatingShippingData: boolean;
+}
+
+export const SHIPPING_AUTOSAVE_DELAY = 1000;
+
+class SingleShippingForm extends Component<SingleShippingFormProps & WithLanguageProps & FormikProps<SingleShippingFormValues>> {
+    state: SingleShippingFormState = {
+        isResettingAddress: false,
+        isUpdatingShippingData: false,
+    };
+
+    private debouncedUpdateAddress: any;
+
+    constructor(props: SingleShippingFormProps & WithLanguageProps & FormikProps<SingleShippingFormValues>) {
+        super(props);
+
+        const { updateAddress } = this.props;
+
+        this.debouncedUpdateAddress = debounce(async (address: Address) => {
+            try {
+                await updateAddress(address);
+            } finally {
+                this.setState({ isUpdatingShippingData: false });
+            }
+        }, SHIPPING_AUTOSAVE_DELAY);
+    }
+
+    render(): ReactNode {
+        const {
+            addresses,
+            cartHasChanged,
+            isLoading,
+            onUnhandledError,
+            methodId,
+            countries,
+            countriesWithAutocomplete,
+            googleMapsApiKey,
+            shippingAddress,
+            consignments,
+            shouldShowOrderComments,
+            initialize,
+            isValid,
+            deinitialize,
+            signOut,
+            values: { shippingAddress: addressForm },
+        } = this.props;
+
+        const {
+            isResettingAddress,
+            isUpdatingShippingData,
+        } = this.state;
+
+        return (
+            <Form autoComplete="on">
+                <Fieldset>
+                    <ShippingAddress
+                        countriesWithAutocomplete={ countriesWithAutocomplete }
+                        isLoading={ isResettingAddress }
+                        onUnhandledError={ onUnhandledError }
+                        methodId={ methodId }
+                        googleMapsApiKey={ googleMapsApiKey }
+                        countries={ countries }
+                        formFields={ this.getFields(addressForm && addressForm.countryCode) }
+                        shippingAddress={ shippingAddress }
+                        consignments={ consignments }
+                        addresses={ addresses }
+                        initialize={ initialize }
+                        deinitialize={ deinitialize }
+                        signOut={ signOut }
+                        onAddressSelect={ this.handleAddressSelect }
+                        onFieldChange={ this.handleFieldChange }
+                        onUseNewAddress={ this.onUseNewAddress }
+                    />
+                    <div className="form-body">
+                        <BillingSameAsShippingField />
+                    </div>
+                </Fieldset>
+
+                <ShippingFormFooter
+                    isMultiShippingMode={ false }
+                    cartHasChanged={ cartHasChanged }
+                    shouldShowOrderComments={ shouldShowOrderComments }
+                    shouldShowShippingOptions={ isValid }
+                    shouldDisableSubmit={ this.shouldDisableSubmit() }
+                    isLoading={ isLoading || isUpdatingShippingData }
+                />
+            </Form>
+        );
+    }
+
+    componentDidUpdate({ isValid: prevIsValid }:
+        SingleShippingFormProps &
+        WithLanguageProps &
+        FormikProps<SingleShippingFormValues>
+    ): void {
+        const { isValid } = this.props;
+
+        if (!prevIsValid && isValid) {
+            this.updateAddressWithFormData();
+        }
+    }
+
+    private shouldDisableSubmit: () => boolean = () => {
+        const {
+            isLoading,
+            consignments,
+            isValid,
+        } = this.props;
+
+        const {
+            isUpdatingShippingData,
+        } = this.state;
+
+        if (!isValid) {
+            return false;
+        }
+
+        return isLoading || isUpdatingShippingData || !hasSelectedShippingOptions(consignments);
+    };
+
+    private handleFieldChange: (name: string) => void = async name => {
+        const {
+            setFieldValue,
+        } = this.props;
+
+        if (name === 'countryCode') {
+            setFieldValue('shippingAddress.stateOrProvince', '');
+            setFieldValue('shippingAddress.stateOrProvinceCode', '');
+        }
+
+        // Enqueue the following code to run after Formik has run validation
+        await new Promise(resolve => setTimeout(resolve));
+
+        const isShippingField = SHIPPING_ADDRESS_FIELDS.includes(name);
+
+        const { isValid } = this.props;
+
+        if (!isValid || !isShippingField) {
+            return;
+        }
+
+        this.updateAddressWithFormData();
+    };
+
+    private updateAddressWithFormData() {
+        const {
+            shippingAddress,
+            values: { shippingAddress: addressForm },
+        } = this.props;
+
+        const updatedShippingAddress = addressForm && mapAddressFromFormValues(addressForm);
+
+        if (!updatedShippingAddress || isEqualAddress(updatedShippingAddress, shippingAddress)) {
+            return;
+        }
+
+        this.setState({ isUpdatingShippingData: true });
+        this.debouncedUpdateAddress(updatedShippingAddress);
+    }
+
+    private handleAddressSelect: (
+        address: Address
+    ) => void = async address => {
+        const {
+            updateAddress,
+            onUnhandledError = noop,
+            values,
+            setValues,
+        } = this.props;
+
+        this.setState({ isResettingAddress: true });
+
+        try {
+            await updateAddress(address);
+
+            setValues({
+                ...values,
+                shippingAddress: mapAddressToFormValues(
+                    this.getFields(address.countryCode),
+                    address
+                ),
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        } finally {
+            this.setState({ isResettingAddress: false });
+        }
+    };
+
+    private onUseNewAddress: () => void = async () => {
+        const {
+            deleteConsignments,
+            onUnhandledError = noop,
+            setValues,
+            values,
+        } = this.props;
+
+        this.setState({ isResettingAddress: true });
+
+        try {
+            const address = await deleteConsignments();
+            setValues({
+                ...values,
+                shippingAddress: mapAddressToFormValues(
+                    this.getFields(address && address.countryCode),
+                    address
+                ),
+            });
+        } catch (e) {
+            onUnhandledError(e);
+        } finally {
+            this.setState({ isResettingAddress: false });
+        }
+    };
+
+    private getFields(countryCode: string | undefined): FormField[] {
+        const {
+            getFields,
+        } = this.props;
+
+        return getFields(countryCode);
+    }
+}
+
+export default withLanguage(withFormik<SingleShippingFormProps & WithLanguageProps, SingleShippingFormValues>({
+    handleSubmit: (values, { props: { onSubmit } }) => {
+        onSubmit(values);
+    },
+    mapPropsToValues: ({ getFields, shippingAddress,  customerMessage }) => ({
+        billingSameAsShipping: true,
+        orderComment: customerMessage,
+        shippingAddress: mapAddressToFormValues(
+            getFields(shippingAddress && shippingAddress.countryCode),
+            shippingAddress
+        ),
+    }),
+    isInitialValid: ({
+        shippingAddress,
+        getFields,
+        language,
+    }) => (
+        !!shippingAddress && getAddressValidationSchema({
+            language,
+            formFields: getFields(shippingAddress.countryCode),
+        }).isValidSync(shippingAddress)
+    ),
+    validationSchema: ({
+        language,
+        getFields,
+        methodId,
+    }: SingleShippingFormProps & WithLanguageProps) => ( methodId ?
+        object() :
+        object({
+            shippingAddress: lazy<Partial<AddressFormValues>>(formValues =>
+                getAddressValidationSchema({
+                    language,
+                    formFields: getFields(formValues && formValues.countryCode),
+                })
+            ),
+        })
+    ),
+    enableReinitialize: false,
+})(SingleShippingForm));

--- a/src/app/shipping/StaticConsignment.scss
+++ b/src/app/shipping/StaticConsignment.scss
@@ -1,0 +1,18 @@
+@import '../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+
+.staticConsignmentContainer {
+    ul {
+        list-style: none;
+        margin: 0;
+    }
+
+    & + .staticConsignmentContainer {
+        border-top: container("border");
+        margin-top: spacing("single");
+        padding-top: spacing("single");
+    }
+}
+
+.staticConsignment-items {
+    margin: spacing("quarter") 0;
+}

--- a/src/app/shipping/StaticConsignment.spec.tsx
+++ b/src/app/shipping/StaticConsignment.spec.tsx
@@ -1,0 +1,34 @@
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+
+import { getCart } from '../cart/carts.mock';
+
+import { getConsignment } from './consignment.mock';
+import StaticConsignment from './StaticConsignment';
+
+describe('StaticConsignment Component', () => {
+    const consignment = getConsignment();
+    const cart = getCart();
+
+    it('renders static consignment without shipping method', () => {
+        const tree = shallow(
+            <StaticConsignment cart={ cart } consignment={ consignment }/>);
+
+        expect(toJson(tree)).toMatchSnapshot();
+    });
+
+    it('renders static consignment with shipping method', () => {
+        const tree = shallow(
+            <StaticConsignment cart={ cart } consignment={ consignment } showShippingMethod={ true }/>);
+
+        expect(toJson(tree)).toMatchSnapshot();
+    });
+
+    it('renders compact view of static consignment', () => {
+        const tree = shallow(
+            <StaticConsignment cart={ cart } compactView={ true } consignment={ consignment } showShippingMethod={ true }/>);
+
+        expect(toJson(tree)).toMatchSnapshot();
+    });
+});

--- a/src/app/shipping/StaticConsignment.tsx
+++ b/src/app/shipping/StaticConsignment.tsx
@@ -1,0 +1,71 @@
+import { Cart, Consignment } from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { StaticAddress } from '../address';
+import { TranslatedString } from '../language';
+
+import StaticShippingOption from './shippingOption/StaticShippingOption';
+import findLineItems from './util/findLineItems';
+import getLineItemsCount from './util/getLineItemsCount';
+import './StaticConsignment.scss';
+
+interface StaticConsignmentProps {
+    consignment: Consignment;
+    cart: Cart;
+    compactView?: boolean;
+    showShippingMethod?: boolean;
+}
+
+const StaticConsignment: React.SFC<StaticConsignmentProps> = ({
+    consignment,
+    cart,
+    showShippingMethod,
+    compactView,
+}) => {
+    const lineItems = findLineItems(cart, consignment);
+    const {
+        shippingAddress: address,
+        selectedShippingOption,
+    } = consignment;
+
+    return (
+        <div className="staticConsignment">
+            { !compactView &&
+                <strong>
+                    <TranslatedString id="shipping.shipping_address_heading" />
+                </strong>
+            }
+            <StaticAddress address={ address } />
+            { !compactView &&
+                <div className="staticConsignment-items">
+                    <strong>
+                        <TranslatedString id="cart.item_count_text"
+                            data={ { count: getLineItemsCount(lineItems) } } />
+                    </strong>
+                    <ul>
+                        { lineItems.map(item =>
+                            <li key={ item.id }>
+                                { item.quantity } x { item.name }
+                            </li>
+                        ) }
+                    </ul>
+                </div>
+            }
+
+            { showShippingMethod && selectedShippingOption &&
+                <div>
+                    { !compactView &&
+                        <strong>
+                            <TranslatedString id="shipping.shipping_method_label"/>
+                        </strong>
+                    }
+                    <div className="shippingOption shippingOption--alt">
+                        <StaticShippingOption method={ selectedShippingOption } />
+                    </div>
+                </div>
+            }
+        </div>
+    );
+};
+
+export default StaticConsignment;

--- a/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
+++ b/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StaticConsignment Component renders compact view of static consignment 1`] = `
+<div
+  className="staticConsignment"
+>
+  <WithCheckout(StaticAddress)
+    address={
+      Object {
+        "address1": "12345 Testing Way",
+        "address2": "",
+        "city": "Some City",
+        "company": "Bigcommerce",
+        "country": "United States",
+        "countryCode": "US",
+        "customFields": Array [],
+        "firstName": "Test",
+        "lastName": "Tester",
+        "phone": "555-555-5555",
+        "postalCode": "95555",
+        "stateOrProvince": "California",
+        "stateOrProvinceCode": "CA",
+      }
+    }
+  />
+  <div>
+    <div
+      className="shippingOption shippingOption--alt"
+    >
+      <StaticShippingOption
+        method={
+          Object {
+            "cost": 0,
+            "description": "Flat Rate",
+            "id": "0:61d4bb52f746477e1d4fb411221318c3",
+            "imageUrl": "",
+            "isRecommended": true,
+            "transitTime": "",
+            "type": "shipping_flatrate",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StaticConsignment Component renders static consignment with shipping method 1`] = `
+<div
+  className="staticConsignment"
+>
+  <strong>
+    <WithLanguage(TranslatedString)
+      id="shipping.shipping_address_heading"
+    />
+  </strong>
+  <WithCheckout(StaticAddress)
+    address={
+      Object {
+        "address1": "12345 Testing Way",
+        "address2": "",
+        "city": "Some City",
+        "company": "Bigcommerce",
+        "country": "United States",
+        "countryCode": "US",
+        "customFields": Array [],
+        "firstName": "Test",
+        "lastName": "Tester",
+        "phone": "555-555-5555",
+        "postalCode": "95555",
+        "stateOrProvince": "California",
+        "stateOrProvinceCode": "CA",
+      }
+    }
+  />
+  <div
+    className="staticConsignment-items"
+  >
+    <strong>
+      <WithLanguage(TranslatedString)
+        data={
+          Object {
+            "count": 0,
+          }
+        }
+        id="cart.item_count_text"
+      />
+    </strong>
+    <ul />
+  </div>
+  <div>
+    <strong>
+      <WithLanguage(TranslatedString)
+        id="shipping.shipping_method_label"
+      />
+    </strong>
+    <div
+      className="shippingOption shippingOption--alt"
+    >
+      <StaticShippingOption
+        method={
+          Object {
+            "cost": 0,
+            "description": "Flat Rate",
+            "id": "0:61d4bb52f746477e1d4fb411221318c3",
+            "imageUrl": "",
+            "isRecommended": true,
+            "transitTime": "",
+            "type": "shipping_flatrate",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StaticConsignment Component renders static consignment without shipping method 1`] = `
+<div
+  className="staticConsignment"
+>
+  <strong>
+    <WithLanguage(TranslatedString)
+      id="shipping.shipping_address_heading"
+    />
+  </strong>
+  <WithCheckout(StaticAddress)
+    address={
+      Object {
+        "address1": "12345 Testing Way",
+        "address2": "",
+        "city": "Some City",
+        "company": "Bigcommerce",
+        "country": "United States",
+        "countryCode": "US",
+        "customFields": Array [],
+        "firstName": "Test",
+        "lastName": "Tester",
+        "phone": "555-555-5555",
+        "postalCode": "95555",
+        "stateOrProvince": "California",
+        "stateOrProvinceCode": "CA",
+      }
+    }
+  />
+  <div
+    className="staticConsignment-items"
+  >
+    <strong>
+      <WithLanguage(TranslatedString)
+        data={
+          Object {
+            "count": 0,
+          }
+        }
+        id="cart.item_count_text"
+      />
+    </strong>
+    <ul />
+  </div>
+</div>
+`;

--- a/src/app/shipping/errors/AssignItemFailedError.ts
+++ b/src/app/shipping/errors/AssignItemFailedError.ts
@@ -1,0 +1,16 @@
+import { setPrototypeOf, CustomError } from '../../common/error';
+import { getLanguageService } from '../../locale';
+
+const languageService = getLanguageService();
+
+export class AssignItemFailedError extends CustomError {
+    constructor(data: Error) {
+        super({
+            name: 'ASSIGN_ITEM_FAILED',
+            message: languageService.translate('shipping.assign_item_error'),
+            data,
+        });
+
+        setPrototypeOf(this, AssignItemFailedError.prototype);
+    }
+}

--- a/src/app/shipping/errors/AssignItemInvalidAddressError.ts
+++ b/src/app/shipping/errors/AssignItemInvalidAddressError.ts
@@ -1,0 +1,17 @@
+import { setPrototypeOf, CustomError } from '../../common/error';
+import { getLanguageService } from '../../locale';
+
+const languageService = getLanguageService();
+
+export class AssignItemInvalidAddressError extends CustomError {
+    constructor(data?: Error) {
+        super({
+            name: 'ASSIGN_ITEM_INVALID_ADDRESS',
+            message: languageService.translate('shipping.assign_item_invalid_address_error'),
+            title: languageService.translate('shipping.assign_item_invalid_address_error_heading'),
+            data,
+        });
+
+        setPrototypeOf(this, AssignItemInvalidAddressError.prototype);
+    }
+}

--- a/src/app/shipping/errors/UnassignItemError.ts
+++ b/src/app/shipping/errors/UnassignItemError.ts
@@ -1,0 +1,16 @@
+import { setPrototypeOf, CustomError } from '../../common/error';
+import { getLanguageService } from '../../locale';
+
+const languageService = getLanguageService();
+
+export class UnassignItemError extends CustomError {
+    constructor(data: Error) {
+        super({
+            name: 'UNASSIGN_ITEM_FAILED',
+            message: languageService.translate('shipping.unassign_item_error'),
+            data,
+        });
+
+        setPrototypeOf(this, UnassignItemError.prototype);
+    }
+}

--- a/src/app/shipping/getShippingMethodId.ts
+++ b/src/app/shipping/getShippingMethodId.ts
@@ -1,0 +1,12 @@
+import { Checkout } from '@bigcommerce/checkout-sdk';
+
+import getPreselectedPayment from '../payment/getPreselectedPayment';
+
+export default function getShippingMethodId(checkout: Checkout): string | undefined {
+    const SHIPPING_METHOD_IDS = ['amazon'];
+    const preselectedPayment = getPreselectedPayment(checkout);
+
+    return preselectedPayment && SHIPPING_METHOD_IDS.indexOf(preselectedPayment.providerId) > -1 ?
+        preselectedPayment.providerId :
+        undefined;
+}

--- a/src/app/shipping/index.ts
+++ b/src/app/shipping/index.ts
@@ -1,5 +1,13 @@
+import { ShippingProps } from './Shipping';
+
+export type ShippingProps = ShippingProps;
+
+export { default as StaticShippingOption } from './shippingOption/StaticShippingOption';
+export { default as ShippingOptionsList } from './shippingOption/ShippingOptionsList';
+export { default as StaticConsignment } from './StaticConsignment';
+
 export { default as hasUnassignedLineItems } from './util/hasUnassignedLineItems';
 export { default as isUsingMultiShipping } from './util/isUsingMultiShipping';
 export { default as hasSelectedShippingOptions } from './util/hasSelectedShippingOptions';
-export { default as getShippableLineItems } from './util/getShippableLineItems';
 export { default as getShippableItemsCount } from './util/getShippableItemsCount';
+export { default as Shipping } from './Shipping';

--- a/src/app/shipping/mapToShippingProps.spec.ts
+++ b/src/app/shipping/mapToShippingProps.spec.ts
@@ -1,0 +1,90 @@
+import { createCheckoutService, Cart, Checkout, CheckoutService, StoreConfig } from '@bigcommerce/checkout-sdk';
+
+import { getCart } from '../cart/carts.mock';
+import { getPhysicalItem } from '../cart/lineItem.mock';
+import { CheckoutContextProps } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+
+import { mapToShippingProps } from './Shipping';
+
+describe('mapToShippingProps()', () => {
+    let checkoutContextProps: CheckoutContextProps;
+    let checkoutService: CheckoutService;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+
+        checkoutContextProps = {
+            checkoutService,
+            checkoutState: checkoutService.getState(),
+        };
+    });
+
+    it('returns null when not initialized', () => {
+        expect(mapToShippingProps(checkoutContextProps))
+            .toEqual(null);
+    });
+
+    describe('shouldShowMultiShipping', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(getCheckout());
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
+            jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(getCustomer());
+            jest.spyOn(checkoutService.getState().data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [ {
+                        ...getPhysicalItem(),
+                        quantity: 3,
+                    }],
+                },
+            } as Cart);
+        });
+
+        it('returns true when enabled', () => {
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(mapToShippingProps(checkoutContextProps)!.shouldShowMultiShipping)
+                .toEqual(true);
+        });
+
+        it('returns false when not enabled', () => {
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                ...getStoreConfig(),
+                checkoutSettings: {
+                    features: {},
+                    hasMultiShippingEnabled: false,
+                },
+            } as StoreConfig);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(mapToShippingProps(checkoutContextProps)!.shouldShowMultiShipping)
+                .toEqual(false);
+        });
+
+        it('returns false when no physical items', () => {
+            jest.spyOn(checkoutService.getState().data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [],
+                },
+            } as unknown as Cart);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(mapToShippingProps(checkoutContextProps)!.shouldShowMultiShipping)
+                .toEqual(false);
+        });
+
+        it('returns false when remote shipping', () => {
+            jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                payments: [{ providerId: 'amazon' }],
+            } as Checkout);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(mapToShippingProps(checkoutContextProps)!.shouldShowMultiShipping)
+                .toEqual(false);
+        });
+    });
+});

--- a/src/app/shipping/shippingOption/BillingSameAsShippingField.tsx
+++ b/src/app/shipping/shippingOption/BillingSameAsShippingField.tsx
@@ -1,0 +1,21 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../language';
+import { CheckboxFormField } from '../../ui/form';
+
+export interface BillingSameAsShippingFieldProps {
+    onChange?(isChecked: boolean): void;
+}
+
+const BillingSameAsShippingField: FunctionComponent<BillingSameAsShippingFieldProps>  = ({
+    onChange,
+}) => (
+    <CheckboxFormField
+        name="billingSameAsShipping"
+        id="sameAsBilling"
+        labelContent={ <TranslatedString id="billing.use_shipping_address_label" /> }
+        onChange={ onChange }
+    />
+);
+
+export default BillingSameAsShippingField;

--- a/src/app/shipping/shippingOption/ShippingOptions.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptions.tsx
@@ -1,0 +1,94 @@
+import { Cart, CheckoutSelectors, Consignment } from '@bigcommerce/checkout-sdk';
+import { createSelector } from 'reselect';
+
+import { withCheckout, CheckoutContextProps } from '../../checkout';
+import getShippingMethodId from '../getShippingMethodId';
+
+import ShippingOptionsForm from './ShippingOptionsForm';
+
+export interface ShippingOptionsProps {
+    isMultiShippingMode: boolean;
+    isUpdatingAddress?: boolean;
+    shouldShowShippingOptions: boolean;
+}
+
+export interface WithCheckoutShippingOptionsProps {
+    invalidShippingMessage: string;
+    methodId?: string;
+    consignments?: Consignment[];
+    cart: Cart;
+    isSelectingShippingOption(consignmentId?: string): boolean;
+    subscribeToConsignments(subscriber: (state: CheckoutSelectors) => void): () => void;
+    selectShippingOption(consignmentId: string, optionId: string): void;
+    isLoading(consignmentId?: string): boolean;
+}
+
+const subscribeToConsignmentsSelector = createSelector(
+    ({ checkoutService }: CheckoutContextProps) => checkoutService.subscribe,
+    subscribe => (subscriber: (state: CheckoutSelectors) => void) => {
+        return subscribe(subscriber, ({ data }) => data.getConsignments());
+    }
+);
+
+const isLoadingSelector = createSelector(
+    (_: CheckoutSelectors, { isUpdatingAddress }: ShippingOptionsProps) => isUpdatingAddress,
+    ({ statuses }: CheckoutSelectors) => statuses.isLoadingShippingOptions,
+    ({ statuses }: CheckoutSelectors) => statuses.isSelectingShippingOption,
+    ({ statuses }: CheckoutSelectors) => statuses.isUpdatingConsignment,
+    ({ statuses }: CheckoutSelectors) => statuses.isCreatingConsignments,
+    (isUpdatingAddress, isLoadingShippingOptions, isSelectingShippingOption, isUpdatingConsignment, isCreatingConsignments) => {
+        return (consignmentId?: string) => {
+            return (
+                isUpdatingAddress ||
+                isLoadingShippingOptions() ||
+                isSelectingShippingOption(consignmentId) ||
+                isUpdatingConsignment(consignmentId) ||
+                isCreatingConsignments()
+            );
+        };
+    }
+);
+
+function mapToShippingOptions(
+    { checkoutService, checkoutState }: CheckoutContextProps,
+    props: ShippingOptionsProps
+): WithCheckoutShippingOptionsProps | null {
+    const {
+        data: {
+            getCart,
+            getConsignments,
+            getConfig,
+            getCustomer,
+            getCheckout,
+        },
+        statuses: {
+            isSelectingShippingOption,
+        },
+    } = checkoutState;
+
+    const consignments = getConsignments() || [];
+    const customer = getCustomer();
+    const cart = getCart();
+    const config = getConfig();
+    const checkout = getCheckout();
+
+    if (!config || !checkout || !customer || !cart) {
+        return null;
+    }
+
+    const methodId = getShippingMethodId(checkout);
+    const { shippingQuoteFailedMessage } = config.checkoutSettings;
+
+    return {
+        cart,
+        consignments,
+        invalidShippingMessage: shippingQuoteFailedMessage,
+        isLoading: isLoadingSelector(checkoutState, props),
+        isSelectingShippingOption,
+        methodId,
+        selectShippingOption: checkoutService.selectConsignmentShippingOption,
+        subscribeToConsignments: subscribeToConsignmentsSelector({ checkoutService, checkoutState }),
+    };
+}
+
+export default withCheckout(mapToShippingOptions)(ShippingOptionsForm);

--- a/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
@@ -1,0 +1,128 @@
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { getCart } from '../../cart/carts.mock';
+import { TranslatedString } from '../../language';
+import { getConsignment } from '../consignment.mock';
+import StaticConsignment from '../StaticConsignment';
+
+import ShippingOptionsForm, { ShippingOptionsFormProps } from './ShippingOptionsForm';
+import ShippingOptionsList from './ShippingOptionsList';
+
+describe('ShippingOptions Component', () => {
+    const consignments = [
+        {
+            ...getConsignment(),
+            id: 'bar',
+        },
+        {
+            ...getConsignment(),
+            id: 'foo',
+        },
+    ];
+    const defaultProps: ShippingOptionsFormProps = {
+        isMultiShippingMode: true,
+        consignments,
+        invalidShippingMessage: 'foo',
+        cart: getCart(),
+        shouldShowShippingOptions: true,
+        isSelectingShippingOption: jest.fn(() => false),
+        subscribeToConsignments: jest.fn(),
+        selectShippingOption: jest.fn(),
+        isLoading: jest.fn(() => false),
+    };
+
+    it('renders sorted options for all consignments when multi-shipping', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ noop }>
+                <ShippingOptionsForm
+                    { ...defaultProps }
+                />
+            </Formik>
+        );
+
+        expect(component.find(StaticConsignment).at(0).props()).toEqual(
+            expect.objectContaining({
+                cart: getCart(),
+                consignment: consignments[1],
+            })
+        );
+
+        expect(component.find(ShippingOptionsList).length).toEqual(2);
+
+        expect(component.find(StaticConsignment).at(1).props()).toEqual(
+            expect.objectContaining({
+                cart: getCart(),
+                consignment: consignments[0],
+            })
+        );
+
+        expect(component.find('.shippingOptions-panel-message').length)
+            .toEqual(0);
+    });
+
+    it('renders only shipping options for one consignment when no multi-shipping', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ noop }>
+                <ShippingOptionsForm
+                    { ...defaultProps }
+                    isMultiShippingMode={ false }
+                />
+            </Formik>
+        );
+
+        expect(component.find(ShippingOptionsList).length).toEqual(1);
+    });
+
+    it('renders enter shipping address when no consignments', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ noop }>
+                <ShippingOptionsForm
+                    { ...defaultProps }
+                    isMultiShippingMode={ false }
+                    isLoading={ () => false }
+                    consignments={ [] }
+                />
+            </Formik>
+        );
+
+        expect(component.find(TranslatedString).prop('id'))
+            .toEqual('shipping.enter_shipping_address_text');
+    });
+
+    it('renders select shipping address when no consignments and amazon shipping', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ noop }>
+                <ShippingOptionsForm
+                    { ...defaultProps }
+                    isLoading={ () => false }
+                    methodId="amazon"
+                    consignments={ [] }
+                />
+            </Formik>
+        );
+
+        expect(component.find(TranslatedString).prop('id'))
+            .toEqual('shipping.select_shipping_address_text');
+    });
+
+    it('renders invalid shipping when no shipping options available', () => {
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ noop }>
+                <ShippingOptionsForm
+                    { ...defaultProps }
+                    consignments={ [ {
+                        ...getConsignment(),
+                        availableShippingOptions: [],
+                    } ] }
+                    isMultiShippingMode={ false }
+                />
+            </Formik>
+        );
+
+        expect(component.find('.shippingOptions-panel-message').text())
+            .toEqual(defaultProps.invalidShippingMessage);
+    });
+});

--- a/src/app/shipping/shippingOption/ShippingOptionsForm.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptionsForm.tsx
@@ -1,0 +1,159 @@
+import { CheckoutSelectors } from '@bigcommerce/checkout-sdk';
+import { withFormik, FormikProps } from 'formik';
+import { noop } from 'lodash';
+import React, { Component, Fragment, ReactNode } from 'react';
+
+import { ShippingOptionsList } from '..';
+import { TranslatedString } from '../../language';
+import { LoadingOverlay } from '../../ui/loading';
+import getRecommendedShippingOption from '../util/getRecommendedShippingOption';
+import StaticConsignment from '../StaticConsignment';
+
+import { ShippingOptionsProps, WithCheckoutShippingOptionsProps } from './ShippingOptions';
+
+export type ShippingOptionsFormProps = ShippingOptionsProps & WithCheckoutShippingOptionsProps;
+
+class ShippingOptionsForm extends Component<ShippingOptionsFormProps & FormikProps<ShippingOptionsFormValues>> {
+    private unsubscribe?: () => void;
+
+    componentDidMount(): void {
+        const { subscribeToConsignments } = this.props;
+
+        this.unsubscribe = subscribeToConsignments(this.selectDefaultShippingOption);
+    }
+
+    componentWillUnmount(): void {
+        if (this.unsubscribe) {
+            this.unsubscribe();
+            this.unsubscribe = undefined;
+        }
+    }
+
+    render(): ReactNode {
+        const {
+            cart,
+            consignments,
+            isMultiShippingMode,
+            selectShippingOption,
+            isLoading,
+            shouldShowShippingOptions,
+            invalidShippingMessage,
+            methodId,
+        } = this.props;
+
+        if (!consignments ||
+            !consignments.length ||
+            !shouldShowShippingOptions
+        ) {
+            return (
+                <LoadingOverlay isLoading={ isLoading() } >
+                    { this.renderNoShippingOptions(
+                        <TranslatedString
+                            id={ methodId || isMultiShippingMode ?
+                                'shipping.select_shipping_address_text' :
+                                'shipping.enter_shipping_address_text'
+                            }
+                        />)
+                    }
+                </LoadingOverlay>
+            );
+        }
+
+        return (
+            <Fragment> { consignments
+                .slice(0, isMultiShippingMode ? undefined : 1)
+                .sort((a, b) => (a.id > b.id ? -1 : 1))
+                .map(consignment => (
+                    <div className="shippingOptions-container form-fieldset" key={ consignment.id }>
+                        { isMultiShippingMode &&
+                            <StaticConsignment cart={ cart } consignment={ consignment } />
+                        }
+
+                        <ShippingOptionsList
+                            inputName={ getRadioInputName(consignment.id) }
+                            consignmentId={ consignment.id }
+                            shippingOptions={ consignment.availableShippingOptions }
+                            isLoading={ isLoading(consignment.id) }
+                            selectedShippingOptionId={ consignment.selectedShippingOption && consignment.selectedShippingOption.id }
+                            onSelectedOption={ selectShippingOption }
+                        />
+
+                        { (!consignment.availableShippingOptions || !consignment.availableShippingOptions.length) &&
+                            <LoadingOverlay isLoading={ isLoading(consignment.id) } hideContentWhenLoading>
+                                { this.renderNoShippingOptions(invalidShippingMessage) }
+                            </LoadingOverlay>
+                        }
+                    </div>
+                ))
+            } </Fragment>
+        );
+    }
+
+    private selectDefaultShippingOption: (state: CheckoutSelectors) => void = ({ data }) => {
+        const {
+            selectShippingOption,
+            isSelectingShippingOption,
+        } = this.props;
+
+        (data.getConsignments() || []).map(consignment => {
+            const {
+                id,
+                selectedShippingOption,
+            } = consignment;
+
+            if (selectedShippingOption || isSelectingShippingOption(consignment.id)) {
+                return;
+            }
+
+            const recommendedOption = getRecommendedShippingOption(consignment);
+            const defaultShippingOption = recommendedOption || (
+                consignment.availableShippingOptions &&
+                consignment.availableShippingOptions.length === 1 ?
+                    consignment.availableShippingOptions[0] :
+                    undefined
+                );
+
+            if (!defaultShippingOption) {
+                return;
+            }
+
+            return selectShippingOption(id, defaultShippingOption.id);
+        });
+    };
+
+    private renderNoShippingOptions(message: ReactNode): ReactNode {
+        return (
+            <div className="shippingOptions-panel optimizedCheckout-overlay">
+                <p className="shippingOptions-panel-message optimizedCheckout-primaryContent">
+                    { message }
+                </p>
+            </div>
+        );
+    }
+}
+
+function getRadioInputName(consignmentId: string): string {
+    return `shippingOptionIds.${consignmentId}`;
+}
+
+export interface ShippingOptionsFormValues {
+    shippingOptionIds: {
+        [shippingOptionIds: string]: string;
+    };
+}
+
+export default withFormik<ShippingOptionsFormProps, ShippingOptionsFormValues>({
+    handleSubmit: noop,
+    enableReinitialize: true,
+    mapPropsToValues({ consignments }) {
+        const shippingOptionIds: { [id: string]: string } = {};
+
+        (consignments || []).forEach(consignment => {
+            shippingOptionIds[consignment.id] = consignment.selectedShippingOption ?
+                consignment.selectedShippingOption.id :
+                '';
+        });
+
+        return { shippingOptionIds };
+    },
+})(ShippingOptionsForm);

--- a/src/app/shipping/shippingOption/ShippingOptionsList.spec.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptionsList.spec.tsx
@@ -1,0 +1,90 @@
+import { mount, shallow } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { ChecklistItem } from '../../ui/form';
+import { LoadingOverlay } from '../../ui/loading';
+
+import { getShippingOption } from './shippingMethod.mock';
+import ShippingOptionsList from './ShippingOptionsList';
+import StaticShippingOption from './StaticShippingOption';
+
+describe('ShippingOptionsList Component', () => {
+    let localeContext: LocaleContextType;
+    const shippingOptions = [
+        {
+            ...getShippingOption(),
+            id: 'foo',
+        },
+        {
+            ...getShippingOption(),
+            id: 'bar',
+        },
+    ];
+
+    const onSelected = jest.fn();
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+    });
+
+    it('renders shipping option list with expected props', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    onSubmit={ noop }
+                    initialValues={ { } }
+                >
+                    <ShippingOptionsList
+                        inputName="c_id"
+                        consignmentId="c_id"
+                        selectedShippingOptionId="bar"
+                        shippingOptions={ shippingOptions }
+                        isLoading={ true }
+                        onSelectedOption={ onSelected }
+                    />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find(LoadingOverlay).prop('isLoading')).toBeTruthy();
+        expect(component.find(ChecklistItem).length).toEqual(2);
+        expect(component
+            .find(StaticShippingOption)
+            .at(0)
+            .prop('method')
+        )
+            .toMatchObject(shippingOptions[0]);
+
+        expect(component
+            .find('.form-checklist-item--selected')
+            .find(StaticShippingOption)
+            .prop('method')
+        )
+            .toMatchObject(shippingOptions[1]);
+    });
+
+    it('does not render if there are no shipping optionss', () => {
+        let component = shallow(<ShippingOptionsList
+            inputName="c_id"
+            consignmentId="c_id"
+            isLoading={ false }
+            onSelectedOption={ onSelected }
+        />);
+
+        expect(component.getElement()).toBeFalsy();
+
+        component = shallow(<ShippingOptionsList
+            inputName="c_id"
+            consignmentId="c_id"
+            shippingOptions={ [] }
+            isLoading={ false }
+            onSelectedOption={ onSelected }
+        />);
+
+        expect(component.getElement()).toBeFalsy();
+    });
+});

--- a/src/app/shipping/shippingOption/ShippingOptionsList.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptionsList.tsx
@@ -1,0 +1,55 @@
+import { ShippingOption } from '@bigcommerce/checkout-sdk';
+import React, { FunctionComponent } from 'react';
+
+import { Checklist, ChecklistItem } from '../../ui/form';
+import { LoadingOverlay } from '../../ui/loading';
+
+import StaticShippingOption from './StaticShippingOption';
+
+interface ShippingOptionListProps {
+    consignmentId: string;
+    inputName: string;
+    isLoading: boolean;
+    selectedShippingOptionId?: string;
+    shippingOptions?: ShippingOption[];
+    onSelectedOption(consignmentId: string, shippingOptionId: string): void;
+}
+
+const ShippingOptionsList: FunctionComponent<ShippingOptionListProps> = ({
+    consignmentId,
+    inputName,
+    isLoading,
+    shippingOptions,
+    selectedShippingOptionId,
+    onSelectedOption,
+ }) => {
+    if (!shippingOptions || !shippingOptions.length) {
+        return null;
+    }
+
+    return (
+        <LoadingOverlay isLoading={ isLoading }>
+            <Checklist
+                aria-live="polite"
+                defaultSelectedItemId={ selectedShippingOptionId }
+                name={ inputName }
+                onSelect={ value => onSelectedOption(consignmentId, value) }
+            >
+                { shippingOptions.map(shippingOption => (
+                    <ChecklistItem
+                        htmlId={ `shippingOptionRadio-${consignmentId}-${shippingOption.id}` }
+                        key={ shippingOption.id }
+                        label={ () =>
+                            <div className="shippingOptionLabel">
+                                <StaticShippingOption method={ shippingOption } />
+                            </div>
+                        }
+                        value={ shippingOption.id }
+                    />
+                )) }
+            </Checklist>
+        </LoadingOverlay>
+    );
+};
+
+export default ShippingOptionsList;

--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -1,0 +1,64 @@
+@import '../../../../node_modules/@bigcommerce/citadel/src/tools/toolkit';
+@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+
+// Static Shipping Option
+// ---------------------------------------------------
+.shippingOption {
+    display: inline-block;
+    min-height: 0;
+    width: 100%;
+}
+
+.shippingOption-figure,
+.shippingOption-desc,
+.shippingOption-price {
+    display: inline-block;
+    font-size: fontSize("base");
+}
+
+.shippingOption-img {
+    padding-right: spacing("half");
+}
+
+.shippingOption-price {
+    font-weight: fontWeight("bold");
+    max-width: none;
+    min-width: 0;
+    padding-left: spacing("half");
+}
+
+.shippingOption-transitTime {
+    display: block;
+    font-size: fontSize("base");
+    font-weight: fontWeight("normal");
+}
+
+// ShippingOption Label
+// ---------------------------------------------------
+.shippingOptionLabel {
+    .shippingOption {
+        align-items: center;
+        display: flex;
+        min-height: remCalc(35px);
+    }
+
+    .shippingOption-price {
+        max-width: remCalc(55px);
+        min-width: remCalc(55px);
+        text-align: right;
+    }
+
+    .shippingOption-figure,
+    .shippingOption-desc,
+    .shippingOption-price {
+        flex: 1;
+        font-size: inherit;
+        line-height: lineHeight("base");
+        vertical-align: middle;
+    }
+
+    .shippingOption-figure {
+        max-width: remCalc(50px);
+        min-width: remCalc(50px);
+    }
+}

--- a/src/app/shipping/shippingOption/StaticShippingOption.spec.tsx
+++ b/src/app/shipping/shippingOption/StaticShippingOption.spec.tsx
@@ -1,0 +1,28 @@
+import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
+import React from 'react';
+
+import { getShippingOption } from './shippingMethod.mock';
+import StaticShippingOption from './StaticShippingOption';
+
+describe('StaticShippingOption Component', () => {
+    const method = getShippingOption();
+
+    it( 'renders static shipping option with optional information', () => {
+        const tree = shallow(<StaticShippingOption method={ method } />);
+
+        expect(toJson(tree)).toMatchSnapshot();
+    });
+
+    it( 'renders static shipping option with minimum information', () => {
+        const tree = shallow(
+            <StaticShippingOption method={ {
+                ...method,
+                imageUrl: '',
+                transitTime: '',
+            } } />
+        );
+
+        expect(toJson(tree)).toMatchSnapshot();
+    });
+});

--- a/src/app/shipping/shippingOption/StaticShippingOption.tsx
+++ b/src/app/shipping/shippingOption/StaticShippingOption.tsx
@@ -1,0 +1,36 @@
+import { ShippingOption } from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { ShopperCurrency } from '../../currency';
+
+import './StaticShippingOption.scss';
+
+interface StaticShippingOptionProps {
+    method: ShippingOption;
+}
+
+const StaticShippingOption: React.FunctionComponent<StaticShippingOptionProps> = ({ method }) => (
+    <div className="shippingOption shippingOption--alt">
+        { method.imageUrl &&
+            <span className="shippingOption-figure">
+                <img alt={ method.description }
+                    className="shippingOption-img"
+                    src={ method.imageUrl } />
+            </span>
+        }
+        <span className="shippingOption-desc">
+            { method.description }
+            { method.transitTime &&
+                <span className="shippingOption-transitTime">
+                    { method.transitTime }
+                </span>
+            }
+        </span>
+        <span className="shippingOption-price">
+            <ShopperCurrency amount={ method.cost }>
+            </ShopperCurrency>
+        </span>
+    </div>
+);
+
+export default StaticShippingOption;

--- a/src/app/shipping/shippingOption/__snapshots__/StaticShippingOption.spec.tsx.snap
+++ b/src/app/shipping/shippingOption/__snapshots__/StaticShippingOption.spec.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StaticShippingOption Component renders static shipping option with minimum information 1`] = `
+<div
+  className="shippingOption shippingOption--alt"
+>
+  <span
+    className="shippingOption-desc"
+  >
+    Flat Rate
+  </span>
+  <span
+    className="shippingOption-price"
+  >
+    <WithCurrency(ShopperCurrency)
+      amount={0}
+    />
+  </span>
+</div>
+`;
+
+exports[`StaticShippingOption Component renders static shipping option with optional information 1`] = `
+<div
+  className="shippingOption shippingOption--alt"
+>
+  <span
+    className="shippingOption-desc"
+  >
+    Flat Rate
+  </span>
+  <span
+    className="shippingOption-price"
+  >
+    <WithCurrency(ShopperCurrency)
+      amount={0}
+    />
+  </span>
+</div>
+`;


### PR DESCRIPTION
## What?
Add `Shipping` form components, including single shipping, multishipping, and amazon widget.

## Why?
So we can capture the customer's shipping information, including is: shipping address, shipping items, and shipping option.

## Testing / Proof
unit

@bigcommerce/checkout
