### PR TITLE
PAYMENTS-4917 Clear instrumentId when InstrumentSelect gets unmounted

### DIFF
--- a/src/app/payment/storedInstrument/AccountInstrumentSelect.spec.tsx
+++ b/src/app/payment/storedInstrument/AccountInstrumentSelect.spec.tsx
@@ -201,4 +201,45 @@ describe('AccountInstrumentSelect', () => {
         expect(defaultProps.onUseNewInstrument)
             .toHaveBeenCalled();
     });
+
+    it('cleans the instrumentId when the component unmounts', async () => {
+        const submit = jest.fn();
+        initialValues.instrumentId = '1234';
+
+        const Component = ({ show }: { show: boolean }) =>
+            <Formik initialValues={ initialValues } onSubmit={ submit }>
+                { ({ handleSubmit }) => <form onSubmit={ handleSubmit }>
+                    { show && <Field name="instrumentId">
+                        { (field: FieldProps<string>) => (
+                            <AccountInstrumentSelect
+                                { ...field }
+                                { ...defaultProps }
+                            />
+                        ) }
+                    </Field> }
+                </form> }
+            </Formik>;
+
+        const component = mount(<Component show={ true } />);
+
+        component.find('form')
+            .simulate('submit')
+            .update();
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(submit).toHaveBeenCalledWith({ instrumentId: '1234' }, expect.anything());
+
+        component
+            .setProps({ show: false })
+            .update();
+
+        component.find('form')
+            .simulate('submit')
+            .update();
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(submit).toHaveBeenCalledWith({ instrumentId: '' }, expect.anything());
+    });
 });

--- a/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
+++ b/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
@@ -21,7 +21,12 @@ export interface AccountInstrumentSelectValues {
 
 class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps> {
     componentDidMount() {
-        setTimeout(() => this.updateFieldValue());
+        const { selectedInstrumentId } = this.props;
+
+        // FIXME: Used setTimeout here because setFieldValue call doesnot set value if called before formik is properly mounted.
+        //        This ensures that update Field value is called after formik has mounted.
+        // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
+        setTimeout(() => this.updateFieldValue(selectedInstrumentId));
     }
 
     componentDidUpdate(prevProps: Readonly<AccountInstrumentSelectProps>) {
@@ -29,8 +34,12 @@ class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps
         const { selectedInstrumentId } = this.props;
 
         if (prevSelectedInstrumentId !== selectedInstrumentId) {
-            this.updateFieldValue();
+            this.updateFieldValue(selectedInstrumentId);
         }
+    }
+
+    componentWillUnmount() {
+        this.updateFieldValue();
     }
 
     render(): ReactNode {
@@ -70,14 +79,13 @@ class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps
         );
     }
 
-    private updateFieldValue(): void {
+    private updateFieldValue(instrumentId: string = ''): void {
         const {
             form,
             field,
-            selectedInstrumentId,
         } = this.props;
 
-        form.setFieldValue(field.name, selectedInstrumentId || '');
+        form.setFieldValue(field.name, instrumentId);
     }
 }
 

--- a/src/app/payment/storedInstrument/InstrumentSelect.spec.tsx
+++ b/src/app/payment/storedInstrument/InstrumentSelect.spec.tsx
@@ -240,4 +240,45 @@ describe('InstrumentSelect', () => {
         expect(defaultProps.onUseNewInstrument)
             .toHaveBeenCalled();
     });
+
+    it('cleans the instrumentId when the component unmounts', async () => {
+        const submit = jest.fn();
+        initialValues.instrumentId = '1234';
+
+        const Component = ({ show }: { show: boolean }) =>
+            <Formik initialValues={ initialValues } onSubmit={ submit }>
+                { ({ handleSubmit }) => <form onSubmit={ handleSubmit }>
+                    { show && <Field name="instrumentId">
+                        { (field: FieldProps<string>) => (
+                            <InstrumentSelect
+                                { ...field }
+                                { ...defaultProps }
+                            />
+                        ) }
+                    </Field> }
+                </form> }
+            </Formik>;
+
+        const component = mount(<Component show={ true } />);
+
+        component.find('form')
+            .simulate('submit')
+            .update();
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(submit).toHaveBeenCalledWith({ instrumentId: '1234' }, expect.anything());
+
+        component
+            .setProps({ show: false })
+            .update();
+
+        component.find('form')
+            .simulate('submit')
+            .update();
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(submit).toHaveBeenCalledWith({ instrumentId: '' }, expect.anything());
+    });
 });

--- a/src/app/payment/storedInstrument/InstrumentSelect.tsx
+++ b/src/app/payment/storedInstrument/InstrumentSelect.tsx
@@ -25,10 +25,12 @@ export interface InstrumentSelectValues {
 
 class InstrumentSelect extends PureComponent<InstrumentSelectProps> {
     componentDidMount() {
+        const { selectedInstrumentId } = this.props;
+
         // FIXME: Used setTimeout here because setFieldValue call doesnot set value if called before formik is properly mounted.
         //        This ensures that update Field value is called after formik has mounted.
         // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
-        setTimeout(() => this.updateFieldValue());
+        setTimeout(() => this.updateFieldValue(selectedInstrumentId));
     }
 
     componentDidUpdate(prevProps: Readonly<InstrumentSelectProps>) {
@@ -36,8 +38,12 @@ class InstrumentSelect extends PureComponent<InstrumentSelectProps> {
         const { selectedInstrumentId } = this.props;
 
         if (prevSelectedInstrumentId !== selectedInstrumentId) {
-            this.updateFieldValue();
+            this.updateFieldValue(selectedInstrumentId);
         }
+    }
+
+    componentWillUnmount() {
+        this.updateFieldValue();
     }
 
     render(): ReactNode {
@@ -77,14 +83,13 @@ class InstrumentSelect extends PureComponent<InstrumentSelectProps> {
         );
     }
 
-    private updateFieldValue(): void {
+    private updateFieldValue(instrumentId: string = ''): void {
         const {
             form,
             field,
-            selectedInstrumentId,
         } = this.props;
 
-        form.setFieldValue(field.name, selectedInstrumentId || '');
+        form.setFieldValue(field.name, instrumentId);
     }
 }
 


### PR DESCRIPTION
## What?
Clear formik's instrumentId when InstrumentSelect or AccountInstrumentSelect are unmounted

## Why?
When the InstrumentSelect component gets unmounted, we need to clear the
current instrumentId to avoid using the wrong id for the form
submission.

## Testing / Proof
- Unit / Functional / Manual

PS: The `instrumentId` was only printed as part of the screen recording to showcase the issue and the fix.

### Before
![before](https://user-images.githubusercontent.com/4542735/68552965-1f3b0a80-0471-11ea-9915-e9966884c989.gif)

### After
![after](https://user-images.githubusercontent.com/4542735/68552964-1ea27400-0471-11ea-8675-fd007d86bd18.gif)



@bigcommerce/checkout @bigcommerce/payments 
