### PR TITLE
CHECKOUT-4638 Reduce consignments request in multishipping

### DIFF
--- a/src/app/shipping/getRecommendedShippingOption.spec.ts
+++ b/src/app/shipping/getRecommendedShippingOption.spec.ts
@@ -3,27 +3,16 @@ import getRecommendedShippingOption from './getRecommendedShippingOption';
 import { getShippingOption, getShippingOptionPickUpStore } from './shippingOption/shippingMethod.mock';
 
 describe('getShippabgetRecommendedShippingOptioneLineItems()', () => {
-    it('returns falsy if it has a selected shipping option', () => {
-        expect(getRecommendedShippingOption(getConsignment()))
-            .toBeFalsy();
-    });
-
     it('returns falsy if it has no recommended shipping options', () => {
-        expect(getRecommendedShippingOption({
-            ...getConsignment(),
-            availableShippingOptions: [
-                getShippingOptionPickUpStore(),
-            ],
-            selectedShippingOption: undefined,
-        }))
+        expect(getRecommendedShippingOption([
+            getShippingOptionPickUpStore(),
+        ]))
             .toBeFalsy();
     });
 
     it('returns recommended shipping option when has no shipping option', () => {
-        expect(getRecommendedShippingOption({
-            ...getConsignment(),
-            selectedShippingOption: undefined,
-        }))
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(getRecommendedShippingOption(getConsignment().availableShippingOptions!))
             .toEqual(getShippingOption());
     });
 });

--- a/src/app/shipping/getRecommendedShippingOption.ts
+++ b/src/app/shipping/getRecommendedShippingOption.ts
@@ -1,12 +1,9 @@
-import { Consignment, ShippingOption } from '@bigcommerce/checkout-sdk';
+import { ShippingOption } from '@bigcommerce/checkout-sdk';
 
-export default function getRecommendedShippingOption(consignment: Consignment): ShippingOption | undefined {
-    if (consignment.selectedShippingOption ||
-        !consignment.availableShippingOptions ||
-        !consignment.availableShippingOptions.length
-    ) {
+export default function getRecommendedShippingOption(availableShippingOptions: ShippingOption[]): ShippingOption | undefined {
+    if (!availableShippingOptions) {
         return;
     }
 
-    return consignment.availableShippingOptions.find((option: { isRecommended: any }) => option.isRecommended);
+    return availableShippingOptions.find(({ isRecommended }: { isRecommended: any }) => isRecommended);
 }

--- a/src/app/shipping/shippingOption/ShippingOptions.tsx
+++ b/src/app/shipping/shippingOption/ShippingOptions.tsx
@@ -19,7 +19,7 @@ export interface WithCheckoutShippingOptionsProps {
     cart: Cart;
     isSelectingShippingOption(consignmentId?: string): boolean;
     subscribeToConsignments(subscriber: (state: CheckoutSelectors) => void): () => void;
-    selectShippingOption(consignmentId: string, optionId: string): void;
+    selectShippingOption(consignmentId: string, optionId: string): Promise<CheckoutSelectors>;
     isLoading(consignmentId?: string): boolean;
 }
 


### PR DESCRIPTION
## What?
- Remove `enableReinitialize: true` from multishipping form
- Make sure we use the latest data available in consignments when triggering automatic selection of shipping options.

## Why?
The code was intended to automatically select a shipping option for a new consignment when eligible (meaning, a single shipping option available or if more than one, one that is marked as recommended).

However, the `enableReinitialize` behaviour was triggering the form to update every time a new shipping option was selected, triggering `onChange` in `ChecklistItem`, we would re-trigger the same request again.

Also, since the code was using a `consignments.map()`, it would make the `for` loop run using an outdated snapshot, triggering requests for consignments that already had shipping options selected.

## Testing / Proof
manual
functional https://github.com/bigcommerce/bigcommerce/pull/33725

@bigcommerce/checkout
