### PR TITLE
feat(payment): INT-2532 Accept payments through StripeV3 using iDEAL and SEPA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -838,9 +838,9 @@
           "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
         },
         "regenerator-runtime": {
-          "version": "0.13.6",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.6.tgz",
-          "integrity": "sha512-GmwlGiazQEbOwQWDdbbaP10i15pGtScYWLbMZuu+RKRz0cZ+g8IUONazBnaZqe7j1670IV1HgE4/8iy7CQPf4Q=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },
@@ -1609,9 +1609,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.83.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.83.0.tgz",
-      "integrity": "sha512-RqTn3hjP1lhSdpovhwrrCajpSbIzmzK7MzMPRsYAE2mPVaPuoJ1DrtUY2DqQXQuddZIHjGK4CpYRtF6TXljSng==",
+      "version": "1.84.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.84.0.tgz",
+      "integrity": "sha512-hACODL85dGx/Az3eNqYJzBtDpfFTHuItMP/LHeaUVMvt+Z5QIuFEJVbBuFgE/p+A8C8xw+qnKgAKu8lYJzv/pQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.9.0",
@@ -1806,7 +1806,7 @@
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -2263,7 +2263,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/credit-card-type": {
       "version": "7.0.0",
@@ -12146,7 +12146,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.83.0",
+    "@bigcommerce/checkout-sdk": "^1.84.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -247,8 +247,9 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         const { selectedMethod = defaultMethod } = this.state;
 
         // TODO: Perhaps there is a better way to handle `adyen`, `afterpay`, `amazon`,
-        // `checkout.com`, `converge`, `sagepay` and `sezzle`. They require a redirection to another website
-        // during the payment flow but are not categorised as hosted payment methods.
+        // `checkout.com`, `converge`, `sagepay`, `stripev3` and `sezzle`. They require
+        //  a redirection to another website during the payment flow but are not
+        //  categorised as hosted payment methods.
         if (!isSubmittingOrder ||
             !selectedMethod ||
             selectedMethod.type === PaymentMethodProviderType.Hosted ||
@@ -256,11 +257,12 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.AmazonPay ||
             selectedMethod.id === PaymentMethodId.Checkoutcom ||
             selectedMethod.id === PaymentMethodId.Converge ||
+            selectedMethod.id === PaymentMethodId.Laybuy ||
             selectedMethod.id === PaymentMethodId.SagePay ||
             selectedMethod.id === PaymentMethodId.Sezzle ||
-            selectedMethod.id === PaymentMethodId.Laybuy ||
             selectedMethod.gateway === PaymentMethodId.AdyenV2 ||
-            selectedMethod.gateway === PaymentMethodId.Afterpay) {
+            selectedMethod.gateway === PaymentMethodId.Afterpay ||
+            selectedMethod.gateway === PaymentMethodId.StripeV3) {
             return;
         }
 

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -64,7 +64,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
         return <SquarePaymentMethod { ...props } />;
     }
 
-    if (method.id === PaymentMethodId.StripeV3) {
+    if (method.gateway === PaymentMethodId.StripeV3) {
         return <StripePaymentMethod { ...props } />;
     }
 

--- a/src/scss/components/checkout/widget/_widget.scss
+++ b/src/scss/components/checkout/widget/_widget.scss
@@ -59,6 +59,7 @@
 
     margin-bottom: remCalc(20px);
     margin-top: remCalc(20px);
+    padding: 1rem;
 }
 
 .StripeElement--focus {


### PR DESCRIPTION
## What? [INT-2532](https://jira.bigcommerce.com/browse/INT-2532)
Accept iDEAL & SEPA payments on StripeV3

## Why?
I want merchants to offer iDEAL & SEPA APM support over my StripeV3 gateway implementation

## Testing / Proof

- Unit

- Manual

## How can this change be undone in case of failure?
1. Revert this PR

## Dependencies
[#937](https://github.com/bigcommerce/checkout-sdk-js/pull/911)

@bigcommerce/checkout @bigcommerce/apex-integrations 
