### PR TITLE
fix(payment): INT-3308 added style to avoid overlapping cards fields with Postcode label on it on stripeV3

### DIFF
--- a/src/scss/components/checkout/widget/_widget.scss
+++ b/src/scss/components/checkout/widget/_widget.scss
@@ -72,15 +72,21 @@
     margin-top: remCalc(20px);
     padding: 1rem;
 
-    @media screen and (max-width: 375px) {
-        margin: remCalc(20px) -2rem remCalc(20px) -2rem;
-        padding: 1rem;
+    @media screen and (max-width: $screen-large-iPhone) {
+        margin: remCalc(20px) 0 remCalc(20px) 0;
+        padding: 1rem 0 1rem 1rem;
         width: 20rem;
     }
 
-    @media screen and (max-width: 320px) {
+    @media screen and (max-width: $screen-medium-iPhone) {
+        margin: remCalc(20px) -2rem remCalc(20px) -2rem;
+        padding: 1rem 0 1rem 1rem;
+        width: 20rem;
+    }
+
+    @media screen and (max-width: $screen-xxsmall) {
         margin: remCalc(20px) -2rem remCalc(20px) -3rem;
-        padding: 1rem;
+        padding: 1rem 0 1rem 0.25rem;
         width: 19rem;
     }
 }

--- a/src/scss/settings/global/screensizes/_screensizes.scss
+++ b/src/scss/settings/global/screensizes/_screensizes.scss
@@ -13,3 +13,6 @@ $screen-medium:                 801px;
 $screen-small:                  551px;
 $screen-xsmall:                 481px;
 $screen-xxsmall:                320px;
+
+$screen-large-iPhone:           414px;
+$screen-medium-iPhone:          375px;


### PR DESCRIPTION
## What? [INT-3308](https://jira.bigcommerce.com/browse/INT-3308)
Added style to avoid overlapping Cards fields with Postcode label on it on stripeV3

## Why?
In order to avoid overlapping fields when Postcode label is showed on StripeV3.

## Testing / Proof
[Testing Proof video INT-2902](https://drive.google.com/file/d/1QylTdxD2BPOTW-0bpcjVI6silm1R919e/view?usp=sharing)

![Screen Shot 2020-10-08 at 6 35 26 PM](https://user-images.githubusercontent.com/61981535/95523777-288c6a00-0995-11eb-951a-8cb78cf59531.png)

@bigcommerce/checkout @bigcommerce/apex-integrations 


