### PR TITLE
CHECKOUT-4556 Provide auto-loader file

### DIFF
--- a/src/app/auto-loader.ts
+++ b/src/app/auto-loader.ts
@@ -1,0 +1,42 @@
+import { BrowserOptions } from '@sentry/browser';
+
+import { loadFiles } from './loader';
+
+export interface CustomCheckoutWindow extends Window {
+    checkoutConfig: {
+        containerId: string;
+        orderId?: number;
+        checkoutId?: string;
+        publicPath?: string;
+        sentryConfig?: BrowserOptions;
+    };
+}
+
+function isCustomCheckoutWindow(window: Window): window is CustomCheckoutWindow {
+    const customCheckoutWindow: CustomCheckoutWindow = window as CustomCheckoutWindow;
+
+    return !!customCheckoutWindow.checkoutConfig;
+}
+
+(async function autoLoad() {
+    if (!isCustomCheckoutWindow(window)) {
+        throw new Error('Checkout config is missing.');
+    }
+
+    const {
+        renderOrderConfirmation,
+        renderCheckout,
+    } = await loadFiles();
+
+    const {
+        orderId,
+        checkoutId,
+        ...appProps
+    } = window.checkoutConfig;
+
+    if (orderId) {
+        renderOrderConfirmation({ ...appProps, orderId });
+    } else if (checkoutId) {
+        renderCheckout({ ...appProps, checkoutId });
+    }
+})();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const { AsyncHookPlugin, BuildHookPlugin, getNextVersion, transformManifest } = 
 
 const ENTRY_NAME = 'checkout';
 const LIBRARY_NAME = 'checkout';
+const AUTO_LOADER_ENTRY_NAME = 'auto-loader';
 const LOADER_ENTRY_NAME = 'loader';
 const LOADER_LIBRARY_NAME = 'checkoutLoader';
 const SUPPORTED_BROWSERS = [
@@ -208,6 +209,7 @@ function loaderConfig(options, argv) {
             return {
                 entry: {
                     [LOADER_ENTRY_NAME]: join(__dirname, 'src', 'app', 'loader.ts'),
+                    [AUTO_LOADER_ENTRY_NAME]: join(__dirname, 'src', 'app', 'auto-loader.ts'),
                 },
                 mode,
                 devtool: isProduction ? 'source-map' : 'eval-source-map',
@@ -240,6 +242,7 @@ function loaderConfig(options, argv) {
                     new BuildHookPlugin({
                         onDone() {
                             copyFileSync(`dist/${LOADER_ENTRY_NAME}-${appVersion}.js`, `dist/${LOADER_ENTRY_NAME}.js`);
+                            copyFileSync(`dist/${AUTO_LOADER_ENTRY_NAME}-${appVersion}.js`, `dist/${AUTO_LOADER_ENTRY_NAME}.js`);
                         },
                     }),
                 ],


### PR DESCRIPTION
## What?
If checkout config is global, make app auto-load with shared configuration.

## Why?
Because this way, when a developer forks UCO and pastes the `loader.js` URL into the custom script URL field, the script should be able to invoke the loader function automatically.

## Testing / Proof
manual

@bigcommerce/checkout
