### PR TITLE
fix(checkout): CHECKOUT-4240 Error Code Modal styling and display cha…

### DIFF
--- a/src/app/common/error/ErrorCode.scss
+++ b/src/app/common/error/ErrorCode.scss
@@ -2,6 +2,7 @@
 
 .errorCode {
     font-size: fontSize("tiny");
+    opacity: 0.4;
 
     .errorCode-value {
         word-break: break-word;

--- a/src/app/order/OrderConfirmation.tsx
+++ b/src/app/order/OrderConfirmation.tsx
@@ -232,6 +232,7 @@ class OrderConfirmation extends Component<
             <ErrorModal
                 error={ error }
                 onClose={ this.handleErrorModalClose }
+                shouldShowErrorCode={ false }
             />
         );
     }


### PR DESCRIPTION
## What?
Error Code design changes and removal from instances where they are not needed. Currently the error code now looks very faint on the modal and removed from scenarios like "password mismatch" where the code was not usable at all.

## Why?
The error code is very prominent on the Error modal and is not of any use to the shopper or the merchant. It is used internally by developers to query logs especially in 3rd party integrations. Primarily used to debug payment specific errors.

## Testing / Proof
Manual

<img width="1680" alt="Screen Shot 2019-10-02 at 9 12 23 am" src="https://user-images.githubusercontent.com/55068632/66009322-6098db80-e4fd-11e9-8586-4bde3cff8c08.png">
