### PR TITLE
CHECKOUT-4163 Run tslint rules with eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
+        "project": "./tsconfig.json",
         "ecmaFeatures": {
             "modules": true,
             "jsx": true
@@ -13,10 +14,12 @@
         "useJSXTextNode": true
     },
     "plugins": [
+        "@typescript-eslint/tslint",
         "react-hooks"
     ],
     "rules": {
         "react-hooks/exhaustive-deps": "error",
-        "react-hooks/rules-of-hooks": "error"
+        "react-hooks/rules-of-hooks": "error",
+        "@typescript-eslint/tslint/config": ["error", { "lintFile": "./tslint.json" }]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1538,14 +1538,48 @@
       "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.22.tgz",
       "integrity": "sha512-AhUPifCc7j2BEfp+wye3Mj7v3mMhbtu5BbO7n0zpwC/NVSETc8+MHENRmoxjE8wLC8AmFr5+uEhg5cvqusaRFQ=="
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
+      "integrity": "sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "2.0.0",
+        "eslint-utils": "^1.4.0",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^2.0.1",
+        "tsutils": "^3.14.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.17.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+          "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/eslint-plugin-tslint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.0.0.tgz",
+      "integrity": "sha512-5RzjQE25QTIZet/MTY1eNd4hdDVOQJ53tWBDCZH1sEBqxlFH0KMA6SozFl9Qd4xbPKsftAyBKmjW8/5AAWkamg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "2.0.0",
+        "lodash.memoize": "^4.1.2"
+      }
+    },
     "@typescript-eslint/experimental-utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.0.0.tgz",
+      "integrity": "sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "1.13.0",
+        "@typescript-eslint/typescript-estree": "2.0.0",
         "eslint-scope": "^4.0.0"
       }
     },
@@ -1559,22 +1593,51 @@
         "@typescript-eslint/experimental-utils": "1.13.0",
         "@typescript-eslint/typescript-estree": "1.13.0",
         "eslint-visitor-keys": "^1.0.0"
-      }
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
       },
       "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+          "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "1.13.0",
+            "eslint-scope": "^4.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+          "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          }
+        },
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.0.0.tgz",
+      "integrity": "sha512-NXbmzA3vWrSgavymlzMWNecgNOuiMMp62MO3kI7awZRLRcsA1QrYWo6q08m++uuAGVbXH/prZi2y1AWuhSu63w==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -10248,6 +10311,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.sortby": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "@types/node": "^12.6.9",
     "@types/object-hash": "^1.2.0",
     "@types/react-test-renderer": "^16.8.3",
+    "@typescript-eslint/eslint-plugin": "^2.0.0",
+    "@typescript-eslint/eslint-plugin-tslint": "^2.0.0",
     "@typescript-eslint/parser": "^1.13.0",
     "babel-loader": "^8.0.6",
     "core-js": "^3.1.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,10 +81,6 @@ module.exports = function (options, argv) {
             }),
             new ForkTsCheckerWebpackPlugin({
                 async: !isProduction,
-                tslint: true,
-            }),
-            new ForkTsCheckerWebpackPlugin({
-                async: !isProduction,
                 eslint: true,
             }),
             !isProduction && new BuildHooks(),


### PR DESCRIPTION
## What?
Use eslint to run tslint

## Why?
- Since tslint is deprecated, this is the recommended method of transitioning to eslint.
- To run both separately we needed to include `ForkTsCheckerWebpackPlugin` twice.

## Testing / Proof
Manual

### Dev mode:
<img width="572" alt="image" src="https://user-images.githubusercontent.com/4542735/63001656-6be56880-beb7-11e9-8e6f-59997d22ee38.png">

### Production mode:
<img width="796" alt="image" src="https://user-images.githubusercontent.com/4542735/63001755-a7803280-beb7-11e9-9b32-1bf79a528157.png">
<img width="740" alt="image" src="https://user-images.githubusercontent.com/4542735/63001740-a0f1bb00-beb7-11e9-9fed-e28816e4793c.png">

@bigcommerce/checkout @deini 
