### PR TITLE
fix(checkout): INT-3174 Allows create customized error modal

### DIFF
--- a/src/app/checkout/Checkout.spec.tsx
+++ b/src/app/checkout/Checkout.spec.tsx
@@ -9,7 +9,7 @@ import { BillingProps } from '../billing';
 import Billing from '../billing/Billing';
 import { getCart } from '../cart/carts.mock';
 import { getPhysicalItem } from '../cart/lineItem.mock';
-import { createErrorLogger, ErrorModal } from '../common/error';
+import { createErrorLogger, CustomError, ErrorModal } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
 import { CustomerInfo, CustomerInfoProps, CustomerProps, CustomerViewType } from '../customer';
 import { getCustomer } from '../customer/customers.mock';
@@ -159,6 +159,7 @@ describe('Checkout', () => {
             .mockReturnValue([
                 {
                     message: 'flash message',
+                    title: '',
                     type: 'error',
                 },
             ]);
@@ -170,6 +171,26 @@ describe('Checkout', () => {
 
         expect(container.find(ErrorModal).prop('error'))
             .toEqual(new Error('flash message'));
+    });
+
+    it('renders modal error when theres an custom error flash message', async () => {
+        jest.spyOn(checkoutState.data, 'getFlashMessages')
+            .mockReturnValue([
+                {
+                    message: 'flash message',
+                    title: 'flash title',
+                    type: 'error',
+                },
+            ]);
+
+        const container = mount(<CheckoutTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+        container.update();
+
+        const errorData = {data: {}, message: 'flash message', title: 'flash title', name: 'default'};
+        expect(container.find(ErrorModal).prop('error'))
+            .toEqual(new CustomError(errorData));
     });
 
     it('renders required checkout steps', () => {

--- a/src/app/common/error/CustomError.ts
+++ b/src/app/common/error/CustomError.ts
@@ -1,4 +1,4 @@
-export default abstract class CustomError extends Error {
+export default class CustomError extends Error {
     static shouldReport: boolean;
 
     data: any;


### PR DESCRIPTION
## What? [INT-3174](https://jira.bigcommerce.com/browse/INT-3174)
Allows create customized errors

## Why?
with that we are able to change the title

## Testing / Proof
https://drive.google.com/file/d/1ftq1CteeynosKSd1roKwBKE5_JGvtbHi/view?usp=sharing

## Siblings PRs
https://github.com/bigcommerce/checkout-sdk-js/pull/998
https://github.com/bigcommerce/bigcommerce/pull/37501

@bigcommerce/checkout @bigcommerce/apex-integrations 
