### PR TITLE
PAYMENTS-4886 Do not render payment methods at all if payment data is not required

### DIFF
--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -60,6 +60,9 @@ describe('PaymentForm', () => {
         jest.spyOn(checkoutState.data, 'getCustomer')
             .mockReturnValue(getCustomer());
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentFormTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <PaymentContext.Provider value={ paymentContext }>

--- a/src/app/payment/paymentMethod/AdyenV2PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2PaymentMethod.spec.tsx
@@ -43,6 +43,9 @@ describe('when using Adyen V2 payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/AmazonPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/AmazonPaymentMethod.spec.tsx
@@ -41,6 +41,9 @@ describe('when using Amazon payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/ChasePayPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/ChasePayPaymentMethod.spec.tsx
@@ -46,6 +46,9 @@ describe('when using ChasePay payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.spec.tsx
@@ -110,16 +110,6 @@ describe('CreditCardPaymentMethod', () => {
             .toEqual(Object.keys(expectedSchema.describe().fields));
     });
 
-    it('does not set validation schema if payment is not required', () => {
-        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
-            .mockReturnValue(false);
-
-        mount(<CreditCardPaymentMethodTest { ...defaultProps } />);
-
-        expect(paymentContext.setValidationSchema)
-            .toHaveBeenCalledWith(defaultProps.method, null);
-    });
-
     it('deinitializes payment method when component unmounts', () => {
         const component = mount(<CreditCardPaymentMethodTest { ...defaultProps } />);
 

--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
@@ -30,7 +30,6 @@ interface WithCheckoutCreditCardPaymentMethodProps {
     isInstrumentCardCodeRequired: boolean;
     isInstrumentFeatureAvailable: boolean;
     isLoadingInstruments: boolean;
-    isPaymentDataRequired: boolean;
     isInstrumentCardNumberRequired(instrument: Instrument): boolean;
     loadInstruments(): Promise<CheckoutSelectors>;
 }
@@ -179,14 +178,9 @@ class CreditCardPaymentMethod extends Component<
             isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
             isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
-            isPaymentDataRequired,
             language,
             method,
         } = this.props;
-
-        if (!isPaymentDataRequired) {
-            return null;
-        }
 
         const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
         const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
@@ -229,7 +223,6 @@ function mapFromCheckoutProps(): MapToProps<
 
     return (context, props) => {
         const {
-            formik: { values },
             isUsingMultiShipping = false,
             method,
         } = props;
@@ -242,7 +235,6 @@ function mapFromCheckoutProps(): MapToProps<
                 getConfig,
                 getCustomer,
                 getInstruments,
-                isPaymentDataRequired,
             },
             statuses: {
                 isLoadingInstruments,
@@ -272,7 +264,6 @@ function mapFromCheckoutProps(): MapToProps<
                 paymentMethod: method,
             }),
             isLoadingInstruments: isLoadingInstruments(),
-            isPaymentDataRequired: isPaymentDataRequired(values.useStoreCredit),
             loadInstruments: checkoutService.loadInstruments,
         };
     };

--- a/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
@@ -46,6 +46,9 @@ describe('when using Google Pay payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
@@ -33,7 +33,6 @@ interface WithCheckoutHostedPaymentMethodProps {
     isInstrumentFeatureAvailable: boolean;
     isLoadingInstruments: boolean;
     isNewAddress: boolean;
-    isPaymentDataRequired: boolean;
     loadInstruments(): Promise<CheckoutSelectors>;
 }
 
@@ -176,7 +175,6 @@ function mapFromCheckoutProps(): MapToProps<
 
     return (context, props) => {
         const {
-            formik: { values },
             isUsingMultiShipping = false,
             method,
         } = props;
@@ -189,7 +187,6 @@ function mapFromCheckoutProps(): MapToProps<
                 getConfig,
                 getCustomer,
                 getInstruments,
-                isPaymentDataRequired,
                 isPaymentDataSubmitted,
             },
             statuses: {
@@ -223,7 +220,6 @@ function mapFromCheckoutProps(): MapToProps<
                     paymentMethod: method,
                 }),
             isLoadingInstruments: isLoadingInstruments(),
-            isPaymentDataRequired: isPaymentDataRequired(values.useStoreCredit),
             loadInstruments: checkoutService.loadInstruments,
         };
     };

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -61,9 +61,6 @@ describe('HostedWidgetPaymentMethod', () => {
         jest.spyOn(checkoutState.data, 'getCustomer')
             .mockReturnValue(getCustomer());
 
-        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
-            .mockReturnValue(true);
-
         HostedWidgetPaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <PaymentContext.Provider value={ paymentContext }>
@@ -96,16 +93,6 @@ describe('HostedWidgetPaymentMethod', () => {
 
         expect(defaultProps.deinitializePayment)
             .toHaveBeenCalled();
-    });
-
-    it('does not initialize payment method if payment data is not required', () => {
-        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
-            .mockReturnValue(false);
-
-        mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
-
-        expect(defaultProps.initializePayment)
-            .not.toHaveBeenCalled();
     });
 
     it('renders loading overlay while waiting for method to initialize', () => {
@@ -225,19 +212,6 @@ describe('HostedWidgetPaymentMethod', () => {
 
             expect(paymentContext.setSubmit)
                 .toHaveBeenCalledWith(defaultProps.method, defaultProps.signInCustomer);
-        });
-
-        it('does not ask user to sign in if payment data is not required', () => {
-            jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
-                .mockReturnValue(false);
-
-            mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
-
-            expect(defaultProps.initializeCustomer)
-                .not.toHaveBeenCalled();
-
-            expect(paymentContext.setSubmit)
-                .not.toHaveBeenCalledWith(defaultProps.method, defaultProps.signInCustomer);
         });
     });
 

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -38,7 +38,6 @@ interface WithCheckoutHostedWidgetPaymentMethodProps {
     isInstrumentCardCodeRequired: boolean;
     isInstrumentFeatureAvailable: boolean;
     isLoadingInstruments: boolean;
-    isPaymentDataRequired: boolean;
     isSignedIn: boolean;
     isInstrumentCardNumberRequired(instrument: Instrument): boolean;
     loadInstruments(): void;
@@ -182,7 +181,6 @@ class HostedWidgetPaymentMethod extends Component<
 
     private async initializeMethod(): Promise<CheckoutSelectors | void> {
         const {
-            isPaymentDataRequired,
             isSignedIn,
             isSignInRequired,
             initializeCustomer = noop,
@@ -191,12 +189,6 @@ class HostedWidgetPaymentMethod extends Component<
             setSubmit,
             signInCustomer = noop,
         } = this.props;
-
-        if (!isPaymentDataRequired) {
-            setSubmit(method, null);
-
-            return Promise.resolve();
-        }
 
         if (isSignInRequired && !isSignedIn) {
             setSubmit(method, signInCustomer);
@@ -287,7 +279,6 @@ function mapFromCheckoutProps(): MapToProps<
     return (context, props) => {
 
         const {
-            formik: { values },
             isUsingMultiShipping = false,
             method,
         } = props;
@@ -301,7 +292,6 @@ function mapFromCheckoutProps(): MapToProps<
                 getConfig,
                 getCustomer,
                 getInstruments,
-                isPaymentDataRequired,
             },
             statuses: {
                 isLoadingInstruments,
@@ -320,7 +310,6 @@ function mapFromCheckoutProps(): MapToProps<
         return {
             instruments: filterInstruments(getInstruments(method)),
             isLoadingInstruments: isLoadingInstruments(),
-            isPaymentDataRequired: isPaymentDataRequired(values.useStoreCredit),
             isSignedIn: some(checkout.payments, { providerId: method.id }),
             isInstrumentCardCodeRequired: isInstrumentCardCodeRequired({
                 config,

--- a/src/app/payment/paymentMethod/KlarnaPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/KlarnaPaymentMethod.spec.tsx
@@ -41,6 +41,9 @@ describe('when using Klarna payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/MasterpassPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/MasterpassPaymentMethod.spec.tsx
@@ -46,6 +46,9 @@ describe('when using Masterpass payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
@@ -57,6 +57,9 @@ describe('PaymentMethod', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <PaymentContext.Provider value={ paymentContext }>
@@ -83,6 +86,15 @@ describe('PaymentMethod', () => {
 
         expect(defaultProps.onUnhandledError)
             .toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('does not render the payment method when payment is not required', () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(false);
+
+        const container = mount(<PaymentMethodTest { ...defaultProps } />);
+
+        expect(container.html()).toEqual('');
     });
 
     describe('when using hosted / offsite payment', () => {

--- a/src/app/payment/paymentMethod/PaypalExpressPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PaypalExpressPaymentMethod.spec.tsx
@@ -42,6 +42,9 @@ describe('when using Paypal Express payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/PaypalPaymentsProPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PaypalPaymentsProPaymentMethod.spec.tsx
@@ -42,6 +42,9 @@ describe('when using Paypal Payments Pro payment method', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleProvider checkoutService={ checkoutService }>

--- a/src/app/payment/paymentMethod/SquarePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/SquarePaymentMethod.spec.tsx
@@ -41,6 +41,9 @@ describe('when using Square payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -40,6 +40,9 @@ describe('when using Stripe payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>

--- a/src/app/payment/paymentMethod/VisaCheckoutPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/VisaCheckoutPaymentMethod.spec.tsx
@@ -46,6 +46,9 @@ describe('when using Visa Checkout payment', () => {
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
                 <LocaleContext.Provider value={ localeContext }>


### PR DESCRIPTION
## What?
Do not render or initialize payment methods if payment data is not required

## Why?
We do not use the payment method if payment data is not required

## Testing / Proof
### Before
You can notice the credit card form being render behind the overlay:
<img width="574" alt="image" src="https://user-images.githubusercontent.com/4542735/67827013-9cd25280-fb22-11e9-879c-c9caffbb2ba3.png">

### 1. After
You can notice the credit card form is not even render in this case:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/4542735/67827054-c4c1b600-fb22-11e9-92b0-0a4725b5981b.png">

@bigcommerce/checkout @bigcommerce/payments 