### PR TITLE
fix(payment): INT-2181 Add validation to handle initializePayment when Instrument got available

### DIFF
--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -80,13 +80,27 @@ class HostedWidgetPaymentMethod extends Component<
         }
     }
 
-    async componentDidUpdate(): Promise<void> {
-        const { onUnhandledError = noop } = this.props;
+    async componentDidUpdate(_prevProps: Readonly<HostedWidgetPaymentMethodProps>, prevState: Readonly<HostedWidgetPaymentMethodState>): Promise<void> {
+        const {
+            deinitializePayment = noop,
+            method,
+            onUnhandledError = noop,
+        } = this.props;
 
-        try {
-            await this.initializeMethod();
-        } catch (error) {
-            onUnhandledError(error);
+        const {
+            selectedInstrumentId,
+        } = this.state;
+
+        if (selectedInstrumentId !== prevState.selectedInstrumentId) {
+            try {
+                await deinitializePayment({
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                });
+                await this.initializeMethod();
+            } catch (error) {
+                onUnhandledError(error);
+            }
         }
     }
 


### PR DESCRIPTION
## What?
Replace default fields in Trusted Shipping Address verification and vaulting (CVV / CVC) with Adyen Custom Card Components so we can ensure encrypted communication.

## Why?
Adyen is requiring to send TSV data as a secure field, using theirs library (JS) and mount the secured fields.

## Testing / Proof
No tests affected

@bigcommerce/checkout @bigcommerce/intersys-integrations  
