### PR TITLE
CHECKOUT-4485: Use ESLint to enforce use of newline in import statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,12 @@
                     "**/shipping/Shipping.tsx"
                 ]
             }
+        ],
+        "object-curly-newline": [
+            "error",
+            {
+                "ImportDeclaration": "never"
+            }
         ]
     }
 }

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteScriptLoader.ts
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteScriptLoader.ts
@@ -1,9 +1,6 @@
 import { getScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 
-import {
-    GoogleAutocompleteWindow,
-    GoogleMapsSdk,
-} from './googleAutocompleteTypes';
+import { GoogleAutocompleteWindow, GoogleMapsSdk } from './googleAutocompleteTypes';
 
 export default class GoogleAutocompleteScriptLoader {
     private _scriptLoader: ScriptLoader;

--- a/src/app/cart/CartSummary.tsx
+++ b/src/app/cart/CartSummary.tsx
@@ -1,8 +1,4 @@
-import {
-    Checkout,
-    ShopperCurrency,
-    StoreCurrency,
-} from '@bigcommerce/checkout-sdk';
+import { Checkout, ShopperCurrency, StoreCurrency } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent } from 'react';
 
 import { withCheckout } from '../checkout';

--- a/src/app/guestSignup/GuestSignUpForm.tsx
+++ b/src/app/guestSignup/GuestSignUpForm.tsx
@@ -64,9 +64,8 @@ export default withLanguage(withFormik<SignUpFormProps & WithLanguageProps, Sign
     },
     validationSchema: ({
         language,
-        passwordRequirements: { description, numeric, alpha, minLength } }:
-        SignUpFormProps & WithLanguageProps
-    ) => object({
+        passwordRequirements: { description, numeric, alpha, minLength },
+    }: SignUpFormProps & WithLanguageProps) => object({
         password: string()
             .required(description || language.translate('customer.password_required_error'))
             .matches(numeric, description || language.translate('customer.password_number_required_error'))

--- a/src/app/order/OrderSummaryDrawer.tsx
+++ b/src/app/order/OrderSummaryDrawer.tsx
@@ -1,8 +1,4 @@
-import {
-    LineItemMap,
-    ShopperCurrency as ShopperCurrencyType,
-    StoreCurrency
-} from '@bigcommerce/checkout-sdk';
+import { LineItemMap, ShopperCurrency as ShopperCurrencyType, StoreCurrency } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import React, { memo, useCallback, FunctionComponent, ReactNode } from 'react';
 

--- a/src/app/order/getStoreCreditAmount.spec.ts
+++ b/src/app/order/getStoreCreditAmount.spec.ts
@@ -1,10 +1,5 @@
 import getStoreCreditAmount from './getStoreCreditAmount';
-import {
-    getGatewayOrderPayment,
-    getGiftCertificateOrderPayment,
-    getOrder,
-    getStoreCreditPayment
-} from './orders.mock';
+import { getGatewayOrderPayment, getGiftCertificateOrderPayment, getOrder, getStoreCreditPayment } from './orders.mock';
 
 describe('getStoreCreditAmount()', () => {
     describe('when there are no store credit payments', () => {

--- a/src/app/payment/creditCard/CreditCardIcon.tsx
+++ b/src/app/payment/creditCard/CreditCardIcon.tsx
@@ -1,16 +1,6 @@
 import React, { memo, FunctionComponent } from 'react';
 
-import {
-    IconCardAmex,
-    IconCardDinersClub,
-    IconCardDiscover,
-    IconCardJCB,
-    IconCardMaestro,
-    IconCardMastercard,
-    IconCardUnionPay,
-    IconCardVisa,
-    IconSize
-} from '../../ui/icon';
+import { IconCardAmex, IconCardDinersClub, IconCardDiscover, IconCardJCB, IconCardMaestro, IconCardMastercard, IconCardUnionPay, IconCardVisa, IconSize } from '../../ui/icon';
 
 export interface CreditCardIconProps {
     cardType?: string;

--- a/src/app/payment/mapToOrderRequestBody.ts
+++ b/src/app/payment/mapToOrderRequestBody.ts
@@ -2,12 +2,7 @@ import { OrderRequestBody } from '@bigcommerce/checkout-sdk';
 
 import { unformatCreditCardExpiryDate, unformatCreditCardNumber } from './creditCard';
 import { parseUniquePaymentMethodId } from './paymentMethod';
-import {
-    isCreditCardFieldsetValues,
-    isHostedWidgetValues,
-    isInstrumentFieldsetValues,
-    PaymentFormValues
-} from './PaymentForm';
+import { isCreditCardFieldsetValues, isHostedWidgetValues, isInstrumentFieldsetValues, PaymentFormValues } from './PaymentForm';
 
 export default function mapToOrderRequestBody(
     values: PaymentFormValues,

--- a/src/app/payment/paymentMethod/AmazonPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/AmazonPaymentMethod.tsx
@@ -1,8 +1,4 @@
-import {
-    CheckoutSelectors,
-    CustomerInitializeOptions,
-    PaymentInitializeOptions,
-} from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, CustomerInitializeOptions, PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { useCallback, useContext, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 

--- a/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -1,9 +1,4 @@
-import {
-    createCheckoutService,
-    CheckoutSelectors,
-    CheckoutService,
-    PaymentMethod
-} from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, CheckoutSelectors, CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import { noop } from 'lodash';


### PR DESCRIPTION
## What?
Use ESLint to enforce the use of newlines in import statements.

## Why?
This is to fix inconsistency in import statements, similar to [this PR](https://github.com/bigcommerce/checkout-sdk-js/pull/725).

## Testing / Proof
CircleCI

@bigcommerce/checkout
