### PR TITLE
CHECKOUT-4947: Fix `package.json` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/checkout",
-  "version": "1.68.0",
+  "version": "1.70.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/checkout",
-  "version": "1.68.0",
+  "version": "1.70.0",
   "private": true,
   "description": "Browser-based application providing a seamless UI for BigCommerce shoppers to complete their checkout.",
   "scripts": {


### PR DESCRIPTION
## What?
I made a mistake with the rebase for my last PR (https://github.com/bigcommerce/checkout-js/pull/349). 🤦 

## Why?
See above

## Testing / Proof
Manual (the latest release is 1.70.0)

@bigcommerce/checkout
