### PR TITLE
CHECKOUT-5135: Fix error handler for Braintree hosted form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,9 +1609,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.99.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.99.1.tgz",
-      "integrity": "sha512-NK3IEx3KQsBySGT9GnAJ6WHSfyYIBfWfCCl6kSFu1t1TJ6OJB3q18RMkseb1uPGr1ny4xRjia7bHuU4OWss8tQ==",
+      "version": "1.99.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.99.2.tgz",
+      "integrity": "sha512-NGReIieW3q+k5NqYH61fbY4rlCGa5625AxoDL1mQX6u1fZ0UkJVTlOUZemOxTbfSzNoTJzmktLEsiBqaPQgxXg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.99.1",
+    "@bigcommerce/checkout-sdk": "^1.99.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/Payment.spec.tsx
+++ b/src/app/payment/Payment.spec.tsx
@@ -429,6 +429,16 @@ describe('Payment', () => {
             .toHaveLength(0);
     });
 
+    it('does not render error modal when there is invalid payment form error', () => {
+        jest.spyOn(checkoutState.errors, 'getSubmitOrderError')
+            .mockReturnValue({ type: 'payment_invalid_form' } as CustomError);
+
+        const container = mount(<PaymentTest { ...defaultProps } />);
+
+        expect(container.find(ErrorModal))
+            .toHaveLength(0);
+    });
+
     it('does not render error modal when there is invalid hosted form value error', () => {
         jest.spyOn(checkoutState.errors, 'getSubmitOrderError')
             .mockReturnValue({ type: 'invalid_hosted_form_value' } as CustomError);

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -189,6 +189,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         if (!error ||
             error.type === 'order_finalization_not_required' ||
             error.type === 'payment_cancelled' ||
+            error.type === 'payment_invalid_form' ||
             error.type === 'spam_protection_not_completed' ||
             error.type === 'invalid_hosted_form_value') {
             return null;

--- a/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.spec.tsx
+++ b/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.spec.tsx
@@ -251,6 +251,16 @@ describe('withHostedCreditCardFieldset', () => {
             .toEqual(expect.objectContaining({
                 cardNumber: 'required',
             }));
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(last(formikRender.mock.calls)![0].touched)
+            .toEqual(expect.objectContaining({
+                hostedForm: {
+                    errors: {
+                        cardNumber: true,
+                    },
+                },
+            }));
     });
 
     it('passes card type from hosted form to Formik form', async () => {

--- a/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.tsx
+++ b/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.tsx
@@ -47,7 +47,7 @@ export default function withHostedCreditCardFieldset<TProps extends WithHostedCr
         WithFormProps &
         ConnectFormikProps<PaymentFormValues>
     > = ({
-        formik: { setFieldValue, submitForm },
+        formik: { setFieldValue, setFieldTouched, submitForm },
         isCardCodeRequired,
         isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
         isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
@@ -122,10 +122,13 @@ export default function withHostedCreditCardFieldset<TProps extends WithHostedCr
                 },
                 onValidate: ({ errors = {} }) => {
                     forIn(errors, (fieldErrors = [], fieldType) => {
-                        setFieldValue(
-                            `hostedForm.errors.${fieldType}`,
-                            fieldErrors[0] ? fieldErrors[0].type : ''
-                        );
+                        const errorKey = `hostedForm.errors.${fieldType}`;
+
+                        setFieldValue(errorKey, fieldErrors[0]?.type ?? '');
+
+                        if (fieldErrors[0]) {
+                            setFieldTouched(errorKey);
+                        }
                     });
                 },
             };
@@ -138,6 +141,7 @@ export default function withHostedCreditCardFieldset<TProps extends WithHostedCr
             language,
             method,
             setFieldValue,
+            setFieldTouched,
             setFocusedFieldType,
             setSubmitted,
             submitForm,


### PR DESCRIPTION
## What?
Fix the error handler form Braintree hosted payment form.

Related PR: https://github.com/bigcommerce/checkout-sdk-js/pull/981

## Why?
Otherwise the inline error message doesn't show up.

## Testing / Proof
<img width="505" alt="Screen Shot 2020-09-14 at 9 00 34 am" src="https://user-images.githubusercontent.com/667603/93039029-cee09a80-f689-11ea-8b60-8598b94ee8bb.png">

@bigcommerce/checkout
