### PR TITLE
CHECKOUT-4897 Bump SDK + Reword button to Go Back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1595,9 +1595,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.69.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.69.1.tgz",
-      "integrity": "sha512-8uC8CfSY9SS/IjKXznL0/w+GVdG92Gg9A/DIbssOigpkw3IBaiUzlWhAdMofRY28JaGlyDZqGf6wld1pvYKs2g==",
+      "version": "1.69.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.69.2.tgz",
+      "integrity": "sha512-bJSJiqdOZh3h5kiFzRlo/sbhN+2mrNEPKhf2O6uv+UFGNWExo0UWu+iSJIhJ1TXbBJcsmSRa4cjtzXrWqFga1Q==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.6.0",
@@ -1654,9 +1654,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.151",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.151.tgz",
-          "integrity": "sha512-Zst90IcBX5wnwSu7CAS0vvJkTjTELY4ssKbHiTnGcJgi170uiS8yQDdc3v6S77bRqYQIN1App5a1Pc2lceE5/g=="
+          "version": "4.14.152",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.152.tgz",
+          "integrity": "sha512-Vwf9YF2x1GE3WNeUMjT5bTHa2DqgUo87ocdgTScupY2JclZ5Nn7W2RLM/N0+oreexUk8uaVugR81NnTY/jNNXg=="
         },
         "@types/yup": {
           "version": "0.26.37",
@@ -1821,12 +1821,13 @@
       }
     },
     "@istanbuljs/load-nyc-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "requires": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
       },
@@ -8845,6 +8846,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
     },
     "get-pkg-repo": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.69.1",
+    "@bigcommerce/checkout-sdk": "^1.69.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -568,7 +568,8 @@ describe('Customer', () => {
             await new Promise(resolve => process.nextTick(resolve));
             component.update();
 
-            expect(sendLoginEmail).toHaveBeenCalledWith('foo@bar.com');
+            expect(sendLoginEmail)
+                .toHaveBeenCalledWith({ email: 'foo@bar.com' });
             expect(component.find(EmailLoginForm).prop('emailHasBeenRequested'))
                 .toEqual(true);
         });
@@ -588,7 +589,8 @@ describe('Customer', () => {
             await new Promise(resolve => process.nextTick(resolve));
             component.update();
 
-            expect(sendLoginEmail).toHaveBeenCalledWith('foo@bar.com');
+            expect(sendLoginEmail)
+                .toHaveBeenCalledWith({ email: 'foo@bar.com' });
             expect(component.find(EmailLoginForm).prop('emailHasBeenRequested'))
                 .toEqual(true);
         });

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -44,7 +44,7 @@ export interface WithCheckoutCustomerProps {
     continueAsGuest(credentials: GuestCredentials): Promise<CheckoutSelectors>;
     deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
     initializeCustomer(options: CustomerInitializeOptions): Promise<CheckoutSelectors>;
-    sendLoginEmail(email: string): Promise<CheckoutSelectors>;
+    sendLoginEmail(params: { email: string }): Promise<CheckoutSelectors>;
     signIn(credentials: CustomerCredentials): Promise<CheckoutSelectors>;
 }
 
@@ -212,7 +212,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
         } = this.props;
 
         try {
-            await sendLoginEmail(values.email);
+            await sendLoginEmail(values);
         } finally {
             this.setState({
                 hasRequestedLoginEmail: true,
@@ -339,7 +339,7 @@ export function mapToWithCheckoutCustomerProps(
         clearError: checkoutService.clearError,
         continueAsGuest: checkoutService.continueAsGuest,
         // todo: remove casting when method is properly exposed.
-        sendLoginEmail: (checkoutService as any).sendSignInEmail as (email: string) => Promise<CheckoutSelectors>,
+        sendLoginEmail: (checkoutService as any).sendSignInEmail as (params: { email: string }) => Promise<CheckoutSelectors>,
         createAccountUrl: config.links.createAccountLink,
         defaultShouldSubscribe: config.shopperConfig.defaultNewsletterSignup,
         deinitializeCustomer: checkoutService.deinitializeCustomer,

--- a/src/app/customer/EmailLoginForm.spec.tsx
+++ b/src/app/customer/EmailLoginForm.spec.tsx
@@ -35,7 +35,7 @@ describe('EmailLoginForm', () => {
             .toEqual('Send');
 
         expect(component.find('button[type="button"]').text())
-            .toEqual('Use Password Instead');
+            .toEqual('Go Back');
 
         expect(component.find(ModalHeader).find(TranslatedString).prop('id'))
             .toEqual('login_email.header');
@@ -65,7 +65,7 @@ describe('EmailLoginForm', () => {
             .toEqual('Send');
 
         expect(component.find('button[type="button"]').text())
-            .toEqual('Use Password Instead');
+            .toEqual('Go Back');
     });
 
     it('notifies when user submits form', async () => {

--- a/src/app/customer/EmailLoginForm.tsx
+++ b/src/app/customer/EmailLoginForm.tsx
@@ -100,7 +100,7 @@ const EmailLoginForm: FunctionComponent<EmailLoginFormProps & WithLanguageProps 
                     onClick={ onRequestClose }
                     type="button"
                 >
-                    <TranslatedString id="login_email.use_password_action" />
+                    <TranslatedString id="common.go_back" />
                 </Button>
                 <Button
                     isLoading={ isSendingEmail }

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -87,6 +87,7 @@
             "order_loading_error": "There was an error loading your order. Please try again.",
             "order_fatal_error_heading": "There was an error placing your order",
             "order_fatal_error_extra": "Please choose another payment method or contact us for further assistance.",
+            "go_back": "Go Back",
             "show_more": "Show more"
         },
         "customer": {


### PR DESCRIPTION
## What?
- Bump checkout SDK so OTP request payload includes `redirect_url` param.
- Reword button to "Go Back" instead of "Use Password Instead" as per @bc-charlesho feedback

## Why?
- So shoppers clicking on the OTP link are taken to checkout instead of account page

## Testing / Proof
unit

@bigcommerce/checkout
