### PR TITLE
fix(payment): PAYMENTS-4753 Apply validation highlighting to Square V2

### DIFF
--- a/src/scss/components/foundation/forms/_forms.scss
+++ b/src/scss/components/foundation/forms/_forms.scss
@@ -90,6 +90,11 @@
         }
     }
 
+    .form-input--error {
+        border-color: $color-error;
+        box-shadow: $input-box-shadow-error;
+    }
+
     .form-legend-container {
         align-items: center;
         display: flex;

--- a/src/scss/settings/foundation/forms/_settings.scss
+++ b/src/scss/settings/foundation/forms/_settings.scss
@@ -40,6 +40,7 @@ $input-disabled-borderColor:         container("borderColor", "dark");
 $input-disabled-color:               color("greys", "darker");
 $input-disabled-cursor:              not-allowed;
 $input-box-shadow:                   inset 0 1px 1px color("greys", "light");
+$input-box-shadow-error:             0 0 3px rgba($color-error, 0.6);
 $input-include-glowing-effect:       true;
 
 // We use these to style the fieldset border and spacing.


### PR DESCRIPTION
## What?
Highlight Square V2 form fields in checkout page when form a field validation fails.

## Why?
To make it clear to the customer which payment input is failing validation.

## Testing / Proof
screenshot
<img width="552" alt="Screen Shot 2019-09-26 at 11 20 22 am" src="https://user-images.githubusercontent.com/36555311/65650824-b548dc00-e04f-11e9-9606-44afdde31c39.png">

@bigcommerce/checkout
@bigcommerce/payments 
