### PR TITLE
CHECKOUT-4995: Upgrade `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1610,9 +1610,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.80.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.80.1.tgz",
-      "integrity": "sha512-A580iW3HO3LupECBhskEPJIqHvULlmyVdjlTcJsOv7mP6ldx3sLczzXo0n0D/7yoTWAokZWwh3qENFOnieG7Ww==",
+      "version": "1.80.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.80.2.tgz",
+      "integrity": "sha512-+DD/GXXq595RjdCHXtRT7jrqvl/3edemTe2A0q2NT9595F2TXeT753NJUYET8K8mwFBXjj5t77Lstmzcr+4ilQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.80.1",
+    "@bigcommerce/checkout-sdk": "^1.80.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Upgrade `checkout-sdk` version

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
