### PR TITLE
fix(payment): INT-3053 Add shouldShow property to HostedWidgetPaymentMethod

### DIFF
--- a/src/app/payment/paymentMethod/AmazonPayV2PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/AmazonPayV2PaymentMethod.tsx
@@ -1,12 +1,10 @@
-import { CheckoutSelectors, PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { useCallback, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
 import HostedWidgetPaymentMethod , { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
 
-export interface AmazonPayV2PaymentMethodProps extends Omit<HostedWidgetPaymentMethodProps, 'buttonId' | 'containerId' | 'hideWidget' | 'isSignInRequired' | 'paymentDescriptor' | 'shouldShowDescriptor' | 'shouldShowEditButton'> {
-    initializePayment(options: PaymentInitializeOptions): Promise<CheckoutSelectors>;
-}
+export type AmazonPayV2PaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'buttonId' | 'containerId' | 'deinitializeCustomer' | 'hideWidget' | 'initializeCustomer' | 'isSignInRequired' | 'onSignOut' | 'paymentDescriptor' | 'shouldShow' | 'shouldShowDescriptor' | 'shouldShowEditButton'>;
 
 const AmazonPayV2PaymentMethod: FunctionComponent<AmazonPayV2PaymentMethodProps> = ({
     initializePayment,
@@ -35,6 +33,7 @@ const AmazonPayV2PaymentMethod: FunctionComponent<AmazonPayV2PaymentMethodProps>
         method={ method }
         onSignOut={ reload }
         paymentDescriptor={ paymentDescriptor }
+        shouldShow={ !!paymentToken }
         shouldShowDescriptor={ !!paymentToken }
         shouldShowEditButton={ !!paymentToken }
     />;

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -171,6 +171,16 @@ describe('HostedWidgetPaymentMethod', () => {
         expect(component.find('.payment-descriptor')).toHaveLength(0);
     });
 
+    it('does not render the component', () => {
+        const component = mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
+
+        expect(component.isEmptyRender()).toBe(false);
+
+        component.setProps({ shouldShow: false });
+
+        expect(component.isEmptyRender()).toBe(true);
+    });
+
     describe('when user is signed into their payment method account', () => {
         beforeEach(() => {
             jest.spyOn(checkoutState.data, 'getCheckout')

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -31,6 +31,7 @@ export interface HostedWidgetPaymentMethodProps {
     method: PaymentMethod;
     paymentDescriptor?: string;
     shouldHideInstrumentExpiryDate?: boolean;
+    shouldShow?: boolean;
     shouldShowDescriptor?: boolean;
     shouldShowEditButton?: boolean;
     validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
@@ -157,12 +158,17 @@ class HostedWidgetPaymentMethod extends Component<
             isLoadingInstruments,
             additionalContainerClassName,
             shouldHideInstrumentExpiryDate = false,
+            shouldShow = true,
         } = this.props;
 
         const {
             isAddingNewCard,
             selectedInstrumentId = this.getDefaultInstrumentId(),
         } = this.state;
+
+        if (!shouldShow) {
+            return null;
+        }
 
         const selectedInstrument = instruments.find(instrument => instrument.bigpayToken === selectedInstrumentId) || instruments[0];
 


### PR DESCRIPTION
## What? [INT-3053](https://jira.bigcommerce.com/browse/INT-3053)
This change allows `AmazonPayV2PaymentMethod` to hide `HostedWidgetPaymentMethod` entirely when Amazon Pay is selected and there's no content to show.

## Why?
Because `AmazonPayV2PaymentMethod` is rendering `HostedWidgetPaymentMethod` when is selected and the user doesn't have an amazon session yet, therefore, that is causing `form-checklist-body` to have empty content with extra height.

## Testing / Proof
CirlceCI
BEFORE / AFTER
<img width="350" alt="before" src="https://user-images.githubusercontent.com/4843328/90566490-2e708680-e16e-11ea-9d61-2e7a7e98282f.png"> <img width="350" alt="after" src="https://user-images.githubusercontent.com/4843328/90566493-2f091d00-e16e-11ea-9b96-96c5b99a43ed.png">

@bigcommerce/checkout