### PR TITLE
CHECKOUT-4740 Enforce log-in when account exists

### DIFF
--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -234,6 +234,54 @@ describe('Customer', () => {
                 .toHaveBeenCalled();
         });
 
+        it('renders cancellable log-in form if continue as guest fails with code 403', async () => {
+            jest.spyOn(checkoutService, 'continueAsGuest')
+                .mockRejectedValue({ status: 403 });
+
+            const component = mount(
+                <CustomerTest viewType={ CustomerViewType.Guest } />
+            );
+
+            (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
+                .prop('onContinueAsGuest')({
+                    email: 'test@bigcommerce.com',
+                    shouldSubscribe: false,
+                });
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
+            expect(component.find(LoginForm).props())
+                .toMatchObject({
+                    accountExists: true,
+                    canCancel: true,
+                });
+        });
+
+        it('renders mandatory log-in form if continue as guest fails with code 429', async () => {
+            jest.spyOn(checkoutService, 'continueAsGuest')
+                .mockRejectedValue({ status: 429 });
+
+            const component = mount(
+                <CustomerTest viewType={ CustomerViewType.Guest } />
+            );
+
+            (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
+                .prop('onContinueAsGuest')({
+                    email: 'test@bigcommerce.com',
+                    shouldSubscribe: false,
+                });
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
+            expect(component.find(LoginForm).props())
+                .toMatchObject({
+                    accountExists: true,
+                    canCancel: false,
+                });
+        });
+
         it('triggers error callback if customer is unable to continue as guest', async () => {
             jest.spyOn(checkoutService, 'continueAsGuest')
                 .mockRejectedValue({ type: 'unknown_error' });

--- a/src/app/customer/LoginForm.spec.tsx
+++ b/src/app/customer/LoginForm.spec.tsx
@@ -3,7 +3,8 @@ import { noop } from 'lodash';
 import React from 'react';
 
 import { getStoreConfig } from '../config/config.mock';
-import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedHtml } from '../locale';
+import { Alert } from '../ui/alert';
 
 import LoginForm from './LoginForm';
 
@@ -120,6 +121,58 @@ describe('LoginForm', () => {
 
         expect(component.find('[data-test="password-field-error-message"]').text())
             .toEqual('Password is required');
+    });
+
+    it('renders info alert if account exists, and hides it if email changes', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <LoginForm
+                    accountExists
+                    canCancel
+                    createAccountUrl={ '/create-account' }
+                    email="foo@bar.com"
+                    forgotPasswordUrl={ '/forgot-password' }
+                    onSignIn={ noop }
+                />
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find(Alert).prop('type'))
+            .toEqual('info');
+
+        expect(component.find(Alert).find(TranslatedHtml).props())
+            .toEqual({
+                id: 'customer.account_must_login',
+                data: { email: 'foo@bar.com' },
+            });
+
+        component.find('input[name="email"]')
+            .simulate('change', { target: { value: 'test@bigcommerce.com', name: 'email' } });
+
+        expect(component.find(Alert).length).toEqual(0);
+    });
+
+    it('renders error alert if account exists and cant cancel', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <LoginForm
+                    accountExists
+                    createAccountUrl={ '/create-account' }
+                    email="foo@bar.com"
+                    forgotPasswordUrl={ '/forgot-password' }
+                    onSignIn={ noop }
+                />
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find(Alert).prop('type'))
+            .toEqual('error');
+
+        expect(component.find(Alert).find(TranslatedHtml).props())
+            .toEqual({
+                id: 'customer.guest_temporary_disabled',
+                data: { url: '/create-account' },
+            });
     });
 
     it('renders error as alert if password is incorrect', () => {

--- a/src/app/customer/LoginForm.tsx
+++ b/src/app/customer/LoginForm.tsx
@@ -18,6 +18,7 @@ export interface LoginFormProps {
     createAccountUrl: string;
     email?: string;
     forgotPasswordUrl: string;
+    accountExists?: boolean;
     isSigningIn?: boolean;
     signInError?: Error;
     onCancel?(): void;
@@ -34,11 +35,14 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
     canCancel,
     createAccountUrl,
     forgotPasswordUrl,
+    email,
     isSigningIn,
     language,
+    accountExists,
     onCancel,
     onChangeEmail,
     signInError,
+    values: { email: formEmail },
 }) => (
     <Form
         className="checkout-form"
@@ -58,12 +62,28 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
                 { mapErrorMessage(signInError, key => language.translate(key)) }
             </Alert> }
 
-            <p>
+            { !accountExists && <p>
                 <TranslatedHtml
                     data={ { url: createAccountUrl } }
                     id="customer.create_account_to_continue_text"
                 />
-            </p>
+            </p> }
+
+            { accountExists && canCancel && email === formEmail &&
+                <Alert type={ AlertType.Info }>
+                    <TranslatedHtml
+                        data={ { email } }
+                        id="customer.account_must_login"
+                    />
+                </Alert> }
+
+            { accountExists && !canCancel &&
+                <Alert type={ AlertType.Error }>
+                    <TranslatedHtml
+                        data={ { url: createAccountUrl } }
+                        id="customer.guest_temporary_disabled"
+                    />
+                </Alert> }
 
             <EmailField onChange={ onChangeEmail } />
 

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -98,6 +98,8 @@
             "create_account_success": "Your account has been created!",
             "create_account_text": "Create an account for a faster checkout in the future",
             "create_account_to_continue_text": "Don’t have an account? <a href=\"{url}\" target=\"_blank\">Create an account</a> to continue.",
+            "account_must_login": "Looks like you have an account with us. Please sign in to proceed with {email}, or cancel to use a different email.",
+            "guest_temporary_disabled": "Guest checkouts are temporarily disabled. Please sign in or <a href=\"{url}\" target=\"_blank\">create an account</a> to continue.",
             "customer_heading": "Customer",
             "email_invalid_error": "Email address must be valid",
             "email_label": "Email Address",


### PR DESCRIPTION
## What?
Enforce log-in when an email registered to an account is used as a guest.

## Why?
To honor CP settings.

## Testing / Proof
Provided email is linked to an existing account:
![forced_login](https://user-images.githubusercontent.com/1621894/77431634-113ec280-6e31-11ea-960b-e54ee2862364.gif)

When too many attempts is reached:
![too_many_attempts](https://user-images.githubusercontent.com/1621894/77431638-13a11c80-6e31-11ea-9d29-b8ec21974ce7.gif)

@bigcommerce/checkout
