### PR TITLE
CHECKOUT-4632: CSS styling change for gift certificate icon

### DIFF
--- a/src/scss/components/checkout/cartDrawer/_cartDrawer.scss
+++ b/src/scss/components/checkout/cartDrawer/_cartDrawer.scss
@@ -76,9 +76,14 @@
 }
 
 .cartDrawer-imageWrapper {
+    display: flex;
     height: 100%;
     overflow: hidden;
     width: 100%;
+}
+
+.cartDrawer-imageWrapper svg {
+    margin: auto;
 }
 
 .productImage-giftCertificate {


### PR DESCRIPTION
## What?
Align Gift certificate icon on checkout drawer in the centre of the box. 

## Testing / Proof
Manual 

Before
<img width="899" alt="Screen Shot 2020-01-16 at 12 48 56 AM" src="https://user-images.githubusercontent.com/55068632/73328028-579df800-42ac-11ea-8da2-7593be4aced1.png">


After
<img width="1647" alt="Screen Shot 2020-01-29 at 3 27 39 pm" src="https://user-images.githubusercontent.com/55068632/73327995-34734880-42ac-11ea-95b7-ed136777dc89.png">


@bigcommerce/checkout
