### PR TITLE
CHECKOUT-4403 INT-1759: Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,9 +886,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.35.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.35.2.tgz",
-      "integrity": "sha512-3OLKR3pvdVYVziTYeTaGij1OuRM/auL87rQeaUtehTqkAe5if0u9mW6LEM2nI0B4TUI0n+drOp5j50QMczMEhw==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.37.0.tgz",
+      "integrity": "sha512-KHX4QdfcoxQa3tJrgkIUgICkjciViUrbJjIZCMFdn5jNjqt0Iv1gMN8Zhzkaj3JFi1WYNoXXYc+ohT2DArT5kg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.5.0",
@@ -898,18 +898,18 @@
         "@bigcommerce/request-sender": "^0.3.0",
         "@bigcommerce/script-loader": "^0.1.6",
         "@types/iframe-resizer": "^3.5.6",
-        "@types/lodash": "^4.14.92",
+        "@types/lodash": "^4.14.139",
         "@types/reselect": "^2.2.0",
         "@types/shallowequal": "^1.1.1",
         "core-js": "^3.1.2",
         "iframe-resizer": "^3.6.2",
         "local-storage-fallback": "^4.1.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "messageformat": "2.1.0",
         "reselect": "^4.0.0",
         "rxjs": "^6.3.3",
         "shallowequal": "^1.1.0",
-        "tslib": "^1.8.0"
+        "tslib": "^1.10.0"
       },
       "dependencies": {
         "@bigcommerce/script-loader": {
@@ -919,6 +919,11 @@
           "requires": {
             "tslib": "^1.8.0"
           }
+        },
+        "@types/lodash": {
+          "version": "4.14.139",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.139.tgz",
+          "integrity": "sha512-Z6pbDYaWpluqcF8+6qgv6STPEl0jIlyQmpYGwTrzhgwqok8ltBh/p7GAmYnz81wUhxQRhEr8MBpQrB4fQ/hwIA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.35.2",
+    "@bigcommerce/checkout-sdk": "^1.37.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/intersys-integrations  
