### PR TITLE
docs(common): ISSUE-475 Update OS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ In order to build from the source code, you must have the following set up in yo
 
 * Node >= v10.
 * NPM >= v3.
+* Unix-based operating system.
 
 One of the simplest ways to install Node is using [NVM](https://github.com/nvm-sh/nvm#installation-and-update). You can follow their instructions to set up your environment if it is not already set up.
 


### PR DESCRIPTION
## What?
Update OS requirement, as per https://github.com/bigcommerce/checkout-js/issues/475

## Why?
So devs know that Unix-like is supported. In order to use Windows, they might need a Unix simulator tool.

## Testing / Proof
n/a

@bigcommerce/checkout
