### PR TITLE
CHECKOUT-5300: Fix order confirmation page redirection fails if existing url contains query param

### DIFF
--- a/src/app/checkout/Checkout.spec.tsx
+++ b/src/app/checkout/Checkout.spec.tsx
@@ -687,7 +687,7 @@ describe('Checkout', () => {
                 .prop('onSubmit')!();
 
             expect(location.replace)
-                .toHaveBeenCalledWith(`${window.location.href}/order-confirmation`);
+                .toHaveBeenCalledWith('/order-confirmation');
         });
 
         it('navigates to order confirmation page when order is finalized', () => {
@@ -696,7 +696,7 @@ describe('Checkout', () => {
                 .prop('onFinalize')!();
 
             expect(location.replace)
-                .toHaveBeenCalledWith(`${window.location.href}/order-confirmation`);
+                .toHaveBeenCalledWith('/order-confirmation');
         });
 
         it('posts message to parent of embedded checkout when shopper completes checkout', () => {

--- a/src/app/checkout/navigateToOrderConfirmation.spec.tsx
+++ b/src/app/checkout/navigateToOrderConfirmation.spec.tsx
@@ -1,0 +1,30 @@
+import navigateToOrderConfirmation from './navigateToOrderConfirmation';
+
+describe('navigateToOrderConfirmation', () => {
+    let locationMock: Pick<Location, 'pathname' | 'href' | 'replace'>;
+
+    beforeEach(() => {
+        locationMock = {
+            href: 'https://store.com/checkout',
+            pathname: '/checkout',
+            replace: jest.fn(),
+        };
+    });
+
+    it('navigates to order confirmation page based on its current path', () => {
+        navigateToOrderConfirmation(locationMock as Location);
+
+        expect(locationMock.replace)
+            .toHaveBeenCalledWith('/checkout/order-confirmation');
+    });
+
+    it('discards any query params when navigating to order confirmation page', () => {
+        locationMock.href = 'https://store.com/embedded-checkout?setCurrencyId=1';
+        locationMock.pathname = '/embedded-checkout';
+
+        navigateToOrderConfirmation(locationMock as Location);
+
+        expect(locationMock.replace)
+            .toHaveBeenCalledWith('/embedded-checkout/order-confirmation');
+    });
+});

--- a/src/app/checkout/navigateToOrderConfirmation.tsx
+++ b/src/app/checkout/navigateToOrderConfirmation.tsx
@@ -1,9 +1,9 @@
 import { noop } from 'lodash';
 
-export default function navigateToOrderConfirmation(): Promise<never> {
-    const url = `${window.location.href}/order-confirmation`;
+export default function navigateToOrderConfirmation(location = window.location): Promise<never> {
+    const url = `${location.pathname.replace(/\/$/, '')}/order-confirmation`;
 
-    window.location.replace(url);
+    location.replace(url);
 
     return new Promise(noop);
 }


### PR DESCRIPTION
## What?
At the moment, the redirect to the order confirmation page fails if the current page URL contains a query param, e.g.: `/embedded-checkout?setCurrencyId=1`. This PR fixes the issue by discarding the query param when constructing the redirect URL.

This PR addresses #446.

## Why?
Otherwise, the redirection doesn't work (see the below & after screenshots below).

## Testing / Proof

Please note that embedded-checkout is supposed to load inside an iframe. But for the purpose of demonstration, I loaded it directly in the browser so that the URL could be visible.

### Before
<img width="1282" alt="Screen Shot 2020-12-01 at 5 10 51 pm" src="https://user-images.githubusercontent.com/667603/100708797-0f39f400-3401-11eb-83d0-c64f96a0c8dc.png">

### After
![currency-redirect](https://user-images.githubusercontent.com/667603/100708810-16610200-3401-11eb-9b1c-e8557086ebd5.gif)

@bigcommerce/checkout
