### PR TITLE
CHECKOUT-4409: Configure public path before rendering apps

### DIFF
--- a/src/app/checkout/CheckoutApp.spec.tsx
+++ b/src/app/checkout/CheckoutApp.spec.tsx
@@ -15,7 +15,6 @@ describe('CheckoutApp', () => {
             checkoutId: getCheckout().id,
             containerId: 'checkout-app',
             flashMessages: [],
-            publicPath: 'https://foobar.com/assets/',
         };
 
         container = document.createElement('div');

--- a/src/app/checkout/CheckoutApp.tsx
+++ b/src/app/checkout/CheckoutApp.tsx
@@ -4,8 +4,8 @@ import { BrowserOptions } from '@sentry/browser';
 import React, { Component } from 'react';
 import ReactModal from 'react-modal';
 
+import '../../scss/App.scss';
 import { StepTracker, StepTrackerFactory } from '../analytics';
-import { configurePublicPath } from '../common/bundler';
 import { createErrorLogger, ErrorLogger, ErrorLoggingBoundary } from '../common/error';
 import { NewsletterService, NewsletterSubscribeData } from '../customer';
 import { createEmbeddedCheckoutStylesheet, createEmbeddedCheckoutSupport } from '../embeddedCheckout';
@@ -18,8 +18,7 @@ import CheckoutProvider from './CheckoutProvider';
 export interface CheckoutAppProps {
     checkoutId: string;
     containerId: string;
-    flashMessages: FlashMessage[]; // TODO: Expose flash messages from SDK
-    publicPath?: string;
+    flashMessages?: FlashMessage[]; // TODO: Expose flash messages from SDK
     sentryConfig?: BrowserOptions;
 }
 
@@ -36,8 +35,6 @@ export default class CheckoutApp extends Component<CheckoutAppProps> {
 
     constructor(props: Readonly<CheckoutAppProps>) {
         super(props);
-
-        configurePublicPath(props.publicPath);
 
         this.errorLogger = createErrorLogger(
             { sentry: props.sentryConfig },

--- a/src/app/checkout/renderCheckout.spec.tsx
+++ b/src/app/checkout/renderCheckout.spec.tsx
@@ -1,0 +1,68 @@
+import { omit } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import renderCheckout, { RenderCheckoutOptions } from './renderCheckout';
+import { CheckoutAppProps } from './CheckoutApp';
+
+let CheckoutApp: FunctionComponent<CheckoutAppProps>;
+let configurePublicPath: (path: string) => void;
+let publicPath: string;
+
+jest.mock('../common/bundler', () => {
+    configurePublicPath = jest.fn(path => {
+        publicPath = path;
+    });
+
+    return {
+        configurePublicPath,
+    };
+});
+
+jest.mock('./CheckoutApp', () => {
+    CheckoutApp = jest.fn(() => <>{ publicPath }</>);
+
+    return {
+        default: CheckoutApp,
+    };
+});
+
+describe('renderCheckout()', () => {
+    let container: HTMLElement;
+    let options: RenderCheckoutOptions;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'app';
+
+        document.body.appendChild(container);
+
+        options = {
+            checkoutId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+            containerId: 'app',
+            publicPath: 'https://foobar.com/assets/',
+        };
+    });
+
+    afterEach(() => {
+        container.remove();
+
+        publicPath = '';
+    });
+
+    it('configures public path before mounting app component', () => {
+        renderCheckout(options);
+
+        expect(configurePublicPath)
+            .toHaveBeenCalledWith(options.publicPath);
+
+        expect(container.innerHTML)
+            .toEqual(options.publicPath);
+    });
+
+    it('passes props to app component', () => {
+        renderCheckout(options);
+
+        expect(CheckoutApp)
+            .toHaveBeenCalledWith(omit(options, 'publicPath'), {});
+    });
+});

--- a/src/app/checkout/renderCheckout.tsx
+++ b/src/app/checkout/renderCheckout.tsx
@@ -1,11 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import CheckoutApp, { CheckoutAppProps } from './CheckoutApp';
+import { configurePublicPath } from '../common/bundler';
 
-export default function renderCheckout(props: CheckoutAppProps): void {
+import { CheckoutAppProps } from './CheckoutApp';
+
+export interface RenderCheckoutOptions extends CheckoutAppProps {
+    publicPath: string;
+}
+
+export default function renderCheckout({
+    containerId,
+    publicPath,
+    ...props
+}: RenderCheckoutOptions): void {
+    configurePublicPath(publicPath);
+
+    const { default: CheckoutApp } = require('./CheckoutApp');
+
     ReactDOM.render(
-        <CheckoutApp { ...props } />,
-        document.getElementById(props.containerId)
+        <CheckoutApp
+            containerId={ containerId }
+            { ...props }
+        />,
+        document.getElementById(containerId)
     );
 }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import '../scss/App.scss';
-
 if (process.env.NODE_ENV === 'development') {
     // We want to use `require` because we only want to import the package in
     // development mode.

--- a/src/app/order/OrderConfirmationApp.spec.tsx
+++ b/src/app/order/OrderConfirmationApp.spec.tsx
@@ -12,7 +12,6 @@ describe('OrderConfirmationApp', () => {
         defaultProps = {
             orderId: 100,
             containerId: 'bar',
-            publicPath: 'https://foobar.com/assets/',
         };
 
         container = document.createElement('div');

--- a/src/app/order/OrderConfirmationApp.tsx
+++ b/src/app/order/OrderConfirmationApp.tsx
@@ -3,9 +3,9 @@ import { BrowserOptions } from '@sentry/browser';
 import React, { Component, ReactNode } from 'react';
 import ReactModal from 'react-modal';
 
+import '../../scss/App.scss';
 import { StepTracker, StepTrackerFactory } from '../analytics';
 import { CheckoutProvider } from '../checkout';
-import { configurePublicPath } from '../common/bundler';
 import { createErrorLogger, ErrorLogger, ErrorLoggingBoundary } from '../common/error';
 import { createEmbeddedCheckoutStylesheet } from '../embeddedCheckout';
 import { AccountService, CreatedCustomer, SignUpFormValues } from '../guestSignup';
@@ -16,7 +16,6 @@ import OrderConfirmation from './OrderConfirmation';
 export interface OrderConfirmationAppProps {
     containerId: string;
     orderId: number;
-    publicPath?: string;
     sentryConfig?: BrowserOptions;
 }
 
@@ -32,8 +31,6 @@ class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
 
     constructor(props: Readonly<OrderConfirmationAppProps>) {
         super(props);
-
-        configurePublicPath(props.publicPath);
 
         this.errorLogger = createErrorLogger(
             { sentry: props.sentryConfig },

--- a/src/app/order/renderOrderConfirmation.spec.tsx
+++ b/src/app/order/renderOrderConfirmation.spec.tsx
@@ -1,0 +1,68 @@
+import { omit } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import renderOrderConfirmation, { RenderOrderConfirmationOptions } from './renderOrderConfirmation';
+import { OrderConfirmationAppProps } from './OrderConfirmationApp';
+
+let OrderConfirmationApp: FunctionComponent<OrderConfirmationAppProps>;
+let configurePublicPath: (path: string) => void;
+let publicPath: string;
+
+jest.mock('../common/bundler', () => {
+    configurePublicPath = jest.fn(path => {
+        publicPath = path;
+    });
+
+    return {
+        configurePublicPath,
+    };
+});
+
+jest.mock('./OrderConfirmationApp', () => {
+    OrderConfirmationApp = jest.fn(() => <>{ publicPath }</>);
+
+    return {
+        default: OrderConfirmationApp,
+    };
+});
+
+describe('renderOrderConfirmation()', () => {
+    let container: HTMLElement;
+    let options: RenderOrderConfirmationOptions;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'app';
+
+        document.body.appendChild(container);
+
+        options = {
+            containerId: 'app',
+            orderId: 295,
+            publicPath: 'https://foobar.com/assets/',
+        };
+    });
+
+    afterEach(() => {
+        container.remove();
+
+        publicPath = '';
+    });
+
+    it('configures public path before mounting app component', () => {
+        renderOrderConfirmation(options);
+
+        expect(configurePublicPath)
+            .toHaveBeenCalledWith(options.publicPath);
+
+        expect(container.innerHTML)
+            .toEqual(options.publicPath);
+    });
+
+    it('passes props to app component', () => {
+        renderOrderConfirmation(options);
+
+        expect(OrderConfirmationApp)
+            .toHaveBeenCalledWith(omit(options, 'publicPath'), {});
+    });
+});

--- a/src/app/order/renderOrderConfirmation.tsx
+++ b/src/app/order/renderOrderConfirmation.tsx
@@ -1,13 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import OrderConfirmationApp, { OrderConfirmationAppProps } from './OrderConfirmationApp';
+import { configurePublicPath } from '../common/bundler';
 
-function renderOrderConfirmation(props: OrderConfirmationAppProps): void {
-    ReactDOM.render(
-        <OrderConfirmationApp { ...props } />,
-        document.getElementById(props.containerId)
-    );
+import { OrderConfirmationAppProps } from './OrderConfirmationApp';
+
+export interface RenderOrderConfirmationOptions extends OrderConfirmationAppProps {
+    publicPath: string;
 }
 
-export default renderOrderConfirmation;
+export default function renderOrderConfirmation({
+    containerId,
+    publicPath,
+    ...props
+}: RenderOrderConfirmationOptions): void {
+    configurePublicPath(publicPath);
+
+    const { default: OrderConfirmationApp } = require('./OrderConfirmationApp');
+
+    ReactDOM.render(
+        <OrderConfirmationApp
+            containerId={ containerId }
+            { ...props }
+        />,
+        document.getElementById(containerId)
+    );
+}


### PR DESCRIPTION
## What?
Configure the public path before render app components

## Why?
Some of the Webpack features require the public path to be set in order to work. If the path is not set, things might not work properly. For example, in development mode, if the path is not set, it's not able to load the assets that are referenced in the stylesheets. Therefore I think what we should do is to call `configurePublicPath` before we import and mount the `CheckoutApp` or `OrderConfirmationApp` component. That way we can ensure that the public path is set before everything else.

## Testing / Proof
CircleCI

@bigcommerce/checkout
