### PR TITLE
CHECKOUT-5477 Check if multi-shipping is enabled once config is loaded

### DIFF
--- a/src/app/checkout/Checkout.spec.tsx
+++ b/src/app/checkout/Checkout.spec.tsx
@@ -62,7 +62,18 @@ describe('Checkout', () => {
         };
 
         jest.spyOn(checkoutService, 'loadCheckout')
-            .mockResolvedValue(checkoutState);
+            .mockImplementation(() => new Promise(resolve => {
+                jest.spyOn(checkoutState.data, 'getConfig')
+                    .mockReturnValue({
+                        ...getStoreConfig(),
+                        checkoutSettings: {
+                            ...getStoreConfig().checkoutSettings,
+                            hasMultiShippingEnabled: true,
+                        },
+                    });
+
+                resolve(checkoutState);
+            }));
 
         jest.spyOn(checkoutService, 'getState')
             .mockImplementation(() => checkoutState);
@@ -486,15 +497,6 @@ describe('Checkout', () => {
                     omit(getConsignment(), 'selectedShippingOption'),
                 ]);
 
-            jest.spyOn(checkoutState.data, 'getConfig')
-                .mockReturnValue({
-                    ...getStoreConfig(),
-                    checkoutSettings: {
-                        ...getStoreConfig().checkoutSettings,
-                        hasMultiShippingEnabled: true,
-                    },
-                });
-
             container = mount(<CheckoutTest { ...defaultProps } />);
 
             (container.find(CheckoutStep) as ReactWrapper<CheckoutStepProps>)
@@ -517,14 +519,19 @@ describe('Checkout', () => {
                     omit(getConsignment(), 'selectedShippingOption'),
                 ]);
 
-            jest.spyOn(checkoutState.data, 'getConfig')
-                .mockReturnValue({
-                    ...getStoreConfig(),
-                    checkoutSettings: {
-                        ...getStoreConfig().checkoutSettings,
-                        hasMultiShippingEnabled: false,
-                    },
-                });
+            jest.spyOn(checkoutService, 'loadCheckout')
+                .mockImplementation(() => new Promise(resolve => {
+                    jest.spyOn(checkoutState.data, 'getConfig')
+                        .mockReturnValue({
+                            ...getStoreConfig(),
+                            checkoutSettings: {
+                                ...getStoreConfig().checkoutSettings,
+                                hasMultiShippingEnabled: false,
+                            },
+                        });
+
+                    resolve(checkoutState);
+                }));
 
             container = mount(<CheckoutTest { ...defaultProps } />);
 

--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -84,7 +84,6 @@ export interface WithCheckoutProps {
     hasCartChanged: boolean;
     flashMessages?: FlashMessage[];
     isGuestEnabled: boolean;
-    hasMultiShippingEnabled?: boolean;
     isLoadingCheckout: boolean;
     isPending: boolean;
     loginUrl: string;
@@ -124,7 +123,6 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
             embeddedStylesheet,
             loadCheckout,
             subscribeToConsignments,
-            hasMultiShippingEnabled,
         } = this.props;
 
         try {
@@ -165,6 +163,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
             const consignments = data.getConsignments();
             const cart = data.getCart();
+            const hasMultiShippingEnabled = data.getConfig()?.checkoutSettings?.hasMultiShippingEnabled;
             const isMultiShippingMode = !!cart &&
                 !!consignments &&
                 hasMultiShippingEnabled &&

--- a/src/app/checkout/mapToCheckoutProps.ts
+++ b/src/app/checkout/mapToCheckoutProps.ts
@@ -16,7 +16,6 @@ export default function mapToCheckoutProps(
     const {
         checkoutSettings: {
             guestCheckoutEnabled: isGuestEnabled = false,
-            hasMultiShippingEnabled = false,
         } = {},
         links: { loginLink: loginUrl = '' } = {},
     } = data.getConfig() || {};
@@ -35,7 +34,6 @@ export default function mapToCheckoutProps(
         consignments: data.getConsignments(),
         hasCartChanged: submitOrderError && submitOrderError.type === 'cart_changed', // TODO: Need to clear the error once it's displayed
         isGuestEnabled,
-        hasMultiShippingEnabled,
         isLoadingCheckout: statuses.isLoadingCheckout(),
         isPending: statuses.isPending(),
         loadCheckout: checkoutService.loadCheckout,


### PR DESCRIPTION
## What?
Check if multi-shipping is enabled once checkout has loaded.

## Why?
At the moment we check if the setting is enabled before the config is loaded, which will result in always false, causing single-shipping mode to always be loaded after a new address is added via the account settings page.

## Testing / Proof
![multishipping](https://user-images.githubusercontent.com/1621894/102742889-305f8600-43aa-11eb-9794-adc0371304e3.gif)


@bigcommerce/checkout
