### PR TITLE
fix(payment): PAYMENTS-5178 Default vaulted instrument is not used as…

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -425,7 +425,14 @@ export function mapToPaymentProps({
 
     const isTermsConditionsRequired = isTermsConditionsEnabled;
     const selectedPayment = find(checkout.payments, { providerType: PaymentMethodProviderType.Hosted });
-    const selectedPaymentMethod = selectedPayment ? getPaymentMethod(selectedPayment.providerId, selectedPayment.gatewayId) : undefined;
+
+    let selectedPaymentMethod;
+    if (selectedPayment) {
+        selectedPaymentMethod = getPaymentMethod(selectedPayment.providerId, selectedPayment.gatewayId);
+    } else {
+        selectedPaymentMethod = find(methods, { config: { hasDefaultStoredInstrument: true } });
+    }
+
     const filteredMethods = selectedPaymentMethod ? compact([selectedPaymentMethod]) : methods;
 
     return {


### PR DESCRIPTION
… default payment method

## What?
As a shopper who has stored credit cards and stored PayPal account, when I set a stored instrument (card or account) as default, I expect this instrument to be the default payment option on checkout.

What happens before this PR is:
- the first payment method (alphabetically) is the default checkout payment option on checkout regardless of the default stored instrument.
- Within every payment method, if a related vaulted instrument is set as default, then this instrument is the default payment option "within" this payment method.

**Sibling PRs in order:**
- bcapp: https://github.com/bigcommerce/bigcommerce/pull/34359
- checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/828
- checkout-js: https://github.com/bigcommerce/checkout-js/pull/252

## Why?
The whole idea of setting a shopper stored instrument as default, is to use that instrument as the default payment method on checkout page each time.

## Testing / Proof
- Unit tests
- Screenshots of the initial display of checkout payment section when a PayPal account is set as the default instrument/payment method on My Account.

**Before**
<img width="639" alt="Screen Shot 2020-03-31 at 1 51 49 pm" src="https://user-images.githubusercontent.com/36555311/77990370-de368a80-736c-11ea-9780-024d0fd6d2ca.png">

**After**
<img width="652" alt="Screen Shot 2020-03-31 at 1 50 46 pm" src="https://user-images.githubusercontent.com/36555311/77990373-e098e480-736c-11ea-8edf-f126d96dbc6f.png">

## How can this change be undone in case of failure?
1. Revert this PR

ping @bigcommerce/payments 
ping @bigcommerce-labs/payments
@bigcommerce/checkout
