### PR TITLE
CHECKOUT-5099: Only show inline error messages if form validation fails without any input attempt

### DIFF
--- a/src/app/payment/Payment.spec.tsx
+++ b/src/app/payment/Payment.spec.tsx
@@ -410,6 +410,16 @@ describe('Payment', () => {
             .toHaveLength(0);
     });
 
+    it('does not render error modal when there is invalid hosted form value error', () => {
+        jest.spyOn(checkoutState.errors, 'getSubmitOrderError')
+            .mockReturnValue({ type: 'invalid_hosted_form_value' } as CustomError);
+
+        const container = mount(<PaymentTest { ...defaultProps } />);
+
+        expect(container.find(ErrorModal))
+            .toHaveLength(0);
+    });
+
     it('renders error modal if there is error when finalizing order', () => {
         jest.spyOn(checkoutState.errors, 'getFinalizeOrderError')
             .mockReturnValue({ type: 'request' } as CustomError);

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -189,7 +189,8 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         if (!error ||
             error.type === 'order_finalization_not_required' ||
             error.type === 'payment_cancelled' ||
-            error.type === 'spam_protection_not_completed') {
+            error.type === 'spam_protection_not_completed' ||
+            error.type === 'invalid_hosted_form_value') {
             return null;
         }
 


### PR DESCRIPTION
## What?
Only show inline error messages if form validation fails without any input attempt.

## Why?
Without this change, an error modal will also pop up when there's a form validation error.

## Testing / Proof
CircleCI + Manual

#### Before
<img width="947" alt="Screen Shot 2020-08-13 at 6 41 23 pm" src="https://user-images.githubusercontent.com/667603/90113592-eed42400-dd94-11ea-8063-b1ebe94b4ad6.png">

#### After
<img width="590" alt="Screen Shot 2020-08-13 at 6 40 34 pm" src="https://user-images.githubusercontent.com/667603/90113603-f3004180-dd94-11ea-82be-aabc110beb9e.png">

@bigcommerce/checkout
