### PR TITLE
INT-1829 INT-1836 CHECKOUT-4272: Bump checkout-sdk version to v1.34.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -872,9 +872,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.34.0.tgz",
-      "integrity": "sha512-ENyS6sR0Vc7VXxPfNZT9iOMXvaN5YzUrvD+TDEfEaWsiYzVsnf2Qq58jxEsVcXADlqs4setrOAkS2sUdJir5/w==",
+      "version": "1.34.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.34.1.tgz",
+      "integrity": "sha512-OjrbiNqZXtmvfuOaQWe3ilMSkscfAE5OmYPq9WNtabzzrKC1DvoqTOIDDjnpD/CRCbp7CGYD4CK2VhDZkGKqmQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.2.0",
@@ -1701,16 +1701,6 @@
           "dev": true
         }
       }
-    },
-    "@ungap/custom-event": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/custom-event/-/custom-event-0.2.0.tgz",
-      "integrity": "sha512-jovJx+4IaAL8JAzepJXDBVlS9t9mR3vKbbjcHwHCF+sN0KKCYQ2pNVAlQYiRrPqeNBl5VXU7uUDOKBg9ODB+0Q=="
-    },
-    "@ungap/event-target": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ungap/event-target/-/event-target-0.1.0.tgz",
-      "integrity": "sha512-W2oyj0Fe1w/XhPZjkI3oUcDUAmu5P4qsdT2/2S8aMhtAWM/CE/jYWtji0pKNPDfxLI75fa5gWSEmnynKMNP/oA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.34.0",
+    "@bigcommerce/checkout-sdk": "^1.34.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/request-sender": "^0.3.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version to v1.34.1

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCi

@bigcommerce/checkout
