### PR TITLE
feat(payment): PAYPAL-293 Bump checkout-sdk-js to 1.65.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -955,9 +955,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.5.1.tgz",
-      "integrity": "sha512-40GJ7YuVFwB3lHNZOJuOAnBPX46LijK+d8VWmKnsT33TrFbCllv5PVJ98db9pqsRv+iOn/IJXzUMFd6WSGfnqw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.6.0.tgz",
+      "integrity": "sha512-qxv6dmlS8WWrTy/nuG1Pho/i5FE/T43gbcnZEfsjkwOdk/ihHQKnPngp//cedABtYZvqMr13Y2CHhQdkz2KZlg==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^25.2.0",
@@ -1598,12 +1598,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.63.1.tgz",
-      "integrity": "sha512-rG7XytzWgHfwzUZ9uVQ+8SpikKXu04To2h4SDKnnz4yCAnc0UJeSyABa2IdYlPnQssTRTGdCKVl8QoTRt+vMig==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.65.0.tgz",
+      "integrity": "sha512-blQ1J+mrxLVge3uvO3GY3squ6LCDx4i/689UWNkfKQJkJZXCL2gbsiKqdStSTrSH5xGUhB5rbmx2AQE0FqkndQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.5.1",
+        "@bigcommerce/bigpay-client": "^5.6.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1743,7 +1743,7 @@
     "@bigcommerce/request-sender": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@bigcommerce/request-sender/-/request-sender-0.5.1.tgz",
-      "integrity": "sha512-CzzuG70zulcWaACepxh+TgjDkwJ/gFnZc5vO7jQX/21zAqD/s++l67t+9UUhq7Qv0XPlRNT1VwL6eERrd1H/4g==",
+      "integrity": "sha1-VIgmUprQYTYt3SrnTcy0KyN5Mjc=",
       "requires": {
         "@types/js-cookie": "^2.1.0",
         "@types/lodash": "^4.14.133",
@@ -1757,7 +1757,7 @@
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -1778,7 +1778,7 @@
         "@bigcommerce/request-sender": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/@bigcommerce/request-sender/-/request-sender-0.3.0.tgz",
-          "integrity": "sha512-qILGm+r6JqZ56kGtgxLq/eAHlQXZMxq64nA2mIB7uxp8RpgDupJrpnVKd7uSQSOoHemUsD6UM/sCYWbGprw2lg==",
+          "integrity": "sha1-NoBu2TNsSycCkF4FZatKoUvDm3w=",
           "requires": {
             "@types/js-cookie": "^2.1.0",
             "@types/lodash": "^4.14.133",
@@ -1792,7 +1792,7 @@
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -2356,7 +2356,7 @@
     "@types/js-cookie": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.6.tgz",
-      "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw=="
+      "integrity": "sha1-8aHLNa/0e8XPsFywxEHKkekUwm8="
     },
     "@types/json-schema": {
       "version": "7.0.3",
@@ -2422,7 +2422,7 @@
     "@types/query-string": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-5.1.0.tgz",
-      "integrity": "sha512-9/sJK+T04pNq7uwReR0CLxqXj1dhxiTapZ1tIxA0trEsT6FRS0bz09YMcMb7tsVBTm4RJ0NEBYGsAjoEmqoFXg=="
+      "integrity": "sha1-f0DN6kndr6DqTz2zX7bCTTv9Tcw="
     },
     "@types/react": {
       "version": "16.8.25",
@@ -11463,7 +11463,7 @@
     "js-cookie": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+      "integrity": "sha1-aeEG3F1YBolFYpAqpbrsN0Tpsrg="
     },
     "js-levenshtein": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.63.1",
+    "@bigcommerce/checkout-sdk": "^1.65.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js to 1.65.0

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/847

## Testing / Proof
Unit tests/manual testing

@bigcommerce/checkout
