### PR TITLE
CHECKOUT-4640 Allow guest shopper to provide marketing email consent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.52.1.tgz",
-      "integrity": "sha512-IvsYb+7VvfB110sWgjh98+c/8PrBWXeb1QGtTpRU0PRrjsTzekLjobTO4fN/BKvEbyyHOs8XbrEFt3K7uJFWfw==",
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.53.1.tgz",
+      "integrity": "sha512-cl6+yVcH90wSRn8kjYma3fLB12nA5nZp6gWl3HdLJ66jV4HWwALhRGiFJcTT8oHUSuJtNhQ/hbYlF/S/Q21rHQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.4.1",
@@ -943,9 +943,9 @@
           "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
         },
         "@types/yup": {
-          "version": "0.26.30",
-          "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.30.tgz",
-          "integrity": "sha512-b/uklO68T/eShWnxjlgwOJlEFOQ11ib3i1wQQiLmHqFJTxDMvz+tb4XzThGQISzOcelMnoSdb1Po4s69YkEQeg=="
+          "version": "0.26.32",
+          "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.32.tgz",
+          "integrity": "sha512-55WFAq8lNYXdRzSP1cenMFFXtPRe7PWsqn5y9ibqKHOQZ/cSLErkcnB1LE89M7W2TSXVDFtx+T7eFePkGoB+xw=="
         },
         "rxjs": {
           "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.52.1",
+    "@bigcommerce/checkout-sdk": "^1.53.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/config/config.mock.ts
+++ b/src/app/config/config.mock.ts
@@ -25,6 +25,7 @@ export function getStoreConfig(): StoreConfig {
             orderTermsAndConditions: '',
             orderTermsAndConditionsLink: '',
             orderTermsAndConditionsType: '',
+            privacyPolicyUrl: '',
             shippingQuoteFailedMessage: 'Unfortunately one or more items in your cart can\'t be shipped to your \
             location.Please choose a different delivery address.',
             realtimeShippingProviders: [
@@ -32,6 +33,7 @@ export function getStoreConfig(): StoreConfig {
                 'UPS',
                 'USPS',
             ],
+            requiresMarketingConsent: false,
             features: {},
             remoteCheckoutProviders: [],
         },

--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -127,7 +127,10 @@ describe('Customer', () => {
                 });
 
             expect(checkoutService.continueAsGuest)
-                .toHaveBeenCalledWith({ email: 'test@bigcommerce.com' });
+                .toHaveBeenCalledWith({
+                    email: 'test@bigcommerce.com',
+                    marketingEmailConsent: true,
+                });
 
             expect(subscribeToNewsletter)
                 .toHaveBeenCalledWith({
@@ -155,7 +158,10 @@ describe('Customer', () => {
                 });
 
             expect(checkoutService.continueAsGuest)
-                .toHaveBeenCalledWith({ email: 'test@bigcommerce.com' });
+                .toHaveBeenCalledWith({
+                    email: 'test@bigcommerce.com',
+                    marketingEmailConsent: undefined,
+                });
 
             expect(subscribeToNewsletter)
                 .not.toHaveBeenCalled();

--- a/src/app/customer/GuestForm.spec.tsx
+++ b/src/app/customer/GuestForm.spec.tsx
@@ -19,6 +19,7 @@ describe('GuestForm', () => {
             onChangeEmail: jest.fn(),
             onContinueAsGuest: jest.fn(),
             onShowLogin: jest.fn(),
+            requiresMarketingConsent: false,
         };
 
         localeContext = createLocaleContext(getStoreConfig());
@@ -67,13 +68,20 @@ describe('GuestForm', () => {
         component.find('input[name="email"]')
             .simulate('change', { target: { value: 'test@bigcommerce.com', name: 'email' } });
 
+        component.find('input[name="shouldSubscribe"]')
+            .simulate('change', { target: { value: true, name: 'shouldSubscribe' } });
+
         component.find('form')
             .simulate('submit');
 
         await new Promise(resolve => process.nextTick(resolve));
 
         expect(handleContinueAsGuest)
-            .toHaveBeenCalled();
+            .toHaveBeenCalledWith({
+                email: 'test@bigcommerce.com',
+                privacyPolicy: false,
+                shouldSubscribe: true,
+            });
     });
 
     it('displays error message if email is not valid', async () => {
@@ -196,6 +204,25 @@ describe('GuestForm', () => {
             </LocaleContext.Provider>
         );
 
+        expect(component.find('label[htmlFor="shouldSubscribe"]').text())
+            .toEqual('Subscribe to our newsletter.');
+        expect(component.exists('input[name="shouldSubscribe"]'))
+            .toEqual(true);
+    });
+
+    it('renders marketing consent field', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <GuestForm
+                    { ...defaultProps }
+                    canSubscribe={ true }
+                    requiresMarketingConsent={ true }
+                />
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find('label[htmlFor="shouldSubscribe"]').text())
+            .toEqual('I would like to receive updates and offers.');
         expect(component.exists('input[name="shouldSubscribe"]'))
             .toEqual(true);
     });

--- a/src/app/customer/GuestForm.tsx
+++ b/src/app/customer/GuestForm.tsx
@@ -1,5 +1,5 @@
-import { withFormik, FormikProps } from 'formik';
-import React, { memo, FunctionComponent, ReactNode } from 'react';
+import { withFormik, FieldProps, FormikProps } from 'formik';
+import React, { memo, useCallback, FunctionComponent, ReactNode } from 'react';
 import { object, string } from 'yup';
 
 import { withLanguage, TranslatedHtml, TranslatedString, WithLanguageProps } from '../locale';
@@ -13,6 +13,7 @@ import SubscribeField from './SubscribeField';
 export interface GuestFormProps {
     canSubscribe: boolean;
     checkoutButtons?: ReactNode;
+    requiresMarketingConsent: boolean;
     defaultShouldSubscribe: boolean;
     email?: string;
     isContinuingAsGuest: boolean;
@@ -34,75 +35,88 @@ const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikPr
     onChangeEmail,
     onShowLogin,
     privacyPolicyUrl,
-}) => (
-    <Form
-        className="checkout-form"
-        id="checkout-customer-guest"
-        testId="checkout-customer-guest"
-    >
-        <Fieldset
-            legend={
-                <Legend hidden>
-                    <TranslatedString id="customer.guest_customer_text" />
-                </Legend>
-            }
+    requiresMarketingConsent,
+}) => {
+    const renderField = useCallback((fieldProps: FieldProps<boolean>) => (
+        <SubscribeField
+            { ...fieldProps }
+            requiresMarketingConsent={ requiresMarketingConsent }
+        />
+    ), [
+        requiresMarketingConsent,
+    ]);
+
+    return (
+        <Form
+            className="checkout-form"
+            id="checkout-customer-guest"
+            testId="checkout-customer-guest"
         >
-            <p>
-                <TranslatedHtml id="customer.checkout_as_guest_text" />
-            </p>
+            <Fieldset
+                legend={
+                    <Legend hidden>
+                        <TranslatedString id="customer.guest_customer_text" />
+                    </Legend>
+                }
+            >
+                <p>
+                    <TranslatedHtml id="customer.checkout_as_guest_text" />
+                </p>
 
-            <div className="customerEmail-container">
-                <div className="customerEmail-body">
-                    <EmailField onChange={ onChangeEmail } />
+                <div className="customerEmail-container">
+                    <div className="customerEmail-body">
+                        <EmailField onChange={ onChangeEmail } />
 
-                    { canSubscribe && <BasicFormField
-                        component={ SubscribeField }
-                        name="shouldSubscribe"
-                    /> }
+                        { (canSubscribe || requiresMarketingConsent) && <BasicFormField
+                            name="shouldSubscribe"
+                            render={ renderField }
+                        /> }
 
-                    { privacyPolicyUrl && <PrivacyPolicyField
-                        url={ privacyPolicyUrl }
-                    /> }
+                        { privacyPolicyUrl && <PrivacyPolicyField
+                            url={ privacyPolicyUrl }
+                        /> }
+                    </div>
+
+                    <div className="form-actions customerEmail-action">
+                        <Button
+                            className="customerEmail-button"
+                            id="checkout-customer-continue"
+                            isLoading={ isContinuingAsGuest }
+                            testId="customer-continue-as-guest-button"
+                            type="submit"
+                            variant={ ButtonVariant.Primary }
+                        >
+                            <TranslatedString id="customer.continue_as_guest_action" />
+                        </Button>
+                    </div>
                 </div>
 
-                <div className="form-actions customerEmail-action">
-                    <Button
-                        className="customerEmail-button"
-                        id="checkout-customer-continue"
-                        isLoading={ isContinuingAsGuest }
-                        testId="customer-continue-as-guest-button"
-                        type="submit"
-                        variant={ ButtonVariant.Primary }
+                <p>
+                    <TranslatedString id="customer.login_text" />
+                    { ' ' }
+                    <a
+                        data-test="customer-continue-button"
+                        id="checkout-customer-login"
+                        onClick={ onShowLogin }
                     >
-                        <TranslatedString id="customer.continue_as_guest_action" />
-                    </Button>
-                </div>
-            </div>
+                        <TranslatedString id="customer.login_action" />
+                    </a>
+                </p>
 
-            <p>
-                <TranslatedString id="customer.login_text" />
-                { ' ' }
-                <a
-                    data-test="customer-continue-button"
-                    id="checkout-customer-login"
-                    onClick={ onShowLogin }
-                >
-                    <TranslatedString id="customer.login_action" />
-                </a>
-            </p>
-
-            { checkoutButtons }
-        </Fieldset>
-    </Form>
-);
+                { checkoutButtons }
+            </Fieldset>
+        </Form>
+    );
+};
 
 export default withLanguage(withFormik<GuestFormProps & WithLanguageProps, GuestFormValues>({
     mapPropsToValues: ({
         email = '',
         defaultShouldSubscribe = false,
+        requiresMarketingConsent,
     }) => ({
         email,
-        shouldSubscribe: defaultShouldSubscribe,
+        shouldSubscribe: requiresMarketingConsent ? false : defaultShouldSubscribe,
         privacyPolicy: false,
     }),
     handleSubmit: (values, { props: { onContinueAsGuest } }) => {

--- a/src/app/customer/SubscribeField.tsx
+++ b/src/app/customer/SubscribeField.tsx
@@ -4,9 +4,11 @@ import React, { memo, Fragment, FunctionComponent } from 'react';
 import { TranslatedString } from '../locale';
 import { Input, Label } from '../ui/form';
 
-export type SubscribeFieldProps = FieldProps<boolean>;
+export type SubscribeFieldProps = FieldProps<boolean> & {
+    requiresMarketingConsent: boolean;
+};
 
-const SubscribeField: FunctionComponent<SubscribeFieldProps> = ({ field }) => (
+const SubscribeField: FunctionComponent<SubscribeFieldProps> = ({ field, requiresMarketingConsent }) => (
     <Fragment>
         <Input
             { ...field }
@@ -17,7 +19,10 @@ const SubscribeField: FunctionComponent<SubscribeFieldProps> = ({ field }) => (
         />
 
         <Label htmlFor={ field.name }>
-            <TranslatedString id="customer.guest_subscribe_to_newsletter_text" />
+            <TranslatedString id={ requiresMarketingConsent ?
+                'customer.guest_marketing_consent' :
+                'customer.guest_subscribe_to_newsletter_text' }
+            />
         </Label>
     </Fragment>
 );

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -105,6 +105,7 @@
             "forgot_password_action": "Forgot password?",
             "guest_customer_text": "Guest Customer",
             "guest_subscribe_to_newsletter_text": "Subscribe to our newsletter.",
+            "guest_marketing_consent": "I would like to receive updates and offers.",
             "login_action": "Sign in now",
             "login_text": "Already have an account?",
             "password_confirmation_error": "Passwords do not match",


### PR DESCRIPTION
## What?
Allow guest shopper to provide marketing email consent
REQUIRES https://github.com/bigcommerce/checkout-sdk-js/pull/794

## Why?
GDPR compliance for Abandoned Cart Saver feature

## Testing / Proof
unit

<img width="654" alt="Screen Shot 2020-02-10 at 5 56 20 pm" src="https://user-images.githubusercontent.com/1621894/74127415-b52c3000-4c2e-11ea-9ba5-9204f3a2d6bd.png">


@bigcommerce/checkout
