### PR TITLE
refactor(payment): INT-3054 Customize submit button text for AmazonPayV2

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -160,6 +160,7 @@
             "afterpay_name_text": "Afterpay",
             "afterpay_description": "Checkout with Afterpay",
             "amazon_continue_action": "Continue with Amazon",
+            "amazonpay_continue_action": "Continue with Amazon",
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Continue",
             "bluesnap_v2_continue_action": "Continue",

--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -1,4 +1,4 @@
-import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, CheckoutSelectors, CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 import { act } from 'react-dom/test-utils';
@@ -16,6 +16,7 @@ import { PaymentMethodList, PaymentMethodListProps } from './paymentMethod';
 import { StoreCreditField, StoreCreditFieldProps, StoreCreditOverlay } from './storeCredit';
 import PaymentContext, { PaymentContextProps } from './PaymentContext';
 import PaymentForm, { PaymentFormProps } from './PaymentForm';
+import PaymentSubmitButton from './PaymentSubmitButton';
 import SpamProtectionField, { SpamProtectionProps } from './SpamProtectionField';
 
 jest.useFakeTimers();
@@ -299,5 +300,63 @@ describe('PaymentForm', () => {
 
         expect(container.exists('[data-test="cc-number-field-error-message"]'))
             .toEqual(false);
+    });
+
+    describe('PaymentSubmitButton', () => {
+        let selectedMethod: PaymentMethod;
+
+        beforeEach(() => {
+            selectedMethod = { ...getPaymentMethod(), id: 'foo', method: 'bar', gateway: 'baz' };
+        });
+
+        it('renders with default label', () => {
+            defaultProps = { ...defaultProps, selectedMethod };
+            const container = mount(<PaymentFormTest { ...defaultProps } />);
+            const submitButton = container.find(PaymentSubmitButton);
+
+            expect(submitButton)
+                .toHaveLength(1);
+
+            expect(submitButton.props())
+                .toEqual(expect.objectContaining({
+                    methodGateway: 'baz',
+                    methodId: 'foo',
+                    methodType: 'bar',
+                }));
+        });
+
+        it('renders with default label if selected method is amazonpay and there is paymentToken', () => {
+            selectedMethod = { ...selectedMethod, id: 'amazonpay', initializationData: { paymentToken: 'foo' } };
+            defaultProps = { ...defaultProps, selectedMethod };
+            const container = mount(<PaymentFormTest { ...defaultProps } />);
+            const submitButton = container.find(PaymentSubmitButton);
+
+            expect(submitButton)
+                .toHaveLength(1);
+
+            expect(submitButton.props())
+                .toEqual(expect.objectContaining({
+                    methodGateway: 'baz',
+                    methodId: undefined,
+                    methodType: 'bar',
+                }));
+        });
+
+        it('renders with special label if selected method is amazonpay and there is no paymentToken', () => {
+            selectedMethod = { ...selectedMethod, id: 'amazonpay', initializationData: { paymentToken: '' } };
+            defaultProps = { ...defaultProps, selectedMethod };
+            const container = mount(<PaymentFormTest { ...defaultProps } />);
+            const submitButton = container.find(PaymentSubmitButton);
+
+            expect(submitButton)
+                .toHaveLength(1);
+
+            expect(submitButton.props())
+                .toEqual(expect.objectContaining({
+                    methodGateway: 'baz',
+                    methodId: 'amazonpay',
+                    methodType: 'bar',
+                }));
+        });
     });
 });

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -11,7 +11,7 @@ import { Fieldset, Form, FormContext, Legend } from '../ui/form';
 import { CreditCardFieldsetValues } from './creditCard';
 import getPaymentValidationSchema from './getPaymentValidationSchema';
 import { HostedCreditCardFieldsetValues } from './hostedCreditCard';
-import { getUniquePaymentMethodId, PaymentMethodList } from './paymentMethod';
+import { getUniquePaymentMethodId, PaymentMethodId, PaymentMethodList } from './paymentMethod';
 import { CardInstrumentFieldsetValues } from './storedInstrument';
 import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
 import PaymentRedeemables from './PaymentRedeemables';
@@ -83,6 +83,24 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     usableStoreCredit = 0,
     values,
 }) => {
+    const selectedMethodId = useMemo(() => {
+        if (!selectedMethod) {
+            return;
+        }
+
+        switch (selectedMethod.id) {
+        case PaymentMethodId.AmazonPay:
+            if (selectedMethod.initializationData.paymentToken) {
+                return;
+            }
+
+            return selectedMethod.id;
+
+        default:
+            return selectedMethod.id;
+        }
+    }, [selectedMethod]);
+
     if (shouldExecuteSpamCheck) {
         return <SpamProtectionField
             didExceedSpamLimit={ didExceedSpamLimit }
@@ -126,7 +144,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
                 <PaymentSubmitButton
                     isDisabled={ shouldDisableSubmit }
                     methodGateway={ selectedMethod && selectedMethod.gateway }
-                    methodId={ selectedMethod && selectedMethod.id }
+                    methodId={ selectedMethodId }
                     methodType={ selectedMethod && selectedMethod.method }
                 />
             </div>

--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -67,6 +67,15 @@ describe('PaymentSubmitButton', () => {
             .toEqual(languageService.translate('payment.amazon_continue_action'));
     });
 
+    it('renders button with special label for Amazon Pay', () => {
+        const component = mount(
+            <PaymentSubmitButtonTest methodId="amazon" />
+        );
+
+        expect(component.text())
+            .toEqual(languageService.translate('payment.amazonpay_continue_action'));
+    });
+
     it('renders button with special label for Bolt', () => {
         const component = mount(
             <PaymentSubmitButtonTest methodId="bolt" />

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -17,6 +17,10 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
         return <TranslatedString id="payment.amazon_continue_action" />;
     }
 
+    if (methodId === PaymentMethodId.AmazonPay) {
+        return <TranslatedString id="payment.amazonpay_continue_action" />;
+    }
+
     if (methodId === PaymentMethodId.Bolt) {
         return <TranslatedString id="payment.bolt_continue_action" />;
     }


### PR DESCRIPTION
…zonPayV2

## What? [INT-3054](https://jira.bigcommerce.com/browse/INT-3054)
Display 'Continue with Amazon' instead of 'Place Order' for the submit payment button.

## Why?
Because it is not very accurate as you are not placing the order at that moment, and you are just going to redirect to choose payment/address settings.

## Testing / Proof
CircleCI
<img width="350" alt="Continue with Amazon" src="https://user-images.githubusercontent.com/4843328/90425582-97300400-e085-11ea-8619-8c08aa802276.png"> <img width="350" alt="Place Order" src="https://user-images.githubusercontent.com/4843328/90425711-cd6d8380-e085-11ea-8198-d0f7392dc254.png">

@bigcommerce/checkout
