### PR TITLE
CHECKOUT-5324: Upgrade `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,9 +1249,9 @@
           }
         },
         "@types/yargs": {
-          "version": "15.0.12",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
-          "integrity": "sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==",
+          "version": "15.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -1506,9 +1506,9 @@
           "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -1608,9 +1608,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.124.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.124.0.tgz",
-      "integrity": "sha512-rbBi/nVwMNTUqqyiTrmSX1xQQXk8DT8qpWf0OAdFkIbOEygKyEHIhlUcxsZ3Fi2nV2qWdDOI5WkD5NhOWZ4aUA==",
+      "version": "1.124.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.124.1.tgz",
+      "integrity": "sha512-4rJuYAu6Epy8eTn5O4wjjJMojeXlQDKYIleiUeBjZRaNK79k+64zYrfXqG2oC6kRWclG8dRRzSW2DrndLlqhxg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.124.0",
+    "@bigcommerce/checkout-sdk": "^1.124.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Upgrade `checkout-sdk` version to `1.124.1`.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/compare/v1.124.0...v1.124.1

## Testing / Proof
See the related PRs.

@bigcommerce/checkout
