### PR TITLE
fix(shipping): INT-2813 revert passing down isLoading prop to Shippin…

### DIFF
--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -128,7 +128,7 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
                         googleMapsApiKey={ googleMapsApiKey }
                         hasRequestedShippingOptions={ hasRequestedShippingOptions }
                         initialize={ initialize }
-                        isLoading={ isLoading || isResettingAddress }
+                        isLoading={ isResettingAddress }
                         methodId={ methodId }
                         onAddressSelect={ this.handleAddressSelect }
                         onFieldChange={ this.handleFieldChange }


### PR DESCRIPTION
…gAddress

## What? [INT-2813](https://jira.bigcommerce.com/browse/INT-2813)
Revert passing down isLoading prop to the ShippingAddress component. We introduced the change in order to show a LoadingOverlay on the StaticAddressEditable used by AmazonPayV2.

## Why?
To fix the bug.

## Testing / Proof
![issue](https://user-images.githubusercontent.com/4843328/85770160-3c5ed980-b6e0-11ea-87b0-9d8720574e83.gif)

@bigcommerce/checkout
