### PR TITLE
feat(shipping): INT-2823 Show spinner in StaticAddressEditable

### DIFF
--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -40,6 +40,7 @@ export interface WithCheckoutShippingProps {
     isGuest: boolean;
     isInitializing: boolean;
     isLoading: boolean;
+    isShippingStepPending: boolean;
     methodId?: string;
     shippingAddress?: Address;
     shouldShowMultiShipping: boolean;
@@ -300,7 +301,6 @@ export function mapToShippingProps({
     const methodId = getShippingMethodId(checkout);
     const shippableItemsCount = getShippableItemsCount(cart);
     const isLoading = (
-        isShippingStepPending() ||
         isLoadingShippingOptions() ||
         isSelectingShippingOption() ||
         isUpdatingConsignment() ||
@@ -339,6 +339,7 @@ export function mapToShippingProps({
         hasSaveAddressFeature: features['CHECKOUT-4642.uco_save_address_checkbox'],
         isInitializing: isLoadingShippingCountries() || isLoadingShippingOptions(),
         isLoading,
+        isShippingStepPending: isShippingStepPending(),
         loadShippingAddressFields: checkoutService.loadShippingAddressFields,
         loadShippingOptions: checkoutService.loadShippingOptions,
         methodId,

--- a/src/app/shipping/ShippingAddress.spec.tsx
+++ b/src/app/shipping/ShippingAddress.spec.tsx
@@ -24,6 +24,7 @@ describe('ShippingAddress Component', () => {
         },
         countriesWithAutocomplete: [],
         isLoading: false,
+        isShippingStepPending: false,
         hasRequestedShippingOptions: false,
         formFields: getFormFields(),
         onAddressSelect: jest.fn(),

--- a/src/app/shipping/ShippingAddress.tsx
+++ b/src/app/shipping/ShippingAddress.tsx
@@ -17,6 +17,7 @@ export interface ShippingAddressProps {
     formFields: FormField[];
     googleMapsApiKey?: string;
     isLoading: boolean;
+    isShippingStepPending: boolean;
     methodId?: string;
     shippingAddress?: Address;
     shouldShowSaveAddress?: boolean;
@@ -48,6 +49,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = props => {
         addresses,
         shouldShowSaveAddress,
         onUnhandledError = noop,
+        isShippingStepPending,
     } = props;
 
     const { setSubmitted } = useContext(FormContext);
@@ -107,7 +109,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = props => {
                     deinitialize={ deinitialize }
                     formFields={ formFields }
                     initialize={ initializeShipping(options) }
-                    isLoading={ isLoading }
+                    isLoading={ isShippingStepPending }
                     methodId={ methodId }
                     onFieldChange={ onFieldChange }
                 />

--- a/src/app/shipping/ShippingForm.spec.tsx
+++ b/src/app/shipping/ShippingForm.spec.tsx
@@ -55,6 +55,7 @@ describe('ShippingForm Component', () => {
             onMultiShippingSubmit: jest.fn(),
             onSingleShippingSubmit: jest.fn(),
             isLoading: false,
+            isShippingStepPending: false,
             deleteConsignments: jest.fn(),
             updateAddress: jest.fn(),
             onUseNewAddress: jest.fn(),

--- a/src/app/shipping/ShippingForm.tsx
+++ b/src/app/shipping/ShippingForm.tsx
@@ -18,6 +18,7 @@ export interface ShippingFormProps {
     googleMapsApiKey?: string;
     isGuest: boolean;
     isLoading: boolean;
+    isShippingStepPending: boolean;
     isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
@@ -68,6 +69,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
             shouldShowSaveAddress,
             signOut,
             updateAddress,
+            isShippingStepPending,
         } = this.props;
 
         return isMultiShippingMode ?
@@ -102,6 +104,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
                 initialize={ initialize }
                 isLoading={ isLoading }
                 isMultiShippingMode={ isMultiShippingMode }
+                isShippingStepPending={ isShippingStepPending }
                 methodId={ methodId }
                 onSubmit={ onSingleShippingSubmit }
                 onUnhandledError={ onUnhandledError }

--- a/src/app/shipping/SingleShippingForm.spec.tsx
+++ b/src/app/shipping/SingleShippingForm.spec.tsx
@@ -29,6 +29,7 @@ describe('SingleShippingForm', () => {
             consignments: [],
             cartHasChanged: false,
             isLoading: false,
+            isShippingStepPending: false,
             onSubmit: jest.fn(),
             getFields: jest.fn(() => addressFormFields),
             onUnhandledError: jest.fn(),

--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -23,6 +23,7 @@ export interface SingleShippingFormProps {
     customerMessage: string;
     googleMapsApiKey?: string;
     isLoading: boolean;
+    isShippingStepPending: boolean;
     isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
@@ -104,6 +105,7 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
             isValid,
             deinitialize,
             values: { shippingAddress: addressForm },
+            isShippingStepPending,
         } = this.props;
 
         const {
@@ -129,6 +131,7 @@ class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLan
                         hasRequestedShippingOptions={ hasRequestedShippingOptions }
                         initialize={ initialize }
                         isLoading={ isResettingAddress }
+                        isShippingStepPending={ isShippingStepPending }
                         methodId={ methodId }
                         onAddressSelect={ this.handleAddressSelect }
                         onFieldChange={ this.handleFieldChange }

--- a/src/app/shipping/StaticAddressEditable.spec.tsx
+++ b/src/app/shipping/StaticAddressEditable.spec.tsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme';
+import { mount, shallow, ShallowWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
@@ -9,6 +9,7 @@ import { getFormFields } from '../address/formField.mock';
 import { getStoreConfig } from '../config/config.mock';
 import { createLocaleContext, LocaleContext } from '../locale';
 import { Button } from '../ui/button';
+import { LoadingOverlay } from '../ui/loading';
 
 import StaticAddressEditable, { StaticAddressEditableProps } from './StaticAddressEditable';
 
@@ -93,5 +94,19 @@ describe('StaticAddressEditable Component', () => {
             .simulate('change', { target: { value: 'foo', name: 'shippingAddress.customFields.field_25' } });
 
         expect(defaultProps.onFieldChange).toHaveBeenCalledWith(inputFieldName, 'foo');
+    });
+
+    it('renders loading overlay while loading, updating or interacting', () => {
+        let wrapper: ShallowWrapper;
+
+        wrapper = shallow(<StaticAddressEditable { ...defaultProps } isLoading={ true } />);
+
+        expect(wrapper.find(LoadingOverlay).prop('isLoading'))
+            .toEqual(true);
+
+        wrapper = shallow(<StaticAddressEditable { ...defaultProps } />);
+
+        expect(wrapper.find(LoadingOverlay).prop('isLoading'))
+            .toEqual(false);
     });
 });


### PR DESCRIPTION
## What? [INT-2823](https://jira.bigcommerce.com/browse/INT-2823)
Pass `isShippingStepPending` down to `StaticAddressEditable` in order to show a spinner in front while initializing, updating, or interacting.

## Why?
UX/UI and avoid clicking while something is pending.

## Testing / Proof
CircleCI
<image src="https://user-images.githubusercontent.com/4843328/87584027-78afa500-c6a2-11ea-8ed7-75def0f8959a.gif" width="400" />

## PLEASE NOTICE:
This is another approach to the one introduced in #271 but reverted in #328 because caused a bug.

@bigcommerce/checkout
