### PR TITLE
fix(payment): INT-2995 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,9 +1609,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.92.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.92.0.tgz",
-      "integrity": "sha512-dp2JpFfM8a9vdhkTbgnVRWIVMFYt1Jt2eHA+O5pRYQJFbpqmxAH7EjO/M/Q40bgkJzHql1zL7qkBqyN890qwgg==",
+      "version": "1.92.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.92.1.tgz",
+      "integrity": "sha512-ApEBlh0CKZhIvrZsTAVWpdgtP1ITkW8ocGb4CXZGuzFJ8mJ4wf59IPEEXOsd/zL69+kZropPY/GdHMLS8DUwEQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.92.0",
+    "@bigcommerce/checkout-sdk": "^1.92.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
As per title.

## Why?
Releasing https://github.com/bigcommerce/checkout-sdk-js/pull/955

## Testing / Proof
Circle.

@bigcommerce/checkout
