### PR TITLE
CHECKOUT-4418: Check whether stack trace exists under exception key rather than at top level

### DIFF
--- a/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/src/app/common/error/SentryErrorLogger.spec.ts
@@ -41,8 +41,13 @@ describe('SentryErrorLogger', () => {
 
         DEFAULT_ERROR_TYPES.forEach(type => {
             const event = {
-                exception: { values: [{ type, value: `${type} error message` }] },
-                stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+                exception: {
+                    values: [{
+                        stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+                        type,
+                        value: `${type} error message`,
+                    }],
+                },
             };
             const originalException = new Error(`${type} error message`);
 
@@ -55,8 +60,13 @@ describe('SentryErrorLogger', () => {
 
         ['Foo', 'Bar'].forEach(type => {
             const event = {
-                exception: { values: [{ type, value: `${type} error message` }] },
-                stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+                exception: {
+                    values: [{
+                        stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+                        type,
+                        value: `${type} error message`,
+                    }],
+                },
             };
             const originalException = new Error(`${type} error message`);
 
@@ -76,8 +86,13 @@ describe('SentryErrorLogger', () => {
 
         ['Foo', 'Bar'].forEach(type => {
             const event = {
-                exception: { values: [{ type, value: `${type} error message` }] },
-                stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+                exception: {
+                    values: [{
+                        stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+                        type,
+                        value: `${type} error message`,
+                    }],
+                },
             };
             const originalException = new Error(`${type} error message`);
 
@@ -95,8 +110,13 @@ describe('SentryErrorLogger', () => {
 
         const clientOptions: BrowserOptions = (init as jest.Mock).mock.calls[0][0];
         const event = {
-            exception: { values: [{ type: 'Error', value: 'Unexpected error' }] },
-            stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+            exception: {
+                values: [{
+                    stacktrace: { frames: [{ filename: 'js/app-123.js' }] },
+                    type: 'Error',
+                    value: 'Unexpected error',
+                }],
+            },
         };
         const hint = { originalException: 'Unexpected error' };
 

--- a/src/app/common/error/SentryErrorLogger.ts
+++ b/src/app/common/error/SentryErrorLogger.ts
@@ -1,7 +1,7 @@
 import { captureException, init, withScope, BrowserOptions, Event, Severity, StackFrame } from '@sentry/browser';
 import { RewriteFrames } from '@sentry/integrations';
 import { EventHint } from '@sentry/types';
-import { includes, isEmpty } from 'lodash';
+import { every, includes, isEmpty } from 'lodash';
 
 import computeErrorCode from './computeErrorCode';
 import DEFAULT_ERROR_TYPES from './defaultErrorTypes';
@@ -90,7 +90,7 @@ export default class SentryErrorLogger implements ErrorLogger {
                 return null;
             }
 
-            if (!event.stacktrace || isEmpty(event.stacktrace.frames)) {
+            if (every(event.exception.values, value => !value.stacktrace || isEmpty(value.stacktrace.frames))) {
                 return null;
             }
 


### PR DESCRIPTION
## What?
Check whether the `stacktrace` is defined under the `exception` key rather than at the top level.

## Why?
`stacktrace` is not defined directly under the `event` object.

## Testing / Proof
<img width="290" alt="Screen Shot 2019-09-24 at 3 54 41 pm" src="https://user-images.githubusercontent.com/667603/65484976-d42a5f80-dee3-11e9-8176-f5a23b68e19a.png">

@bigcommerce/checkout
