### PR TITLE
Reinitialize widget when apply store credit checkbox state changes

### DIFF
--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -103,6 +103,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
             <PaymentMethodListFieldset
                 isEmbedded={ isEmbedded }
                 isPaymentDataRequired={ isPaymentDataRequired }
+                isStoreCreditApplied={ isStoreCreditApplied }
                 isUsingMultiShipping={ isUsingMultiShipping }
                 methods={ methods }
                 onMethodSelect={ onMethodSelect }
@@ -132,6 +133,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
 
 interface PaymentMethodListFieldsetProps {
     isEmbedded?: boolean;
+    isStoreCreditApplied?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
     values: PaymentFormValues;
@@ -144,6 +146,7 @@ interface PaymentMethodListFieldsetProps {
 const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProps> = ({
     isEmbedded,
     isPaymentDataRequired,
+    isStoreCreditApplied,
     isUsingMultiShipping,
     methods,
     onMethodSelect = noop,
@@ -192,6 +195,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
 
             <PaymentMethodList
                 isEmbedded={ isEmbedded }
+                isStoreCreditApplied = { isStoreCreditApplied }
                 isUsingMultiShipping={ isUsingMultiShipping }
                 methods={ methods }
                 onSelect={ handlePaymentMethodSelect }

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -23,6 +23,7 @@ export interface HostedWidgetPaymentMethodProps {
     isInitializing?: boolean;
     isUsingMultiShipping?: boolean;
     isSignInRequired?: boolean;
+    isStoreCreditApplied?: boolean;
     method: PaymentMethod;
     shouldHideInstrumentExpiryDate?: boolean;
     validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
@@ -52,6 +53,7 @@ interface WithCheckoutHostedWidgetPaymentMethodProps {
 interface HostedWidgetPaymentMethodState {
     isAddingNewCard: boolean;
     selectedInstrumentId?: string;
+    isStoreCreditApplied?: boolean;
 }
 
 class HostedWidgetPaymentMethod extends Component<
@@ -69,8 +71,10 @@ class HostedWidgetPaymentMethod extends Component<
             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
             loadInstruments,
             onUnhandledError = noop,
+            isStoreCreditApplied,
         } = this.props;
 
+        this.setState({ isStoreCreditApplied });
         try {
             if (isInstrumentFeatureAvailableProp) {
                 await loadInstruments();
@@ -86,6 +90,7 @@ class HostedWidgetPaymentMethod extends Component<
         const {
             deinitializePayment = noop,
             method,
+            isStoreCreditApplied,
             onUnhandledError = noop,
         } = this.props;
 
@@ -93,7 +98,9 @@ class HostedWidgetPaymentMethod extends Component<
             selectedInstrumentId,
         } = this.state;
 
-        if (selectedInstrumentId !== prevState.selectedInstrumentId) {
+        if (selectedInstrumentId !== prevState.selectedInstrumentId || isStoreCreditApplied !== prevState.isStoreCreditApplied) {
+            this.setState({ isStoreCreditApplied });
+
             try {
                 await deinitializePayment({
                     gatewayId: method.gateway,

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -30,6 +30,7 @@ import VisaCheckoutPaymentMethod from './VisaCheckoutPaymentMethod';
 export interface PaymentMethodProps {
     method: PaymentMethod;
     isEmbedded?: boolean;
+    isStoreCreditApplied?: boolean;
     isUsingMultiShipping?: boolean;
     onUnhandledError?(error: Error): void;
 }

--- a/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -11,6 +11,7 @@ import PaymentMethodTitle from './PaymentMethodTitle';
 
 export interface PaymentMethodListProps {
     isEmbedded?: boolean;
+    isStoreCreditApplied?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
     onSelect?(method: PaymentMethod): void;
@@ -34,6 +35,7 @@ const PaymentMethodList: FunctionComponent<
 > = ({
     formik: { values },
     isEmbedded,
+    isStoreCreditApplied,
     isUsingMultiShipping,
     methods,
     onSelect = noop,
@@ -57,6 +59,7 @@ const PaymentMethodList: FunctionComponent<
             return (
                 <PaymentMethodListItem
                     isEmbedded={ isEmbedded }
+                    isStoreCreditApplied = { isStoreCreditApplied }
                     isUsingMultiShipping={ isUsingMultiShipping }
                     key={ value }
                     method={ method }
@@ -70,6 +73,7 @@ const PaymentMethodList: FunctionComponent<
 
 interface PaymentMethodListItemProps {
     isEmbedded?: boolean;
+    isStoreCreditApplied?: boolean;
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
     value: string;
@@ -78,6 +82,7 @@ interface PaymentMethodListItemProps {
 
 const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     isEmbedded,
+    isStoreCreditApplied,
     isUsingMultiShipping,
     method,
     onUnhandledError,
@@ -86,12 +91,14 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     const renderPaymentMethod = useMemo(() => (
         <PaymentMethodComponent
             isEmbedded={ isEmbedded }
+            isStoreCreditApplied = { isStoreCreditApplied }
             isUsingMultiShipping={ isUsingMultiShipping }
             method={ method }
             onUnhandledError={ onUnhandledError }
         />
     ), [
         isEmbedded,
+        isStoreCreditApplied,
         isUsingMultiShipping,
         method,
         onUnhandledError,


### PR DESCRIPTION
[INT-2001](https://jira.bigcommerce.com/browse/INT-2001)

## What?
We are reinitializing the widget when store credit checkbox state changes

## Why?
KlarnaV2 widget show the final amount to pay so every time checkbox state changes we should update that amount

## Testing / Proof
[DEMO](https://drive.google.com/file/d/1KYXW38mhY6ZhzxkaSzsnpQzu0aLPxF73/view?usp=sharing)

@bigcommerce/checkout
