### PR TITLE
CHECKOUT-4973: Upgrade `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,9 +970,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.8.0.tgz",
-      "integrity": "sha512-LKv6QZz6gSpthIX4VAfVX16xVRbCypSC/TqKHoSKMpTMcWEEyROdC6vwiQJ7MktFXxOK9CI7JQec0k00XreNIA==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.9.0.tgz",
+      "integrity": "sha512-AiocWVss9uSpDI4PV408tl8bvyC/Ga5t1rwgJPQX32E7VjRDjNKbpXOQjkW1Y4yLf83usNbLJ1V+UCxb6KGxmg==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^25.2.0",
@@ -1610,12 +1610,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.80.0.tgz",
-      "integrity": "sha512-TSTBTYq8dH03TRPqIMpyv9GGdv+amKU9YkPU5y2gVjsNiuqWDVBiqJimtVCTI/qAaydSCO6r2zLk9Chd5jXskw==",
+      "version": "1.80.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.80.1.tgz",
+      "integrity": "sha512-A580iW3HO3LupECBhskEPJIqHvULlmyVdjlTcJsOv7mP6ldx3sLczzXo0n0D/7yoTWAokZWwh3qENFOnieG7Ww==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.7.0",
+        "@bigcommerce/bigpay-client": "^5.9.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1686,9 +1686,9 @@
           }
         },
         "rxjs": {
-          "version": "6.5.5",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-          "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+          "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
           "requires": {
             "tslib": "^1.9.0"
           }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.80.0",
+    "@bigcommerce/checkout-sdk": "^1.80.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Upgrade `checkout-sdk` version

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments 
