### PR TITLE
CHECKOUT-4739 Rename hasAccount to shouldEncourageSignIn

### DIFF
--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -248,12 +248,12 @@ describe('Customer', () => {
             expect(handleChangeViewType).toHaveBeenCalledWith(CustomerViewType.CancellableEnforcedLogin);
         });
 
-        it('renders SuggestedLogin form if continue as guest returns truthy hasAccount', async () => {
+        it('renders SuggestedLogin form if continue as guest returns truthy shouldEncourageSignIn', async () => {
             jest.spyOn(checkoutService.getState().data, 'getCustomer')
                 .mockReturnValue({
                     ...getCustomer(),
                     isGuest: true,
-                    hasAccount: true,
+                    shouldEncourageSignIn: true,
                 } as any);
 
             jest.spyOn(checkoutService, 'continueAsGuest')

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -149,9 +149,9 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps> {
             });
 
             // todo: remove when SDK has been updated
-            const { hasAccount, isGuest } = data.getCustomer() as unknown as CustomerType & { hasAccount: boolean };
+            const { shouldEncourageSignIn, isGuest } = data.getCustomer() as unknown as CustomerType & { shouldEncourageSignIn: boolean };
 
-            if (hasAccount && isGuest) {
+            if (shouldEncourageSignIn && isGuest) {
                 return onChangeViewType(CustomerViewType.SuggestedLogin);
             }
 


### PR DESCRIPTION
## What?
Rename `hasAccount` to `shouldEncourageSignIn`

## Why?
To match API

## Testing / Proof
unit

@bigcommerce/checkout
