### PR TITLE
CHECKOUT-4418: Ignore errors coming from polyfill and Sentry client

### DIFF
--- a/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/src/app/common/error/SentryErrorLogger.spec.ts
@@ -178,6 +178,19 @@ describe('SentryErrorLogger', () => {
             });
     });
 
+    it('configures client to ignore errors from polyfill and Sentry client', () => {
+        // tslint:disable-next-line:no-unused-expression
+        new SentryErrorLogger(config);
+
+        expect(init)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                blacklistUrls: [
+                    'polyfill~checkout',
+                    'sentry~checkout',
+                ],
+            }));
+    });
+
     it('does not rewrite filename of error frames if it does match with public path', () => {
         // tslint:disable-next-line:no-unused-expression
         new SentryErrorLogger(config, { publicPath: 'https://cdn.foo.bar' });

--- a/src/app/common/error/SentryErrorLogger.ts
+++ b/src/app/common/error/SentryErrorLogger.ts
@@ -40,6 +40,11 @@ export default class SentryErrorLogger implements ErrorLogger {
 
         init({
             beforeSend: this.handleBeforeSend,
+            blacklistUrls: [
+                ...(config.blacklistUrls || []),
+                'polyfill~checkout',
+                'sentry~checkout',
+            ],
             integrations: [
                 new Integrations.GlobalHandlers({
                     onerror: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,11 @@ function appConfig(options, argv) {
                                 reuseExistingChunk: true,
                                 enforce: true,
                             },
+                            sentry: {
+                                test: /\/node_modules\/@sentry/,
+                                reuseExistingChunk: true,
+                                enforce: true,
+                            },
                         },
                     },
                 },


### PR DESCRIPTION
## What?
Ignore errors coming from polyfill file and Sentry client.

## Why?
This is change is required for two reasons:
1) Some error frames don't have a file name associated with them. It usually happens when you dynamically insert inline scripts on the page, i.e.: the client script of [Fera.ai](https://www.fera.ai/) does something like that. In some browsers, i.e.: Chrome, they are shown as `<anonymous>`, In some browsers, i.e.: Edge, they are completely dropped. For the latter case, if these errors are captured by Sentry's `TryCatch` or `GlobalHandlers` plugin, they will not be filtered out. This is because the last known error frame will point to the file of these Sentry plugins, which are contained in a file hosted by us. The image below is an example of the error.
<img width="1564" alt="Screen Shot 2019-10-04 at 9 45 08 am" src="https://user-images.githubusercontent.com/667603/66184696-5115c000-e6c0-11e9-9cdd-deb05b46cc19.png">

2) We also want to ignore errors that come from `polyfill~checkout` file. This is because merchants could have injected scripts on the page that rely on functions provided by our polyfill files. If their scripts incorrectly call these functions, the top of the call stack will be our polyfill file. Similarly, as the polyfill file is hosted by us, the error will not get filtered.

If you're wondering adding `sentry~checkout` to the blacklist would ignore all errors that are captured by the `TryCatch` plugin (as the plugin actually patches all the async functions such as `setTimeout` and re-throws any error that is caught), the answer is it won't. This is because Sentry client automatically drops such frame from the stack trace.

## Testing / Proof
Unit

@bigcommerce/checkout
