### PR TITLE
CHECKOUT-4374: Check out tag before uploading artifacts to Sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           command: |
             source /tmp/release_version.txt
             git checkout $RELEASE_VERSION
-            SENTRY_RELEASE=$SENTRY_PROJECT@$RELEASE_VERSION
+            SENTRY_RELEASE=$SENTRY_PROJECT@${RELEASE_VERSION#v}
             SENTRY_COMMIT=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME@$RELEASE_REVISION
             sentry-cli releases --project $SENTRY_PROJECT --org $SENTRY_ORG new $SENTRY_RELEASE
             sentry-cli releases --project $SENTRY_PROJECT --org $SENTRY_ORG set-commits $SENTRY_RELEASE --commit $SENTRY_COMMIT


### PR DESCRIPTION
## What?
Check out the tag of the release before uploading its artifacts to Sentry.

## Why?
Otherwise, we would be uploading the artifacts of the previous release.

## Testing / Proof
Manual

@bigcommerce/checkout
