### PR TITLE
 CHECKOUT-4515: Add `prerelease` command for creating test builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ If you are developing the application locally and want to build the source code 
 npm run dev
 ```
 
+If you want to create a prerelease (i.e.: `alpha`) for testing in the integration environment, you can run the following command:
+
+```sh
+npm run prerelease
+```
+
 ## Theme integration
 
 In the checkout template of your theme, you have to include a script tag that points to the loader file of this application. The loader file is responsible for loading the all the required assets, located in the `dist` folder, and inserting them on the page. You will need to find a way to serve these assets, i.e.: via a CDN provider, that is best suited to your needs.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "rm -rf dist && webpack --mode production",
     "dev": "webpack --mode development --watch",
     "dev:server": "http-server dist",
+    "prerelease": "npm run test -- --coverage && npm run build -- --prerelease && npm run release:version",
     "release": "npm run test -- --coverage && npm run build && npm run release:version",
     "release:version": "git add dist && standard-version -a",
     "test": "jest",
@@ -121,5 +122,10 @@
     "webpack-inject-plugin": "^1.5.3",
     "yargs": "^14.0.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "standard-version": {
+    "scripts": {
+      "prebump": "./scripts/standard-version/prebump.js"
+    }
+  }
 }

--- a/scripts/standard-version/prebump.js
+++ b/scripts/standard-version/prebump.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const { appVersion } = require('../../dist/manifest.json');
+
+process.stdout.write(appVersion);

--- a/scripts/webpack/get-next-version.js
+++ b/scripts/webpack/get-next-version.js
@@ -16,7 +16,9 @@ function getNextVersion() {
             }
 
             if (argv.prerelease) {
-                return resolve(semver.inc(packageJson.version, argv.prerelease));
+                const prereleaseType = typeof argv.prerelease === 'string' ? argv.prerelease : 'alpha';
+
+                return resolve(semver.inc(packageJson.version, 'prerelease', prereleaseType).replace(/\.\d+$/, `.${Date.now()}`));
             }
 
             resolve(semver.inc(packageJson.version, release.releaseType));


### PR DESCRIPTION
## What?
Add `prerelease` command for creating test builds. When you run it, it will create a new prerelease version that looks like this `v1.2.3-alpha.1571870792492`.

## Why?
We need this because we often have to create builds for testing in our integration environment. If we just run the standard `npm run build` command, it will create a new `loader` file with the next version number appended to its file name. This is a problem because it wouldn't allow us to revise our changes and create a new build for further testing, as it would produce a new `loader` file with the same file name. The file would be cached on the CDN, which means we wouldn't be able to see new updates unless we somehow expire the cache.

## Testing / Proof
Manual

@bigcommerce/checkout
