### PR TITLE
INT-2428 Display vaulted accounts on payment step for Adyenv2

### DIFF
--- a/src/app/payment/storedInstrument/AccountInstrumentSelect.spec.tsx
+++ b/src/app/payment/storedInstrument/AccountInstrumentSelect.spec.tsx
@@ -7,6 +7,7 @@ import { Omit } from 'utility-types';
 import { getStoreConfig } from '../../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
 
+import { isBankAccountInstrument } from './index';
 import { getInstruments } from './instruments.mock';
 import isAccountInstrument from './isAccountInstrument';
 import AccountInstrumentSelect, { AccountInstrumentSelectProps } from './AccountInstrumentSelect';
@@ -241,5 +242,70 @@ describe('AccountInstrumentSelect', () => {
         await new Promise(resolve => process.nextTick(resolve));
 
         expect(submit).toHaveBeenCalledWith({ instrumentId: '' }, expect.anything());
+    });
+
+    it('shows list of instruments when clicked and is a bank instrument', () => {
+        defaultProps.instruments = getInstruments().filter(isBankAccountInstrument);
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <Field
+                        name="instrumentId"
+                        render={ (field: FieldProps<string>) => (
+                            <AccountInstrumentSelect
+                                { ...field }
+                                { ...defaultProps }
+                            />
+                        ) }
+                    />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        component.find('[data-test="instrument-select"]')
+            .simulate('click')
+            .update();
+
+        expect(component.exists('[data-test="instrument-select-menu"]'))
+            .toEqual(true);
+
+        expect(component.find('[data-test="instrument-select-option"]').at(0).text())
+            .toContain('Iban ending in: ABCIssuer: DEF');
+    });
+
+    it('notifies parent when instrument is selected and is a bank instrument', () => {
+        defaultProps.instruments = getInstruments().filter(isBankAccountInstrument);
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ initialValues }
+                    onSubmit={ noop }
+                >
+                    <Field
+                        name="instrumentId"
+                        render={ (field: FieldProps<string>) => (
+                            <AccountInstrumentSelect
+                                { ...field }
+                                { ...defaultProps }
+                            />
+                        ) }
+                    />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        component.find('[data-test="instrument-select"]')
+            .simulate('click')
+            .update();
+
+        component.find('[data-test="instrument-select-option"]').at(1)
+            .simulate('click')
+            .update();
+
+        expect(defaultProps.onSelectInstrument)
+            .toHaveBeenCalledWith('45454545');
     });
 });

--- a/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
+++ b/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
@@ -8,6 +8,8 @@ import { TranslatedString } from '../../locale';
 import { DropdownTrigger } from '../../ui/dropdown';
 import { IconNewAccount, IconPaypal, IconSize } from '../../ui/icon';
 
+import isBankAccountInstrument from './isBankAccountInstrument';
+
 export interface AccountInstrumentSelectProps extends FieldProps<string> {
     instruments: AccountInstrument[];
     selectedInstrumentId?: string;
@@ -152,12 +154,19 @@ const AccountInstrumentSelectButton: FunctionComponent<AccountInstrumentSelectBu
     }
 
     return (
-        <AccountInstrumentMenuItem
-            className="instrumentSelect-button optimizedCheckout-form-select dropdown-button form-input"
-            instrument={ instrument }
-            onClick={ onClick }
-            testId={ testId }
-        />
+        !isBankAccountInstrument(instrument) ?
+            (<AccountInstrumentMenuItem
+                className="instrumentSelect-button optimizedCheckout-form-select dropdown-button form-input"
+                instrument={ instrument }
+                onClick={ onClick }
+                testId={ testId }
+            />) :
+            (<BankInstrumentMenuItem
+                className="instrumentSelect-button optimizedCheckout-form-select dropdown-button form-input"
+                instrument={ instrument }
+                onClick={ onClick }
+                testId={ testId }
+            />)
     );
 };
 
@@ -179,11 +188,17 @@ const AccountInstrumentOption: FunctionComponent<AccountInstrumentOptionProps> =
     ]);
 
     return (
-        <AccountInstrumentMenuItem
-            instrument={ instrument }
-            onClick={ handleClick }
-            testId="instrument-select-option"
-        />
+        !isBankAccountInstrument(instrument) ?
+            (<AccountInstrumentMenuItem
+                instrument={ instrument }
+                onClick={ handleClick }
+                testId="instrument-select-option"
+            />) :
+            (<BankInstrumentMenuItem
+                instrument={ instrument }
+                onClick={ handleClick }
+                testId="instrument-select-option"
+            />)
     );
 };
 
@@ -222,6 +237,38 @@ const AccountInstrumentMenuItem: FunctionComponent<AccountInstrumentMenuItemProp
                     data-test={ `${testId}-externalId` }
                 >
                     { externalId }
+                </div>
+            </div>
+        </button>
+    );
+};
+
+const BankInstrumentMenuItem: FunctionComponent<AccountInstrumentMenuItemProps> = ({
+      className,
+      instrument,
+      testId,
+      onClick,
+}) => {
+    const issuerName = `Issuer: ${instrument.issuer}`;
+    const maskIban = `Iban ending in: ${instrument.iban}`;
+
+    return (
+        <button
+            className={ className }
+            data-test={ testId }
+            onClick={ onClick }
+            type="button"
+        >
+            <div className="instrumentSelect-details">
+                {
+                    // TODO: When we include new account instrument types we can
+                    // abstract these icons in a similar way we did for credit cards.
+                }
+                <div className="instrumentSelect-card">
+                    { maskIban }
+                </div>
+                <div className="instrumentSelect-issuer">
+                    { issuerName }
                 </div>
             </div>
         </button>

--- a/src/app/payment/storedInstrument/ManageAccountInstrumentsTable.tsx
+++ b/src/app/payment/storedInstrument/ManageAccountInstrumentsTable.tsx
@@ -5,6 +5,8 @@ import { TranslatedString } from '../../locale';
 import { IconPaypal, IconSize } from '../../ui/icon';
 import { LoadingOverlay } from '../../ui/loading';
 
+import isBankAccountInstrument from './isBankAccountInstrument';
+
 export interface ManageAccountInstrumentsTableProps {
     instruments: AccountInstrument[];
     isDeletingInstrument: boolean;
@@ -65,10 +67,10 @@ const ManageInstrumentsRow: FunctionComponent<ManageInstrumentsRowProps> = ({
     return (
         <tr>
             <td data-test="manage-instrument-accountExternalId">
-                <IconPaypal
+                { !isBankAccountInstrument(instrument) && <IconPaypal
                     additionalClassName="accountIcon-icon"
                     size={ IconSize.Medium }
-                />
+                /> }
 
                 <span className="instrumentModal-instrumentAccountExternalId">
                     { instrument.externalId }

--- a/src/app/payment/storedInstrument/ManageInstrumentsModal.tsx
+++ b/src/app/payment/storedInstrument/ManageInstrumentsModal.tsx
@@ -8,6 +8,7 @@ import { Button, ButtonSize, ButtonVariant } from '../../ui/button';
 import { Modal, ModalHeader } from '../../ui/modal';
 
 import isAccountInstrument from './isAccountInstrument';
+import isBankAccountInstrument from './isBankAccountInstrument';
 import isCardInstrument from './isCardInstrument';
 import ManageAccountInstrumentsTable from './ManageAccountInstrumentsTable';
 import ManageCardInstrumentsTable from './ManageCardInstrumentsTable';
@@ -79,7 +80,9 @@ class ManageInstrumentsModal extends Component<ManageInstrumentsModalProps & Wit
             );
         }
         const cardInstruments = instruments.filter(isCardInstrument);
+        const bankInstruments = instruments.filter(isBankAccountInstrument);
         const accountInstruments = instruments.filter(isAccountInstrument);
+        accountInstruments.push(...bankInstruments, ...accountInstruments);
 
         return (
             accountInstruments.length

--- a/src/app/payment/storedInstrument/index.ts
+++ b/src/app/payment/storedInstrument/index.ts
@@ -15,3 +15,4 @@ export { default as CreditCardValidation } from './CreditCardValidation';
 export { default as HostedCreditCardValidation } from './HostedCreditCardValidation';
 export { default as isCardInstrument } from './isCardInstrument';
 export { default as isAccountInstrument } from './isAccountInstrument';
+export { default as isBankAccountInstrument } from './isBankAccountInstrument';

--- a/src/app/payment/storedInstrument/instruments.mock.ts
+++ b/src/app/payment/storedInstrument/instruments.mock.ts
@@ -46,6 +46,28 @@ export function getInstruments(): PaymentInstrument[] {
             method: 'paypal',
             type: 'account',
         },
+        {
+            bigpayToken: '12341234',
+            provider: 'adyen',
+            iban: 'ABC',
+            issuer: 'DEF',
+            externalId: 'test@external-id-3.com',
+            trustedShippingAddress: false,
+            defaultInstrument: false,
+            method: 'ideal',
+            type: 'bank',
+        },
+        {
+            bigpayToken: '45454545',
+            provider: 'adyen',
+            iban: 'GHI',
+            issuer: 'JKL',
+            externalId: 'test@external-id-4.com',
+            trustedShippingAddress: false,
+            defaultInstrument: false,
+            method: 'ideal',
+            type: 'bank',
+        },
     ];
 }
 
@@ -74,5 +96,17 @@ export function getAccountInstrument(): AccountInstrument {
         defaultInstrument: true,
         method: 'paypal',
         type: 'account',
+    };
+}
+
+export function getBankInstrument(): AccountInstrument {
+    return {
+        bigpayToken: '454545',
+        provider: 'adyen',
+        externalId: 'test@external-id-3.com',
+        trustedShippingAddress: true,
+        defaultInstrument: true,
+        method: 'ideal',
+        type: 'bank',
     };
 }

--- a/src/app/payment/storedInstrument/isBankAccountInstrument.spec.ts
+++ b/src/app/payment/storedInstrument/isBankAccountInstrument.spec.ts
@@ -1,0 +1,12 @@
+import { isBankAccountInstrument } from '.';
+import { getBankInstrument, getCardInstrument } from './instruments.mock';
+
+describe('isBankAccountInstrument', () => {
+    it('returns true for bank instruments', () => {
+        expect(isBankAccountInstrument(getBankInstrument())).toBeTruthy();
+    });
+
+    it('returns false for non bank instruments', () => {
+        expect(isBankAccountInstrument(getCardInstrument())).toBeFalsy();
+    });
+});

--- a/src/app/payment/storedInstrument/isBankAccountInstrument.ts
+++ b/src/app/payment/storedInstrument/isBankAccountInstrument.ts
@@ -1,0 +1,5 @@
+import { AccountInstrument, PaymentInstrument } from '@bigcommerce/checkout-sdk';
+
+export default function isBankAccountInstrument(instrument: PaymentInstrument): instrument is AccountInstrument {
+    return instrument.type === 'bank';
+}

--- a/src/scss/components/checkout/instrumentSelect/_instrumentSelect.scss
+++ b/src/scss/components/checkout/instrumentSelect/_instrumentSelect.scss
@@ -69,6 +69,12 @@
     text-align: right;
 }
 
+.instrumentSelect-issuer {
+    flex-grow: 2;
+    margin-right: remCalc(20px);
+    text-align: left;
+}
+
 .instrumentSelect-expiry--expired {
     color: color("error");
 }


### PR DESCRIPTION
## What? [INT-2428](https://jira.bigcommerce.com/browse/INT-2428)
Adding functionality to the vaulted account instruments dropdown

## Why?
To show bank account instruments on Adyen APM's

## Testing / Proof
![image](https://user-images.githubusercontent.com/42655796/79795208-32ec7600-8319-11ea-93b2-2c56be5c7f90.png)

This PR depends on:
https://github.com/bigcommerce/checkout-sdk-js/pull/842

@bigcommerce/checkout @bigcommerce/apex-integrations 
