### PR TITLE
CHECKOUT-4418: Discard the error event if none of the frames in its stack trace contains a file name

### DIFF
--- a/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/src/app/common/error/SentryErrorLogger.spec.ts
@@ -128,7 +128,7 @@ describe('SentryErrorLogger', () => {
             .toEqual(null);
     });
 
-    it('does not log exeception event if it does not contain stacktrace', () => {
+    it('does not log exception event if it does not contain stacktrace', () => {
         // tslint:disable-next-line:no-unused-expression
         new SentryErrorLogger(config);
 
@@ -141,6 +141,48 @@ describe('SentryErrorLogger', () => {
         // tslint:disable-next-line:no-non-null-assertion
         expect(clientOptions.beforeSend!(event, hint))
             .toEqual(null);
+    });
+
+    it('does not log exception event if all frames in stacktrace are missing filename', () => {
+        // tslint:disable-next-line:no-unused-expression
+        new SentryErrorLogger(config);
+
+        const clientOptions: BrowserOptions = (init as jest.Mock).mock.calls[0][0];
+        const event = {
+            exception: {
+                values: [{
+                    stacktrace: { frames: [{ filename: '' }] },
+                    type: 'Error',
+                    value: 'Unexpected error',
+                }],
+            },
+        };
+        const hint = { originalException: new Error('Unexpected error') };
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(clientOptions.beforeSend!(event, hint))
+            .toEqual(null);
+    });
+
+    it('logs exception event if some frames in stacktrace contain filename', () => {
+        // tslint:disable-next-line:no-unused-expression
+        new SentryErrorLogger(config);
+
+        const clientOptions: BrowserOptions = (init as jest.Mock).mock.calls[0][0];
+        const event = {
+            exception: {
+                values: [{
+                    stacktrace: { frames: [{ filename: '' }, { filename: 'js/app-123.js' }] },
+                    type: 'Error',
+                    value: 'Unexpected error',
+                }],
+            },
+        };
+        const hint = { originalException: new Error('Unexpected error') };
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(clientOptions.beforeSend!(event, hint))
+            .toEqual(event);
     });
 
     it('configures client to rewrite filename of error frames', () => {


### PR DESCRIPTION
## What?
Discard the error event if none of the frames in its stack trace contains a file name. i.e.:
<img width="577" alt="Screen Shot 2019-10-10 at 11 42 44 am" src="https://user-images.githubusercontent.com/667603/66530343-1b0a8d00-eb53-11e9-9181-169d5a3976b3.png">

## Why?
These events are not very useful and are most definitely caused by third party scripts.

## Testing / Proof
Unit

@bigcommerce/checkout
