### PR TITLE
CHECKOUT-5346 Hide multishipping if not enabled

### DIFF
--- a/src/app/checkout/Checkout.spec.tsx
+++ b/src/app/checkout/Checkout.spec.tsx
@@ -1,7 +1,7 @@
 import { createCheckoutService, createEmbeddedCheckoutMessenger, CheckoutSelectors, CheckoutService, EmbeddedCheckoutMessenger, StepTracker } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import { EventEmitter } from 'events';
-import { noop } from 'lodash';
+import { noop, omit } from 'lodash';
 import React, { FunctionComponent } from 'react';
 import { act } from 'react-dom/test-utils';
 
@@ -456,6 +456,68 @@ describe('Checkout', () => {
         it('renders shipping component when shipping step is active', () => {
             expect(container.find(Shipping).length)
                 .toEqual(1);
+        });
+
+        it('renders multi-shipping when enabled and there are multiple consignments', async () => {
+            jest.spyOn(checkoutState.data, 'getConsignments')
+                .mockReturnValue([
+                    omit(getConsignment(), 'selectedShippingOption'),
+                    omit(getConsignment(), 'selectedShippingOption'),
+                ]);
+
+            jest.spyOn(checkoutState.data, 'getConfig')
+                .mockReturnValue({
+                    ...getStoreConfig(),
+                    checkoutSettings: {
+                        ...getStoreConfig().checkoutSettings,
+                        hasMultiShippingEnabled: true,
+                    },
+                });
+
+            container = mount(<CheckoutTest { ...defaultProps } />);
+
+            (container.find(CheckoutStep) as ReactWrapper<CheckoutStepProps>)
+                .findWhere(step => step.prop('type') === CheckoutStepType.Shipping)
+                .at(0)
+                .prop('onEdit')(CheckoutStepType.Shipping);
+
+            // Wait for initial load to complete
+            await new Promise(resolve => process.nextTick(resolve));
+            container.update();
+
+            expect(container.find(Shipping).at(0).prop('isMultiShippingMode'))
+                .toEqual(true);
+        });
+
+        it('does not render multi-shipping when disabled even if there are multiple consignments', async () => {
+            jest.spyOn(checkoutState.data, 'getConsignments')
+                .mockReturnValue([
+                    omit(getConsignment(), 'selectedShippingOption'),
+                    omit(getConsignment(), 'selectedShippingOption'),
+                ]);
+
+            jest.spyOn(checkoutState.data, 'getConfig')
+                .mockReturnValue({
+                    ...getStoreConfig(),
+                    checkoutSettings: {
+                        ...getStoreConfig().checkoutSettings,
+                        hasMultiShippingEnabled: false,
+                    },
+                });
+
+            container = mount(<CheckoutTest { ...defaultProps } />);
+
+            (container.find(CheckoutStep) as ReactWrapper<CheckoutStepProps>)
+                .findWhere(step => step.prop('type') === CheckoutStepType.Shipping)
+                .at(0)
+                .prop('onEdit')(CheckoutStepType.Shipping);
+
+            // Wait for initial load to complete
+            await new Promise(resolve => process.nextTick(resolve));
+            container.update();
+
+            expect(container.find(Shipping).at(0).prop('isMultiShippingMode'))
+                .toEqual(false);
         });
 
         it('navigates to login view when shopper tries to sign in in order to use multi-shipping feature', () => {

--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -84,6 +84,7 @@ export interface WithCheckoutProps {
     hasCartChanged: boolean;
     flashMessages?: FlashMessage[];
     isGuestEnabled: boolean;
+    hasMultiShippingEnabled?: boolean;
     isLoadingCheckout: boolean;
     isPending: boolean;
     loginUrl: string;
@@ -123,6 +124,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
             embeddedStylesheet,
             loadCheckout,
             subscribeToConsignments,
+            hasMultiShippingEnabled,
         } = this.props;
 
         try {
@@ -154,7 +156,10 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
             const consignments = data.getConsignments();
             const cart = data.getCart();
-            const isMultiShippingMode = !!cart && !!consignments && isUsingMultiShipping(consignments, cart.lineItems);
+            const isMultiShippingMode = !!cart &&
+                !!consignments &&
+                hasMultiShippingEnabled &&
+                isUsingMultiShipping(consignments, cart.lineItems);
 
             if (isMultiShippingMode) {
                 this.setState({ isMultiShippingMode }, this.handleReady);

--- a/src/app/checkout/mapToCheckoutProps.ts
+++ b/src/app/checkout/mapToCheckoutProps.ts
@@ -14,7 +14,10 @@ export default function mapToCheckoutProps(
     const { promotions = EMPTY_ARRAY } = data.getCheckout() || {};
     const submitOrderError = errors.getSubmitOrderError() as CustomError;
     const {
-        checkoutSettings: { guestCheckoutEnabled: isGuestEnabled = false } = {},
+        checkoutSettings: {
+            guestCheckoutEnabled: isGuestEnabled = false,
+            hasMultiShippingEnabled = false,
+        } = {},
         links: { loginLink: loginUrl = '' } = {},
     } = data.getConfig() || {};
 
@@ -32,6 +35,7 @@ export default function mapToCheckoutProps(
         consignments: data.getConsignments(),
         hasCartChanged: submitOrderError && submitOrderError.type === 'cart_changed', // TODO: Need to clear the error once it's displayed
         isGuestEnabled,
+        hasMultiShippingEnabled,
         isLoadingCheckout: statuses.isLoadingCheckout(),
         isPending: statuses.isPending(),
         loadCheckout: checkoutService.loadCheckout,

--- a/src/app/shipping/Shipping.spec.tsx
+++ b/src/app/shipping/Shipping.spec.tsx
@@ -339,5 +339,30 @@ describe('Shipping Component', () => {
                 expect(component.find(ShippingForm).length).toEqual(1);
             });
         });
+
+        describe('when there are multiple consignments', () => {
+            beforeEach(async () => {
+                jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([
+                    getConsignment(),
+                    getConsignment(),
+                ]);
+
+                jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                    ...getStoreConfig(),
+                    checkoutSettings: {
+                        ...getStoreConfig().checkoutSettings,
+                        hasMultiShippingEnabled: false,
+                    },
+                });
+
+                component = mount(<ComponentTest { ...defaultProps } />);
+                await new Promise(resolve => process.nextTick(resolve));
+                component.update();
+            });
+
+            it('does not initialize any shipping address', () => {
+                expect(component.find(ShippingForm).prop('address')).toBeFalsy();
+            });
+        });
     });
 });

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -318,6 +318,8 @@ export function mapToShippingProps({
         countriesWithAutocomplete.push('GB');
     }
 
+    const shippingAddress = !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();
+
     return {
         assignItem: checkoutService.assignItemsToAddress,
         billingAddress: getBillingAddress(),
@@ -340,7 +342,7 @@ export function mapToShippingProps({
         loadShippingAddressFields: checkoutService.loadShippingAddressFields,
         loadShippingOptions: checkoutService.loadShippingOptions,
         methodId,
-        shippingAddress: getShippingAddress(),
+        shippingAddress,
         shouldShowMultiShipping,
         shouldShowOrderComments: enableOrderComments,
         signOut: checkoutService.signOutCustomer,


### PR DESCRIPTION
## What?
Hide multi-shipping UI if it is not enabled. If there are multiple consignments, then an empty shipping form will be shown.

## Why?
Checkout UI should honour the Checkout Settings. If it's not enabled, it shouldn't render the multi-shipping UI.
In some cases, some shoppers have been presented with a multi-shipping UI despite the setting being disabled.

Still not sure how they ended up with more than one shipping address in the first place, but this at least will prevent the shopper paying for shipping twice.

## Testing / Proof
<img width="1169" alt="Screen Shot 2020-11-09 at 3 24 49 pm" src="https://user-images.githubusercontent.com/1621894/98502905-625bd380-22a7-11eb-9ba2-eb0b674764a1.png">


@bigcommerce/checkout
