### PR TITLE
fix(checkout): INT-3116 Hide Bolt on checkout

### DIFF
--- a/src/app/payment/Payment.spec.tsx
+++ b/src/app/payment/Payment.spec.tsx
@@ -15,6 +15,7 @@ import { getOrder } from '../order/orders.mock';
 import { Button } from '../ui/button';
 
 import { getPaymentMethod } from './payment-methods.mock';
+import { PaymentMethodId } from './paymentMethod';
 import Payment, { PaymentProps } from './Payment';
 import PaymentForm, { PaymentFormProps } from './PaymentForm';
 
@@ -34,6 +35,7 @@ describe('Payment', () => {
         paymentMethods = [
             getPaymentMethod(),
             { ...getPaymentMethod(), id: 'sagepay' },
+            { ...getPaymentMethod(), id: 'bolt', initializationData: { showInCheckout: true }},
         ];
         selectedPaymentMethod = paymentMethods[0];
         subscribeEventEmitter = new EventEmitter();
@@ -107,6 +109,23 @@ describe('Payment', () => {
                 methods: paymentMethods,
                 onSubmit: expect.any(Function),
                 selectedMethod: paymentMethods[0],
+            }));
+    });
+
+    it('does not render bolt if showInCheckout is false', async () => {
+        const expectedPaymentMethods = paymentMethods.filter(method =>  method.id !== PaymentMethodId.Bolt);
+        paymentMethods[2] = { ...getPaymentMethod(), id: 'bolt', initializationData: { showInCheckout: false } };
+
+        const container = mount(<PaymentTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+        container.update();
+
+        expect(container.find(PaymentForm).props())
+            .toEqual(expect.objectContaining({
+                methods: expectedPaymentMethods,
+                onSubmit: expect.any(Function),
+                selectedMethod: expectedPaymentMethods[0],
             }));
     });
 

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -462,12 +462,22 @@ export function mapToPaymentProps({
 
     let selectedPaymentMethod;
     let filteredMethods;
+
+    // Prevent a payment method from being rendered
+    const prefilteredMethods = methods.filter((method: PaymentMethod) => {
+        if (method.id === PaymentMethodId.Bolt && method.initializationData) {
+            return !!method.initializationData.showInCheckout;
+        }
+
+        return true;
+    });
+
     if (selectedPayment) {
         selectedPaymentMethod = getPaymentMethod(selectedPayment.providerId, selectedPayment.gatewayId);
-        filteredMethods = selectedPaymentMethod ? compact([selectedPaymentMethod]) : methods;
+        filteredMethods = selectedPaymentMethod ? compact([selectedPaymentMethod]) : prefilteredMethods;
     } else {
-        selectedPaymentMethod = find(methods, { config: { hasDefaultStoredInstrument: true } });
-        filteredMethods = methods;
+        selectedPaymentMethod = find(prefilteredMethods, { config: { hasDefaultStoredInstrument: true } });
+        filteredMethods = prefilteredMethods;
     }
 
     return {


### PR DESCRIPTION
## What?
Remove Bolt form payment methods if showInChekout is false , to prevent it from being rendered as payment method.

## Why?
To prevent Bolt's payment method from being rendered, but still usable from the Bolt app and manual orders.

## Sibling PRs
https://github.com/bigcommerce/bigcommerce/pull/36855

## Testing / Proof
Demo video recorded using this Draft PR as base https://github.com/bigcommerce/bigcommerce/pull/36925, actual behavior depends on the sibling PR
[Demo Video](https://drive.google.com/file/d/1u5Y3AxqKN32uYfx-cflInQjLgd23iCAB/view?usp=sharing)

@bigcommerce/checkout