### PR TITLE
INT-1957 Customer name not showed in Orders View when a Guest user try to set same shipping address to billing address

### DIFF
--- a/src/app/shipping/RemoteShippingAddress.spec.tsx
+++ b/src/app/shipping/RemoteShippingAddress.spec.tsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
@@ -6,13 +6,19 @@ import React from 'react';
 import { DynamicFormField } from '../address';
 import { getFormFields } from '../address/formField.mock';
 
+import { getShippingAddress } from './shipping-addresses.mock';
 import RemoteShippingAddress, { RemoteShippingAddressProps } from './RemoteShippingAddress';
 
 describe('RemoteShippingAddress Component', () => {
+    let component: ReactWrapper;
     const defaultProps: RemoteShippingAddressProps = {
         formFields: getFormFields(),
         containerId: 'container',
         methodId: 'amazon',
+        shippingAddress: {
+            ...getShippingAddress(),
+            address1: 'x',
+        },
         initialize: jest.fn(),
         deinitialize: jest.fn(),
         onFieldChange: jest.fn(),
@@ -27,25 +33,37 @@ describe('RemoteShippingAddress Component', () => {
     };
 
     it('renders widget', () => {
-        const component = shallow(<RemoteShippingAddress { ...defaultProps } />);
+        component = mount(
+            <Formik initialValues= { {} } onSubmit={ noop }>
+                <RemoteShippingAddress { ...defaultProps } />
+            </Formik>
+        );
 
         expect(component.find('#container').hasClass('widget--amazon')).toBeTruthy();
     });
 
     it('calls initialize prop on mount', () => {
-        shallow(<RemoteShippingAddress { ...defaultProps } />);
+        component = mount(
+            <Formik initialValues= { {} } onSubmit={ noop }>
+                <RemoteShippingAddress { ...defaultProps } />
+            </Formik>
+        );
 
         expect(defaultProps.initialize).toHaveBeenCalled();
     });
 
     it('calls deinitialize prop on unmount', () => {
-        shallow(<RemoteShippingAddress { ...defaultProps } />).unmount();
+        component = mount(
+            <Formik initialValues= { {} } onSubmit={ noop }>
+                <RemoteShippingAddress { ...defaultProps } />
+            </Formik>
+        ).unmount();
 
-        expect(defaultProps.initialize).toHaveBeenCalled();
+        expect(defaultProps.deinitialize).toHaveBeenCalled();
     });
 
     it('renders correct number of custom form fields', () => {
-        const component = mount(
+        component = mount(
             <Formik
                 initialValues={ initialFormikValues }
                 onSubmit={ noop }
@@ -58,7 +76,7 @@ describe('RemoteShippingAddress Component', () => {
     });
 
     it('calls method to set field value on change in custom form field', () => {
-        const component = mount(
+        component = mount(
             <Formik
                 initialValues={ initialFormikValues }
                 onSubmit={ noop }

--- a/src/app/shipping/RemoteShippingAddress.tsx
+++ b/src/app/shipping/RemoteShippingAddress.tsx
@@ -1,30 +1,40 @@
-import { CheckoutSelectors, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+import { Address, CheckoutSelectors, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React, { PureComponent, ReactNode } from 'react';
 
 import { AddressFormField } from '../address/';
+import { connectFormik, ConnectFormikProps } from '../common/form';
 import { Fieldset } from '../ui/form';
+
+import { SingleShippingFormValues } from './SingleShippingForm';
 
 export interface RemoteShippingAddressProps {
     containerId: string;
     methodId: string;
     formFields: FormField[];
+    shippingAddress?: Address;
     deinitialize(options?: ShippingRequestOptions): Promise<CheckoutSelectors>;
     initialize(options?: ShippingInitializeOptions): Promise<CheckoutSelectors>;
     onUnhandledError?(error: Error): void;
     onFieldChange(fieldName: string, value: string): void;
 }
 
-class RemoteShippingAddress extends PureComponent<RemoteShippingAddressProps> {
+class RemoteShippingAddress extends PureComponent<RemoteShippingAddressProps & ConnectFormikProps<SingleShippingFormValues>> {
+
+    onAddressSelect = () => {
+        const { formik: { setFieldValue }, shippingAddress } = this.props;
+        setFieldValue('shippingAddress', shippingAddress);
+    };
+
     async componentDidMount(): Promise<void> {
         const {
+            containerId,
             initialize,
             methodId,
             onUnhandledError = noop,
         } = this.props;
-
         try {
-            await initialize({ methodId });
+            await initialize({ methodId, amazon: { container: containerId, onAddressSelect: this.onAddressSelect } });
         } catch (error) {
             onUnhandledError(error);
         }
@@ -80,4 +90,4 @@ class RemoteShippingAddress extends PureComponent<RemoteShippingAddressProps> {
     };
 }
 
-export default RemoteShippingAddress;
+export default connectFormik(RemoteShippingAddress);

--- a/src/app/shipping/ShippingAddress.spec.tsx
+++ b/src/app/shipping/ShippingAddress.spec.tsx
@@ -24,7 +24,7 @@ describe('ShippingAddress Component', () => {
         isLoading: false,
         hasRequestedShippingOptions: false,
         formFields: getFormFields(),
-        onAddressSelect: jest.fn(),
+        onAddressSelect: jest.fn().mockReturnValue(null),
         onFieldChange: jest.fn(),
         initialize: jest.fn(),
         deinitialize: jest.fn(),
@@ -102,7 +102,7 @@ describe('ShippingAddress Component', () => {
                 methodId: 'amazon',
                 amazon: {
                     container: 'addressWidget',
-                    onError: defaultProps.onUnhandledError,
+                    onAddressSelect: expect.any(Function),
                 },
             });
         });

--- a/src/app/shipping/ShippingAddress.tsx
+++ b/src/app/shipping/ShippingAddress.tsx
@@ -85,6 +85,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = props => {
                 initialize={ initializeShipping(options) }
                 methodId={ methodId }
                 onFieldChange={ onFieldChange }
+                shippingAddress={ shippingAddress }
             />
         );
     }


### PR DESCRIPTION
[INT-1957](https://jira.bigcommerce.com/browse/INT-1957)

## What?
Display customer name and billing address for all orders in Orders View

## Why?
Because the data were not displayed previously in the order details of CP and they are needed

## Testing / Proof
[demo](https://drive.google.com/file/d/1b6Wl1EZ6-_neoKB2F1gCO8-2yDutpnGG/view?usp=sharing)

@bigcommerce/checkout
