### PR TITLE
feat(payment): PAYMENTS-6576 remove the label "Payment Methods" in checkout

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -220,7 +220,6 @@
             "payment_method_disabled_error": "The selected payment method is no longer valid. Click OK to see the most up-to-date payment methods.",
             "payment_method_error": "Response from payment provider: {message}",
             "payment_method_invalid_error": "There's a problem processing your payment. Please contact us for assistance or choose another payment method.",
-            "payment_method_label": "Payment Method",
             "payment_method_unavailable_error": "This payment provider is temporarily unavailable. Please try again later.",
             "payment_not_required_text": "Payment is not required for this order.",
             "paypal_continue_action": "Continue with PayPal",

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -4,9 +4,9 @@ import { isNil, noop, omitBy } from 'lodash';
 import React, { memo, useCallback, useContext, useMemo, FunctionComponent } from 'react';
 import { ObjectSchema } from 'yup';
 
-import { withLanguage, TranslatedString, WithLanguageProps } from '../locale';
+import { withLanguage, WithLanguageProps } from '../locale';
 import { TermsConditions } from '../termsConditions';
-import { Fieldset, Form, FormContext, Legend } from '../ui/form';
+import { Fieldset, Form, FormContext } from '../ui/form';
 
 import { CreditCardFieldsetValues } from './creditCard';
 import { DocumentOnlyCustomFormFieldsetValues } from './documentOnly';
@@ -215,14 +215,8 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
         setSubmitted,
     ]);
 
-    const legend = useMemo(() => (
-        <Legend>
-            <TranslatedString id="payment.payment_method_label" />
-        </Legend>
-    ), []);
-
     return (
-        <Fieldset legend={ legend }>
+        <Fieldset>
             { !isPaymentDataRequired() && <StoreCreditOverlay /> }
 
             <PaymentMethodList


### PR DESCRIPTION
## What?
- remove the label "Payment Methods" in the checkout 

## Why?
- it not needed

## Testing / Proof
![image](https://user-images.githubusercontent.com/23373100/108786193-2daa2880-75c7-11eb-9280-f8dab9c3c7da.png)


@bigcommerce/checkout
