### PR TITLE
CHECKOUT-4712 Do not send consent if not required

### DIFF
--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -22,7 +22,7 @@ export interface CustomerProps {
     subscribeToNewsletter?(data: { email: string; firstName?: string }): void;
 }
 
-interface WithCheckoutCustomerProps {
+export interface WithCheckoutCustomerProps {
     canSubscribe: boolean;
     checkoutButtonIds: string[];
     createAccountUrl: string;
@@ -135,6 +135,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps> {
             onContinueAsGuest = noop,
             onContinueAsGuestError = noop,
             subscribeToNewsletter = noop,
+            requiresMarketingConsent,
         } = this.props;
 
         const email = formValues.email.trim();
@@ -146,7 +147,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps> {
         try {
             await continueAsGuest({
                 email,
-                marketingEmailConsent: formValues.shouldSubscribe ? true : undefined,
+                marketingEmailConsent: requiresMarketingConsent && formValues.shouldSubscribe ? true : undefined,
             });
             onContinueAsGuest();
 


### PR DESCRIPTION
## What?
If consent is not required, do not send in API

## Why?
We were always sending the consent, which causes trouble because the API for the consent is not live yet. 

## Testing / Proof
- unit

@bigcommerce/checkout
