### PR TITLE
CHECKOUT-4418: Only log exception event if it is raised by error

### DIFF
--- a/src/app/common/error/SentryErrorLogger.ts
+++ b/src/app/common/error/SentryErrorLogger.ts
@@ -1,5 +1,6 @@
 import { captureException, init, withScope, BrowserOptions, Event, Severity, StackFrame } from '@sentry/browser';
 import { RewriteFrames } from '@sentry/integrations';
+import { EventHint } from '@sentry/types';
 
 import computeErrorCode from './computeErrorCode';
 import ErrorLogger, { ErrorLevelType, ErrorLoggerOptions, ErrorTags } from './ErrorLogger';
@@ -73,9 +74,11 @@ export default class SentryErrorLogger implements ErrorLogger {
         }
     }
 
-    private handleBeforeSend: (event: Event) => Event | null = event => {
-        if (event.exception && event.exception.values) {
-            return event.exception.values.some(exception => exception.type && this.errorTypes.indexOf(exception.type) >= 0) ?
+    private handleBeforeSend: (event: Event, hint?: EventHint) => Event | null = (event, hint) => {
+        if (event.exception) {
+            const { originalException = null } = hint || {};
+
+            return originalException instanceof Error && this.errorTypes.indexOf(originalException.name) >= 0 ?
                 event :
                 null;
         }


### PR DESCRIPTION
## What?
Only log an exception event if it is raised when an error is thrown.

## Why?
By default, when Sentry sees a non-Error object being thrown (i.e.: string), it will convert it into a "synthetic" event and log it unless it is filtered out in a `beforeSend` callback. We currently have a filter in `beforeSend` that correctly filters out regular exception events generated by `Error` objects with actual stack traces. But it doesn't filter out synthetic events because these events need to be checked differently. To fix this, we could take a different approach by checking the `hint` object of an event instead. According to the [doc](https://docs.sentry.io/error-reporting/configuration/filtering/?platform=browser#event-hints), it comes with every exception event; it contains the original exception which we can use in a `beforeSend` callback if our filter logic depends on the original thrown value.
 
## Testing / Proof
Unit

@bigcommerce/checkout
