### PR TITLE
fix(payment): INT-1831 widget is now loaded when vaulted instruments exists

### DIFF
--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -156,7 +156,7 @@ class HostedWidgetPaymentMethod extends Component<
                     onUseNewCard={ this.handleUseNewCard }
                 /> }
 
-                { shouldShowCreditCardFieldset && <div
+                <div
                     id={ containerId }
                     className={ classNames(
                         'widget',
@@ -164,10 +164,10 @@ class HostedWidgetPaymentMethod extends Component<
                         'payment-widget'
                     ) }
                     style={ {
-                        display: hideContentWhenSignedOut && isSignInRequired && !isSignedIn ? 'none' : undefined,
+                        display: (hideContentWhenSignedOut && isSignInRequired && !isSignedIn) || !shouldShowCreditCardFieldset ? 'none' : undefined,
                     } }
                     tabIndex={ -1 }
-                /> }
+                />
 
                 { shouldShowCreditCardFieldset && isInstrumentFeatureAvailableProp && <CreditCardStorageField name="shouldSaveInstrument" /> }
 


### PR DESCRIPTION
## What?
[INT-1831](https://jira.bigcommerce.com/browse/INT-1831)

## Why?
There was an issue reported related with Stripe V3 that is not loading stripe payment method when one or more payment providers have vaulting activated.

## Testing / Proof
![Stripe + Vaulting issue](https://user-images.githubusercontent.com/35146660/63183065-b252d880-c019-11e9-9c3d-86575d180a17.gif)

@bigcommerce/checkout @bigcommerce/intersys-integrations 
