### PR TITLE
CHECKOUT-4163 Make WEBPACK_DONE stop the build on failure

### DIFF
--- a/scripts/webpack/build-hook-plugin.js
+++ b/scripts/webpack/build-hook-plugin.js
@@ -16,14 +16,14 @@ class BuildHookPlugin {
     }
 
     process(command) {
-        return () => new Promise((resolve, reject) => {
+        return () => new Promise(resolve => {
             exec(command, (err, stdout, stderr) => {
                 if (err) {
-                    reject(err);
+                    throw err;
                 }
 
                 if (stderr) {
-                    reject(new Error(stderr));
+                    throw new Error(stderr);
                 }
 
                 const cleanOutput = stdout.trim();


### PR DESCRIPTION
## What?
- As per title

## Why?
If the command fails we want the build to stop and notify the user
on the reasons

## Testing / Proof
### Before:
```
❯ WEBPACK_DONE='false' npm run dev

> @bigcommerce/checkout@1.11.2 dev /Users/ignacio.catalina/develop/checkout-js
> webpack --mode development --watch


webpack is watching the files…

Starting type checking service...
Using 1 worker with 2048MB memory limit
Type checking in progress...
No type errors found
Version: typescript 3.5.3, eslint 6.1.0
Time: 31762ms
```

### After:
```
❯ WEBPACK_DONE='false' npm run dev

> @bigcommerce/checkout@1.11.2 dev /Users/ignacio.catalina/develop/checkout-js
> webpack --mode development --watch


webpack is watching the files…

Starting type checking service...
Using 1 worker with 2048MB memory limit
Type checking in progress...
/Users/ignacio.catalina/develop/checkout-js/scripts/webpack/build-hook-plugin.js:22
                    throw err;
                    ^

Error: Command failed: false

    at ChildProcess.exithandler (child_process.js:294:12)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Socket.stream.socket.on (internal/child_process.js:389:11)
    at Socket.emit (events.js:198:13)
    at Pipe._handle.close (net.js:606:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @bigcommerce/checkout@1.11.2 dev: `webpack --mode development --watch`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @bigcommerce/checkout@1.11.2 dev script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ignacio.catalina/.npm/_logs/2019-11-26T00_49_39_031Z-debug.log```

@bigcommerce/checkout
