### PR TITLE
CHECKOUT-5610: Pass accessibility labels to payment form

### DIFF
--- a/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.spec.tsx
+++ b/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.spec.tsx
@@ -158,10 +158,10 @@ describe('withHostedCreditCardFieldset', () => {
         expect(await getHostedFormOptions())
             .toEqual({
                 fields: {
-                    cardCode: { containerId: 'authorizenet-ccCvv' },
-                    cardExpiry: { containerId: 'authorizenet-ccExpiry', placeholder: 'MM / YY' },
-                    cardName: { containerId: 'authorizenet-ccName' },
-                    cardNumber: { containerId: 'authorizenet-ccNumber' },
+                    cardCode: { accessibilityLabel: 'CVV', containerId: 'authorizenet-ccCvv' },
+                    cardExpiry: { accessibilityLabel: 'Expiration', containerId: 'authorizenet-ccExpiry', placeholder: 'MM / YY' },
+                    cardName: { accessibilityLabel: 'Name on Card', containerId: 'authorizenet-ccName' },
+                    cardNumber: { accessibilityLabel: 'Credit Card Number', containerId: 'authorizenet-ccNumber' },
                 },
                 styles: {
                     default: expect.any(Object),
@@ -187,10 +187,12 @@ describe('withHostedCreditCardFieldset', () => {
             .toEqual({
                 fields: {
                     cardCodeVerification: {
+                        accessibilityLabel: 'CVV',
                         containerId: 'authorizenet-ccCvv',
                         instrumentId: getCardInstrument().bigpayToken,
                     },
                     cardNumberVerification: {
+                        accessibilityLabel: 'Credit Card Number',
                         containerId: 'authorizenet-ccNumber',
                         instrumentId: getCardInstrument().bigpayToken,
                     },

--- a/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.tsx
+++ b/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.tsx
@@ -77,12 +77,14 @@ export default function withHostedCreditCardFieldset<TProps extends WithHostedCr
                     {
                         cardCodeVerification: isInstrumentCardCodeRequired && selectedInstrument ?
                             {
+                                accessibilityLabel: language.translate('payment.credit_card_cvv_label'),
                                 containerId: getHostedFieldId('ccCvv'),
                                 instrumentId: selectedInstrument.bigpayToken,
                             } :
                             undefined,
                         cardNumberVerification: isInstrumentCardNumberRequired && selectedInstrument ?
                             {
+                                accessibilityLabel: language.translate('payment.credit_card_number_label'),
                                 containerId: getHostedFieldId('ccNumber'),
                                 instrumentId: selectedInstrument.bigpayToken,
                             } :
@@ -90,14 +92,24 @@ export default function withHostedCreditCardFieldset<TProps extends WithHostedCr
                     } :
                     {
                         cardCode: isCardCodeRequired ?
-                            { containerId: getHostedFieldId('ccCvv') } :
+                            {
+                                accessibilityLabel: language.translate('payment.credit_card_cvv_label'),
+                                containerId: getHostedFieldId('ccCvv'),
+                            } :
                             undefined,
                         cardExpiry: {
+                            accessibilityLabel: language.translate('payment.credit_card_expiration_label'),
                             containerId: getHostedFieldId('ccExpiry'),
                             placeholder: language.translate('payment.credit_card_expiration_placeholder_text'),
                         },
-                        cardName: { containerId: getHostedFieldId('ccName') },
-                        cardNumber: { containerId: getHostedFieldId('ccNumber') },
+                        cardName: {
+                            accessibilityLabel: language.translate('payment.credit_card_name_label'),
+                            containerId: getHostedFieldId('ccName'),
+                        },
+                        cardNumber: {
+                            accessibilityLabel: language.translate('payment.credit_card_number_label'),
+                            containerId: getHostedFieldId('ccNumber'),
+                        },
                     },
                 styles: styleContainerId ?
                     {


### PR DESCRIPTION
## What?
Pass `accessibilityLabel` property to hosted payment form so that the fields can have the appropriate `aria-label`.

## Why?
Without `aria-label`, screen readers won't be able to read them.

## Testing / Proof
I tested using [Google Chrome Screen Reader extension](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en).

Here are some screenshots showing that the `aria-label` attribute is now set.

<img width="870" alt="Screen Shot 2021-02-12 at 11 04 04 am" src="https://user-images.githubusercontent.com/667603/107715114-ac2edc80-6d22-11eb-81d4-5a0565747f66.png">
<img width="858" alt="Screen Shot 2021-02-12 at 11 04 21 am" src="https://user-images.githubusercontent.com/667603/107715122-b0f39080-6d22-11eb-9ba7-9e60bbbf397c.png">

@bigcommerce/checkout
