### PR TITLE
CHECKOUT-5531 Fix spacing in account creation form

### DIFF
--- a/src/app/address/AddressForm.scss
+++ b/src/app/address/AddressForm.scss
@@ -11,8 +11,13 @@
         display: block;
         flex: 1;
         flex-basis: 100%;
+        margin-bottom: spacing("half");
         max-width: 100%;
         padding: 0 spacing("half");
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
 
     .dynamic-form-field--province,
@@ -30,13 +35,5 @@
         @include breakpoint("small") {
             flex-basis: 30%;
         }
-    }
-}
-
-.dynamic-form-field {
-    margin-bottom: spacing("half");
-
-    &:last-child {
-        margin-bottom: 0;
     }
 }

--- a/src/app/customer/CreateAccountForm.scss
+++ b/src/app/customer/CreateAccountForm.scss
@@ -10,8 +10,13 @@
         display: block;
         flex: 1;
         flex-basis: 100%;
+        margin-bottom: spacing("half");
         max-width: 100%;
         padding: 0 spacing("half");
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
 
     .dynamic-form-field--firstName,


### PR DESCRIPTION
## What?
Add missing dynamic-form-field margin to create-account-form

## Why?
Because it was causing all fields to be too close together. This only happens in production because in dev we don't lazy load each component, so styles were being shared from the shipping form.

## Testing / Proof
Reported:
<img width="955" alt="Screen Shot 2021-02-02 at 10 46 59 am" src="https://user-images.githubusercontent.com/1621894/106532345-2651ab00-6544-11eb-90f4-30089e568878.png">

After:
<img width="730" alt="Screen Shot 2021-02-02 at 10 45 47 am" src="https://user-images.githubusercontent.com/1621894/106532359-2c478c00-6544-11eb-8c1d-3bc62582804c.png">
<img width="698" alt="Screen Shot 2021-02-02 at 10 45 55 am" src="https://user-images.githubusercontent.com/1621894/106532365-2d78b900-6544-11eb-94e4-acc5b22bc29d.png">


@bigcommerce/checkout
