### PR TITLE
CHECKOUT-5038 Extend shipping debounce timer

### DIFF
--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -51,7 +51,7 @@ interface SingleShippingFormState {
     hasRequestedShippingOptions: boolean;
 }
 
-export const SHIPPING_AUTOSAVE_DELAY = 1000;
+export const SHIPPING_AUTOSAVE_DELAY = 1700;
 
 class SingleShippingForm extends PureComponent<SingleShippingFormProps & WithLanguageProps & FormikProps<SingleShippingFormValues>> {
     static contextType = FormContext;


### PR DESCRIPTION
## What?
Extend shipping debounce timer

## Why?
To reduce tax API calls

## Testing / Proof
CI

@bigcommerce/checkout
