### PR TITLE
CHECKOUT-4842: Update CircleCI config to use `validate-commits` command provided by our internal orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,15 +46,6 @@ jobs:
           paths:
             - dist
 
-  validate-commits:
-    <<: *node_executor
-    steps:
-      - ci/pre-setup
-      - ci/merge-base
-      - run:
-          name: 'Validate Commits'
-          command: '[ -z "$MERGE_BASE_SHA1" ] || npx @bigcommerce/validate-commits ${MERGE_BASE_SHA1}..${CIRCLE_SHA1}'
-
   release:
     <<: *node_executor
     steps:
@@ -119,7 +110,7 @@ workflows:
       - build:
           filters:
             <<: *pull_request_filter
-      - validate-commits:
+      - ci/validate-commits:
           filters:
             <<: *pull_request_filter
 


### PR DESCRIPTION
## What?
Update CircleCI config to use `validate-commits` command provided by our internal orb.

## Why?
I thought I did it before but I didn't (I only did it for `npm-install`).

## Testing / Proof
CircleCI

@bigcommerce/checkout @icatalina 
