### PR TITLE
fix(payments): INT-3140 Enable checkout button with googlepay when use store credit - StripeV3

### DIFF
--- a/src/app/payment/paymentMethod/WalletButtonPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/WalletButtonPaymentMethod.spec.tsx
@@ -47,6 +47,9 @@ describe('WalletButtonPaymentMethod', () => {
         jest.spyOn(checkoutState.data, 'getBillingAddress')
             .mockReturnValue(getBillingAddress());
 
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
         jest.spyOn(window.location, 'reload')
             .mockImplementation();
 
@@ -149,6 +152,16 @@ describe('WalletButtonPaymentMethod', () => {
 
         expect(paymentContext.disableSubmit)
             .toHaveBeenCalledWith(defaultProps.method, true);
+    });
+
+    it('enables submit button if payment data is not required', () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(false);
+
+        mount(<WalletButtonPaymentMethodTest { ...defaultProps } />);
+
+        expect(paymentContext.disableSubmit)
+            .toHaveBeenCalledWith(defaultProps.method, false);
     });
 
     describe('when user is signed into their payment method account and credit card is selected from their wallet', () => {


### PR DESCRIPTION
[INT-3140](https://jira.bigcommerce.com/browse/INT-3140)

## What?
- Validate if shopper use store credit to enable the checkout button whit wallet

## Why?
- Shopper can place a order when use store credit and googlepay is enabled.

## Testing / Proof
Unit test

@bigcommerce/checkout
