### PR TITLE
feat(payment): PAYPAL-365 Bump checkout-sdk-js to 1.68.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1595,9 +1595,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.67.0.tgz",
-      "integrity": "sha512-oELS3maoBwRa02rCkZz+0W32LYf72etYhxUYvOzw/4PnV2ULinyE9VbZdwVKXZrmITMEEI1omTfdofhN24bzkA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.68.0.tgz",
+      "integrity": "sha512-VVoW7a9u5NNukC6I5sLY5cypzh4T2Hj6+cC0x7gcIjKpRHiEE2zkhDzJjggE6Lip5Akhi19yCRQhEZnYBdEHug==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.67.0",
+    "@bigcommerce/checkout-sdk": "^1.68.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js to 1.68.0

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/869 and https://github.com/bigcommerce/checkout-sdk-js/pull/870

## Testing / Proof
Unit tests/manual testing

@bigcommerce/checkout
