### PR TITLE
feat(customer): INT-2473 change place order button for bluesnapv2

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -140,6 +140,7 @@
             "afterpay_description": "Checkout with Afterpay",
             "amazon_continue_action": "Continue with Amazon",
             "amazon_name_text": "Amazon Pay",
+            "bluesnap_v2_continue_action": "Continue",
             "braintreevisacheckout_continue_action": "Continue with Visa Checkout",
             "ccavenuemars_description_text": "Checkout with CCAvenue",
             "chasepay_continue_action": "Continue with Chase Pay",

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -114,6 +114,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
             <div className="form-actions">
                 <PaymentSubmitButton
                     isDisabled={ shouldDisableSubmit }
+                    methodGateway={ selectedMethod && selectedMethod.gateway }
                     methodId={ selectedMethod && selectedMethod.id }
                     methodType={ selectedMethod && selectedMethod.method }
                 />

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -7,13 +7,18 @@ import { Button, ButtonSize, ButtonVariant } from '../ui/button';
 import { PaymentMethodId, PaymentMethodType } from './paymentMethod';
 
 interface PaymentSubmitButtonTextProps {
+    methodGateway?: string;
     methodId?: string;
     methodType?: string;
 }
 
-const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> = memo(({ methodId, methodType }) => {
+const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> = memo(({ methodId, methodType, methodGateway }) => {
     if (methodId === PaymentMethodId.Amazon) {
         return <TranslatedString id="payment.amazon_continue_action" />;
+    }
+
+    if (methodGateway === PaymentMethodId.BlueSnapV2) {
+        return <TranslatedString id="payment.bluesnap_v2_continue_action" />;
     }
 
     if (methodType === PaymentMethodType.VisaCheckout) {
@@ -36,6 +41,7 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
 });
 
 export interface PaymentSubmitButtonProps {
+    methodGateway?: string;
     methodId?: string;
     methodType?: string;
     isDisabled?: boolean;
@@ -50,6 +56,7 @@ const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithChec
     isDisabled,
     isInitializing,
     isSubmitting,
+    methodGateway,
     methodId,
     methodType,
 }) => (
@@ -63,6 +70,7 @@ const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithChec
         variant={ ButtonVariant.Action }
     >
         <PaymentSubmitButtonText
+            methodGateway={ methodGateway }
             methodId={ methodId }
             methodType={ methodType }
         />


### PR DESCRIPTION
## What? [INT-2473](https://jira.bigcommerce.com/browse/INT-2473)
Replace "Place Order" text in the Place Order's button to read "Continue" 

## Why?
As a user, I want to read "Continue" instead of "Place order" when a shopper selects to pay with BlueSnapV2

## Testing / Proof

[Video](https://drive.google.com/file/d/1mCEOw0SNFurzSUdBzuiIOD_BFex0W11X/view?usp=sharing)

<img width="1409" alt="Screen Shot 2020-03-31 at 2 29 22 PM" src="https://user-images.githubusercontent.com/42154828/78077627-ea6b1980-7365-11ea-871c-be68c2123a58.png">

@bigcommerce/checkout @bigcommerce/intersys-integrations 

