### PR TITLE
feat(payment): INT-2279 Checkout.com handle 3DS in checkout.js

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -248,12 +248,13 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         const { selectedMethod = defaultMethod } = this.state;
 
         // TODO: Perhaps there is a better way to handle `adyen`, `afterpay`, `amazon`,
-        // `converge` and `sagepay``. They require a redirection to another website
+        // `checkout.com`, `converge` and `sagepay``. They require a redirection to another website
         // during the payment flow but are not categorised as hosted payment methods.
         if (!isSubmittingOrder ||
             !selectedMethod ||
             selectedMethod.type === PaymentMethodProviderType.Hosted ||
             selectedMethod.id === PaymentMethodId.Amazon ||
+            selectedMethod.id === PaymentMethodId.Checkoutcom ||
             selectedMethod.id === PaymentMethodId.Converge ||
             selectedMethod.id === PaymentMethodId.SagePay ||
             selectedMethod.gateway === PaymentMethodId.AdyenV2 ||

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -11,6 +11,7 @@ enum PaymentMethodId {
     BraintreeVisaCheckout = 'braintreevisacheckout',
     CCAvenueMars = 'ccavenuemars',
     ChasePay = 'chasepay',
+    Checkoutcom = 'checkoutcom',
     Converge = 'converge',
     Klarna = 'klarna',
     Masterpass = 'masterpass',


### PR DESCRIPTION
## What?
Add checkout.com to handleBeforeUnload() whitelist

## Why?
To allow the customer to be redirected to the 3DS challenge page without the browser warning about leaving the page.

## Testing / Proof
[Demo Video](https://drive.google.com/open?id=1JorF1Z5HE_2ASfpcJj0MG81kkA0UTk4P)

@bigcommerce/checkout @bigcommerce/intersys-integrations 
