### PR TITLE
CHECKOUT-4336 Allow empty date custom field when optional

### DIFF
--- a/src/app/address/getAddressValidationSchema.ts
+++ b/src/app/address/getAddressValidationSchema.ts
@@ -63,7 +63,8 @@ export default memoize(function getAddressValidationSchema({
                             // Transform NaN values to undefined to avoid empty string (empty input) to fail date
                             // validation when it's optional
                             .strict(true)
-                            .transform(value => value === '' ? undefined : value);
+                            .nullable(true)
+                            .transform(value => value === '' ? null : value);
                     } else if (type === 'integer') {
                         schema[name] = number()
                             // Transform NaN values to undefined to avoid empty string (empty input) to fail number

--- a/src/app/address/mapAddressToFormValues.ts
+++ b/src/app/address/mapAddressToFormValues.ts
@@ -48,13 +48,13 @@ export default function mapAddressToFormValues(fields: FormField[], address?: Ad
     return values;
 }
 
-function getValue(fieldType?: string, fieldValue?: string | string[] | number, defaultValue?: string): string | string[] | number | Date {
+function getValue(fieldType?: string, fieldValue?: string | string[] | number, defaultValue?: string): string | string[] | number | Date | undefined {
     if (fieldValue === undefined || fieldValue === null) {
         return getDefaultValue(fieldType, defaultValue);
     }
 
     if (fieldType === DynamicFormFieldType.date && typeof fieldValue === 'string') {
-        return new Date(fieldValue);
+        return fieldValue ? new Date(fieldValue) : undefined;
     }
 
     return fieldValue;


### PR DESCRIPTION
## What?
Allow nullable custom date fields

## Why?
To allow empty date in custom fields that are optional

## Testing / Proof
If required:
<img width="661" alt="Screen Shot 2019-09-10 at 3 57 38 pm" src="https://user-images.githubusercontent.com/1621894/64587781-c8b73e80-d3e3-11e9-884b-593383f19225.png">

If optional
<img width="651" alt="Screen Shot 2019-09-10 at 3 57 48 pm" src="https://user-images.githubusercontent.com/1621894/64587774-c3f28a80-d3e3-11e9-9052-18d217fdaf9c.png">


@bigcommerce/checkout
