### PR TITLE
CHECKOUT-4509 Always save shipping form after changes

### DIFF
--- a/src/app/shipping/ShippingForm.tsx
+++ b/src/app/shipping/ShippingForm.tsx
@@ -1,4 +1,4 @@
-import { Address, Cart, CheckoutSelectors, Consignment, ConsignmentAssignmentRequestBody, Country, CustomerAddress, CustomerRequestOptions, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+import { Address, Cart, CheckoutParams, CheckoutSelectors, Consignment, ConsignmentAssignmentRequestBody, Country, CustomerAddress, CustomerRequestOptions, FormField, RequestOptions, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
 import React, { Component, ReactNode } from 'react';
 
 import { withLanguage, WithLanguageProps } from '../locale';
@@ -33,7 +33,7 @@ export interface ShippingFormProps {
     onUnhandledError(error: Error): void;
     onUseNewAddress(address: Address, itemId: string): void;
     signOut(options?: CustomerRequestOptions): void;
-    updateAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+    updateAddress(address: Partial<Address>, options: RequestOptions<CheckoutParams>): Promise<CheckoutSelectors>;
 }
 
 class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {

--- a/src/app/shipping/SingleShippingForm.spec.tsx
+++ b/src/app/shipping/SingleShippingForm.spec.tsx
@@ -57,7 +57,14 @@ describe('SingleShippingForm', () => {
             expect(defaultProps.updateAddress).toHaveBeenCalledWith({
                 ...getShippingAddress(),
                 address1: 'foo 2',
-            });
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': true,
+                    },
+                },
+             });
             done();
         }, SHIPPING_AUTOSAVE_DELAY * 1.1);
     });
@@ -86,12 +93,21 @@ describe('SingleShippingForm', () => {
         }, SHIPPING_AUTOSAVE_DELAY * 1.1);
     });
 
-    it('does not call updateAddress if modified field does not affect shipping', done => {
+    it('calls updateAddress without including shipping options if modified field does not affect shipping', done => {
         component.find('input[name="shippingAddress.address2"]')
             .simulate('change', { target: { value: 'foo 1', name: 'shippingAddress.address2' } });
 
         setTimeout(() => {
-            expect(defaultProps.updateAddress).not.toHaveBeenCalled();
+            expect(defaultProps.updateAddress).toHaveBeenCalledWith({
+                ...getShippingAddress(),
+                address2: 'foo 1',
+            }, {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': false,
+                    },
+                },
+            });
             done();
         }, SHIPPING_AUTOSAVE_DELAY * 1.1);
     });


### PR DESCRIPTION
## What?
Always save shipping form when it's modified. However only include shipping options when the modified field can affect shipping.

## Why?
Because in some cases the form auto saving and in sometimes not it can be confusing for the shopper, misleading them to think the form has been autosaved. In some scenarios this has caused some orders to have been placed with incomplete phone numbers.

## Testing / Proof
unit

@bigcommerce/checkout
