### PR TITLE
feat(checkout): INT-1916 Customize barclaycard payment method title logos

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -190,6 +190,7 @@ describe('PaymentMethodTitle', () => {
         const methodIds = [
             PaymentMethodId.Amazon,
             PaymentMethodId.ChasePay,
+            PaymentMethodType.Barclaycard,
             PaymentMethodType.GooglePay,
             PaymentMethodType.Masterpass,
         ];
@@ -209,5 +210,27 @@ describe('PaymentMethodTitle', () => {
             expect(component.find('[data-test="payment-method-name"]').length)
                 .toEqual(0);
         });
+    });
+
+    it('renders a different logo for each methodId for Barclaycard', () => {
+        const imageExtension = '.png';
+        const imageFolder = '/img/payment-providers/';
+        const method = PaymentMethodType.Barclaycard;
+        const id = 'card';
+
+        const component = mount(<PaymentMethodTitleTest
+            { ...defaultProps }
+            method={ {
+                ...defaultProps.method,
+                id,
+                method,
+            } }
+        />);
+
+        const expectedPath = `${config.cdnPath}${imageFolder}${method}_${id.toLowerCase()}${imageExtension}`;
+
+        expect(component.find('[data-test="payment-method-logo"]').prop('src'))
+            .toEqual(expectedPath);
+
     });
 });

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -80,6 +80,10 @@ function getPaymentMethodTitle(
                 logoUrl: cdnPath('/img/payment-providers/zip.png'),
                 titleText: language.translate('payment.zip_display_name_text'),
             },
+            [PaymentMethodType.Barclaycard]: {
+                logoUrl: cdnPath(`/img/payment-providers/barclaycard_${method.id.toLowerCase()}.png`),
+                titleText: '',
+            },
         };
 
         // KLUDGE: 'paypal' is actually a credit card method. It is the only

--- a/src/app/payment/paymentMethod/PaymentMethodType.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodType.ts
@@ -1,4 +1,5 @@
 enum PaymentMethodType {
+    Barclaycard = 'barclaycard',
     Chasepay = 'chasepay',
     CreditCard = 'credit-card',
     GooglePay = 'googlepay',


### PR DESCRIPTION
## What?
Add a special case for barclaycard's payment method titles.

## Why?
Each barclaycard's alternate payment method must have it's own logo.

## SIbling PRs
https://github.com/bigcommerce/checkout-sdk-js/pull/731


## Testing / Proof
<img width="639" alt="Screen Shot 2019-10-22 at 3 44 05 PM" src="https://user-images.githubusercontent.com/35502707/67331379-4ee69a80-f4e3-11e9-905d-662966ff1efc.png">


@bigcommerce/checkout @bigcommerce/intersys-integrations 
