### PR TITLE
CHECKOUT-3460 Improve terms readability

### DIFF
--- a/src/app/termsConditions/TermsConditionsField.tsx
+++ b/src/app/termsConditions/TermsConditionsField.tsx
@@ -1,10 +1,9 @@
-import { FieldProps } from 'formik';
-import React, { memo, useCallback, FunctionComponent } from 'react';
+import React, { memo, useCallback, Fragment, FunctionComponent } from 'react';
 
 import { preventDefault } from '../common/dom';
 import { withLanguage, TranslatedHtml, WithLanguageProps } from '../locale';
 import { Button, ButtonSize } from '../ui/button';
-import { CheckboxFormField, FormField, TextArea } from '../ui/form';
+import { CheckboxFormField, FormField } from '../ui/form';
 import { Modal, ModalHeader, ModalTrigger, ModalTriggerModalProps } from '../ui/modal';
 
 export enum TermsConditionsType {
@@ -36,13 +35,15 @@ const TermsConditionsModalLink: FunctionComponent<TermsConditionsTextFieldProps 
     name,
     terms,
 }) => {
-    const renderInput = useCallback(({ field }: FieldProps) => (
-        <TextArea
-            defaultValue={ terms }
-            name={ field.name }
-            readOnly
-            rows={ 5 }
-        />
+    const renderInput = useCallback(() => (
+        <div>
+            { terms.split('\n').map((item, key) =>
+                <Fragment key={ key }>
+                    { item }
+                    <br />
+                </Fragment>
+            ) }
+        </div>
     ), [terms]);
 
     const renderModal = useCallback((props: ModalTriggerModalProps) => (


### PR DESCRIPTION
## What?
Render terms and conditions as regular text instead of textarea.

## Why?
So they are easier to read/scroll. Specially on mobile.

## Testing / Proof
before
![image](https://user-images.githubusercontent.com/1621894/72393566-57b7d700-3787-11ea-95c6-f8b7257190b6.png)

after
<img width="770" alt="Screen Shot 2020-01-15 at 2 19 35 pm" src="https://user-images.githubusercontent.com/1621894/72402078-17b21d80-37a2-11ea-93c9-b3f3a8839995.png">

@bigcommerce/checkout
