### PR TITLE
fix(checkout): CHECKOUT-4774 Fix for invalid container Id issue with non hosted fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,20 +1188,20 @@
           "integrity": "sha512-I6+yXbacr5Go0T15kAdW6EkNpOx9EwXB9aDqx1Q7b/I8ttDHH5Mvoq0vVMrC5y2xBClUKhsmBvNO46B/xEVOYA=="
         },
         "@jest/transform": {
-          "version": "25.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.3.0.tgz",
-          "integrity": "sha512-W01p8kTDvvEX6kd0tJc7Y5VdYyFaKwNWy1HQz6Jqlhu48z/8Gxp+yFCDVj+H8Rc7ezl3Mg0hDaGuFVkmHOqirg==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.4.0.tgz",
+          "integrity": "sha512-t1w2S6V1sk++1HHsxboWxPEuSpN8pxEvNrZN+Ud/knkROWtf8LeUmz73A4ezE8476a5AM00IZr9a8FO9x1+j3g==",
           "requires": {
             "@babel/core": "^7.1.0",
-            "@jest/types": "^25.3.0",
+            "@jest/types": "^25.4.0",
             "babel-plugin-istanbul": "^6.0.0",
             "chalk": "^3.0.0",
             "convert-source-map": "^1.4.0",
             "fast-json-stable-stringify": "^2.0.0",
             "graceful-fs": "^4.2.3",
-            "jest-haste-map": "^25.3.0",
+            "jest-haste-map": "^25.4.0",
             "jest-regex-util": "^25.2.6",
-            "jest-util": "^25.3.0",
+            "jest-util": "^25.4.0",
             "micromatch": "^4.0.2",
             "pirates": "^4.0.1",
             "realpath-native": "^2.0.0",
@@ -1211,9 +1211,9 @@
           }
         },
         "@jest/types": {
-          "version": "25.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.3.0.tgz",
-          "integrity": "sha512-UkaDNewdqXAmCDbN2GlUM6amDKS78eCqiw/UmF5nE0mmLTd6moJkiZJML/X52Ke3LH7Swhw883IRXq8o9nWjVw==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.4.0.tgz",
+          "integrity": "sha512-XBeaWNzw2PPnGW5aXvZt3+VO60M+34RY3XDsCK5tW7kyj3RK0XClRutCfjqcBuaR2aBQTbluEDME9b5MB9UAPw==",
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -1260,15 +1260,15 @@
           }
         },
         "babel-jest": {
-          "version": "25.3.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.3.0.tgz",
-          "integrity": "sha512-qiXeX1Cmw4JZ5yQ4H57WpkO0MZ61Qj+YnsVUwAMnDV5ls+yHon11XjarDdgP7H8lTmiEi6biiZA8y3Tmvx6pCg==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.4.0.tgz",
+          "integrity": "sha512-p+epx4K0ypmHuCnd8BapfyOwWwosNCYhedetQey1awddtfmEX0MmdxctGl956uwUmjwXR5VSS5xJcGX9DvdIog==",
           "requires": {
-            "@jest/transform": "^25.3.0",
-            "@jest/types": "^25.3.0",
+            "@jest/transform": "^25.4.0",
+            "@jest/types": "^25.4.0",
             "@types/babel__core": "^7.1.7",
             "babel-plugin-istanbul": "^6.0.0",
-            "babel-preset-jest": "^25.3.0",
+            "babel-preset-jest": "^25.4.0",
             "chalk": "^3.0.0",
             "slash": "^3.0.0"
           }
@@ -1286,19 +1286,19 @@
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "25.2.6",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.2.6.tgz",
-          "integrity": "sha512-qE2xjMathybYxjiGFJg0mLFrz0qNp83aNZycWDY/SuHiZNq+vQfRQtuINqyXyue1ELd8Rd+1OhFSLjms8msMbw==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.4.0.tgz",
+          "integrity": "sha512-M3a10JCtTyKevb0MjuH6tU+cP/NVQZ82QPADqI1RQYY1OphztsCeIeQmTsHmF/NS6m0E51Zl4QNsI3odXSQF5w==",
           "requires": {
             "@types/babel__traverse": "^7.0.6"
           }
         },
         "babel-preset-jest": {
-          "version": "25.3.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.3.0.tgz",
-          "integrity": "sha512-tjdvLKNMwDI9r+QWz9sZUQGTq1dpoxjUqFUpEasAc7MOtHg9XuLT2fx0udFG+k1nvMV0WvHHVAN7VmCZ+1Zxbw==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.4.0.tgz",
+          "integrity": "sha512-PwFiEWflHdu3JCeTr0Pb9NcHHE34qWFnPQRVPvqQITx4CsDCzs6o05923I10XvLvn9nNsRHuiVgB72wG/90ZHQ==",
           "requires": {
-            "babel-plugin-jest-hoist": "^25.2.6",
+            "babel-plugin-jest-hoist": "^25.4.0",
             "babel-preset-current-node-syntax": "^0.1.2"
           }
         },
@@ -1434,18 +1434,18 @@
           }
         },
         "jest-haste-map": {
-          "version": "25.3.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.3.0.tgz",
-          "integrity": "sha512-LjXaRa+F8wwtSxo9G+hHD/Cp63PPQzvaBL9XCVoJD2rrcJO0Zr2+YYzAFWWYJ5GlPUkoaJFJtOuk0sL6MJY80A==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.4.0.tgz",
+          "integrity": "sha512-5EoCe1gXfGC7jmXbKzqxESrgRcaO3SzWXGCnvp9BcT0CFMyrB1Q6LIsjl9RmvmJGQgW297TCfrdgiy574Rl9HQ==",
           "requires": {
-            "@jest/types": "^25.3.0",
+            "@jest/types": "^25.4.0",
             "anymatch": "^3.0.3",
             "fb-watchman": "^2.0.0",
             "fsevents": "^2.1.2",
             "graceful-fs": "^4.2.3",
             "jest-serializer": "^25.2.6",
-            "jest-util": "^25.3.0",
-            "jest-worker": "^25.2.6",
+            "jest-util": "^25.4.0",
+            "jest-worker": "^25.4.0",
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7",
@@ -1463,20 +1463,20 @@
           "integrity": "sha512-RMVCfZsezQS2Ww4kB5HJTMaMJ0asmC0BHlnobQC6yEtxiFKIxohFA4QSXSabKwSggaNkqxn6Z2VwdFCjhUWuiQ=="
         },
         "jest-util": {
-          "version": "25.3.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.3.0.tgz",
-          "integrity": "sha512-dc625P/KS/CpWTJJJxKc4bA3A6c+PJGBAqS8JTJqx4HqPoKNqXg/Ec8biL2Z1TabwK7E7Ilf0/ukSEXM1VwzNA==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.4.0.tgz",
+          "integrity": "sha512-WSZD59sBtAUjLv1hMeKbNZXmMcrLRWcYqpO8Dz8b4CeCTZpfNQw2q9uwrYAD+BbJoLJlu4ezVPwtAmM/9/SlZA==",
           "requires": {
-            "@jest/types": "^25.3.0",
+            "@jest/types": "^25.4.0",
             "chalk": "^3.0.0",
             "is-ci": "^2.0.0",
             "make-dir": "^3.0.0"
           }
         },
         "jest-worker": {
-          "version": "25.2.6",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
-          "integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.4.0.tgz",
+          "integrity": "sha512-ghAs/1FtfYpMmYQ0AHqxV62XPvKdUDIBBApMZfly+E9JEmYh2K45G0R5dWxx986RN12pRCxsViwQVtGl+N4whw==",
           "requires": {
             "merge-stream": "^2.0.0",
             "supports-color": "^7.0.0"
@@ -1590,9 +1590,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.60.0.tgz",
-      "integrity": "sha512-dGuhZjI4PG7ffDpvhKRl5qAr/ISokxyZNt93fRJFjQAVA+O/SkMpafoGf8djLF9GaMyKnp9hTtaOSnDQ1rC2LA==",
+      "version": "1.60.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.60.1.tgz",
+      "integrity": "sha512-AyWyb7WwM7dbT//mvX5+2U9BUKqrBliutoLAC9PeHWPvPoKwKA79g2s3VJ86BqoTgC/7ol8rN86r0u74ffh2iw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.5.1",
@@ -1635,14 +1635,14 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.149",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-          "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
+          "version": "4.14.150",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
+          "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w=="
         },
         "@types/yup": {
-          "version": "0.26.36",
-          "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.36.tgz",
-          "integrity": "sha512-xOlotjSwyrnkIm7ZzpVu5r1TuFWb65atetUvpLVjNATHIhv/f1oGqBeFSdxrhX7tVbUaf2E5pkBb8e+lFpwHPg=="
+          "version": "0.26.37",
+          "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.37.tgz",
+          "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A=="
         },
         "rxjs": {
           "version": "6.5.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.60.0",
+    "@bigcommerce/checkout-sdk": "^1.60.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Invalid container Id error because of call to getHostedFormOptions even though hosted form fields are not enabled on the store. 

## Why?
Sentry issue logged. 
https://sentry.io/organizations/bigcommerce/issues/1519002299/events/?project=1542560

## Tech Details:
Issue occurs for stores that have credit card vaulting enabled along with vaulting of CVV. 

This fix removes the call to hosted form options method for stores that don't have hosted fields enabled. It also fixes error caused in the scenario where there is no hosted field to be rendered.

This PR depends on https://github.com/bigcommerce/checkout-sdk-js/pull/836

## Testing / Proof
Before
<img width="1647" alt="Screen Shot 2020-04-14 at 2 40 07 pm" src="https://user-images.githubusercontent.com/55068632/79187018-79942900-7e5e-11ea-95d2-703d12ad43aa.png">

After
<img width="1647" alt="Screen Shot 2020-04-14 at 2 40 32 pm" src="https://user-images.githubusercontent.com/55068632/79187025-7e58dd00-7e5e-11ea-832a-23f55b66e75d.png">

@bigcommerce/checkout
