### PR TITLE
CHECKOUT-5029: Prevent shopper from changing payment method during initialisation

### DIFF
--- a/src/app/payment/Payment.spec.tsx
+++ b/src/app/payment/Payment.spec.tsx
@@ -110,6 +110,19 @@ describe('Payment', () => {
             }));
     });
 
+    it('passes initialisation status to payment form', async () => {
+        jest.spyOn(checkoutState.statuses, 'isInitializingPayment')
+            .mockReturnValue(true);
+
+        const container = mount(<PaymentTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+        container.update();
+
+        expect(container.find(PaymentForm).prop('isInitializingPayment'))
+            .toEqual(true);
+    });
+
     it('does not render payment form until initial requests are made', async () => {
         const container = mount(<PaymentTest { ...defaultProps } />);
 

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -35,6 +35,7 @@ interface WithCheckoutPaymentProps {
     cartUrl: string;
     defaultMethod?: PaymentMethod;
     finalizeOrderError?: Error;
+    isInitializingPayment: boolean;
     isSubmittingOrder: boolean;
     isStoreCreditApplied: boolean;
     isTermsConditionsRequired: boolean;
@@ -126,6 +127,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         const {
             defaultMethod,
             finalizeOrderError,
+            isInitializingPayment,
             isUsingMultiShipping,
             methods,
             applyStoreCredit,
@@ -156,6 +158,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
                         defaultGatewayId={ defaultMethod.gateway }
                         defaultMethodId={ defaultMethod.id }
                         didExceedSpamLimit={ didExceedSpamLimit }
+                        isInitializingPayment={ isInitializingPayment }
                         isUsingMultiShipping={ isUsingMultiShipping }
                         methods={ methods }
                         onMethodSelect={ this.setSelectedMethod }
@@ -426,7 +429,10 @@ export function mapToPaymentProps({
             getFinalizeOrderError,
             getSubmitOrderError,
         },
-        statuses: { isSubmittingOrder },
+        statuses: {
+            isInitializingPayment,
+            isSubmittingOrder,
+        },
     } = checkoutState;
 
     const checkout = getCheckout();
@@ -470,6 +476,7 @@ export function mapToPaymentProps({
         finalizeOrderError: getFinalizeOrderError(),
         finalizeOrderIfNeeded: checkoutService.finalizeOrderIfNeeded,
         loadCheckout: checkoutService.loadCheckout,
+        isInitializingPayment: isInitializingPayment(),
         isPaymentDataRequired,
         isStoreCreditApplied,
         isSubmittingOrder: isSubmittingOrder(),

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -23,6 +23,7 @@ export interface PaymentFormProps {
     defaultMethodId: string;
     didExceedSpamLimit?: boolean;
     isEmbedded?: boolean;
+    isInitializingPayment?: boolean;
     isTermsConditionsRequired?: boolean;
     isUsingMultiShipping?: boolean;
     isStoreCreditApplied: boolean;
@@ -63,6 +64,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     availableStoreCredit = 0,
     didExceedSpamLimit,
     isEmbedded,
+    isInitializingPayment,
     isPaymentDataRequired,
     isTermsConditionsRequired,
     isStoreCreditApplied,
@@ -102,6 +104,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
 
             <PaymentMethodListFieldset
                 isEmbedded={ isEmbedded }
+                isInitializingPayment={ isInitializingPayment }
                 isPaymentDataRequired={ isPaymentDataRequired }
                 isUsingMultiShipping={ isUsingMultiShipping }
                 methods={ methods }
@@ -132,6 +135,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
 
 interface PaymentMethodListFieldsetProps {
     isEmbedded?: boolean;
+    isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
     values: PaymentFormValues;
@@ -143,6 +147,7 @@ interface PaymentMethodListFieldsetProps {
 
 const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProps> = ({
     isEmbedded,
+    isInitializingPayment,
     isPaymentDataRequired,
     isUsingMultiShipping,
     methods,
@@ -192,6 +197,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
 
             <PaymentMethodList
                 isEmbedded={ isEmbedded }
+                isInitializingPayment={ isInitializingPayment }
                 isUsingMultiShipping={ isUsingMultiShipping }
                 methods={ methods }
                 onSelect={ handlePaymentMethodSelect }

--- a/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -11,6 +11,7 @@ import PaymentMethodTitle from './PaymentMethodTitle';
 
 export interface PaymentMethodListProps {
     isEmbedded?: boolean;
+    isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
     onSelect?(method: PaymentMethod): void;
@@ -34,6 +35,7 @@ const PaymentMethodList: FunctionComponent<
 > = ({
     formik: { values },
     isEmbedded,
+    isInitializingPayment,
     isUsingMultiShipping,
     methods,
     onSelect = noop,
@@ -48,6 +50,7 @@ const PaymentMethodList: FunctionComponent<
 
     return <Checklist
         defaultSelectedItemId={ values.paymentProviderRadio }
+        isDisabled={ isInitializingPayment }
         name="paymentProviderRadio"
         onSelect={ handleSelect }
     >
@@ -56,6 +59,7 @@ const PaymentMethodList: FunctionComponent<
 
             return (
                 <PaymentMethodListItem
+                    isDisabled={ isInitializingPayment }
                     isEmbedded={ isEmbedded }
                     isUsingMultiShipping={ isUsingMultiShipping }
                     key={ value }
@@ -69,6 +73,7 @@ const PaymentMethodList: FunctionComponent<
 };
 
 interface PaymentMethodListItemProps {
+    isDisabled?: boolean;
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
@@ -77,6 +82,7 @@ interface PaymentMethodListItemProps {
 }
 
 const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
+    isDisabled,
     isEmbedded,
     isUsingMultiShipping,
     method,
@@ -108,6 +114,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
         <ChecklistItem
             content={ renderPaymentMethod }
             htmlId={ `radio-${value}` }
+            isDisabled={ isDisabled }
             label={ renderPaymentMethodTitle }
             value={ value }
         />

--- a/src/app/ui/accordion/Accordion.spec.tsx
+++ b/src/app/ui/accordion/Accordion.spec.tsx
@@ -76,4 +76,34 @@ describe('Accordion', () => {
         expect(onSelect)
             .toHaveBeenCalledWith('foo');
     });
+
+    it('does not change selected item if component is disabled', () => {
+        const onSelect = jest.fn();
+        const component = mount(
+            <Accordion
+                defaultSelectedItemId="bar"
+                isDisabled
+                onSelect={ onSelect }
+            >
+                { items.map(({ label, id }) => (
+                    <AccordionItem
+                        headerContent={ ({ onToggle }) =>
+                            <div id={ id } onClick={ () => onToggle(id) }>{ label }</div> }
+                        itemId={ id }
+                        key={ id }
+                    />
+                )) }
+            </Accordion>
+        );
+
+        component.find('#foo')
+            .simulate('click')
+            .update();
+
+        expect(component.find('.accordion-item--selected').text())
+            .not.toEqual('Foo');
+
+        expect(onSelect)
+            .not.toHaveBeenCalledWith('foo');
+    });
 });

--- a/src/app/ui/accordion/Accordion.tsx
+++ b/src/app/ui/accordion/Accordion.tsx
@@ -8,6 +8,7 @@ export interface AccordionProps {
     children: ReactNode;
     className?: string;
     defaultSelectedItemId?: string;
+    isDisabled?: boolean;
     onSelect?(id: string): void;
 }
 
@@ -44,7 +45,11 @@ export default class Accordion extends Component<AccordionProps, AccordionState>
     }
 
     private handleToggleItem: (id: string) => void = id => {
-        const { onSelect = noop } = this.props;
+        const { isDisabled, onSelect = noop } = this.props;
+
+        if (isDisabled) {
+            return;
+        }
 
         this.setState({ selectedItemId: id });
         onSelect(id);

--- a/src/app/ui/form/Checklist.tsx
+++ b/src/app/ui/form/Checklist.tsx
@@ -7,6 +7,7 @@ import { Accordion } from '../accordion';
 export interface ChecklistProps {
     children: ReactNode;
     defaultSelectedItemId?: string;
+    isDisabled?: boolean;
     name: string;
     onSelect?(value: string): void;
 }

--- a/src/app/ui/form/ChecklistItem.spec.tsx
+++ b/src/app/ui/form/ChecklistItem.spec.tsx
@@ -33,4 +33,25 @@ describe('ChecklistItem', () => {
                 classNameSelected: 'form-checklist-item--selected optimizedCheckout-form-checklist-item--selected',
             }));
     });
+
+    it('can be disabled', () => {
+        const component = mount(
+            <Formik
+                initialValues={ { option: 'foo' } }
+                onSubmit={ noop }
+                render={ () => (
+                    <Checklist name="option">
+                        <ChecklistItem
+                            isDisabled
+                            label="Foo label"
+                            value="foo"
+                        />
+                    </Checklist>
+                ) }
+            />
+        );
+
+        expect(component.find('input').prop('disabled'))
+            .toEqual(true);
+    });
 });

--- a/src/app/ui/form/ChecklistItem.tsx
+++ b/src/app/ui/form/ChecklistItem.tsx
@@ -12,11 +12,13 @@ import ChecklistItemInput from './ChecklistItemInput';
 export interface ChecklistItemProps {
     content?: ReactNode;
     htmlId?: string;
+    isDisabled?: boolean;
     label: ReactNode | ((isSelected: boolean) => ReactNode);
     value: string;
 }
 
 const ChecklistItem: FunctionComponent<ChecklistItemProps> = ({
+    isDisabled,
     value,
     content,
     htmlId = kebabCase(value),
@@ -28,6 +30,7 @@ const ChecklistItem: FunctionComponent<ChecklistItemProps> = ({
     const renderInput = useCallback(memoizeOne((isSelected: boolean) => ({ field }: FieldProps) => (
         <ChecklistItemInput
             { ...field }
+            disabled={ isDisabled }
             id={ htmlId }
             isSelected={ field.value === value }
             value={ value }
@@ -38,6 +41,7 @@ const ChecklistItem: FunctionComponent<ChecklistItemProps> = ({
         </ChecklistItemInput>
     )), [
         htmlId,
+        isDisabled,
         label,
         value,
     ]);


### PR DESCRIPTION
## What?
Disable the payment method checklist when a payment method is in the middle of initialisation.

## Why?
So that the initialisation doesn't get interrupted and can fully complete.

## Testing / Proof
Unit
![prevent_switching_during_init](https://user-images.githubusercontent.com/667603/87271893-e9768600-c517-11ea-8020-2bda6e93bfd2.gif)

@bigcommerce/checkout
