### PR TITLE
feat(payment): INT-1901 Use modal to handle 3DS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
         "resolve": "^1.3.2",
-        "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -63,12 +62,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -799,16 +792,7 @@
         "browserslist": "^4.6.0",
         "core-js-compat": "^3.1.1",
         "invariant": "^2.2.2",
-        "js-levenshtein": "^1.1.3",
-        "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "js-levenshtein": "^1.1.3"
       }
     },
     "@babel/runtime": {
@@ -886,9 +870,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.37.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.37.2.tgz",
-      "integrity": "sha512-NEKjQ96l29CjmlQw/3ijoRaBUt72fIuTUFiqG+UYbPHPPpvK9WM69toRhd4w9uxKNPlimEiKNR71tf+SesZrVg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.38.0.tgz",
+      "integrity": "sha512-hBR3aze2owcVcjHrMe4aPxMm6IOZcI6Rgoo1WMsnFhPy+H+t5dFmvteMFBOgMK9XqqqA+HBP92Yxnn2YchZWHg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.5.0",
@@ -921,9 +905,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.141",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.141.tgz",
-          "integrity": "sha512-v5NYIi9qEbFEUpCyikmnOYe4YlP8BMUdTcNCAquAKzu+FA7rZ1onj9x80mbnDdOW/K5bFf3Tv5kJplP33+gAbQ=="
+          "version": "4.14.142",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.142.tgz",
+          "integrity": "sha512-ZhNS7c4D4WQ49Dr1FftQj7SwngRswOnPfxktmqSy5BettRCuum2q784jRwNTYfxH00r8+fEgRz6Da8j5DHNd1Q=="
         }
       }
     },
@@ -2837,17 +2821,7 @@
       "optional": true,
       "requires": {
         "bin-version": "^3.0.0",
-        "semver": "^5.6.0",
         "semver-truncate": "^1.1.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "bin-wrapper": {
@@ -3034,12 +3008,6 @@
       "requires": {
         "inherits": "~2.0.0"
       }
-    },
-    "bluebird": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-      "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
-      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -3885,18 +3853,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "config-chain": {
       "version": "1.1.12",
@@ -5111,17 +5067,8 @@
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
-        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "crypto-browserify": {
@@ -5288,12 +5235,6 @@
         "bin-wrapper": "^4.0.1",
         "logalot": "^2.1.0"
       }
-    },
-    "cyclist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
-      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
-      "dev": true
     },
     "dargs": {
       "version": "4.1.0",
@@ -5879,18 +5820,6 @@
       "dev": true,
       "optional": true
     },
-    "duplexify": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -6029,16 +5958,7 @@
         "object.values": "^1.1.0",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.6",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "react-test-renderer": "^16.0.0-0"
       }
     },
     "enzyme-adapter-utils": {
@@ -6051,16 +5971,7 @@
         "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
         "object.fromentries": "^2.0.0",
-        "prop-types": "^15.7.2",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "prop-types": "^15.7.2"
       }
     },
     "enzyme-to-json": {
@@ -7149,16 +7060,6 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
-    "flush-write-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
-      }
-    },
     "fn-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
@@ -7222,17 +7123,8 @@
         "chokidar": "^2.0.4",
         "micromatch": "^3.1.10",
         "minimatch": "^3.0.4",
-        "semver": "^5.6.0",
         "tapable": "^1.0.0",
         "worker-rpc": "^0.1.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "form-data": {
@@ -7276,6 +7168,7 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -8666,9 +8559,9 @@
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "handlebars": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
-      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -10505,16 +10398,7 @@
         "jest-resolve": "^24.8.0",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^24.8.0",
-        "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "pretty-format": "^24.8.0"
       }
     },
     "jest-util": {
@@ -11100,16 +10984,7 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "pify": "^4.0.1"
       }
     },
     "make-error": {
@@ -11457,24 +11332,6 @@
         "minipass": "^3.0.0"
       }
     },
-    "mississippi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^3.0.0",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
-      }
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -11613,16 +11470,7 @@
         "commander": "^2.19.0",
         "moo": "^0.4.3",
         "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6",
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "randexp": "0.4.6"
       }
     },
     "neo-async": {
@@ -11733,35 +11581,15 @@
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "node-releases": {
       "version": "1.1.26",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
       "integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "node-sass": {
       "version": "4.12.0",
@@ -11873,16 +11701,7 @@
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "normalize-path": {
@@ -12361,17 +12180,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
       "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
       "dev": true
-    },
-    "parallel-transform": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
-      "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
-      "dev": true,
-      "requires": {
-        "cyclist": "^1.0.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
-      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -13001,29 +12809,6 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-      "dev": true,
-      "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
       }
     },
     "punycode": {
@@ -13940,20 +13725,13 @@
         "loader-utils": "^1.0.1",
         "lodash.tail": "^4.1.1",
         "neo-async": "^2.5.0",
-        "pify": "^3.0.0",
-        "semver": "^5.5.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -14045,19 +13823,7 @@
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
+      "optional": true
     },
     "serialize-javascript": {
       "version": "2.1.0",
@@ -14717,16 +14483,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "stream-each": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "stream-http": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
@@ -14739,12 +14495,6 @@
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
       }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -15944,7 +15694,6 @@
         "make-error": "1.x",
         "mkdirp": "0.x",
         "resolve": "1.x",
-        "semver": "^5.5",
         "yargs-parser": "10.x"
       },
       "dependencies": {
@@ -15967,12 +15716,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "yargs-parser": {
@@ -16071,17 +15814,8 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
-        "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "tsutils": {
@@ -16646,72 +16380,8 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
-      },
-      "dependencies": {
-        "cacache": {
-          "version": "12.0.3",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
-          }
-        },
-        "serialize-javascript": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-          "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-          "dev": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1"
-          }
-        },
-        "terser-webpack-plugin": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-          "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
-          "dev": true,
-          "requires": {
-            "cacache": "^12.0.2",
-            "find-cache-dir": "^2.1.0",
-            "is-wsl": "^1.1.0",
-            "schema-utils": "^1.0.0",
-            "serialize-javascript": "^1.7.0",
-            "source-map": "^0.6.1",
-            "terser": "^4.1.2",
-            "webpack-sources": "^1.4.0",
-            "worker-farm": "^1.7.0"
-          }
-        }
       }
     },
     "webpack-assets-manifest": {
@@ -16744,8 +16414,7 @@
         "interpret": "1.2.0",
         "loader-utils": "1.2.3",
         "supports-color": "6.1.0",
-        "v8-compile-cache": "2.0.3",
-        "yargs": "13.2.4"
+        "v8-compile-cache": "2.0.3"
       },
       "dependencies": {
         "supports-color": {
@@ -16755,25 +16424,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.2.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-          "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.0"
           }
         }
       }
@@ -16895,15 +16545,6 @@
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
-    "worker-farm": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.7"
-      }
-    },
     "worker-rpc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
@@ -16990,9 +16631,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
-      "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.0.tgz",
+      "integrity": "sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -17005,7 +16646,19 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^15.0.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.37.2",
+    "@bigcommerce/checkout-sdk": "^1.38.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -158,6 +158,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
 
                     { !isEmpty(methods) && defaultMethod && <PaymentForm
                         { ...rest }
+                        defaultGatewayId={ defaultMethod.gateway }
                         defaultMethodId={ defaultMethod.id }
                         isUsingMultiShipping={ isUsingMultiShipping }
                         methods={ methods }
@@ -246,8 +247,8 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         const { defaultMethod, isSubmittingOrder, language } = this.props;
         const { selectedMethod = defaultMethod } = this.state;
 
-        // TODO: Perhaps there is a better way to handle `amazon`, `converge`,
-        // `sagepay` and `afterpay`. They require a redirection to another website
+        // TODO: Perhaps there is a better way to handle `adyen`, `afterpay`, `amazon`,
+        // `converge` and `sagepay``. They require a redirection to another website
         // during the payment flow but are not categorised as hosted payment methods.
         if (!isSubmittingOrder ||
             !selectedMethod ||
@@ -255,6 +256,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.Amazon ||
             selectedMethod.id === PaymentMethodId.Converge ||
             selectedMethod.id === PaymentMethodId.SagePay ||
+            selectedMethod.gateway === PaymentMethodId.AdyenV2 ||
             selectedMethod.gateway === PaymentMethodId.Afterpay) {
             return;
         }

--- a/src/app/payment/paymentMethod/AdyenV2PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2PaymentMethod.spec.tsx
@@ -1,0 +1,177 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { mount, ReactWrapper } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { CheckoutProvider } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { Modal, ModalProps } from '../../ui/modal';
+import { getPaymentMethod } from '../payment-methods.mock';
+
+import { AdyenPaymentMethodProps } from './AdyenV2PaymentMethod';
+import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+import { default as PaymentMethodComponent, PaymentMethodProps } from './PaymentMethod';
+
+describe('when using Adyen V2 payment', () => {
+    let method: PaymentMethod;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: PaymentMethodProps;
+    let localeContext: LocaleContextType;
+    let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
+
+    beforeEach(() => {
+        defaultProps = {
+            method: getPaymentMethod(),
+            onUnhandledError: jest.fn(),
+        };
+
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+        method = { ...getPaymentMethod(), id: 'scheme', gateway: 'adyenv2', method: 'scheme' };
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutService, 'deinitializePayment')
+            .mockResolvedValue(checkoutState);
+
+        jest.spyOn(checkoutService, 'initializePayment')
+            .mockResolvedValue(checkoutState);
+
+        PaymentMethodTest = props => (
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleContext.Provider value={ localeContext }>
+                    <Formik
+                        initialValues={ {} }
+                        onSubmit={ noop }
+                    >
+                        <PaymentMethodComponent { ...props } />
+                    </Formik>
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('renders as hosted widget method', () => {
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+        expect(component.props())
+            .toEqual(expect.objectContaining({
+                containerId: 'scheme-adyen-component-field',
+                deinitializePayment: expect.any(Function),
+                initializePayment: expect.any(Function),
+                method,
+            }));
+    });
+
+    it('initializes method with required config', () => {
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+        component.prop('initializePayment')({
+            methodId: method.id,
+            gatewayId: method.gateway,
+        });
+
+        expect(checkoutService.initializePayment).toHaveBeenCalled();
+
+        expect(checkoutService.initializePayment)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                adyenv2: {
+                    containerId: 'scheme-adyen-component-field',
+                    options: {
+                        hasHolderName: true,
+                    },
+                    threeDS2ContainerId: 'scheme-adyen-component-field-3ds',
+                    threeDS2Options: {
+                        widgetSize: '05',
+                        onLoad: expect.any(Function),
+                        onComplete: expect.any(Function),
+                    },
+                },
+                gatewayId: method.gateway,
+                methodId: method.id,
+            }));
+    });
+
+    it('renders 3DS modal if required by selected method', async () => {
+        const defaultAdyenProps: AdyenPaymentMethodProps = {
+            deinitializePayment: jest.fn(),
+            initializePayment: jest.fn(),
+            isInitializing: false,
+            method: getPaymentMethod(),
+            onUnhandledError: jest.fn(),
+        };
+        const container = mount(<PaymentMethodTest { ...defaultAdyenProps } method={ method } />);
+        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+        component.prop('initializePayment')({
+            methodId: method.id,
+            gatewayId: method.gateway,
+        });
+
+        const initializeOptions = (defaultAdyenProps.initializePayment as jest.Mock).mock.calls[0][0];
+
+        act(() => {
+            initializeOptions.adyenv2.threeDS2Options.onLoad(jest.fn());
+        });
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        act(() => {
+            container.update();
+        });
+
+        expect(container.find(Modal).prop('isOpen'))
+            .toEqual(true);
+
+        expect(container.find(Modal).render().find('#scheme-adyen-component-field-3ds'))
+            .toHaveLength(1);
+    });
+
+    it('cancels 3DS modal flow if user chooses to close modal', async () => {
+        const cancelThreeDSecureModalFlow = jest.fn();
+        const defaultAdyenProps: AdyenPaymentMethodProps = {
+            deinitializePayment: jest.fn(),
+            initializePayment: jest.fn(),
+            isInitializing: false,
+            method: getPaymentMethod(),
+            onUnhandledError: jest.fn(),
+        };
+        const container = mount(<PaymentMethodTest { ...defaultAdyenProps } method={ method } />);
+        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+        component.prop('initializePayment')({
+            methodId: method.id,
+            gatewayId: method.gateway,
+        });
+
+        const initializeOptions = (defaultAdyenProps.initializePayment as jest.Mock).mock.calls[0][0];
+
+        act(() => {
+            initializeOptions.adyenv2.threeDS2Options.onLoad(cancelThreeDSecureModalFlow);
+        });
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        act(() => {
+            container.update();
+        });
+
+        const modal: ReactWrapper<ModalProps> = container.find(Modal);
+
+        act(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            modal.prop('onRequestClose')!(new MouseEvent('click') as any);
+        });
+
+        expect(cancelThreeDSecureModalFlow)
+            .toHaveBeenCalled();
+    });
+});

--- a/src/app/payment/paymentMethod/AdyenV2PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2PaymentMethod.tsx
@@ -1,0 +1,119 @@
+import { AdyenCreditCardComponentOptions, PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import React, { createRef, useCallback, useRef, useState, FunctionComponent, RefObject } from 'react';
+import { Omit } from 'utility-types';
+
+import { TranslatedString } from '../../locale';
+import { Modal } from '../../ui/modal';
+
+import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+
+export type AdyenPaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'containerId' | 'hideContentWhenSignedOut'>;
+
+export interface AdyenOptions {
+    scheme: AdyenCreditCardComponentOptions;
+    bcmc: AdyenCreditCardComponentOptions;
+}
+
+export enum AdyenMethodType {
+    scheme = 'scheme',
+    bcmc = 'bcmc',
+}
+
+interface AdyenPaymentMethodRef {
+    threeDSecureContentRef: RefObject<HTMLDivElement>;
+    cancelThreeDSecureVerification?(): void;
+}
+
+const AdyenV2PaymentMethod: FunctionComponent<AdyenPaymentMethodProps> = ({
+    initializePayment,
+    method,
+    ...rest
+}) => {
+    const ref = useRef<AdyenPaymentMethodRef>({
+        threeDSecureContentRef: createRef(),
+    });
+    const [threeDSecureContent, setThreeDSecureContent] = useState<HTMLElement>();
+    const containerId = `${method.id}-adyen-component-field`;
+    const threeDS2ContainerId = `${containerId}-3ds`;
+    const component = method.method as AdyenMethodType;
+    const adyenOptions: AdyenOptions = {
+        [AdyenMethodType.scheme]: {
+            hasHolderName: true,
+        },
+        [AdyenMethodType.bcmc]: {
+            hasHolderName: false,
+        },
+    };
+
+    const onLoad = useCallback(cancel => {
+        const div = document.createElement('div');
+        div.setAttribute('id', threeDS2ContainerId);
+
+        setThreeDSecureContent(div);
+        ref.current.cancelThreeDSecureVerification = cancel;
+    }, [threeDS2ContainerId]);
+
+    const onComplete = useCallback(() => {
+        setThreeDSecureContent(undefined);
+        ref.current.cancelThreeDSecureVerification = undefined;
+    }, []);
+
+    const appendThreeDSecureContent = useCallback(() => {
+        if (ref.current.threeDSecureContentRef.current && threeDSecureContent) {
+            ref.current.threeDSecureContentRef.current.appendChild(threeDSecureContent);
+        }
+    }, [threeDSecureContent]);
+
+    const cancelThreeDSecureModalFlow = useCallback(() => {
+        setThreeDSecureContent(undefined);
+
+        if (ref.current.cancelThreeDSecureVerification) {
+            ref.current.cancelThreeDSecureVerification();
+            ref.current.cancelThreeDSecureVerification = undefined;
+        }
+    }, []);
+
+    const adyenv2 = {
+        containerId,
+        threeDS2ContainerId,
+        options: adyenOptions[component],
+        threeDS2Options: {
+            widgetSize: '05',
+            onLoad,
+            onComplete,
+        },
+    };
+
+    const initializeAdyenPayment = useCallback((options: PaymentInitializeOptions) => {
+        return initializePayment({
+            ...options,
+            adyenv2,
+        });
+    }, [initializePayment, adyenv2]);
+
+    return <>
+        <HostedWidgetPaymentMethod
+            { ...rest }
+            containerId={ containerId }
+            hideContentWhenSignedOut
+            initializePayment={ initializeAdyenPayment }
+            method={ method }
+        />
+
+        <Modal
+            additionalBodyClassName="modal-body--center"
+            closeButtonLabel={ <TranslatedString id="common.close_action" /> }
+            isOpen={ !!threeDSecureContent }
+            onAfterOpen={ appendThreeDSecureContent }
+            onRequestClose={ cancelThreeDSecureModalFlow }
+            shouldShowCloseButton={ true }
+        >
+            <div
+                ref={ ref.current.threeDSecureContentRef }
+                style={ { width: '100%' } }
+            />
+        </Modal>
+    </>;
+};
+
+export default AdyenV2PaymentMethod;

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -3,6 +3,7 @@ import React, { memo, FunctionComponent } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
 
+import AdyenV2PaymentMethod from './AdyenV2PaymentMethod';
 import AffirmPaymentMethod from './AffirmPaymentMethod';
 import AmazonPaymentMethod from './AmazonPaymentMethod';
 import BraintreeCreditCardPaymentMethod from './BraintreeCreditCardPaymentMethod';
@@ -50,6 +51,10 @@ export interface WithCheckoutPaymentMethodProps {
 // tslint:disable:cyclomatic-complexity
 const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckoutPaymentMethodProps> = props => {
     const { method } = props;
+
+    if (method.gateway === PaymentMethodId.AdyenV2) {
+        return <AdyenV2PaymentMethod { ...props } />;
+    }
 
     if (method.id === PaymentMethodId.SquareV2) {
         return <SquarePaymentMethod { ...props } />;

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -1,5 +1,6 @@
 enum PaymentMethodId {
     Adyen = 'adyen',
+    AdyenV2 = 'adyenv2',
     Affirm = 'affirm',
     Afterpay = 'afterpay',
     Amazon = 'amazon',


### PR DESCRIPTION
## What?
3DS 2.0 should show in a modal and you should not be able to do anything else. As well the loading icon keeps showing see screenshot.

## Why?

- The card component displays in its own accordion on the Payment section of the checkout page.
- Vaulted instruments HOC is displayed if a customer is signed in
- When I type credit or debit card details on the Adyen card component I can successfully checkout.

## Testing / Proof
![NewAdyen3DSModal](https://user-images.githubusercontent.com/8570490/66013216-fd249480-e48f-11e9-8d9c-0079cf1233e7.gif)

## Sibling PR
[SDK](https://github.com/bigcommerce/checkout-sdk-js/pull/710)

@bigcommerce/checkout @bigcommerce/payments
