### PR TITLE
CHECKOUT-4455: Resolve without waiting for prefetched scripts to complete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -995,10 +995,11 @@
       }
     },
     "@bigcommerce/script-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-1.0.0.tgz",
-      "integrity": "sha512-qaR2pzyOvkbE5mZtXG1UC+ePbsq0GBYVzyCnK1UGAJ8D7fHhMmZ7lNUMvelKxKr64rSL+hYcixn1d/0NiJ0yDw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.0.0.tgz",
+      "integrity": "sha512-85/LHtiEPgKoezE6X/CxQ3p4wxarSil6tF063vUNpNVaL52oiHK53YZ3Km3ZuwMHfwxzviXqLWcfoDiOcUlKvA==",
       "requires": {
+        "@bigcommerce/request-sender": "^0.3.0",
         "tslib": "^1.10.0"
       }
     },
@@ -8612,9 +8613,9 @@
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",
     "@bigcommerce/request-sender": "^0.3.0",
-    "@bigcommerce/script-loader": "^1.0.0",
+    "@bigcommerce/script-loader": "^2.0.0",
     "@sentry/browser": "^5.6.3",
     "@sentry/integrations": "^5.6.1",
     "@types/card-validator": "^4.1.0",

--- a/src/app/loader.spec.ts
+++ b/src/app/loader.spec.ts
@@ -1,4 +1,5 @@
 import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
+import { noop } from 'lodash';
 
 import { loadFiles, AssetManifest, LoadFilesOptions } from './loader';
 
@@ -137,5 +138,17 @@ describe('loadFiles', () => {
                 containerId: 'checkout-app',
                 publicPath: options.publicPath,
             });
+    });
+
+    it('does not wait for prefetched scripts to resolve', async () => {
+        const scriptLoader = getScriptLoader();
+
+        jest.spyOn(scriptLoader, 'preloadScripts')
+            .mockImplementation((_url, opt) => {
+                return (opt && opt.prefetch ? new Promise(noop) : Promise.resolve());
+            });
+
+        expect(await loadFiles(options))
+            .toBeDefined();
     });
 });

--- a/src/app/loader.ts
+++ b/src/app/loader.ts
@@ -41,24 +41,22 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
         js.map(path => joinPaths(publicPath, path))
     );
 
-    const prefetchedScripts = getScriptLoader().preloadScripts(
-        jsDynamicChunks.map(path => joinPaths(publicPath, path)),
-        { prefetch: true }
-    );
-
     const stylesheets = getStylesheetLoader().loadStylesheets(
         css.map(path => joinPaths(publicPath, path)),
         { prepend: true }
     );
 
-    const prefetchedStylesheets = getStylesheetLoader().preloadStylesheets(
+    getScriptLoader().preloadScripts(
+        jsDynamicChunks.map(path => joinPaths(publicPath, path)),
+        { prefetch: true }
+    );
+
+    getStylesheetLoader().preloadStylesheets(
         cssDynamicChunks.map(path => joinPaths(publicPath, path)),
         { prefetch: true }
     );
 
     return Promise.all([
-        prefetchedScripts,
-        prefetchedStylesheets,
         scripts,
         stylesheets,
     ])


### PR DESCRIPTION
## What?
Resolve without waiting for prefetched scripts to complete.

## Why?
That's the intended behaviour. The prefetched scripts are not required for initialisation. They only need to be loaded in the background as a way to warm up the cache.

## Testing / Proof
Unit

@bigcommerce/checkout
