### PR TITLE
build(common): CHECKOUT-4311 Re-enable commit validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,15 @@ jobs:
           paths:
             - dist
 
+  validate-commits:
+    <<: *node_executor
+    steps:
+      - ci/pre-setup
+      - ci/merge-base
+      - run:
+          name: 'Validate Commits'
+          command: '[ -z "$MERGE_BASE_SHA1" ] || npx @bigcommerce/validate-commits ${MERGE_BASE_SHA1}..${CIRCLE_SHA1}'
+
   release:
     <<: *node_executor
     steps:
@@ -122,6 +131,9 @@ workflows:
           filters:
             <<: *pull_request_filter
       - build:
+          filters:
+            <<: *pull_request_filter
+      - validate-commits:
           filters:
             <<: *pull_request_filter
 


### PR DESCRIPTION
## What?
- Enable commit validation in circle-ci

## Why?
- We want to validate our commits follow the standard format

## Testing / Proof
- This own PR contains a broken commit

@bigcommerce/checkout
