### PR TITLE
CHECKOUT-4655: Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,9 +893,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.52.0.tgz",
-      "integrity": "sha512-E0HC/WN61pZB91XPToJPf+fx7c6EJBTwVXTQPaV1zpLJwXwkjYS+/hj15XLY5vXuhdq9UVBFiYA6Tf6Lxm5Xyw==",
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.52.1.tgz",
+      "integrity": "sha512-IvsYb+7VvfB110sWgjh98+c/8PrBWXeb1QGtTpRU0PRrjsTzekLjobTO4fN/BKvEbyyHOs8XbrEFt3K7uJFWfw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.52.0",
+    "@bigcommerce/checkout-sdk": "^1.52.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version.

## Why?
It's the same as `1.52.0`. But need to bump it in order to get the version number aligned with the CDN version (it's caused by this bug https://github.com/bigcommerce/checkout-sdk-js/pull/795).

## Testing / Proof
Manual

@bigcommerce/checkout
