### PR TITLE
CHECKOUT-4538 Rename prerelease & prevent local releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "rm -rf dist && webpack --mode production",
     "dev": "webpack --mode development --watch",
     "dev:server": "http-server dist",
-    "prerelease": "npm run test -- --coverage && npm run build -- --prerelease && npm run release:version",
-    "release": "npm run test -- --coverage && npm run build && npm run release:version",
+    "release": "echo 'Please do not release locally, use CircleCi'",
+    "release:alpha": "npm run test -- --coverage && npm run build -- --prerelease && npm run release:version",
     "release:version": "git add dist && standard-version -a",
     "test": "jest",
     "test:watch": "jest --watch"


### PR DESCRIPTION
## What?
1. Rename prerelease
2. Prevent local releases

## Why?
1. NPM will run `prerelease` every time we try to run `release` which is unintended behaviour. The current `prerelease` command was meant to be used to cut DEV builds.

2. We no longer run production builds locally, everything needs to be run in CircleCi. We want to remove the command and prompt engineers to use CircleCi for releasing.

## Testing / Proof
- Manual

<img width="396" alt="image" src="https://user-images.githubusercontent.com/4542735/67919632-408c3300-fbf5-11e9-89c6-024e6ab70cd1.png">


@bigcommerce/checkout
