### PR TITLE
fix(order): CHECKOUT-4450 Bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,9 +886,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.37.0.tgz",
-      "integrity": "sha512-KHX4QdfcoxQa3tJrgkIUgICkjciViUrbJjIZCMFdn5jNjqt0Iv1gMN8Zhzkaj3JFi1WYNoXXYc+ohT2DArT5kg==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.37.2.tgz",
+      "integrity": "sha512-NEKjQ96l29CjmlQw/3ijoRaBUt72fIuTUFiqG+UYbPHPPpvK9WM69toRhd4w9uxKNPlimEiKNR71tf+SesZrVg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^4.5.0",
@@ -921,9 +921,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.139",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.139.tgz",
-          "integrity": "sha512-Z6pbDYaWpluqcF8+6qgv6STPEl0jIlyQmpYGwTrzhgwqok8ltBh/p7GAmYnz81wUhxQRhEr8MBpQrB4fQ/hwIA=="
+          "version": "4.14.141",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.141.tgz",
+          "integrity": "sha512-v5NYIi9qEbFEUpCyikmnOYe4YlP8BMUdTcNCAquAKzu+FA7rZ1onj9x80mbnDdOW/K5bFf3Tv5kJplP33+gAbQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.37.0",
+    "@bigcommerce/checkout-sdk": "^1.37.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
As per above.

## Why?
To fix the google recaptcha iframe not found bug due to different language settings
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
