### PR TITLE
fix(checkout): CHECKOUT-4573 Removed extra zero after decimal for gift certificate value

### DIFF
--- a/src/app/order/OrderSummaryDiscount.tsx
+++ b/src/app/order/OrderSummaryDiscount.tsx
@@ -26,7 +26,7 @@ const OrderSummaryDiscount: FunctionComponent<OrderSummaryDiscountProps> = ({
         }) }
         amount={ -1 * (amount || 0) }
     >
-        { remaining && remaining > 0 && <span
+        { !!remaining && remaining > 0 && <span
             className="cart-priceItem-postFix optimizedCheckout-contentSecondary"
             data-test="cart-price-remaining"
         >


### PR DESCRIPTION
## What?
Added a check to eliminate adding an extra zero to the gift certificate discount value.

## Why?
The Gift certificate value displayed an extra zero along with the applied discount. This appeared only in case the gift certification was less than the order subtotal. For cases where the value was larger or equal the value displayed correctly. 

## Tech Implementation Detail
The condition currently checks if "remaining" variable is not undefined followed by a check to see if the value is greater than zero. However if the value is zero the check does fail but react still renders the "0" value.

With this change we now do a check to determine the "truthy" value of the "remaining" variable and not just a check for it to be defined.

## Testing / Proof

Before: 
![2019-11-22_0829](https://user-images.githubusercontent.com/55068632/76480102-e3857100-6461-11ea-94d2-8f668666ebb0.png)

After: 
<img width="1647" alt="After" src="https://user-images.githubusercontent.com/55068632/76480113-eaac7f00-6461-11ea-8861-478ff90c6221.png">

@bigcommerce/checkout
