### PR TITLE
CHECKOUT-4223: Move initialization call of render checker to entry point of app

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -1,4 +1,15 @@
+import React from 'react';
+
 import '../scss/App.scss';
+
+if (process.env.NODE_ENV === 'development') {
+    // We want to use `require` because we only want to import the package in
+    // development mode.
+    // tslint:disable-next-line
+    const { default: whyDidYouRender } = require('@welldone-software/why-did-you-render');
+
+    whyDidYouRender(React);
+}
 
 export { renderCheckout } from '../app/checkout';
 export { renderOrderConfirmation } from '../app/order';

--- a/src/app/checkout/renderCheckout.tsx
+++ b/src/app/checkout/renderCheckout.tsx
@@ -3,15 +3,6 @@ import ReactDOM from 'react-dom';
 
 import CheckoutApp, { CheckoutAppProps } from './CheckoutApp';
 
-if (process.env.NODE_ENV === 'development') {
-    // We want to use `require` because we only want to import the package in
-    // development mode.
-    // tslint:disable-next-line
-    const { default: whyDidYouRender } = require('@welldone-software/why-did-you-render');
-
-    whyDidYouRender(React);
-}
-
 export default function renderCheckout(
     props: CheckoutAppProps
 ) {


### PR DESCRIPTION
## What?
Move the initialisation call of `why-did-you-render` to the entry point of the application.

## Why?
So we can use it in both `CheckoutApp` and `OrderConfirmationApp`.

## Testing / Proof
None

@bigcommerce/checkout
