### PR TITLE
feat(payment): INT-2653 Accept payments through StripeV3 using Alipay

### DIFF
--- a/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -53,6 +53,43 @@ describe('when using Stripe payment', () => {
         );
     });
 
+    describe('when using alipay component', () => {
+        beforeEach(() => {
+            method = { ...getPaymentMethod(), id: 'alipay', gateway: 'stripev3', method: 'alipay' };
+        });
+
+        it('renders as hosted widget method', () => {
+            const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+            const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+            expect(component.props())
+                .toEqual(expect.objectContaining({
+                    containerId: `stripe-alipay-component-field`,
+                    deinitializePayment: expect.any(Function),
+                    initializePayment: expect.any(Function),
+                    method,
+                }));
+        });
+
+        it('initializes method with required config', () => {
+            const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+            const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+            component.prop('initializePayment')({
+                methodId: method.id,
+                gatewayId: method.gateway,
+            });
+
+            expect(checkoutService.initializePayment)
+                .toHaveBeenCalledWith(expect.objectContaining({
+                    methodId: method.id,
+                    stripev3: {
+                        containerId: 'stripe-alipay-component-field',
+                    },
+                }));
+        });
+    });
+
     describe('when using card component', () => {
         beforeEach(() => {
             method = { ...getPaymentMethod(), id: 'card', gateway: 'stripev3', method: 'card'};

--- a/src/app/payment/paymentMethod/StripePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.tsx
@@ -7,23 +7,26 @@ import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './Hos
 export type StripePaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'containerId'>;
 
 export interface StripeOptions {
+    alipay?: StripeElementOptions;
     card: StripeElementOptions;
     iban: StripeElementOptions;
     idealBank: StripeElementOptions;
 }
 
 export enum StripeV3PaymentMethodType {
+    alipay = 'alipay',
     card = 'card',
     iban = 'iban',
     idealBank = 'idealBank',
 }
 
 const StripePaymentMethod: FunctionComponent<StripePaymentMethodProps> = ({
-    initializePayment,
-    method,
-    ...rest
-}) => {
+      initializePayment,
+      method,
+      ...rest
+  }) => {
     const paymentMethodType = method.id as StripeV3PaymentMethodType;
+    const additionalStripeV3Classes = paymentMethodType !== StripeV3PaymentMethodType.alipay ? 'optimizedCheckout-form-input widget--stripev3' : '';
     const containerId = `stripe-${paymentMethodType}-component-field`;
 
     const initializeStripePayment = useCallback(async (options: PaymentInitializeOptions) => {
@@ -55,7 +58,7 @@ const StripePaymentMethod: FunctionComponent<StripePaymentMethodProps> = ({
 
     return <HostedWidgetPaymentMethod
         { ...rest }
-        additionalContainerClassName="optimizedCheckout-form-input widget--stripev3"
+        additionalContainerClassName= { additionalStripeV3Classes }
         containerId={ containerId }
         hideContentWhenSignedOut
         initializePayment={ initializeStripePayment }


### PR DESCRIPTION
## What? [INT-2653](https://jira.bigcommerce.com/browse/INT-2653)
Accept Alipay payments on StripeV3

## Why?
I want merchants to offer Alipay APM support to Chinese shoppers over my StripeV3 gateway implementation

## Testing / Proof

- Unit

- Manual

## How can this change be undone in case of failure?
1. Revert this PR

## Siblings
[#937](https://github.com/bigcommerce/checkout-sdk-js/pull/937)

@bigcommerce/checkout @bigcommerce/apex-integrations 
