### PR TITLE
CHECKOUT-4842: Add missing tooltip for CVV field

### DIFF
--- a/src/app/payment/creditCard/HostedCreditCardCodeField.spec.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardCodeField.spec.tsx
@@ -1,0 +1,48 @@
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { IconHelp } from '../../ui/icon';
+import { TooltipTrigger } from '../../ui/tooltip';
+
+import HostedCreditCardCodeField, { HostedCreditCardCodeFieldProps } from './HostedCreditCardCodeField';
+
+describe('HostedCreditCardCodeField', () => {
+    let HostedCreditCardCodeFieldTest: FunctionComponent<HostedCreditCardCodeFieldProps>;
+    let defaultProps: HostedCreditCardCodeFieldProps;
+    let initialValues: { ccCvv: string };
+    let localeContext: LocaleContextType;
+
+    beforeEach(() => {
+        initialValues = { ccCvv: '' };
+        localeContext = createLocaleContext(getStoreConfig());
+        defaultProps = {
+            appearFocused: true,
+            id: 'ccCvv',
+            name: 'ccCvv',
+        };
+
+        HostedCreditCardCodeFieldTest = props => (
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <HostedCreditCardCodeField { ...props } />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('renders field with tooltip icon', () => {
+        const component = mount(<HostedCreditCardCodeFieldTest { ...defaultProps } />);
+
+        expect(component.find(IconHelp).length)
+            .toEqual(1);
+        expect(component.find(TooltipTrigger).length)
+            .toEqual(1);
+    });
+});

--- a/src/app/payment/creditCard/HostedCreditCardCodeField.tsx
+++ b/src/app/payment/creditCard/HostedCreditCardCodeField.tsx
@@ -1,8 +1,11 @@
-import React, { useCallback, FunctionComponent } from 'react';
+import React, { useCallback, useMemo, Fragment, FunctionComponent } from 'react';
 
 import { TranslatedString } from '../../locale';
 import { FormField, TextInputIframeContainer } from '../../ui/form';
-import { IconLock } from '../../ui/icon';
+import { IconHelp, IconLock } from '../../ui/icon';
+import { TooltipTrigger } from '../../ui/tooltip';
+
+import CreditCardCodeTooltip from './CreditCardCodeTooltip';
 
 export interface HostedCreditCardCodeFieldProps {
     appearFocused: boolean;
@@ -25,11 +28,26 @@ const HostedCreditCardCodeField: FunctionComponent<HostedCreditCardCodeFieldProp
         <IconLock />
     </>), [id, appearFocused]);
 
+    const labelContent = useMemo(() => (
+        <Fragment>
+            <TranslatedString id="payment.credit_card_cvv_label" />
+
+            <TooltipTrigger
+                placement="top-start"
+                tooltip={ <CreditCardCodeTooltip /> }
+            >
+                <span className="has-tip">
+                    <IconHelp />
+                </span>
+            </TooltipTrigger>
+        </Fragment>
+    ), []);
+
     return (
         <FormField
             additionalClassName="form-ccFields-field--ccCvv"
             input={ renderInput }
-            labelContent={ <TranslatedString id="payment.credit_card_cvv_label" /> }
+            labelContent={ labelContent }
             name={ name }
         />
     );


### PR DESCRIPTION
## What?
Add the missing tooltip for CVV field

## Why?
So that shoppers know what information they need to provide in case they don't know what CVV means.

## Testing / Proof
CircleCI + Manual

<img width="362" alt="Screen Shot 2020-04-20 at 12 26 05 pm" src="https://user-images.githubusercontent.com/667603/79708578-15141680-8303-11ea-836d-525529d45e63.png">

@bigcommerce/checkout @bigcommerce/payments 
