### PR TITLE
feat(payment): ADYEN-8  bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,9 +1608,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.122.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.122.0.tgz",
-      "integrity": "sha512-ErHaJBvF7FRKB3dQO9Ati5Ppif0hHTtuvFKXabpznmgu2obB74LOnrEjUIOHoEUL5y8xVMTBPrNHTuQILwP4fA==",
+      "version": "1.123.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.123.0.tgz",
+      "integrity": "sha512-1ghA/Uns79MJ0RmWOf2bWqTCH8rhc7xf+TWzADx1n1kXwf/rLkqmkv8XIqQ0TptwRA4lmpCsZ7N/bqfuT+2rrg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.122.0",
+    "@bigcommerce/checkout-sdk": "^1.123.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk-js version 

## Why?

https://github.com/bigcommerce/checkout-sdk-js/pull/1051

## Testing / Proof

Manual testing of checkout-sdk release https://github.com/bigcommerce/checkout-sdk-js/pull/1051 + unit tests

![image](https://user-images.githubusercontent.com/51989411/105171681-366e9100-5b27-11eb-9160-e6561471b617.png)


@bigcommerce/checkout
