### PR TITLE
CHECKOUT-4378: Add missing spacing between label and dollar amount

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -57,6 +57,7 @@
             "handling_text": "Handling",
             "item_count_text": "{count, plural, one{1 Item} other{# Items} }",
             "print_action": "Print",
+            "remaining_text": "Remaining",
             "remove_action": "remove",
             "see_all_action": "See All",
             "see_less_action": "See Less",

--- a/src/app/order/OrderSummaryDiscount.spec.tsx
+++ b/src/app/order/OrderSummaryDiscount.spec.tsx
@@ -1,20 +1,27 @@
-import { shallow, ShallowWrapper } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 
-import { ShopperCurrency } from '../currency';
+import { getStoreConfig } from '../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
 
 import OrderSummaryDiscount from './OrderSummaryDiscount';
 import OrderSummaryPrice from './OrderSummaryPrice';
 
 describe('OrderSummaryDiscount', () => {
-    let discount: ShallowWrapper;
+    let discount: ReactWrapper;
+    let localeContext: LocaleContextType;
 
     describe('when it is a simple discount', () => {
         beforeEach(() => {
-            discount = shallow(<OrderSummaryDiscount
-                amount={ 10 }
-                label={ <span>Foo</span> }
-            />);
+            localeContext = createLocaleContext(getStoreConfig());
+            discount = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <OrderSummaryDiscount
+                        amount={ 10 }
+                        label={ <span>Foo</span> }
+                    />
+                </LocaleContext.Provider>
+            );
         });
 
         it('passes right props to OrderSummaryPrice', () => {
@@ -28,12 +35,20 @@ describe('OrderSummaryDiscount', () => {
 
     describe('when discount has code and remaining balance', () => {
         beforeEach(() => {
-            discount = shallow(<OrderSummaryDiscount
-                amount={ 10 }
-                code="ABCDFE"
-                label="Gift Certificate"
-                remaining={ 2 }
-            />);
+            discount = mount(
+                <LocaleContext.Provider value={ localeContext }>
+                    <OrderSummaryDiscount
+                        amount={ 10 }
+                        code="ABCDFE"
+                        label="Gift Certificate"
+                        remaining={ 2 }
+                    />
+                </LocaleContext.Provider>
+            );
+        });
+
+        it('matches snapshot', () => {
+            expect(discount.render()).toMatchSnapshot();
         });
 
         it('renders gift certificate code', () => {
@@ -47,7 +62,7 @@ describe('OrderSummaryDiscount', () => {
         });
 
         it('renders remaining balance', () => {
-            expect(discount.find(ShopperCurrency).props())
+            expect(discount.find('[data-test="cart-price-remaining"] ShopperCurrency').props())
                 .toMatchObject({ amount: 2 });
         });
     });

--- a/src/app/order/OrderSummaryDiscount.tsx
+++ b/src/app/order/OrderSummaryDiscount.tsx
@@ -30,7 +30,8 @@ const OrderSummaryDiscount: FunctionComponent<OrderSummaryDiscountProps> = ({
             className="cart-priceItem-postFix optimizedCheckout-contentSecondary"
             data-test="cart-price-remaining"
         >
-            Remaining:
+            <TranslatedString id="cart.remaining_text" />
+            { ': ' }
             <ShopperCurrency amount={ remaining } />
         </span> }
 

--- a/src/app/order/__snapshots__/OrderSummaryDiscount.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummaryDiscount.spec.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OrderSummaryDiscount when discount has code and remaining balance matches snapshot 1`] = `
+<div>
+  <div
+    aria-live="polite"
+    class="cart-priceItem optimizedCheckout-contentPrimary"
+  >
+    <span
+      class="cart-priceItem-label"
+    >
+      <span
+        data-test="cart-price-label"
+      >
+        Gift Certificate  
+      </span>
+    </span>
+    <span
+      class="cart-priceItem-value"
+    >
+      <span
+        data-test="cart-price-value"
+      >
+        -$11.20
+      </span>
+    </span>
+    <span
+      class="cart-priceItem-postFix optimizedCheckout-contentSecondary"
+      data-test="cart-price-remaining"
+    >
+      Remaining: $2.24
+    </span>
+    <span
+      class="cart-priceItem-postFix optimizedCheckout-contentSecondary"
+      data-test="cart-price-code"
+    >
+      ABCDFE
+    </span>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## What?
* Add missing spacing between the label and the dollar amount of `OrderSummaryDiscount` component.
* Define "Remaining" as a translatable string.

## Why?
* Otherwise the functional tests will fail because of the way they read the page content.
* We also want the spacing because it is less readable without it.

## Testing / Proof
<img width="158" alt="Screen Shot 2019-09-25 at 9 36 47 am" src="https://user-images.githubusercontent.com/667603/65557839-04bbd900-df78-11e9-903a-21c720e41242.png">

@bigcommerce/checkout
