### PR TITLE
feat(payment): PAYMENTS-4924 Remove order ID substitution.

### DIFF
--- a/src/app/order/getPaymentInstructions.ts
+++ b/src/app/order/getPaymentInstructions.ts
@@ -15,11 +15,7 @@ function getPaymentInstructions(order: Order): string {
     const gatewayPayment = (order.payments || []).find(isDefaultOrderPayment);
     const instructions = gatewayPayment && gatewayPayment.detail.instructions;
 
-    if (!instructions) {
-        return '';
-    }
-
-    return instructions.replace(/%%OrderID%%/g, order.orderId.toString());
+    return instructions || '';
 }
 
 export default getPaymentInstructions;

--- a/src/app/order/orders.mock.ts
+++ b/src/app/order/orders.mock.ts
@@ -61,7 +61,7 @@ export function getGatewayOrderPayment(): GatewayOrderPayment {
         amount: 190,
         detail: {
             step: 'FINALIZE',
-            instructions: '<strong>%%OrderID%%</strong> something',
+            instructions: '<strong>295</strong> something',
         },
     };
 }


### PR DESCRIPTION
## What?
Remove the logic that substitutes the order ID into the instructions string.

## Why?
This behaviour belongs in the Payments domain and should be supplied via the API.

## Testing / Proof
Circle.

@bigcommerce/checkout
