### PR TITLE
chore(common): PAYPAL-767 Bump checkout-sdk-js 1.118.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,9 +1608,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.118.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.118.1.tgz",
-      "integrity": "sha512-qvWj0HgVQlL5Bo7wOCXf4/yw8hw7cOFuQk6VUMRk8ERmdQNW3TF+FiONzd71OtZGPvM3mfx8k/lmgHicip274A==",
+      "version": "1.118.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.118.2.tgz",
+      "integrity": "sha512-2VgV7PlOlSUzd5fRN2yIV8vn3qMfsDR6goTiEiXButsYr6qrGteBn96bzuBAp3u+/FaMixf2No2lgimMko95bw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.118.1",
+    "@bigcommerce/checkout-sdk": "^1.118.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk-js 1.118.2

## Why?

Fixed Braintree integration

## Testing / Proof
...

@bigcommerce/checkout
