### PR TITLE
CHECKOUT-5529 Render gift wrapping in cart summary

### DIFF
--- a/src/app/order/OrderSummaryItem.spec.tsx
+++ b/src/app/order/OrderSummaryItem.spec.tsx
@@ -69,4 +69,21 @@ describe('OrderSummaryItems', () => {
                 .not.toContain('product-price--beforeDiscount');
         });
     });
+
+    describe('when description is present', () => {
+        beforeEach(() => {
+            orderSummaryItem = shallow(<OrderSummaryItem
+                amount={ 10 }
+                description="Description"
+                id="foo"
+                name="Product"
+                quantity={ 2 }
+            />);
+        });
+
+        it('does render description', () => {
+            expect(orderSummaryItem.find('[data-test="cart-item-product-description"]').text())
+                .toEqual('Description');
+        });
+    });
 });

--- a/src/app/order/OrderSummaryItem.tsx
+++ b/src/app/order/OrderSummaryItem.tsx
@@ -11,6 +11,7 @@ export interface OrderSummaryItemProps {
     name: string;
     amountAfterDiscount?: number;
     image?: ReactNode;
+    description?: ReactNode;
     productOptions?: OrderSummaryItemOption[];
 }
 
@@ -26,6 +27,7 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
     name,
     productOptions,
     quantity,
+    description,
 }) => (
     <div className="product" data-test="cart-item">
         <figure className="product-column product-figure">
@@ -39,7 +41,6 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
             >
                 { `${quantity} x ${name}` }
             </h5>
-
             <ul
                 className="product-options optimizedCheckout-contentSecondary"
                 data-test="cart-item-product-options"
@@ -54,6 +55,12 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                     </li>
                 ) }
             </ul>
+            { description && <div
+                className="product-description optimizedCheckout-contentSecondary"
+                data-test="cart-item-product-description"
+            >
+                { description }
+            </div> }
         </div>
 
         <div className="product-column product-actions">

--- a/src/app/order/mapFromPhysical.tsx
+++ b/src/app/order/mapFromPhysical.tsx
@@ -1,9 +1,25 @@
 import { PhysicalItem } from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { ShopperCurrency } from '../currency';
 
 import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { OrderSummaryItemProps } from './OrderSummaryItem';
 
 function mapFromPhysical(item: PhysicalItem): OrderSummaryItemProps {
+    let description;
+
+    if (item.giftWrapping) {
+        description = (
+            <>
+                { item.giftWrapping.name }
+                { ' (' }
+                <ShopperCurrency amount={ item.giftWrapping.amount } />
+                { ')' }
+            </>
+        );
+    }
+
     return {
         id: item.id,
         quantity: item.quantity,
@@ -11,6 +27,7 @@ function mapFromPhysical(item: PhysicalItem): OrderSummaryItemProps {
         amountAfterDiscount: item.extendedSalePrice,
         name: item.name,
         image: getOrderSummaryItemImage(item),
+        description,
         productOptions: (item.options || []).map(option => ({
             testId: 'cart-item-product-option',
             content: `${option.name} ${option.value}`,

--- a/src/scss/components/checkout/productList/_productList.scss
+++ b/src/scss/components/checkout/productList/_productList.scss
@@ -69,6 +69,10 @@
     margin: 0;
 }
 
+.product-description {
+    margin-top: spacing("quarter");
+}
+
 .product-actions {
     align-self: center;
     margin-left: auto;


### PR DESCRIPTION
## What?
Render gift wrapping as product description

## Why?
Because currently we do not render this information, and totals won't match

## Testing / Proof
<img width="455" alt="Screen Shot 2021-01-15 at 12 19 14 pm" src="https://user-images.githubusercontent.com/1621894/104668762-d180f880-572c-11eb-8750-36049a5d7f93.png">


@bigcommerce/checkout
