### PR TITLE
CHECKOUT-5135: Bump `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1609,9 +1609,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.99.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.99.2.tgz",
-      "integrity": "sha512-NGReIieW3q+k5NqYH61fbY4rlCGa5625AxoDL1mQX6u1fZ0UkJVTlOUZemOxTbfSzNoTJzmktLEsiBqaPQgxXg==",
+      "version": "1.99.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.99.3.tgz",
+      "integrity": "sha512-LvzYdJmk9uPdvtdrQy1CGXqsqBc7ue9JPQggntGw6doVgJU1/L2spIkRtMLsYCidcXiG4X6bfKrxq204whUIFg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.12.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.99.2",
+    "@bigcommerce/checkout-sdk": "^1.99.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
