### PR TITLE
fix(payments): INT-1892 Do not prompt when been redirected to 3DS1 using Converge

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -244,13 +244,14 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         const { defaultMethod, isSubmittingOrder, language } = this.props;
         const { selectedMethod = defaultMethod } = this.state;
 
-        // TODO: Perhaps there is a better way to handle `sagepay` and
-        // `afterpay`. They require a redirection to another website during the
-        // payment flow but are not categorised as hosted payment methods.
+        // TODO: Perhaps there is a better way to handle `amazon`, `converge`,
+        // `sagepay` and `afterpay`. They require a redirection to another website
+        // during the payment flow but are not categorised as hosted payment methods.
         if (!isSubmittingOrder ||
             !selectedMethod ||
             selectedMethod.type === PaymentMethodProviderType.Hosted ||
             selectedMethod.id === PaymentMethodId.Amazon ||
+            selectedMethod.id === PaymentMethodId.Converge ||
             selectedMethod.id === PaymentMethodId.SagePay ||
             selectedMethod.gateway === PaymentMethodId.Afterpay) {
             return;

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -8,6 +8,7 @@ enum PaymentMethodId {
     BraintreeVisaCheckout = 'braintreevisacheckout',
     CCAvenueMars = 'ccavenuemars',
     ChasePay = 'chasepay',
+    Converge = 'converge',
     Klarna = 'klarna',
     Masterpass = 'masterpass',
     PaypalExpress = 'paypalexpress',


### PR DESCRIPTION
## What?
[INT-1892](https://jira.bigcommerce.com/browse/INT-1892)

Avoid displaying confirmation dialog before leaving checkout page to 3DS1 card issuer 3DS1 authorization page.


## Why?
It is not required for this step to be prompted before leaving Big Commerce

## Testing / Proof
![ezgif com-crop](https://user-images.githubusercontent.com/8570490/64378626-b78cbd00-cff2-11e9-8de9-06ff2fec6fc3.gif)


@bigcommerce/checkout
