### PR TITLE
refactor(billing): INT-3025 Update the text when no billing address i…

### DIFF
--- a/src/app/billing/StaticBillingAddress.spec.tsx
+++ b/src/app/billing/StaticBillingAddress.spec.tsx
@@ -85,7 +85,7 @@ describe('StaticBillingAddress', () => {
             .toEqual(0);
 
         expect(container.text())
-            .toEqual(getLanguageService().translate('billing.billing_address_amazon'));
+            .toEqual(getLanguageService().translate('billing.billing_address_amazonpay'));
     });
 
     it('renders address when using Amazon Pay V2 when full address is provided', () => {

--- a/src/app/billing/StaticBillingAddress.tsx
+++ b/src/app/billing/StaticBillingAddress.tsx
@@ -22,10 +22,15 @@ const StaticBillingAddress: FunctionComponent<
     address,
     payments = EMPTY_ARRAY,
 }) => {
-    if (payments.find(payment => payment.providerId === 'amazon') ||
-        (payments.find(payment => payment.providerId === 'amazonpay' && address.firstName === ''))) {
+    if (payments.find(payment => payment.providerId === 'amazon')) {
         return (
             <p><TranslatedString id="billing.billing_address_amazon" /></p>
+        );
+    }
+
+    if (payments.find(payment => payment.providerId === 'amazonpay' && address.firstName === '')) {
+        return (
+            <p><TranslatedString id="billing.billing_address_amazonpay" /></p>
         );
     }
 

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -42,6 +42,7 @@
             "billing_heading": "Billing",
             "save_billing_address_error": "An error occurred while saving the billing address to your price quote. Please try again.",
             "billing_address_amazon": "Same as the Billing address set by you in your Amazon account.",
+            "billing_address_amazonpay": "Managed by Amazon Pay",
             "use_shipping_address_label": "My billing address is the same as my shipping address."
         },
         "cart": {


### PR DESCRIPTION
…s provided for AmazonPayV2

## What? [INT-3025](https://jira.bigcommerce.com/browse/INT-3025)
Update billing address text to 'Managed by Amazon Pay' when no billing address is provided for Amazon Pay V2

## Why?
The change was requested by Amazon

## Testing / Proof
CircleCI
<img width="400" alt="Managed by Amazon Pay" src="https://user-images.githubusercontent.com/4843328/90420537-b6c32e80-e07d-11ea-91f7-9880b59eea71.png">

@bigcommerce/checkout
