### PR TITLE
 CHECKOUT-2322 Show gift wrapping cost

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,9 +1608,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.121.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.121.1.tgz",
-      "integrity": "sha512-xIn6HVrbuKmIVgOcWy442fUlUZ6mWWMUy2sE1vjSjY9LNoHX8yK+nGptAvdxTOrEYH7lPSj8zNkYoZ5TlMblmw==",
+      "version": "1.122.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.122.0.tgz",
+      "integrity": "sha512-ErHaJBvF7FRKB3dQO9Ati5Ppif0hHTtuvFKXabpznmgu2obB74LOnrEjUIOHoEUL5y8xVMTBPrNHTuQILwP4fA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.0",
@@ -1664,9 +1664,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.167",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
-          "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw=="
+          "version": "4.14.168",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+          "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
         "@types/yup": {
           "version": "0.26.37",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.121.1",
+    "@bigcommerce/checkout-sdk": "^1.122.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/cart/mapToOrderSummarySubtotalsProps.ts
+++ b/src/app/cart/mapToOrderSummarySubtotalsProps.ts
@@ -10,6 +10,7 @@ export default function mapToOrderSummarySubtotalsProps({
     consignments,
     handlingCostTotal,
     shippingCostBeforeDiscount,
+    giftWrappingCostTotal,
     coupons,
     taxes,
 }: Checkout): OrderSummarySubtotalsProps {
@@ -17,6 +18,7 @@ export default function mapToOrderSummarySubtotalsProps({
         subtotalAmount: subtotal,
         discountAmount,
         giftCertificates,
+        giftWrappingAmount: giftWrappingCostTotal,
         shippingAmount: hasSelectedShippingOptions(consignments) ?
             shippingCostBeforeDiscount :
             undefined,

--- a/src/app/checkout/checkouts.mock.ts
+++ b/src/app/checkout/checkouts.mock.ts
@@ -32,6 +32,7 @@ export function getCheckout(): Checkout {
         taxTotal: 3,
         subtotal: 190,
         grandTotal: 190,
+        giftWrappingCostTotal: 0,
         outstandingBalance: 190,
         giftCertificates: [],
         balanceDue: 0,

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -65,6 +65,7 @@
             "see_all_action": "See All",
             "see_less_action": "See Less",
             "shipping_text": "Shipping",
+            "gift_wrapping_text": "Gift Wrapping",
             "show_details_action": "Show Details",
             "store_credit_text": "Store Credit",
             "subtotal_text": "Subtotal",

--- a/src/app/order/OrderSummaryDrawer.tsx
+++ b/src/app/order/OrderSummaryDrawer.tsx
@@ -34,6 +34,7 @@ const OrderSummaryDrawer: FunctionComponent<OrderSummaryDrawerProps & OrderSumma
     shippingAmount,
     shopperCurrency,
     storeCreditAmount,
+    giftWrappingAmount,
     storeCurrency,
     subtotalAmount,
     taxes,
@@ -46,6 +47,7 @@ const OrderSummaryDrawer: FunctionComponent<OrderSummaryDrawerProps & OrderSumma
             coupons={ coupons }
             discountAmount={ discountAmount }
             giftCertificates={ giftCertificates }
+            giftWrappingAmount={  giftWrappingAmount }
             handlingAmount={ handlingAmount }
             headerLink={ headerLink }
             lineItems={ lineItems }
@@ -69,6 +71,7 @@ const OrderSummaryDrawer: FunctionComponent<OrderSummaryDrawerProps & OrderSumma
         lineItems,
         onRemovedCoupon,
         onRemovedGiftCertificate,
+        giftWrappingAmount,
         shippingAmount,
         shopperCurrency,
         storeCreditAmount,

--- a/src/app/order/OrderSummarySubtotals.tsx
+++ b/src/app/order/OrderSummarySubtotals.tsx
@@ -11,6 +11,7 @@ export interface OrderSummarySubtotalsProps {
     giftCertificates?: GiftCertificate[];
     discountAmount?: number;
     taxes?: Tax[];
+    giftWrappingAmount?: number;
     shippingAmount?: number;
     handlingAmount?: number;
     storeCreditAmount?: number;
@@ -23,6 +24,7 @@ const OrderSummarySubtotals: FunctionComponent<OrderSummarySubtotalsProps> = ({
     discountAmount,
     giftCertificates,
     taxes,
+    giftWrappingAmount,
     shippingAmount,
     subtotalAmount,
     handlingAmount,
@@ -69,6 +71,12 @@ const OrderSummarySubtotals: FunctionComponent<OrderSummarySubtotalsProps> = ({
                     testId="cart-gift-certificate"
                 />
         ) }
+
+        { !!giftWrappingAmount && <OrderSummaryPrice
+            amount={ giftWrappingAmount }
+            label={ <TranslatedString id="cart.gift_wrapping_text" /> }
+            testId="cart-gift-wrapping"
+        /> }
 
         <OrderSummaryPrice
             amount={ shippingAmount }

--- a/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
@@ -104,6 +104,7 @@ exports[`OrderSummary when shopper has same currency as store renders order summ
           },
         ]
       }
+      giftWrappingAmount={0}
       handlingAmount={8}
       shippingAmount={20}
       storeCreditAmount={0}

--- a/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
@@ -127,6 +127,7 @@ exports[`OrderSummaryModal renders order summary 1`] = `
           },
         ]
       }
+      giftWrappingAmount={0}
       handlingAmount={8}
       shippingAmount={20}
       storeCreditAmount={0}

--- a/src/app/order/mapFromPhysical.tsx
+++ b/src/app/order/mapFromPhysical.tsx
@@ -1,25 +1,9 @@
 import { PhysicalItem } from '@bigcommerce/checkout-sdk';
-import React from 'react';
-
-import { ShopperCurrency } from '../currency';
 
 import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { OrderSummaryItemProps } from './OrderSummaryItem';
 
 function mapFromPhysical(item: PhysicalItem): OrderSummaryItemProps {
-    let description;
-
-    if (item.giftWrapping) {
-        description = (
-            <>
-                { item.giftWrapping.name }
-                { ' (' }
-                <ShopperCurrency amount={ item.giftWrapping.amount } />
-                { ')' }
-            </>
-        );
-    }
-
     return {
         id: item.id,
         quantity: item.quantity,
@@ -27,7 +11,7 @@ function mapFromPhysical(item: PhysicalItem): OrderSummaryItemProps {
         amountAfterDiscount: item.extendedSalePrice,
         name: item.name,
         image: getOrderSummaryItemImage(item),
-        description,
+        description: item.giftWrapping ? item.giftWrapping.name : undefined,
         productOptions: (item.options || []).map(option => ({
             testId: 'cart-item-product-option',
             content: `${option.name} ${option.value}`,

--- a/src/app/order/mapToOrderSummarySubtotalsProps.ts
+++ b/src/app/order/mapToOrderSummarySubtotalsProps.ts
@@ -11,12 +11,14 @@ export default function mapToOrderSummarySubtotalsProps({
     shippingCostBeforeDiscount,
     payments,
     handlingCostTotal,
+    giftWrappingCostTotal,
     coupons,
     taxes,
 }: Order): OrderSummarySubtotalsProps {
     return {
         subtotalAmount: baseAmount,
         shippingAmount: shippingCostBeforeDiscount,
+        giftWrappingAmount: giftWrappingCostTotal,
         discountAmount,
         storeCreditAmount: getStoreCreditAmount(payments),
         handlingAmount: handlingCostTotal,

--- a/src/app/order/orders.mock.ts
+++ b/src/app/order/orders.mock.ts
@@ -40,6 +40,7 @@ export function getOrder(): Order {
                 amount: 3,
             },
         ],
+        giftWrappingCostTotal: 0,
         taxTotal: 3,
         shippingCostTotal: 15,
         shippingCostBeforeDiscount: 20,


### PR DESCRIPTION
## What?
Show gift wrapping cost in order summary. Also "tag" items that contains gift wrapping
Note: depends on SDK Changes and API changes
https://github.com/bigcommerce/bigcommerce/pull/39048
https://github.com/bigcommerce/checkout-sdk-js/pull/1058

## Why?
So totals add up and shoppers can understand the difference between the subtotal and the grand total.

## Testing / Proof
unit
Tested in conjunction with the API changes, see screenshots in https://github.com/bigcommerce/bigcommerce/pull/39048

@bigcommerce/checkout
