### PR TITLE
fix(checkout): INT-1916 INT-1928 PAYMENTS-3836 Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,9 +886,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.41.0.tgz",
-      "integrity": "sha512-yYVv3Ea/cZM35U/7M7bEeCfFVpDRI8Ud+PyJq+FHfif4XgPoHu19gUwSDEFHrO54xsQwcFnQYTEp5jw1Kj1Q1A==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.42.0.tgz",
+      "integrity": "sha512-lomkGrZ2G0gSX7L4bHcJOX3kLoApB2EH/KStgRKmLTXi3ZPPHdsl6ZdMsCOnLgdsBMqCi+bZ9EQ7/q7AJGoWXw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.41.0",
+    "@bigcommerce/checkout-sdk": "^1.42.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

### Bug Fixes

* **payment:** INT-1928 map sku in internal line item ([fcb32dd](https://github.com/bigcommerce/checkout-sdk-js/commit/fcb32dd))
* **payment:** PAYMENTS-4704 Send shipping address when checking out using Braintree PayPal ([b047cfe](https://github.com/bigcommerce/checkout-sdk-js/commit/b047cfe))


### Features

* **checkout:** INT-1916 Make barclaycard compatible with offsite strategy ([cdf578b](https://github.com/bigcommerce/checkout-sdk-js/commit/cdf578b))


## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/intersys-integrations  
