### PR TITLE
INT-1837: Fix conflicting styles injected by Klarna causing modal to be cropped in Firefox

### DIFF
--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -60,6 +60,13 @@
     margin: auto;
 }
 
+// KLUDGE: We need this override when Klarna modal is open because
+// `scroll-behavior: smooth` conflicts with the styles injected by Klarna JS,
+// cropping the content of the modal in Firefox as a result.
+body.klarna-payments-fso-open {
+    scroll-behavior: auto;
+}
+
 #stripe-card-field {
     background-color: white;
     border: remCalc(1px) solid transparent;


### PR DESCRIPTION
## What?
Fix conflicting styles injected by Klarna causing its modal to be cropped in Firefox.

## Why?
This might be a temporary fix if we can get Klarna to make their modal script compatible with `scroll-behavior: smooth`.

## Testing / Proof
**Before**
<img width="775" alt="Screen Shot 2019-08-21 at 5 31 08 pm" src="https://user-images.githubusercontent.com/667603/63411728-82506e80-c439-11e9-9099-959dce9f7f19.png">

**After**
<img width="1025" alt="Screen Shot 2019-08-21 at 5 26 08 pm" src="https://user-images.githubusercontent.com/667603/63411672-60ef8280-c439-11e9-9c29-2381b47ac021.png">

@bigcommerce/checkout
