### PR TITLE
CHECKOUT-4842: Submit hosted payment form when "enter" key is pressed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,9 +1349,9 @@
           }
         },
         "fsevents": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
           "optional": true
         },
         "graceful-fs": {
@@ -1496,9 +1496,9 @@
           }
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "requires": {
             "semver": "^6.0.0"
           }
@@ -1590,9 +1590,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.60.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.60.1.tgz",
-      "integrity": "sha512-AyWyb7WwM7dbT//mvX5+2U9BUKqrBliutoLAC9PeHWPvPoKwKA79g2s3VJ86BqoTgC/7ol8rN86r0u74ffh2iw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.61.0.tgz",
+      "integrity": "sha512-GCZ0G7yErcBX9AhwuvE6tU48JlM064wvLcu4VpzvV4NnpJ8JvR2o8S1vt88w1m58dHSakKs1kj8vijroiyirjA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.5.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.60.1",
+    "@bigcommerce/checkout-sdk": "^1.61.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
@@ -8,6 +8,7 @@ import { withCheckout, CheckoutContextProps } from '../../checkout';
 import { connectFormik, ConnectFormikProps } from '../../common/form';
 import { MapToProps } from '../../common/hoc';
 import { withLanguage, WithLanguageProps } from '../../locale';
+import { withForm, WithFormProps } from '../../ui/form';
 import { LoadingOverlay } from '../../ui/loading';
 import { configureCardValidator, getCreditCardInputStyles, getCreditCardValidationSchema, getHostedCreditCardValidationSchema, CreditCardCustomerCodeField, CreditCardFieldset, CreditCardFieldsetValues, CreditCardInputStylesType, HostedCreditCardFieldset, HostedCreditCardFieldsetValues } from '../creditCard';
 import { getHostedInstrumentValidationSchema, getInstrumentValidationSchema, isCardInstrument, isInstrumentCardCodeRequiredSelector, isInstrumentCardNumberRequiredSelector, isInstrumentFeatureAvailable, CardInstrumentFieldset, CardInstrumentFieldsetValues, CreditCardValidation, HostedCreditCardValidation } from '../storedInstrument';
@@ -49,6 +50,7 @@ interface CreditCardPaymentMethodState {
 class CreditCardPaymentMethod extends Component<
     CreditCardPaymentMethodProps &
         WithCheckoutCreditCardPaymentMethodProps &
+        WithFormProps &
         WithPaymentProps &
         WithLanguageProps &
         ConnectFormikProps<PaymentFormValues>,
@@ -318,6 +320,7 @@ class CreditCardPaymentMethod extends Component<
                 } : {},
             onBlur: this.handleHostedFieldBlur,
             onCardTypeChange: this.handleHostedFieldCardTypeChange,
+            onEnter: this.handleHostedFieldEnter,
             onFocus: this.handleHostedFieldFocus,
             onValidate: this.handleHostedFieldValidate,
         };
@@ -345,6 +348,13 @@ class CreditCardPaymentMethod extends Component<
                 focusedHostedFieldType: undefined,
             });
         }
+    };
+
+    private handleHostedFieldEnter: () => void = () => {
+        const { formik, setSubmitted } = this.props;
+
+        setSubmitted(true);
+        formik.submitForm();
     };
 
     private handleHostedFieldFocus: (event: HostedFieldFocusEventData) => void = ({ fieldType }) => {
@@ -437,4 +447,4 @@ function mapFromCheckoutProps(): MapToProps<
     };
 }
 
-export default connectFormik(withLanguage(withPayment(withCheckout(mapFromCheckoutProps)(CreditCardPaymentMethod))));
+export default connectFormik(withForm(withLanguage(withPayment(withCheckout(mapFromCheckoutProps)(CreditCardPaymentMethod)))));

--- a/src/app/ui/form/index.ts
+++ b/src/app/ui/form/index.ts
@@ -1,3 +1,4 @@
+import { WithFormProps } from './withForm';
 import { BasicFormFieldProps } from './BasicFormField';
 import { CheckboxFormFieldProps } from './CheckboxFormField';
 import { ChecklistProps } from './Checklist';
@@ -29,7 +30,9 @@ export type TextInputProps = TextInputProps;
 export type LabelProps = LabelProps;
 export type LegendProps = LegendProps;
 export type ChecklistItemInputProps = ChecklistItemInputProps;
+export type WithFormProps = WithFormProps;
 
+export { default as withForm } from './withForm';
 export { default as Fieldset } from './Fieldset';
 export { default as Form } from './Form';
 export { default as FormProvider, FormContext } from './FormProvider';

--- a/src/app/ui/form/withForm.tsx
+++ b/src/app/ui/form/withForm.tsx
@@ -1,0 +1,9 @@
+import { createInjectHoc } from '../../common/hoc';
+
+import { FormContext, FormContextType } from './FormProvider';
+
+export type WithFormProps = FormContextType;
+
+const withForm = createInjectHoc(FormContext, { displayNamePrefix: 'WithForm' });
+
+export default withForm;


### PR DESCRIPTION
## What?
Submit the hosted payment form when "enter" key is pressed.

## Why?
It's a better user experience.

## Testing / Proof
CircleCI + Manual

![enter-key](https://user-images.githubusercontent.com/667603/79927165-40713f80-8482-11ea-97f7-8eca99648fb6.gif)

@bigcommerce/checkout @TomA-R 
