### PR TITLE
CHECKOUT-4421: Make customer and billing address objects not mandatory for customer component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,9 +886,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.46.0.tgz",
-      "integrity": "sha512-dI7GcuDX6jz5a2Jol2aqyV6hyyxnTL2kgW3fojd+aujpUpQGpj8faVJIo2TUt6WrKySd4SSpohC4J/VhSagBUw==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.46.1.tgz",
+      "integrity": "sha512-PGxYtWccge5860rBy8A5AjoyPL5Ncm76CiNeJdCvVINzbPa9tZx9f9m8tTdbkQ2Sv+TbFbwMIy+Qb8GVaUu0jg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.46.0",
+    "@bigcommerce/checkout-sdk": "^1.46.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -71,6 +71,30 @@ describe('Customer', () => {
                 .toEqual(true);
         });
 
+        it('renders guest form if billing address is undefined', () => {
+            jest.spyOn(checkoutService.getState().data, 'getBillingAddress')
+                .mockReturnValue(undefined);
+
+            const component = mount(
+                <CustomerTest viewType={ CustomerViewType.Guest } />
+            );
+
+            expect(component.find(GuestForm).exists())
+                .toEqual(true);
+        });
+
+        it('renders guest form if customer is undefined', () => {
+            jest.spyOn(checkoutService.getState().data, 'getCustomer')
+                .mockReturnValue(undefined);
+
+            const component = mount(
+                <CustomerTest viewType={ CustomerViewType.Guest } />
+            );
+
+            expect(component.find(GuestForm).exists())
+                .toEqual(true);
+        });
+
         it('passes data to guest form', () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Guest } />

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -201,7 +201,7 @@ export function mapToWithCheckoutCustomerProps(
     const customer = getCustomer();
     const config = getConfig();
 
-    if (!billingAddress || !checkout || !customer || !config) {
+    if (!checkout || !config) {
         return null;
     }
 
@@ -213,8 +213,8 @@ export function mapToWithCheckoutCustomerProps(
         createAccountUrl: config.links.createAccountLink,
         defaultShouldSubscribe: config.shopperConfig.defaultNewsletterSignup,
         deinitializeCustomer: checkoutService.deinitializeCustomer,
-        email: billingAddress.email || customer.email,
-        firstName: customer.firstName,
+        email: (billingAddress && billingAddress.email) || (customer && customer.email),
+        firstName: customer && customer.firstName,
         forgotPasswordUrl: config.links.forgotPasswordLink,
         initializeCustomer: checkoutService.initializeCustomer,
         isContinuingAsGuest: isContinuingAsGuest(),


### PR DESCRIPTION
## What?
Make `customer` and `billingAddress` objects not mandatory for the customer component.

## Why?
Both `email` and `firstName` props are optional. So the `Customer` component doesn't really need the depended objects to be present in order to render itself.

## Testing / Proof
Unit

@bigcommerce/checkout
