### PR TITLE
feat(payment): INT-3538 Added translation method on  credit debit card title on adyenv2

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -155,6 +155,7 @@
             "unsupported_error": "The following payment methods are not supported by Embedded Checkout: {methods}. Please contact us for assistance."
         },
         "payment": {
+            "adyen_credit_debit_card_text": "Credit/Debit Card",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Pay over time",
             "affirm_body_text": "You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.",

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -111,7 +111,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.AdyenV2]: {
                 logoUrl: `https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/${(method.method === 'scheme') ? 'card' : method.method}.svg`,
-                titleText: (method.config.displayName === 'Credit Card' ? 'Credit/Debit Card' : method.config.displayName) || '',
+                titleText: (method.config.displayName === 'Credit Card' ? language.translate('payment.adyen_credit_debit_card_text') : method.config.displayName) || '',
             },
         };
 


### PR DESCRIPTION
## What? [INT-3538](url)
Added translation method on credit debit card title on adyenv2.

## Why?
So that title payment method could be translated on adyenv2.

## Testing / Proof
![Screen Shot 2020-12-08 at 1 27 41 PM](https://user-images.githubusercontent.com/61981535/101531868-65ef8280-3959-11eb-9eae-91f481d91c67.png)

## Sibling PR's
[Checkout-sdk-js #1031](https://github.com/bigcommerce/checkout-sdk-js/pull/1031)


