### PR TITLE
feat(payment): INT-2437 Add support for GooglePay on Adyen

### DIFF
--- a/src/app/customer/CheckoutButtonList.tsx
+++ b/src/app/customer/CheckoutButtonList.tsx
@@ -11,6 +11,7 @@ export const SUPPORTED_METHODS: string[] = [
     'braintreevisacheckout',
     'chasepay',
     'masterpass',
+    'googlepayadyenv2',
     'googlepayauthorizenet',
     'googlepaybraintree',
     'googlepaycheckoutcom',

--- a/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
@@ -12,6 +12,10 @@ const GooglePayPaymentMethod: FunctionComponent<GooglePayPaymentMethodProps> = (
 }) => {
     const initializeGooglePayPayment = useCallback(options => initializePayment({
         ...options,
+        googlepayadyenv2: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+        },
         googlepayauthorizenet: {
             walletButton: 'walletButton',
             onError: onUnhandledError,

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -99,7 +99,8 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
         return <VisaCheckoutPaymentMethod { ...props } />;
     }
 
-    if (method.id === PaymentMethodId.AuthorizeNetGooglePay ||
+    if (method.id === PaymentMethodId.AdyenV2GooglePay ||
+        method.id === PaymentMethodId.AuthorizeNetGooglePay ||
         method.id === PaymentMethodId.BraintreeGooglePay ||
         method.id === PaymentMethodId.CheckoutcomGooglePay ||
         method.id === PaymentMethodId.StripeGooglePay) {

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -1,6 +1,7 @@
 enum PaymentMethodId {
     Adyen = 'adyen',
     AdyenV2 = 'adyenv2',
+    AdyenV2GooglePay = 'googlepayadyenv2',
     Affirm = 'affirm',
     Afterpay = 'afterpay',
     Amazon = 'amazon',


### PR DESCRIPTION
## What?
I want to be able to offer my world shoppers GooglePay wallet through Adyen

## Why?
So that I can give them alternative methods to pay so that they are more likely to purchase.

## Testing / Proof

- Manual

- Unit

## How can this change be undone in case of failure?
1. Revert this PR

## Sibling PRs
[SDK](https://github.com/bigcommerce/checkout-sdk-js/pull/818)

@bigcommerce/checkout @bigcommerce/payments
