### PR TITLE
CHECKOUT-4351: Enable React-specific ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
         "plugin:import/errors",
         "plugin:import/react",
         "plugin:import/typescript",
-        "plugin:import/warnings"
+        "plugin:import/warnings",
+        "plugin:react/recommended"
     ],
     "env": {
         "browser": true
@@ -21,6 +22,7 @@
     },
     "plugins": [
         "@typescript-eslint/tslint",
+        "react",
         "react-hooks"
     ],
     "rules": {
@@ -30,6 +32,8 @@
                 "lintFile": "./tslint.json"
             }
         ],
+        "react/display-name": "off",
+        "react/prop-types": "off",
         "react-hooks/exhaustive-deps": "error",
         "react-hooks/rules-of-hooks": "error",
         "import/dynamic-import-chunkname": "error",
@@ -51,5 +55,10 @@
                 ]
             }
         ]
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6228,6 +6228,34 @@
         }
       }
     },
+    "eslint-plugin-react": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
     "eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
@@ -10435,6 +10463,16 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "keyv": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "enzyme-to-json": "^3.3.5",
     "eslint": "^6.1.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "file-loader": "^4.1.0",
     "fork-ts-checker-webpack-plugin": "^1.4.3",

--- a/src/app/customer/PasswordField.tsx
+++ b/src/app/customer/PasswordField.tsx
@@ -19,6 +19,7 @@ const PasswordField: FunctionComponent<PasswordFieldProps> = ({
             <a
                 data-test="forgot-password-link"
                 href={ forgotPasswordUrl }
+                rel="noopener noreferrer"
                 target="_blank"
             >
                 <TranslatedString id="customer.forgot_password_action" />

--- a/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -187,6 +187,7 @@ exports[`Customer when view type is "login" matches snapshot 1`] = `
           <a
             data-test="forgot-password-link"
             href="https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password"
+            rel="noopener noreferrer"
             target="_blank"
           >
             Forgot password?

--- a/src/app/customer/__snapshots__/LoginForm.spec.tsx.snap
+++ b/src/app/customer/__snapshots__/LoginForm.spec.tsx.snap
@@ -89,6 +89,7 @@ exports[`LoginForm matches snapshot 1`] = `
           <a
             data-test="forgot-password-link"
             href="/forgot-password"
+            rel="noopener noreferrer"
             target="_blank"
           >
             Forgot password?

--- a/src/app/order/__snapshots__/OrderSummaryItems.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummaryItems.spec.tsx.snap
@@ -77,6 +77,7 @@ exports[`OrderSummaryItems when it has 4 line items or less renders product list
           Object {
             "content": <a
               href="url.php"
+              rel="noopener noreferrer"
               target="_blank"
             >
               <WithLanguage(TranslatedString)

--- a/src/app/order/__snapshots__/mapFromDigital.spec.tsx.snap
+++ b/src/app/order/__snapshots__/mapFromDigital.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`mapFromDigital() returns digital related properties when it has no down
 exports[`mapFromDigital() returns downloadable related properties when it has a download URL 1`] = `
 <a
   href="url.php"
+  rel="noopener noreferrer"
   target="_blank"
 >
   <WithLanguage(TranslatedString)

--- a/src/app/order/mapFromDigital.tsx
+++ b/src/app/order/mapFromDigital.tsx
@@ -37,6 +37,7 @@ function getDigitalItemDescription(item: DigitalItem): OrderSummaryItemOption {
         content:
             <a
                 href={ item.downloadPageUrl }
+                rel="noopener noreferrer"
                 target="_blank"
             >
                 <TranslatedString id="cart.downloads_action" />

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -147,7 +147,10 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
                     unmountContentWhenLoading
                 >
                     { flashMessages.map(message =>
-                        <FlashAlert message={ message } />
+                        <FlashAlert
+                            key={ message.message }
+                            message={ message }
+                        />
                     ) }
 
                     { !isEmpty(methods) && defaultMethod && <PaymentForm


### PR DESCRIPTION
## What?
* Enable React-specific ESLint rules.
* I've only enabled the basic rules configured by the `recommended` preset. We can enable more more rules in the future.
* I've disabled `react/prop-types` because we're using TS so this rule doesn't really applied.
* I've disabled `react/display-name` rule temporarily because there are a few errors. So I'll fix them later.

## Why?
So we don't make mistakes that can be picked up by a linter.

## Testing / Proof
CircleCI

@bigcommerce/checkout
