### PR TITLE
feat(checkout): INT-2602 Replace Barclaycard's Place Order text

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -142,6 +142,7 @@
             "afterpay_description": "Checkout with Afterpay",
             "amazon_continue_action": "Continue with Amazon",
             "amazon_name_text": "Amazon Pay",
+            "barclaycard_continue_action": "Continue",
             "bluesnap_v2_continue_action": "Continue",
             "braintreevisacheckout_continue_action": "Continue with Visa Checkout",
             "ccavenuemars_description_text": "Checkout with CCAvenue",

--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -67,6 +67,15 @@ describe('PaymentSubmitButton', () => {
             .toEqual(languageService.translate('payment.amazon_continue_action'));
     });
 
+    it('renders button with special label for Barclaycard', () => {
+        const component = mount(
+            <PaymentSubmitButtonTest methodGateway="barclaycard" />
+        );
+
+        expect(component.text())
+            .toEqual(languageService.translate('payment.barclaycard_continue_action'));
+    });
+
     it('renders button with special label for Visa Checkout provided by Braintree', () => {
         const component = mount(
             <PaymentSubmitButtonTest methodType="visa-checkout" />

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -17,6 +17,10 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
         return <TranslatedString id="payment.amazon_continue_action" />;
     }
 
+    if (methodGateway === PaymentMethodId.Barclaycard) {
+        return <TranslatedString id="payment.barclaycard_continue_action" />;
+    }
+
     if (methodGateway === PaymentMethodId.BlueSnapV2) {
         return <TranslatedString id="payment.bluesnap_v2_continue_action" />;
     }


### PR DESCRIPTION
## What? [INT-2602](https://jira.bigcommerce.com/browse/INT-2602)
Replace the "Place order" Button text with "Continue" when selecting Barclaycard as payment method.

## Why?
Barclaycard requested this as a `nice to have` in the latest feedback.

## Testing / Proof
[Demo Video](https://drive.google.com/open?id=1nxztbcjvBxIwLXSlv63TveEs7xuYrNsa)
![Screen Shot 2020-04-24 at 12 19 35 PM](https://user-images.githubusercontent.com/35502707/80240010-cded9480-8626-11ea-9d32-073def450f45.png)


@bigcommerce/checkout @bigcommerce/apex-integrations 
