### PR TITLE
fix(payment): INT-2667 Add validation to handle initializePayment whe…

### DIFF
--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -82,9 +82,10 @@ class HostedWidgetPaymentMethod extends Component<
         }
     }
 
-    async componentDidUpdate(_prevProps: Readonly<HostedWidgetPaymentMethodProps>, prevState: Readonly<HostedWidgetPaymentMethodState>): Promise<void> {
+    async componentDidUpdate(prevProps: Readonly<HostedWidgetPaymentMethodProps & WithCheckoutHostedWidgetPaymentMethodProps>, prevState: Readonly<HostedWidgetPaymentMethodState>): Promise<void> {
         const {
             deinitializePayment = noop,
+            instruments,
             method,
             onUnhandledError = noop,
         } = this.props;
@@ -93,7 +94,8 @@ class HostedWidgetPaymentMethod extends Component<
             selectedInstrumentId,
         } = this.state;
 
-        if (selectedInstrumentId !== prevState.selectedInstrumentId) {
+        if (selectedInstrumentId !== prevState.selectedInstrumentId ||
+            (prevProps.instruments.length > 0 && instruments.length === 0)) {
             try {
                 await deinitializePayment({
                     gatewayId: method.gateway,


### PR DESCRIPTION
…n instruments is empty

## What? [INT-2667](https://jira.bigcommerce.com/browse/INT-2667)
Validate when instruments array is empty in order to re-initilize the strategy which mounts the components.

## Why?
Because the account components are not been displayed after deleting all the vaulted instruments.

## Testing / Proof
![sepa](https://user-images.githubusercontent.com/4843328/82356397-1e0f0b00-99c9-11ea-9f9d-6e3580458c20.gif)

@bigcommerce/checkout
