### PR TITLE
CHECKOUT-4401 Redirect to shipping step

### DIFF
--- a/src/app/checkout/mapToCheckoutProps.ts
+++ b/src/app/checkout/mapToCheckoutProps.ts
@@ -1,4 +1,5 @@
-import { CustomError } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, CustomError } from '@bigcommerce/checkout-sdk';
+import { createSelector } from 'reselect';
 
 import { EMPTY_ARRAY } from '../common/utility';
 
@@ -18,6 +19,13 @@ export default function mapToCheckoutProps(
         links: { loginLink: loginUrl = '' } = {},
     } = data.getConfig() || {};
 
+    const subscribeToConsignmentsSelector = createSelector(
+        ({ checkoutService: { subscribe} }: CheckoutContextProps) => subscribe,
+        subscribe => (subscriber: (state: CheckoutSelectors) => void) => {
+            return subscribe(subscriber, ({ data: { getConsignments } }) => getConsignments());
+        }
+    );
+
     return {
         billingAddress: data.getBillingAddress(),
         cart: data.getCart(),
@@ -30,6 +38,7 @@ export default function mapToCheckoutProps(
         loadCheckout: checkoutService.loadCheckout,
         loginUrl,
         promotions,
+        subscribeToConsignments: subscribeToConsignmentsSelector({ checkoutService, checkoutState }),
         steps: data.getCheckout() ? getCheckoutStepStatuses(checkoutState) : EMPTY_ARRAY,
         usableStoreCredit: Math.min(grandTotal, storeCredit),
     };

--- a/src/app/shipping/shippingOption/ShippingOptionExpiredError.ts
+++ b/src/app/shipping/shippingOption/ShippingOptionExpiredError.ts
@@ -1,0 +1,14 @@
+import { setPrototypeOf, CustomError } from '../../common/error';
+import { getLanguageService } from '../../locale';
+
+export default class ShippingOptionExpiredError extends CustomError {
+    constructor() {
+        super({
+            name: 'SHIPPING_OPTION_EXPIRED',
+            message: getLanguageService().translate('shipping.shipping_option_expired_error'),
+            title: getLanguageService().translate('shipping.shipping_option_expired_heading'),
+        });
+
+        setPrototypeOf(this, ShippingOptionExpiredError.prototype);
+    }
+}

--- a/src/app/shipping/shippingOption/index.ts
+++ b/src/app/shipping/shippingOption/index.ts
@@ -1,3 +1,4 @@
 export { default as StaticShippingOption } from './StaticShippingOption';
 export { default as ShippingOptions } from './ShippingOptions';
 export { default as ShippingOptionsList } from './ShippingOptionsList';
+export { default as ShippingOptionExpiredError } from './ShippingOptionExpiredError';


### PR DESCRIPTION
## What?
Redirect to shipping step when there shipping options get invalidated

## Why?
We had this same logic in ng-checkout but never added this functionality to checkout-js https://github.com/bigcommerce-labs/ng-checkout/blob/master/src/app/checkout/checkout.controller.js#L43-L52

## Testing / Proof
manual / functional

https://circleci.com/gh/bigcommerce/bigcommerce/59394#tests/containers/6
![shipping](https://user-images.githubusercontent.com/1621894/66976809-05ffa200-f0ef-11e9-886a-3e6baedac3aa.gif)




@bigcommerce/checkout
