### PR TITLE
PAYMENTS-4848 Bump checkout sdk version to 1.45.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -876,9 +876,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.0.0.tgz",
-      "integrity": "sha512-xM9AJJPCXGHRVAtfCWBTTNHiWC2tn8pVSvpecuDyAU+VcqA0W9xxpUedlJzioAPQly3qbMQvl8CpKX0fSuiHWw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.2.0.tgz",
+      "integrity": "sha512-k6uKSaNa8HRiNFLAlDGCTdDguVzpMOuQ1wjFoPI8qVrKqJDSP2TqXMxo8cOYIVBABW23yPGVV1dEZZzlT3e2cw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.2.1",
         "deep-assign": "^2.0.0",
@@ -886,12 +886,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.45.0.tgz",
-      "integrity": "sha512-p3qc4/tplHdQPK1DGTUX4bMAts6oRphbmQ2I41uQCsKEfQBTzgvNefKcXTcyXpW3ygsWyUJv/kOc1yQFMwp4qg==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.45.1.tgz",
+      "integrity": "sha512-6ZjtYDOtlQDwoTC4U3cuRrXJDfo5mbkKEx86EBycusDfnFXNuHEAEu3+fteZfAYZa5WXE4lM6sUS3Wg8UzYHZA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.0.0",
+        "@bigcommerce/bigpay-client": "^5.2.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.3.0",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.45.0",
+    "@bigcommerce/checkout-sdk": "^1.45.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.45.1

## Why?
So that checkout can send shipping transit times to bigpay
https://jira.bigcommerce.com/browse/PAYMENTS-4848 

## Testing / Proof
Manual testing:
bigcommerce/bigpay-client-js#90

Manual and unit tests:
bigcommerce/bigpay#2009

@bigcommerce/payments @jvpcode 
