### PR TITLE
CHECKOUT-4321: Bump checkout-sdk version to v1.32.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "checkout-js",
+  "name": "@bigcommerce/checkout",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -872,9 +872,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.32.0.tgz",
-      "integrity": "sha512-7xRFi6rFcXY6EP0521p4WUTB8vblZ/4DQdG4QkmMbkaLVbp6KpTG7eNnxh45g6Ewb9H2HTlSNQVJvF90suRqtw==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.32.1.tgz",
+      "integrity": "sha512-n/9WkPfPk0749BbGo6SPHNtu45JPQZjytpToJv8z1hzXJIXnzGso24ITMdTuqA46tFTJoX7a1rhCuve4mL3QAg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.29.0",
+    "@bigcommerce/checkout-sdk": "^1.32.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/request-sender": "^0.3.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version to v1.32.1

## Why?
To fix a bug. For more details, please refer to the [changelog](https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md).

## Testing / Proof
CircleCI

@bigcommerce/checkout
