### PR TITLE
fix(payment): INT-2427 Use ExpiryDate while paying with a vaulted Ban…

### DIFF
--- a/src/app/payment/paymentMethod/AdyenV2CardValidation.spec.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2CardValidation.spec.tsx
@@ -8,23 +8,35 @@ describe('AdyenV2CardValidation', () => {
     let AdyenV2CardValidationTest: FunctionComponent<AdyenV2CardValidationProps>;
 
     beforeEach(() => {
-        defaultProps = {
-            verificationFieldsContainerId: 'container',
-            shouldShowNumberField: true,
-        };
-
         AdyenV2CardValidationTest = props => (
             <AdyenV2CardValidation { ...props } />
         );
     });
 
-    it('renders Adyen V2 secured fields', () => {
+    it('renders Adyen V2 Card Number and CVV fields', () => {
+        defaultProps = {
+            paymentMethodType: 'scheme',
+            shouldShowNumberField: true,
+            verificationFieldsContainerId: 'container',
+        };
+
         const container = mount(<AdyenV2CardValidationTest { ...defaultProps } />);
 
-        expect(container.props())
-            .toEqual(expect.objectContaining({
-                verificationFieldsContainerId: 'container',
-                shouldShowNumberField: true,
-            }));
+        const field = container.find('[id="encryptedSecurityCode"]');
+
+        expect(field).toHaveLength(1);
+    });
+
+    it('renders Adyen V2 Card Number and Expiry Date fields', () => {
+        defaultProps = {
+            paymentMethodType: 'bcmc',
+            shouldShowNumberField: true,
+            verificationFieldsContainerId: 'container',
+        };
+        const container = mount(<AdyenV2CardValidationTest { ...defaultProps } />);
+
+        const field = container.find('[id="encryptedExpiryDate"]');
+
+        expect(field).toHaveLength(1);
     });
 });

--- a/src/app/payment/paymentMethod/AdyenV2CardValidation.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2CardValidation.tsx
@@ -6,11 +6,13 @@ import { TranslatedString } from '../../locale';
 export interface AdyenV2CardValidationProps {
     verificationFieldsContainerId?: string;
     shouldShowNumberField: boolean;
+    paymentMethodType: string;
 }
 
 const AdyenV2CardValidation: React.FunctionComponent<AdyenV2CardValidationProps> = ({
     verificationFieldsContainerId,
     shouldShowNumberField,
+    paymentMethodType,
 }) => (
     <div>
         { shouldShowNumberField && <p>
@@ -24,13 +26,13 @@ const AdyenV2CardValidation: React.FunctionComponent<AdyenV2CardValidationProps>
         </p> }
 
         <div className="form-ccFields" id={ verificationFieldsContainerId }>
-            { <div className="form-field form-field--ccNumber" style={ { display: (shouldShowNumberField) ? undefined : 'none' } }>
+            <div className="form-field form-field--ccNumber" style={ { display: (shouldShowNumberField) ? undefined : 'none' } }>
                 <label htmlFor="encryptedCardNumber">
                     <TranslatedString id="payment.credit_card_number_label" />
                 </label>
                 <div className="form-input optimizedCheckout-form-input has-icon" data-cse="encryptedCardNumber" id="encryptedCardNumber" />
-            </div> }
-            <div className="form-field form-ccFields-field--ccCvv">
+            </div>
+            { paymentMethodType === 'scheme' && <div className="form-field form-ccFields-field--ccCvv">
                 <label htmlFor="encryptedSecurityCode">
                     <TranslatedString id="payment.credit_card_cvv_label" />
                 </label>
@@ -43,7 +45,21 @@ const AdyenV2CardValidation: React.FunctionComponent<AdyenV2CardValidationProps>
                     data-cse="encryptedSecurityCode"
                     id="encryptedSecurityCode"
                 />
-            </div>
+            </div> }
+            { paymentMethodType === 'bcmc' && <div className="form-field form-field--ccExpiry">
+                <label htmlFor="encryptedExpiryDate">
+                    <TranslatedString id="payment.credit_card_expiration_label" />
+                </label>
+                <div
+                    className={ classNames(
+                        'form-input',
+                        'optimizedCheckout-form-input',
+                        'has-icon'
+                    ) }
+                    data-cse="encryptedExpiryDate"
+                    id="encryptedExpiryDate"
+                />
+            </div> }
         </div>
     </div>
 );

--- a/src/app/payment/paymentMethod/AdyenV2PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/AdyenV2PaymentMethod.tsx
@@ -119,6 +119,7 @@ const AdyenV2PaymentMethod: FunctionComponent<AdyenPaymentMethodProps> = ({
 
     const validateInstrument = (shouldShowNumberField: boolean) => {
         return <AdyenV2CardValidation
+            paymentMethodType={ method.method }
             shouldShowNumberField={ shouldShowNumberField }
             verificationFieldsContainerId={ cardVerificationContainerId }
         />;


### PR DESCRIPTION
[INT-2427](https://jira.bigcommerce.com/browse/INT-2427)

## What?
Use ExpiryDate while paying with a vaulted Bancontact card rather than CVV

## Why?
Bancontact cards do not have CVV

## Testing / Proof

## How can this change be undone in case of failure?
Revert this PR

@bigcommerce/checkout @bigcommerce/payments
