### PR TITLE
fix(checkout): CHECKOUT-4472 Fixed inconsistent zero in the price of free item in CLD

### DIFF
--- a/src/app/order/OrderSummaryItem.tsx
+++ b/src/app/order/OrderSummaryItem.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { isNumber } from 'lodash';
 import React, { memo, FunctionComponent, ReactNode } from 'react';
 
 import { ShopperCurrency } from '../currency';
@@ -60,14 +61,14 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                 className={ classNames(
                     'product-price',
                     'optimizedCheckout-contentPrimary',
-                    { 'product-price--beforeDiscount': amountAfterDiscount && amountAfterDiscount !== amount }
+                    { 'product-price--beforeDiscount': isNumber(amountAfterDiscount) && amountAfterDiscount !== amount }
                 ) }
                 data-test="cart-item-product-price"
             >
                 <ShopperCurrency amount={ amount } />
             </div>
 
-            { amountAfterDiscount && amountAfterDiscount !== amount && <div
+            { isNumber(amountAfterDiscount) && amountAfterDiscount !== amount && <div
                 className="product-price"
                 data-test="cart-item-product-price--afterDiscount"
             >


### PR DESCRIPTION
## What?
On applying cart level discounts for products we could see an inconsistent zero value if the discounted item was free. The happened for both cases where the product was marked free automatically( product gets added as soon as the eligible product is added to cart) or manually (product value is updated when an eligible product is added to cart).

## Why?
The inconsistent zero did not make sense to the end user. 

It was caused due to a check in the code which checked for amountAfterDiscount. A zero value would evaluate to false in the truthy test but would render the zero value in the currency part. Also, the same logic caused the strike through to not get rendered as 'classNames' expected a boolean but found 0 instead.

## Testing / Proof

Before: 
![2019-10-07_0931](https://user-images.githubusercontent.com/55068632/67360041-a0109000-f5b0-11e9-968a-54b93b75c809.png)

After:
Manual
![Screen Shot 2019-10-23 at 2 41 38 pm](https://user-images.githubusercontent.com/55068632/67360089-bcacc800-f5b0-11e9-9016-f997ca9ad3e8.png)


Automatic: 
<img width="1678" alt="Screen Shot 2019-10-23 at 4 08 56 pm" src="https://user-images.githubusercontent.com/55068632/67360099-c46c6c80-f5b0-11e9-8257-7c71cb6ee0e4.png">


Manually verified that the inconsistent zero is no longer present.
Also the value before discount now shows strikethrough in case of manual and price after discount for automatic scenario.

@bigcommerce/checkout
