### PR TITLE
[wip] feat(payment): INT-2532 Accept payments through StripeV3 using iDEAL

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -253,8 +253,8 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         const { defaultMethod, isSubmittingOrder, language } = this.props;
         const { selectedMethod = defaultMethod } = this.state;
 
-        // TODO: Perhaps there is a better way to handle `adyen`, `afterpay`, `amazon`,
-        // `checkout.com`, `converge` and `sagepay``. They require a redirection to another website
+        // TODO: Perhaps there is a better way to handle `adyen`, `afterpay`, `amazon`, `checkout.com`,
+        // `converge`, `laybuy`, `sagepay` and `stripev3`. They require a redirection to another website
         // during the payment flow but are not categorised as hosted payment methods.
         if (!isSubmittingOrder ||
             !selectedMethod ||
@@ -262,10 +262,13 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.Amazon ||
             selectedMethod.id === PaymentMethodId.Checkoutcom ||
             selectedMethod.id === PaymentMethodId.Converge ||
-            selectedMethod.id === PaymentMethodId.SagePay ||
             selectedMethod.id === PaymentMethodId.Laybuy ||
+            selectedMethod.id === PaymentMethodId.SagePay ||
+            selectedMethod.id === PaymentMethodId.StripeV3 || // tmp
             selectedMethod.gateway === PaymentMethodId.AdyenV2 ||
             selectedMethod.gateway === PaymentMethodId.Afterpay) {
+            // selectedMethod.gateway === PaymentMethodId.Afterpay ||
+            // selectedMethod.gateway === PaymentMethodId.StripeV3) {
             return;
         }
 

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -63,6 +63,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
         return <SquarePaymentMethod { ...props } />;
     }
 
+    // if (method.gateway === PaymentMethodId.StripeV3) {
     if (method.id === PaymentMethodId.StripeV3) {
         return <StripePaymentMethod { ...props } />;
     }

--- a/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -17,7 +17,7 @@ jest.mock('../creditCard', () => ({
     ...jest.requireActual('../creditCard'),
     getCreditCardInputStyles: jest.fn<ReturnType<typeof getCreditCardInputStyles>, Parameters<typeof getCreditCardInputStyles>>(
         (_containerId, _fieldType) => {
-            return Promise.resolve({ color: 'rgb(255, 0, 0)', fontWeight: '500', fontFamily: 'Montserrat, Arial, Helvetica, sans-serif', fontSize: '14px', fontSmoothing: 'auto'});
+            return Promise.resolve({ color: 'rgb(255, 0, 0)', fontWeight: '500', fontFamily: 'Montserrat, Arial, Helvetica, sans-serif', fontSize: '14px'});
         }
     ),
 }));
@@ -39,6 +39,7 @@ describe('when using Stripe payment', () => {
         checkoutService = createCheckoutService();
         checkoutState = checkoutService.getState();
         localeContext = createLocaleContext(getStoreConfig());
+        // method = { ...getPaymentMethod(), id: 'card', gateway: 'stripev3' };
         method = { ...getPaymentMethod(), id: 'stripev3' };
 
         jest.spyOn(checkoutState.data, 'getConfig')
@@ -70,7 +71,7 @@ describe('when using Stripe payment', () => {
 
         expect(component.props())
             .toEqual(expect.objectContaining({
-                containerId: 'stripe-card-field',
+                containerId: `stripe-card-element`,
                 deinitializePayment: expect.any(Function),
                 initializePayment: expect.any(Function),
                 additionalContainerClassName: 'optimizedCheckout-form-input',
@@ -88,7 +89,7 @@ describe('when using Stripe payment', () => {
         });
 
         expect(getCreditCardInputStyles)
-            .toHaveBeenCalledWith('stripe-card-field', ['color', 'fontFamily', 'fontWeight', 'fontSmoothing']);
+            .toHaveBeenCalledWith('stripe-card-element', ['color', 'fontFamily', 'fontSize', 'fontWeight']);
 
         await new Promise(resolve => process.nextTick(resolve));
 
@@ -96,25 +97,26 @@ describe('when using Stripe payment', () => {
             .toHaveBeenCalledWith(expect.objectContaining({
                 methodId: method.id,
                 gatewayId: method.gateway,
+                // [method.gateway]: {
                 [method.id]: {
-                    containerId: 'stripe-card-field',
+                    type: 'card',
+                    containerId: 'stripe-card-element',
                     style: {
                         base: {
                             color: 'rgb(255, 0, 0)',
                             fontWeight: '500',
                             fontFamily: 'Montserrat, Arial, Helvetica, sans-serif',
                             fontSize: '14px',
-                            fontSmoothing: 'auto',
                             '::placeholder': {
                                 color: '#E1E1E1',
-                           },
+                            },
+                            padding: '5px',
                         },
                         invalid: {
                             color: 'rgb(255, 0, 0)',
                             fontWeight: '500',
                             fontFamily: 'Montserrat, Arial, Helvetica, sans-serif',
                             fontSize: '14px',
-                            fontSmoothing: 'auto',
                             iconColor: 'rgb(255, 0, 0)',
                         },
                     },

--- a/src/app/payment/paymentMethod/StripePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.tsx
@@ -6,26 +6,34 @@ import { getCreditCardInputStyles, CreditCardInputStylesType } from '../creditCa
 
 import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
 
-export type SquarePaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'containerId' | 'hideContentWhenSignedOut'>;
+export type StripePaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'containerId'>;
 
-const StripePaymentMethod: FunctionComponent<SquarePaymentMethodProps> = ({
+const StripePaymentMethod: FunctionComponent<StripePaymentMethodProps> = ({
     initializePayment,
     ...rest
 }) => {
+    // method.gateway = 'stripev3';
+    // method.id = 'card' | 'idealBank' | 'iban';
+    const type = 'card' || rest.method.id;
+    const containerId = `stripe-${type}-element`;
+
     const initializeStripePayment = useCallback(async (options: PaymentInitializeOptions) => {
-        const creditCardInputStyles =  await getCreditCardInputStyles('stripe-card-field', ['color', 'fontFamily', 'fontWeight', 'fontSmoothing']);
-        const creditCardInputErrorStyles = await getCreditCardInputStyles('stripe-card-field', ['color'], CreditCardInputStylesType.Error);
+        const properties = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
+        const creditCardInputStyles =  await getCreditCardInputStyles(containerId, properties);
+        const creditCardInputErrorStyles = await getCreditCardInputStyles(containerId, properties, CreditCardInputStylesType.Error);
 
         return initializePayment({
             ...options,
             stripev3: {
-                containerId: 'stripe-card-field',
+                type,
+                containerId,
                 style: {
                     base: {
                         ...creditCardInputStyles,
                         '::placeholder': {
                             color: '#E1E1E1',
                         },
+                        padding: '5px',
                     },
                     invalid: {
                         ...creditCardInputErrorStyles,
@@ -34,12 +42,12 @@ const StripePaymentMethod: FunctionComponent<SquarePaymentMethodProps> = ({
                 },
             },
         });
-    }, [initializePayment]);
+    }, [containerId, initializePayment, type]);
 
     return <HostedWidgetPaymentMethod
         { ...rest }
         additionalContainerClassName="optimizedCheckout-form-input"
-        containerId="stripe-card-field"
+        containerId={ containerId }
         hideContentWhenSignedOut
         initializePayment={ initializeStripePayment }
     />;


### PR DESCRIPTION
## What? [INT-2532](https://jira.bigcommerce.com/browse/INT-2532)
- Register stripev3 on `handleBeforeUnload` to avoid leave warning.
- Dynamically initialize the type of stripe element to mount.

## Why?
To accept payments through StripeV3 using iDEAL.

## Testing / Proof
CircleCI but, won't pass because depends on:
[checkout-sdk-js/pull/860](https://github.com/bigcommerce/checkout-sdk-js/pull/860)

[//]: # "@bigcommerce/checkout"
