### PR TITLE
fix(common): CHECKOUT-5332 Only send in-app errors to Sentry

### DIFF
--- a/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/src/app/common/error/SentryErrorLogger.spec.ts
@@ -3,7 +3,6 @@ import { RewriteFrames } from '@sentry/integrations';
 import { Integration } from '@sentry/types';
 
 import computeErrorCode from './computeErrorCode';
-import DEFAULT_ERROR_TYPES from './defaultErrorTypes';
 import ConsoleErrorLogger from './ConsoleErrorLogger';
 import { ErrorLevelType } from './ErrorLogger';
 import SentryErrorLogger from './SentryErrorLogger';
@@ -93,7 +92,7 @@ describe('SentryErrorLogger', () => {
             .toEqual(null);
     });
 
-    it('logs exception event if some frames in stacktrace contain filename', () => {
+    it('logs exception event if all frames in stacktrace reference app file', () => {
         // tslint:disable-next-line:no-unused-expression
         new SentryErrorLogger(config);
 
@@ -101,7 +100,7 @@ describe('SentryErrorLogger', () => {
         const event = {
             exception: {
                 values: [{
-                    stacktrace: { frames: [{ filename: '' }, { filename: 'js/app-123.js' }] },
+                    stacktrace: { frames: [{ filename: 'app:///js/app-123.js' }, { filename: 'app:///js/app-456.js' }] },
                     type: 'Error',
                     value: 'Unexpected error',
                 }],


### PR DESCRIPTION
## What?
Only send errors that originated from application code and its dependencies.

## Why?
We're not responsible for errors that are caused by code that is external to the application.

At the moment, we are seeing some errors in our log that are caused by third party scripts, such as [Klaviyo](https://sentry.io/organizations/bigcommerce/issues/1904396678) and [Poptin](https://sentry.io/organizations/bigcommerce/issues/2050108407). We realised that `whitelistUrls` and `blacklistUrls` config provided by Sentry client only checks the topmost frame in the stack trace. This means that it won't filter out those exception events if they are caused by problems deeper in the stack trace. i.e.:

<img width="673" alt="Screen Shot 2020-11-23 at 1 47 13 pm" src="https://user-images.githubusercontent.com/667603/99937354-a4156f80-2db9-11eb-8906-7cbd011cd66c.png">

We can't filter them using Sentry's server-side config because it can only filter out exceptions by error messages, not file path. File paths can only be used for grouping of events. So the filtering has to be done on the client side.

## Testing / Proof
### Before
There's a call to Sentry, even though the error is caused by an external script (https://127.0.0.1:8080/index.js):

<img width="1258" alt="Screen Shot 2020-11-23 at 6 03 27 pm" src="https://user-images.githubusercontent.com/667603/99937369-ad064100-2db9-11eb-9abf-e9c663d2d597.png">

### After
There's no call to Sentry:

<img width="1259" alt="Screen Shot 2020-11-23 at 6 06 37 pm" src="https://user-images.githubusercontent.com/667603/99937386-b5f71280-2db9-11eb-88da-ed5701c1041b.png">

Exceptions thrown by the application still get logged:

<img width="1259" alt="Screen Shot 2020-11-23 at 6 06 37 pm" src="https://user-images.githubusercontent.com/667603/99937479-f060af80-2db9-11eb-9fb1-5fbc8dee85ee.png">

@bigcommerce/checkout
