### PR TITLE
CHECKOUT-4378: Enable `react/destructuring-assignment`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
                 "lintFile": "./tslint.json"
             }
         ],
+        "react/destructuring-assignment": "error",
         "react/display-name": "off",
         "react/jsx-closing-bracket-location": [
             "error", 

--- a/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -44,7 +44,11 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
             onToggleOpen = noop,
             inputProps = {},
         } = this.props;
-        const { items } = this.state;
+
+        const {
+            autoComplete,
+            items,
+        } = this.state;
 
         return (
             <Autocomplete
@@ -53,7 +57,7 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
                 initialHighlightedIndex={ 0 }
                 inputProps={ {
                     ...inputProps,
-                    autoComplete: this.state.autoComplete,
+                    autoComplete,
                 } }
                 initialValue={ initialValue }
                 onSelect={ this.onSelect }
@@ -67,6 +71,7 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
 
     private onSelect: (item: AutocompleteItem) => void = item => {
         const {
+            fields,
             onSelect = noop,
             nextElement,
         } = this.props;
@@ -74,7 +79,7 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
         this.googleAutocompleteService.getPlacesServices().then(service => {
             service.getDetails({
                 placeId: item.id,
-                fields: this.props.fields || ['address_components', 'name'],
+                fields: fields || ['address_components', 'name'],
             }, result => {
                 if (nextElement) {
                     nextElement.focus();
@@ -91,7 +96,7 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
             onChange = noop,
         } = this.props;
 
-        onChange(input);
+        onChange(input, false);
 
         if (!isAutocompleteEnabled) {
             return this.resetAutocomplete();
@@ -108,11 +113,16 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
             return;
         }
 
+        const {
+            componentRestrictions,
+            types,
+        } = this.props;
+
         this.googleAutocompleteService.getAutocompleteService().then(service => {
             service.getPlacePredictions({
                 input,
-                types: this.props.types || ['geocode'],
-                componentRestrictions: this.props.componentRestrictions,
+                types: types || ['geocode'],
+                componentRestrictions,
             }, results =>
                 this.setState({ items: this.toAutocompleteItems(results) })
             );

--- a/src/app/order/OrderSummaryItems.tsx
+++ b/src/app/order/OrderSummaryItems.tsx
@@ -114,7 +114,9 @@ class OrderSummaryItems extends React.Component<OrderSummaryItemsProps, OrderSum
     }
 
     private handleToggle: () => void = () => {
-        this.setState({ isExpanded: !this.state.isExpanded });
+        const { isExpanded } = this.state;
+
+        this.setState({ isExpanded: !isExpanded });
     };
 }
 

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -228,14 +228,15 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         disabled?: boolean
     ) => void = (method, disabled = true) => {
         const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
+        const { shouldDisableSubmit } = this.state;
 
-        if (this.state.shouldDisableSubmit[uniqueId] === disabled) {
+        if (shouldDisableSubmit[uniqueId] === disabled) {
             return;
         }
 
         this.setState({
             shouldDisableSubmit: {
-                ...this.state.shouldDisableSubmit,
+                ...shouldDisableSubmit,
                 [uniqueId]: disabled,
             },
         });
@@ -324,7 +325,9 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
     };
 
     private setSelectedMethod: (method?: PaymentMethod) => void = method => {
-        if (this.state.selectedMethod === method) {
+        const { selectedMethod } = this.state;
+
+        if (selectedMethod === method) {
             return;
         }
 
@@ -336,14 +339,15 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         fn: (values: PaymentFormValues) => void | null
     ) => void = (method, fn) => {
         const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
+        const { submitFunctions } = this.state;
 
-        if (this.state.submitFunctions[uniqueId] === fn) {
+        if (submitFunctions[uniqueId] === fn) {
             return;
         }
 
         this.setState({
             submitFunctions: {
-                ...this.state.submitFunctions,
+                ...submitFunctions,
                 [uniqueId]: fn,
             },
         });
@@ -354,14 +358,15 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         schema: ObjectSchema<Partial<PaymentFormValues>> | null
     ) => void = (method, schema) => {
         const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
+        const { validationSchemas } = this.state;
 
-        if (this.state.validationSchemas[uniqueId] === schema) {
+        if (validationSchemas[uniqueId] === schema) {
             return;
         }
 
         this.setState({
             validationSchemas: {
-                ...this.state.validationSchemas,
+                ...validationSchemas,
                 [uniqueId]: schema,
             },
         });

--- a/src/app/payment/TermsConditionsField.tsx
+++ b/src/app/payment/TermsConditionsField.tsx
@@ -23,7 +23,12 @@ interface TermsConditionsTextAreaFieldProps {
     type: TermsConditionsType.TextArea;
 }
 
-const TermsConditionsTextField: FunctionComponent<{ name: string; terms: string }> = ({
+interface TermsConditionsTextFieldProps {
+    name: string;
+    terms: string;
+}
+
+const TermsConditionsTextField: FunctionComponent<TermsConditionsTextFieldProps> = ({
     name,
     terms,
 }) => {
@@ -42,7 +47,13 @@ const TermsConditionsTextField: FunctionComponent<{ name: string; terms: string 
         />
     );
 };
-const TermsConditionsCheckboxField: FunctionComponent<{ name: string; url?: string }> = ({
+
+interface TermsConditionsCheckboxFieldProps {
+    name: string;
+    url?: string;
+}
+
+const TermsConditionsCheckboxField: FunctionComponent<TermsConditionsCheckboxFieldProps> = ({
     name,
     url,
 }) => {
@@ -68,11 +79,15 @@ const TermsConditionsField: FunctionComponent<TermsConditionsFieldProps> = props
                 <TranslatedString id="terms_and_conditions.terms_and_conditions_heading" />
             </Legend> }
         >
-            { props.type === TermsConditionsType.TextArea && <TermsConditionsTextField { ...props } /> }
+            { areTermsConditionsTextFieldProps(props) && <TermsConditionsTextField { ...props } /> }
 
             <TermsConditionsCheckboxField { ...props } />
         </Fieldset>
     );
 };
+
+function areTermsConditionsTextFieldProps(props: any): props is TermsConditionsTextFieldProps {
+    return props.type === TermsConditionsType.TextArea;
+}
 
 export default memo(TermsConditionsField);

--- a/src/app/shipping/MultiShippingForm.tsx
+++ b/src/app/shipping/MultiShippingForm.tsx
@@ -150,10 +150,11 @@ class MultiShippingForm extends PureComponent<MultiShippingFormProps & WithLangu
         address: Address,
         data: CheckoutStoreSelector
     ) => void = (key, address, data) => {
+        const { items: currentItems } = this.state;
         const items = updateShippableItems(
-            this.state.items,
+            currentItems,
             {
-                updatedItemIndex: this.state.items.findIndex(item => item.key === key),
+                updatedItemIndex: currentItems.findIndex(item => item.key === key),
                 address,
             },
             {

--- a/src/app/ui/form/ChecklistItemInput.tsx
+++ b/src/app/ui/form/ChecklistItemInput.tsx
@@ -8,6 +8,7 @@ export interface ChecklistItemInputProps extends InputHTMLAttributes<HTMLInputEl
 }
 
 const ChecklistItemInput: FunctionComponent<ChecklistItemInputProps> = ({
+    id,
     isSelected,
     children,
     ...props
@@ -17,10 +18,11 @@ const ChecklistItemInput: FunctionComponent<ChecklistItemInputProps> = ({
             { ...props }
             checked={ isSelected }
             className="form-checklist-checkbox optimizedCheckout-form-checklist-checkbox"
+            id={ id }
             type="radio"
         />
 
-        <Label htmlFor={ props.id }>
+        <Label htmlFor={ id }>
             { children }
         </Label>
     </>

--- a/src/app/ui/toggle/Toggle.tsx
+++ b/src/app/ui/toggle/Toggle.tsx
@@ -17,17 +17,18 @@ export default class Toggle extends Component<ToggleProps, ToggleState> {
     }
 
     render(): ReactNode {
-        const {
-            children,
-        } = this.props;
+        const { children } = this.props;
+        const { isOpen } = this.state;
 
         return children({
-            ...this.state,
+            isOpen,
             toggle: this.toggle,
         });
     }
 
     private toggle: () => void = () => {
-        this.setState({ isOpen: !this.state.isOpen });
+        const { isOpen } = this.state;
+
+        this.setState({ isOpen: !isOpen });
     };
 }


### PR DESCRIPTION
## What?
Enable `react/destructuring-assignment` rule.

## Why?
This is a stylistic convention we already follow. But there are some consistencies in the codebase. This PR attempts to enforce the convention and fix the consistencies.

## Testing / Proof
CircleCI

@bigcommerce/checkout
