### PR TITLE
CHECKOUT-4515: Ensure next version number is calculated once per build run

### DIFF
--- a/scripts/webpack/get-next-version.js
+++ b/scripts/webpack/get-next-version.js
@@ -4,26 +4,32 @@ const argv = require('yargs').argv;
 
 const packageJson = require('../../package.json');
 
+let nextVersion;
+
 function getNextVersion() {
-    return new Promise((resolve, reject) => {
-        if (argv.releaseAs) {
-            return resolve(semver.clean(argv.releaseAs));
-        }
-
-        conventionalRecommendedBump({ preset: 'angular' }, (err, release) => {
-            if (err) {
-                return reject(err);
+    if (!nextVersion) {
+        nextVersion = new Promise((resolve, reject) => {
+            if (argv.releaseAs) {
+                return resolve(semver.clean(argv.releaseAs));
             }
 
-            if (argv.prerelease) {
-                const prereleaseType = typeof argv.prerelease === 'string' ? argv.prerelease : 'alpha';
+            conventionalRecommendedBump({ preset: 'angular' }, (err, release) => {
+                if (err) {
+                    return reject(err);
+                }
 
-                return resolve(semver.inc(packageJson.version, 'prerelease', prereleaseType).replace(/\.\d+$/, `.${Date.now()}`));
-            }
+                if (argv.prerelease) {
+                    const prereleaseType = typeof argv.prerelease === 'string' ? argv.prerelease : 'alpha';
 
-            resolve(semver.inc(packageJson.version, release.releaseType));
-        })
-    });
+                    return resolve(semver.inc(packageJson.version, 'prerelease', prereleaseType).replace(/\.\d+$/, `.${Date.now()}`));
+                }
+
+                resolve(semver.inc(packageJson.version, release.releaseType));
+            })
+        });
+    }
+
+    return nextVersion;
 }
 
 module.exports = getNextVersion;


### PR DESCRIPTION
## What?
Ensure the next version number is calculated once per build run.

## Why?
Otherwise, if `getNextVersion` is called at a different time, it might produce a different version number. This problem always impacts pre-releases because their version number is based on a timestamp.

## Testing / Proof
**Before**
```
Loader filename: loader-1.6.1-alpha.1572219138662.js
Version in manifest.json: 1.6.1-alpha.1572219138461
```

**After**
```
Loader filename: loader-1.6.1-alpha.1572218995476.js
Version in manifest.json: 1.6.1-alpha.1572218995476
```

@bigcommerce/checkout
