### PR TITLE
CHECKOUT-4374: Update README to include instructions on tagging new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ After that, you can make changes to the source code and run the following comman
 npm run build
 ```
 
+## Release
+
+Everytime a PR is merged to the master branch, CircleCI will trigger a build automatically. However, it won't create a new Git release until it is approved by a person with write access to the repository. If you have write access, you can approve a release job by going to [CircleCI](https://circleci.com/gh/bigcommerce/workflows/checkout-js/tree/master) and look for the job you wish to approve. You can also navigate directly to the release job by clicking on the yellow dot next to the merged commit.
+
+
 ## Contribution
 
 We currently do not accept Pull Requests from external parties. However, if you are an external party and want to report a bug or provide your feedback, you are more than welcome to raise a GitHub Issue. We will attend to these issues as quickly as we can. 


### PR DESCRIPTION
## What?
Update `README` file to include instructions on how to build and tag a new Git release.

## Why?
So it's clear for everyone working for BigCommerce.

## Testing / Proof
None

@bigcommerce/checkout
