### PR TITLE
feat(payment): INT-2317 Added validation to show payment provider logos for AdyenV2

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -85,6 +85,10 @@ function getPaymentMethodTitle(
                 logoUrl: cdnPath(`/img/payment-providers/barclaycard_${method.id.toLowerCase()}.png`),
                 titleText: '',
             },
+            [PaymentMethodId.AdyenV2]: {
+                logoUrl: `https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/${(method.id === 'scheme') ? 'card' : method.id.toLowerCase()}.svg`,
+                titleText: method.config.displayName || '',
+            },
         };
 
         // KLUDGE: 'paypal' is actually a credit card method. It is the only


### PR DESCRIPTION
[INT-2317](https://jira.bigcommerce.com/browse/INT-2317)

## What?
Display APM logos on checkout accordion and correct display name

## Why?
To identify easily the APM

## Testing / Proof
![image](https://user-images.githubusercontent.com/42655796/74767153-e8cd1280-524b-11ea-86ae-0f5e83d43584.png)


@bigcommerce/checkout
