### PR TITLE
[WIP] feat(payments): PAYPAL-654 Embedded Submit button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,9 +1609,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.99.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.99.3.tgz",
-      "integrity": "sha512-LvzYdJmk9uPdvtdrQy1CGXqsqBc7ue9JPQggntGw6doVgJU1/L2spIkRtMLsYCidcXiG4X6bfKrxq204whUIFg==",
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.100.0.tgz",
+      "integrity": "sha512-mx9XQ/x5hEw9ipS/bVoxKtvCMLyBd3KTZeF8BUuwO5Cfy6y0qqVSzsNuRT/PNfem7q540GCdzxs/ro3D7+YH6w==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.99.3",
+    "@bigcommerce/checkout-sdk": "^1.100.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -59,6 +59,7 @@ interface PaymentState {
     isReady: boolean;
     selectedMethod?: PaymentMethod;
     shouldDisableSubmit: { [key: string]: boolean };
+    shouldHidePaymentSubmitButton: { [key: string]: boolean };
     submitFunctions: { [key: string]: ((values: PaymentFormValues) => void) | null };
     validationSchemas: { [key: string]: ObjectSchema<Partial<PaymentFormValues>> | null };
 }
@@ -68,6 +69,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         didExceedSpamLimit: false,
         isReady: false,
         shouldDisableSubmit: {},
+        shouldHidePaymentSubmitButton: {},
         validationSchemas: {},
         submitFunctions: {},
     };
@@ -77,6 +79,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             disableSubmit: this.disableSubmit,
             setSubmit: this.setSubmit,
             setValidationSchema: this.setValidationSchema,
+            hidePaymentSubmitButton: this.hidePaymentSubmitButton,
         };
     });
 
@@ -140,6 +143,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod = defaultMethod,
             shouldDisableSubmit,
             validationSchemas,
+            shouldHidePaymentSubmitButton,
         } = this.state;
 
         const uniqueSelectedMethodId = (
@@ -166,6 +170,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
                         onSubmit={ this.handleSubmit }
                         selectedMethod={ selectedMethod }
                         shouldDisableSubmit={ uniqueSelectedMethodId && shouldDisableSubmit[uniqueSelectedMethodId] || undefined }
+                        shouldHidePaymentSubmitButton={ uniqueSelectedMethodId && shouldHidePaymentSubmitButton[uniqueSelectedMethodId] || undefined }
                         validationSchema={ uniqueSelectedMethodId && validationSchemas[uniqueSelectedMethodId] || undefined }
                     /> }
                 </LoadingOverlay>
@@ -239,6 +244,25 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         this.setState({
             shouldDisableSubmit: {
                 ...shouldDisableSubmit,
+                [uniqueId]: disabled,
+            },
+        });
+    };
+
+    private hidePaymentSubmitButton: (
+        method: PaymentMethod,
+        disabled?: boolean
+    ) => void = (method, disabled = true) => {
+        const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
+        const { shouldHidePaymentSubmitButton } = this.state;
+
+        if (shouldHidePaymentSubmitButton[uniqueId] === disabled) {
+            return;
+        }
+
+        this.setState({
+            shouldHidePaymentSubmitButton: {
+                ...shouldHidePaymentSubmitButton,
                 [uniqueId]: disabled,
             },
         });

--- a/src/app/payment/PaymentContext.tsx
+++ b/src/app/payment/PaymentContext.tsx
@@ -15,7 +15,7 @@ export interface PaymentContextProps {
     // can remove this prop.
     setSubmit(method: PaymentMethod, fn: ((values: PaymentFormValues) => void) | null): void;
     setValidationSchema(method: PaymentMethod, schema: ObjectSchema<Partial<PaymentFormValues>> | null): void;
-    hidePaymentSubmitButton(method: PaymentMethod, hided?: boolean): void;
+    hidePaymentSubmitButton(method: PaymentMethod, hidden?: boolean): void;
 }
 
 const PaymentContext = createContext<PaymentContextProps | undefined>(undefined);

--- a/src/app/payment/PaymentContext.tsx
+++ b/src/app/payment/PaymentContext.tsx
@@ -15,6 +15,7 @@ export interface PaymentContextProps {
     // can remove this prop.
     setSubmit(method: PaymentMethod, fn: ((values: PaymentFormValues) => void) | null): void;
     setValidationSchema(method: PaymentMethod, schema: ObjectSchema<Partial<PaymentFormValues>> | null): void;
+    hidePaymentSubmitButton(method: PaymentMethod, hided?: boolean): void;
 }
 
 const PaymentContext = createContext<PaymentContextProps | undefined>(undefined);

--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -48,6 +48,7 @@ describe('PaymentForm', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutService, 'initializePayment')

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -1,7 +1,7 @@
 import { PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { withFormik, FormikProps, WithFormikConfig } from 'formik';
 import { isNil, noop, omitBy } from 'lodash';
-import React, { memo, useCallback, useContext, useMemo, FunctionComponent } from 'react';
+import React, { memo, useCallback, useContext, useMemo, useState, FunctionComponent } from 'react';
 import { ObjectSchema } from 'yup';
 
 import { withLanguage, TranslatedString, WithLanguageProps } from '../locale';
@@ -84,10 +84,16 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     usableStoreCredit = 0,
     values,
 }) => {
+    const [isShowingPaymentButton, setShowingPaymentButton] = useState(true);
+
+    const hidePaymentButton = () => setShowingPaymentButton(false);
+
     const selectedMethodId = useMemo(() => {
         if (!selectedMethod) {
             return;
         }
+
+        setShowingPaymentButton(true);
 
         switch (selectedMethod.id) {
         case PaymentMethodId.AmazonPay:
@@ -131,6 +137,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
                 onMethodSelect={ onMethodSelect }
                 onUnhandledError={ onUnhandledError }
                 resetForm={ resetForm }
+                hidePaymentButton={ hidePaymentButton }
                 submitForm={ submitForm }
                 values={ values }
             />
@@ -145,6 +152,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
             <div className="form-actions">
                 <PaymentSubmitButton
                     isDisabled={ shouldDisableSubmit }
+                    isShown={ isShowingPaymentButton }
                     methodGateway={ selectedMethod && selectedMethod.gateway }
                     methodId={ selectedMethodId }
                     methodType={ selectedMethod && selectedMethod.method }
@@ -162,6 +170,7 @@ interface PaymentMethodListFieldsetProps {
     values: PaymentFormValues;
     isPaymentDataRequired(): boolean;
     submitForm(): void;
+    hidePaymentButton(): void;
     onMethodSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
     resetForm(nextValues?: PaymentFormValues): void;
@@ -175,6 +184,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     methods,
     onMethodSelect = noop,
     onUnhandledError,
+    hidePaymentButton,
     submitForm,
     resetForm,
     values,
@@ -225,6 +235,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
                 methods={ methods }
                 onSelect={ handlePaymentMethodSelect }
                 onUnhandledError={ onUnhandledError }
+                hidePaymentButton={ hidePaymentButton }
                 submitForm={ submitForm }
             />
         </Fieldset>

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -75,6 +75,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     onStoreCreditChange,
     onUnhandledError,
     resetForm,
+    submitForm,
     selectedMethod,
     shouldDisableSubmit,
     shouldExecuteSpamCheck,
@@ -130,6 +131,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
                 onMethodSelect={ onMethodSelect }
                 onUnhandledError={ onUnhandledError }
                 resetForm={ resetForm }
+                submitForm={ submitForm }
                 values={ values }
             />
 
@@ -159,6 +161,7 @@ interface PaymentMethodListFieldsetProps {
     methods: PaymentMethod[];
     values: PaymentFormValues;
     isPaymentDataRequired(): boolean;
+    submitForm(): void;
     onMethodSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
     resetForm(nextValues?: PaymentFormValues): void;
@@ -172,6 +175,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     methods,
     onMethodSelect = noop,
     onUnhandledError,
+    submitForm,
     resetForm,
     values,
 }) => {
@@ -221,6 +225,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
                 methods={ methods }
                 onSelect={ handlePaymentMethodSelect }
                 onUnhandledError={ onUnhandledError }
+                submitForm={ submitForm }
             />
         </Fieldset>
     );

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -157,7 +157,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
 };
 
 const PaymentMethodSubmitButtonContainer: FunctionComponent = () => {
-    return <div id="checkout-payment-continue" />;
+    return <div className="submitButtonContainer" id="checkout-payment-continue" />;
 };
 
 interface PaymentMethodListFieldsetProps {

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -62,7 +62,6 @@ export interface PaymentSubmitButtonProps {
 interface WithCheckoutPaymentSubmitButtonProps {
     isInitializing?: boolean;
     isSubmitting?: boolean;
-    isShowEmbeddedSubmitButton?: boolean;
 }
 
 const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithCheckoutPaymentSubmitButtonProps> = ({
@@ -72,8 +71,7 @@ const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithChec
     methodGateway,
     methodId,
     methodType,
-}) => {
-    return (
+}) => (
         <Button
             disabled={ isInitializing || isSubmitting || isDisabled }
             id="checkout-payment-continue"
@@ -90,7 +88,6 @@ const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithChec
             />
         </Button>
     );
-};
 
 export default withCheckout(({ checkoutState }) => {
     const {

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -57,7 +57,6 @@ export interface PaymentSubmitButtonProps {
     methodId?: string;
     methodType?: string;
     isDisabled?: boolean;
-    isShown?: boolean;
 }
 
 interface WithCheckoutPaymentSubmitButtonProps {
@@ -69,16 +68,11 @@ interface WithCheckoutPaymentSubmitButtonProps {
 const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithCheckoutPaymentSubmitButtonProps> = ({
     isDisabled,
     isInitializing,
-    isShown,
     isSubmitting,
     methodGateway,
     methodId,
     methodType,
 }) => {
-    if (!isShown) {
-        return  <div id="paymentButtonWidget" />;
-    }
-
     return (
         <Button
             disabled={ isInitializing || isSubmitting || isDisabled }

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -62,32 +62,40 @@ export interface PaymentSubmitButtonProps {
 interface WithCheckoutPaymentSubmitButtonProps {
     isInitializing?: boolean;
     isSubmitting?: boolean;
+    isShowEmbeddedSubmitButton?: boolean;
 }
 
 const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithCheckoutPaymentSubmitButtonProps> = ({
     isDisabled,
     isInitializing,
     isSubmitting,
+    isShowEmbeddedSubmitButton,
     methodGateway,
     methodId,
     methodType,
-}) => (
-    <Button
-        disabled={ isInitializing || isSubmitting || isDisabled }
-        id="checkout-payment-continue"
-        isFullWidth
-        isLoading={ isSubmitting }
-        size={ ButtonSize.Large }
-        type="submit"
-        variant={ ButtonVariant.Action }
-    >
-        <PaymentSubmitButtonText
-            methodGateway={ methodGateway }
-            methodId={ methodId }
-            methodType={ methodType }
-        />
-    </Button>
-);
+}) => {
+    if (isShowEmbeddedSubmitButton) {
+        return  <div id="paymentButtonWidget" />;
+    }
+
+    return (
+        <Button
+            disabled={ isInitializing || isSubmitting || isDisabled }
+            id="checkout-payment-continue"
+            isFullWidth
+            isLoading={ isSubmitting }
+            size={ ButtonSize.Large }
+            type="submit"
+            variant={ ButtonVariant.Action }
+        >
+            <PaymentSubmitButtonText
+                methodGateway={ methodGateway }
+                methodId={ methodId }
+                methodType={ methodType }
+            />
+        </Button>
+    );
+};
 
 export default withCheckout(({ checkoutState }) => {
     const {
@@ -96,10 +104,14 @@ export default withCheckout(({ checkoutState }) => {
             isInitializingPayment,
             isSubmittingOrder,
         },
+        data: {
+            isShowEmbeddedSubmitButton,
+        },
     } = checkoutState;
 
     return {
         isInitializing: isInitializingCustomer() || isInitializingPayment(),
         isSubmitting: isSubmittingOrder(),
+        isShowEmbeddedSubmitButton: isShowEmbeddedSubmitButton(),
     };
 })(memo(PaymentSubmitButton));

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -57,6 +57,7 @@ export interface PaymentSubmitButtonProps {
     methodId?: string;
     methodType?: string;
     isDisabled?: boolean;
+    isShown?: boolean;
 }
 
 interface WithCheckoutPaymentSubmitButtonProps {
@@ -68,13 +69,13 @@ interface WithCheckoutPaymentSubmitButtonProps {
 const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithCheckoutPaymentSubmitButtonProps> = ({
     isDisabled,
     isInitializing,
+    isShown,
     isSubmitting,
-    isShowEmbeddedSubmitButton,
     methodGateway,
     methodId,
     methodType,
 }) => {
-    if (isShowEmbeddedSubmitButton) {
+    if (!isShown) {
         return  <div id="paymentButtonWidget" />;
     }
 
@@ -104,14 +105,10 @@ export default withCheckout(({ checkoutState }) => {
             isInitializingPayment,
             isSubmittingOrder,
         },
-        data: {
-            isShowEmbeddedSubmitButton,
-        },
     } = checkoutState;
 
     return {
         isInitializing: isInitializingCustomer() || isInitializingPayment(),
         isSubmitting: isSubmittingOrder(),
-        isShowEmbeddedSubmitButton: isShowEmbeddedSubmitButton(),
     };
 })(memo(PaymentSubmitButton));

--- a/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.spec.tsx
+++ b/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.spec.tsx
@@ -73,6 +73,7 @@ describe('withHostedCreditCardFieldset', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         formContext = {

--- a/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.spec.tsx
@@ -45,6 +45,7 @@ describe('when using BlueSnapV2 payment', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutState.data, 'getCart')

--- a/src/app/payment/paymentMethod/BoltPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/BoltPaymentMethod.spec.tsx
@@ -42,6 +42,7 @@ describe('when using Bolt payment', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutState.data, 'getCart')

--- a/src/app/payment/paymentMethod/BraintreeCreditCardPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/BraintreeCreditCardPaymentMethod.spec.tsx
@@ -90,6 +90,7 @@ describe('when using Braintree payment', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutState.data, 'getCart')

--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.spec.tsx
@@ -63,6 +63,7 @@ describe('CreditCardPaymentMethod', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
         formContext = {
             isSubmitted: false,

--- a/src/app/payment/paymentMethod/HostedPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedPaymentMethod.spec.tsx
@@ -43,6 +43,7 @@ describe('HostedPaymentMethod', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutState.data, 'getCart')

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -41,6 +41,7 @@ describe('HostedWidgetPaymentMethod', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutState.data, 'getCheckout')

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -34,6 +34,7 @@ export interface HostedWidgetPaymentMethodProps {
     shouldShow?: boolean;
     shouldShowDescriptor?: boolean;
     shouldShowEditButton?: boolean;
+    hidePaymentButton?(): void;
     submitForm?(): void | undefined;
     validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
     deinitializeCustomer?(options: CustomerRequestOptions): Promise<CheckoutSelectors>;

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -34,8 +34,6 @@ export interface HostedWidgetPaymentMethodProps {
     shouldShow?: boolean;
     shouldShowDescriptor?: boolean;
     shouldShowEditButton?: boolean;
-    hidePaymentButton?(): void;
-    submitForm?(): void | undefined;
     validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
     deinitializeCustomer?(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
@@ -308,6 +306,7 @@ class HostedWidgetPaymentMethod extends Component<
             initializePayment = noop,
             method,
             setSubmit,
+            hidePaymentSubmitButton,
             signInCustomer = noop,
         } = this.props;
 
@@ -327,6 +326,7 @@ class HostedWidgetPaymentMethod extends Component<
             });
         }
         setSubmit(method, null);
+        hidePaymentSubmitButton(method, false);
 
         return initializePayment({
             gatewayId: method.gateway,

--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -34,6 +34,7 @@ export interface HostedWidgetPaymentMethodProps {
     shouldShow?: boolean;
     shouldShowDescriptor?: boolean;
     shouldShowEditButton?: boolean;
+    submitForm?(): void | undefined;
     validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
     deinitializeCustomer?(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
@@ -84,7 +85,6 @@ class HostedWidgetPaymentMethod extends Component<
             if (isInstrumentFeatureAvailableProp) {
                 await loadInstruments();
             }
-
             await this.initializeMethod();
         } catch (error) {
             onUnhandledError(error);
@@ -325,7 +325,6 @@ class HostedWidgetPaymentMethod extends Component<
                 methodId: method.id,
             });
         }
-
         setSubmit(method, null);
 
         return initializePayment({

--- a/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
@@ -40,6 +40,7 @@ describe('PaymentMethod', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutState.data, 'getCart')

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -36,7 +36,6 @@ export interface PaymentMethodProps {
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     onUnhandledError?(error: Error): void;
-    hidePaymentButton?(): void;
     submitForm?(): void;
 }
 

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -24,6 +24,7 @@ import PaymentMethodId from './PaymentMethodId';
 import PaymentMethodProviderType from './PaymentMethodProviderType';
 import PaymentMethodType from './PaymentMethodType';
 import PaypalCommerceCreditCardPaymentMethod from './PaypalCommerceCreditCardPaymentMethod';
+import PaypalCommercePaymentMethod from './PaypalCommercePaymentMethod';
 import PaypalExpressPaymentMethod from './PaypalExpressPaymentMethod';
 import PaypalPaymentsProPaymentMethod from './PaypalPaymentsProPaymentMethod';
 import SquarePaymentMethod from './SquarePaymentMethod';
@@ -35,6 +36,7 @@ export interface PaymentMethodProps {
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     onUnhandledError?(error: Error): void;
+    submitForm?(): void;
 }
 
 export interface WithCheckoutPaymentMethodProps {
@@ -124,6 +126,11 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.id === PaymentMethodId.PaypalCommerceCreditCards) {
         return <PaypalCommerceCreditCardPaymentMethod { ...props } />;
+    }
+
+    if (method.id === PaymentMethodId.PaypalCommerce ||
+        method.id === PaymentMethodId.PaypalCommerceCredit) {
+        return <PaypalCommercePaymentMethod { ...props } />;
     }
 
     if (method.id === PaymentMethodId.PaypalExpress) {

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -36,6 +36,7 @@ export interface PaymentMethodProps {
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     onUnhandledError?(error: Error): void;
+    hidePaymentButton?(): void;
     submitForm?(): void;
 }
 

--- a/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -14,6 +14,7 @@ export interface PaymentMethodListProps {
     isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
+    submitForm?(): void;
     onSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
 }
@@ -40,6 +41,7 @@ const PaymentMethodList: FunctionComponent<
     methods,
     onSelect = noop,
     onUnhandledError,
+    submitForm,
 }) => {
     const handleSelect = useCallback((value: string) => {
         onSelect(getPaymentMethodFromListValue(methods, value));
@@ -65,6 +67,7 @@ const PaymentMethodList: FunctionComponent<
                     key={ value }
                     method={ method }
                     onUnhandledError={ onUnhandledError }
+                    submitForm={ submitForm }
                     value={ value }
                 />
             );
@@ -78,6 +81,7 @@ interface PaymentMethodListItemProps {
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
     value: string;
+    submitForm?(): void;
     onUnhandledError?(error: Error): void;
 }
 
@@ -87,6 +91,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     isUsingMultiShipping,
     method,
     onUnhandledError,
+    submitForm,
     value,
 }) => {
     const renderPaymentMethod = useMemo(() => (
@@ -95,10 +100,12 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
             isUsingMultiShipping={ isUsingMultiShipping }
             method={ method }
             onUnhandledError={ onUnhandledError }
+            submitForm={ submitForm }
         />
     ), [
         isEmbedded,
         isUsingMultiShipping,
+        submitForm,
         method,
         onUnhandledError,
     ]);

--- a/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -14,6 +14,7 @@ export interface PaymentMethodListProps {
     isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
+    hidePaymentButton(): void;
     submitForm?(): void;
     onSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
@@ -41,6 +42,7 @@ const PaymentMethodList: FunctionComponent<
     methods,
     onSelect = noop,
     onUnhandledError,
+    hidePaymentButton,
     submitForm,
 }) => {
     const handleSelect = useCallback((value: string) => {
@@ -67,6 +69,7 @@ const PaymentMethodList: FunctionComponent<
                     key={ value }
                     method={ method }
                     onUnhandledError={ onUnhandledError }
+                    hidePaymentButton={ hidePaymentButton }
                     submitForm={ submitForm }
                     value={ value }
                 />
@@ -81,6 +84,7 @@ interface PaymentMethodListItemProps {
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
     value: string;
+    hidePaymentButton?(): void;
     submitForm?(): void;
     onUnhandledError?(error: Error): void;
 }
@@ -91,6 +95,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     isUsingMultiShipping,
     method,
     onUnhandledError,
+    hidePaymentButton,
     submitForm,
     value,
 }) => {
@@ -100,6 +105,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
             isUsingMultiShipping={ isUsingMultiShipping }
             method={ method }
             onUnhandledError={ onUnhandledError }
+            hidePaymentButton={ hidePaymentButton }
             submitForm={ submitForm }
         />
     ), [
@@ -108,6 +114,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
         submitForm,
         method,
         onUnhandledError,
+        hidePaymentButton,
     ]);
 
     const renderPaymentMethodTitle = useCallback((isSelected: boolean) => (

--- a/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -14,8 +14,6 @@ export interface PaymentMethodListProps {
     isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
-    hidePaymentButton(): void;
-    submitForm?(): void;
     onSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
 }
@@ -42,8 +40,6 @@ const PaymentMethodList: FunctionComponent<
     methods,
     onSelect = noop,
     onUnhandledError,
-    hidePaymentButton,
-    submitForm,
 }) => {
     const handleSelect = useCallback((value: string) => {
         onSelect(getPaymentMethodFromListValue(methods, value));
@@ -69,8 +65,6 @@ const PaymentMethodList: FunctionComponent<
                     key={ value }
                     method={ method }
                     onUnhandledError={ onUnhandledError }
-                    hidePaymentButton={ hidePaymentButton }
-                    submitForm={ submitForm }
                     value={ value }
                 />
             );
@@ -84,8 +78,6 @@ interface PaymentMethodListItemProps {
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
     value: string;
-    hidePaymentButton?(): void;
-    submitForm?(): void;
     onUnhandledError?(error: Error): void;
 }
 
@@ -95,8 +87,6 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     isUsingMultiShipping,
     method,
     onUnhandledError,
-    hidePaymentButton,
-    submitForm,
     value,
 }) => {
     const renderPaymentMethod = useMemo(() => (
@@ -105,16 +95,12 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
             isUsingMultiShipping={ isUsingMultiShipping }
             method={ method }
             onUnhandledError={ onUnhandledError }
-            hidePaymentButton={ hidePaymentButton }
-            submitForm={ submitForm }
         />
     ), [
         isEmbedded,
         isUsingMultiShipping,
-        submitForm,
         method,
         onUnhandledError,
-        hidePaymentButton,
     ]);
 
     const renderPaymentMethodTitle = useCallback((isSelected: boolean) => (

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -1,15 +1,22 @@
-import React, { useCallback, FunctionComponent } from 'react';
+import React, { useCallback, useContext, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
+import PaymentContext from '../PaymentContext';
+
 import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+// import {WithPaymentProps} from "../withPayment";
 
 export type PaypalCommercePaymentMethod = Omit<HostedWidgetPaymentMethodProps, 'containerId'>;
 
 const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod> = ({
       initializePayment,
+      onUnhandledError,
+      hidePaymentButton,
       submitForm,
+      // disableSubmit,
       ...rest
   }) => {
+    const paymentContext = useContext(PaymentContext);
     const initializePayPalCommercePayment = useCallback(options => initializePayment({
         ...options,
         paypalcommerce: {
@@ -19,9 +26,15 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
                 color: 'black',
                 label: 'pay',
             },
+            hidePaymentButton,
             submitForm,
+            onError: () => {
+                if (paymentContext) {
+                    paymentContext.disableSubmit(rest.method, true);
+                }
+            },
         },
-    }), [initializePayment, submitForm]);
+    }), [initializePayment, submitForm, hidePaymentButton, paymentContext, rest.method]);
 
     return <HostedWidgetPaymentMethod
         { ...rest }

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback, FunctionComponent } from 'react';
+import { Omit } from 'utility-types';
+
+import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+
+export type PaypalCommercePaymentMethod = Omit<HostedWidgetPaymentMethodProps, 'containerId'>;
+
+const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod> = ({
+      initializePayment,
+      submitForm,
+      ...rest
+  }) => {
+    const initializePayPalComemrcePayment = useCallback(options => initializePayment({
+        ...options,
+        paypalcommerce: {
+            container: '#paymentButtonWidget', // TODO add container for hosted submit button
+            submitForm,
+        },
+    }), [initializePayment, submitForm]);
+
+    return <HostedWidgetPaymentMethod
+        { ...rest }
+        containerId="paymentWidget"
+        initializePayment={ initializePayPalComemrcePayment }
+    />;
+};
+
+export default PaypalCommercePaymentMethod;

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -1,46 +1,53 @@
 import React, { useCallback, useContext, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
+import { connectFormik, ConnectFormikProps } from '../../common/form';
 import PaymentContext from '../PaymentContext';
+import { PaymentFormValues } from '../PaymentForm';
 
 import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
-// import {WithPaymentProps} from "../withPayment";
 
-export type PaypalCommercePaymentMethod = Omit<HostedWidgetPaymentMethodProps, 'containerId'>;
+export type PaypalCommercePaymentMethod = Omit<HostedWidgetPaymentMethodProps, 'containerId'> & ConnectFormikProps<PaymentFormValues>;
 
 const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod> = ({
       initializePayment,
       onUnhandledError,
-      hidePaymentButton,
-      submitForm,
-      // disableSubmit,
+      formik: { submitForm },
       ...rest
   }) => {
     const paymentContext = useContext(PaymentContext);
     const initializePayPalCommercePayment = useCallback(options => initializePayment({
         ...options,
         paypalcommerce: {
-            container: '#paymentButtonWidget', // TODO add container for hosted submit button
+            container: '#checkout-payment-continue', // TODO add container for hosted submit button
             style: {
                 height: 55,
                 color: 'black',
                 label: 'pay',
             },
-            hidePaymentButton,
-            submitForm,
-            onError: () => {
+            hidePaymentButton: () => {
                 if (paymentContext) {
-                    paymentContext.disableSubmit(rest.method, true);
+                    paymentContext.hidePaymentSubmitButton(rest.method, true);
                 }
             },
+            submitForm,
         },
-    }), [initializePayment, submitForm, hidePaymentButton, paymentContext, rest.method]);
+    }), [initializePayment, submitForm, paymentContext, rest.method]);
+
+    const onError = (error: Error) => {
+        if (paymentContext) {
+            paymentContext.disableSubmit(rest.method, true);
+        }
+
+        onUnhandledError?.(error);
+    };
 
     return <HostedWidgetPaymentMethod
         { ...rest }
         containerId="paymentWidget"
         initializePayment={ initializePayPalCommercePayment }
+        onUnhandledError={ onError }
     />;
 };
 
-export default PaypalCommercePaymentMethod;
+export default connectFormik(PaypalCommercePaymentMethod);

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -10,10 +10,15 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
       submitForm,
       ...rest
   }) => {
-    const initializePayPalComemrcePayment = useCallback(options => initializePayment({
+    const initializePayPalCommercePayment = useCallback(options => initializePayment({
         ...options,
         paypalcommerce: {
             container: '#paymentButtonWidget', // TODO add container for hosted submit button
+            style: {
+                height: 55,
+                color: 'black',
+                label: 'pay',
+            },
             submitForm,
         },
     }), [initializePayment, submitForm]);
@@ -21,7 +26,7 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
     return <HostedWidgetPaymentMethod
         { ...rest }
         containerId="paymentWidget"
-        initializePayment={ initializePayPalComemrcePayment }
+        initializePayment={ initializePayPalCommercePayment }
     />;
 };
 

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useContext, FunctionComponent } from 'react';
-import { Omit } from 'utility-types';
 
 import { connectFormik, ConnectFormikProps } from '../../common/form';
 import PaymentContext from '../PaymentContext';
@@ -19,7 +18,7 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
     const initializePayPalCommercePayment = useCallback(options => initializePayment({
         ...options,
         paypalcommerce: {
-            container: '#checkout-payment-continue', // TODO add container for hosted submit button
+            container: '#checkout-payment-continue',
             style: {
                 height: 55,
                 color: 'black',

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -46,6 +46,7 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
         containerId="paymentWidget"
         initializePayment={ initializePayPalCommercePayment }
         onUnhandledError={ onError }
+        shouldShow={ false }
     />;
 };
 

--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -25,7 +25,7 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
                 color: 'black',
                 label: 'pay',
             },
-            hidePaymentButton: () => {
+            onRenderButton: () => {
                 if (paymentContext) {
                     paymentContext.hidePaymentSubmitButton(rest.method, true);
                 }

--- a/src/app/payment/paymentMethod/WalletButtonPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/WalletButtonPaymentMethod.spec.tsx
@@ -39,6 +39,7 @@ describe('WalletButtonPaymentMethod', () => {
             disableSubmit: jest.fn(),
             setSubmit: jest.fn(),
             setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
         };
 
         jest.spyOn(checkoutState.data, 'getCheckout')

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -79,3 +79,8 @@ body.klarna-payments-fso-open {
 #stripe-card-field--webkit-autofill {
     background-color: #fefde5 !important;
 }
+
+#paymentButtonWidget {
+    margin-left: 0;
+    width: 100%;
+}

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -80,7 +80,7 @@ body.klarna-payments-fso-open {
     background-color: #fefde5 !important;
 }
 
-#paymentButtonWidget {
+.submitButtonContainer {
     margin-left: 0;
     width: 100%;
 }


### PR DESCRIPTION
## What?
Smart payment buttons were added to checkout page. 
Adding an embedded button instead of the submit button

Relevant [PR](https://github.com/bigcommerce/checkout-sdk-js/pull/980)  on the checkout-sdk 

## Why?

PPCP pop up is blocked on the BC hosted checkout page and Embedded checkout. Pop ups work for SPB at the shopping cart page.

## Testing / Proof

![image](https://user-images.githubusercontent.com/51989411/92879920-2bd41a80-f416-11ea-8e0b-4088c7bb8c49.png)

@bigcommerce/checkout
