### PR TITLE
feat(payments): INT-3086 added optional custom render fields on StripeV3

### DIFF
--- a/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -2,7 +2,7 @@ import { createCheckoutService, BankInstrument, CheckoutSelectors, CheckoutServi
 import { mount, ReactWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, ReactElement } from 'react';
 
 import { getCart } from '../../cart/carts.mock';
 import { CheckoutProvider } from '../../checkout';
@@ -181,6 +181,64 @@ describe('HostedWidgetPaymentMethod', () => {
         component.setProps({ shouldShow: false });
 
         expect(component.isEmptyRender()).toBe(true);
+    });
+
+    it('renders custom payment method component', () => {
+        const MockComponent = (): ReactElement => {
+            return <div id="custom-form-id" />;
+        };
+
+        defaultProps = {
+            ...defaultProps,
+            method : {
+                ...getPaymentMethod(),
+                id: 'card',
+            },
+            renderCustomPaymentForm: () => <MockComponent />,
+            shouldRenderCustomInstrument: true,
+        };
+
+        const component = mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
+
+        expect(component.find('[id="custom-form-id"]')).toHaveLength(1);
+    });
+
+    it('does execute validateCustomRender', () => {
+        defaultProps = {
+            ...defaultProps,
+            method : {
+                ...getPaymentMethod(),
+                id: 'card',
+            },
+            renderCustomPaymentForm: jest.fn(),
+            shouldRenderCustomInstrument : true,
+        };
+
+        mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
+
+        expect(defaultProps.renderCustomPaymentForm).toHaveBeenCalled();
+    });
+
+    it('does not render custom payment method component', () => {
+        const MockComponent = (): ReactElement => {
+            return <div id="custom-form-id" />;
+        };
+
+        defaultProps = {
+            ...defaultProps,
+            method : {
+                ...getPaymentMethod(),
+                id: 'card',
+            },
+
+            renderCustomPaymentForm: () => <MockComponent />,
+            shouldRenderCustomInstrument : false,
+        };
+
+        const component = mount(<HostedWidgetPaymentMethodTest { ...defaultProps } />);
+
+        expect(component.find('[id="custom-form-id"]')).toHaveLength(0);
+
     });
 
     describe('when user is signed into their payment method account', () => {

--- a/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -55,7 +55,13 @@ describe('when using Stripe payment', () => {
 
     describe('when using alipay component', () => {
         beforeEach(() => {
-            method = { ...getPaymentMethod(), id: 'alipay', gateway: 'stripev3', method: 'alipay' };
+            method = {
+                ...getPaymentMethod(),
+                id: 'alipay',
+                gateway: 'stripev3',
+                method: 'alipay',
+                initializationData: {},
+            };
         });
 
         it('renders as hosted widget method', () => {
@@ -92,7 +98,15 @@ describe('when using Stripe payment', () => {
 
     describe('when using card component', () => {
         beforeEach(() => {
-            method = { ...getPaymentMethod(), id: 'card', gateway: 'stripev3', method: 'card'};
+            method = {
+                ...getPaymentMethod(),
+                id: 'card',
+                gateway: 'stripev3',
+                method: 'card',
+                initializationData: {
+                    useIndividualCardFields: false,
+                },
+            };
         });
 
         it('renders as hosted widget method', () => {
@@ -122,20 +136,72 @@ describe('when using Stripe payment', () => {
                 .toHaveBeenCalledWith(expect.objectContaining({
                     methodId: method.id,
                     stripev3: {
-                        containerId: 'stripe-card-component-field',
                         options: {
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',
                             },
                         },
+                        containerId: 'stripe-card-component-field',
                     },
                 }));
+        });
+
+        it('initializes method with required config when useIndividualCardFields option is true', () => {
+            method.initializationData.useIndividualCardFields = true;
+            const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+            const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+            component.prop('initializePayment')({
+                methodId: method.id,
+                gatewayId: method.gateway,
+            });
+
+            expect(checkoutService.initializePayment)
+                .toHaveBeenCalledWith({
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                    stripev3: {
+                        containerId: 'stripe-card-component-field',
+                        options: {
+                            cardNumberElementOptions: {
+                                showIcon: true,
+                                classes: {
+                                    base: 'form-input optimizedCheckout-form-input',
+                                },
+                                placeholder: '',
+                                containerId: 'stripe-card-number-component-field',
+                            },
+                            cardExpiryElementOptions: {
+                                classes: {
+                                    base: 'form-input optimizedCheckout-form-input',
+                                },
+                                containerId: 'stripe-expiry-component-field',
+                            },
+                            cardCvcElementOptions: {
+                                classes: {
+                                    base: 'form-input optimizedCheckout-form-input',
+                                },
+                                placeholder: '',
+                                containerId: 'stripe-cvc-component-field',
+                            },
+                            zipCodeElementOptions: {
+                                containerId: 'stripe-postal-code-component-field',
+                            },
+                        },
+                    },
+                });
         });
     });
 
     describe('when using ideal component', () => {
         beforeEach(() => {
-            method = { ...getPaymentMethod(), id: 'idealBank', gateway: 'stripev3', method: 'idealBank'};
+            method = {
+                ...getPaymentMethod(),
+                id: 'idealBank',
+                gateway: 'stripev3',
+                method: 'idealBank',
+                initializationData: {},
+            };
         });
 
         it('renders as hosted widget method', () => {
@@ -179,7 +245,13 @@ describe('when using Stripe payment', () => {
 
     describe('when using iban component', () => {
         beforeEach(() => {
-            method = { ...getPaymentMethod(), id: 'iban', gateway: 'stripev3', method: 'iban'};
+            method = {
+                ...getPaymentMethod(),
+                id: 'iban',
+                gateway: 'stripev3',
+                method: 'iban',
+                initializationData: {},
+            };
         });
 
         it('renders as hosted widget method', () => {
@@ -209,15 +281,23 @@ describe('when using Stripe payment', () => {
                 .toHaveBeenCalledWith(expect.objectContaining({
                     methodId: method.id,
                     stripev3: {
-                        containerId: 'stripe-iban-component-field',
                         options: {
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',
                             },
                             supportedCountries: ['SEPA'],
                         },
+                        containerId: 'stripe-iban-component-field',
                     },
                 }));
+        });
+
+        it('returns storeUrl null if getConfig is undefined ', () => {
+            jest.spyOn(checkoutState.data, 'getConfig')
+                .mockReturnValue(undefined);
+            const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+
+            expect(container.prop('storeUrl')).toBe(undefined);
         });
     });
 });

--- a/src/app/payment/paymentMethod/StripePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.tsx
@@ -6,62 +6,110 @@ import { withCheckout, CheckoutContextProps } from '../../checkout';
 import { TranslatedString } from '../../locale';
 
 import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+import StripeV3CustomCardForm from './StripeV3CustomCardForm';
 
 export type StripePaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'containerId'>;
 
 export interface StripeOptions {
     alipay?: StripeElementOptions;
     card: StripeElementOptions;
+    cardCvc: StripeElementOptions;
+    cardExpiry: StripeElementOptions;
+    cardNumber: StripeElementOptions;
     iban: StripeElementOptions;
     idealBank: StripeElementOptions;
 }
 interface WithCheckoutStripePaymentMethodProps {
     storeUrl: string;
 }
-
-export enum StripeV3PaymentMethodType {
+export enum StripeElementType {
     alipay = 'alipay',
     card = 'card',
+    cardCvc = 'cardCvc',
+    cardExpiry = 'cardExpiry',
+    cardNumber = 'cardNumber',
     iban = 'iban',
     idealBank = 'idealBank',
 }
-
 const StripePaymentMethod: FunctionComponent<StripePaymentMethodProps & WithCheckoutStripePaymentMethodProps> = ({
       initializePayment,
       method,
       storeUrl,
       ...rest
   }) => {
-    const paymentMethodType = method.id as StripeV3PaymentMethodType;
-    const additionalStripeV3Classes = paymentMethodType !== StripeV3PaymentMethodType.alipay ? 'optimizedCheckout-form-input widget--stripev3' : '';
+    const { useIndividualCardFields } = method.initializationData;
+    const paymentMethodType = method.id as StripeElementType;
+    const additionalStripeV3Classes = paymentMethodType !== StripeElementType.alipay ? 'optimizedCheckout-form-input widget--stripev3' : '';
     const containerId = `stripe-${paymentMethodType}-component-field`;
+    const classes = {
+        base: 'form-input optimizedCheckout-form-input',
+    };
+    const stripeOptions: StripeOptions = {
+        [StripeElementType.card]: {
+            classes,
+        },
+        [StripeElementType.cardCvc]: {
+            classes,
+            placeholder: '',
+        },
+        [StripeElementType.cardExpiry]: {
+            classes,
+        },
+        [StripeElementType.cardNumber]: {
+            classes,
+            showIcon: true,
+            placeholder: '',
+        },
+        [StripeElementType.iban]: {
+            classes,
+            supportedCountries: ['SEPA'],
+        },
+        [StripeElementType.idealBank]: {
+            classes,
+        },
+    };
+
+    const getIndividualCardElementOptions = useCallback((stripeInitializeOptions: StripeOptions) => {
+        return {
+            cardNumberElementOptions: {
+                ...stripeInitializeOptions[StripeElementType.cardNumber],
+                containerId: 'stripe-card-number-component-field',
+            },
+            cardExpiryElementOptions: {
+                ...stripeInitializeOptions[StripeElementType.cardExpiry],
+                containerId: 'stripe-expiry-component-field',
+            },
+            cardCvcElementOptions: {
+                ...stripeInitializeOptions[StripeElementType.cardCvc],
+                containerId: 'stripe-cvc-component-field',
+            },
+            zipCodeElementOptions: {
+                containerId: 'stripe-postal-code-component-field',
+            },
+        };
+    }, []);
+
+    const getStripeOptions = useCallback((shouldRenderCustomComponents: boolean, stripeInitializeOptions: StripeOptions) => {
+        if (shouldRenderCustomComponents) {
+            return getIndividualCardElementOptions(stripeInitializeOptions);
+        }
+
+        return stripeInitializeOptions[paymentMethodType];
+    }, [paymentMethodType, getIndividualCardElementOptions]);
 
     const initializeStripePayment = useCallback(async (options: PaymentInitializeOptions) => {
-        const classes = {
-            base: 'form-input optimizedCheckout-form-input',
-        };
-
-        const stripeOptions: StripeOptions = {
-            [StripeV3PaymentMethodType.card]: {
-                classes,
-            },
-            [StripeV3PaymentMethodType.iban]: {
-                ...{ classes },
-                supportedCountries: ['SEPA'],
-            },
-            [StripeV3PaymentMethodType.idealBank]: {
-                classes,
-            },
-        };
-
         return initializePayment({
             ...options,
-            stripev3: {
-                containerId,
-                options: stripeOptions[paymentMethodType],
-            },
+            stripev3: { containerId,
+                options: getStripeOptions(useIndividualCardFields, stripeOptions) },
         });
-    }, [initializePayment, containerId, paymentMethodType]);
+    }, [initializePayment, containerId, getStripeOptions, useIndividualCardFields, stripeOptions]);
+
+    const renderCustomPaymentForm = () => {
+        const optionsCustomForm = getIndividualCardElementOptions(stripeOptions);
+
+        return <StripeV3CustomCardForm options={ optionsCustomForm } />;
+    };
 
     return <>
         <HostedWidgetPaymentMethod
@@ -71,6 +119,8 @@ const StripePaymentMethod: FunctionComponent<StripePaymentMethodProps & WithChec
             hideContentWhenSignedOut
             initializePayment={ initializeStripePayment }
             method={ method }
+            renderCustomPaymentForm={ renderCustomPaymentForm }
+            shouldRenderCustomInstrument={ useIndividualCardFields }
         />
         {
             method.id === 'iban' &&

--- a/src/app/payment/paymentMethod/StripeV3CustomCardForm.spec.tsx
+++ b/src/app/payment/paymentMethod/StripeV3CustomCardForm.spec.tsx
@@ -1,0 +1,56 @@
+import { mount } from 'enzyme';
+import React, { FunctionComponent } from 'react';
+
+import StripeV3CustomCardForm, { StripeV3CustomCardFormProps } from './StripeV3CustomCardForm';
+
+describe('StripeV3CustomCardForm', () => {
+    let defaultProps: StripeV3CustomCardFormProps;
+    let StripeV3CustomCardFormTest: FunctionComponent<StripeV3CustomCardFormProps>;
+
+    beforeEach(() => {
+        defaultProps = {
+            options: {
+                cardNumberElementOptions: {
+                    containerId: 'stripe-card-number-component-field',
+                },
+                cardExpiryElementOptions: {
+                    containerId: 'stripe-expiry-component-field',
+                },
+                cardCvcElementOptions: {
+                    containerId: 'stripe-cvc-component-field',
+                },
+                zipCodeElementOptions: {
+                    containerId: 'stripe-postal-code-component-field',
+                },
+            },
+        };
+
+        StripeV3CustomCardFormTest = props => (
+                <StripeV3CustomCardForm { ...props } />
+        );
+    });
+
+    it('renders stripeV3 card number field', () => {
+        const container = mount(<StripeV3CustomCardFormTest { ...defaultProps }  />);
+
+        expect(container.find('[id="stripe-card-number-component-field"]')).toHaveLength(1);
+    });
+
+    it('renders stripeV3 expiry date field', () => {
+        const container = mount(<StripeV3CustomCardFormTest { ...defaultProps } />);
+
+        expect(container.find('#stripe-expiry-component-field').length).toEqual(1);
+    });
+
+    it('renders stripeV3 CVV field', () => {
+        const container = mount(<StripeV3CustomCardFormTest { ...defaultProps } />);
+
+        expect(container.find('#stripe-cvc-component-field').length).toEqual(1);
+    });
+
+    it('renders stripeV3 postal code field', () => {
+        const container = mount(<StripeV3CustomCardFormTest { ...defaultProps } />);
+
+        expect(container.find('#stripe-postal-code-component-field').length).toEqual(1);
+    });
+});

--- a/src/app/payment/paymentMethod/StripeV3CustomCardForm.tsx
+++ b/src/app/payment/paymentMethod/StripeV3CustomCardForm.tsx
@@ -1,0 +1,106 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import { TranslatedString } from '../../locale';
+import { IconHelp, IconLock } from '../../ui/icon';
+import { TooltipTrigger } from '../../ui/tooltip';
+import { CreditCardCodeTooltip } from '../creditCard';
+export interface StripeV3CustomCardFormProps {
+    options: {
+        cardNumberElementOptions: {
+            containerId: string;
+        };
+        cardExpiryElementOptions: {
+            containerId: string;
+        };
+        cardCvcElementOptions: {
+            containerId: string;
+        };
+        zipCodeElementOptions?: {
+            containerId: string;
+        };
+    };
+}
+
+const StripeV3CustomCardForm: React.FunctionComponent<StripeV3CustomCardFormProps> = ({options}) => (
+    <div className="form-ccFields">
+        <div className={ classNames(
+            'form-field',
+            'form-field--stripe-ccNumber'
+            ) }
+        >
+            <label className="form-label optimizedCheckout-form-label" htmlFor={ options.cardNumberElementOptions.containerId }>
+                <TranslatedString id="payment.credit_card_number_label" />
+            </label>
+            <>
+                <div
+                    className={ classNames(
+                        'form-input',
+                        'optimizedCheckout-form-input',
+                        'has-icon',
+                        'widget-input--stripev3'
+                    ) }
+                    data-cse="CardNumber"
+                    id={ options.cardNumberElementOptions.containerId }
+                />
+                <IconLock />
+            </>
+        </div>
+        <div className="form-field form-field--ccExpiry">
+            <label className="form-label optimizedCheckout-form-label" htmlFor={ options.cardExpiryElementOptions.containerId }>
+                <TranslatedString id="payment.credit_card_expiration_label" />
+            </label>
+            <div
+                className={ classNames(
+                    'form-input',
+                    'optimizedCheckout-form-input',
+                    'widget-input--stripev3'
+                ) }
+                data-cse="ExpiryDate"
+                id={ options.cardExpiryElementOptions.containerId }
+            />
+        </div>
+        <div className="form-field form-ccFields-field--ccCvv">
+            <label className="form-label optimizedCheckout-form-label" htmlFor={ options.cardCvcElementOptions.containerId }>
+                <TranslatedString id="payment.credit_card_cvv_label" />
+                <TooltipTrigger
+                    placement="top-start"
+                    tooltip={ <CreditCardCodeTooltip /> }
+                >
+                    <span className="has-tip">
+                        <IconHelp />
+                    </span>
+                </TooltipTrigger>
+            </label>
+            <>
+                <div
+                    className={ classNames(
+                        'form-input',
+                        'optimizedCheckout-form-input',
+                        'has-icon',
+                        'widget-input--stripev3'
+                    ) }
+                    data-cse="SecurityCode"
+                    id={ options.cardCvcElementOptions.containerId }
+                />
+                <IconLock />
+            </>
+        </div>
+        { options.zipCodeElementOptions && <div className="form-field form-field--stripe-postalCode">
+            <label className="form-label optimizedCheckout-form-label" htmlFor={ options.zipCodeElementOptions.containerId }>
+                <TranslatedString id="payment.postal_code_label" />
+            </label>
+            <input
+                className={ classNames(
+                    'form-input',
+                    'optimizedCheckout-form-input',
+                    'widget-input--stripev3'
+                ) }
+                data-cse="stripe-postal-code"
+                id={ options.zipCodeElementOptions.containerId }
+            />
+        </div> }
+    </div>
+);
+
+export default StripeV3CustomCardForm;

--- a/src/scss/components/bigcommerce/forms-ccFields/_forms-ccFields.scss
+++ b/src/scss/components/bigcommerce/forms-ccFields/_forms-ccFields.scss
@@ -20,6 +20,10 @@
     flex-basis: 65%;
 }
 
+.form-field--stripe-ccNumber {
+    flex-basis: 100%;
+}
+
 .form-field--ccNumber--hasExpiryDate {
     flex-basis: 50%;
 }
@@ -40,6 +44,11 @@
 
 .form-field--postCode {
     flex-basis: 100%;
+    order: 5;
+}
+
+.form-field--stripe-postalCode {
+    flex-basis: 1%;
     order: 5;
 }
 

--- a/src/scss/components/checkout/widget/_widget.scss
+++ b/src/scss/components/checkout/widget/_widget.scss
@@ -54,6 +54,17 @@
     text-align: center;
 }
 
+.widget-input--stripev3 {
+    color: $color-black;
+    font: 400 1.1rem/normal sans-serif;
+    padding: 1rem;
+
+    &::placeholder {
+        color: rgb(117, 117, 117);
+        font: 400 1.1rem/normal sans-serif;
+    }
+}
+
 .widget--stripev3 {
     @extend .form-input;
 


### PR DESCRIPTION
## What? [INT-3086](https://jira.bigcommerce.com/browse/INT-3086)
Added optional render individual credit card fields on StripeV3
## Why?
So that merchants have the ability to display single card component or independent for each field.

## Testing / Proof
<img width="1327" alt="Testing Proof INt-3086" src="https://user-images.githubusercontent.com/61981535/94191543-432df180-fe73-11ea-8906-7a8969ae4d14.png">

## Dependencies
[Checkout-sdk #985](https://github.com/bigcommerce/checkout-sdk-js/pull/985)


@bigcommerce/checkout @bigcommerce/apex-integrations 
