### PR TITLE
PAYMENTS-4886 Disable vaulting if isPaymentDataSubmitted is true

### DIFF
--- a/src/app/payment/paymentMethod/HostedPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedPaymentMethod.spec.tsx
@@ -165,13 +165,23 @@ describe('HostedPaymentMethod', () => {
 
             const component = mount(<HostedPaymentMethodTest { ...defaultProps } />);
 
-            expect(component.find(storedInstrumentModule.AccountInstrumentFieldset).length)
-                .toBe(1);
+            expect(component.find(storedInstrumentModule.AccountInstrumentFieldset))
+                .toHaveLength(1);
         });
 
         it('does not show instruments fieldset when there are no stored instruments', () => {
             jest.spyOn(checkoutState.data, 'getInstruments')
                 .mockReturnValue([]);
+
+            const component = mount(<HostedPaymentMethodTest { ...defaultProps } />);
+
+            expect(component.find(storedInstrumentModule.AccountInstrumentFieldset))
+                .toHaveLength(0);
+        });
+
+        it('does not show instruments fieldset when starting from the cart', () => {
+            jest.spyOn(checkoutState.data, 'isPaymentDataSubmitted')
+                .mockReturnValue(true);
 
             const component = mount(<HostedPaymentMethodTest { ...defaultProps } />);
 
@@ -207,8 +217,8 @@ describe('HostedPaymentMethod', () => {
             it('does not render the dropdown', () => {
                 const component = mount(<HostedPaymentMethodTest { ...defaultProps } />);
 
-                expect(component.find(storedInstrumentModule.AccountInstrumentFieldset).length)
-                    .toBe(0);
+                expect(component.find(storedInstrumentModule.AccountInstrumentFieldset))
+                    .toHaveLength(0);
             });
 
             it('does not prompt to save the instrument', () => {
@@ -220,8 +230,8 @@ describe('HostedPaymentMethod', () => {
                     { ...defaultProps }
                 />);
 
-                expect(component.find('.form-field--saveInstrument').length)
-                    .toBe(0);
+                expect(component.find('.form-field--saveInstrument'))
+                    .toHaveLength(0);
             });
         });
     });

--- a/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
@@ -175,7 +175,6 @@ function mapFromCheckoutProps(): MapToProps<
     const filterTrustedInstruments = memoizeOne((instruments: AccountInstrument[] = []) => instruments.filter(({ trustedShippingAddress }) => trustedShippingAddress));
 
     return (context, props) => {
-
         const {
             formik: { values },
             isUsingMultiShipping = false,
@@ -191,6 +190,7 @@ function mapFromCheckoutProps(): MapToProps<
                 getCustomer,
                 getInstruments,
                 isPaymentDataRequired,
+                isPaymentDataSubmitted,
             },
             statuses: {
                 isLoadingInstruments,
@@ -214,12 +214,14 @@ function mapFromCheckoutProps(): MapToProps<
         return {
             instruments: trustedInstruments,
             isNewAddress: trustedInstruments.length === 0 && currentMethodInstruments.length > 0,
-            isInstrumentFeatureAvailable: features['PAYMENTS-4579.braintree_paypal_vaulting'] && isInstrumentFeatureAvailable({
-                config,
-                customer,
-                isUsingMultiShipping,
-                paymentMethod: method,
-            }),
+            isInstrumentFeatureAvailable: features['PAYMENTS-4579.braintree_paypal_vaulting']
+                && !isPaymentDataSubmitted(method.id, method.gateway)
+                && isInstrumentFeatureAvailable({
+                    config,
+                    customer,
+                    isUsingMultiShipping,
+                    paymentMethod: method,
+                }),
             isLoadingInstruments: isLoadingInstruments(),
             isPaymentDataRequired: isPaymentDataRequired(values.useStoreCredit),
             loadInstruments: checkoutService.loadInstruments,


### PR DESCRIPTION
## What?
Do not show the vaulting information if payment data was submitted from the cart

## Why?
When we start the payment process from the cart we can't offer vaulting
functionality and the customer has already picked their payment method,
we should not show the dropdown or options to vault instruments.

## Testing / Proof
- Unit / Functional

### Before
<img width="610" alt="image" src="https://user-images.githubusercontent.com/4542735/67827002-90e69080-fb22-11e9-8feb-0cbfa2e7dd8a.png">

### After
<img width="656" alt="image" src="https://user-images.githubusercontent.com/4542735/67826954-609ef200-fb22-11e9-90a7-7acb81bd61f6.png">

@bigcommerce/checkout