### PR TITLE
CHECKOUT-4418: Prefer `main` field over `module` field when resolving packages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,11 @@ function appConfig(options, argv) {
                 devtool: isProduction ? 'source-map' : 'eval-source-map',
                 resolve: {
                     extensions: ['.ts', '.tsx', '.js'],
-                    mainFields: ['module', 'browser', 'main'],
+                    // It seems some packages, i.e.: Formik, have incorrect
+                    // source maps for their ESM bundle. Therefore, until that
+                    // issue is fixed, we prefer to resolve packages using the
+                    // `main` field rather `module` field.
+                    mainFields: ['browser', 'main', 'module'],
                 },
                 optimization: {
                     runtimeChunk: 'single',


### PR DESCRIPTION
## What?
Prefer `main` field over `module` field when resolving packages.

## Why?
* It seems some packages, i.e.: Formik, have incorrect source maps for their ESM bundle. Therefore, until that issue is fixed, we prefer to resolve packages using the `main` field rather `module` field.
* I will raise a ticket with the author of Formik and see if he has any idea. It could be a configuration issue or an issue with the bundler itself.

## Testing / Proof
You can test this by running the following script:

```js
const { readFileSync } = require('fs');
const { SourceMapConsumer } = require('source-map');

new SourceMapConsumer(readFileSync('./node_modules/formik/dist/formik.esm.js.map').toString())
    .then(smc => {
        console.log(smc.originalPositionFor({ line: 739, column: 4 }));
    });
```

This will return `null`. And if you switch to a CJS file `formik.cjs.development.js.map` and use this location `{ line: 571, column: 4 }`. You will be able to get a result.

@bigcommerce/checkout
