### PR TITLE
INT-2541 Add Laybuy payment method

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -257,6 +257,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.Checkoutcom ||
             selectedMethod.id === PaymentMethodId.Converge ||
             selectedMethod.id === PaymentMethodId.SagePay ||
+            selectedMethod.id === PaymentMethodId.Laybuy ||
             selectedMethod.gateway === PaymentMethodId.AdyenV2 ||
             selectedMethod.gateway === PaymentMethodId.Afterpay) {
             return;

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -127,6 +127,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
     }
 
     if (method.gateway === PaymentMethodId.Afterpay ||
+        method.id === PaymentMethodId.Laybuy ||
         method.id === PaymentMethodId.Zip ||
         method.method === PaymentMethodType.Paypal ||
         method.method === PaymentMethodType.PaypalCredit ||

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -16,6 +16,7 @@ enum PaymentMethodId {
     CheckoutcomGooglePay = 'googlepaycheckoutcom',
     Converge = 'converge',
     Klarna = 'klarna',
+    Laybuy = 'laybuy',
     Masterpass = 'masterpass',
     PaypalExpress = 'paypalexpress',
     PaypalPaymentsPro = 'paypal',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -31,6 +31,7 @@ describe('PaymentMethodTitle', () => {
         chasepay: '/img/payment-providers/chase-pay.png',
         googlepay: '/img/payment-providers/google-pay.png',
         klarna: '/img/payment-providers/klarna-header.png',
+        laybuy: '/img/payment-providers/laybuy-checkout-header.png',
         masterpass: 'https://masterpass.com/dyn/img/acc/global/mp_mark_hor_blk.svg',
         paypal: '/img/payment-providers/paypalpaymentsprouk.png',
         zip: '/img/payment-providers/zip.png',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -73,6 +73,10 @@ function getPaymentMethodTitle(
                 logoUrl: cdnPath('/img/payment-providers/klarna-header.png'),
                 titleText: method.config && method.config.displayName || '',
             },
+            [PaymentMethodId.Laybuy]: {
+                logoUrl: cdnPath('/img/payment-providers/laybuy-checkout-header.png'),
+                titleText: '',
+            },
             [PaymentMethodId.Masterpass]: {
                 logoUrl: 'https://masterpass.com/dyn/img/acc/global/mp_mark_hor_blk.svg',
                 titleText: '',


### PR DESCRIPTION
## What? [INT-2541](https://jira.bigcommerce.com/browse/INT-2541)
Create the Laybuy payment strategy and make it available in checkout.

## Why?
A new payment method is required to support Laybuy

## PR Dependencies
https://github.com/bigcommerce/checkout-sdk-js/pull/837

## Testing / Proof
[Video](https://drive.google.com/file/d/1kT8tpTtpl7F3hXlPcixo6qcDtHnbVdfu/view?usp=sharing)
<img width="745" alt="Screen Shot 2020-04-21 at 12 22 24 PM" src="https://user-images.githubusercontent.com/42154828/79894290-d77ac080-83ca-11ea-90e1-27abbd15266d.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
