### PR TITLE
CHECKOUT-4880 Copy changes in passwordless login

### DIFF
--- a/src/app/customer/EmailLoginForm.spec.tsx
+++ b/src/app/customer/EmailLoginForm.spec.tsx
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 
 import { getStoreConfig } from '../config/config.mock';
-import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedString } from '../locale';
+import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedHtml, TranslatedString } from '../locale';
 import { Alert, AlertType } from '../ui/alert';
 import { Form } from '../ui/form';
 import { LoadingSpinner } from '../ui/loading';
@@ -35,7 +35,7 @@ describe('EmailLoginForm', () => {
             .toEqual('Send');
 
         expect(component.find('button[type="button"]').text())
-            .toEqual('Cancel');
+            .toEqual('Use another email');
 
         expect(component.find(ModalHeader).find(TranslatedString).prop('id'))
             .toEqual('login_email.header');
@@ -109,9 +109,6 @@ describe('EmailLoginForm', () => {
 
         expect(component.find(ModalHeader).find(TranslatedString).prop('id'))
             .toEqual('common.error_heading');
-
-        expect(component.find('button[type="button"]').text())
-            .toEqual('Ok');
     });
 
     it('renders "account not found" if error.status === 404', () => {
@@ -174,7 +171,7 @@ describe('EmailLoginForm', () => {
             />
         );
 
-        expect(component.find('p').find(TranslatedString).props())
+        expect(component.find('p').find(TranslatedHtml).props())
             .toEqual({
                 id: 'login_email.sent_text',
                 data: {
@@ -189,8 +186,11 @@ describe('EmailLoginForm', () => {
         expect(component.find(EmailField).exists())
             .toEqual(false);
 
-        expect(component.find('button[type="submit"]').text())
-            .toEqual('Resend');
+        expect(component.find('form a').at(0).text())
+            .toEqual('Resend the link');
+
+        expect(component.find('form a').at(1).text())
+            .toEqual('sign in using your password');
     });
 
     it('displays error message if email is invalid', async () => {

--- a/src/app/customer/LoginForm.tsx
+++ b/src/app/customer/LoginForm.tsx
@@ -157,7 +157,7 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
 
                     { canCancel &&
                         viewType !== CustomerViewType.EnforcedLogin &&
-                        viewType !== CustomerViewType.SuggestedLogin  &&
+                        viewType !== CustomerViewType.SuggestedLogin &&
                         <a
                             className="button optimizedCheckout-buttonSecondary"
                             data-test="customer-cancel-button"
@@ -165,7 +165,10 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
                             id="checkout-customer-cancel"
                             onClick={ preventDefault(onCancel) }
                         >
-                            <TranslatedString id="common.cancel_action" />
+                            <TranslatedString id={ viewType === CustomerViewType.CancellableEnforcedLogin ?
+                                'login_email.use_another_email' :
+                                'common.cancel_action' }
+                            />
                         </a> }
                 </div>
 

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -135,14 +135,16 @@
             "error_server": "We couldn't send you a sign-in link. Please try again.",
             "error_not_found": "The entered email is not associated to an account. Please try with a different email.",
             "sent_header": "Check your inbox",
-            "sent_text": "We’ve sent an email to {email} that contains a sign-in link. This will expire in {minutes} minutes - If you don’t see it in your inbox, check your junk folder.",
+            "sent_text": "We’ve sent an email to <strong>{email}</strong> that contains a sign-in link. This will expire in {minutes} minutes - If you don’t see it in your inbox, check your junk folder.",
             "text": "Enter the email address associated to your account. We will send you a sign-in link.",
             "header": "Enter your email address",
             "header_with_email": "Confirm your email address",
-            "link": "Forgot password? <a>Send me a sign-in link</a>.",
+            "link": "<a>Send me a sign-in link instead</a>.",
+            "use_another_email": "Use another email",
             "send": "Send",
             "error_temporary_disabled": "Sign-in email functionality is temporary unavailable. Please sign in by entering your password.",
-            "resend": "Resend"
+            "resend_link": "Didn't get the email? <a>Resend the link</a>",
+            "use_password": " or <a>sign in using your password</a> instead."
         },
         "embedded_checkout": {
             "unsupported_error": "The following payment methods are not supported by Embedded Checkout: {methods}. Please contact us for assistance."

--- a/src/scss/components/foundation/modal/_modal.scss
+++ b/src/scss/components/foundation/modal/_modal.scss
@@ -96,6 +96,13 @@
         @include headingStyle("h4");
     }
 
+    .modal-body {
+        .modal-footer {
+            padding-left: 0;
+            padding-right: 0;
+        }
+    }
+
     .modal-footer {
         border-top: 0;
 


### PR DESCRIPTION
## What?
Copy changes for passwordless login:
1. "use another email" instead of "cancel" when enforced login form
2. remove buttons in confirmation modal, replace them with links
3. fix alignment in buttons in modal 

## Why?
Design review

## Testing / Proof
<img width="533" alt="Screen Shot 2020-05-12 at 2 07 11 pm" src="https://user-images.githubusercontent.com/1621894/81637938-f238d600-945a-11ea-899c-9f66e874695c.png">
<img width="587" alt="Screen Shot 2020-05-12 at 2 11 56 pm" src="https://user-images.githubusercontent.com/1621894/81637940-f4029980-945a-11ea-8193-6d4002b857aa.png">
<img width="665" alt="Screen Shot 2020-05-12 at 2 02 40 pm" src="https://user-images.githubusercontent.com/1621894/81637955-fcf36b00-945a-11ea-90be-0e1b8b7bd522.png">
<img width="720" alt="Screen Shot 2020-05-12 at 2 14 57 pm" src="https://user-images.githubusercontent.com/1621894/81637959-fe249800-945a-11ea-88d8-45bc8676f20f.png">


@bigcommerce/checkout
