### PR TITLE
CHECKOUT-4356 Enable source-maps for dependencies in dev mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,6 +2269,15 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -13854,6 +13863,16 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "source-map-loader": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
+      "dev": true,
+      "requires": {
+        "async": "^2.5.0",
+        "loader-utils": "^1.1.0"
+      }
     },
     "source-map-resolve": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "node-sass": "^4.12.0",
     "react-test-renderer": "^16.8.6",
     "sass-loader": "^7.1.0",
+    "source-map-loader": "^0.2.4",
     "standard-version": "^7.0.0",
     "style-loader": "^0.23.1",
     "stylelint": "^10.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,11 @@ module.exports = function (options, argv) {
         module: {
             rules: [
                 {
+                    test: /\.[tj]sx?$/,
+                    enforce: 'pre',
+                    loader: require.resolve('source-map-loader'),
+                },
+                {
                     test: /\.tsx?$/,
                     include: join(__dirname, 'src'),
                     use: [


### PR DESCRIPTION
## What?
- As per title

## Why?
- We rely on those for debugging

## Testing / Proof

### Before
<img width="747" alt="image" src="https://user-images.githubusercontent.com/4542735/63476020-b328b600-c4c2-11e9-888a-81a48e09ee71.png">

### After
<img width="938" alt="image" src="https://user-images.githubusercontent.com/4542735/63475887-19610900-c4c2-11e9-8be1-cc78a68918dd.png">

@bigcommerce/checkout
