### PR TITLE
CHECKOUT-4223: Changes to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "checkout-js",
+  "name": "@bigcommerce/checkout",
   "version": "0.0.0",
   "private": true,
   "description": "Browser-based application providing a seamless UI for BigCommerce shoppers to complete their checkout. ",


### PR DESCRIPTION
## What?
1. Add `private` property to `package.json` to prevent us from accidentally publishing this package.
1. Add `bigcommerce` organisation scope to  the package name.

## Why?
1. We don't want to publish because it's not ready for the public yet.
1. All npm packages created by BigCommerce should be scoped under `bigcommerce`

## Testing / Proof
None

@bigcommerce/checkout
