### PR TITLE
CHECKOUT-4606 Set right timezone in custom date field

### DIFF
--- a/src/app/address/mapAddressFromFormValues.ts
+++ b/src/app/address/mapAddressFromFormValues.ts
@@ -7,12 +7,25 @@ export default function mapAddressFromFormValues(formValues: AddressFormValues):
     const { customFields: customFieldsObject, ...address } = formValues;
     const customFields: Array<{fieldId: string; fieldValue: string}> = [];
 
-    forIn(customFieldsObject, (value, key) =>
+    forIn(customFieldsObject, (value, key) => {
+        let fieldValue: string;
+
+        if (isDate(value)) {
+            const dateValue = new Date(value);
+            // We want the field value to match the exact date that the user entered.
+            // However, when we call toISOString, it will converted to UTC and the user timezone could affect the
+            // UTC representation by ±1 day. To avoid this, subtract the time offset from the date.
+            dateValue.setMinutes(dateValue.getMinutes() - dateValue.getTimezoneOffset());
+            fieldValue = dateValue.toISOString().slice(0, 10);
+        } else {
+            fieldValue = value;
+        }
+
         customFields.push({
             fieldId: key,
-            fieldValue: isDate(value) ? value.toISOString().slice(0, 10) : value,
-        })
-    );
+            fieldValue,
+        });
+    });
 
     return {
         ...address,


### PR DESCRIPTION
## What?
When converting custom date fields to address values, take into account the time offset (timezone).

## Why?
We want the field value to match the exact date that the user entered. However, when we call toISOString, it will converted to UTC and the user timezone could affect the UTC representation by ±1 day. To avoid this, subtract the time offset from the date.

## Testing / Proof
BEFORE
UI date value and API request payload DOES NOT match
<img width="1205" alt="Screen Shot 2019-12-30 at 3 23 25 pm" src="https://user-images.githubusercontent.com/1621894/71568254-f8688e80-2b19-11ea-936b-095487aa633c.png">

AFTER
UI date value and API request payload DOES match
<img width="1104" alt="Screen Shot 2019-12-30 at 3 27 16 pm" src="https://user-images.githubusercontent.com/1621894/71568260-00283300-2b1a-11ea-976d-a2689080bebf.png">


@bigcommerce/checkout
