### PR TITLE
PAYMENTS-4899 Make formik update form values correctly in AccountInstrumentSelect

### DIFF
--- a/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
+++ b/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
@@ -21,7 +21,7 @@ export interface AccountInstrumentSelectValues {
 
 class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps> {
     componentDidMount() {
-        this.updateFieldValue();
+        setTimeout(() => this.updateFieldValue());
     }
 
     componentDidUpdate(prevProps: Readonly<AccountInstrumentSelectProps>) {


### PR DESCRIPTION
## What?
As per title

## Why?
There is a bug in the current version of formik that causes values not
to update properly if setFieldValue is called too early when the
component mounts. Adding a setTimeout acts as a workaround and makes the
value update.

## Testing / Proof
- Manual

**PS:** I've modified checkout for the screen recordings so it shows the actual value in the form.

### Before
![formik_before](https://user-images.githubusercontent.com/4542735/68178815-73616d00-ffe1-11e9-91c3-52bbed1f61ad.gif)

### After
![formik_after](https://user-images.githubusercontent.com/4542735/68178814-73616d00-ffe1-11e9-988a-e4bb52bc604e.gif)


@bigcommerce/checkout
