### PR TITLE
CHECKOUT-4421 Reset billing address when selecting new address

### DIFF
--- a/src/app/billing/BillingForm.tsx
+++ b/src/app/billing/BillingForm.tsx
@@ -120,8 +120,34 @@ class BillingForm extends PureComponent<BillingFormProps & WithLanguageProps & F
         }
     };
 
-    private handleUseNewAddress: () => void = () => {
-        this.handleSelectAddress({});
+    private handleUseNewAddress: () => void = async () => {
+        const {
+            updateAddress,
+            onUnhandledError,
+            setValues,
+            customerMessage,
+            getFields,
+        } = this.props;
+
+        this.setState({ isResettingAddress: true });
+
+        try {
+            const { data: { getBillingAddress } } = await updateAddress({});
+
+            const billingAddress = getBillingAddress();
+
+            setValues({
+                ...mapAddressToFormValues(
+                    getFields(billingAddress && billingAddress.countryCode),
+                    billingAddress
+                ),
+                orderComment: customerMessage,
+            });
+        } catch (e) {
+            onUnhandledError(e);
+        } finally {
+            this.setState({ isResettingAddress: false });
+        }
     };
 }
 


### PR DESCRIPTION
## What?
When selecting "enter new address", send a request to API so it erases the address in the server. 

## Why?
This way, the SDK will pre-select the geoip country.

## Testing / Proof
![billing-after](https://user-images.githubusercontent.com/1621894/70592637-9f9a8a00-1c2e-11ea-8978-8b7fbd57e230.gif)

@bigcommerce/checkout
