### PR TITLE
CHECKOUT-4418: Use default fingerprint grouping

### DIFF
--- a/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/src/app/common/error/SentryErrorLogger.spec.ts
@@ -234,7 +234,7 @@ describe('SentryErrorLogger', () => {
             (withScope as jest.Mock).mockImplementation(fn => fn(scope));
         });
 
-        it('logs error with provided error code, level and specific fingerprint', () => {
+        it('logs error with provided error code, level and default fingerprint', () => {
             const logger = new SentryErrorLogger(config, { errorTypes: ['Foo', 'Bar'] });
             const error = new Error();
             const tags = { errorCode: 'foo' };
@@ -248,7 +248,7 @@ describe('SentryErrorLogger', () => {
                 .toHaveBeenCalledWith(tags);
 
             expect(scope.setFingerprint)
-                .toHaveBeenCalledWith(['{{ default }}', tags.errorCode]);
+                .toHaveBeenCalledWith(['{{ default }}']);
 
             expect(captureException)
                 .toHaveBeenCalledWith(error);
@@ -267,7 +267,7 @@ describe('SentryErrorLogger', () => {
                 .toHaveBeenCalledWith({ errorCode: computeErrorCode(error) });
 
             expect(scope.setFingerprint)
-                .toHaveBeenCalledWith(['{{ default }}', computeErrorCode(error)]);
+                .toHaveBeenCalledWith(['{{ default }}']);
 
             expect(captureException)
                 .toHaveBeenCalledWith(error);

--- a/src/app/common/error/SentryErrorLogger.ts
+++ b/src/app/common/error/SentryErrorLogger.ts
@@ -62,15 +62,13 @@ export default class SentryErrorLogger implements ErrorLogger {
 
         withScope(scope => {
             const { errorCode = computeErrorCode(error) } = tags || {};
-            const fingerprint = ['{{ default }}'];
 
             if (errorCode) {
-                fingerprint.push(errorCode);
                 scope.setTags({ errorCode });
             }
 
             scope.setLevel(this.mapToSentryLevel(level));
-            scope.setFingerprint(fingerprint);
+            scope.setFingerprint(['{{ default }}']);
 
             captureException(error);
         });


### PR DESCRIPTION
## What?
Use the default fingerprint grouping only.

## Why?
We don't need to add error codes as a fingerprint because they would make the grouping overly specific. It might be better to just rely on Sentry's default [grouping algorithm](https://docs.sentry.io/data-management/event-grouping/).

## Testing / Proof
CircleCI

@bigcommerce/checkout
