### PR TITLE
fix(payment): INT-3027 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,9 +1609,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.97.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.97.0.tgz",
-      "integrity": "sha512-Jejk75eBjsNFu1shzLYjrDAV7/8Ik29P2hFhuq+MtciM43NS8IyiKloQ/2S66CqQFEVg6RzG0Tjm7tLu2CAGJA==",
+      "version": "1.97.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.97.1.tgz",
+      "integrity": "sha512-72eXU3XoCmdBtBnOVEWlz+MLPQF5uD7/94o50juGtnKS+O8g7SlZO6av5YakCfqiRKkck+EwKo7n6kifLcaeLw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.12.0",
@@ -1685,9 +1685,9 @@
           }
         },
         "rxjs": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-          "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
           "requires": {
             "tslib": "^1.9.0"
           }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.97.0",
+    "@bigcommerce/checkout-sdk": "^1.97.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk

## Why?
To revert https://github.com/bigcommerce/checkout-sdk-js/pull/978 while we get the dependencies reviewed

## Testing / Proof
CircleCI

@bigcommerce/checkout