### PR TITLE
CHECKOUT-4352: Turn on `react/jsx-no-bind` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
             }
         ],
         "react/display-name": "off",
+        "react/jsx-no-bind": "error",
         "react/prop-types": "off",
         "react-hooks/exhaustive-deps": "error",
         "react-hooks/rules-of-hooks": "error",


### PR DESCRIPTION
## What?
* Turn on `react/jsx-no-bind` rule.
* The build will fail until all the changes related to this rule are merged.

## Why?
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
