### PR TITLE
feat(checkout): INT-2350 Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -898,9 +898,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.56.0.tgz",
-      "integrity": "sha512-nXq5CfY4FkKVN/k/U0oERWRwuJZ95AjHPCt0Vfg7c74taNcwibbgya/FzDEc71l4fXXwxmVQOvDU245SG6M+Fw==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.56.1.tgz",
+      "integrity": "sha512-VkBdttuxpXwMApAksB8mpptZZHOEbUEJV241Ga8ESjbOlc7YimfN0HxEaredp7P1lXrbo3TfhNXTuCkNsxxK5w==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.56.0",
+    "@bigcommerce/checkout-sdk": "^1.56.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

Ping @bigcommerce/checkout @bigcommerce/intersys-integrations