### PR TITLE
CHECKOUT-5295 Hide AmazonPay when multi-shipping

### DIFF
--- a/src/app/payment/Payment.spec.tsx
+++ b/src/app/payment/Payment.spec.tsx
@@ -12,6 +12,7 @@ import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
 import { getOrder } from '../order/orders.mock';
+import { getConsignment } from '../shipping/consignment.mock';
 import { Button } from '../ui/button';
 
 import { getPaymentMethod } from './payment-methods.mock';
@@ -110,6 +111,26 @@ describe('Payment', () => {
                 onSubmit: expect.any(Function),
                 selectedMethod: paymentMethods[0],
             }));
+    });
+
+    it('does not render amazon if multi-shipping', async () => {
+        paymentMethods.push({ ...getPaymentMethod(), id: 'amazonpay' });
+
+        jest.spyOn(checkoutState.data, 'getConsignments')
+            .mockReturnValue([
+                getConsignment(),
+                getConsignment(),
+            ]);
+
+        const container = mount(<PaymentTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+        container.update();
+
+        paymentMethods.pop();
+
+        expect(container.find(PaymentForm).prop('methods'))
+            .toEqual(paymentMethods);
     });
 
     it('does not render bolt if showInCheckout is false', async () => {


### PR DESCRIPTION
## What?
Filter out `amazon` and `amazonpay` from payment methods when there are multiple consignments.

## Why?
Because those payment providers only support one single consignment.

## Testing / Proof
unit

<img width="584" alt="Screen Shot 2020-11-04 at 5 40 31 pm" src="https://user-images.githubusercontent.com/1621894/98078359-07e8fe80-1ec6-11eb-80fc-1d8184bee23e.png">
<img width="631" alt="Screen Shot 2020-11-04 at 5 40 46 pm" src="https://user-images.githubusercontent.com/1621894/98078364-091a2b80-1ec6-11eb-9e84-e04fabf540b0.png">


@bigcommerce/checkout
