### PR TITLE
fix(payment): PAYMENTS-4997 Bump checkout-sdk to v1.47.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -730,9 +730,9 @@
       }
     },
     "@babel/polyfill": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
-      "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.3.tgz",
+      "integrity": "sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -893,9 +893,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.47.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.47.3.tgz",
-      "integrity": "sha512-QznUIEgj4uadRsuRoY2wUXXlwmi07cDIplPH6aJQhRO8V72MYir2g0DBV0eZ2k77nQAc7K6eSwbREyn2X+z/Ow==",
+      "version": "1.47.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.47.4.tgz",
+      "integrity": "sha512-cqufUTEMzZmXEroJw1K235HVEJ+WKeOWSJm34M4/tzkhago8WECSc8ZgHh5TTVmZLGHsL9CldJMvzxwQ0OBLuQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.47.3",
+    "@bigcommerce/checkout-sdk": "^1.47.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.47.4

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
