### PR TITLE
fix(checkout): CHECKOUT-4536 fix console error while adding address when there is no consignment

### DIFF
--- a/src/app/shipping/Shipping.spec.tsx
+++ b/src/app/shipping/Shipping.spec.tsx
@@ -45,6 +45,9 @@ describe('Shipping Component', () => {
         jest.spyOn(checkoutService, 'loadShippingOptions')
             .mockResolvedValue({} as CheckoutSelectors);
 
+        jest.spyOn(checkoutService, 'deleteConsignment')
+            .mockResolvedValue({} as CheckoutSelectors);
+
         jest.spyOn(checkoutState.data, 'getCart')
             .mockReturnValue({
                 ...getCart(),
@@ -234,6 +237,45 @@ describe('Shipping Component', () => {
         expect(checkoutService.updateShippingAddress).not.toHaveBeenCalled();
         expect(checkoutService.updateCheckout).not.toHaveBeenCalled();
         expect(defaultProps.navigateNextStep).toHaveBeenCalledWith(true);
+    });
+
+    it('calls delete consignment if consignments exist when adding a new address', async () => {
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+            ...getCustomer(),
+        });
+
+        jest.spyOn(checkoutState.data, 'getConsignments')
+        .mockReturnValue([getConsignment()]);
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+
+        component.update();
+        component.find('#addressToggle').simulate('click');
+        component.find('#addressDropdown li').first().find('a').simulate('click');
+
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        expect(checkoutService.deleteConsignment).toHaveBeenCalled();
+    });
+
+    it('does not Call delete consignment if consignment doesnot exist when adding a new address', async () => {
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+            ...getCustomer(),
+        });
+
+        jest.spyOn(checkoutState.data, 'getConsignments')
+            .mockReturnValue([]);
+
+        component = mount(<ComponentTest { ...defaultProps } />);
+        await new Promise(resolve => process.nextTick(resolve));
+
+        component.update();
+        component.find('#addressToggle').simulate('click');
+        component.find('#addressDropdown li').first().find('a').simulate('click');
+
+        expect(checkoutService.deleteConsignment).not.toHaveBeenCalled();
     });
 
     describe('when multishipping mode is on', () => {

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -225,7 +225,11 @@ const deleteConsignmentsSelector = createSelector(
     ({ checkoutService: { deleteConsignment } }: CheckoutContextProps) => deleteConsignment,
     ({ checkoutState: { data } }: CheckoutContextProps) => data.getConsignments(),
     (deleteConsignment, consignments) => async () => {
-        const [{ data }] = await Promise.all((consignments || []).map(({ id }) =>
+        if (!consignments || !consignments.length) {
+            return;
+        }
+
+        const [{ data }] = await Promise.all(consignments.map(({ id }) =>
             deleteConsignment(id)
         ));
 


### PR DESCRIPTION
## What?
[Sentry Error](https://sentry.io/organizations/bigcommerce/issues/1278559094/events/aec2870d227f4b20a28595b68f827c3f/?project=1542560.) 

Unable to read property 'data' of undefined. 

## Why?
When adding a new shipping address the Shipping costs are recalculated. In case there are no consignments in the cart for whatever reasons one of them being emptying cart on a separate tab, it causes the promise to return with an empty value. With the fix the consignment array is checked at the outset for null before the get address on the consignment items.

## Testing / Proof
No failure logs on console. 

@bigcommerce/checkout
