### PR TITLE
CHECKOUT-4509 Make sure shipping options are requested at least once

### DIFF
--- a/src/app/shipping/SingleShippingForm.spec.tsx
+++ b/src/app/shipping/SingleShippingForm.spec.tsx
@@ -93,7 +93,7 @@ describe('SingleShippingForm', () => {
         }, SHIPPING_AUTOSAVE_DELAY * 1.1);
     });
 
-    it('calls updateAddress without including shipping options if modified field does not affect shipping', done => {
+    it('calls updateAddress including shipping options if modified field does not affect shipping but has never requested shipping options', done => {
         component.find('input[name="shippingAddress.address2"]')
             .simulate('change', { target: { value: 'foo 1', name: 'shippingAddress.address2' } });
 
@@ -104,11 +104,35 @@ describe('SingleShippingForm', () => {
             }, {
                 params: {
                     include: {
-                        'consignments.availableShippingOptions': false,
+                        'consignments.availableShippingOptions': true,
                     },
                 },
             });
             done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+
+    it('calls updateAddress without shipping options if modified field does not affect shipping and shipping options have already been requested', done => {
+        component.find('input[name="shippingAddress.address2"]')
+            .simulate('change', { target: { value: 'foo 1', name: 'shippingAddress.address2' } });
+
+        setTimeout(() => {
+            component.find('input[name="shippingAddress.address2"]')
+                .simulate('change', { target: { value: 'foo 2', name: 'shippingAddress.address2' } });
+
+            setTimeout(() => {
+                expect(defaultProps.updateAddress).toHaveBeenLastCalledWith({
+                    ...getShippingAddress(),
+                    address2: 'foo 2',
+                }, {
+                    params: {
+                        include: {
+                            'consignments.availableShippingOptions': false,
+                        },
+                    },
+                });
+                done();
+            }, SHIPPING_AUTOSAVE_DELAY * 1.1);
         }, SHIPPING_AUTOSAVE_DELAY * 1.1);
     });
 

--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -46,6 +46,7 @@ export interface SingleShippingFormValues {
 interface SingleShippingFormState {
     isResettingAddress: boolean;
     isUpdatingShippingData: boolean;
+    hasRequestedShippingOptions: boolean;
 }
 
 export const SHIPPING_AUTOSAVE_DELAY = 1000;
@@ -54,6 +55,7 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
     state: SingleShippingFormState = {
         isResettingAddress: false,
         isUpdatingShippingData: false,
+        hasRequestedShippingOptions: false,
     };
 
     private debouncedUpdateAddress: any;
@@ -72,6 +74,9 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
                         },
                     },
                 });
+                if (includeShippingOptions) {
+                    this.setState({ hasRequestedShippingOptions: true });
+                }
             } finally {
                 this.setState({ isUpdatingShippingData: false });
             }
@@ -141,18 +146,6 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
         );
     }
 
-    componentDidUpdate({ isValid: prevIsValid }:
-        SingleShippingFormProps &
-        WithLanguageProps &
-        FormikProps<SingleShippingFormValues>
-    ): void {
-        const { isValid } = this.props;
-
-        if (!prevIsValid && isValid) {
-            this.updateAddressWithFormData(true);
-        }
-    }
-
     private shouldDisableSubmit: () => boolean = () => {
         const {
             isLoading,
@@ -187,12 +180,13 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
         const isShippingField = SHIPPING_ADDRESS_FIELDS.includes(name);
 
         const { isValid } = this.props;
+        const { hasRequestedShippingOptions } = this.state;
 
         if (!isValid) {
             return;
         }
 
-        this.updateAddressWithFormData(isShippingField);
+        this.updateAddressWithFormData(isShippingField || !hasRequestedShippingOptions);
     };
 
     private updateAddressWithFormData(includeShippingOptions: boolean) {


### PR DESCRIPTION
## What?
Make sure shipping options are requested at least once.

## Why?
We use to have a check that when the form becomes valid, we would fetch shipping options. However because now we always trigger the debouncer, a new function call would overwrite the previous one. If the last field to make the form required doesnt affect shipping, the form would have never requested shipping options.

## Testing / Proof
unit

@bigcommerce/checkout
