### PR TITLE
CHECKOUT-5102: Show request ID in error modal if available

### DIFF
--- a/src/app/common/error/ErrorCode.tsx
+++ b/src/app/common/error/ErrorCode.tsx
@@ -1,14 +1,19 @@
-import React, { memo, FunctionComponent } from 'react';
+import React, { memo, FunctionComponent, ReactNode } from 'react';
 
 import { TranslatedString } from '../../locale';
 
 import './ErrorCode.scss';
 
-const ErrorCode: FunctionComponent<{code: string}> = ({ code }) => {
+export interface ErrorCodeProps {
+    code: string;
+    label?: ReactNode;
+}
+
+const ErrorCode: FunctionComponent<ErrorCodeProps> = ({ code, label }) => {
     return (
         <div className="errorCode">
             <span className="errorCode-label">
-                <TranslatedString id="common.error_code" />
+                { label ?? <TranslatedString id="common.error_code" /> }
             </span>
             { ' ' }
             <span className="errorCode-value">{ code }</span>

--- a/src/app/common/error/ErrorModal.spec.tsx
+++ b/src/app/common/error/ErrorModal.spec.tsx
@@ -1,3 +1,4 @@
+import { RequestError } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 
@@ -13,7 +14,7 @@ import ErrorModal, { ErrorModalProps } from './ErrorModal';
 describe('ErrorModal', () => {
     let errorModal: ReactWrapper;
     let localeContext: LocaleContextType;
-    let error: Error;
+    let error: Error | RequestError;
     const onClose = jest.fn();
 
     const ErrorModalContainer = (props: ErrorModalProps) => (
@@ -46,6 +47,18 @@ describe('ErrorModal', () => {
 
     it('renders error code', () => {
         expect(errorModal.find(ErrorCode).length).toEqual(1);
+    });
+
+    it('renders request ID if available', () => {
+        error = {
+            type: 'request',
+            headers: { 'x-request-id': 'foobar' },
+        } as unknown as RequestError;
+
+        errorModal = mount(<ErrorModalContainer error={ error } />);
+
+        expect(errorModal.find(ErrorCode).text())
+            .toEqual('Request ID: foobar');
     });
 
     it('overrides error message', () => {

--- a/src/app/common/error/ErrorModal.tsx
+++ b/src/app/common/error/ErrorModal.tsx
@@ -1,3 +1,4 @@
+import { RequestError } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React, { Fragment, PureComponent, ReactNode, SyntheticEvent } from 'react';
 
@@ -8,10 +9,11 @@ import { Modal, ModalHeader } from '../../ui/modal';
 
 import computeErrorCode from './computeErrorCode';
 import isCustomError from './isCustomError';
+import isRequestError from './isRequestError';
 import ErrorCode from './ErrorCode';
 
 export interface ErrorModalProps {
-    error?: Error;
+    error?: Error | RequestError;
     message?: ReactNode;
     title?: ReactNode;
     shouldShowErrorCode?: boolean;
@@ -89,6 +91,13 @@ export default class ErrorModal extends PureComponent<ErrorModalProps> {
 
         if (!error || !shouldShowErrorCode) {
             return;
+        }
+
+        if (isRequestError(error) && error?.headers?.['x-request-id']) {
+            return <ErrorCode
+                code={ error.headers['x-request-id'] }
+                label={ <TranslatedString id="common.request_id" /> }
+            />;
         }
 
         const errorCode = computeErrorCode(error);

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -81,6 +81,7 @@
             "loading_text": "Loading",
             "ok_action": "Ok",
             "error_code": "Error code:",
+            "request_id": "Request ID:",
             "optional_text": "(Optional)",
             "unavailable_error": "Checkout is temporarily unavailable. Please try again later.",
             "unavailable_heading": "Checkout is temporarily unavailable",


### PR DESCRIPTION
## What?
Display the request ID of a failed API request in an error modal if it's available.

## Why?
If a screenshot of the error modal is taken and shared with us, we can grab the request ID from it to look up more information in our logs.

## Testing / Proof
CircleCI

#### Order creation
<img width="705" alt="Screen Shot 2020-08-14 at 4 58 38 pm" src="https://user-images.githubusercontent.com/667603/90224823-a3347f80-de53-11ea-8efb-2d482961642b.png">

#### Payment submission
<img width="700" alt="Screen Shot 2020-08-14 at 5 01 25 pm" src="https://user-images.githubusercontent.com/667603/90224842-aa5b8d80-de53-11ea-9732-b1a27827cfe9.png">

@bigcommerce/checkout @icatalina 
