### PR TITLE
[WIP] [TESTING] hosted submit button instead regular submit button feat(payments): PAYPAL-654 test submit trigger action

### DIFF
--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -75,6 +75,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     onStoreCreditChange,
     onUnhandledError,
     resetForm,
+    submitForm,
     selectedMethod,
     shouldDisableSubmit,
     shouldExecuteSpamCheck,
@@ -130,6 +131,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
                 onMethodSelect={ onMethodSelect }
                 onUnhandledError={ onUnhandledError }
                 resetForm={ resetForm }
+                submitForm={ submitForm }
                 values={ values }
             />
 
@@ -159,6 +161,7 @@ interface PaymentMethodListFieldsetProps {
     methods: PaymentMethod[];
     values: PaymentFormValues;
     isPaymentDataRequired(): boolean;
+    submitForm(): void;
     onMethodSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
     resetForm(nextValues?: PaymentFormValues): void;
@@ -172,6 +175,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     methods,
     onMethodSelect = noop,
     onUnhandledError,
+    submitForm,
     resetForm,
     values,
 }) => {
@@ -221,6 +225,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
                 methods={ methods }
                 onSelect={ handlePaymentMethodSelect }
                 onUnhandledError={ onUnhandledError }
+                submitForm={ submitForm }
             />
         </Fieldset>
     );

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -62,32 +62,41 @@ export interface PaymentSubmitButtonProps {
 interface WithCheckoutPaymentSubmitButtonProps {
     isInitializing?: boolean;
     isSubmitting?: boolean;
+    isEmbeddedSubmitButton?: boolean;
 }
 
 const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithCheckoutPaymentSubmitButtonProps> = ({
     isDisabled,
     isInitializing,
+    isEmbeddedSubmitButton,
     isSubmitting,
     methodGateway,
     methodId,
     methodType,
-}) => (
-    <Button
-        disabled={ isInitializing || isSubmitting || isDisabled }
-        id="checkout-payment-continue"
-        isFullWidth
-        isLoading={ isSubmitting }
-        size={ ButtonSize.Large }
-        type="submit"
-        variant={ ButtonVariant.Action }
-    >
-        <PaymentSubmitButtonText
-            methodGateway={ methodGateway }
-            methodId={ methodId }
-            methodType={ methodType }
-        />
-    </Button>
-);
+}) => {
+
+    if (isEmbeddedSubmitButton) {
+        return <div id="embeddedSubmitButtonContainer" />;
+    }
+
+    return (
+        <Button
+            disabled={ isInitializing || isSubmitting || isDisabled }
+            id="checkout-payment-continue"
+            isFullWidth
+            isLoading={ isSubmitting }
+            size={ ButtonSize.Large }
+            type="submit"
+            variant={ ButtonVariant.Action }
+        >
+            <PaymentSubmitButtonText
+                methodGateway={ methodGateway }
+                methodId={ methodId }
+                methodType={ methodType }
+            />
+        </Button>
+    );
+};
 
 export default withCheckout(({ checkoutState }) => {
     const {
@@ -95,11 +104,13 @@ export default withCheckout(({ checkoutState }) => {
             isInitializingCustomer,
             isInitializingPayment,
             isSubmittingOrder,
+            isEmbeddedSubmitButton,
         },
     } = checkoutState;
 
     return {
         isInitializing: isInitializingCustomer() || isInitializingPayment(),
         isSubmitting: isSubmittingOrder(),
+        isEmbeddedSubmitButton: isEmbeddedSubmitButton(),
     };
 })(memo(PaymentSubmitButton));

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -34,6 +34,7 @@ export interface HostedWidgetPaymentMethodProps {
     shouldShow?: boolean;
     shouldShowDescriptor?: boolean;
     shouldShowEditButton?: boolean;
+    submitForm?(): void | undefined;
     validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
     deinitializeCustomer?(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
@@ -84,7 +85,6 @@ class HostedWidgetPaymentMethod extends Component<
             if (isInstrumentFeatureAvailableProp) {
                 await loadInstruments();
             }
-
             await this.initializeMethod();
         } catch (error) {
             onUnhandledError(error);
@@ -332,7 +332,6 @@ class HostedWidgetPaymentMethod extends Component<
                 methodId: method.id,
             });
         }
-
         setSubmit(method, null);
 
         return initializePayment({

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -22,6 +22,7 @@ import OfflinePaymentMethod from './OfflinePaymentMethod';
 import PaymentMethodId from './PaymentMethodId';
 import PaymentMethodProviderType from './PaymentMethodProviderType';
 import PaymentMethodType from './PaymentMethodType';
+import PaypalCommercePaymentMethod from './PaypalCommercePaymentMethod';
 import PaypalExpressPaymentMethod from './PaypalExpressPaymentMethod';
 import PaypalPaymentsProPaymentMethod from './PaypalPaymentsProPaymentMethod';
 import SquarePaymentMethod from './SquarePaymentMethod';
@@ -33,6 +34,7 @@ export interface PaymentMethodProps {
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     onUnhandledError?(error: Error): void;
+    submitForm?(): void;
 }
 
 export interface WithCheckoutPaymentMethodProps {
@@ -118,6 +120,10 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.id === PaymentMethodId.Braintree) {
         return <BraintreeCreditCardPaymentMethod { ...props } />;
+    }
+
+    if (method.id === PaymentMethodId.PaypalCommerce) {
+        return <PaypalCommercePaymentMethod { ...props } />;
     }
 
     if (method.id === PaymentMethodId.PaypalExpress) {

--- a/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -14,6 +14,7 @@ export interface PaymentMethodListProps {
     isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
+    submitForm?(): void;
     onSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
 }
@@ -40,6 +41,7 @@ const PaymentMethodList: FunctionComponent<
     methods,
     onSelect = noop,
     onUnhandledError,
+    submitForm,
 }) => {
     const handleSelect = useCallback((value: string) => {
         onSelect(getPaymentMethodFromListValue(methods, value));
@@ -65,6 +67,7 @@ const PaymentMethodList: FunctionComponent<
                     key={ value }
                     method={ method }
                     onUnhandledError={ onUnhandledError }
+                    submitForm={ submitForm }
                     value={ value }
                 />
             );
@@ -78,6 +81,7 @@ interface PaymentMethodListItemProps {
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
     value: string;
+    submitForm?(): void;
     onUnhandledError?(error: Error): void;
 }
 
@@ -87,6 +91,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     isUsingMultiShipping,
     method,
     onUnhandledError,
+    submitForm,
     value,
 }) => {
     const renderPaymentMethod = useMemo(() => (
@@ -95,10 +100,12 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
             isUsingMultiShipping={ isUsingMultiShipping }
             method={ method }
             onUnhandledError={ onUnhandledError }
+            submitForm={ submitForm }
         />
     ), [
         isEmbedded,
         isUsingMultiShipping,
+        submitForm,
         method,
         onUnhandledError,
     ]);

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback, FunctionComponent } from 'react';
+import { Omit } from 'utility-types';
+
+import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+
+export type PaypalCommercePaymentMethod = Omit<HostedWidgetPaymentMethodProps, 'containerId'>;
+
+const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod> = ({
+      initializePayment,
+      submitForm,
+      ...rest
+  }) => {
+    const initializePayPalComemrcePayment = useCallback(options => initializePayment({
+        ...options,
+        paypalcommerce: {
+            container: '#paymentButtonWidget', // TODO add container for hosted submit button
+            submitForm,
+        },
+    }), [initializePayment, submitForm]);
+
+    return <HostedWidgetPaymentMethod
+        { ...rest }
+        containerId="paymentWidget"
+        initializePayment={ initializePayPalComemrcePayment }
+    />;
+};
+
+export default PaypalCommercePaymentMethod;

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -13,7 +13,7 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
     const initializePayPalComemrcePayment = useCallback(options => initializePayment({
         ...options,
         paypalcommerce: {
-            container: '#paymentButtonWidget', // TODO add container for hosted submit button
+            container: '#embeddedSubmitButtonContainer', // TODO add container for hosted submit button
             submitForm,
         },
     }), [initializePayment, submitForm]);


### PR DESCRIPTION
## What?
replace the regular payment submit button with the hosted button. pass form submit method to payment option so hosted button callbacks could trigger payment form submit

## Why?

![image](https://user-images.githubusercontent.com/51989411/92329999-51f36680-f074-11ea-97f4-acf02e924fdd.png)


## Testing / Proof
...

@bigcommerce/checkout
