### PR TITLE
CHECKOUT-4575: Display different message if order is awaiting payment

### DIFF
--- a/src/app/order/OrderStatus.spec.tsx
+++ b/src/app/order/OrderStatus.spec.tsx
@@ -2,6 +2,8 @@ import { Order } from '@bigcommerce/checkout-sdk';
 import { shallow, ShallowWrapper } from 'enzyme';
 import React from 'react';
 
+import { TranslatedString } from '../locale';
+
 import { getOrder } from './orders.mock';
 import OrderStatus from './OrderStatus';
 
@@ -54,6 +56,22 @@ describe('OrderStatus', () => {
 
         it('renders status with special text', () => {
             expect(orderStatus).toMatchSnapshot();
+        });
+    });
+
+    describe('when order is awaiting payment', () => {
+        beforeEach(() => {
+            orderStatus = shallow(<OrderStatus
+                order={ {
+                    ...getOrder(),
+                    status: 'AWAITING_PAYMENT',
+                } }
+            />);
+        });
+
+        it('displays order is pending text', () => {
+            expect(orderStatus.find(TranslatedString).prop('id'))
+                .toEqual('order_confirmation.order_pending_review_text');
         });
     });
 

--- a/src/app/order/OrderStatus.tsx
+++ b/src/app/order/OrderStatus.tsx
@@ -17,6 +17,7 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
     supportPhoneNumber,
 }) => {
     const isPendingReview = order.status === 'MANUAL_VERIFICATION_REQUIRED';
+    const isAwaitingPayment = order.status === 'AWAITING_PAYMENT';
     const orderNumber = order.orderId;
 
     return <OrderConfirmationSection>
@@ -28,14 +29,14 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
             />
         </p> }
 
-        { isPendingReview &&
+        { (isPendingReview || isAwaitingPayment) &&
         <p>
             <TranslatedString
                 id="order_confirmation.order_pending_review_text"
             />
         </p> }
 
-        { !isPendingReview &&
+        { !(isPendingReview || isAwaitingPayment) &&
         <p>
             <TranslatedHtml
                 data={ { orderNumber, supportEmail, supportPhoneNumber } }


### PR DESCRIPTION
## What?
Display a different message when a shopper completes their checkout process but their payment hasn't been confirmed yet. By default, they will see the following message when they get to the order confirmation page (unless the message is overridden by a language file).
> Your order was sent to us but is currently awaiting payment. Once we receive the payment for your order, it will be completed. If you've already provided payment details then we will process your order manually and send you an email when it's completed.

This text is the same that we use when payment needs to be manually verified (due to fraud detection). It is also the same that we use for LCO.

## Why?
Make it clear that their order is still pending.

## Testing / Proof
CircleCI

@bigcommerce/checkout
