### PR TITLE
feat(payments): INT-3018 added sepa verbiage on stripeV3

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -239,6 +239,7 @@
             "instrument_trusted_shipping_address_text": "This additional security step is applied to your card when shipping to an address for the first time or if the shipping address was edited recently.",
             "instrument_trusted_shipping_address_title_text": "Please re-enter your card number to authorize this transaction.",
             "sezzle_display_name_text": "Pay Later. 0% Interest.",
+            "stripe_sepa_mandate_disclaimer": "By providing your IBAN and confirming this payment, you authorise (A) {storeUrl} and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. You are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within eight weeks starting from the date on which your account was debited.",
             "vco_name_text": "Visa Checkout",
             "visa_checkout_continue_action": "Continue with Visa Checkout",
             "zip_continue_action": "Continue with Zip",

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -67,6 +67,11 @@ body.klarna-payments-fso-open {
     scroll-behavior: auto;
 }
 
+.stripe-sepa-mandate-disclaimer {
+    margin-bottom: 0;
+    padding-bottom: remCalc(20px);
+}
+
 #stripe-card-field--invalid {
     border-color: #fa755a;
 }


### PR DESCRIPTION
## What? [INT-3018](https://jira.bigcommerce.com/browse/INT-3018)
Added sepa mandate disclaimer on stripeV3.

## Why?
So that shopper consents to the transaction being authorized and debited from their bank account.

## Testing / Proof
<img width="737" alt="Screen Shot 2020-08-17 at 7 19 50 PM" src="https://user-images.githubusercontent.com/61981535/90456662-2c9bba00-e0bf-11ea-865b-5025d3bc6b45.png">



@bigcommerce/checkout @bigcommerce/apex-integrations 
