### PR TITLE
feat(payment): INT-2181 Use Adyen Custom Card Components for TSV and vaulting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,9 +886,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.46.1.tgz",
-      "integrity": "sha512-PGxYtWccge5860rBy8A5AjoyPL5Ncm76CiNeJdCvVINzbPa9tZx9f9m8tTdbkQ2Sv+TbFbwMIy+Qb8GVaUu0jg==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.47.0.tgz",
+      "integrity": "sha512-uLdywcS80QGPuSFE+1Cd65S1VdsHu26NJu0858sYlEvINccgM1Il+dh/Km4tAuUCN/ieh6gmDic8FSlr0ldNww==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.2.0",
@@ -927,9 +927,9 @@
           "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
         },
         "rxjs": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-          "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+          "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
           "requires": {
             "tslib": "^1.9.0"
           }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.46.1",
+    "@bigcommerce/checkout-sdk": "^1.47.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/paymentMethod/AdyenV2CardValidation.spec.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2CardValidation.spec.tsx
@@ -1,0 +1,30 @@
+import { mount } from 'enzyme';
+import React, { FunctionComponent } from 'react';
+
+import AdyenV2CardValidation, { AdyenV2CardValidationProps } from './AdyenV2CardValidation';
+
+describe('AdyenV2CardValidation', () => {
+    let defaultProps: AdyenV2CardValidationProps;
+    let AdyenV2CardValidationTest: FunctionComponent<AdyenV2CardValidationProps>;
+
+    beforeEach(() => {
+        defaultProps = {
+            verificationFieldsContainerId: 'container',
+            shouldShowNumberField: true,
+        };
+
+        AdyenV2CardValidationTest = props => (
+            <AdyenV2CardValidation { ...props } />
+        );
+    });
+
+    it('renders Adyen V2 secured fields', () => {
+        const container = mount(<AdyenV2CardValidationTest { ...defaultProps } />);
+
+        expect(container.props())
+            .toEqual(expect.objectContaining({
+                verificationFieldsContainerId: 'container',
+                shouldShowNumberField: true,
+            }));
+    });
+});

--- a/src/app/payment/paymentMethod/AdyenV2CardValidation.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2CardValidation.tsx
@@ -1,0 +1,51 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import { TranslatedString } from '../../locale';
+
+export interface AdyenV2CardValidationProps {
+    verificationFieldsContainerId?: string;
+    shouldShowNumberField: boolean;
+}
+
+const AdyenV2CardValidation: React.FunctionComponent<AdyenV2CardValidationProps> = ({
+    verificationFieldsContainerId,
+    shouldShowNumberField,
+}) => (
+    <div>
+        { shouldShowNumberField && <p>
+            <strong>
+                <TranslatedString id="payment.instrument_trusted_shipping_address_title_text" />
+            </strong>
+
+            <br />
+
+            <TranslatedString id="payment.instrument_trusted_shipping_address_text" />
+        </p> }
+
+        <div className="form-ccFields" id={ verificationFieldsContainerId }>
+            { <div className="form-field form-field--ccNumber" style={ { display: (shouldShowNumberField) ? undefined : 'none' } }>
+                <label htmlFor="encryptedCardNumber">
+                    <TranslatedString id="payment.credit_card_number_label" />
+                </label>
+                <div className="form-input optimizedCheckout-form-input has-icon" data-cse="encryptedCardNumber" id="encryptedCardNumber" />
+            </div> }
+            <div className="form-field form-ccFields-field--ccCvv">
+                <label htmlFor="encryptedSecurityCode">
+                    <TranslatedString id="payment.credit_card_cvv_label" />
+                </label>
+                <div
+                    className={ classNames(
+                        'form-input',
+                        'optimizedCheckout-form-input',
+                        'has-icon'
+                    ) }
+                    data-cse="encryptedSecurityCode"
+                    id="encryptedSecurityCode"
+                />
+            </div>
+        </div>
+    </div>
+);
+
+export default AdyenV2CardValidation;

--- a/src/app/payment/paymentMethod/AdyenV2PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2PaymentMethod.spec.tsx
@@ -84,6 +84,7 @@ describe('when using Adyen V2 payment', () => {
         expect(checkoutService.initializePayment)
             .toHaveBeenCalledWith(expect.objectContaining({
                 adyenv2: {
+                    cardVerificationContainerId: undefined,
                     containerId: 'scheme-adyen-component-field',
                     options: {
                         hasHolderName: true,

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -265,16 +265,6 @@ describe('HostedWidgetPaymentMethod', () => {
                 .toHaveLength(1);
         });
 
-        it('does not show instruments fieldset when there are no stored instruments', () => {
-            jest.spyOn(checkoutState.data, 'getInstruments')
-                .mockReturnValue([]);
-
-            const component = mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
-
-            expect(component.find(storedInstrumentModule.CardInstrumentFieldset))
-                .toHaveLength(0);
-        });
-
         it('uses PaymentMethod to retrieve instruments', () => {
             mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
 

--- a/src/app/payment/storedInstrument/CardInstrumentFieldset.spec.tsx
+++ b/src/app/payment/storedInstrument/CardInstrumentFieldset.spec.tsx
@@ -87,6 +87,6 @@ describe('CardInstrumentFieldset', () => {
         );
 
         expect(component.find(ValidateInstrument).length)
-            .toEqual(0);
+            .toEqual(1);
     });
 });

--- a/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
+++ b/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
@@ -75,7 +75,9 @@ const CardInstrumentFieldset: FunctionComponent<CardInstrumentFieldsetProps> = (
             render={ renderInput }
         />
 
-        { selectedInstrumentId && validateInstrument }
+        <div style={ {display: selectedInstrumentId ? undefined : 'none'} }>
+            { validateInstrument }
+        </div>
     </Fieldset>;
 };
 


### PR DESCRIPTION
## What?
Replace default fields in Trusted Shipping Address verification and vaulting (CVV / CVC) with Adyen Custom Card Components so we can ensure encrypted communication.

## Why?
Adyen is requiring to send TSV data as a secure field, using theirs library (JS) and mount the secured fields.

## Testing / Proof
![image](https://user-images.githubusercontent.com/8570490/71600487-c7d22600-2b14-11ea-8306-61d607163bd0.png)

## Dependencies
[SDK](https://github.com/bigcommerce/checkout-sdk-js/pull/766)

@bigcommerce/checkout @bigcommerce/intersys-integrations 
