### PR TITLE
fix(payment): INT-2754 added time to get correct data for the vaulted credit cards and accounts

### DIFF
--- a/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
+++ b/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
@@ -28,7 +28,7 @@ class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps
         // FIXME: Used setTimeout here because setFieldValue call doesnot set value if called before formik is properly mounted.
         //        This ensures that update Field value is called after formik has mounted.
         // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
-        setTimeout(() => this.updateFieldValue(selectedInstrumentId));
+        setTimeout(() => this.updateFieldValue(selectedInstrumentId), 800);
     }
 
     componentDidUpdate(prevProps: Readonly<AccountInstrumentSelectProps>) {

--- a/src/app/payment/storedInstrument/InstrumentSelect.tsx
+++ b/src/app/payment/storedInstrument/InstrumentSelect.tsx
@@ -31,7 +31,7 @@ class InstrumentSelect extends PureComponent<InstrumentSelectProps> {
         // FIXME: Used setTimeout here because setFieldValue call doesnot set value if called before formik is properly mounted.
         //        This ensures that update Field value is called after formik has mounted.
         // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
-        setTimeout(() => this.updateFieldValue(selectedInstrumentId));
+        setTimeout(() => this.updateFieldValue(selectedInstrumentId), 800);
     }
 
     componentDidUpdate(prevProps: Readonly<InstrumentSelectProps>) {


### PR DESCRIPTION
## What? [INT-2754](https://jira.bigcommerce.com/browse/INT-2754)
Actually when you have more than one Payment method with Vaulted accounts and you navigate in the radio buttons menu for the payment methods and try to pay with a vaulted instrument it fails because the bigpayToken for that vaulted instrument is not loaded, so we need to add time to the setTimeout function when the component mounts.

## Why?
To let the information arrives correctly and be sure that we have the BigPayToken for the vaulted instrument


@bigcommerce/checkout @bigcommerce/apex-integrations 
