### PR TITLE
CHECKOUT-4645 Render terms and conditions as textarea

### DIFF
--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -1,9 +1,8 @@
-import { CheckoutSelectors, CheckoutSettings, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, GuestCredentials } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, GuestCredentials } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React, { Component, Fragment, ReactNode } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../checkout';
-import { TermsConditionsType } from '../termsConditions';
 
 import CheckoutButtonList from './CheckoutButtonList';
 import CustomerViewType from './CustomerViewType';
@@ -34,10 +33,7 @@ interface WithCheckoutCustomerProps {
     isContinuingAsGuest: boolean;
     isGuestEnabled: boolean;
     isSigningIn: boolean;
-    isTermsConditionsRequired: boolean;
     signInError?: Error;
-    termsConditionsText?: string;
-    termsConditionsUrl?: string;
     clearError(error: Error): Promise<CheckoutSelectors>;
     continueAsGuest(credentials: GuestCredentials): Promise<CheckoutSelectors>;
     deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
@@ -75,10 +71,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps> {
             email,
             initializeCustomer,
             isContinuingAsGuest = false,
-            isTermsConditionsRequired,
             onUnhandledError = noop,
-            termsConditionsUrl,
-            termsConditionsText,
         } = this.props;
 
         return (
@@ -96,12 +89,9 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps> {
                 defaultShouldSubscribe={ defaultShouldSubscribe }
                 email={ this.draftEmail || email }
                 isContinuingAsGuest={ isContinuingAsGuest }
-                isTermsConditionsRequired={ isTermsConditionsRequired }
                 onChangeEmail={ this.handleChangeEmail }
                 onContinueAsGuest={ this.handleContinueAsGuest }
                 onShowLogin={ this.handleShowLogin }
-                termsConditionsText={ termsConditionsText }
-                termsConditionsUrl={ termsConditionsUrl }
             />
         );
     }
@@ -215,16 +205,6 @@ export function mapToWithCheckoutCustomerProps(
         return null;
     }
 
-    const {
-        enableTermsAndConditions: isTermsConditionsEnabled,
-        orderTermsAndConditionsType: termsConditionsType,
-        orderTermsAndConditionsLocation: termsAndConditionsLocation,
-        orderTermsAndConditions: termsCondtitionsText,
-        orderTermsAndConditionsLink: termsCondtitionsUrl,
-    } = config.checkoutSettings as CheckoutSettings & { orderTermsAndConditionsLocation: string };
-
-    const isTermsConditionsRequired = isTermsConditionsEnabled && termsAndConditionsLocation === 'customer';
-
     return {
         canSubscribe: config.shopperConfig.showNewsletterSignup,
         checkoutButtonIds: config.checkoutSettings.remoteCheckoutProviders,
@@ -239,16 +219,9 @@ export function mapToWithCheckoutCustomerProps(
         initializeCustomer: checkoutService.initializeCustomer,
         isContinuingAsGuest: isContinuingAsGuest(),
         isGuestEnabled: config.checkoutSettings.guestCheckoutEnabled,
-        isTermsConditionsRequired,
         isSigningIn: isSigningIn(),
         signIn: checkoutService.signInCustomer,
         signInError: getSignInError(),
-        termsConditionsText: isTermsConditionsRequired && termsConditionsType === TermsConditionsType.TextArea ?
-            termsCondtitionsText :
-            undefined,
-        termsConditionsUrl: isTermsConditionsRequired && termsConditionsType === TermsConditionsType.Link ?
-            termsCondtitionsUrl :
-            undefined,
     };
 }
 

--- a/src/app/customer/GuestForm.spec.tsx
+++ b/src/app/customer/GuestForm.spec.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { getStoreConfig } from '../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
-import { TermsConditions } from '../termsConditions';
 
 import GuestForm, { GuestFormProps } from './GuestForm';
 
@@ -19,7 +18,6 @@ describe('GuestForm', () => {
             onChangeEmail: jest.fn(),
             onContinueAsGuest: jest.fn(),
             onShowLogin: jest.fn(),
-            isTermsConditionsRequired: false,
         };
 
         localeContext = createLocaleContext(getStoreConfig());
@@ -220,47 +218,5 @@ describe('GuestForm', () => {
 
         expect(componentB.find('input[name="shouldSubscribe"]').prop('value'))
             .toEqual(false);
-    });
-
-    it('renders terms and conditions field', () => {
-        const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <GuestForm
-                    { ...defaultProps }
-                    isTermsConditionsRequired={ true }
-                />
-            </LocaleContext.Provider>
-        );
-
-        expect(component.find(TermsConditions)).toHaveLength(1);
-    });
-
-    it('displays error message if newsletter is required and not checked', async () => {
-        const handleContinueAsGuest = jest.fn();
-        const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <GuestForm
-                    { ...defaultProps }
-                    isTermsConditionsRequired={ true }
-                    onContinueAsGuest={ handleContinueAsGuest }
-                />
-            </LocaleContext.Provider>
-        );
-
-        component.find('input[name="email"]')
-            .simulate('change', { target: { value: 'test@test.com', name: 'email' } });
-
-        component.find('form')
-            .simulate('submit');
-
-        await new Promise(resolve => process.nextTick(resolve));
-
-        component.update();
-
-        expect(handleContinueAsGuest)
-            .not.toHaveBeenCalled();
-
-        expect(component.find('[data-test="terms-field-error-message"]').text())
-            .toEqual('Please agree to the terms and conditions');
     });
 });

--- a/src/app/customer/GuestForm.tsx
+++ b/src/app/customer/GuestForm.tsx
@@ -3,7 +3,6 @@ import React, { memo, FunctionComponent, ReactNode } from 'react';
 import { object, string } from 'yup';
 
 import { withLanguage, TranslatedHtml, TranslatedString, WithLanguageProps } from '../locale';
-import { getTermsConditionsValidationSchema, TermsConditions } from '../termsConditions';
 import { Button, ButtonVariant } from '../ui/button';
 import { BasicFormField, Fieldset, Form, Legend  } from '../ui/form';
 
@@ -16,9 +15,6 @@ export interface GuestFormProps {
     defaultShouldSubscribe: boolean;
     email?: string;
     isContinuingAsGuest: boolean;
-    isTermsConditionsRequired: boolean;
-    termsConditionsText?: string;
-    termsConditionsUrl?: string;
     onChangeEmail(email: string): void;
     onContinueAsGuest(data: GuestFormValues): void;
     onShowLogin(): void;
@@ -27,7 +23,6 @@ export interface GuestFormProps {
 export interface GuestFormValues {
     email: string;
     shouldSubscribe: boolean;
-    terms?: boolean;
 }
 
 const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikProps<GuestFormValues>> = ({
@@ -36,9 +31,6 @@ const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikPr
     isContinuingAsGuest,
     onChangeEmail,
     onShowLogin,
-    isTermsConditionsRequired,
-    termsConditionsText,
-    termsConditionsUrl,
 }) => (
     <Form
         className="checkout-form"
@@ -63,10 +55,6 @@ const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikPr
                     { canSubscribe && <BasicFormField
                         component={ SubscribeField }
                         name="shouldSubscribe"
-                    /> }
-                    { isTermsConditionsRequired && <TermsConditions
-                        termsConditionsText={ termsConditionsText }
-                        termsConditionsUrl={ termsConditionsUrl }
                     /> }
                 </div>
 
@@ -113,16 +101,12 @@ export default withLanguage(withFormik<GuestFormProps & WithLanguageProps, Guest
     handleSubmit: (values, { props: { onContinueAsGuest } }) => {
         onContinueAsGuest(values);
     },
-    validationSchema: ({ language, isTermsConditionsRequired }: GuestFormProps & WithLanguageProps) => {
+    validationSchema: ({ language }: GuestFormProps & WithLanguageProps) => {
         const email = string()
             .email(language.translate('customer.email_invalid_error'))
             .max(256)
             .required(language.translate('customer.email_required_error'));
 
-        return object({ email })
-            .concat(getTermsConditionsValidationSchema({
-                isTermsConditionsRequired,
-                language,
-            }));
+        return object({ email });
     },
 })(memo(GuestForm)));

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -418,16 +418,11 @@ export function mapToPaymentProps({
     const {
         enableTermsAndConditions: isTermsConditionsEnabled,
         orderTermsAndConditionsType: termsConditionsType,
-        orderTermsAndConditionsLocation: termsAndConditionsLocation,
         orderTermsAndConditions: termsCondtitionsText,
         orderTermsAndConditionsLink: termsCondtitionsUrl,
     } = config.checkoutSettings as CheckoutSettings & { orderTermsAndConditionsLocation: string };
 
-    const termsAndConditionsAtPayment = termsAndConditionsLocation === 'payment' ||
-        (termsAndConditionsLocation === 'customer' && !customer.isGuest);
-
-    const isTermsConditionsRequired = isTermsConditionsEnabled && termsAndConditionsAtPayment;
-
+    const isTermsConditionsRequired = isTermsConditionsEnabled;
     const selectedPayment = find(checkout.payments, { providerType: PaymentMethodProviderType.Hosted });
     const selectedPaymentMethod = selectedPayment ? getPaymentMethod(selectedPayment.providerId, selectedPayment.gatewayId) : undefined;
     const filteredMethods = selectedPaymentMethod ? compact([selectedPaymentMethod]) : methods;

--- a/src/app/termsConditions/TermsConditionsField.spec.tsx
+++ b/src/app/termsConditions/TermsConditionsField.spec.tsx
@@ -17,6 +17,26 @@ describe('TermsConditionsField', () => {
         localeContext = createLocaleContext(getStoreConfig());
     });
 
+    it('renders terms and conditions checkbox with link if type is "modal"', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <TermsConditionsField
+                        name="terms"
+                        terms="Hello world"
+                        type={ TermsConditionsType.Modal }
+                    />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find('label[htmlFor="terms"]').text())
+            .toEqual('Yes, I agree with the terms and conditions.');
+    });
+
     it('renders terms and conditions checkbox with link if type is "text"', () => {
         const component = mount(
             <LocaleContext.Provider value={ localeContext }>
@@ -34,7 +54,10 @@ describe('TermsConditionsField', () => {
         );
 
         expect(component.find('label[htmlFor="terms"]').text())
-            .toEqual('Yes, I agree with the terms and conditions.');
+            .toEqual('Yes, I agree with the above terms and conditions.');
+
+        expect(component.find('textarea').length)
+            .toBeGreaterThan(0);
     });
 
     it('renders terms and conditions checkbox with link if type is "url"', () => {


### PR DESCRIPTION
## What?
- Remove ability to render terms in checkout step (no longer required)
- Render terms as textarea

## Why?
Despite the worst UX, some merchants have some mechanisms in place to force users to scroll through the textarea in order to proceed.

## Testing / Proof
unit
manual
BEFORE
<img width="651" alt="Screen Shot 2020-01-23 at 3 35 38 pm" src="https://user-images.githubusercontent.com/1621894/72957196-d3083100-3df6-11ea-89e4-85619f28de92.png">

AFTER
<img width="617" alt="Screen Shot 2020-01-23 at 3 40 22 pm" src="https://user-images.githubusercontent.com/1621894/72957199-d3a0c780-3df6-11ea-8897-3edfe3d7613a.png">


@bigcommerce/checkout
