### PR TITLE
CHECKOUT-5157 Revoke abandoned cart consent if box left unchecked

### DIFF
--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -154,7 +154,7 @@ describe('Customer', () => {
                 .toHaveBeenCalledWith({
                     email: 'test@bigcommerce.com',
                     acceptsMarketingNewsletter: undefined,
-                    acceptsAbandonedCartEmails: undefined,
+                    acceptsAbandonedCartEmails: false,
                 });
 
             expect(subscribeToNewsletter)

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -236,7 +236,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             const { data } = await continueAsGuest({
                 email,
                 acceptsMarketingNewsletter: canSubscribe && formValues.shouldSubscribe ? true : undefined,
-                acceptsAbandonedCartEmails: formValues.shouldSubscribe ? true : undefined,
+                acceptsAbandonedCartEmails: formValues.shouldSubscribe ? true : false,
             });
 
             const customer = data.getCustomer();


### PR DESCRIPTION
## What?
Revoke abandoned cart consent if box left unchecked

## Why?
For a stricter GDPR compliance

## Testing / Proof
unit

@bigcommerce/checkout
