### PR TITLE
feat(payments): INT-3637 removed Zip code from individual fields form on StripeV3

### DIFF
--- a/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -184,9 +184,6 @@ describe('when using Stripe payment', () => {
                                 placeholder: '',
                                 containerId: 'stripe-cvc-component-field',
                             },
-                            zipCodeElementOptions: {
-                                containerId: 'stripe-postal-code-component-field',
-                            },
                         },
                     },
                 });

--- a/src/app/payment/paymentMethod/StripePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.tsx
@@ -83,9 +83,6 @@ const StripePaymentMethod: FunctionComponent<StripePaymentMethodProps & WithChec
                 ...stripeInitializeOptions[StripeElementType.cardCvc],
                 containerId: 'stripe-cvc-component-field',
             },
-            zipCodeElementOptions: {
-                containerId: 'stripe-postal-code-component-field',
-            },
         };
     }, []);
 

--- a/src/app/payment/paymentMethod/StripeV3CustomCardForm.spec.tsx
+++ b/src/app/payment/paymentMethod/StripeV3CustomCardForm.spec.tsx
@@ -19,9 +19,6 @@ describe('StripeV3CustomCardForm', () => {
                 cardCvcElementOptions: {
                     containerId: 'stripe-cvc-component-field',
                 },
-                zipCodeElementOptions: {
-                    containerId: 'stripe-postal-code-component-field',
-                },
             },
         };
 
@@ -46,11 +43,5 @@ describe('StripeV3CustomCardForm', () => {
         const container = mount(<StripeV3CustomCardFormTest { ...defaultProps } />);
 
         expect(container.find('#stripe-cvc-component-field').length).toEqual(1);
-    });
-
-    it('renders stripeV3 postal code field', () => {
-        const container = mount(<StripeV3CustomCardFormTest { ...defaultProps } />);
-
-        expect(container.find('#stripe-postal-code-component-field').length).toEqual(1);
     });
 });

--- a/src/app/payment/paymentMethod/StripeV3CustomCardForm.tsx
+++ b/src/app/payment/paymentMethod/StripeV3CustomCardForm.tsx
@@ -16,9 +16,6 @@ export interface StripeV3CustomCardFormProps {
         cardCvcElementOptions: {
             containerId: string;
         };
-        zipCodeElementOptions?: {
-            containerId: string;
-        };
     };
 }
 
@@ -86,20 +83,6 @@ const StripeV3CustomCardForm: React.FunctionComponent<StripeV3CustomCardFormProp
                 <IconLock />
             </>
         </div>
-        { options.zipCodeElementOptions && <div className="form-field form-field--stripe-postalCode">
-            <label className="form-label optimizedCheckout-form-label" htmlFor={ options.zipCodeElementOptions.containerId }>
-                <TranslatedString id="payment.postal_code_label" />
-            </label>
-            <input
-                className={ classNames(
-                    'form-input',
-                    'optimizedCheckout-form-input',
-                    'widget-input--stripev3'
-                ) }
-                data-cse="stripe-postal-code"
-                id={ options.zipCodeElementOptions.containerId }
-            />
-        </div> }
     </div>
 );
 


### PR DESCRIPTION
## What? [INT-3637](https://jira.bigcommerce.com/browse/INT-3637)
Removed Zip code from individual fields form on StripeV3

## Why?
Removed the zip code field from payment step to reduce the redundancy of having to enter zip code twice in checkout.

## Testing / Proof

Before:

![Screen Shot 2020-12-23 at 10 46 13 AM](https://user-images.githubusercontent.com/61981535/103019314-3c635900-450c-11eb-9bb6-dd2d04fefbb5.png)

After:

![Screen Shot 2020-12-22 at 1 16 49 PM](https://user-images.githubusercontent.com/61981535/102934752-606e5e00-446a-11eb-8aab-49828f8f540a.png)


@bigcommerce/checkout @bigcommerce/apex-integrations 
