### PR TITLE
CHECKOUT-5327 Validate checkout safe values 

### DIFF
--- a/src/app/address/getAddressCustomFieldsValidationSchema.ts
+++ b/src/app/address/getAddressCustomFieldsValidationSchema.ts
@@ -8,6 +8,7 @@ import DynamicFormFieldType from './DynamicFormFieldType';
 export interface AddressValidationSchemaOptions {
     formFields: FormField[];
     language?: LanguageService;
+    shouldValidateSafeInput?: boolean;
 }
 
 const ERROR_KEYS: { [fieldName: string]: string } = {

--- a/src/app/billing/Billing.tsx
+++ b/src/app/billing/Billing.tsx
@@ -30,6 +30,7 @@ export interface WithCheckoutBillingProps {
     shouldShowOrderComments: boolean;
     billingAddress?: Address;
     methodId?: string;
+    shouldValidateSafeInput: boolean;
     getFields(countryCode?: string): FormField[];
     initialize(): Promise<CheckoutSelectors>;
     updateAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
@@ -162,6 +163,7 @@ function mapToBillingProps({
         countries: getBillingCountries() || EMPTY_ARRAY,
         countriesWithAutocomplete,
         customer,
+        shouldValidateSafeInput: features['CHECKOUT-5327.validate_checkout_values'],
         customerMessage: checkout.customerMessage,
         getFields: getBillingAddressFields,
         googleMapsApiKey,

--- a/src/app/billing/BillingForm.tsx
+++ b/src/app/billing/BillingForm.tsx
@@ -24,6 +24,7 @@ export interface BillingFormProps {
     isUpdating: boolean;
     methodId?: string;
     shouldShowOrderComments: boolean;
+    shouldValidateSafeInput: boolean;
     getFields(countryCode?: string): FormField[];
     onSubmit(values: BillingFormValues): void;
     onUnhandledError(error: Error): void;
@@ -155,10 +156,12 @@ export default withLanguage(withFormik<BillingFormProps & WithLanguageProps, Bil
     isInitialValid: ({
         billingAddress,
         getFields,
+        shouldValidateSafeInput,
         language,
     }) => (
         !!billingAddress && getAddressValidationSchema({
             language,
+            shouldValidateSafeInput,
             formFields: getFields(billingAddress.countryCode),
         }).isValidSync(billingAddress)
     ),
@@ -166,6 +169,7 @@ export default withLanguage(withFormik<BillingFormProps & WithLanguageProps, Bil
         language,
         getFields,
         methodId,
+        shouldValidateSafeInput,
     }: BillingFormProps & WithLanguageProps) => methodId === 'amazonpay' ?
         (lazy<Partial<AddressFormValues>>(values => getAddressCustomFieldsValidationSchema({
             language,
@@ -173,6 +177,7 @@ export default withLanguage(withFormik<BillingFormProps & WithLanguageProps, Bil
         }))) :
         (lazy<Partial<AddressFormValues>>(values => getAddressValidationSchema({
             language,
+            shouldValidateSafeInput,
             formFields: getFields(values && values.countryCode),
         }))),
     enableReinitialize: true,

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -17,6 +17,7 @@
             "custom_required_error": "{label} is required",
             "custom_min_error": "{label} should be bigger than {min}",
             "custom_max_error": "{label} should be smaller than {max}",
+            "invalid_characters_error": "{label} contains invalid characters",
             "custom_valid_error": "{label} is not valid",
             "edit_address_action": "Edit address",
             "enter_address_action": "Enter a new address",

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -44,6 +44,7 @@ export interface WithCheckoutShippingProps {
     shippingAddress?: Address;
     shouldShowMultiShipping: boolean;
     shouldShowOrderComments: boolean;
+    shouldValidateSafeInput: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitializeShippingMethod(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -343,6 +344,7 @@ export function mapToShippingProps({
         shippingAddress: getShippingAddress(),
         shouldShowMultiShipping,
         shouldShowOrderComments: enableOrderComments,
+        shouldValidateSafeInput: features['CHECKOUT-5327.validate_checkout_values'],
         signOut: checkoutService.signOutCustomer,
         unassignItem: checkoutService.unassignItemsToAddress,
         updateBillingAddress: checkoutService.updateBillingAddress,

--- a/src/app/shipping/ShippingForm.tsx
+++ b/src/app/shipping/ShippingForm.tsx
@@ -24,6 +24,7 @@ export interface ShippingFormProps {
     shippingAddress?: Address;
     shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
+    shouldValidateSafeInput: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -67,6 +68,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
             shippingAddress,
             shouldShowOrderComments,
             shouldShowSaveAddress,
+            shouldValidateSafeInput,
             signOut,
             updateAddress,
             isShippingStepPending,
@@ -111,6 +113,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
                 shippingAddress={ shippingAddress }
                 shouldShowOrderComments={ shouldShowOrderComments }
                 shouldShowSaveAddress={ shouldShowSaveAddress }
+                shouldValidateSafeInput={ shouldValidateSafeInput }
                 signOut={ signOut }
                 updateAddress={ updateAddress }
             />;

--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -28,6 +28,7 @@ export interface SingleShippingFormProps {
     methodId?: string;
     shippingAddress?: Address;
     shouldShowSaveAddress?: boolean;
+    shouldValidateSafeInput: boolean;
     shouldShowOrderComments: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -309,6 +310,7 @@ export default withLanguage(withFormik<SingleShippingFormProps & WithLanguagePro
         language,
         getFields,
         methodId,
+        shouldValidateSafeInput,
     }: SingleShippingFormProps & WithLanguageProps) => methodId ?
         object({
             shippingAddress: lazy<Partial<AddressFormValues>>(formValues =>
@@ -322,6 +324,7 @@ export default withLanguage(withFormik<SingleShippingFormProps & WithLanguagePro
             shippingAddress: lazy<Partial<AddressFormValues>>(formValues =>
                 getAddressValidationSchema({
                     language,
+                    shouldValidateSafeInput,
                     formFields: getFields(formValues && formValues.countryCode),
                 })
             ),


### PR DESCRIPTION
## What?
Validate that provided values are considered "safe", that means, does not contain any of the following:
```
< >
```

## Why?
To avoid fraudulent/suspicious activity.

## Testing / Proof
Experiment ON:
<img width="736" alt="Screen Shot 2020-11-09 at 5 14 13 pm" src="https://user-images.githubusercontent.com/1621894/98506161-02692b00-22af-11eb-9e26-d46c14984336.png">


Experiment OFF:
<img width="735" alt="Screen Shot 2020-11-09 at 5 15 02 pm" src="https://user-images.githubusercontent.com/1621894/98506225-1f9df980-22af-11eb-9ae7-717f586ef5f9.png">


@bigcommerce/checkout
