### PR TITLE
CHECKOUT-4352: Optimize rendering of static address

### DIFF
--- a/src/app/address/localizeAddress.ts
+++ b/src/app/address/localizeAddress.ts
@@ -1,7 +1,6 @@
 import { Address } from '@bigcommerce/checkout-sdk';
 import { find, isEmpty } from 'lodash';
 
-import { memoize } from '../common/utility';
 import { Country, LocalizedGeography } from '../geography';
 
 const localizeAddress = <T1 extends Address>(
@@ -19,4 +18,4 @@ const localizeAddress = <T1 extends Address>(
     };
 };
 
-export default memoize(localizeAddress);
+export default localizeAddress;


### PR DESCRIPTION
## What?
Optimize the rendering of `StaticAddress` component.

## Why?
I realise that with the changes introduced by #74, we're now calling `isValidAddress` every time the checkout state changes. What we want instead is to call `isValidAddress` function when the `address` object (that's passed into `StaticAddress` component) changes. We can do this by moving the call inside the render function of the component and making render function pure.

## Testing / Proof
CircleCI

@bigcommerce/checkout
