### PR TITLE
CHECKOUT-4606 Use padStart to construct date value

### DIFF
--- a/src/app/address/mapAddressFromFormValues.spec.ts
+++ b/src/app/address/mapAddressFromFormValues.spec.ts
@@ -1,0 +1,36 @@
+import { omit } from 'lodash';
+
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+
+import mapAddressFromFormValues from './mapAddressFromFormValues';
+import { AddressFormValues } from './mapAddressToFormValues';
+
+describe('mapAddressFromFormValues', () => {
+    it('converts address form values to address object', () => {
+        const formValues: AddressFormValues = {
+            ...omit(getShippingAddress(), 'customFields'),
+            customFields: {},
+        };
+
+        expect(mapAddressFromFormValues(formValues)).toMatchObject(getShippingAddress());
+    });
+
+    it('converts formats date values to YYYY-MM-DD format', () => {
+        const formValues: AddressFormValues = {
+            ...omit(getShippingAddress(), 'customFields'),
+            customFields: {
+                id1: new Date('18 Dec 2019'),
+            },
+        };
+
+        expect(mapAddressFromFormValues(formValues)).toMatchObject({
+            ...getShippingAddress(),
+            customFields: [
+                {
+                    fieldId: 'id1',
+                    fieldValue: '2019-12-18',
+                },
+            ],
+        });
+    });
+});

--- a/src/app/address/mapAddressFromFormValues.ts
+++ b/src/app/address/mapAddressFromFormValues.ts
@@ -1,5 +1,5 @@
 import { Address } from '@bigcommerce/checkout-sdk';
-import { forIn, isDate } from 'lodash';
+import { forIn, isDate, padStart } from 'lodash';
 
 import { AddressFormValues } from './mapAddressToFormValues';
 
@@ -11,12 +11,9 @@ export default function mapAddressFromFormValues(formValues: AddressFormValues):
         let fieldValue: string;
 
         if (isDate(value)) {
-            const dateValue = new Date(value);
-            // We want the field value to match the exact date that the user entered.
-            // However, when we call toISOString, it will converted to UTC and the user timezone could affect the
-            // UTC representation by ±1 day. To avoid this, subtract the time offset from the date.
-            dateValue.setMinutes(dateValue.getMinutes() - dateValue.getTimezoneOffset());
-            fieldValue = dateValue.toISOString().slice(0, 10);
+            const padMonth = padStart((value.getMonth() + 1).toString(), 2, '0');
+            const padDay = padStart((value.getDate()).toString(), 2, '0');
+            fieldValue = `${value.getFullYear()}-${padMonth}-${padDay}`;
         } else {
             fieldValue = value;
         }


### PR DESCRIPTION
## What?
Refactor and use padStart instead of toISOString()

## Why?
Because the previous solution was not ideal. This one presents a more clear solution.

## Testing / Proof
manual

@bigcommerce/checkout
