### PR TITLE
fix(checkout): CHECKOUT-4773 fix IE/EDGE when clicking print button multiple times

### DIFF
--- a/src/app/order/PrintLink.tsx
+++ b/src/app/order/PrintLink.tsx
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash';
 import React, { memo, useCallback, FunctionComponent } from 'react';
 
 import { TranslatedString } from '../locale';
@@ -7,10 +8,13 @@ export interface PrintLinkProps {
     className?: string;
 }
 
+const PRINT_MODAL_THROTTLE = 500;
+
 const PrintLink: FunctionComponent<PrintLinkProps> = ({ className }) => {
-    const handleClick = useCallback(() => {
+
+    const handleClick = useCallback(throttle(() => {
         window.print();
-    }, []);
+    }, PRINT_MODAL_THROTTLE), []);
 
     if (typeof window.print !== 'function') {
         return null;


### PR DESCRIPTION
## What?
As above

## Why?
IE/Edge renders the print modal differently, allowing users to click the print button multiple times, this also throws an error 
`The operation was canceled by the user`
https://sentry.io/organizations/bigcommerce/issues/1280452959/?project=1542560&referrer=jira_integration

## Testing / Proof
### Before
![Screen Shot 2020-06-24 at 6 35 32 pm](https://user-images.githubusercontent.com/9570178/85523661-a036c300-b64a-11ea-9aaa-b677b0731082.png)

...and then renders modal
![Screen Shot 2020-06-24 at 6 35 49 pm](https://user-images.githubusercontent.com/9570178/85523674-a3ca4a00-b64a-11ea-9091-c04681d623bb.png)

### After
![Screen Shot 2020-06-24 at 6 33 50 pm](https://user-images.githubusercontent.com/9570178/85523721-af1d7580-b64a-11ea-8fbb-1f3e5576316d.png)

@bigcommerce/checkout 
