### PR TITLE
CHECKOUT-5161: Re-initialise credit card form after deleting last stored card

### DIFF
--- a/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
@@ -175,6 +175,7 @@ class CreditCardPaymentMethod extends Component<
                 <div className="paymentMethod paymentMethod--creditCard">
                     { shouldShowInstrumentFieldset && <CardInstrumentFieldset
                         instruments={ instruments }
+                        onDeleteInstrument={ this.handleDeleteInstrument }
                         onSelectInstrument={ this.handleSelectInstrument }
                         onUseNewInstrument={ this.handleUseNewCard }
                         selectedInstrumentId={ selectedInstrument && selectedInstrument.bigpayToken }
@@ -270,6 +271,26 @@ class CreditCardPaymentMethod extends Component<
             isAddingNewCard: false,
             selectedInstrumentId: id,
         });
+    };
+
+    private handleDeleteInstrument: (id: string) => void = id => {
+        const { instruments, formik: { setFieldValue } } = this.props;
+        const { selectedInstrumentId } = this.state;
+
+        if (instruments.length === 0) {
+            this.setState({
+                isAddingNewCard: true,
+                selectedInstrumentId: undefined,
+            });
+
+            setFieldValue('instrumentId', '');
+        } else if (selectedInstrumentId === id) {
+            this.setState({
+                selectedInstrumentId: this.getDefaultInstrumentId(),
+            });
+
+            setFieldValue('instrumentId', this.getDefaultInstrumentId());
+        }
     };
 }
 

--- a/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
+++ b/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
@@ -16,6 +16,7 @@ export interface CardInstrumentFieldsetProps {
     selectedInstrumentId?: string;
     shouldHideExpiryDate?: boolean;
     validateInstrument?: React.ReactNode;
+    onDeleteInstrument?(instrumentId: string): void;
     onSelectInstrument(id: string): void;
     onUseNewInstrument(): void;
 }
@@ -26,6 +27,7 @@ export type CardInstrumentFieldsetValues = {
 
 const CardInstrumentFieldset: FunctionComponent<CardInstrumentFieldsetProps> = ({
     instruments,
+    onDeleteInstrument,
     onSelectInstrument,
     onUseNewInstrument,
     selectedInstrumentId,
@@ -52,9 +54,13 @@ const CardInstrumentFieldset: FunctionComponent<CardInstrumentFieldsetProps> = (
     const renderModal = useCallback((props: ModalTriggerModalProps) => (
         <ManageInstrumentsModal
             instruments={ instruments }
+            onDeleteInstrument={ onDeleteInstrument }
             { ...props }
         />
-    ), [instruments]);
+    ), [
+        instruments,
+        onDeleteInstrument,
+    ]);
 
     return <Fieldset
         additionalClassName="instrumentFieldset"

--- a/src/app/payment/storedInstrument/ManageInstrumentsModal.tsx
+++ b/src/app/payment/storedInstrument/ManageInstrumentsModal.tsx
@@ -18,6 +18,7 @@ export interface ManageInstrumentsModalProps {
     isOpen: boolean;
     instruments: PaymentInstrument[];
     onAfterOpen?(): void;
+    onDeleteInstrument?(instrumentId: string): void;
     onDeleteInstrumentError?(error: Error): void;
     onRequestClose?(): void;
 }
@@ -165,7 +166,7 @@ class ManageInstrumentsModal extends Component<ManageInstrumentsModalProps & Wit
     };
 
     private handleConfirmDelete: () => void = async () => {
-        const { deleteInstrument, onDeleteInstrumentError = noop, onRequestClose = noop } = this.props;
+        const { deleteInstrument, onDeleteInstrument = noop, onDeleteInstrumentError = noop, onRequestClose = noop } = this.props;
         const { selectedInstrumentId } = this.state;
 
         if (!selectedInstrumentId) {
@@ -174,6 +175,7 @@ class ManageInstrumentsModal extends Component<ManageInstrumentsModalProps & Wit
 
         try {
             await deleteInstrument(selectedInstrumentId);
+            onDeleteInstrument(selectedInstrumentId);
             onRequestClose();
         } catch (error) {
             onDeleteInstrumentError(error);


### PR DESCRIPTION
## What?
Re-initialise the credit card form after deleting the last stored card.

## Why?
Otherwise, you can be in a situation where you can't enter a new card because there's no form for you to enter your details.

## Testing / Proof
CircleCI + Manual

### Deleting a selected card
![delete_instrument](https://user-images.githubusercontent.com/667603/93063774-13842a00-f6ba-11ea-8d3f-3f4c8e969450.gif)

### Deleting the last card
![delete_instrument_empty](https://user-images.githubusercontent.com/667603/93063797-1da62880-f6ba-11ea-97b3-85a18ee45d1b.gif)

@bigcommerce/checkout
