### PR TITLE
feat(payment): PAYPAL-483 Bump checkout-sdk-js to 1.77.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1610,9 +1610,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.77.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.77.2.tgz",
-      "integrity": "sha512-LJi1Wcr39KYtM1sEachoNHywrieCQAYcIUKwlynLETmqlaNWUQfUWqwp7Zir82+kb/1IgONYi+B+r+8PysrR0A==",
+      "version": "1.77.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.77.3.tgz",
+      "integrity": "sha512-hPQ+hWq9NXwXxpWmGd/dU0V7PiW0ey4zgZwRIHYj1wPVweVjUpC7LETW8r3A9TMu68LUHjdxsk+Vchw4fBvnWA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.77.2",
+    "@bigcommerce/checkout-sdk": "^1.77.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js to 1.77.3

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/906

## Testing / Proof
Unit tests/manual testing

@bigcommerce/checkout
