### PR TITLE
fix(payment): INT-3717 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1366,9 +1366,9 @@
           }
         },
         "fsevents": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
-          "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+          "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
           "optional": true
         },
         "graceful-fs": {
@@ -1608,9 +1608,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.121.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.121.0.tgz",
-      "integrity": "sha512-p8dOTd6jJrsQz+v9ge9fpTqYheAT0TzPpTmayfNEQI3R+Qha/S3CovSB7jbkH2vC5uelRkFDpvBfdV7ayZAQuw==",
+      "version": "1.121.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.121.1.tgz",
+      "integrity": "sha512-xIn6HVrbuKmIVgOcWy442fUlUZ6mWWMUy2sE1vjSjY9LNoHX8yK+nGptAvdxTOrEYH7lPSj8zNkYoZ5TlMblmw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.0",
@@ -1664,9 +1664,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.166",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
-          "integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA=="
+          "version": "4.14.167",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
+          "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw=="
         },
         "@types/yup": {
           "version": "0.26.37",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.121.0",
+    "@bigcommerce/checkout-sdk": "^1.121.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to v1.121.1

## Why?
To include https://github.com/bigcommerce/checkout-sdk-js/pull/1054

## Testing / Proof
Circle CI, Manual

@bigcommerce/checkout
