### PR TITLE
CHECKOUT-4163 Default Webpack to production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ const babelOptions = {
 };
 
 module.exports = function (options, argv) {
-    const mode = argv.mode || 'development';
+    const mode = argv.mode || 'production';
     const isProduction = mode !== 'development';
 
     return {


### PR DESCRIPTION
## What?
- Default Webpack to production mode if no mode is passed

## Why?
- It is normally safer to default to production

## Testing / Proof
- Manual

@bigcommerce/checkout
