### PR TITLE
CHECKOUT-4418: Fix `instanceof` check not returning true when code is minified

### DIFF
--- a/src/app/common/error/SentryErrorLogger.ts
+++ b/src/app/common/error/SentryErrorLogger.ts
@@ -79,7 +79,7 @@ export default class SentryErrorLogger implements ErrorLogger {
         if (event.exception) {
             const { originalException = null } = hint || {};
 
-            if (!(originalException instanceof Error)) {
+            if (!originalException || typeof originalException === 'string') {
                 return null;
             }
 


### PR DESCRIPTION
## What?
Fix `instanceof` check not returning true when code is minified.

## Why?
`instanceof` doesn't work if code is minified. `originalException` is defined as `null | string | Error`, so another way to check if `originalException` is an `Error` is by checking if it is not a string.

## Testing / Proof
Unit

@bigcommerce/checkout
