### PR TITLE
CHECKOUT-4431 Create common stylesheet for react components

### DIFF
--- a/src/app/address/googleAutocomplete/GoogleAutocomplete.scss
+++ b/src/app/address/googleAutocomplete/GoogleAutocomplete.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import '../../ui/Base';
 
 $googleLogoHeight: 18px;
 

--- a/src/app/common/error/ErrorCode.scss
+++ b/src/app/common/error/ErrorCode.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import '../../ui/Base';
 
 .errorCode {
     font-size: fontSize("tiny");

--- a/src/app/shipping/StaticConsignment.scss
+++ b/src/app/shipping/StaticConsignment.scss
@@ -1,4 +1,4 @@
-@import '../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import '../ui/Base';
 
 .staticConsignmentContainer {
     ul {

--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -1,5 +1,4 @@
-@import '../../../../node_modules/@bigcommerce/citadel/src/tools/toolkit';
-@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import '../../ui/Base';
 
 // Static Shipping Option
 // ---------------------------------------------------

--- a/src/app/ui/Base.scss
+++ b/src/app/ui/Base.scss
@@ -1,0 +1,4 @@
+@import '../../../node_modules/@bigcommerce/citadel/src/tools/toolkit';
+@import '../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+
+$global-radius: 4px;

--- a/src/app/ui/loading/LazyContainer.scss
+++ b/src/app/ui/loading/LazyContainer.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import '../Base';
 
 .lazyContainer-error {
     padding: spacing("double");

--- a/src/app/ui/popover/Popover.scss
+++ b/src/app/ui/popover/Popover.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import '../Base';
 
 .popover {
     background: container("fill");

--- a/src/app/ui/popover/PopoverList.scss
+++ b/src/app/ui/popover/PopoverList.scss
@@ -1,4 +1,4 @@
-@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import '../Base';
 
 .popoverList {
     list-style: none;


### PR DESCRIPTION
## What?
Create a base stylesheet for react components.

## Why?
Because eventually we would like to remove references to citadel. This base stylesheet will later be refactored to include the basic mixins like spacing and font.

## Testing / Proof
manual

@bigcommerce/checkout
