### PR TITLE
CHECKOUT-4926: Assign unique IDs to hosted form field containers

### DIFF
--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.spec.tsx
@@ -359,10 +359,10 @@ describe('CreditCardPaymentMethod', () => {
                     creditCard: {
                         form: {
                             fields: {
-                                cardCode: { containerId: 'ccCvv' },
-                                cardExpiry: { containerId: 'ccExpiry', placeholder: 'MM / YY' },
-                                cardName: { containerId: 'ccName' },
-                                cardNumber: { containerId: 'ccNumber' },
+                                cardCode: { containerId: 'authorizenet-ccCvv' },
+                                cardExpiry: { containerId: 'authorizenet-ccExpiry', placeholder: 'MM / YY' },
+                                cardName: { containerId: 'authorizenet-ccName' },
+                                cardNumber: { containerId: 'authorizenet-ccNumber' },
                             },
                             styles: {
                                 default: expect.any(Object),
@@ -385,11 +385,11 @@ describe('CreditCardPaymentMethod', () => {
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(getCreditCardInputStyles)
-                .toHaveBeenCalledWith('ccNumber', ['color', 'fontFamily', 'fontSize', 'fontWeight']);
+                .toHaveBeenCalledWith('authorizenet-ccNumber', ['color', 'fontFamily', 'fontSize', 'fontWeight']);
             expect(getCreditCardInputStyles)
-                .toHaveBeenCalledWith('ccNumber', ['color', 'fontFamily', 'fontSize', 'fontWeight'], CreditCardInputStylesType.Error);
+                .toHaveBeenCalledWith('authorizenet-ccNumber', ['color', 'fontFamily', 'fontSize', 'fontWeight'], CreditCardInputStylesType.Error);
             expect(getCreditCardInputStyles)
-                .toHaveBeenCalledWith('ccNumber', ['color', 'fontFamily', 'fontSize', 'fontWeight'], CreditCardInputStylesType.Focus);
+                .toHaveBeenCalledWith('authorizenet-ccNumber', ['color', 'fontFamily', 'fontSize', 'fontWeight'], CreditCardInputStylesType.Focus);
 
             // tslint:disable-next-line:no-non-null-assertion
             expect(defaultProps.initializePayment.mock.calls[0][0].creditCard!.form)
@@ -517,11 +517,11 @@ describe('CreditCardPaymentMethod', () => {
                             form: {
                                 fields: {
                                     cardCodeVerification: {
-                                        containerId: 'ccCvv',
+                                        containerId: 'authorizenet-ccCvv',
                                         instrumentId: getCardInstrument().bigpayToken,
                                     },
                                     cardNumberVerification: {
-                                        containerId: 'ccNumber',
+                                        containerId: 'authorizenet-ccNumber',
                                         instrumentId: getCardInstrument().bigpayToken,
                                     },
                                 },

--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
@@ -15,6 +15,8 @@ import { getHostedInstrumentValidationSchema, getInstrumentValidationSchema, isC
 import withPayment, { WithPaymentProps } from '../withPayment';
 import { PaymentFormValues } from '../PaymentForm';
 
+import getUniquePaymentMethodId from './getUniquePaymentMethodId';
+
 export interface CreditCardPaymentMethodProps {
     isInitializing?: boolean;
     isUsingMultiShipping?: boolean;
@@ -189,8 +191,8 @@ class CreditCardPaymentMethod extends Component<
                         selectedInstrumentId={ selectedInstrumentId }
                         validateInstrument={ shouldUseHostedFieldset ?
                             <HostedCreditCardValidation
-                                cardCodeId={ shouldShowCardCodeField ? 'ccCvv' : undefined }
-                                cardNumberId={ shouldShowNumberField ? 'ccNumber' : undefined }
+                                cardCodeId={ shouldShowCardCodeField ? this.getHostedFieldId('ccCvv') : undefined }
+                                cardNumberId={ shouldShowNumberField ? this.getHostedFieldId('ccNumber') : undefined }
                                 focusedFieldType={ focusedHostedFieldType }
                             /> :
                             <CreditCardValidation
@@ -207,10 +209,10 @@ class CreditCardPaymentMethod extends Component<
 
                     { shouldShowCreditCardFieldset && shouldUseHostedFieldset && <HostedCreditCardFieldset
                         additionalFields={ isCustomerCodeRequired && <CreditCardCustomerCodeField name="ccCustomerCode" /> }
-                        cardCodeId={ isCardCodeRequired ? 'ccCvv' : undefined }
-                        cardExpiryId="ccExpiry"
-                        cardNameId="ccName"
-                        cardNumberId="ccNumber"
+                        cardCodeId={ isCardCodeRequired ? this.getHostedFieldId('ccCvv') : undefined }
+                        cardExpiryId={ this.getHostedFieldId('ccExpiry') }
+                        cardNameId={ this.getHostedFieldId('ccName') }
+                        cardNumberId={ this.getHostedFieldId('ccNumber') }
                         focusedFieldType={ focusedHostedFieldType }
                         shouldShowSaveCardField={ isInstrumentFeatureAvailableProp }
                     /> }
@@ -297,20 +299,20 @@ class CreditCardPaymentMethod extends Component<
         const shouldShowNumberVerificationField = selectedInstrument ? isInstrumentCardNumberRequiredProp(selectedInstrument) : false;
         const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
         const styleContainerId = shouldShowInstrumentFieldset && selectedInstrument ?
-            (isInstrumentCardCodeRequiredProp(selectedInstrument, method) ? 'ccCvv' : undefined) :
-            'ccNumber';
+            (isInstrumentCardCodeRequiredProp(selectedInstrument, method) ? this.getHostedFieldId('ccCvv') : undefined) :
+            this.getHostedFieldId('ccNumber');
 
         return {
             fields: shouldShowInstrumentFieldset && selectedInstrumentId && selectedInstrument ?
                 {
-                    cardCodeVerification: isInstrumentCardCodeRequiredProp(selectedInstrument, method) ? { containerId: 'ccCvv', instrumentId: selectedInstrumentId } : undefined,
-                    cardNumberVerification: shouldShowNumberVerificationField ? { containerId: 'ccNumber', instrumentId: selectedInstrumentId } : undefined,
+                    cardCodeVerification: isInstrumentCardCodeRequiredProp(selectedInstrument, method) ? { containerId: this.getHostedFieldId('ccCvv'), instrumentId: selectedInstrumentId } : undefined,
+                    cardNumberVerification: shouldShowNumberVerificationField ? { containerId: this.getHostedFieldId('ccNumber'), instrumentId: selectedInstrumentId } : undefined,
                 } :
                 {
-                    cardCode: isCardCodeRequired ? { containerId: 'ccCvv' } : undefined,
-                    cardExpiry: { containerId: 'ccExpiry', placeholder: language.translate('payment.credit_card_expiration_placeholder_text') },
-                    cardName: { containerId: 'ccName' },
-                    cardNumber: { containerId: 'ccNumber' },
+                    cardCode: isCardCodeRequired ? { containerId: this.getHostedFieldId('ccCvv') } : undefined,
+                    cardExpiry: { containerId: this.getHostedFieldId('ccExpiry'), placeholder: language.translate('payment.credit_card_expiration_placeholder_text') },
+                    cardName: { containerId: this.getHostedFieldId('ccName') },
+                    cardNumber: { containerId: this.getHostedFieldId('ccNumber') },
                 },
             styles: styleContainerId ?
                 {
@@ -324,6 +326,12 @@ class CreditCardPaymentMethod extends Component<
             onFocus: this.handleHostedFieldFocus,
             onValidate: this.handleHostedFieldValidate,
         };
+    }
+
+    private getHostedFieldId(name: string): string {
+        const { method: { id, gateway } } = this.props;
+
+        return `${getUniquePaymentMethodId(id, gateway)}-${name}`;
     }
 
     private handleUseNewCard: () => void = () => {


### PR DESCRIPTION
## What?
Assign unique IDs to hosted form field containers.

## Why?
When a shopper switches from one payment method to another, there's a moment when two containers with the same ID can exist at the same time. That moment is when the newly selected payment method component initialises its hosted form field containers. But instead of targeting its own containers, it'd target the containers from the previously selected payment method component instead.

To fix this problem, we just need to give more unique names to the hosted field containers for each payment method.

## Testing / Proof
![fix-hosted-field-container-id](https://user-images.githubusercontent.com/667603/83713321-1b6c1100-a66b-11ea-805b-d909133359f7.gif)

@bigcommerce/checkout
