### PR TITLE
CHECKOUT-4315 Do not strike-through amount without tax

### DIFF
--- a/src/app/order/mapFromPhysical.tsx
+++ b/src/app/order/mapFromPhysical.tsx
@@ -4,10 +4,13 @@ import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { OrderSummaryItemProps } from './OrderSummaryItem';
 
 function mapFromPhysical(item: PhysicalItem): OrderSummaryItemProps {
+    // FIXME: add type in Checkout SDK
+    const comparisonPrice = (item as PhysicalItem & { comparisonPrice: number }).comparisonPrice;
+
     return {
         id: item.id,
         quantity: item.quantity,
-        amount: item.extendedListPrice,
+        amount: item.listPrice < comparisonPrice ? item.extendedSalePrice : item.extendedListPrice,
         amountAfterDiscount: item.extendedSalePrice,
         name: item.name,
         image: getOrderSummaryItemImage(item),


### PR DESCRIPTION
## What?
Use listPrice only when it matches comparisonPrice, otherwise use salePrice.

## Why?
Because sometimes listPrice and salePrice can be different because salePrice includes tax but listPrice doesn't, hence these two values can be different showing a strikethrough. Instead, compare listPrice with comparisonPrice

## Testing / Proof
When salePrice and listPrice are different (because of discount)
<img width="407" alt="Screen Shot 2019-09-10 at 9 55 44 am" src="https://user-images.githubusercontent.com/1621894/64574187-c76d1e00-d3b1-11e9-9835-32608709367f.png">

When salePrice and listPrice are different (because of tax)
<img width="389" alt="Screen Shot 2019-09-10 at 9 56 13 am" src="https://user-images.githubusercontent.com/1621894/64574188-c76d1e00-d3b1-11e9-9f8a-0fd6206b97c3.png">
<img width="149" alt="Screen Shot 2019-09-10 at 10 07 58 am" src="https://user-images.githubusercontent.com/1621894/64574456-e4562100-d3b2-11e9-9080-464a84b5422a.png">



@bigcommerce/checkout
