### PR TITLE
CHECKOUT-4418: Fix import path of external ESM modules that are conditionally required

### DIFF
--- a/src/app/checkout/renderCheckout.spec.tsx
+++ b/src/app/checkout/renderCheckout.spec.tsx
@@ -7,6 +7,8 @@ let CheckoutApp: FunctionComponent<CheckoutAppProps>;
 let configurePublicPath: (path: string) => void;
 let publicPath: string;
 
+jest.mock('@welldone-software/why-did-you-render', () => jest.fn());
+
 jest.mock('../common/bundler', () => {
     configurePublicPath = jest.fn(path => {
         publicPath = path;
@@ -65,5 +67,29 @@ describe('renderCheckout()', () => {
 
         expect(CheckoutApp)
             .toHaveBeenCalledWith(options, {});
+    });
+
+    it('does not configure `whyDidYouRender` if not in development mode', () => {
+        renderCheckout(options);
+
+        expect(require('@welldone-software/why-did-you-render'))
+            .not.toHaveBeenCalled();
+
+        process.env.NODE_ENV = 'development';
+    });
+
+    it('configures `whyDidYouRender` if in development mode', () => {
+        const env = process.env.NODE_ENV;
+
+        process.env.NODE_ENV = 'development';
+
+        renderCheckout(options);
+
+        expect(require('@welldone-software/why-did-you-render'))
+            .toHaveBeenCalledWith(React, {
+                collapseGroups: true,
+            });
+
+        process.env.NODE_ENV = env;
     });
 });

--- a/src/app/checkout/renderCheckout.tsx
+++ b/src/app/checkout/renderCheckout.tsx
@@ -13,7 +13,20 @@ export default function renderCheckout({
     ...props
 }: RenderCheckoutOptions): void {
     const configuredPublicPath = configurePublicPath(publicPath);
+
+    // We want to use `require` here because we want to set up the public path
+    // first before importing the app component and its dependencies.
     const { default: CheckoutApp } = require('./CheckoutApp');
+
+    // We want to use `require` here because we only want to import the package
+    // in development mode.
+    if (process.env.NODE_ENV === 'development') {
+        const whyDidYouRender = require('@welldone-software/why-did-you-render');
+
+        whyDidYouRender(React, {
+            collapseGroups: true,
+        });
+    }
 
     ReactDOM.render(
         <CheckoutApp

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,15 +1,2 @@
-import React from 'react';
-
-if (process.env.NODE_ENV === 'development') {
-    // We want to use `require` because we only want to import the package in
-    // development mode.
-    // tslint:disable-next-line
-    const { default: whyDidYouRender } = require('@welldone-software/why-did-you-render');
-
-    whyDidYouRender(React, {
-        collapseGroups: true,
-    });
-}
-
 export { default as renderCheckout } from '../app/checkout/renderCheckout';
 export { default as renderOrderConfirmation } from '../app/order/renderOrderConfirmation';

--- a/src/app/order/renderOrderConfirmation.spec.tsx
+++ b/src/app/order/renderOrderConfirmation.spec.tsx
@@ -7,6 +7,8 @@ let OrderConfirmationApp: FunctionComponent<OrderConfirmationAppProps>;
 let configurePublicPath: (path: string) => void;
 let publicPath: string;
 
+jest.mock('@welldone-software/why-did-you-render', () => jest.fn());
+
 jest.mock('../common/bundler', () => {
     configurePublicPath = jest.fn(path => {
         publicPath = path;
@@ -65,5 +67,29 @@ describe('renderOrderConfirmation()', () => {
 
         expect(OrderConfirmationApp)
             .toHaveBeenCalledWith(options, {});
+    });
+
+    it('does not configure `whyDidYouRender` if not in development mode', () => {
+        renderOrderConfirmation(options);
+
+        expect(require('@welldone-software/why-did-you-render'))
+            .not.toHaveBeenCalled();
+
+        process.env.NODE_ENV = 'development';
+    });
+
+    it('configures `whyDidYouRender` if in development mode', () => {
+        const env = process.env.NODE_ENV;
+
+        process.env.NODE_ENV = 'development';
+
+        renderOrderConfirmation(options);
+
+        expect(require('@welldone-software/why-did-you-render'))
+            .toHaveBeenCalledWith(React, {
+                collapseGroups: true,
+            });
+
+        process.env.NODE_ENV = env;
     });
 });

--- a/src/app/order/renderOrderConfirmation.tsx
+++ b/src/app/order/renderOrderConfirmation.tsx
@@ -13,7 +13,20 @@ export default function renderOrderConfirmation({
     ...props
 }: RenderOrderConfirmationOptions): void {
     const configuredPublicPath = configurePublicPath(publicPath);
+
+    // We want to use `require` here because we want to set up the public path
+    // first before importing the app component and its dependencies.
     const { default: OrderConfirmationApp } = require('./OrderConfirmationApp');
+
+    // We want to use `require` here because we only want to import the package
+    // in development mode.
+    if (process.env.NODE_ENV === 'development') {
+        const whyDidYouRender = require('@welldone-software/why-did-you-render');
+
+        whyDidYouRender(React, {
+            collapseGroups: true,
+        });
+    }
 
     ReactDOM.render(
         <OrderConfirmationApp


### PR DESCRIPTION
## What?
* Fix the import path of external ESM modules that are conditionally required.
* Move the `whyDidYouRender` call into `renderCheckout` and `renderOrderConfirmation` functions so it can be tested and leaves the main `index` file without any side effect.

## Why?
* Modules that are imported using the `require` function don't have the `esModuleInterop` option applied. Therefore, after [this change](https://github.com/bigcommerce/checkout-js/pull/129), their import path needs to change accordingly. 

## Testing / Proof
CircleCI

@bigcommerce/checkout
