### PR TITLE
CHECKOUT-4398 Prevent default when sign in to visa

### DIFF
--- a/src/app/payment/paymentMethod/WalletButtonPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/WalletButtonPaymentMethod.tsx
@@ -4,6 +4,7 @@ import { noop, some } from 'lodash';
 import React, { Component, Fragment, ReactNode } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
+import { preventDefault } from '../../common/dom';
 import { withLanguage, TranslatedString, WithLanguageProps } from '../../locale';
 import { LoadingOverlay } from '../../ui/loading';
 import withPayment, { WithPaymentProps } from '../withPayment';
@@ -125,6 +126,7 @@ class WalletButtonPaymentMethod extends Component<
             <a
                 className={ signInButtonClassName }
                 id={ buttonId }
+                onClick={ preventDefault() }
                 href="#"
             >
                 { signInButtonLabel || <TranslatedString
@@ -173,6 +175,7 @@ class WalletButtonPaymentMethod extends Component<
                     <a
                         className={ editButtonClassName }
                         href="#"
+                        onClick={ preventDefault() }
                         id={ buttonId }
                     >
                         { editButtonLabel || <TranslatedString id="remote.select_different_card_action" /> }

--- a/src/app/ui/toggle/Toggle.tsx
+++ b/src/app/ui/toggle/Toggle.tsx
@@ -26,8 +26,10 @@ export default class Toggle extends Component<ToggleProps, ToggleState> {
         });
     }
 
-    private toggle: () => void = () => {
+    private toggle: (event: Event) => void = event => {
         const { isOpen } = this.state;
+
+        event.preventDefault();
 
         this.setState({ isOpen: !isOpen });
     };


### PR DESCRIPTION
## What?
Add prevent default when clicking on wallet links

## Why?
Because `href="#"` was causing to get redirected outside checkout when clicking on those links.

## Testing / Proof
![visacheckout](https://user-images.githubusercontent.com/1621894/64759376-43b25d80-d57a-11e9-88e7-a51c57da5a43.gif)

@bigcommerce/checkout
