### PR TITLE
fix(payment) Removed  credit card fields in Adyen v1 using Paypal

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
@@ -85,6 +85,26 @@ describe('PaymentMethod', () => {
             .toHaveBeenCalledWith(expect.any(Error));
     });
 
+    it('renders as hosted paypal payment method in Adyen v1', () => {
+        let method: PaymentMethod;
+
+        method = {
+            ...getPaymentMethod(),
+            id: 'paypal',
+            gateway: PaymentMethodId.Adyen,
+            type: PaymentMethodProviderType.Hosted,
+        };
+
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+
+        expect(container.find(HostedPaymentMethod).props())
+            .toEqual(expect.objectContaining({
+                deinitializePayment: expect.any(Function),
+                initializePayment: expect.any(Function),
+                method,
+            }));
+    });
+
     describe('when using hosted / offsite payment', () => {
         let method: PaymentMethod;
 

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -119,7 +119,8 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
         return <PaypalExpressPaymentMethod { ...props } />;
     }
 
-    if (method.id === PaymentMethodId.PaypalPaymentsPro) {
+    if (method.type !== PaymentMethodProviderType.Hosted &&
+        method.id === PaymentMethodId.PaypalPaymentsPro) {
         return <PaypalPaymentsProPaymentMethod { ...props } />;
     }
 


### PR DESCRIPTION
## What?  [INT-2595](https://jira.bigcommerce.com/browse/INT-2595)
When we have adyen v1 as payment method, paypal is asking by credit card information then this PR removes the credit card information request when is selected

## Why?
because paypal in Adyen v1 is a hosted payment method

## Testing / Proof
https://drive.google.com/file/d/1IBYLImOjNz_tpzJoBSvI6YbUHlguA_wO/view?usp=sharing


@bigcommerce/checkout. @bigcommerce/apex-integrations
