### PR TITLE
fix(payment): INT-3043 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,9 +1609,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.91.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.91.0.tgz",
-      "integrity": "sha512-VO5k5lD3erYdxutI7dnFwAz37m1LnzmJjtObhxJ8olsm1PXHdsgraTWEG/R+HZvhZRfSUx+pv75rGMJ+T8k3bA==",
+      "version": "1.91.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.91.1.tgz",
+      "integrity": "sha512-HLyQ+8DnHOlucfCFo2w+AOVf2jWq+RQVL98zFvxpyUWCw6FHnz4lK9jiqHJ8Hh2wXf3N3evvllhfWJETUNFxBQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.91.0",
+    "@bigcommerce/checkout-sdk": "^1.91.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
As per title.

## Why?
Releasing https://github.com/bigcommerce/checkout-sdk-js/pull/958

## Testing / Proof
Circle.

@bigcommerce/checkout
