### PR TITLE
CHECKOUT-4655: Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.51.0.tgz",
-      "integrity": "sha512-1217yOcxC7Sdrcq4dhI+bK1YiigQmMh0dP4Ck167uShQdrktvxjTZOo8qUTbM510xGX8A5l6R9oT18AmtAfNqQ==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.51.1.tgz",
+      "integrity": "sha512-ooX1OvQJCfnnDWDLg+nzXd4KwLyWu9PT2ICJeyR3jr9dEhSYf/fGc/djhnL1a7EY7HBsMf9voNZnYISoYS0CDA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.51.0",
+    "@bigcommerce/checkout-sdk": "^1.51.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version

## Why?
https://github.com/bigcommerce/checkout-sdk-js/compare/v1.51.0...v1.51.1

## Testing / Proof
CircleCI

@bigcommerce/checkout
