### PR TITLE
[WIP] feat(payments): PAYPAL-654 testing paypal button in the list 

### DIFF
--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -34,6 +34,7 @@ export interface HostedWidgetPaymentMethodProps {
     shouldShow?: boolean;
     shouldShowDescriptor?: boolean;
     shouldShowEditButton?: boolean;
+    disableSubmitButton?: boolean;
     validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
     deinitializeCustomer?(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
@@ -77,6 +78,7 @@ class HostedWidgetPaymentMethod extends Component<
         const {
             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
             loadInstruments,
+            disableSubmitButton,
             onUnhandledError = noop,
         } = this.props;
 
@@ -84,7 +86,9 @@ class HostedWidgetPaymentMethod extends Component<
             if (isInstrumentFeatureAvailableProp) {
                 await loadInstruments();
             }
-
+            if (disableSubmitButton) {
+                this.turnOffSubmit();
+            }
             await this.initializeMethod();
         } catch (error) {
             onUnhandledError(error);
@@ -266,6 +270,14 @@ class HostedWidgetPaymentMethod extends Component<
         return !isAddingNewCard && selectedInstrument && isBankAccountInstrument(selectedInstrument) ? selectedInstrument : undefined;
     }
 
+    private turnOffSubmit(): void {
+        const {
+            disableSubmit,
+            method,
+        } = this.props;
+        disableSubmit(method, true);
+    }
+
     private renderEditButtonIfAvailable() {
         const { shouldShowEditButton, buttonId } = this.props;
         const translatedString = <TranslatedString id="remote.select_different_card_action" />;
@@ -332,7 +344,6 @@ class HostedWidgetPaymentMethod extends Component<
                 methodId: method.id,
             });
         }
-
         setSubmit(method, null);
 
         return initializePayment({

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -22,6 +22,7 @@ import OfflinePaymentMethod from './OfflinePaymentMethod';
 import PaymentMethodId from './PaymentMethodId';
 import PaymentMethodProviderType from './PaymentMethodProviderType';
 import PaymentMethodType from './PaymentMethodType';
+import PaypalCommercePaymentMethod from './PaypalCommercePaymentMethod';
 import PaypalExpressPaymentMethod from './PaypalExpressPaymentMethod';
 import PaypalPaymentsProPaymentMethod from './PaypalPaymentsProPaymentMethod';
 import SquarePaymentMethod from './SquarePaymentMethod';
@@ -118,6 +119,10 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.id === PaymentMethodId.Braintree) {
         return <BraintreeCreditCardPaymentMethod { ...props } />;
+    }
+
+    if (method.id === PaymentMethodId.PaypalCommerce) {
+        return <PaypalCommercePaymentMethod { ...props } />;
     }
 
     if (method.id === PaymentMethodId.PaypalExpress) {

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -1,0 +1,27 @@
+import React, { useCallback, FunctionComponent } from 'react';
+import { Omit } from 'utility-types';
+
+import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+
+export type PaypalCommercePaymentMethod = Omit<HostedWidgetPaymentMethodProps, 'containerId' | 'disableSubmitButton'>;
+
+const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod> = ({
+                                                                              initializePayment,
+                                                                              ...rest
+                                                                          }) => {
+    const initializePayPalComemrcePayment = useCallback(options => initializePayment({
+        ...options,
+        paypalcommerce: {
+            container: '#paymentWidget',
+        },
+    }), [initializePayment]);
+
+    return <HostedWidgetPaymentMethod
+        { ...rest }
+        containerId="paymentWidget"
+        disableSubmitButton={ true }
+        initializePayment={ initializePayPalComemrcePayment }
+    />;
+};
+
+export default PaypalCommercePaymentMethod;


### PR DESCRIPTION
## What?

Testing PayPal option in the payment list 

## Why?

Use native PayPal solution (button)  for checkout

## Testing / Proof

![image](https://user-images.githubusercontent.com/51989411/91587324-452d8f00-e95f-11ea-8e60-b9fd0a5f047a.png)

TODO 

- use `isSignInRequired` instead of newly added param



@bigcommerce/checkout
