### PR TITLE
chore(payment): INT-2691 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1595,9 +1595,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.72.0.tgz",
-      "integrity": "sha512-8u4w+9Dw9lldhxL3nBvGOvZRWp8OuVwe/rfxqQ9+MlhMn6djqevktdOElty4cCttmPqtplmqYQFLSNAOJFtTYw==",
+      "version": "1.72.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.72.2.tgz",
+      "integrity": "sha512-u7VAS25ousGiCXPjiBaqwrfZAZAJeRVTIMhnIVACP1WdPGV8EuSiesHVwdpLJ4i4EzTk3CCz9nhow6vqWmqfPw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.72.0",
+    "@bigcommerce/checkout-sdk": "^1.72.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

Ping @bigcommerce/checkout