### PR TITLE
fix(checkout): CHECKOUT-5505 When using a Custom Address Form Field Checkbox selecting None does not remove selections

### DIFF
--- a/src/app/ui/form/CheckboxGroupFormField.tsx
+++ b/src/app/ui/form/CheckboxGroupFormField.tsx
@@ -29,7 +29,6 @@ const MultiCheckboxFormField: FunctionComponent<MultiCheckboxFormFieldProps> = (
     name,
     onChange = noop,
     options,
-    pop,
     push,
     remove,
 }) => {
@@ -51,13 +50,13 @@ const MultiCheckboxFormField: FunctionComponent<MultiCheckboxFormFieldProps> = (
     const handleSelectNone = useCallback(() => {
         const checkedValues: string[] = getIn(values, name) || [];
 
-        checkedValues.forEach(() => pop());
+        checkedValues.forEach(() => remove(0));
 
         onChange(getIn(values, name));
     }, [
         name,
         onChange,
-        pop,
+        remove,
         values,
     ]);
 


### PR DESCRIPTION
## What?
Updating `handleSelectNone` to use `remove(0)` instead of `pop()`
## Why?
I am not sure why `pop()` does not uncheck the UI elements but, using `remove()` with the 0 index works.


## Testing / Proof
before: 
![before](https://user-images.githubusercontent.com/20911717/106178424-5f160c80-615f-11eb-95c4-bbaa871c3bdd.gif)

after:
![after](https://user-images.githubusercontent.com/20911717/106178445-65a48400-615f-11eb-9081-f7973dd33774.gif)


@bigcommerce/checkout
