### PR TITLE
CHECKOUT-4344: Fix checkout steps not collapsing in mobile view

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,19 +1,26 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { noop } from 'lodash';
 
 configure({ adapter: new Adapter() });
 
 // https://github.com/FezVrasta/popper.js/issues/478
-if (global.document) {
+if (window.document) {
     document.createRange = () => ({
-        setStart: () => {},
-        setEnd: () => {},
+        setStart: noop,
+        setEnd: noop,
         commonAncestorContainer: {
             nodeName: 'BODY',
             ownerDocument: document,
         },
-    });
+    } as Range);
 }
+
+window.matchMedia = jest.fn(() => ({
+    matches: false,
+    addEventListener: noop,
+    removeEventListener: noop,
+} as MediaQueryList));
 
 beforeAll(() => {
     expect.hasAssertions();

--- a/src/app/checkout/CheckoutStep.spec.tsx
+++ b/src/app/checkout/CheckoutStep.spec.tsx
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import React from 'react';
+import { CSSTransition } from 'react-transition-group';
 
 import CheckoutStep, { CheckoutStepProps } from './CheckoutStep';
 import CheckoutStepHeader from './CheckoutStepHeader';
@@ -9,6 +10,7 @@ jest.useFakeTimers();
 
 describe('CheckoutStep', () => {
     let defaultProps: CheckoutStepProps;
+    let isMobile: boolean;
 
     beforeEach(() => {
         defaultProps = {
@@ -17,12 +19,18 @@ describe('CheckoutStep', () => {
             onExpanded: jest.fn(),
         };
 
+        isMobile = false;
+
         // JSDOM does not support `scrollTo`
         window.scrollTo = jest.fn();
+
+        // Mock `matchMedia` to detect mobile viewport
+        window.matchMedia = jest.fn(query => ({ matches: query === '(max-width: 968px)' ? isMobile : false }) as MediaQueryList);
     });
 
     afterEach(() => {
         delete window.scrollTo;
+        delete window.matchMedia;
 
         // Reset the focused element after each test
         if (document.activeElement) {
@@ -148,5 +156,21 @@ describe('CheckoutStep', () => {
 
         expect(component.exists('.checkout-view-content'))
             .toEqual(false);
+    });
+
+    it('animates using CSS transition in desktop view', () => {
+        const component = mount(<CheckoutStep { ...defaultProps } />);
+
+        expect(component.find(CSSTransition))
+            .toHaveLength(1);
+    });
+
+    it('does not animate using CSS transition in mobile view', () => {
+        isMobile = true;
+
+        const component = mount(<CheckoutStep { ...defaultProps } />);
+
+        expect(component.find(CSSTransition))
+            .toHaveLength(0);
     });
 });

--- a/src/app/checkout/CheckoutStep.tsx
+++ b/src/app/checkout/CheckoutStep.tsx
@@ -21,7 +21,8 @@ const LARGE_SCREEN_BREAKPOINT = 968;
 const LARGE_SCREEN_ANIMATION_DELAY = 610;
 
 export default class CheckoutStep extends Component<CheckoutStepProps> {
-    private containerRef: RefObject<HTMLElement> = createRef();
+    private containerRef = createRef<HTMLElement>();
+    private mobileQuery = window.matchMedia(`(max-width: ${LARGE_SCREEN_BREAKPOINT}px)`);
     private timeoutRef?: number;
 
     componentDidMount(): void {
@@ -49,8 +50,6 @@ export default class CheckoutStep extends Component<CheckoutStepProps> {
     }
 
     render(): ReactNode {
-        const { children } = this.props;
-
         const {
             heading,
             isActive,
@@ -82,30 +81,50 @@ export default class CheckoutStep extends Component<CheckoutStepProps> {
                     />
                 </div>
 
-                <CSSTransition
-                    addEndListener={ (node, done) => {
-                        node.addEventListener('transitionend', ({ target }) => {
-                            if (target === node) {
-                                done();
-                            }
-                        });
-                    } }
-                    classNames="checkout-view-content"
-                    timeout={ {} }
-                    in={ isActive }
-                    unmountOnExit
-                    mountOnEnter
-                >
-                    <div className="checkout-view-content">
-                        { children }
-                    </div>
-                </CSSTransition>
+                { this.renderContent() }
             </li>
         );
     }
 
+    private renderContent(): ReactNode {
+        const { children, isActive } = this.props;
+
+        if (this.mobileQuery.matches) {
+            if (!isActive) {
+                return null;
+            }
+
+            return (
+                <div className="checkout-view-content">
+                    { children }
+                </div>
+            );
+        }
+
+        return (
+            <CSSTransition
+                addEndListener={ (node, done) => {
+                    node.addEventListener('transitionend', ({ target }) => {
+                        if (target === node) {
+                            done();
+                        }
+                    });
+                } }
+                classNames="checkout-view-content"
+                timeout={ {} }
+                in={ isActive }
+                unmountOnExit
+                mountOnEnter
+            >
+                <div className="checkout-view-content">
+                    { children }
+                </div>
+            </CSSTransition>
+        );
+    }
+
     private focusStep(): void {
-        const delay = window.innerWidth > LARGE_SCREEN_BREAKPOINT ? LARGE_SCREEN_ANIMATION_DELAY : 0;
+        const delay = this.mobileQuery.matches ? 0 : LARGE_SCREEN_ANIMATION_DELAY;
 
         this.timeoutRef = window.setTimeout(() => {
             const input = this.getChildInput();


### PR DESCRIPTION
## What?
Fix checkout steps not collapsing in mobile view.

## Why?
There was a problem because mobile view doesn't have any CSS transition. Therefore, `CSSTransition` doesn't run and unmount its children when `isActive` is `false`. The fix for this problem is to conditionally render `CSSTransition` depending on the screen size. In mobile view, don't render `CSSTransition` and directly unmount `children` when `isActive` is `false`.

## Testing / Proof
* Unit
* Manual

|Before|After|
|-|-|
|![checkout-step-not-collapsing-bug](https://user-images.githubusercontent.com/667603/63240812-95760980-c294-11e9-86fa-5693fe5be289.gif)|![checkout-step-not-collapsing-fix](https://user-images.githubusercontent.com/667603/63240814-97d86380-c294-11e9-84e0-1a57b12fe1d9.gif)|




@bigcommerce/checkout
