### PR TITLE
INT-1608 INT-1811: Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -872,9 +872,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.32.1.tgz",
-      "integrity": "sha512-n/9WkPfPk0749BbGo6SPHNtu45JPQZjytpToJv8z1hzXJIXnzGso24ITMdTuqA46tFTJoX7a1rhCuve4mL3QAg==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.34.0.tgz",
+      "integrity": "sha512-ENyS6sR0Vc7VXxPfNZT9iOMXvaN5YzUrvD+TDEfEaWsiYzVsnf2Qq58jxEsVcXADlqs4setrOAkS2sUdJir5/w==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.32.1",
+    "@bigcommerce/checkout-sdk": "^1.34.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/request-sender": "^0.3.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
