### PR TITLE
CHECKOUT-4203: Use hosted form fields for credit card payment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.47.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.47.4.tgz",
-      "integrity": "sha512-cqufUTEMzZmXEroJw1K235HVEJ+WKeOWSJm34M4/tzkhago8WECSc8ZgHh5TTVmZLGHsL9CldJMvzxwQ0OBLuQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.49.0.tgz",
+      "integrity": "sha512-P5Rgi/j0JwVu9enHMiOxD5w/0JEyNCIB6ZByDAKvdNVonlen7Z4bX1hMBixM0EgdDFs5uynsT9zSmZveSPFFkQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.4.1",
@@ -904,11 +904,16 @@
         "@bigcommerce/memoize": "^1.0.0",
         "@bigcommerce/request-sender": "^0.3.0",
         "@bigcommerce/script-loader": "^2.1.0",
+        "@types/card-validator": "^4.1.0",
+        "@types/credit-card-type": "^7.0.0",
         "@types/iframe-resizer": "^3.5.6",
         "@types/lodash": "^4.14.139",
         "@types/reselect": "^2.2.0",
         "@types/shallowequal": "^1.1.1",
+        "@types/yup": "^0.26.24",
+        "card-validator": "^6.2.0",
         "core-js": "^3.1.2",
+        "credit-card-type": "^8.3.0",
         "iframe-resizer": "^3.6.2",
         "local-storage-fallback": "^4.1.1",
         "lodash": "^4.17.15",
@@ -916,7 +921,8 @@
         "reselect": "^4.0.0",
         "rxjs": "^6.5.3",
         "shallowequal": "^1.1.0",
-        "tslib": "^1.10.0"
+        "tslib": "^1.10.0",
+        "yup": "^0.27.0"
       },
       "dependencies": {
         "@bigcommerce/script-loader": {
@@ -933,12 +939,35 @@
           "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
           "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
         },
+        "@types/yup": {
+          "version": "0.26.27",
+          "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.27.tgz",
+          "integrity": "sha512-Rlsq3DExOHfWur75nQUAa5I0fXA2vSrw0u0qK3SI4PAkyOWjNzZsTaK+U9/sofWm3ttwWYn+C92pSq0s4rob4w=="
+        },
+        "credit-card-type": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/credit-card-type/-/credit-card-type-8.3.0.tgz",
+          "integrity": "sha512-czfZUpQ7W9CDxZL4yFLb1kFtM/q2lTOY975hL2aO+DC8+GRNDVSXVCHXhVFZPxiUKmQCZbFP8vIhxx5TBQaThw=="
+        },
         "rxjs": {
           "version": "6.5.4",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
           "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
           "requires": {
             "tslib": "^1.9.0"
+          }
+        },
+        "yup": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
+          "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "fn-name": "~2.0.1",
+            "lodash": "^4.17.11",
+            "property-expr": "^1.5.0",
+            "synchronous-promise": "^2.0.6",
+            "toposort": "^2.0.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.47.4",
+    "@bigcommerce/checkout-sdk": "^1.49.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/config/config.mock.ts
+++ b/src/app/config/config.mock.ts
@@ -16,6 +16,7 @@ export function getStoreConfig(): StoreConfig {
             guestCheckoutEnabled: true,
             isAnalyticsEnabled: true,
             isCardVaultingEnabled: true,
+            isHostedPaymentFormEnabled: false,
             isPaymentRequestEnabled: false,
             isPaymentRequestCanMakePaymentEnabled: false,
             isSpamProtectionEnabled: false,

--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -224,8 +224,21 @@ describe('PaymentForm', () => {
                 ccCvv: '123',
                 ccName: 'Foo Bar',
                 ccExpiry: '10 / 22',
+                hostedForm: {
+                    cardType: '',
+                    errors: {
+                        cardCode: '',
+                        cardCodeVerification: '',
+                        cardExpiry: '',
+                        cardName: '',
+                        cardNumber: '',
+                        cardNumberVerification: '',
+                    },
+                },
                 paymentProviderRadio: defaultProps.defaultMethodId,
                 shouldSaveInstrument: false,
+                terms: false,
+                useStoreCredit: false,
             });
     });
 

--- a/src/app/payment/creditCard/HostedCreditCardCodeField.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardCodeField.tsx
@@ -1,0 +1,38 @@
+import React, { useCallback, FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../locale';
+import { FormField, TextInputIframeContainer } from '../../ui/form';
+import { IconLock } from '../../ui/icon';
+
+export interface HostedCreditCardCodeFieldProps {
+    appearFocused: boolean;
+    id: string;
+    name: string;
+}
+
+const HostedCreditCardCodeField: FunctionComponent<HostedCreditCardCodeFieldProps> = ({
+    appearFocused,
+    id,
+    name,
+}) => {
+    const renderInput = useCallback(() => (<>
+        <TextInputIframeContainer
+            additionalClassName="has-icon"
+            appearFocused={ appearFocused }
+            id={ id }
+        />
+
+        <IconLock />
+    </>), [id, appearFocused]);
+
+    return (
+        <FormField
+            additionalClassName="form-ccFields-field--ccCvv"
+            input={ renderInput }
+            labelContent={ <TranslatedString id="payment.credit_card_cvv_label" /> }
+            name={ name }
+        />
+    );
+};
+
+export default HostedCreditCardCodeField;

--- a/src/app/payment/creditCard/HostedCreditCardExpiryField.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardExpiryField.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback, FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../locale';
+import { FormField, TextInputIframeContainer } from '../../ui/form';
+
+export interface HostedCreditCardExpiryFieldProps {
+    appearFocused: boolean;
+    id: string;
+    name: string;
+}
+
+const HostedCreditCardExpiryField: FunctionComponent<HostedCreditCardExpiryFieldProps> = ({
+    appearFocused,
+    id,
+    name,
+}) => {
+    const renderInput = useCallback(() => (<>
+        <TextInputIframeContainer
+            appearFocused={ appearFocused }
+            id={ id }
+        />
+    </>), [id, appearFocused]);
+
+    return (
+        <FormField
+            additionalClassName="form-field--ccExpiry"
+            input={ renderInput }
+            labelContent={ <TranslatedString id="payment.credit_card_expiration_label" /> }
+            name={ name }
+        />
+    );
+};
+
+export default HostedCreditCardExpiryField;

--- a/src/app/payment/creditCard/HostedCreditCardFieldset.spec.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardFieldset.spec.tsx
@@ -1,0 +1,97 @@
+import { mount } from 'enzyme';
+import { Field, Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import CreditCardStorageField from './CreditCardStorageField';
+import HostedCreditCardCodeField from './HostedCreditCardCodeField';
+import HostedCreditCardExpiryField from './HostedCreditCardExpiryField';
+import HostedCreditCardFieldset, { HostedCreditCardFieldsetProps } from './HostedCreditCardFieldset';
+import HostedCreditCardNameField from './HostedCreditCardNameField';
+import HostedCreditCardNumberField from './HostedCreditCardNumberField';
+
+/* eslint-disable react/jsx-no-bind */
+describe('HostedCreditCardFieldset', () => {
+    let defaultProps: HostedCreditCardFieldsetProps;
+    let HostedCreditCardFieldsetTest: FunctionComponent<HostedCreditCardFieldsetProps>;
+
+    beforeEach(() => {
+        defaultProps = {
+            cardExpiryId: 'cardExpiry',
+            cardNumberId: 'cardNumber',
+        };
+
+        HostedCreditCardFieldsetTest = props => (
+            <Formik
+                initialValues={ { hostedForm: {} } }
+                onSubmit={ noop }
+                render={ () => <HostedCreditCardFieldset { ...props } /> }
+            />
+        );
+    });
+
+    it('renders required field containers', () => {
+        const component = mount(
+            <HostedCreditCardFieldsetTest { ...defaultProps } />
+        );
+
+        expect(component.find(HostedCreditCardNumberField).length)
+            .toEqual(1);
+
+        expect(component.find(HostedCreditCardExpiryField).length)
+            .toEqual(1);
+    });
+
+    it('renders optional field containers', () => {
+        const component = mount(
+            <HostedCreditCardFieldsetTest
+                { ...defaultProps }
+                cardCodeId="cardCode"
+                cardNameId="cardName"
+            />
+        );
+
+        expect(component.find(HostedCreditCardCodeField).length)
+            .toEqual(1);
+
+        expect(component.find(HostedCreditCardNameField).length)
+            .toEqual(1);
+    });
+
+    it('renders with "save card" checkbox if configured', () => {
+        const component = mount(
+            <HostedCreditCardFieldsetTest
+                { ...defaultProps }
+                shouldShowSaveCardField
+            />
+        );
+
+        expect(component.find(CreditCardStorageField).length)
+            .toEqual(1);
+    });
+
+    it('renders additional fields if provided', () => {
+        const component = mount(
+            <HostedCreditCardFieldsetTest
+                { ...defaultProps }
+                additionalFields={ <Field name="foobar" /> }
+            />
+        );
+
+        expect(component.find('input[name="foobar"]').length)
+            .toEqual(1);
+    });
+
+    it('renders field container with focus styles', () => {
+        const component = mount(
+            <HostedCreditCardFieldsetTest
+                { ...defaultProps }
+                focusedFieldType="cardNumber"
+            />
+        );
+
+        expect(component.find('TextInputIframeContainer[id="cardNumber"]').prop('appearFocused'))
+            .toBeTruthy();
+    });
+});
+/* eslint-enable react/jsx-no-bind */

--- a/src/app/payment/creditCard/HostedCreditCardFieldset.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardFieldset.tsx
@@ -1,0 +1,83 @@
+import React, { FunctionComponent, ReactNode } from 'react';
+
+import { TranslatedString } from '../../locale';
+import { Fieldset, Legend } from '../../ui/form';
+
+import CreditCardStorageField from './CreditCardStorageField';
+import HostedCreditCardCodeField from './HostedCreditCardCodeField';
+import HostedCreditCardExpiryField from './HostedCreditCardExpiryField';
+import HostedCreditCardNameField from './HostedCreditCardNameField';
+import HostedCreditCardNumberField from './HostedCreditCardNumberField';
+
+export interface HostedCreditCardFieldsetProps {
+    additionalFields?: ReactNode;
+    cardCodeId?: string;
+    cardExpiryId: string;
+    cardNameId?: string;
+    cardNumberId: string;
+    focusedFieldType?: string;
+    shouldShowSaveCardField?: boolean;
+}
+
+export interface HostedCreditCardFieldsetValues {
+    hostedForm: {
+        cardType?: string;
+        errors?: {
+            cardCode?: string;
+            cardExpiry?: string;
+            cardName?: string;
+            cardNumber?: string;
+        };
+    };
+    shouldSaveInstrument?: boolean;
+}
+
+const HostedCreditCardFieldset: FunctionComponent<HostedCreditCardFieldsetProps> = ({
+    additionalFields,
+    cardCodeId,
+    cardExpiryId,
+    cardNameId,
+    cardNumberId,
+    focusedFieldType,
+    shouldShowSaveCardField,
+}) => (
+    <Fieldset
+        legend={
+            <Legend hidden>
+                <TranslatedString id="payment.credit_card_text" />
+            </Legend>
+        }
+    >
+        <div className="form-ccFields">
+            <HostedCreditCardNumberField
+                appearFocused={ focusedFieldType === 'cardNumber' }
+                id={ cardNumberId }
+                name="hostedForm.errors.cardNumber"
+            />
+
+            <HostedCreditCardExpiryField
+                appearFocused={ focusedFieldType === 'cardExpiry' }
+                id={ cardExpiryId }
+                name="hostedForm.errors.cardExpiry"
+            />
+
+            { cardNameId && <HostedCreditCardNameField
+                appearFocused={ focusedFieldType === 'cardName' }
+                id={ cardNameId }
+                name="hostedForm.errors.cardName"
+            /> }
+
+            { cardCodeId && <HostedCreditCardCodeField
+                appearFocused={ focusedFieldType === 'cardCode' }
+                id={ cardCodeId }
+                name="hostedForm.errors.cardCode"
+            /> }
+
+            { additionalFields }
+
+            { shouldShowSaveCardField && <CreditCardStorageField name="shouldSaveInstrument" /> }
+        </div>
+    </Fieldset>
+);
+
+export default HostedCreditCardFieldset;

--- a/src/app/payment/creditCard/HostedCreditCardNameField.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardNameField.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback, FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../locale';
+import { FormField, TextInputIframeContainer } from '../../ui/form';
+
+export interface HostedCreditCardNameFieldProps {
+    appearFocused: boolean;
+    id: string;
+    name: string;
+}
+
+const HostedCreditCardNameField: FunctionComponent<HostedCreditCardNameFieldProps> = ({
+    appearFocused,
+    id,
+    name,
+}) => {
+    const renderInput = useCallback(() => (<>
+        <TextInputIframeContainer
+            appearFocused={ appearFocused }
+            id={ id }
+        />
+    </>), [id, appearFocused]);
+
+    return (
+        <FormField
+            additionalClassName="form-field--ccName"
+            input={ renderInput }
+            labelContent={ <TranslatedString id="payment.credit_card_name_label" /> }
+            name={ name }
+        />
+    );
+};
+
+export default HostedCreditCardNameField;

--- a/src/app/payment/creditCard/HostedCreditCardNumberField.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardNumberField.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback, FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../locale';
+import { FormField, TextInputIframeContainer } from '../../ui/form';
+import { IconLock } from '../../ui/icon';
+
+export interface HostedCreditCardNumberFieldProps {
+    appearFocused: boolean;
+    id: string;
+    name: string;
+}
+
+const HostedCreditCardNumberField: FunctionComponent<HostedCreditCardNumberFieldProps> = ({
+    appearFocused,
+    id,
+    name,
+}) => {
+    const renderInput = useCallback(() => (<>
+        <TextInputIframeContainer
+            additionalClassName="has-icon"
+            appearFocused={ appearFocused }
+            id={ id }
+        />
+
+        <IconLock />
+    </>), [id, appearFocused]);
+
+    return (
+        <FormField
+            input={ renderInput }
+            labelContent={ <TranslatedString id="payment.credit_card_number_label" /> }
+            name={ name }
+        />
+    );
+};
+
+export default HostedCreditCardNumberField;

--- a/src/app/payment/creditCard/getHostedCreditCardValidationSchema.spec.ts
+++ b/src/app/payment/creditCard/getHostedCreditCardValidationSchema.spec.ts
@@ -1,0 +1,77 @@
+import { LanguageService } from '@bigcommerce/checkout-sdk';
+import { ObjectSchema } from 'yup';
+
+import getHostedCreditCardValidationSchema from './getHostedCreditCardValidationSchema';
+import { HostedCreditCardFieldsetValues } from './HostedCreditCardFieldset';
+
+describe('getHostedCreditCardValidationSchema', () => {
+    let language: Pick<LanguageService, 'translate'>;
+    let schema: ObjectSchema;
+    let values: HostedCreditCardFieldsetValues;
+
+    beforeEach(() => {
+        language = {
+            translate: jest.fn(key => key),
+        };
+
+        values = { hostedForm: {} };
+
+        schema = getHostedCreditCardValidationSchema({
+            language: language as LanguageService,
+        });
+    });
+
+    it('does not throw error if data is valid', () => {
+        expect(() => schema.validateSync(values))
+            .not.toThrow();
+    });
+
+    it('throws error if card code field is missing', () => {
+        values.hostedForm.errors = { cardCode: 'required' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_cvv_required_error');
+    });
+
+    it('throws error if card code field is invalid', () => {
+        values.hostedForm.errors = { cardCode: 'invalid_card_code' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_cvv_invalid_error');
+    });
+
+    it('throws error if card expiry field is missing', () => {
+        values.hostedForm.errors = { cardExpiry: 'required' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_expiration_required_error');
+    });
+
+    it('throws error if card expiry field is invalid', () => {
+        values.hostedForm.errors = { cardExpiry: 'invalid_card_expiry' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_expiration_invalid_error');
+    });
+
+    it('throws error if card name field is missing', () => {
+        values.hostedForm.errors = { cardName: 'required' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_name_required_error');
+    });
+
+    it('throws error if card number field is missing', () => {
+        values.hostedForm.errors = { cardNumber: 'required' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_number_required_error');
+    });
+
+    it('throws error if card number field is invalid', () => {
+        values.hostedForm.errors = { cardNumber: 'invalid_card_number' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_number_invalid_error');
+    });
+});

--- a/src/app/payment/creditCard/getHostedCreditCardValidationSchema.ts
+++ b/src/app/payment/creditCard/getHostedCreditCardValidationSchema.ts
@@ -1,0 +1,64 @@
+import { LanguageService } from '@bigcommerce/checkout-sdk';
+import { memoize } from '@bigcommerce/memoize';
+import { object, string, ObjectSchema } from 'yup';
+
+export interface HostedCreditCardValidationSchemaOptions {
+    language: LanguageService;
+}
+
+export interface HostedCreditCardValidationSchemaShape {
+    hostedForm: {
+        errors: {
+            cardCode: string;
+            cardExpiry: string;
+            cardName: string;
+            cardNumber: string;
+        };
+    };
+}
+
+export default memoize(function getHostedCreditCardValidationSchema({
+    language,
+}: HostedCreditCardValidationSchemaOptions): ObjectSchema<HostedCreditCardValidationSchemaShape> {
+    return object({
+        hostedForm: object({
+            errors: object({
+                cardCode: string()
+                    .test({
+                        message: language.translate('payment.credit_card_cvv_required_error'),
+                        test: value => value !== 'required',
+                    })
+                    .test({
+                        message: language.translate('payment.credit_card_cvv_invalid_error'),
+                        test: value => value !== 'invalid_card_code',
+                    }),
+
+                cardExpiry: string()
+                    .test({
+                        message: language.translate('payment.credit_card_expiration_required_error'),
+                        test: value => value !== 'required',
+                    })
+                    .test({
+                        message: language.translate('payment.credit_card_expiration_invalid_error'),
+                        test: value => value !== 'invalid_card_expiry',
+                    }),
+
+                cardName: string()
+                    .test({
+                        message: language.translate('payment.credit_card_name_required_error'),
+                        test: value => value !== 'required',
+                    }),
+
+                cardNumber: string()
+                    .test({
+                        message: language.translate('payment.credit_card_number_required_error'),
+                        test: value => value !== 'required',
+                    })
+                    .test({
+                        message: language.translate('payment.credit_card_number_invalid_error'),
+                        test: value => value !== 'invalid_card_number',
+                    }),
+            }),
+        }),
+    });
+});

--- a/src/app/payment/creditCard/index.ts
+++ b/src/app/payment/creditCard/index.ts
@@ -1,16 +1,27 @@
 import { CreditCardFieldsetProps, CreditCardFieldsetValues } from './CreditCardFieldset';
+import { HostedCreditCardFieldsetProps, HostedCreditCardFieldsetValues } from './HostedCreditCardFieldset';
 
 export type CreditCardFieldsetProps = CreditCardFieldsetProps;
 export type CreditCardFieldsetValues = CreditCardFieldsetValues;
+export type HostedCreditCardFieldsetProps = HostedCreditCardFieldsetProps;
+export type HostedCreditCardFieldsetValues = HostedCreditCardFieldsetValues;
 
 export { default as configureCardValidator } from './configureCardValidator';
 export { default as CreditCardFieldset } from './CreditCardFieldset';
 export { default as CreditCardIcon } from './CreditCardIcon';
 export { default as CreditCardIconList } from './CreditCardIconList';
 export { default as CreditCardCodeField } from './CreditCardCodeField';
+export { default as CreditCardCustomerCodeField } from './CreditCardCustomerCodeField';
 export { default as CreditCardNumberField } from './CreditCardNumberField';
 export { default as CreditCardStorageField } from './CreditCardStorageField';
+export { default as HostedCreditCardFieldset } from './HostedCreditCardFieldset';
+export { default as HostedCreditCardCodeField } from './HostedCreditCardCodeField';
+export { default as HostedCreditCardExpiryField } from './HostedCreditCardExpiryField';
+export { default as HostedCreditCardNameField } from './HostedCreditCardNameField';
+export { default as HostedCreditCardNumberField } from './HostedCreditCardNumberField';
+export { default as getCreditCardInputStyles, CreditCardInputStylesType } from './getCreditCardInputStyles';
 export { default as getCreditCardValidationSchema } from './getCreditCardValidationSchema';
+export { default as getHostedCreditCardValidationSchema } from './getHostedCreditCardValidationSchema';
 export { default as mapFromPaymentMethodCardType } from './mapFromPaymentMethodCardType';
 export { default as unformatCreditCardNumber } from './unformatCreditCardNumber';
 export { default as unformatCreditCardExpiryDate } from './unformatCreditCardExpiryDate';

--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
@@ -1,6 +1,6 @@
-import { CardInstrument, CheckoutSelectors, Instrument, PaymentInitializeOptions, PaymentInstrument, PaymentMethod, PaymentRequestOptions } from '@bigcommerce/checkout-sdk';
+import { CardInstrument, CheckoutSelectors, HostedFieldBlurEventData, HostedFieldCardTypeChangeEventData, HostedFieldFocusEventData, HostedFieldType, HostedFieldValidateEventData, HostedFormOptions, Instrument, PaymentInitializeOptions, PaymentInstrument, PaymentMethod, PaymentRequestOptions } from '@bigcommerce/checkout-sdk';
 import { memoizeOne } from '@bigcommerce/memoize';
-import { find, noop } from 'lodash';
+import { find, forIn, noop, some } from 'lodash';
 import React, { Component, ReactNode } from 'react';
 import { ObjectSchema } from 'yup';
 
@@ -9,8 +9,8 @@ import { connectFormik, ConnectFormikProps } from '../../common/form';
 import { MapToProps } from '../../common/hoc';
 import { withLanguage, WithLanguageProps } from '../../locale';
 import { LoadingOverlay } from '../../ui/loading';
-import { configureCardValidator, getCreditCardValidationSchema, CreditCardFieldset, CreditCardFieldsetValues } from '../creditCard';
-import { getInstrumentValidationSchema, isCardInstrument, isInstrumentCardCodeRequired, isInstrumentCardNumberRequiredSelector, isInstrumentFeatureAvailable, CardInstrumentFieldset, CardInstrumentFieldsetValues, CreditCardValidation } from '../storedInstrument';
+import { configureCardValidator, getCreditCardInputStyles, getCreditCardValidationSchema, getHostedCreditCardValidationSchema, CreditCardCustomerCodeField, CreditCardFieldset, CreditCardFieldsetValues, CreditCardInputStylesType, HostedCreditCardFieldset, HostedCreditCardFieldsetValues } from '../creditCard';
+import { getHostedInstrumentValidationSchema, getInstrumentValidationSchema, isCardInstrument, isInstrumentCardCodeRequired, isInstrumentCardNumberRequiredSelector, isInstrumentFeatureAvailable, CardInstrumentFieldset, CardInstrumentFieldsetValues, CreditCardValidation, HostedCreditCardValidation } from '../storedInstrument';
 import withPayment, { WithPaymentProps } from '../withPayment';
 import { PaymentFormValues } from '../PaymentForm';
 
@@ -23,19 +23,24 @@ export interface CreditCardPaymentMethodProps {
     onUnhandledError?(error: Error): void;
 }
 
-export type CreditCardPaymentMethodValues = CreditCardFieldsetValues | CardInstrumentFieldsetValues;
+export type CreditCardPaymentMethodValues = CreditCardFieldsetValues | CardInstrumentFieldsetValues | HostedCreditCardFieldsetValues;
 
 interface WithCheckoutCreditCardPaymentMethodProps {
     instruments: CardInstrument[];
+    isCardCodeRequired: boolean;
+    isCustomerCodeRequired: boolean;
     isInstrumentCardCodeRequired: boolean;
     isInstrumentFeatureAvailable: boolean;
     isLoadingInstruments: boolean;
     isPaymentDataRequired: boolean;
+    shouldUseHostedFieldset: boolean;
+    shouldShowInstrumentFieldset: boolean;
     isInstrumentCardNumberRequired(instrument: Instrument): boolean;
     loadInstruments(): Promise<CheckoutSelectors>;
 }
 
 interface CreditCardPaymentMethodState {
+    focusedHostedFieldType?: HostedFieldType;
     isAddingNewCard: boolean;
     selectedInstrumentId?: string;
 }
@@ -60,20 +65,24 @@ class CreditCardPaymentMethod extends Component<
             method,
             onUnhandledError = noop,
             setValidationSchema,
+            shouldUseHostedFieldset,
         } = this.props;
 
         setValidationSchema(method, this.getValidationSchema());
         configureCardValidator();
 
         try {
-            await initializePayment({
-                gatewayId: method.gateway,
-                methodId: method.id,
-            });
-
             if (isInstrumentFeatureAvailableProp) {
                 await loadInstruments();
             }
+
+            await initializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+                creditCard: shouldUseHostedFieldset ?
+                    { form: await this.getHostedFormOptions() } :
+                    undefined,
+            });
         } catch (error) {
             onUnhandledError(error);
         }
@@ -99,33 +108,65 @@ class CreditCardPaymentMethod extends Component<
         }
     }
 
-    componentDidUpdate(): void {
+    async componentDidUpdate(_prevProps: Readonly<CreditCardPaymentMethodProps>, prevState: Readonly<CreditCardPaymentMethodState>): Promise<void> {
         const {
+            deinitializePayment,
+            initializePayment,
             method,
+            onUnhandledError = noop,
             setValidationSchema,
+            shouldUseHostedFieldset,
         } = this.props;
 
+        const {
+            isAddingNewCard,
+            selectedInstrumentId,
+        } = this.state;
+
         setValidationSchema(method, this.getValidationSchema());
+
+        if (shouldUseHostedFieldset &&
+            selectedInstrumentId !== prevState.selectedInstrumentId ||
+            isAddingNewCard !== prevState.isAddingNewCard) {
+            try {
+                await deinitializePayment({
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                });
+
+                await initializePayment({
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                    creditCard: { form: await this.getHostedFormOptions() },
+                });
+            } catch (error) {
+                onUnhandledError(error);
+            }
+        }
     }
 
     render(): ReactNode {
         const {
             instruments,
+            isCardCodeRequired,
+            isCustomerCodeRequired,
             isInitializing,
             isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
             isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
             isLoadingInstruments,
+            shouldShowInstrumentFieldset,
+            shouldUseHostedFieldset,
             method,
         } = this.props;
 
         const {
+            focusedHostedFieldType,
             isAddingNewCard,
             selectedInstrumentId = this.getDefaultInstrumentId(),
         } = this.state;
 
         const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
-        const shouldShowInstrumentFieldset = isInstrumentFeatureAvailableProp && instruments.length > 0;
         const shouldShowCreditCardFieldset = !shouldShowInstrumentFieldset || isAddingNewCard;
         const isLoading = isInitializing || isLoadingInstruments;
         const shouldShowNumberField = selectedInstrument ? isInstrumentCardNumberRequiredProp(selectedInstrument) : false;
@@ -141,15 +182,31 @@ class CreditCardPaymentMethod extends Component<
                         onSelectInstrument={ this.handleSelectInstrument }
                         onUseNewInstrument={ this.handleUseNewCard }
                         selectedInstrumentId={ selectedInstrumentId }
-                        validateInstrument={ <CreditCardValidation
-                            shouldShowCardCodeField={ isInstrumentCardCodeRequiredProp }
-                            shouldShowNumberField={ shouldShowNumberField }
-                        /> }
+                        validateInstrument={ shouldUseHostedFieldset ?
+                            <HostedCreditCardValidation
+                                cardCodeId={ isInstrumentCardCodeRequiredProp ? 'ccCvv' : undefined }
+                                cardNumberId={ shouldShowNumberField ? 'ccNumber' : undefined }
+                                focusedFieldType={ focusedHostedFieldType }
+                            /> :
+                            <CreditCardValidation
+                                shouldShowCardCodeField={ isInstrumentCardCodeRequiredProp }
+                                shouldShowNumberField={ shouldShowNumberField }
+                            /> }
                     /> }
 
-                    { shouldShowCreditCardFieldset && <CreditCardFieldset
+                    { shouldShowCreditCardFieldset && !shouldUseHostedFieldset && <CreditCardFieldset
                         shouldShowCardCodeField={ method.config.cardCode || method.config.cardCode === null }
                         shouldShowCustomerCodeField={ method.config.requireCustomerCode }
+                        shouldShowSaveCardField={ isInstrumentFeatureAvailableProp }
+                    /> }
+
+                    { shouldShowCreditCardFieldset && shouldUseHostedFieldset && <HostedCreditCardFieldset
+                        additionalFields={ isCustomerCodeRequired && <CreditCardCustomerCodeField name="ccCustomerCode" /> }
+                        cardCodeId={ isCardCodeRequired ? 'ccCvv' : undefined }
+                        cardExpiryId="ccExpiry"
+                        cardNameId="ccName"
+                        cardNumberId="ccNumber"
+                        focusedFieldType={ focusedHostedFieldType }
                         shouldShowSaveCardField={ isInstrumentFeatureAvailableProp }
                     /> }
                 </div>
@@ -182,6 +239,7 @@ class CreditCardPaymentMethod extends Component<
             isPaymentDataRequired,
             language,
             method,
+            shouldUseHostedFieldset,
         } = this.props;
 
         if (!isPaymentDataRequired) {
@@ -191,18 +249,72 @@ class CreditCardPaymentMethod extends Component<
         const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
         const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
 
-        return isInstrumentFeatureAvailableProp && selectedInstrument ?
-            getInstrumentValidationSchema({
-                instrumentBrand: selectedInstrument.brand,
-                instrumentLast4: selectedInstrument.last4,
-                isCardCodeRequired: isInstrumentCardCodeRequiredProp,
-                isCardNumberRequired: isInstrumentCardNumberRequiredProp(selectedInstrument),
-                language,
-            }) :
-            getCreditCardValidationSchema({
+        if (isInstrumentFeatureAvailableProp && selectedInstrument) {
+            if (!shouldUseHostedFieldset) {
+                return getInstrumentValidationSchema({
+                    instrumentBrand: selectedInstrument.brand,
+                    instrumentLast4: selectedInstrument.last4,
+                    isCardCodeRequired: isInstrumentCardCodeRequiredProp,
+                    isCardNumberRequired: isInstrumentCardNumberRequiredProp(selectedInstrument),
+                    language,
+                });
+            }
+
+            return getHostedInstrumentValidationSchema({ language });
+        }
+
+        if (!shouldUseHostedFieldset) {
+            return getCreditCardValidationSchema({
                 isCardCodeRequired: method.config.cardCode === true,
                 language,
             });
+        }
+
+        return getHostedCreditCardValidationSchema({ language });
+    }
+
+    private async getHostedFormOptions(): Promise<HostedFormOptions> {
+        const {
+            instruments,
+            isCardCodeRequired,
+            isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
+            isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
+            shouldShowInstrumentFieldset,
+        } = this.props;
+
+        const {
+            selectedInstrumentId = this.getDefaultInstrumentId(),
+        } = this.state;
+
+        const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
+        const shouldShowNumberVerificationField = selectedInstrument ? isInstrumentCardNumberRequiredProp(selectedInstrument) : false;
+        const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
+        const styleContainerId = shouldShowInstrumentFieldset && selectedInstrumentId ?
+            (isInstrumentCardCodeRequiredProp ? 'ccCvv' : 'ccNumber') :
+            'ccNumber';
+
+        return {
+            fields: shouldShowInstrumentFieldset && selectedInstrumentId ?
+                {
+                    cardCodeVerification: isInstrumentCardCodeRequiredProp ? { containerId: 'ccCvv', instrumentId: selectedInstrumentId } : undefined,
+                    cardNumberVerification: shouldShowNumberVerificationField ? { containerId: 'ccNumber', instrumentId: selectedInstrumentId } : undefined,
+                } :
+                {
+                    cardCode: isCardCodeRequired ? { containerId: 'ccCvv' } : undefined,
+                    cardExpiry: { containerId: 'ccExpiry' },
+                    cardName: { containerId: 'ccName' },
+                    cardNumber: { containerId: 'ccNumber' },
+                },
+            styles: {
+                default: await getCreditCardInputStyles(styleContainerId, styleProps),
+                error: await getCreditCardInputStyles(styleContainerId, styleProps, CreditCardInputStylesType.Error),
+                focus: await getCreditCardInputStyles(styleContainerId, styleProps, CreditCardInputStylesType.Focus),
+            },
+            onBlur: this.handleHostedFieldBlur,
+            onCardTypeChange: this.handleHostedFieldCardTypeChange,
+            onFocus: this.handleHostedFieldFocus,
+            onValidate: this.handleHostedFieldValidate,
+        };
     }
 
     private handleUseNewCard: () => void = () => {
@@ -217,6 +329,39 @@ class CreditCardPaymentMethod extends Component<
             isAddingNewCard: false,
             selectedInstrumentId: id,
         });
+    };
+
+    private handleHostedFieldBlur: (event: HostedFieldBlurEventData) => void = ({ fieldType }) => {
+        const { focusedHostedFieldType } = this.state;
+
+        if (focusedHostedFieldType === fieldType) {
+            this.setState({
+                focusedHostedFieldType: undefined,
+            });
+        }
+    };
+
+    private handleHostedFieldFocus: (event: HostedFieldFocusEventData) => void = ({ fieldType }) => {
+        this.setState({
+            focusedHostedFieldType: fieldType,
+        });
+    };
+
+    private handleHostedFieldValidate: (data: HostedFieldValidateEventData) => void = ({ errors }) => {
+        const { formik: { setFieldValue } } = this.props;
+
+        forIn(errors, (fieldErrors = [], fieldType) => {
+            setFieldValue(
+                `hostedForm.errors.${fieldType}`,
+                fieldErrors[0] ? fieldErrors[0].type : ''
+            );
+        });
+    };
+
+    private handleHostedFieldCardTypeChange: (data: HostedFieldCardTypeChangeEventData) => void = ({ cardType }) => {
+        const { formik: { setFieldValue } } = this.props;
+
+        setFieldValue('hostedForm.cardType', cardType);
     };
 }
 
@@ -257,23 +402,35 @@ function mapFromCheckoutProps(): MapToProps<
             return null;
         }
 
+        const instruments = filterInstruments(getInstruments(method));
+        const isInstrumentFeatureAvailableProp = isInstrumentFeatureAvailable({
+            config,
+            customer,
+            isUsingMultiShipping,
+            paymentMethod: method,
+        });
+
         return {
-            instruments: filterInstruments(getInstruments(method)),
+            instruments,
+            isCardCodeRequired: method.config.cardCode || method.config.cardCode === null,
+            isCustomerCodeRequired: !!method.config.requireCustomerCode,
             isInstrumentCardCodeRequired: isInstrumentCardCodeRequired({
                 config,
                 lineItems: cart.lineItems,
                 paymentMethod: method,
             }),
             isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredSelector(checkoutState),
-            isInstrumentFeatureAvailable: isInstrumentFeatureAvailable({
-                config,
-                customer,
-                isUsingMultiShipping,
-                paymentMethod: method,
-            }),
+            isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
             isLoadingInstruments: isLoadingInstruments(),
             isPaymentDataRequired: isPaymentDataRequired(values.useStoreCredit),
             loadInstruments: checkoutService.loadInstruments,
+            shouldShowInstrumentFieldset: isInstrumentFeatureAvailableProp && instruments.length > 0,
+            shouldUseHostedFieldset: (
+                config.checkoutSettings.isHostedPaymentFormEnabled &&
+                some(config.paymentSettings.clientSidePaymentProviders, id =>
+                    method.id === id || method.gateway === id
+                )
+            ),
         };
     };
 }

--- a/src/app/payment/paymentMethod/HostedFieldPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedFieldPaymentMethod.tsx
@@ -19,6 +19,7 @@ export interface HostedFieldPaymentMethodProps {
     onUnhandledError?(error: Error): void;
 }
 
+// TODO: Use HostedCreditCardFieldset
 export default class HostedFieldPaymentMethod extends Component<HostedFieldPaymentMethodProps> {
     async componentDidMount(): Promise<void> {
         const {

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -7,6 +7,7 @@ import { withCheckout, CheckoutContextProps } from '../../checkout';
 import { connectFormik, ConnectFormikProps } from '../../common/form';
 import { withLanguage, WithLanguageProps } from '../../locale';
 import { mapFromPaymentMethodCardType, CreditCardIconList } from '../creditCard';
+import { PaymentFormValues } from '../PaymentForm';
 
 import getPaymentMethodName from './getPaymentMethodName';
 import PaymentMethodId from './PaymentMethodId';
@@ -102,7 +103,7 @@ function getPaymentMethodTitle(
     };
 }
 
-const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLanguageProps & WithCdnPathProps & ConnectFormikProps<{ ccNumber: string }>> = ({
+const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLanguageProps & WithCdnPathProps & ConnectFormikProps<PaymentFormValues>> = ({
     cdnBasePath,
     formik: { values },
     isSelected,
@@ -111,7 +112,26 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
 }) => {
     const methodName = getPaymentMethodName(language)(method);
     const { logoUrl, titleText } = getPaymentMethodTitle(language, cdnBasePath)(method);
-    const { type: selectedCardType = '' } = isSelected ? (number(values.ccNumber).card || {}) : {};
+
+    const getSelectedCardType = () => {
+        if (!isSelected) {
+            return;
+        }
+
+        if ('hostedForm' in values && 'cardType' in values.hostedForm && values.hostedForm.cardType) {
+            return values.hostedForm.cardType;
+        }
+
+        if ('ccNumber' in values && values.ccNumber) {
+            const { card } = number(values.ccNumber);
+
+            if (!card) {
+                return;
+            }
+
+            return card.type;
+        }
+    };
 
     return (
         <Fragment>
@@ -132,7 +152,7 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
             <div className="paymentProviderHeader-cc">
                 <CreditCardIconList
                     cardTypes={ compact(method.supportedCards.map(mapFromPaymentMethodCardType)) }
-                    selectedCardType={ selectedCardType }
+                    selectedCardType={ getSelectedCardType() }
                 />
             </div>
         </Fragment>

--- a/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
+++ b/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
@@ -6,6 +6,8 @@ import { TranslatedString } from '../../locale';
 import { BasicFormField, Fieldset, Legend } from '../../ui/form';
 import { ModalTrigger, ModalTriggerModalProps } from '../../ui/modal';
 
+import { CreditCardValidationValues } from './CreditCardValidation';
+import { HostedCreditCardValidationValues } from './HostedCreditCardValidation';
 import InstrumentSelect from './InstrumentSelect';
 import ManageInstrumentsModal from './ManageInstrumentsModal';
 
@@ -17,11 +19,9 @@ export interface CardInstrumentFieldsetProps {
     onUseNewInstrument(): void;
 }
 
-export interface CardInstrumentFieldsetValues {
-    ccCvv?: string;
-    ccNumber?: string;
+export type CardInstrumentFieldsetValues = {
     instrumentId: string;
-}
+} & CreditCardValidationValues | HostedCreditCardValidationValues;
 
 const CardInstrumentFieldset: FunctionComponent<CardInstrumentFieldsetProps> = ({
     instruments,

--- a/src/app/payment/storedInstrument/CreditCardValidation.tsx
+++ b/src/app/payment/storedInstrument/CreditCardValidation.tsx
@@ -8,6 +8,11 @@ interface CreditCardValidationProps {
     shouldShowNumberField: boolean;
 }
 
+export interface CreditCardValidationValues {
+    ccCvv?: string;
+    ccNumber?: string;
+}
+
 const CreditCardValidation: React.FunctionComponent<CreditCardValidationProps> = ({
     shouldShowNumberField,
     shouldShowCardCodeField,

--- a/src/app/payment/storedInstrument/HostedCreditCardValidation.spec.tsx
+++ b/src/app/payment/storedInstrument/HostedCreditCardValidation.spec.tsx
@@ -1,0 +1,62 @@
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext } from '../../locale';
+import { HostedCreditCardCodeField, HostedCreditCardNumberField } from '../creditCard';
+
+import HostedCreditCardValidation, { HostedCreditCardValidationProps } from './HostedCreditCardValidation';
+
+describe('HostedCreditCardValidation', () => {
+    let HostedCreditCardValidationTest: FunctionComponent<HostedCreditCardValidationProps>;
+
+    beforeEach(() => {
+        const localeContext = createLocaleContext(getStoreConfig());
+
+        HostedCreditCardValidationTest = props => (
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik initialValues={ {} } onSubmit={ noop }>
+                    <HostedCreditCardValidation { ...props } />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('shows card number field if configured', () => {
+        const component = mount(
+            <HostedCreditCardValidationTest cardNumberId="cardNumber" />
+        );
+
+        expect(component.find(HostedCreditCardNumberField).length)
+            .toEqual(1);
+    });
+
+    it('hides card number field if configured', () => {
+        const component = mount(
+            <HostedCreditCardValidationTest cardCodeId="cardCode" />
+        );
+
+        expect(component.find(HostedCreditCardNumberField).length)
+            .toEqual(0);
+    });
+
+    it('shows card code field if configured', () => {
+        const component = mount(
+            <HostedCreditCardValidationTest cardCodeId="cardCode" />
+        );
+
+        expect(component.find(HostedCreditCardCodeField).length)
+            .toEqual(1);
+    });
+
+    it('hides card code field if configured', () => {
+        const component = mount(
+            <HostedCreditCardValidationTest cardNumberId="cardNumber" />
+        );
+
+        expect(component.find(HostedCreditCardCodeField).length)
+            .toEqual(0);
+    });
+});

--- a/src/app/payment/storedInstrument/HostedCreditCardValidation.tsx
+++ b/src/app/payment/storedInstrument/HostedCreditCardValidation.tsx
@@ -1,0 +1,51 @@
+import React, { FunctionComponent } from 'react';
+
+import { TranslatedString } from '../../locale';
+import { HostedCreditCardCodeField, HostedCreditCardNumberField } from '../creditCard';
+
+export interface HostedCreditCardValidationProps {
+    cardCodeId?: string;
+    cardNumberId?: string;
+    focusedFieldType?: string;
+}
+
+export interface HostedCreditCardValidationValues {
+    hostedForm: {
+        errors?: {
+            cardCodeVerification?: string;
+            cardNumberVerification?: string;
+        };
+    };
+}
+
+const HostedCreditCardValidation: FunctionComponent<HostedCreditCardValidationProps> = ({
+    cardCodeId,
+    cardNumberId,
+    focusedFieldType,
+}) => (<>
+    { cardNumberId && <p>
+        <strong>
+            <TranslatedString id="payment.instrument_trusted_shipping_address_title_text" />
+        </strong>
+
+        <br />
+
+        <TranslatedString id="payment.instrument_trusted_shipping_address_text" />
+    </p> }
+
+    <div className="form-ccFields">
+        { cardNumberId && <HostedCreditCardNumberField
+            appearFocused={ focusedFieldType === 'cardNumber' }
+            id={ cardNumberId }
+            name="hostedForm.errors.cardNumberVerification"
+        /> }
+
+        { cardCodeId && <HostedCreditCardCodeField
+            appearFocused={ focusedFieldType === 'cardCode' }
+            id={ cardCodeId }
+            name="hostedForm.errors.cardCodeVerification"
+        /> }
+    </div>
+</>);
+
+export default HostedCreditCardValidation;

--- a/src/app/payment/storedInstrument/getHostedInstrumentValidationSchema.spec.ts
+++ b/src/app/payment/storedInstrument/getHostedInstrumentValidationSchema.spec.ts
@@ -1,0 +1,73 @@
+import { LanguageService } from '@bigcommerce/checkout-sdk';
+import { ObjectSchema } from 'yup';
+
+import getHostedInstrumentValidationSchema from './getHostedInstrumentValidationSchema';
+import { HostedCreditCardValidationValues } from './HostedCreditCardValidation';
+
+describe('getHostedInstrumentValidationSchema', () => {
+    let language: Pick<LanguageService, 'translate'>;
+    let schema: ObjectSchema;
+    let values: HostedCreditCardValidationValues & { instrumentId: string };
+
+    beforeEach(() => {
+        language = {
+            translate: jest.fn(key => key),
+        };
+
+        values = {
+            instrumentId: '123',
+            hostedForm: {},
+        };
+
+        schema = getHostedInstrumentValidationSchema({
+            language: language as LanguageService,
+        });
+    });
+
+    it('does not throw error if data is valid', () => {
+        expect(() => schema.validateSync(values))
+            .not.toThrow();
+    });
+
+    it('throws error if instrument ID is missing', () => {
+        values.instrumentId = '';
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('required');
+    });
+
+    it('throws error if card code field is missing', () => {
+        values.hostedForm.errors = { cardCodeVerification: 'required' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_cvv_required_error');
+    });
+
+    it('throws error if card code field is invalid', () => {
+        values.hostedForm.errors = { cardCodeVerification: 'invalid_card_code' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_cvv_invalid_error');
+    });
+
+    it('throws error if card number field is missing', () => {
+        values.hostedForm.errors = { cardNumberVerification: 'required' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_number_required_error');
+    });
+
+    it('throws error if card number field is invalid', () => {
+        values.hostedForm.errors = { cardNumberVerification: 'invalid_card_number' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_number_invalid_error');
+    });
+
+    it('throws error if card number field does not match with stored instrument', () => {
+        values.hostedForm.errors = { cardNumberVerification: 'mismatched_card_number' };
+
+        expect(() => schema.validateSync(values))
+            .toThrowError('payment.credit_card_number_mismatch_error');
+    });
+});

--- a/src/app/payment/storedInstrument/getHostedInstrumentValidationSchema.ts
+++ b/src/app/payment/storedInstrument/getHostedInstrumentValidationSchema.ts
@@ -1,0 +1,54 @@
+import { LanguageService } from '@bigcommerce/checkout-sdk';
+import { memoize } from '@bigcommerce/memoize';
+import { object, string, ObjectSchema } from 'yup';
+
+export interface HostedInstrumentValidationSchemaOptions {
+    language: LanguageService;
+}
+
+export interface HostedInstrumentValidationSchemaShape {
+    hostedForm: {
+        errors: {
+            cardCodeVerification: string;
+            cardNumberVerification: string;
+        };
+    };
+    instrumentId: string;
+}
+
+export default memoize(function getHostedInstrumentValidationSchema({
+    language,
+}: HostedInstrumentValidationSchemaOptions): ObjectSchema<HostedInstrumentValidationSchemaShape> {
+    return object({
+        instrumentId: string()
+            .required(),
+
+        hostedForm: object({
+            errors: object({
+                cardCodeVerification: string()
+                    .test({
+                        message: language.translate('payment.credit_card_cvv_required_error'),
+                        test: value => value !== 'required',
+                    })
+                    .test({
+                        message: language.translate('payment.credit_card_cvv_invalid_error'),
+                        test: value => value !== 'invalid_card_code',
+                    }),
+
+                cardNumberVerification: string()
+                    .test({
+                        message: language.translate('payment.credit_card_number_required_error'),
+                        test: value => value !== 'required',
+                    })
+                    .test({
+                        message: language.translate('payment.credit_card_number_invalid_error'),
+                        test: value => value !== 'invalid_card_number',
+                    })
+                    .test({
+                        message: language.translate('payment.credit_card_number_mismatch_error'),
+                        test: value => value !== 'mismatched_card_number',
+                    }),
+            }),
+        }),
+    });
+});

--- a/src/app/payment/storedInstrument/index.ts
+++ b/src/app/payment/storedInstrument/index.ts
@@ -4,11 +4,13 @@ export type CardInstrumentFieldsetValues = CardInstrumentFieldsetValues;
 
 export { default as isInstrumentFeatureAvailable } from './isInstrumentFeatureAvailable';
 export { default as getInstrumentValidationSchema } from './getInstrumentValidationSchema';
+export { default as getHostedInstrumentValidationSchema } from './getHostedInstrumentValidationSchema';
 export { default as isInstrumentCardCodeRequired } from './isInstrumentCardCodeRequired';
 export { default as isInstrumentCardNumberRequired } from './isInstrumentCardNumberRequired';
 export { default as isInstrumentCardNumberRequiredSelector } from './isInstrumentCardNumberRequiredSelector';
 export { default as AccountInstrumentFieldset } from './AccountInstrumentFieldset';
 export { default as CardInstrumentFieldset } from './CardInstrumentFieldset';
 export { default as CreditCardValidation } from './CreditCardValidation';
+export { default as HostedCreditCardValidation } from './HostedCreditCardValidation';
 export { default as isCardInstrument } from './isCardInstrument';
 export { default as isAccountInstrument } from './isAccountInstrument';

--- a/src/app/ui/form/TextInputIframeContainer.spec.tsx
+++ b/src/app/ui/form/TextInputIframeContainer.spec.tsx
@@ -1,0 +1,44 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import TextInputIframeContainer from './TextInputIframeContainer';
+
+describe('TextInputIframeContainer', () => {
+    it('renders container with default input CSS classes', () => {
+        const component = mount(<TextInputIframeContainer />);
+
+        expect(component.childAt(0).hasClass('form-input'))
+            .toBeTruthy();
+        expect(component.childAt(0).hasClass('optimizedCheckout-form-input'))
+            .toBeTruthy();
+    });
+
+    it('renders container with additional CSS classes', () => {
+        const component = mount(<TextInputIframeContainer additionalClassName="has-icon" />);
+
+        expect(component.childAt(0).hasClass('form-input'))
+            .toBeTruthy();
+        expect(component.childAt(0).hasClass('optimizedCheckout-form-input'))
+            .toBeTruthy();
+        expect(component.childAt(0).hasClass('has-icon'))
+            .toBeTruthy();
+    });
+
+    it('renders container with focus styles', () => {
+        const component = mount(<TextInputIframeContainer appearFocused />);
+
+        expect(component.childAt(0).hasClass('form-input--focus'))
+            .toBeTruthy();
+        expect(component.childAt(0).hasClass('optimizedCheckout-form-input--focus'))
+            .toBeTruthy();
+    });
+
+    it('does not render container with focus styles unless specified', () => {
+        const component = mount(<TextInputIframeContainer appearFocused={ false } />);
+
+        expect(component.childAt(0).hasClass('form-input--focus'))
+            .toBeFalsy();
+        expect(component.childAt(0).hasClass('optimizedCheckout-form-input--focus'))
+            .toBeFalsy();
+    });
+});

--- a/src/app/ui/form/TextInputIframeContainer.tsx
+++ b/src/app/ui/form/TextInputIframeContainer.tsx
@@ -1,0 +1,29 @@
+import classNames from 'classnames';
+import React, { FunctionComponent, HTMLAttributes } from 'react';
+
+export interface TextInputIframeContainerProps extends HTMLAttributes<HTMLDivElement> {
+    additionalClassName?: string;
+    appearFocused?: boolean;
+    testId?: string;
+}
+
+const TextInputIframeContainer: FunctionComponent<TextInputIframeContainerProps> = ({
+    additionalClassName,
+    appearFocused,
+    testId,
+    ...props
+}) => (
+    <div
+        { ...props }
+        className={ classNames(
+            'form-input',
+            'optimizedCheckout-form-input',
+            { 'form-input--focus': appearFocused },
+            { 'optimizedCheckout-form-input--focus': appearFocused },
+            additionalClassName
+        ) }
+        data-test={ testId }
+    />
+);
+
+export default TextInputIframeContainer;

--- a/src/app/ui/form/index.ts
+++ b/src/app/ui/form/index.ts
@@ -43,6 +43,7 @@ export { default as FormFieldContainer } from './FormFieldContainer';
 export { default as Input } from './Input';
 export { default as TextArea } from './TextArea';
 export { default as TextInput } from './TextInput';
+export { default as TextInputIframeContainer } from './TextInputIframeContainer';
 export { default as RadioInput } from './RadioInput';
 export { default as CheckboxInput } from './CheckboxInput';
 export { default as Label } from './Label';


### PR DESCRIPTION
## What?
Use hosted form fields for credit card payment.

## Why?
To pull in the changes proposed in this PR: https://github.com/bigcommerce/checkout-sdk-js/pull/761

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments 
