### PR TITLE
CHECKOUT-4388: Upgrade `checkout-sdk` version to v1.34.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -872,9 +872,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.34.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.34.2.tgz",
-      "integrity": "sha512-ENhI2+LobVW4hjCRTwGkp5OqDheHiZ0h0EO4Qpkj8YZbeHLlkp3/vBZfSpszPlbtMu+gZz7RQEZiJRNi2Zn8dw==",
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.34.3.tgz",
+      "integrity": "sha512-14fKLI9UJFc0lbKhro3MT2Thp/X4gHs/H/o/CUFR/Y+cbfYRJSfDKoDzUX7kTP3P0o5eMNujfV/FWI+YtqYMug==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.34.2",
+    "@bigcommerce/checkout-sdk": "^1.34.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/request-sender": "^0.3.0",


### PR DESCRIPTION
## What?
Upgrade `checkout-sdk` version to v1.34.3

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
