### PR TITLE
fix(payment): PAYMENTS-5380 Checkout payment methods list is not complete …

### DIFF
--- a/src/app/payment/Payment.spec.tsx
+++ b/src/app/payment/Payment.spec.tsx
@@ -177,7 +177,22 @@ describe('Payment', () => {
             .toEqual(paymentMethods[0]);
     });
 
-    it('sets selected hosted payment as default selected payment method', async () => {
+    it('sets default selected payment method to the one with default stored instrument', async () => {
+        paymentMethods[1].config.hasDefaultStoredInstrument = true;
+
+        const container = mount(<PaymentTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+        container.update();
+
+        expect(container.find(PaymentForm).props())
+            .toEqual(expect.objectContaining({
+                methods: paymentMethods,
+                selectedMethod: paymentMethods[1],
+            }));
+    });
+
+    it('sets selected hosted payment as default selected payment method and filters methods prop to the hosted payment only', async () => {
         jest.spyOn(checkoutState.data, 'getCheckout')
             .mockReturnValue({
                 ...getCheckout(),
@@ -192,8 +207,11 @@ describe('Payment', () => {
         await new Promise(resolve => process.nextTick(resolve));
         container.update();
 
-        expect(container.find(PaymentForm).prop('selectedMethod'))
-            .toEqual(paymentMethods[1]);
+        expect(container.find(PaymentForm).props())
+            .toEqual(expect.objectContaining({
+                methods: [paymentMethods[1]],
+                selectedMethod: paymentMethods[1],
+            }));
     });
 
     it('updates default selected payment method when list changes', async () => {

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -427,13 +427,14 @@ export function mapToPaymentProps({
     const selectedPayment = find(checkout.payments, { providerType: PaymentMethodProviderType.Hosted });
 
     let selectedPaymentMethod;
+    let filteredMethods;
     if (selectedPayment) {
         selectedPaymentMethod = getPaymentMethod(selectedPayment.providerId, selectedPayment.gatewayId);
+        filteredMethods = selectedPaymentMethod ? compact([selectedPaymentMethod]) : methods;
     } else {
         selectedPaymentMethod = find(methods, { config: { hasDefaultStoredInstrument: true } });
+        filteredMethods = methods;
     }
-
-    const filteredMethods = selectedPaymentMethod ? compact([selectedPaymentMethod]) : methods;
 
     return {
         availableStoreCredit: customer.storeCredit,

--- a/src/app/payment/payment-methods.mock.ts
+++ b/src/app/payment/payment-methods.mock.ts
@@ -15,6 +15,7 @@ export function getPaymentMethod(): PaymentMethod {
             displayName: 'Authorizenet',
             cardCode: true,
             enablePaypal: undefined,
+            hasDefaultStoredInstrument: false,
             helpText: '',
             is3dsEnabled: undefined,
             isVisaCheckoutEnabled: undefined,


### PR DESCRIPTION
…if default vaulted instrument is not BT

## What?
When a non-Braintree payment method (vaulted instrument) is set as default on My Account, this method is the only one existing in the payment methods list on Checkout, i.e. no other payment method is listed

## Why?
All available payment methods should be listed with the default method pre-selected.

## Testing / Proof
Unit tests
Screenshots (with Authorize.net credit card set as default payment method)
**Before**
<img width="655" alt="Screen Shot 2020-04-20 at 5 39 26 pm" src="https://user-images.githubusercontent.com/36555311/79726291-e95a5600-832d-11ea-9100-829503e03be6.png">

**After**
<img width="672" alt="Screen Shot 2020-04-20 at 5 38 25 pm" src="https://user-images.githubusercontent.com/36555311/79726300-ea8b8300-832d-11ea-9be8-5c0c2d8d05ef.png">


@bigcommerce/checkout
@bigcommerce/payments 