### PR TITLE
CHECKOUT-4690: Only show CVV field when using stored card if configured to be required or shipping address is untrusted

### DIFF
--- a/src/app/payment/storedInstrument/index.ts
+++ b/src/app/payment/storedInstrument/index.ts
@@ -6,6 +6,7 @@ export { default as isInstrumentFeatureAvailable } from './isInstrumentFeatureAv
 export { default as getInstrumentValidationSchema } from './getInstrumentValidationSchema';
 export { default as getHostedInstrumentValidationSchema } from './getHostedInstrumentValidationSchema';
 export { default as isInstrumentCardCodeRequired } from './isInstrumentCardCodeRequired';
+export { default as isInstrumentCardCodeRequiredSelector } from './isInstrumentCardCodeRequiredSelector';
 export { default as isInstrumentCardNumberRequired } from './isInstrumentCardNumberRequired';
 export { default as isInstrumentCardNumberRequiredSelector } from './isInstrumentCardNumberRequiredSelector';
 export { default as AccountInstrumentFieldset } from './AccountInstrumentFieldset';

--- a/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.ts
+++ b/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.ts
@@ -1,23 +1,27 @@
-import { LineItemMap, PaymentMethod, StoreConfig } from '@bigcommerce/checkout-sdk';
+import { LineItemMap, PaymentInstrument, PaymentMethod } from '@bigcommerce/checkout-sdk';
 
 export interface IsInstrumentCardCodeRequiredState {
-    config: StoreConfig;
+    instrument: PaymentInstrument;
     lineItems: LineItemMap;
     paymentMethod: PaymentMethod;
 }
 
 export default function isInstrumentCardCodeRequired({
-    config,
+    instrument,
     lineItems,
     paymentMethod,
 }: IsInstrumentCardCodeRequiredState): boolean {
-    if (config.checkoutSettings.isTrustedShippingAddressEnabled !== true ||
-        lineItems.digitalItems.length > 0 ||
-        lineItems.giftCertificates.length > 0 ||
-        paymentMethod.config.isVaultingCvvEnabled ||
-        paymentMethod.config.cardCode) {
+    // If there's a digital item in the cart, always show CVV field
+    if (lineItems.digitalItems.length > 0 || lineItems.giftCertificates.length > 0) {
         return true;
     }
 
-    return false;
+    // If the shipping address is trusted, show CVV field based on the merchant's configuration
+    if (instrument.trustedShippingAddress) {
+        return !!paymentMethod.config.isVaultingCvvEnabled;
+    }
+
+    // Otherwise, if the shipping address is untrusted, show CVV field if the
+    // merchant either requires it for regular card or stored card payments.
+    return !!(paymentMethod.config.isVaultingCvvEnabled || paymentMethod.config.cardCode);
 }

--- a/src/app/payment/storedInstrument/isInstrumentCardCodeRequiredSelector.ts
+++ b/src/app/payment/storedInstrument/isInstrumentCardCodeRequiredSelector.ts
@@ -1,0 +1,25 @@
+import { CheckoutSelectors, Instrument, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { createSelector } from 'reselect';
+
+import isInstrumentCardCodeRequired from './isInstrumentCardCodeRequired';
+
+const isInstrumentCardCodeRequiredSelector = createSelector(
+    ({ data }: CheckoutSelectors) => {
+        const cart = data.getCart();
+
+        return cart && cart.lineItems;
+    },
+    lineItems => (instrument: Instrument, method: PaymentMethod) => {
+        if (!lineItems) {
+            return false;
+        }
+
+        return isInstrumentCardCodeRequired({
+            instrument,
+            lineItems,
+            paymentMethod: method,
+        });
+    }
+);
+
+export default isInstrumentCardCodeRequiredSelector;

--- a/src/app/payment/storedInstrument/isInstrumentCardNumberRequired.ts
+++ b/src/app/payment/storedInstrument/isInstrumentCardNumberRequired.ts
@@ -1,18 +1,15 @@
-import { Instrument, LineItemMap, StoreConfig } from '@bigcommerce/checkout-sdk';
+import { Instrument, LineItemMap } from '@bigcommerce/checkout-sdk';
 
 export interface IsInstrumentCardNumberRequiredState {
-    config: StoreConfig;
     lineItems: LineItemMap;
     instrument: Instrument;
 }
 
 export default function isInstrumentCardNumberRequired({
-    config,
     lineItems,
     instrument,
 }: IsInstrumentCardNumberRequiredState): boolean {
-    if (!(config.checkoutSettings as any).isTrustedShippingAddressEnabled ||
-        lineItems.physicalItems.length === 0) {
+    if (lineItems.physicalItems.length === 0) {
         return false;
     }
 

--- a/src/app/payment/storedInstrument/isInstrumentCardNumberRequiredSelector.ts
+++ b/src/app/payment/storedInstrument/isInstrumentCardNumberRequiredSelector.ts
@@ -4,19 +4,17 @@ import { createSelector } from 'reselect';
 import isInstrumentCardNumberRequired from './isInstrumentCardNumberRequired';
 
 const isInstrumentCardNumberRequiredSelector = createSelector(
-    ({ data }: CheckoutSelectors) => data.getConfig(),
     ({ data }: CheckoutSelectors) => {
         const cart = data.getCart();
 
         return cart && cart.lineItems;
     },
-    (config, lineItems) => (instrument: Instrument) => {
-        if (!config || !lineItems) {
+    lineItems => (instrument: Instrument) => {
+        if (!lineItems) {
             return false;
         }
 
         return isInstrumentCardNumberRequired({
-            config,
             lineItems,
             instrument,
         });


### PR DESCRIPTION
## What?
* When using a stored credit card, only show the CVV field if CVV is configured to be required or the shipping address is new (untrusted).
* Stop checking `isTrustedShippingAddressEnabled` because it's always enabled now.

## Why?
At the moment, CVV verification field for stored cards can be visible even if it is configured to be hidden and the shipping address is trusted. This is because we also check the configuration value for regular card payments -  as long as it is true, we show the CVV verification field.

## Testing / Proof
Unit

@bigcommerce/checkout
