### PR TITLE
 CHECKOUT-4642 Expose Save Address checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1595,9 +1595,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.71.0.tgz",
-      "integrity": "sha512-u0cbASrqbIRvGZ489lGO9zuojAd3TN8uNov8a+z9stxxX7QvOZ1MJj9I81J847vWMDc8Ki++J4MrYXvCvF25iw==",
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.72.0.tgz",
+      "integrity": "sha512-8u4w+9Dw9lldhxL3nBvGOvZRWp8OuVwe/rfxqQ9+MlhMn6djqevktdOElty4cCttmPqtplmqYQFLSNAOJFtTYw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.71.0",
+    "@bigcommerce/checkout-sdk": "^1.72.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/address/AddressForm.spec.tsx
+++ b/src/app/address/AddressForm.spec.tsx
@@ -42,6 +42,9 @@ describe('AddressForm Component', () => {
             </LocaleContext.Provider>
         );
 
+        expect(component.find('[name="address.shouldSaveAddress"]').exists())
+            .toEqual(false);
+
         expect(component.find(AddressFormField).length).toEqual(formFields.length);
     });
 
@@ -55,6 +58,7 @@ describe('AddressForm Component', () => {
                     <AddressForm
                         fieldName="address"
                         formFields={ formFields }
+                        shouldShowSaveAddress={ true }
                     />
                 </Formik>
             </LocaleContext.Provider>
@@ -66,6 +70,9 @@ describe('AddressForm Component', () => {
                 placeholder: undefined,
             })
         );
+
+        expect(component.find('[name="address.shouldSaveAddress"]').exists())
+            .toEqual(true);
 
         expect(component.find(AddressFormField).at(0).prop('field')).toEqual(
             expect.objectContaining({

--- a/src/app/address/isEqualAddress.spec.ts
+++ b/src/app/address/isEqualAddress.spec.ts
@@ -11,6 +11,7 @@ describe('isEqualAddress', () => {
             stateOrProvinceCode: 'w',
             id: 'x',
             email: 'y',
+            shouldSaveAddress: false,
             type: 'z',
         })).toBeTruthy();
     });

--- a/src/app/address/isEqualAddress.ts
+++ b/src/app/address/isEqualAddress.ts
@@ -16,7 +16,7 @@ export default function isEqualAddress(address1?: ComparableAddress, address2?: 
 }
 
 function normalizeAddress(address: ComparableAddress) {
-    const ignoredFields: ComparableAddressFields[] = ['id', 'stateOrProvinceCode', 'type', 'email'];
+    const ignoredFields: ComparableAddressFields[] = ['id', 'shouldSaveAddress', 'stateOrProvinceCode', 'type', 'email'];
 
     return omit(
         {

--- a/src/app/address/mapAddressFromFormValues.spec.ts
+++ b/src/app/address/mapAddressFromFormValues.spec.ts
@@ -12,7 +12,8 @@ describe('mapAddressFromFormValues', () => {
             customFields: {},
         };
 
-        expect(mapAddressFromFormValues(formValues)).toMatchObject(getShippingAddress());
+        expect(mapAddressFromFormValues(formValues))
+            .toMatchObject(getShippingAddress());
     });
 
     it('converts formats date values to YYYY-MM-DD format', () => {

--- a/src/app/address/mapAddressFromFormValues.ts
+++ b/src/app/address/mapAddressFromFormValues.ts
@@ -5,6 +5,7 @@ import { AddressFormValues } from './mapAddressToFormValues';
 
 export default function mapAddressFromFormValues(formValues: AddressFormValues): Address {
     const { customFields: customFieldsObject, ...address } = formValues;
+    const shouldSaveAddress = formValues.shouldSaveAddress;
     const customFields: Array<{fieldId: string; fieldValue: string}> = [];
 
     forIn(customFieldsObject, (value, key) => {
@@ -26,6 +27,7 @@ export default function mapAddressFromFormValues(formValues: AddressFormValues):
 
     return {
         ...address,
+        shouldSaveAddress,
         customFields,
     };
 }

--- a/src/app/address/mapAddressToFormValues.ts
+++ b/src/app/address/mapAddressToFormValues.ts
@@ -36,6 +36,10 @@ export default function mapAddressToFormValues(fields: FormField[], address?: Ad
         ),
     });
 
+    values.shouldSaveAddress = address && address.shouldSaveAddress !== undefined ?
+        address.shouldSaveAddress :
+        true;
+
     // Manually backfill stateOrProvince to avoid Formik warning (uncontrolled to controlled input)
     if (values.stateOrProvince === undefined) {
         values.stateOrProvince = '';
@@ -72,6 +76,6 @@ function getDefaultValue(fieldType?: string, defaultValue?: string): string | st
     return defaultValue || '';
 }
 
-function isSystemAddressFieldName(fieldName: string): fieldName is Exclude<keyof Address, 'customFields'> {
-    return fieldName !== 'customFields';
+function isSystemAddressFieldName(fieldName: string): fieldName is Exclude<keyof Address, 'customFields' | 'shouldSaveAddress'> {
+    return fieldName !== 'customFields' && fieldName !== 'shouldSaveAddress';
 }

--- a/src/app/billing/Billing.spec.tsx
+++ b/src/app/billing/Billing.spec.tsx
@@ -168,6 +168,7 @@ describe('Billing Component', () => {
             stateOrProvinceCode: '',
             firstName: 'foo',
             lastName: 'Tester',
+            shouldSaveAddress: true,
         });
 
         expect(defaultProps.navigateNextStep).toHaveBeenCalled();

--- a/src/app/billing/Billing.tsx
+++ b/src/app/billing/Billing.tsx
@@ -27,6 +27,7 @@ export interface WithCheckoutBillingProps {
     googleMapsApiKey: string;
     isInitializing: boolean;
     isUpdating: boolean;
+    hasSaveAddressFeature: boolean;
     shouldShowOrderComments: boolean;
     getFields(countryCode?: string): FormField[];
     initialize(): Promise<CheckoutSelectors>;
@@ -166,6 +167,7 @@ function mapToBillingProps({
         initialize: checkoutService.loadBillingAddressFields,
         isInitializing: isLoadingBillingCountries(),
         isUpdating: isUpdatingBillingAddress() || isUpdatingCheckout(),
+        hasSaveAddressFeature: features['CHECKOUT-4642.uco_save_address_checkbox'],
         shouldShowOrderComments: enableOrderComments && getShippableItemsCount(cart) < 1,
         updateAddress: checkoutService.updateBillingAddress,
         updateCheckout: checkoutService.updateCheckout,

--- a/src/app/billing/BillingForm.spec.tsx
+++ b/src/app/billing/BillingForm.spec.tsx
@@ -31,6 +31,7 @@ describe('BillingForm Component', () => {
             customer: getCustomer(),
             countries: getCountries(),
             googleMapsApiKey: 'key',
+            hasSaveAddressFeature: true,
             getFields: () => getFormFields(),
             onUnhandledError: jest.fn(),
             updateAddress: jest.fn(),
@@ -111,6 +112,7 @@ describe('BillingForm Component', () => {
             stateOrProvinceCode: '',
             firstName: 'foo',
             lastName: 'Tester',
+            shouldSaveAddress: true,
         });
     });
 

--- a/src/app/billing/BillingForm.tsx
+++ b/src/app/billing/BillingForm.tsx
@@ -20,6 +20,7 @@ export interface BillingFormProps {
     countriesWithAutocomplete: string[];
     googleMapsApiKey: string;
     isUpdating: boolean;
+    hasSaveAddressFeature: boolean;
     shouldShowOrderComments: boolean;
     getFields(countryCode?: string): FormField[];
     onUnhandledError(error: Error): void;
@@ -43,12 +44,13 @@ class BillingForm extends PureComponent<BillingFormProps & WithLanguageProps & F
             googleMapsApiKey,
             billingAddress,
             countriesWithAutocomplete,
-            customer: { addresses },
+            customer: { addresses, isGuest },
             getFields,
             countries,
             isUpdating,
             setFieldValue,
             shouldShowOrderComments,
+            hasSaveAddressFeature,
             values,
         } = this.props;
 
@@ -81,6 +83,7 @@ class BillingForm extends PureComponent<BillingFormProps & WithLanguageProps & F
                                 formFields={ getFields(values.countryCode) }
                                 googleMapsApiKey={ googleMapsApiKey }
                                 setFieldValue={ setFieldValue }
+                                shouldShowSaveAddress={ hasSaveAddressFeature && !isGuest }
                             />
                         </LoadingOverlay> }
                 </Fieldset>

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -28,6 +28,7 @@
             "phone_number_required_error": "Phone Number is required",
             "postal_code_label": "Postal Code",
             "postal_code_required_error": "Postal Code is required",
+            "save_in_addressbook": "Save this address in my address book.",
             "select_country_action": "Select a country",
             "select_state_action": "Select a state",
             "state_label": "State/Province",
@@ -41,7 +42,7 @@
             "billing_heading": "Billing",
             "save_billing_address_error": "An error occurred while saving the billing address to your price quote. Please try again.",
             "billing_address_amazon": "Same as the Billing address set by you in your Amazon account.",
-            "use_shipping_address_label": "My Billing address is the same as my Shipping address"
+            "use_shipping_address_label": "My billing address is the same as my shipping address."
         },
         "cart": {
             "billed_amount_text": "*You will be charged and invoiced {total} ({code}) for this order.",
@@ -145,7 +146,6 @@
             "send": "Send",
             "error_temporary_disabled": "Sign-in link functionality is temporary unavailable. Please sign in by entering your password.",
             "resend_link": "Didn't get the email? <a>Resend the link</a>",
-            "use_password_action": "Use Password Instead",
             "use_password_link": " or <a>sign in using your password</a> instead."
         },
         "embedded_checkout": {

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -36,6 +36,7 @@ export interface WithCheckoutShippingProps {
     customer: Customer;
     customerMessage: string;
     googleMapsApiKey: string;
+    hasSaveAddressFeature: boolean;
     isGuest: boolean;
     isInitializing: boolean;
     isLoading: boolean;
@@ -102,6 +103,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             initializeShippingMethod,
             deinitializeShippingMethod,
             isMultiShippingMode,
+            hasSaveAddressFeature,
             onToggleMultiShipping,
             ...shippingFormProps
         } = this.props;
@@ -133,6 +135,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         onMultiShippingSubmit={ this.handleMultiShippingSubmit }
                         onSingleShippingSubmit={ this.handleSingleShippingSubmit }
                         onUseNewAddress={ this.handleUseNewAddress }
+                        shouldShowSaveAddress={ !isGuest && hasSaveAddressFeature }
                         updateAddress={ updateShippingAddress }
                     />
                 </LoadingOverlay>
@@ -322,6 +325,7 @@ export function mapToShippingProps({
         googleMapsApiKey,
         initializeShippingMethod: checkoutService.initializeShipping,
         isGuest: customer.isGuest,
+        hasSaveAddressFeature: features['CHECKOUT-4642.uco_save_address_checkbox'],
         isInitializing: isLoadingShippingCountries() || isLoadingShippingOptions(),
         isLoading,
         loadShippingAddressFields: checkoutService.loadShippingAddressFields,

--- a/src/app/shipping/ShippingAddress.tsx
+++ b/src/app/shipping/ShippingAddress.tsx
@@ -18,6 +18,7 @@ export interface ShippingAddressProps {
     isLoading: boolean;
     methodId?: string;
     shippingAddress?: Address;
+    shouldShowSaveAddress?: boolean;
     hasRequestedShippingOptions: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
@@ -44,6 +45,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = props => {
         shippingAddress,
         hasRequestedShippingOptions,
         addresses,
+        shouldShowSaveAddress,
         onUnhandledError = noop,
     } = props;
 
@@ -102,6 +104,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = props => {
             onAddressSelect={ onAddressSelect }
             onFieldChange={ handleFieldChange }
             onUseNewAddress={ onUseNewAddress }
+            shouldShowSaveAddress={ shouldShowSaveAddress }
         />
     );
 };

--- a/src/app/shipping/ShippingAddressForm.tsx
+++ b/src/app/shipping/ShippingAddressForm.tsx
@@ -17,6 +17,7 @@ export interface ShippingAddressFormProps {
     googleMapsApiKey?: string;
     isLoading: boolean;
     formFields: FormField[];
+    shouldShowSaveAddress?: boolean;
     onUseNewAddress(): void;
     onFieldChange(fieldName: string, value: string): void;
     onAddressSelect(address: Address): void;
@@ -31,6 +32,7 @@ class ShippingAddressForm extends Component<ShippingAddressFormProps & ConnectFo
             address: shippingAddress,
             onAddressSelect,
             onUseNewAddress,
+            shouldShowSaveAddress,
             countries,
             countriesWithAutocomplete,
             formFields,
@@ -72,6 +74,7 @@ class ShippingAddressForm extends Component<ShippingAddressFormProps & ConnectFo
                             onAutocompleteToggle={ this.handleAutocompleteToggle }
                             onChange={ this.handleChange }
                             setFieldValue={ this.setFieldValue }
+                            shouldShowSaveAddress={ shouldShowSaveAddress }
                         />
                     </LoadingOverlay> }
             </Fieldset>

--- a/src/app/shipping/ShippingForm.tsx
+++ b/src/app/shipping/ShippingForm.tsx
@@ -21,6 +21,7 @@ export interface ShippingFormProps {
     isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
+    shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
@@ -64,6 +65,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
             onUseNewAddress,
             shippingAddress,
             shouldShowOrderComments,
+            shouldShowSaveAddress,
             signOut,
             updateAddress,
         } = this.props;
@@ -105,6 +107,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
                 onUnhandledError={ onUnhandledError }
                 shippingAddress={ shippingAddress }
                 shouldShowOrderComments={ shouldShowOrderComments }
+                shouldShowSaveAddress={ shouldShowSaveAddress }
                 signOut={ signOut }
                 updateAddress={ updateAddress }
             />;

--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -26,6 +26,7 @@ export interface SingleShippingFormProps {
     isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
+    shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -92,6 +93,7 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
             isLoading,
             onUnhandledError,
             methodId,
+            shouldShowSaveAddress,
             countries,
             countriesWithAutocomplete,
             googleMapsApiKey,
@@ -132,6 +134,7 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
                         onUnhandledError={ onUnhandledError }
                         onUseNewAddress={ this.onUseNewAddress }
                         shippingAddress={ shippingAddress }
+                        shouldShowSaveAddress={ shouldShowSaveAddress }
                     />
                     {
                         shouldShowBillingSameAsShipping && <div className="form-body">

--- a/src/app/shipping/shipping-addresses.mock.ts
+++ b/src/app/shipping/shipping-addresses.mock.ts
@@ -10,6 +10,7 @@ export function getShippingAddress(): Address {
         city: 'Some City',
         stateOrProvince: 'California',
         stateOrProvinceCode: 'CA',
+        shouldSaveAddress: true,
         country: 'United States',
         countryCode: 'US',
         postalCode: '95555',


### PR DESCRIPTION
## What?
Show "Save address" checkbox.

**Note:** requires SDK bump
https://github.com/bigcommerce/checkout-sdk-js/pull/886

## Why?
As required by merchants.

## Testing / Proof
<img width="670" alt="Screen Shot 2020-05-25 at 4 34 15 pm" src="https://user-images.githubusercontent.com/1621894/82786613-49ea2f00-9ea8-11ea-92da-31bd8e2f8a96.png">

@bigcommerce/checkout
