### PR TITLE
CHECKOUT-4954: Transpile dependencies in case they are not compatible with our targeted environments

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,13 +16,20 @@ const LIBRARY_NAME = 'checkout';
 const AUTO_LOADER_ENTRY_NAME = 'auto-loader';
 const LOADER_ENTRY_NAME = 'loader';
 const LOADER_LIBRARY_NAME = 'checkoutLoader';
-const SUPPORTED_BROWSERS = [
-    'last 2 versions',
-    'not ie < 11',
-    'not Baidu > 0',
-    'not QQAndroid > 0',
-    'not Android < 62',
-];
+const BABEL_PRESET_ENV_CONFIG = {
+    corejs: '3',
+    targets: {
+        browsers: [
+            'last 2 versions',
+            'not ie < 11',
+            'not Baidu > 0',
+            'not QQAndroid > 0',
+            'not Android < 62',
+        ],
+    },
+    useBuiltIns: 'usage',
+    modules: false,
+};
 
 const eventEmitter = new EventEmitter();
 
@@ -155,17 +162,28 @@ function appConfig(options, argv) {
                                         cacheDirectory: true,
                                         presets: [
                                             ['@babel/preset-env', {
-                                                corejs: '3',
-                                                targets: {
-                                                    browsers: SUPPORTED_BROWSERS,
-                                                },
+                                                ...BABEL_PRESET_ENV_CONFIG,
                                                 useBuiltIns: 'entry',
-                                                modules: false,
                                             }],
                                         ],
                                     },
                                 },
                             ],
+                        },
+                        {
+                            test: /\.js$/,
+                            loader: 'babel-loader',
+                            include: join(__dirname, 'node_modules'),
+                            exclude: [
+                                /\/node_modules\/core-js\//,
+                                /\/node_modules\/webpack\//,
+                            ],
+                            options: {
+                                presets: [
+                                    ['@babel/preset-env', BABEL_PRESET_ENV_CONFIG],
+                                ],
+                                sourceType: 'unambiguous',
+                            },
                         },
                         {
                             test: /\.scss$/,
@@ -262,14 +280,7 @@ function loaderConfig(options, argv) {
                                     options: {
                                         cacheDirectory: true,
                                         presets: [
-                                            ['@babel/preset-env', {
-                                                corejs: '3',
-                                                targets: {
-                                                    browsers: SUPPORTED_BROWSERS,
-                                                },
-                                                useBuiltIns: 'usage',
-                                                modules: false,
-                                            }],
+                                            ['@babel/preset-env', BABEL_PRESET_ENV_CONFIG],
                                         ],
                                     },
                                 },
@@ -281,6 +292,21 @@ function loaderConfig(options, argv) {
                                     },
                                 },
                             ],
+                        },
+                        {
+                            test: /\.js$/,
+                            loader: 'babel-loader',
+                            include: join(__dirname, 'node_modules'),
+                            exclude: [
+                                /\/node_modules\/core-js\//,
+                                /\/node_modules\/webpack\//,
+                            ],
+                            options: {
+                                presets: [
+                                    ['@babel/preset-env', BABEL_PRESET_ENV_CONFIG],
+                                ],
+                                sourceType: 'unambiguous',
+                            },
                         },
                     ],
                 },


### PR DESCRIPTION
## What?
Transpile dependencies in case they are not compatible with our targeted environments.

## Why?
Yesterday we upgraded `request-sender` version, which includes a change made by our external partner - https://github.com/bigcommerce/request-sender-js/pull/29. This change is incompatible with IE11. Unless we configure our Webpack config to also transpile `node_modules` dependencies, we end up serving ES6 code to IE11 users.

There are a couple of ways to address this problem. Arguably the change to `request-sender` is a breaking one and we probably want to revert it. But considering in the future, we can inadvertently pull in other dependencies that similarly have ESM exports, which will lead to the same problem as what we're having now. So a better or safer approach is to simply change our Webpack config to also transpile `node_modules`.

## Testing / Proof
Manual

### Before
<img width="1315" alt="Screen Shot 2020-06-25 at 9 32 28 am" src="https://user-images.githubusercontent.com/667603/85638542-81c3dc80-b6c9-11ea-9a3b-ad4034fac7ad.png">

### After
<img width="1298" alt="Screen Shot 2020-06-25 at 9 29 28 am" src="https://user-images.githubusercontent.com/667603/85638537-7bcdfb80-b6c9-11ea-9dd0-7d9b3b187d6f.png">

@bigcommerce/checkout
