### PR TITLE
feat(payments): INT-3061 added mandate link on confirmation page

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -335,7 +335,8 @@
             "thank_you_customer_heading": "Thank you {name}!",
             "thank_you_heading": "Thank you!",
             "continue_shopping": "Continue Shopping »",
-            "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger"
+            "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger",
+            "mandate_link_text": "{provider} Mandate"
         }
     }
 }

--- a/src/app/order/OrderStatus.tsx
+++ b/src/app/order/OrderStatus.tsx
@@ -34,6 +34,13 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
             />
         </p>
 
+        { order.mandate && <a href={ order.mandate } rel="noopener noreferrer" target="_blank">
+                <TranslatedString
+                    data={ {provider : order?.payments?.[0].description === 'Stripe (SEPA)' ? 'SEPA Direct Debit ' : order?.payments?.[0].description } }
+                    id="order_confirmation.mandate_link_text"
+                />
+        </a> }
+
         { order.hasDigitalItems &&
         <p data-test="order-confirmation-digital-items-text">
             <TranslatedHtml


### PR DESCRIPTION
## What? [INT-3061]()
Added mandate link on confirmation page,

## Why?
In order to show sepa mandate link to the customer.

## Testing / Proof
<img width="803" alt="Screen Shot 2020-08-26 at 10 46 24 AM" src="https://user-images.githubusercontent.com/61981535/91325959-65a3f080-e789-11ea-9fb1-a935af6fdf76.png">

## Sibling PR's
[Checkout-sdk-js #966](https://github.com/bigcommerce/checkout-sdk-js/pull/966)
[Bigpay #2906](https://github.com/bigcommerce/bigpay/pull/2906)
[BigCommerce #36755](https://github.com/bigcommerce/bigcommerce/pull/36755)


