### PR TITLE
fix(payment): INT-3813  added bankAccount in order to render account Instrument Table

### DIFF
--- a/src/app/payment/storedInstrument/ManageAccountInstrumentsTable.tsx
+++ b/src/app/payment/storedInstrument/ManageAccountInstrumentsTable.tsx
@@ -70,7 +70,9 @@ const ManageInstrumentsRow: FunctionComponent<ManageInstrumentsRowProps> = ({
                 { isBankAccountInstrument(instrument) ? (
                         <span className="instrumentModal-instrumentAccountNumber">
                             <TranslatedString id="payment.instrument_manage_table_header_ending_in_text" />
-                            <span>{ instrument.accountNumber }</span>
+                            <span>
+                                { ` ${instrument.accountNumber}` }
+                            </span>
                         </span>
                     ) : (
                         <>

--- a/src/app/payment/storedInstrument/ManageInstrumentsModal.spec.tsx
+++ b/src/app/payment/storedInstrument/ManageInstrumentsModal.spec.tsx
@@ -9,6 +9,7 @@ import { Modal } from '../../ui/modal';
 
 import { getInstruments } from './instruments.mock';
 import isAccountInstrument from './isAccountInstrument';
+import isBankAccountInstrument from './isBankAccountInstrument';
 import isCardInstrument from './isCardInstrument';
 import ManageAccountInstrumentsTable from './ManageAccountInstrumentsTable';
 import ManageCardInstrumentsTable from './ManageCardInstrumentsTable';
@@ -67,6 +68,19 @@ describe('ManageInstrumentsModal', () => {
         const component = mount(<ManageInstrumentsModalTest
             { ...defaultProps }
             instruments={ getInstruments().filter(isAccountInstrument) }
+        />);
+
+        expect(component.find(ManageAccountInstrumentsTable).length)
+            .toEqual(1);
+
+        expect(component.find(ManageCardInstrumentsTable).length)
+            .toEqual(0);
+    });
+
+    it('renders list of bank instruments in table format', () => {
+        const component = mount(<ManageInstrumentsModalTest
+            { ...defaultProps }
+            instruments={ getInstruments().filter(isBankAccountInstrument) }
         />);
 
         expect(component.find(ManageAccountInstrumentsTable).length)

--- a/src/app/payment/storedInstrument/ManageInstrumentsModal.tsx
+++ b/src/app/payment/storedInstrument/ManageInstrumentsModal.tsx
@@ -85,21 +85,24 @@ class ManageInstrumentsModal extends Component<ManageInstrumentsModalProps & Wit
         const bankInstruments = instruments.filter(isBankAccountInstrument);
         const accountInstruments = instruments.filter(isAccountInstrument);
 
+        const bankAndAccountInstruments = [...bankInstruments, ...accountInstruments];
+
+        if (bankAndAccountInstruments.length) {
+            return (
+                <ManageAccountInstrumentsTable
+                    instruments={ bankAndAccountInstruments }
+                    isDeletingInstrument={ isDeletingInstrument }
+                    onDeleteInstrument={ this.handleDeleteInstrument }
+                />
+            );
+        }
+
         return (
-            accountInstruments.length
-                ? <ManageAccountInstrumentsTable
-                    instruments={ [
-                        ...bankInstruments,
-                        ...accountInstruments,
-                    ] }
-                    isDeletingInstrument={ isDeletingInstrument }
-                    onDeleteInstrument={ this.handleDeleteInstrument }
-                />
-                : <ManageCardInstrumentsTable
-                    instruments={ cardInstruments }
-                    isDeletingInstrument={ isDeletingInstrument }
-                    onDeleteInstrument={ this.handleDeleteInstrument }
-                />
+            <ManageCardInstrumentsTable
+                instruments={ cardInstruments }
+                isDeletingInstrument={ isDeletingInstrument }
+                onDeleteInstrument={ this.handleDeleteInstrument }
+            />
         );
     }
 


### PR DESCRIPTION
## What? [INT-3813](https://jira.bigcommerce.com/browse/INT-3813)
Added bankAccount option in order to render account Instrument Table

## Why?
In order to allow deleting vaulted bank account instruments from account Instrument Table Modal

## Siblings PR's
[Bigpay #3442](https://github.com/bigcommerce/bigpay/pull/3442)

## Testing / Proof
![Screen Shot 2021-02-09 at 10 48 46 AM](https://user-images.githubusercontent.com/61981535/107397638-77bde500-6ac4-11eb-90cb-9336ba48a626.png)
![Screen Shot 2021-02-12 at 9 48 46 AM](https://user-images.githubusercontent.com/61981535/107789916-cd3e0000-6d17-11eb-8f86-7a09eed503ab.png)



[TESTING PROOF VIDEO](https://drive.google.com/file/d/16EWwuaIa2TpKmWnG9kGD2KVtIgMA5FNe/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/apex-integrations 
