### PR TITLE
CHECKOUT-4879 Render flash message as popup

### DIFF
--- a/src/app/checkout/Checkout.spec.tsx
+++ b/src/app/checkout/Checkout.spec.tsx
@@ -8,7 +8,7 @@ import { BillingProps } from '../billing';
 import Billing from '../billing/Billing';
 import { getCart } from '../cart/carts.mock';
 import { getPhysicalItem } from '../cart/lineItem.mock';
-import { createErrorLogger } from '../common/error';
+import { createErrorLogger, ErrorModal } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
 import { CustomerInfo, CustomerInfoProps, CustomerProps, CustomerViewType } from '../customer';
 import { getCustomer } from '../customer/customers.mock';
@@ -152,6 +152,21 @@ describe('Checkout', () => {
 
         expect(defaultProps.embeddedStylesheet.append)
             .toHaveBeenCalledWith(styles);
+    });
+
+    it('renders modal error when theres an error flash message', () => {
+        const container = mount(<CheckoutTest
+            { ...defaultProps }
+            flashMessages={ [
+                {
+                    message: 'flash message',
+                    type: 0,
+                },
+            ] }
+        />);
+
+        expect(container.find(ErrorModal).prop('error'))
+            .toEqual(new Error('flash message'));
     });
 
     it('renders required checkout steps', () => {

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -9,7 +9,6 @@ import { isRequestError, ErrorModal, ErrorModalOnCloseProps } from '../common/er
 import { EMPTY_ARRAY } from '../common/utility';
 import { withLanguage, WithLanguageProps } from '../locale';
 import { TermsConditionsType } from '../termsConditions';
-import { FlashAlert, FlashMessage } from '../ui/alert';
 import { LoadingOverlay } from '../ui/loading';
 
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
@@ -21,7 +20,6 @@ import PaymentForm, { PaymentFormValues } from './PaymentForm';
 export interface PaymentProps {
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
-    flashMessages?: FlashMessage[]; // TODO: Remove once we can read flash messages from SDK
     checkEmbeddedSupport?(methodIds: string[]): void; // TODO: We're currently doing this check in multiple places, perhaps we should move it up so this check get be done in a single place instead.
     onCartChangedError?(error: Error): void;
     onFinalize?(): void;
@@ -128,7 +126,6 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         const {
             defaultMethod,
             finalizeOrderError,
-            flashMessages = [],
             isUsingMultiShipping,
             methods,
             applyStoreCredit,
@@ -154,13 +151,6 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
                     isLoading={ !isReady }
                     unmountContentWhenLoading
                 >
-                    { flashMessages.map(message =>
-                        <FlashAlert
-                            key={ message.message }
-                            message={ message }
-                        />
-                    ) }
-
                     { !isEmpty(methods) && defaultMethod && <PaymentForm
                         { ...rest }
                         defaultGatewayId={ defaultMethod.gateway }


### PR DESCRIPTION
## What?
Render flash messages as popup.

## Why?
Currently we only render them in payment step. However, flash messages could happen at different steps, e.g. after a failed OTP sign-in attempt. Customers could aim to sign in via OTP at any progress of checkout, so showing at step 1 would not be sufficient.

This also  ensures the flash message is only rendered once. After modal is closed, the message is removed from state.

## Testing / Proof
Failed OTP with cart
![flash-message](https://user-images.githubusercontent.com/1621894/81267430-d19f0380-9089-11ea-8882-8203fa5c4f60.gif)

Failed OTP with no cart
![flash-message-no-cart](https://user-images.githubusercontent.com/1621894/81267442-d6fc4e00-9089-11ea-839a-e9af604eb899.gif)


@bigcommerce/checkout
