### PR TITLE
refactor(payment): INT-3105 Update submit button text for AmazonPayV2

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -160,7 +160,7 @@
             "afterpay_name_text": "Afterpay",
             "afterpay_description": "Checkout with Afterpay",
             "amazon_continue_action": "Continue with Amazon",
-            "amazonpay_continue_action": "Continue with Amazon",
+            "amazonpay_continue_action": "Continue with Amazon Pay",
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Continue",
             "bluesnap_v2_continue_action": "Continue",

--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -69,7 +69,7 @@ describe('PaymentSubmitButton', () => {
 
     it('renders button with special label for Amazon Pay', () => {
         const component = mount(
-            <PaymentSubmitButtonTest methodId="amazon" />
+            <PaymentSubmitButtonTest methodId="amazonpay" />
         );
 
         expect(component.text())


### PR DESCRIPTION
## What? [INT-3105](https://jira.bigcommerce.com/browse/INT-3105)
- Update the '_Continue with Amazon_' text to '_Continue with Amazon Pay_'
- Fixed the related test

## Why?
It's a 'nice to have' change requested by the Amazon Pay team.

## Testing / Proof
<img width="646" alt="Screen Shot 2020-09-11 at 12 14 51 PM" src="https://user-images.githubusercontent.com/4843328/92955509-e40bbe00-f42a-11ea-80c2-0383e388dbfd.png">


@bigcommerce/checkout
