### PR TITLE
CHECKOUT-4596 Trim customer email

### DIFF
--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -122,7 +122,7 @@ describe('Customer', () => {
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
-                    email: 'test@bigcommerce.com',
+                    email: ' test@bigcommerce.com ',
                     shouldSubscribe: true,
                 });
 

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -134,12 +134,14 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps> {
             subscribeToNewsletter = noop,
         } = this.props;
 
+        const email = formValues.email.trim();
+
         if (canSubscribe && formValues.shouldSubscribe) {
-            subscribeToNewsletter({ email: formValues.email, firstName });
+            subscribeToNewsletter({ email, firstName });
         }
 
         try {
-            await continueAsGuest({ email: formValues.email });
+            await continueAsGuest({ email });
             onContinueAsGuest();
 
             this.draftEmail = undefined;


### PR DESCRIPTION
## What?
Trim customer email

## Why?
To avoid issues during payment caused by extra whitespaces

## Testing / Proof
unit

@bigcommerce/checkout
