### PR TITLE
feat(payment): INT-2066 Hide cc icon list from payment method title

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -210,4 +210,24 @@ describe('PaymentMethodTitle', () => {
                 .toEqual(0);
         });
     });
+
+    it('renders credit card icons', () => {
+        const component = mount(<PaymentMethodTitleTest { ...defaultProps } />);
+
+        expect(component.find('[data-test="payment-method-cc_icon_list"]'))
+            .toHaveLength(1);
+    });
+
+    it('should not render credit card icons if gateway is bluesnapv2', () => {
+        const component = mount(<PaymentMethodTitleTest
+            { ...defaultProps }
+            method={ {
+                ...defaultProps.method,
+                gateway: 'bluesnapv2',
+            } }
+        />);
+
+        expect(component.find('[data-test="payment-method-cc_icon_list"]'))
+            .toHaveLength(0);
+    });
 });

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -108,6 +108,7 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
     const methodName = getPaymentMethodName(language)(method);
     const { logoUrl, titleText } = getPaymentMethodTitle(language, cdnBasePath)(method);
     const { type: selectedCardType = '' } = isSelected ? (number(values.ccNumber).card || {}) : {};
+    const cardTypes: string[] = shouldHideIconList(method.gateway) ? [] : compact(method.supportedCards.map(mapFromPaymentMethodCardType));
 
     return (
         <Fragment>
@@ -125,15 +126,26 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
                 { titleText }
             </span> }
 
-            <div className="paymentProviderHeader-cc">
+            { cardTypes.length > 0 && <div
+                className="paymentProviderHeader-cc"
+                data-test="payment-method-cc_icon_list"
+            >
                 <CreditCardIconList
-                    cardTypes={ compact(method.supportedCards.map(mapFromPaymentMethodCardType)) }
+                    cardTypes={ cardTypes }
                     selectedCardType={ selectedCardType }
                 />
-            </div>
+            </div> }
         </Fragment>
     );
 };
+
+function shouldHideIconList(provider = ''): boolean {
+    if (!provider) {
+        return false;
+    }
+
+    return provider === 'bluesnapv2';
+}
 
 function mapToCdnPathProps({ checkoutState }: CheckoutContextProps): WithCdnPathProps | null {
     const { data: { getConfig } } = checkoutState;


### PR DESCRIPTION
## What? [INT-2066](https://jira.bigcommerce.com/browse/INT-2066)
Hide credit card icon list from the payment method title.

## Why?
Because isn't required for BlueSnap V2 to show those icons.

## Sibling PR
[bigcommerce/checkout-js](https://github.com/bigcommerce/checkout-js/pull/155)

## Testing / Proof
![image](https://user-images.githubusercontent.com/4843328/68623915-32fb6680-049b-11ea-9a9b-d5fb682bfa36.png)
![image](https://user-images.githubusercontent.com/4843328/68622676-55d84b80-0498-11ea-90ef-abffbb343087.png)

@bigcommerce/checkout @bigcommerce/intersys-integrations 
