### PR TITLE
feat(payment): PAYMENTS-5425 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1595,12 +1595,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.70.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.70.1.tgz",
-      "integrity": "sha512-azRneQYk7WWmI01pkuhrxrcccAcsxmrIwQWdZZumM1zNt1iUKTDzHjqaSc166FcAOgABz8txiore7kyroZeYoQ==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.71.0.tgz",
+      "integrity": "sha512-u0cbASrqbIRvGZ489lGO9zuojAd3TN8uNov8a+z9stxxX7QvOZ1MJj9I81J847vWMDc8Ki++J4MrYXvCvF25iw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.6.0",
+        "@bigcommerce/bigpay-client": "^5.7.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1645,9 +1645,9 @@
           }
         },
         "@bigcommerce/script-loader": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.1.0.tgz",
-          "integrity": "sha512-8gDZLB9MBcXw9UsicgL5sQu8pBlEGLG/Hq7ks7CdDxiHile/ySvLUwvBQWcrDBbh9VfzGtKMjNUbfqeVdo+PJg==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.2.1.tgz",
+          "integrity": "sha512-FnZP0UZsju1A79qx30H6mj3pz/KB/pX/5y+DazVJXOAuyfQ+guuwJsCVBWA4aZ279w/l2eHdqoKMrymFDFew8w==",
           "requires": {
             "@bigcommerce/request-sender": "^0.3.0",
             "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.70.1",
+    "@bigcommerce/checkout-sdk": "^1.71.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump SDK version to 1.71.0

## Why?
To handle newly implemented `additional_action_required` responses from the payments API (specifically, one requesting ReCaptcha verification at payment)

## Testing / Proof
unit
@bigcommerce/checkout
