### PR TITLE
chore(common): CHECKOUT-4337 Remove Babel DynamicImportPlugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2311,12 +2311,6 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-      "dev": true
-    },
     "babel-preset-jest": {
       "version": "24.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@types/react-test-renderer": "^16.8.3",
     "@typescript-eslint/parser": "^1.13.0",
     "babel-loader": "^8.0.6",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "core-js": "^3.1.4",
     "css-loader": "^3.1.0",
     "enzyme": "^3.10.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,9 +9,6 @@ const WebpackAssetsManifest = require('webpack-assets-manifest');
 
 const babelOptions = {
     cacheDirectory: true,
-    plugins: [
-        '@babel/plugin-syntax-dynamic-import',
-    ],
     presets: [
         ['@babel/preset-env', {
             corejs: '3',


### PR DESCRIPTION
## What?
Remove unnecessary plugin.

## Why?
This plugin is not really required for using dynamic imports. If `modules`
is set to `false` webpack will handle the dynamic module imports making
this plugin redundant.

## Testing / Proof
- Manual

### Before
<img width="734" alt="image" src="https://user-images.githubusercontent.com/4542735/62988091-63286e80-be86-11e9-87bc-54bf3ef2b9df.png">

### After
<img width="737" alt="image" src="https://user-images.githubusercontent.com/4542735/62988037-2ceaef00-be86-11e9-9473-73cbe6e075cb.png">

@bigcommerce/checkout
