### PR TITLE
fix(payments): INT-2902  added style in order to avoid overlapping fields with small devices on stripeV3

### DIFF
--- a/src/scss/components/checkout/widget/_widget.scss
+++ b/src/scss/components/checkout/widget/_widget.scss
@@ -60,6 +60,18 @@
     margin-bottom: remCalc(20px);
     margin-top: remCalc(20px);
     padding: 1rem;
+
+    @media screen and (max-width: 375px) {
+        margin: remCalc(20px) -2rem remCalc(20px) -2rem;
+        padding: 1rem;
+        width: 20rem;
+    }
+
+    @media screen and (max-width: 320px) {
+        margin: remCalc(20px) -2rem remCalc(20px) -3rem;
+        padding: 1rem;
+        width: 19rem;
+    }
 }
 
 .StripeElement--focus {


### PR DESCRIPTION
## What? [INT-2902](https://jira.bigcommerce.com/browse/INT-2902)
Added style in order to avoid  overlapping fields on small devices on stripeV3

## Why?
In order to avoid overlapping fields on small devices on stripeV3

## Testing / Proof
[Testing Proof Video INT-2902](https://drive.google.com/file/d/1zpdrihmiZBOkb-Sqw0qazLkgnxiBtsF1/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/apex-integrations 
