### PR TITLE
feat(shipping): SHIPPING- 1384 Display shipping rate quote description(s) in checkout

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -86,7 +86,8 @@
             "unstable_network_error": "It looks like the server is taking too long to respond, this can be caused by either poor connectivity or an error with our servers. Please try again in a while.",
             "order_loading_error": "There was an error loading your order. Please try again.",
             "order_fatal_error_heading": "There was an error placing your order",
-            "order_fatal_error_extra": "Please choose another payment method or contact us for further assistance."
+            "order_fatal_error_extra": "Please choose another payment method or contact us for further assistance.",
+            "show_more": "Show more"
         },
         "customer": {
             "checkout_as_guest_text": "Checking out as a <strong>Guest</strong>? You'll be able to save your details to create an account with us later.",

--- a/src/app/shipping/StaticConsignment.tsx
+++ b/src/app/shipping/StaticConsignment.tsx
@@ -49,7 +49,10 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
                             <TranslatedString id="shipping.shipping_method_label" />
                         </strong> }
                     <div className="shippingOption shippingOption--alt">
-                        <StaticShippingOption method={ selectedShippingOption } />
+                        <StaticShippingOption
+                            displayAdditionalInformation={ false }
+                            method={ selectedShippingOption }
+                        />
                     </div>
                 </div> }
         </div>

--- a/src/app/shipping/shippingOption/ShippingOptionAdditionalDescription.spec.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptionAdditionalDescription.spec.tsx
@@ -1,0 +1,27 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import ShippingOptionAdditionalDescription from './ShippingOptionAdditionalDescription';
+
+describe('ShippingOptionAdditionalDescription Component', () => {
+    it('renders additional description', () => {
+        const component = mount(
+            <ShippingOptionAdditionalDescription description="Test this" />
+        );
+
+        expect(component.find('.shippingOption-additionalDescription').text()).toBe('Test this');
+    });
+
+    it('renders additional description', () => {
+        const longDescription = 'This is a really long description, it just goes on and on and on';
+        const component = mount(
+            <ShippingOptionAdditionalDescription description={ longDescription } />
+        );
+
+        expect(component.find('.shippingOption-additionalDescription')
+            .hasClass('shippingOption-additionalDescription--collapsed')).toBe(true);
+        component.find('.shippingOption-readMore').simulate('click');
+        expect(component.find('.shippingOption-additionalDescription')
+            .hasClass('shippingOption-additionalDescription--expanded')).toBe(true);
+    });
+});

--- a/src/app/shipping/shippingOption/ShippingOptionAdditionalDescription.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptionAdditionalDescription.tsx
@@ -1,0 +1,37 @@
+import React, { memo } from 'react';
+
+import { preventDefault } from '../../common/dom';
+import { TranslatedString } from '../../locale';
+import { Toggle } from '../../ui/toggle';
+
+interface ShippingOptionAdditionalDescriptionProps {
+    description: string;
+}
+
+const ShippingOptionAdditionalDescription: React.FunctionComponent<ShippingOptionAdditionalDescriptionProps> = ({
+description,
+}) => {
+    const CHRACTER_LIMIT = 45;
+
+    return (
+        <div className="shippingOption-additionalDescription--container">
+            <Toggle openByDefault={ description.length < CHRACTER_LIMIT }>
+                { ({ isOpen, toggle }) => (
+                    <>
+                        <span className={ `shippingOption-additionalDescription ${ isOpen ?
+                            'shippingOption-additionalDescription--expanded' : 'shippingOption-additionalDescription--collapsed' }` }
+                        >
+                            { description }
+                        </span>
+                        { !isOpen &&
+                            <a className="shippingOption-readMore" onClick={ preventDefault(toggle) }>
+                            <TranslatedString id="common.show_more" />
+                        </a> }
+                    </>
+                ) }
+            </Toggle>
+        </div>
+    );
+};
+
+export default memo(ShippingOptionAdditionalDescription);

--- a/src/app/shipping/shippingOption/ShippingOptionsList.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptionsList.tsx
@@ -18,7 +18,7 @@ const ShippingOptionListItem: FunctionComponent<ShippingOptionListItemProps> = (
 }) => {
     const renderLabel = useCallback(() => (
         <div className="shippingOptionLabel">
-            <StaticShippingOption method={ shippingOption } />
+            <StaticShippingOption displayAdditionalInformation={ true } method={ shippingOption } />
         </div>
     ), [shippingOption]);
 

--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -61,4 +61,34 @@
         max-width: remCalc(50px);
         min-width: remCalc(50px);
     }
+
+    .shippingOption-additionalDescription--container {
+        display: flex;
+        flex-direction: row;
+        line-height: 1.5rem;
+
+        .shippingOption-additionalDescription {
+            font-size: fontSize("smaller");
+            font-weight: fontWeight("normal");
+            text-overflow: ellipsis;
+        }
+
+        .shippingOption-additionalDescription--collapsed {
+            height: 2.2rem;
+            overflow: hidden;
+            white-space: nowrap;
+            width: 80%;
+        }
+
+        .shippingOption-additionalDescription--expanded {
+            height: auto;
+            overflow: visible;
+            white-space: initial;
+            width: 100%;
+        }
+
+        .shippingOption-readMore {
+            font-weight: normal;
+        }
+    }
 }

--- a/src/app/shipping/shippingOption/StaticShippingOption.tsx
+++ b/src/app/shipping/shippingOption/StaticShippingOption.tsx
@@ -3,33 +3,44 @@ import React from 'react';
 
 import { ShopperCurrency } from '../../currency';
 
+import ShippingOptionAdditionalDescription from './ShippingOptionAdditionalDescription';
 import './StaticShippingOption.scss';
 
 interface StaticShippingOptionProps {
+    displayAdditionalInformation?: boolean;
     method: ShippingOption;
 }
 
-const StaticShippingOption: React.FunctionComponent<StaticShippingOptionProps> = ({ method }) => (
-    <div className="shippingOption shippingOption--alt">
-        { method.imageUrl &&
-            <span className="shippingOption-figure">
-                <img
-                    alt={ method.description }
-                    className="shippingOption-img"
-                    src={ method.imageUrl }
-                />
-            </span> }
-        <span className="shippingOption-desc">
-            { method.description }
-            { method.transitTime &&
-                <span className="shippingOption-transitTime">
-                    { method.transitTime }
-                </span> }
-        </span>
-        <span className="shippingOption-price">
-            <ShopperCurrency amount={ method.cost } />
-        </span>
-    </div>
-);
+const StaticShippingOption: React.FunctionComponent<StaticShippingOptionProps> = ({
+displayAdditionalInformation = true,
+method,
+}) => {
+    return (
+        <>
+            <div className="shippingOption shippingOption--alt">
+                { method.imageUrl &&
+                    <span className="shippingOption-figure">
+                        <img
+                            alt={ method.description }
+                            className="shippingOption-img"
+                            src={ method.imageUrl }
+                        />
+                    </span> }
+                <span className="shippingOption-desc">
+                    { method.description }
+                    { method.transitTime &&
+                        <span className="shippingOption-transitTime">
+                            { method.transitTime }
+                        </span> }
+                    { method.additionalDescription && displayAdditionalInformation &&
+                        <ShippingOptionAdditionalDescription description={ method.additionalDescription } /> }
+                </span>
+                <span className="shippingOption-price">
+                    <ShopperCurrency amount={ method.cost } />
+                </span>
+            </div>
+        </>
+    );
+};
 
 export default StaticShippingOption;

--- a/src/app/shipping/shippingOption/__snapshots__/StaticShippingOption.spec.tsx.snap
+++ b/src/app/shipping/shippingOption/__snapshots__/StaticShippingOption.spec.tsx.snap
@@ -1,39 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StaticShippingOption Component renders static shipping option with minimum information 1`] = `
-<div
-  className="shippingOption shippingOption--alt"
->
-  <span
-    className="shippingOption-desc"
+<Fragment>
+  <div
+    className="shippingOption shippingOption--alt"
   >
-    Flat Rate
-  </span>
-  <span
-    className="shippingOption-price"
-  >
-    <WithCurrency(ShopperCurrency)
-      amount={0}
-    />
-  </span>
-</div>
+    <span
+      className="shippingOption-desc"
+    >
+      Flat Rate
+      <Memo(ShippingOptionAdditionalDescription)
+        description="Pick up in store additional description"
+      />
+    </span>
+    <span
+      className="shippingOption-price"
+    >
+      <WithCurrency(ShopperCurrency)
+        amount={0}
+      />
+    </span>
+  </div>
+</Fragment>
 `;
 
 exports[`StaticShippingOption Component renders static shipping option with optional information 1`] = `
-<div
-  className="shippingOption shippingOption--alt"
->
-  <span
-    className="shippingOption-desc"
+<Fragment>
+  <div
+    className="shippingOption shippingOption--alt"
   >
-    Flat Rate
-  </span>
-  <span
-    className="shippingOption-price"
-  >
-    <WithCurrency(ShopperCurrency)
-      amount={0}
-    />
-  </span>
-</div>
+    <span
+      className="shippingOption-desc"
+    >
+      Flat Rate
+      <Memo(ShippingOptionAdditionalDescription)
+        description="Pick up in store additional description"
+      />
+    </span>
+    <span
+      className="shippingOption-price"
+    >
+      <WithCurrency(ShopperCurrency)
+        amount={0}
+      />
+    </span>
+  </div>
+</Fragment>
 `;

--- a/src/app/shipping/shippingOption/shippingMethod.mock.ts
+++ b/src/app/shipping/shippingOption/shippingMethod.mock.ts
@@ -2,7 +2,7 @@ import { ShippingOption } from '@bigcommerce/checkout-sdk';
 
 export function getShippingOption(): ShippingOption {
     return {
-        additionalDescription: 'Flat rate additional description',
+        additionalDescription: 'Pick up in store additional description',
         description: 'Flat Rate',
         id: '0:61d4bb52f746477e1d4fb411221318c3',
         imageUrl: '',


### PR DESCRIPTION
## What?
Display shipping rate quote description(s) in checkout

## Why?
When shipping rate quotes are returned in UCO

We want to display the description value for each shipping rate quote 

So that shipping providers can present shipping rate quote descriptions in checkout

## Testing / Proof
- Tests
- Screenshot

<img width="1680" alt="Screen Shot 2019-10-17 at 3 23 55 pm" src="https://user-images.githubusercontent.com/7134802/66977650-778d1f80-f0f2-11e9-9a69-37a67364eebb.png">
<img width="1680" alt="Screen Shot 2019-10-17 at 3 23 57 pm" src="https://user-images.githubusercontent.com/7134802/66977651-778d1f80-f0f2-11e9-8b7d-c355cff6c2ad.png">
<img width="1680" alt="Screen Shot 2019-10-17 at 3 24 06 pm" src="https://user-images.githubusercontent.com/7134802/66977652-7825b600-f0f2-11e9-9e2e-97a92c3a3a1e.png">


@bigcommerce/checkout @davidchin 
