### PR TITLE
feat(checkout): INT-3112 Add Bolt Payment method

### DIFF
--- a/src/app/payment/paymentMethod/BoltPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/BoltPaymentMethod.spec.tsx
@@ -1,0 +1,90 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { getCart } from '../../cart/carts.mock';
+import { CheckoutProvider } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { getCustomer } from '../../customer/customers.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { getPaymentMethod } from '../payment-methods.mock';
+import PaymentContext, { PaymentContextProps } from '../PaymentContext';
+
+import BoltPaymentMethod from './BoltPaymentMethod';
+import HostedPaymentMethod, { HostedPaymentMethodProps } from './HostedPaymentMethod';
+import PaymentMethodId from './PaymentMethodId';
+
+describe('when using Bolt payment', () => {
+    let defaultProps: HostedPaymentMethodProps;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let localeContext: LocaleContextType;
+    let paymentContext: PaymentContextProps;
+    let PaymentMethodTest: FunctionComponent;
+
+    beforeEach(() => {
+        defaultProps = {
+            initializePayment: jest.fn(),
+            deinitializePayment: jest.fn(),
+            method: {
+                ...getPaymentMethod(),
+                id: PaymentMethodId.Bolt,
+            },
+        };
+
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+
+        paymentContext = {
+            disableSubmit: jest.fn(),
+            setSubmit: jest.fn(),
+            setValidationSchema: jest.fn(),
+        };
+
+        jest.spyOn(checkoutState.data, 'getCart')
+            .mockReturnValue(getCart());
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getCustomer')
+            .mockReturnValue(getCustomer());
+
+        PaymentMethodTest = props => (
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <PaymentContext.Provider value={ paymentContext }>
+                    <LocaleContext.Provider value={ localeContext }>
+                        <Formik
+                            initialValues={ {} }
+                            onSubmit={ noop }
+                        >
+                            <BoltPaymentMethod { ...defaultProps } { ...props } />
+                        </Formik>
+                    </LocaleContext.Provider>
+                </PaymentContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('renders as hosted payment method', () => {
+        const container = mount(<PaymentMethodTest />);
+
+        expect(container.find(HostedPaymentMethod).length)
+            .toEqual(1);
+    });
+
+    it('initializes method with required config', () => {
+        mount(<PaymentMethodTest />);
+
+        expect(defaultProps.initializePayment)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                methodId: defaultProps.method.id,
+                [defaultProps.method.id]: {
+                    useBigCommerceCheckout: true,
+                },
+            }));
+    });
+});

--- a/src/app/payment/paymentMethod/BoltPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/BoltPaymentMethod.tsx
@@ -1,0 +1,22 @@
+import React, { useCallback, FunctionComponent } from 'react';
+
+import HostedPaymentMethod, { HostedPaymentMethodProps } from './HostedPaymentMethod';
+
+const BoltPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = ({
+    initializePayment,
+    ...rest
+}) => {
+    const initializeBoltPayment = useCallback(options => initializePayment({
+        ...options,
+        bolt: {
+            useBigCommerceCheckout: true,
+        },
+    }), [initializePayment]);
+
+    return <HostedPaymentMethod
+        { ...rest }
+        initializePayment={ initializeBoltPayment }
+    />;
+};
+
+export default BoltPaymentMethod;

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -9,6 +9,7 @@ import AmazonPaymentMethod from './AmazonPaymentMethod';
 import AmazonPayV2PaymentMethod from './AmazonPayV2PaymentMethod';
 import BarclaycardPaymentMethod from './BarclaycardPaymentMethod';
 import BlueSnapV2PaymentMethod from './BlueSnapV2PaymentMethod';
+import BoltPaymentMethod from './BoltPaymentMethod';
 import BraintreeCreditCardPaymentMethod from './BraintreeCreditCardPaymentMethod';
 import ChasePayPaymentMethod from './ChasePayPaymentMethod';
 import CCAvenueMarsPaymentMethod from './CCAvenueMarsPaymentMethod';
@@ -133,8 +134,11 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
         return <BarclaycardPaymentMethod { ...props } />;
     }
 
+    if (method.id === PaymentMethodId.Bolt) {
+        return <BoltPaymentMethod { ...props } />;
+    }
+
     if (method.gateway === PaymentMethodId.Afterpay ||
-        method.id === PaymentMethodId.Bolt ||
         method.id === PaymentMethodId.Laybuy ||
         method.id === PaymentMethodId.Sezzle ||
         method.id === PaymentMethodId.Zip ||


### PR DESCRIPTION
## What? [INT-3112](https://jira.bigcommerce.com/browse/INT-3112)
Create bolt payment method and pass the `useClientScript` initialization options

## Why?
To allow checkout-js to use the client script flow implemented in https://github.com/bigcommerce/checkout-sdk-js/pull/975

### Sibling PR
https://github.com/bigcommerce/checkout-sdk-js/pull/975

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/apex-integrations 
