### PR TITLE
CHECKOUT-5324: Upgrade `checkout-sdk` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,9 +970,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.13.1.tgz",
-      "integrity": "sha512-gvM4bHKZCFly+tcTc/t6bntLrKikkAotGYa6obQq0hsYif+SdFMnB84FKFkgrENL69ZHPBt110MLfzqJiSUOxQ==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.13.2.tgz",
+      "integrity": "sha512-AbYL4WV3Y7DZ6dYnyvppGXHAcstVhutONwROuIZcxB/nTqcqFWol5SFMRxWGHZTaQK7bHbIuDThJ0LgWn52g1w==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^25.2.0",
@@ -1608,12 +1608,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.129.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.129.0.tgz",
-      "integrity": "sha512-Wk5cYSgnOJDNtHwimb1u6W2pBSMV2QK2jyWPF4ok7JLeycep6OpxeaJZvquTfMiMAaUw8zAdcGSx/M8J6Aegjw==",
+      "version": "1.129.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.129.1.tgz",
+      "integrity": "sha512-869QXlqMs/a+XKNdOjcSciAsKra9Wao/y5UJol/koqO4HJdb+p7SyoiV/hWScgkt4EBcwg16i16q0nhf+jSSrQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.13.0",
+        "@bigcommerce/bigpay-client": "^5.13.2",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2320,9 +2320,9 @@
       "integrity": "sha512-4J1fYJhLnzsfZgeAgrzBfNHFVoZHcWp/rK7oImeV7ZhplL19T1kxCoA4xJTuPfS+sKiN06E+xTvj2K13L7Wc1g=="
     },
     "@types/graceful-fs": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
-      "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+      "integrity": "sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.129.0",
+    "@bigcommerce/checkout-sdk": "^1.129.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Upgrade `checkout-sdk` version to 1.129.1.

## Why?
See https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
CircleCI

@bigcommerce/checkout
