### PR TITLE
chore(common): CHECKOUT-4909 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1222,9 +1222,9 @@
           }
         },
         "@types/babel__core": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
-          "integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
+          "version": "7.1.8",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
+          "integrity": "sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==",
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0",
@@ -1595,9 +1595,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.76.0.tgz",
-      "integrity": "sha512-tSXYnkEO5SFsQ6nETcRy6QdiCtGnHtPT6KUI89KiMEVpMCkhkhXGbLZj8R0Z8CwZJ2xNrcL+Yta+wOxAo460IA==",
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.76.1.tgz",
+      "integrity": "sha512-jZBWcftnfhyNEwmPMjD6cPz2cF3n4U4hGGyD9VjoBQQ0EuqUZsokwEzhiqky5XG8i665qX6V2zkZArJcB7mDZQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.7.0",
@@ -1605,7 +1605,7 @@
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
         "@bigcommerce/request-sender": "^0.3.0",
-        "@bigcommerce/script-loader": "^2.1.0",
+        "@bigcommerce/script-loader": "^2.2.1",
         "@types/card-validator": "^4.1.0",
         "@types/iframe-resizer": "^3.5.6",
         "@types/lodash": "^4.14.139",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.76.0",
+    "@bigcommerce/checkout-sdk": "^1.76.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Raise the SDK version.

## Why?
Releasing a script loader fix.

## Testing / Proof
Circle.

@bigcommerce/checkout
