### PR TITLE
feat(checkout): INT-3137 Split cc icons into rows

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -159,25 +159,27 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
 
     return (
         <Fragment>
-            { logoUrl && <img
-                alt={ methodName }
-                className="paymentProviderHeader-img"
-                data-test="payment-method-logo"
-                src={ logoUrl }
-            /> }
+            <div className="paymentProviderHeader-container">
+                { logoUrl && <img
+                    alt={ methodName }
+                    className="paymentProviderHeader-img"
+                    data-test="payment-method-logo"
+                    src={ logoUrl }
+                /> }
 
-            { titleText && <span
-                className="paymentProviderHeader-name"
-                data-test="payment-method-name"
-            >
-                { titleText }
-            </span> }
+                { titleText && <span
+                    className="paymentProviderHeader-name"
+                    data-test="payment-method-name"
+                >
+                    { titleText }
+                </span> }
 
-            <div className="paymentProviderHeader-cc">
-                <CreditCardIconList
-                    cardTypes={ compact(method.supportedCards.map(mapFromPaymentMethodCardType)) }
-                    selectedCardType={ getSelectedCardType() }
-                />
+                <div className="paymentProviderHeader-cc">
+                    <CreditCardIconList
+                        cardTypes={ compact(method.supportedCards.map(mapFromPaymentMethodCardType)) }
+                        selectedCardType={ getSelectedCardType() }
+                    />
+                </div>
             </div>
         </Fragment>
     );

--- a/src/scss/components/bigcommerce/credit-card-types/_credit-card-types.scss
+++ b/src/scss/components/bigcommerce/credit-card-types/_credit-card-types.scss
@@ -14,10 +14,13 @@
 
 @if $exportCSS--credit-card-types {
     .creditCardTypes-list {
+        align-content: flex-end;
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
-        margin-bottom: 1em;
+        justify-content: space-evenly;
+        margin-left: spacing("single");
+        min-width: 9em;
     }
 
     .creditCardTypes-list-item {

--- a/src/scss/components/bigcommerce/credit-card-types/_credit-card-types.scss
+++ b/src/scss/components/bigcommerce/credit-card-types/_credit-card-types.scss
@@ -13,6 +13,13 @@
 // -----------------------------------------------------------------------------
 
 @if $exportCSS--credit-card-types {
+    .creditCardTypes-list {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-bottom: 1em;
+    }
+
     .creditCardTypes-list-item {
         opacity: 1;
         transition: all 0.6s ease-out;

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -2,7 +2,14 @@
 // PAYMENT PROVIDER (Component)
 // =============================================================================
 
+.paymentProviderHeader-container {
+    display: flex;
+    justify-content: space-between;
+}
+
 .paymentProviderHeader-img {
+    align-self: center;
+    display: flex;
     height: fontSize("large");
 
     + .paymentProviderHeader-name {
@@ -16,9 +23,19 @@
 
 .paymentProviderHeader-cc {
     @include breakpoint("small") {
-        float: right;
-        max-width: 14em;
+        align-items: flex-end;
+        display: flex;
+        flex-grow: 0;
+        flex-shrink: 2;
     }
+}
+
+.paymentProviderHeader-name {
+    align-items: flex-start;
+    align-self: center;
+    display: flex;
+    flex-grow: 1;
+    flex-shrink: 1;
 }
 
 .paymentMethod--creditCard,

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -17,6 +17,7 @@
 .paymentProviderHeader-cc {
     @include breakpoint("small") {
         float: right;
+        max-width: 14em;
     }
 }
 


### PR DESCRIPTION
## What?
Modify the CSS for the credit Card icon list to allow multiple rows and match spacing above and below the list

## Why?
https://jira.bigcommerce.com/browse/INT-3137

## Testing / Proof
<img width="689" alt="Screen Shot 2020-09-22 at 2 54 53 PM" src="https://user-images.githubusercontent.com/35502707/93930851-9c671b00-fce3-11ea-9631-d7686e01cc71.png">

[Demo Video](https://drive.google.com/file/d/1kwDd9osasDACAtWIYtctOE8WaXhTtT9v/view?usp=sharing)

@bigcommerce/checkout
