### PR TITLE
feat(payments): INT-3061 added mandate link on confirmation page

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -337,7 +337,8 @@
             "thank_you_customer_heading": "Thank you {name}!",
             "thank_you_heading": "Thank you!",
             "continue_shopping": "Continue Shopping »",
-            "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger"
+            "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger",
+            "mandate_link_text": "{provider} Mandate"
         }
     }
 }

--- a/src/app/order/OrderStatus.spec.tsx
+++ b/src/app/order/OrderStatus.spec.tsx
@@ -227,4 +227,51 @@ describe('OrderStatus', () => {
                 });
         });
     });
+
+    describe('when order has mandate', () => {
+        beforeEach(() => {
+            order = {
+                ...getOrder(),
+                mandate: 'mandateLink',
+            };
+        });
+
+        it('renders mandate link if it is provided', () => {
+            const orderStatus = mount(
+                <OrderStatusTest
+                    { ...defaultProps }
+                    order={ order }
+                />
+            );
+
+            expect(orderStatus.find('[data-test="order-confirmation-mandate-link-text"]')
+                .prop('href'))
+                .toEqual('mandateLink');
+        });
+
+        it('renders "SEPA Direct Debit Mandate" text on mandate link when provider description is Stripe (SEPA)', () => {
+            const orderStatus = mount(
+                <OrderStatusTest
+                    { ...defaultProps }
+                    order={ {
+                        ...order,
+                        payments: [{
+                            providerId: 'stripev3',
+                            description: 'Stripe (SEPA)',
+                            amount: 190,
+                            detail: {
+                                step: 'FINALIZE',
+                                instructions: '<strong>295</strong> something',
+                            },
+                        }],
+                    } }
+                />
+            );
+
+            expect(orderStatus.find('[data-test="order-confirmation-mandate-link-text"]')
+                .text())
+                .toEqual('SEPA Direct Debit Mandate');
+        });
+    });
+
 });

--- a/src/app/order/OrderStatus.tsx
+++ b/src/app/order/OrderStatus.tsx
@@ -1,5 +1,5 @@
 import { Order } from '@bigcommerce/checkout-sdk';
-import React, { memo, FunctionComponent } from 'react';
+import React, { memo, useCallback, FunctionComponent } from 'react';
 
 import { TranslatedHtml, TranslatedString } from '../locale';
 
@@ -16,6 +16,11 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
     supportEmail,
     supportPhoneNumber,
 }) => {
+
+    const getMandateProvider = useCallback(() => {
+        return order?.payments?.[0].description === 'Stripe (SEPA)' ? 'SEPA Direct Debit' : order?.payments?.[0].description;
+    }, [order]);
+
     return <OrderConfirmationSection>
         { order.orderId &&
         <p data-test="order-confirmation-order-number-text">
@@ -33,6 +38,13 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
                 supportPhoneNumber={ supportPhoneNumber }
             />
         </p>
+
+        { order.mandate && <a data-test="order-confirmation-mandate-link-text" href={ order.mandate } rel="noopener noreferrer" target="_blank">
+                <TranslatedString
+                    data={ { provider : getMandateProvider() } }
+                    id="order_confirmation.mandate_link_text"
+                />
+        </a> }
 
         { order.hasDigitalItems &&
         <p data-test="order-confirmation-digital-items-text">


### PR DESCRIPTION
## What? [INT-3061](https://jira.bigcommerce.com/browse/INT-3061)
Added mandate link on confirmation page.

## Why?
In order to show sepa mandate link to the customer.

## Testing / Proof
<img width="803" alt="Screen Shot 2020-08-26 at 10 46 24 AM" src="https://user-images.githubusercontent.com/61981535/91325959-65a3f080-e789-11ea-9fb1-a935af6fdf76.png">

## Dependencies
[Bigpay #2906](https://github.com/bigcommerce/bigpay/pull/2906)
[BigCommerce #36755](https://github.com/bigcommerce/bigcommerce/pull/36755)
[Checkout-sdk-js #966](https://github.com/bigcommerce/checkout-sdk-js/pull/966)

@bigcommerce/checkout @bigcommerce/apex-integrations 
