### PR TITLE
CHECKOUT-4223: Check to make sure there are no unused locals and parameters

### DIFF
--- a/src/app/address/AddressSelect.tsx
+++ b/src/app/address/AddressSelect.tsx
@@ -1,5 +1,4 @@
 import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
-import { some } from 'lodash';
 import React, { Component, FunctionComponent, ReactNode } from 'react';
 
 import { preventDefault } from '../common/dom';
@@ -89,7 +88,6 @@ type AddressSelectButtonProps = Pick<AddressSelectProps, 'selectedAddress' | 'ad
 
 const AddressSelectButton: FunctionComponent<AddressSelectButtonProps> = ({
     selectedAddress,
-    addresses,
 }) => (
     <a
         className="button dropdown-button dropdown-toggle--select"

--- a/src/app/analytics/NoopStepTracker.ts
+++ b/src/app/analytics/NoopStepTracker.ts
@@ -9,11 +9,11 @@ export default class NoopStepTracker implements StepTracker {
         return;
     }
 
-    trackStepViewed(step: string): void {
+    trackStepViewed(): void {
         return;
     }
 
-    trackStepCompleted(step: string): void {
+    trackStepCompleted(): void {
         return;
     }
 }

--- a/src/app/checkout/mapToCheckoutProps.ts
+++ b/src/app/checkout/mapToCheckoutProps.ts
@@ -3,7 +3,7 @@ import { CustomError } from '@bigcommerce/checkout-sdk';
 import { EMPTY_ARRAY } from '../common/utility';
 
 import getCheckoutStepStatuses from './getCheckoutStepStatuses';
-import { CheckoutProps, WithCheckoutProps } from './Checkout';
+import { WithCheckoutProps } from './Checkout';
 import { CheckoutContextProps } from './CheckoutContext';
 
 export default function mapToCheckoutProps(

--- a/src/app/common/hoc/createInjectHoc.spec.tsx
+++ b/src/app/common/hoc/createInjectHoc.spec.tsx
@@ -32,7 +32,7 @@ describe('createInjectHoc()', () => {
 
     it('creates HOC that injects additional props picked from context', () => {
         const withFoo = createInjectHoc(FooContext, {
-            pickProps: (value, key) => key === 'count',
+            pickProps: (_, key) => key === 'count',
         });
         const Inner = () => <div />;
         const Outer = withFoo(Inner);

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -259,7 +259,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
     private handleCloseModal: (
         event: Event,
         props: ErrorModalOnCloseProps
-    ) => void = (event, { error }) => {
+    ) => void = (_, { error }) => {
         if (!error) {
             return;
         }

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -233,13 +233,6 @@ const deleteConsignmentsSelector = createSelector(
     }
 );
 
-const updateOrderCommentSelector = createSelector(
-    ({ checkoutService: { updateCheckout } }: CheckoutContextProps) => updateCheckout,
-    updateCheckout => (comment: string) => {
-        return updateCheckout({ customerMessage: comment });
-    }
-);
-
 export function mapToShippingProps({
     checkoutService,
     checkoutState,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,9 @@
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "noUnusedParameters": true,
+        "noUnusedLocals": true
     },
     "files": [
         "types/supported-files.d.ts",


### PR DESCRIPTION
## What?
Check to make sure there are no unused locals and parameters.

## Why?
These rules can help us improve the maintainability of the code.

I think we used to check for unused variables using TSLint before, but we have [removed the rule](https://github.com/bigcommerce/tslint-config/pull/16) few months ago and forgot to enable its replacement.

## Testing / Proof
CircleCI

@bigcommerce/checkout
