### PR TITLE
CHECKOUT-5618 Update address in dropdown when multishipping

### DIFF
--- a/src/app/address/isEqualAddress.spec.ts
+++ b/src/app/address/isEqualAddress.spec.ts
@@ -9,6 +9,7 @@ describe('isEqualAddress', () => {
         expect(isEqualAddress(getAddress(), {
             ...getAddress(),
             stateOrProvinceCode: 'w',
+            country: 'none',
             id: 'x',
             email: 'y',
             shouldSaveAddress: false,

--- a/src/app/address/isEqualAddress.ts
+++ b/src/app/address/isEqualAddress.ts
@@ -16,7 +16,14 @@ export default function isEqualAddress(address1?: ComparableAddress, address2?: 
 }
 
 function normalizeAddress(address: ComparableAddress) {
-    const ignoredFields: ComparableAddressFields[] = ['id', 'shouldSaveAddress', 'stateOrProvinceCode', 'type', 'email'];
+    const ignoredFields: ComparableAddressFields[] = [
+        'id',
+        'shouldSaveAddress',
+        'stateOrProvinceCode',
+        'type',
+        'email',
+        'country',
+    ];
 
     return omit(
         {


### PR DESCRIPTION
## What?
Ignore `country` when checking if two addresses are equal

## Why?
We already rely on `countryCode`, so we can safely ignore `country`. 
The request payload doesn't have `country`, that's why when comparing the request address to the response address, they wouldn't match

## Testing / Proof
![multishipping2](https://user-images.githubusercontent.com/1621894/108302621-72654680-71f8-11eb-9900-fa2489155ac1.gif)


@bigcommerce/checkout
