### PR TITLE
CHECKOUT-5612 Hide create account link/form if account creation is disabled

### DIFF
--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -374,7 +374,10 @@ describe('Customer', () => {
     describe('when view type is "login"', () => {
         it('matches snapshot', () => {
             const component = mount(
-                <CustomerTest viewType={ CustomerViewType.Login } />
+                <CustomerTest
+                    isAccountCreationEnabled={ true }
+                    viewType={ CustomerViewType.Login }
+                />
             );
 
             expect(component.render())

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -1,4 +1,4 @@
-import { CheckoutSelectors, CustomerAccountRequestBody, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, FormField, GuestCredentials, SignInEmail } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, CustomerAccountRequestBody, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, FormField, GuestCredentials, SignInEmail, StoreConfig } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React, { Component, Fragment, ReactNode } from 'react';
 
@@ -45,6 +45,7 @@ export interface WithCheckoutCustomerProps {
     requiresMarketingConsent: boolean;
     signInEmail?: SignInEmail;
     signInEmailError?: Error;
+    isAccountCreationEnabled: boolean;
     createAccountError?: Error;
     signInError?: Error;
     clearError(error: Error): Promise<CheckoutSelectors>;
@@ -196,6 +197,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             isGuestEnabled,
             isSendingSignInEmail,
             isSigningIn,
+            isAccountCreationEnabled,
             onContinueAsGuest,
             signInError,
             viewType,
@@ -215,6 +217,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
                 onCreateAccount={ this.showCreateAccount }
                 onSendLoginEmail={ this.handleEmailLoginClicked }
                 onSignIn={ this.handleSignIn }
+                shouldShowCreateAccountLink={ isAccountCreationEnabled }
                 signInError={ signInError }
                 viewType={ viewType }
             />
@@ -393,8 +396,9 @@ export function mapToWithCheckoutCustomerProps(
             privacyPolicyUrl,
             requiresMarketingConsent,
             isSignInEmailEnabled,
+            isAccountCreationEnabled,
         },
-    } = config;
+    } = config as StoreConfig & { checkoutSettings: { isAccountCreationEnabled: boolean } };
 
     return {
         customerAccountFields: getCustomerAccountFields(),
@@ -414,6 +418,7 @@ export function mapToWithCheckoutCustomerProps(
         createAccountError: getCreateCustomerAccountError(),
         isContinuingAsGuest: isContinuingAsGuest(),
         isSignInEmailEnabled,
+        isAccountCreationEnabled,
         isGuestEnabled: config.checkoutSettings.guestCheckoutEnabled,
         isSigningIn: isSigningIn(),
         isSendingSignInEmail: isSendingSignInEmail(),

--- a/src/app/customer/LoginForm.tsx
+++ b/src/app/customer/LoginForm.tsx
@@ -26,6 +26,7 @@ export interface LoginFormProps {
     signInEmailError?: Error;
     viewType?: Omit<CustomerViewType, 'guest'>;
     passwordlessLogin?: boolean;
+    shouldShowCreateAccountLink?: boolean;
     onCancel?(): void;
     onCreateAccount?(): void;
     onChangeEmail?(email: string): void;
@@ -52,6 +53,7 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
     onCreateAccount = noop,
     onSendLoginEmail = noop,
     signInError,
+    shouldShowCreateAccountLink,
     viewType = CustomerViewType.Login,
 }) => {
     const changeEmailLink = useCallback(() => {
@@ -98,7 +100,7 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
                         />
                     </Alert> }
 
-                { viewType === CustomerViewType.Login && <p>
+                { viewType === CustomerViewType.Login && shouldShowCreateAccountLink && <p>
                     <TranslatedLink
                         id="customer.create_account_to_continue_text"
                         onClick={ onCreateAccount }

--- a/src/app/customer/__snapshots__/LoginForm.spec.tsx.snap
+++ b/src/app/customer/__snapshots__/LoginForm.spec.tsx.snap
@@ -19,15 +19,6 @@ exports[`LoginForm matches snapshot 1`] = `
       <div
         class="form-body"
       >
-        <p>
-          Don’t have an account? 
-          <a
-            href="#"
-          >
-            Create an account
-          </a>
-           to continue.
-        </p>
         <div
           class="form-field"
         >


### PR DESCRIPTION
## What?
Hide create account link/form if account creation is disabled

## Why?
To honour the Store setting.

## Testing / Proof
### BEFORE
<img width="1215" alt="Screen Shot 2021-02-17 at 3 49 42 pm" src="https://user-images.githubusercontent.com/1621894/108157949-028f8700-7138-11eb-8774-15a000eb5bfc.png">
<img width="700" alt="Screen Shot 2021-02-17 at 3 50 55 pm" src="https://user-images.githubusercontent.com/1621894/108157954-04594a80-7138-11eb-8574-2723f0d46a16.png">


### AFTER
<img width="691" alt="Screen Shot 2021-02-17 at 3 48 01 pm" src="https://user-images.githubusercontent.com/1621894/108157968-0c18ef00-7138-11eb-9d2b-3ea156de29df.png">
<img width="1177" alt="Screen Shot 2021-02-17 at 3 49 21 pm" src="https://user-images.githubusercontent.com/1621894/108157970-0d4a1c00-7138-11eb-8d40-6b6336ebf466.png">


@bigcommerce/checkout
