### PR TITLE
feat(payments): PAYPAL-202 bump checkout-sdk to 1.90

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,9 +970,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.11.0.tgz",
-      "integrity": "sha512-5i+jd7CswjLh6wgnwe4YjH3G6nkiAI16oaDLomslDwsQHhAbUtZ4GqIrMVgj6oleP2cBazjRCy1NlkhRcdJbUQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.12.0.tgz",
+      "integrity": "sha512-n6FD4gZVWmUsbotijw+xy2AVvuUd/snL4hzmNVzSifs+IbbMSrntYUk9UsIwxUYouk/6ZmAaYKB6UvZ87xrzpw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^25.2.0",
@@ -1609,12 +1609,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.89.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.89.0.tgz",
-      "integrity": "sha512-omCPboM2Ml15o7ucTD0dKG7zz3T0hOdhDx6sNzpmdGfPJ8Q6TrTX93kza2zKA6C9To9810tF0LcgoQjbzEO7ng==",
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.90.0.tgz",
+      "integrity": "sha512-RUeH8c/R9XX/fxqK7FjJ5+J64olj+84Jmdjm8nOfj6geKvzyBkH3yTGJcF/kHpslEM0AWign2zMmlfzolth7Uw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.11.0",
+        "@bigcommerce/bigpay-client": "^5.12.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1806,7 +1806,7 @@
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -2263,7 +2263,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA="
     },
     "@types/credit-card-type": {
       "version": "7.0.0",
@@ -12146,7 +12146,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.89.0",
+    "@bigcommerce/checkout-sdk": "^1.90.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout-sdk to 1.90

## Why?
released https://github.com/bigcommerce/checkout-sdk-js/pull/953

## Testing / Proof
unit / manual

@bigcommerce/checkout
