### PR TITLE
fix(checkout): CHECKOUT-4513 Remove strike-through logic from UI - read from extendedComparisonPrice instead

### DIFF
--- a/src/app/cart/lineItem.mock.ts
+++ b/src/app/cart/lineItem.mock.ts
@@ -31,7 +31,7 @@ export function getPhysicalItem(): PhysicalItem {
         comparisonPrice: 200,
         extendedListPrice: 200,
         extendedSalePrice: 200,
-        extendedComparisonPrice: 150,
+        extendedComparisonPrice: 250,
         isShippingRequired: true,
         addedByPromotion: false,
         options: [
@@ -69,7 +69,7 @@ export function getDigitalItem(): DigitalItem {
         downloadSize: '',
         extendedListPrice: 200,
         extendedSalePrice: 200,
-        extendedComparisonPrice: 150,
+        extendedComparisonPrice: 250,
         addedByPromotion: false,
         options: [
             {

--- a/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`OrderSummary when shopper has same currency as store renders order summ
               "couponAmount": 0,
               "discountAmount": 0,
               "discounts": Array [],
-              "extendedComparisonPrice": 150,
+              "extendedComparisonPrice": 250,
               "extendedListPrice": 200,
               "extendedSalePrice": 200,
               "id": "666",

--- a/src/app/order/__snapshots__/OrderSummaryItems.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummaryItems.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`OrderSummaryItems when it has 4 line items or less renders product list
     key="666"
   >
     <Memo(OrderSummaryItem)
-      amount={200}
+      amount={250}
       amountAfterDiscount={200}
       id="666"
       image={

--- a/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
@@ -65,7 +65,7 @@ exports[`OrderSummaryModal renders order summary 1`] = `
               "couponAmount": 0,
               "discountAmount": 0,
               "discounts": Array [],
-              "extendedComparisonPrice": 150,
+              "extendedComparisonPrice": 250,
               "extendedListPrice": 200,
               "extendedSalePrice": 200,
               "id": "666",

--- a/src/app/order/mapFromPhysical.tsx
+++ b/src/app/order/mapFromPhysical.tsx
@@ -4,13 +4,10 @@ import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { OrderSummaryItemProps } from './OrderSummaryItem';
 
 function mapFromPhysical(item: PhysicalItem): OrderSummaryItemProps {
-    // FIXME: add type in Checkout SDK
-    const comparisonPrice = (item as PhysicalItem & { comparisonPrice: number }).comparisonPrice;
-
     return {
         id: item.id,
         quantity: item.quantity,
-        amount: item.listPrice < comparisonPrice ? item.extendedSalePrice : item.extendedListPrice,
+        amount: item.extendedComparisonPrice,
         amountAfterDiscount: item.extendedSalePrice,
         name: item.name,
         image: getOrderSummaryItemImage(item),


### PR DESCRIPTION
## What?
Read the comparison price from `extendedComparisonPrice`

## Why?
To fix the strike-through issue when prices are inc/ex tax but showing as ex/inc tax

## Testing / Proof
price inc tax, show ex tax (no discount):
Before:
<img width="389" alt="Screen Shot 2019-11-20 at 9 49 55 am" src="https://user-images.githubusercontent.com/12888727/69193835-cdcf0180-0b7b-11ea-8a35-1c59fb2165f7.png">

After:
<img width="378" alt="Screen Shot 2019-11-20 at 9 39 11 am" src="https://user-images.githubusercontent.com/12888727/69193868-e3442b80-0b7b-11ea-9f0d-76a6f7cd8178.png">

price ex tax, show in tax (no discount):
Before:
<img width="391" alt="Screen Shot 2019-11-20 at 9 49 16 am" src="https://user-images.githubusercontent.com/12888727/69193888-f0611a80-0b7b-11ea-90ac-ad9c8931d834.png">

After:
<img width="380" alt="Screen Shot 2019-11-20 at 9 41 25 am" src="https://user-images.githubusercontent.com/12888727/69193907-fd7e0980-0b7b-11ea-8252-1cbed43d25b0.png">

@bigcommerce/checkout
