### PR TITLE
CHECKOUT-4448 Show min purchase error when coupon doesnt meet requirements

### DIFF
--- a/src/app/cart/Redeemable.spec.tsx
+++ b/src/app/cart/Redeemable.spec.tsx
@@ -3,7 +3,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 
 import { getStoreConfig } from '../config/config.mock';
-import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedString } from '../locale';
 import { Alert } from '../ui/alert';
 
 import Redeemable from './Redeemable';
@@ -16,6 +16,9 @@ describe('CartSummary Component', () => {
     const clearError = jest.fn();
     const onRemovedCoupon = jest.fn();
     const onRemovedGiftCertificate = jest.fn();
+    const minPurchaseError = {
+        errors: [ { code: 'min_purchase' } ],
+    } as RequestError;
     const appliedError = {
         errors: [ {} ],
     } as RequestError;
@@ -27,7 +30,7 @@ describe('CartSummary Component', () => {
             component = mount(
                 <LocaleContext.Provider value={ localeContext }>
                     <Redeemable
-                        appliedRedeemableError={ appliedError }
+                        appliedRedeemableError={ minPurchaseError }
                         applyCoupon={ applyCoupon }
                         applyGiftCertificate={ applyGiftCertificate }
                         clearError={ clearError }
@@ -38,6 +41,11 @@ describe('CartSummary Component', () => {
                     />
                 </LocaleContext.Provider>
             );
+        });
+
+        it('renders min purchase error', () => {
+            expect(component.find(Alert).find(TranslatedString).prop('id'))
+                .toEqual('redeemable.coupon_min_order_total');
         });
 
         it('does not render toggle link', () => {

--- a/src/app/cart/Redeemable.tsx
+++ b/src/app/cart/Redeemable.tsx
@@ -107,13 +107,23 @@ const RedeemableForm: FunctionComponent<Partial<RedeemableProps> & FormikProps<R
         </Label>
     ), []);
 
+    const renderErrorMessage = useCallback((errorCode: string) => {
+        switch (errorCode) {
+        case 'min_purchase':
+            return <TranslatedString id="redeemable.coupon_min_order_total" />;
+        case 'not_applicable':
+            return <TranslatedString id="redeemable.coupon_location_error" />;
+        default:
+            return <TranslatedString id="redeemable.code_invalid_error" />;
+        }
+    }, []);
+
     const renderInput = useCallback((setSubmitted: FormContextType['setSubmitted']) => ({ field }: FieldProps) => (
         <Fragment>
-            { appliedRedeemableError && <Alert type={ AlertType.Error }>
-                { appliedRedeemableError.errors[0].code === 'not_applicable' ?
-                    <TranslatedString id="redeemable.coupon_location_error" /> :
-                    <TranslatedString id="redeemable.code_invalid_error" /> }
-            </Alert> }
+            { appliedRedeemableError && appliedRedeemableError.errors && appliedRedeemableError.errors[0] &&
+                <Alert type={ AlertType.Error }>
+                    { renderErrorMessage(appliedRedeemableError.errors[0].code) }
+                </Alert> }
 
             <div className="form-prefixPostfix">
                 <TextInput
@@ -140,6 +150,7 @@ const RedeemableForm: FunctionComponent<Partial<RedeemableProps> & FormikProps<R
         handleKeyDown,
         handleSubmit,
         isApplyingRedeemable,
+        renderErrorMessage,
     ]);
 
     const renderContent = useCallback(memoizeOne(({ setSubmitted }: FormContextType) => (

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -226,6 +226,7 @@
             "code_label": "Gift Certificate or Coupon Code",
             "code_required_error": "Please enter a gift certificate or coupon code",
             "coupon_location_error": "Your shipping address doesn't meet the location requirements for the coupon code you entered.",
+            "coupon_min_order_total": "Your order does not meet the minimum total for this coupon code to be applied.",
             "coupon_text": "Coupon",
             "gift_certificate_remaining_text": "Remaining",
             "gift_certificate_text": "Gift Certificate",


### PR DESCRIPTION
## What?
Show min purchase error when coupon doesnt meet requirements

## Why?
So it's more accurate for shoppers

## Testing / Proof
<img width="390" alt="Screen Shot 2019-11-20 at 1 48 25 pm" src="https://user-images.githubusercontent.com/1621894/69207143-fe766180-0ba2-11ea-9ef4-8ae5b6bf6441.png">

@bigcommerce/checkout
