### PR TITLE
CHECKOUT-4556: Update prerelease command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ npm run dev
 If you want to create a prerelease (i.e.: `alpha`) for testing in the integration environment, you can run the following command:
 
 ```sh
-npm run prerelease
+npm run release:alpha
 ```
+
+After that, you need to push the prerelease tag to your fork so it can be referenced remotely.
 
 ## Theme integration
 


### PR DESCRIPTION
## What?
Update the prerelease command in the README file.

## Why?
It has been changed to `npm run release:alpha`.

## Testing / Proof
None

@bigcommerce/checkout
