### PR TITLE
CHECKOUT-5263 Default to empty array if no payments are set

### DIFF
--- a/src/app/customer/CheckoutButtonList.spec.tsx
+++ b/src/app/customer/CheckoutButtonList.spec.tsx
@@ -45,6 +45,20 @@ describe('CheckoutButtonList', () => {
             .toHaveLength(2);
     });
 
+    it('does not crash when no methods are passed', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <CheckoutButtonList
+                    deinitialize={ noop }
+                    initialize={ noop }
+                />
+            </LocaleContext.Provider>
+        );
+
+        expect(component.html())
+            .toBeFalsy();
+    });
+
     it('does not render if there are no supported methods', () => {
         const component = mount(
             <LocaleContext.Provider value={ localeContext }>

--- a/src/app/customer/CheckoutButtonList.tsx
+++ b/src/app/customer/CheckoutButtonList.tsx
@@ -20,7 +20,7 @@ export const SUPPORTED_METHODS: string[] = [
 ];
 
 export interface CheckoutButtonListProps {
-    methodIds: string[];
+    methodIds?: string[];
     checkEmbeddedSupport?(methodIds: string[]): void;
     deinitialize(options: CustomerRequestOptions): void;
     initialize(options: CustomerInitializeOptions): void;
@@ -33,7 +33,7 @@ const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
     methodIds,
     ...rest
 }) => {
-    const supportedMethodIds = methodIds
+    const supportedMethodIds = (methodIds ?? [])
         .filter(methodId => SUPPORTED_METHODS.indexOf(methodId) !== -1);
 
     if (supportedMethodIds.length === 0) {


### PR DESCRIPTION
## What?
Default to empty array if no payments are set

## Why?
Because some merchants are testing out installing a custom checkout without having any payment set up and it fails:
<img width="1189" alt="Screen Shot 2020-10-21 at 9 47 46 am" src="https://user-images.githubusercontent.com/1621894/96652400-8dc36080-1382-11eb-9198-28a321e61ef1.png">

## Testing / Proof
manual + unit

@bigcommerce/checkout
