### PR TITLE
CHECKOUT-4418: Log error in console

### DIFF
--- a/src/app/common/error/ConsoleErrorLogger.spec.ts
+++ b/src/app/common/error/ConsoleErrorLogger.spec.ts
@@ -1,0 +1,77 @@
+import ConsoleErrorLogger from './ConsoleErrorLogger';
+import { ErrorLevelType } from './ErrorLogger';
+
+describe('ConsoleErrorLogger', () => {
+    let mockConsole: Console;
+
+    beforeEach(() => {
+        mockConsole = {
+            error: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+        } as unknown as Console;
+    });
+
+    it('logs error as error to console by default', () => {
+        const logger = new ConsoleErrorLogger({ console: mockConsole });
+        const error = new Error('Testing 123');
+        const tags = { errorCode: 'abc' };
+
+        logger.log(error, tags);
+
+        expect(mockConsole.error)
+            .toHaveBeenCalledWith(error, tags);
+    });
+
+    it('logs error as warning to console', () => {
+        const logger = new ConsoleErrorLogger({ console: mockConsole });
+        const error = new Error('Testing 123');
+        const tags = { errorCode: 'abc' };
+
+        logger.log(error, tags, ErrorLevelType.Warning);
+
+        expect(mockConsole.warn)
+            .toHaveBeenCalledWith(error, tags);
+    });
+
+    it('logs error as info to console', () => {
+        const logger = new ConsoleErrorLogger({ console: mockConsole });
+        const error = new Error('Testing 123');
+        const tags = { errorCode: 'abc' };
+
+        logger.log(error, tags, ErrorLevelType.Info);
+
+        expect(mockConsole.info)
+            .toHaveBeenCalledWith(error, tags);
+    });
+
+    it('allows additional error types to be logged', () => {
+        const logger = new ConsoleErrorLogger({
+            console: mockConsole,
+            errorTypes: ['Foo'],
+        });
+
+        const error = new Error('Foo');
+        error.name = 'Foo';
+
+        logger.log(error);
+
+        expect(mockConsole.error)
+            .toHaveBeenCalledWith(error, undefined);
+    });
+
+    it('does not log custom errors unless they are listed as additional error types', () => {
+        const logger = new ConsoleErrorLogger({
+            console: mockConsole,
+            errorTypes: ['Foo'],
+        });
+
+        const error = new Error('Bar');
+        error.name = 'Bar';
+
+        logger.log(error);
+
+        expect(mockConsole.error)
+            .not.toHaveBeenCalledWith(error, undefined);
+    });
+});

--- a/src/app/common/error/ConsoleErrorLogger.ts
+++ b/src/app/common/error/ConsoleErrorLogger.ts
@@ -1,0 +1,51 @@
+import { includes } from 'lodash';
+
+import DEFAULT_ERROR_TYPES from './defaultErrorTypes';
+import ErrorLogger, { ErrorLevelType, ErrorTags } from './ErrorLogger';
+
+export interface ConsoleErrorLoggerOptions {
+    console?: Console;
+    errorTypes?: string[];
+}
+
+// tslint:disable:no-console
+export default class ConsoleErrorLogger implements ErrorLogger {
+    private console: Console;
+    private errorTypes: string[];
+
+    constructor(
+        options?: ConsoleErrorLoggerOptions
+    ) {
+        const {
+            console: customConsole = console,
+            errorTypes = [],
+        } = options || {};
+
+        this.console = customConsole;
+        this.errorTypes = [
+            ...DEFAULT_ERROR_TYPES,
+            ...errorTypes,
+        ];
+    }
+
+    log(
+        error: Error,
+        tags?: ErrorTags,
+        level: ErrorLevelType = ErrorLevelType.Error
+    ): void {
+        if (!includes(this.errorTypes, error.name)) {
+            return;
+        }
+
+        switch (level) {
+        case ErrorLevelType.Error:
+            return this.console.error(error, tags);
+
+        case ErrorLevelType.Info:
+            return this.console.info(error, tags);
+
+        case ErrorLevelType.Warning:
+            return this.console.warn(error, tags);
+        }
+    }
+}

--- a/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/src/app/common/error/SentryErrorLogger.spec.ts
@@ -3,8 +3,10 @@ import { RewriteFrames } from '@sentry/integrations';
 import { Integration } from '@sentry/types';
 
 import computeErrorCode from './computeErrorCode';
+import DEFAULT_ERROR_TYPES from './defaultErrorTypes';
+import ConsoleErrorLogger from './ConsoleErrorLogger';
 import { ErrorLevelType } from './ErrorLogger';
-import SentryErrorLogger, { DEFAULT_ERROR_TYPES } from './SentryErrorLogger';
+import SentryErrorLogger from './SentryErrorLogger';
 
 jest.mock('@sentry/browser', () => {
     return {
@@ -253,6 +255,23 @@ describe('SentryErrorLogger', () => {
 
             expect(scope.setLevel)
                 .toHaveBeenNthCalledWith(3, Severity.Info);
+        });
+
+        it('logs error in console if console logger is provided', () => {
+            const consoleLogger = new ConsoleErrorLogger();
+
+            jest.spyOn(consoleLogger, 'log')
+                .mockImplementation();
+
+            const logger = new SentryErrorLogger(config, { consoleLogger });
+            const error = new Error('Testing 123');
+            const tags = { errorCode: 'abc' };
+            const level = ErrorLevelType.Error;
+
+            logger.log(error, tags, level);
+
+            expect(consoleLogger.log)
+                .toHaveBeenCalledWith(error, tags, level);
         });
     });
 });

--- a/src/app/common/error/createErrorLogger.ts
+++ b/src/app/common/error/createErrorLogger.ts
@@ -1,3 +1,4 @@
+import ConsoleErrorLogger from './ConsoleErrorLogger';
 import ErrorLogger, { ErrorLoggerOptions, ErrorLoggerServiceConfig } from './ErrorLogger';
 import NoopErrorLogger from './NoopErrorLogger';
 import SentryErrorLogger from './SentryErrorLogger';
@@ -9,9 +10,13 @@ export default function createErrorLogger(
     if (serviceConfig && serviceConfig.sentry) {
         return new SentryErrorLogger(
             serviceConfig.sentry,
-            options
+            { ...options, consoleLogger: new ConsoleErrorLogger(options) }
         );
     }
 
-    return new NoopErrorLogger();
+    if (process.env.NODE_ENV === 'test') {
+        return new NoopErrorLogger();
+    }
+
+    return new ConsoleErrorLogger(options);
 }

--- a/src/app/common/error/defaultErrorTypes.ts
+++ b/src/app/common/error/defaultErrorTypes.ts
@@ -1,0 +1,11 @@
+const DEFAULT_ERROR_TYPES = [
+    'Error',
+    'EvalError',
+    'RangeError',
+    'ReferenceError',
+    'SyntaxError',
+    'TypeError',
+    'URIError',
+];
+
+export default DEFAULT_ERROR_TYPES;


### PR DESCRIPTION
## What?
Log error in console.

## Why?
Before this change, when there's an error and it is unhandled, it will eventually be caught and log in Sentry (unless it is filtered out during the process). However, because it is caught, it won't be logged in the console. This problem also affects local development environment, where Sentry is disabled, because `NoopErrorLogger` is used, which by its nature does nothing. To fix this issue, I have introduced a third logger - `ConsoleErrorLogger` - which logs to the console when we call the error logger in environments other than the test environment.

## Testing / Proof
Unit

@bigcommerce/checkout
