### PR TITLE
CHECKOUT-4415: Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -872,9 +872,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.35.1.tgz",
-      "integrity": "sha512-TQ6xuKCJiF569MhvBaSsxDgh4I9uZSBGAvoXXOvWM4TGgdXpvufNbaMbCnVf7gmnORg3tzWfVsN03P7Y6wpnsw==",
+      "version": "1.35.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.35.2.tgz",
+      "integrity": "sha512-3OLKR3pvdVYVziTYeTaGij1OuRM/auL87rQeaUtehTqkAe5if0u9mW6LEM2nI0B4TUI0n+drOp5j50QMczMEhw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.35.1",
+    "@bigcommerce/checkout-sdk": "^1.35.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
