### PR TITLE
fix(checkout): INT-1902 Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -730,9 +730,9 @@
       }
     },
     "@babel/polyfill": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
-      "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
+      "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -886,9 +886,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.43.0.tgz",
-      "integrity": "sha512-FiVlu0vZ69Pfn30ppMm9iNTfuVqahoVMPDE4B8e+q5x0uBeO7xBAcpoJ2FjrQ9vvnCAuBEFMVRpecTpqeDqdLg==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.44.0.tgz",
+      "integrity": "sha512-my9Ho/BZBF7isCcuFdDOzjFs9ITM2ZzE9t9HF9tff+4S8VI+1iJCiyuqZAaxoTK8GiqxH5f9tfXyVIjtfXIm9A==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.0.0",
@@ -922,9 +922,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.144",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
-          "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg=="
+          "version": "4.14.146",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.146.tgz",
+          "integrity": "sha512-JzJcmQ/ikHSv7pbvrVNKJU5j9jL9VLf3/gqs048CEnBVVVEv4kve3vLxoPHGvclutS+Il4SBIuQQ087m1eHffw=="
         },
         "rxjs": {
           "version": "6.5.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.43.0",
+    "@bigcommerce/checkout-sdk": "^1.44.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout @clopezh