### PR TITLE
fix(shipping): CHECKOUT-4664 Fix expensive shipping quote overflow from shipping option container

### DIFF
--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -21,8 +21,6 @@
 
 .shippingOption-price {
     font-weight: fontWeight("bold");
-    max-width: none;
-    min-width: 0;
     padding-left: spacing("half");
 }
 
@@ -41,19 +39,17 @@
         min-height: remCalc(35px);
     }
 
-    .shippingOption-price {
-        max-width: remCalc(55px);
-        min-width: remCalc(55px);
-        text-align: right;
-    }
-
     .shippingOption-figure,
     .shippingOption-desc,
     .shippingOption-price {
-        flex: 1;
         font-size: inherit;
         line-height: lineHeight("base");
         vertical-align: middle;
+    }
+
+    .shippingOption-figure,
+    .shippingOption-desc {
+        flex: 1;
     }
 
     .shippingOption-figure {


### PR DESCRIPTION
## What?
As per above.

## Why?
By setting the max and min width, it makes the shipping quote to overflow 

## Testing / Proof
Manual testing

Before:
<img width="665" alt="Screen Shot 2020-02-06 at 2 01 12 pm" src="https://user-images.githubusercontent.com/22089936/73902399-db2d9980-48e9-11ea-904f-db8f5f4e1f74.png">


After:
<img width="625" alt="Screen Shot 2020-02-06 at 2 00 20 pm" src="https://user-images.githubusercontent.com/22089936/73902377-c7823300-48e9-11ea-9f5c-23cadd068a17.png">

<img width="594" alt="Screen Shot 2020-02-06 at 2 36 20 pm" src="https://user-images.githubusercontent.com/22089936/73903832-2ea1e680-48ee-11ea-99d9-74aa7d3773e1.png">
<img width="518" alt="Screen Shot 2020-02-06 at 2 36 53 pm" src="https://user-images.githubusercontent.com/22089936/73903835-2fd31380-48ee-11ea-9611-40d28327c35a.png">



@bigcommerce/checkout
