### PR TITLE
CHECKOUT-4459 Bypass address validation for amazon

### DIFF
--- a/src/app/checkout/getCheckoutStepStatuses.spec.ts
+++ b/src/app/checkout/getCheckoutStepStatuses.spec.ts
@@ -5,6 +5,7 @@ import { getBillingAddress } from '../billing/billingAddresses.mock';
 import { getCart } from '../cart/carts.mock';
 import { getCustomer, getGuestCustomer } from '../customer/customers.mock';
 import { getOrder } from '../order/orders.mock';
+import { getPaymentMethod } from '../payment/payment-methods.mock';
 import { getConsignment } from '../shipping/consignment.mock';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 
@@ -168,6 +169,32 @@ describe('getCheckoutStepStatuses()', () => {
             // tslint:disable-next-line:no-non-null-assertion
             expect(find(steps, { type: CheckoutStepType.Shipping })!.isComplete)
                 .toEqual(false);
+        });
+
+        it('is marked as complete if shipping address is not valid but payment is amazon', () => {
+            jest.spyOn(state.data, 'getShippingAddress')
+                .mockReturnValue({
+                    ...getShippingAddress(),
+                    address1: '',
+                });
+
+            jest.spyOn(state.data, 'getCart')
+                .mockReturnValue(getCart());
+
+            jest.spyOn(state.data, 'getSelectedPaymentMethod')
+                .mockReturnValue({
+                    ...getPaymentMethod(),
+                    id: 'amazon',
+                });
+
+            jest.spyOn(state.data, 'getConsignments')
+                .mockReturnValue([getConsignment()]);
+
+            const steps = getCheckoutStepStatuses(state);
+
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(find(steps, { type: CheckoutStepType.Shipping })!.isComplete)
+                .toEqual(true);
         });
 
         it('is marked as incomplete if shipping option is not provided', () => {

--- a/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/src/app/checkout/getCheckoutStepStatuses.ts
@@ -56,16 +56,19 @@ const getShippingStepStatus = createSelector(
     ({ data }: CheckoutSelectors) => data.getShippingAddress(),
     ({ data }: CheckoutSelectors) => data.getConsignments(),
     ({ data }: CheckoutSelectors) => data.getCart(),
+    ({ data }: CheckoutSelectors) => data.getSelectedPaymentMethod(),
     ({ data }: CheckoutSelectors) => {
         const shippingAddress = data.getShippingAddress();
 
         return shippingAddress ? data.getShippingAddressFields(shippingAddress.countryCode) : EMPTY_ARRAY;
     },
-    (shippingAddress, consignments, cart, shippingAddressFields) => {
+    (shippingAddress, consignments, cart, payment, shippingAddressFields) => {
         const hasAddress = shippingAddress ? isValidAddress(shippingAddress, shippingAddressFields) : false;
+        // @todo: interim solution, ideally we should render custom form fields below amazon shipping widget
+        const hasRemoteAddress = !!shippingAddress && !!payment && payment.id === 'amazon';
         const hasOptions = consignments ? hasSelectedShippingOptions(consignments) : false;
         const hasUnassignedItems = cart && consignments ? hasUnassignedLineItems(consignments, cart.lineItems) : true;
-        const isComplete = hasAddress && hasOptions && !hasUnassignedItems;
+        const isComplete = (hasAddress || hasRemoteAddress) && hasOptions && !hasUnassignedItems;
         const isRequired = cart ? cart.lineItems.physicalItems.some(lineItem => lineItem.isShippingRequired) : false;
 
         return {


### PR DESCRIPTION
## What?
Bypass address validation when using Amazon Pay

## Why?
Because merchant might have set up required custom form fields, which are not rendered by amazon

## Testing / Proof
unit
manual

@bigcommerce/checkout
