### PR TITLE
CHECKOUT-4842: Add missing class name which causes fields to be misaligned in tablet view

### DIFF
--- a/src/app/payment/creditCard/HostedCreditCardNumberField.spec.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardNumberField.spec.tsx
@@ -1,0 +1,45 @@
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { FormField } from '../../ui/form';
+
+import HostedCreditCardNumberField, { HostedCreditCardNumberFieldProps } from './HostedCreditCardNumberField';
+
+describe('HostedCreditCardNumberField', () => {
+    let HostedCreditCardNumberFieldTest: FunctionComponent<HostedCreditCardNumberFieldProps>;
+    let defaultProps: HostedCreditCardNumberFieldProps;
+    let initialValues: { ccNumber: string };
+    let localeContext: LocaleContextType;
+
+    beforeEach(() => {
+        initialValues = { ccNumber: '' };
+        localeContext = createLocaleContext(getStoreConfig());
+        defaultProps = {
+            appearFocused: true,
+            id: 'ccNumber',
+            name: 'ccNumber',
+        };
+
+        HostedCreditCardNumberFieldTest = props => (
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <HostedCreditCardNumberField { ...props } />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('renders field with expected class name', () => {
+        const component = mount(<HostedCreditCardNumberFieldTest { ...defaultProps } />);
+
+        expect(component.find(FormField).prop('additionalClassName'))
+            .toContain('form-field--ccNumber');
+    });
+});

--- a/src/app/payment/creditCard/HostedCreditCardNumberField.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardNumberField.tsx
@@ -27,6 +27,7 @@ const HostedCreditCardNumberField: FunctionComponent<HostedCreditCardNumberField
 
     return (
         <FormField
+            additionalClassName="form-field--ccNumber"
             input={ renderInput }
             labelContent={ <TranslatedString id="payment.credit_card_number_label" /> }
             name={ name }


### PR DESCRIPTION
## What?
We need `form-field--ccNumber` for the card field to align properly with other payment form fields

## Why?
Otherwise the fields are not aligned in tablet view.

## Testing / Proof
CircleCI

**Before**
<img width="532" alt="Screen Shot 2020-04-17 at 9 56 17 am" src="https://user-images.githubusercontent.com/667603/79705126-e80e3680-82f7-11ea-85ee-a35189d3a0b0.png">

**After**
<img width="529" alt="Screen Shot 2020-04-17 at 9 56 29 am" src="https://user-images.githubusercontent.com/667603/79705138-ee041780-82f7-11ea-9cde-6fee641c2ba5.png">

@bigcommerce/checkout
