### PR TITLE
CHECKOUT-4954: Upgrade `script-loader` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1801,32 +1801,38 @@
       }
     },
     "@bigcommerce/script-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.0.0.tgz",
-      "integrity": "sha512-85/LHtiEPgKoezE6X/CxQ3p4wxarSil6tF063vUNpNVaL52oiHK53YZ3Km3ZuwMHfwxzviXqLWcfoDiOcUlKvA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.2.2.tgz",
+      "integrity": "sha512-BpMo7R4swcuiYGUVa8yaShdw/+rUHbMLyNL/u0te7sD6xZtW2B4uCRehasxal0vYxoI5hx764kni84AdH+6mNw==",
       "requires": {
-        "@bigcommerce/request-sender": "^0.3.0",
+        "@bigcommerce/request-sender": "^1.1.0",
         "tslib": "^1.10.0"
       },
       "dependencies": {
         "@bigcommerce/request-sender": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@bigcommerce/request-sender/-/request-sender-0.3.0.tgz",
-          "integrity": "sha1-NoBu2TNsSycCkF4FZatKoUvDm3w=",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@bigcommerce/request-sender/-/request-sender-1.1.0.tgz",
+          "integrity": "sha512-sa7zJ9cIPm2BWCf3O2FMD93WTcxYemkbiad6ZYPX5SbWu/lU2y8iBOZrHaeVMm3e+9EMPsiAnhzZo681+DSgjg==",
           "requires": {
-            "@types/js-cookie": "^2.1.0",
-            "@types/lodash": "^4.14.133",
+            "@types/js-cookie": "^2.2.6",
             "@types/query-string": "^5.1.0",
-            "js-cookie": "^2.1.4",
-            "lodash": "^4.17.11",
-            "query-string": "^5.0.0",
-            "tslib": "^1.8.0"
+            "js-cookie": "^2.2.1",
+            "lodash.merge": "^4.6.2",
+            "query-string": "^5.1.1",
+            "tslib": "^1.11.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.13.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+              "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+            }
           }
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",
     "@bigcommerce/request-sender": "^0.5.1",
-    "@bigcommerce/script-loader": "^2.0.0",
+    "@bigcommerce/script-loader": "^2.2.2",
     "@sentry/browser": "^5.6.3",
     "@sentry/integrations": "^5.6.1",
     "@types/card-validator": "^4.1.0",


### PR DESCRIPTION
## What?
Upgrade `script-loader` version to bring in this [fix](https://github.com/bigcommerce/script-loader-js/pull/12).

## Why?
To fix this [GH issue](https://github.com/bigcommerce/checkout-sdk-js/issues/905).

## Testing / Proof
CircleCI

@bigcommerce/checkout
