### PR TITLE
feat(payment): INT-3840 Add DigitalRiver payment method

### DIFF
--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -1,0 +1,105 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { mount, ReactWrapper } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { CheckoutProvider } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { getPaymentMethod } from '../payment-methods.mock';
+
+import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+import { default as PaymentMethodComponent, PaymentMethodProps } from './PaymentMethod';
+import PaymentMethodId from './PaymentMethodId';
+
+describe('when using Digital River payment', () => {
+    let method: PaymentMethod;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: PaymentMethodProps;
+    let localeContext: LocaleContextType;
+    let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
+
+    beforeEach(() => {
+        defaultProps = {
+            method: getPaymentMethod(),
+            onUnhandledError: jest.fn(),
+        };
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+        method = { ...getPaymentMethod(), id: PaymentMethodId.DigitalRiver };
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutService, 'deinitializePayment')
+            .mockResolvedValue(checkoutState);
+
+        jest.spyOn(checkoutService, 'initializePayment')
+            .mockResolvedValue(checkoutState);
+
+        PaymentMethodTest = props => (
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleContext.Provider value={ localeContext }>
+                    <Formik
+                        initialValues={ {} }
+                        onSubmit={ noop }
+                    >
+                        <PaymentMethodComponent { ...props } />
+                    </Formik>
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('renders as hosted widget method', () => {
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+        expect(component.props())
+            .toEqual(expect.objectContaining({
+                containerId: `${method}-component-field`,
+                initializePayment: expect.any(Function),
+                method,
+            }));
+    });
+
+    it('initializes method with required config', () => {
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+
+        component.prop('initializePayment')({
+            methodId: method.id,
+            gatewayId: method.gateway,
+        });
+
+        expect(checkoutService.initializePayment)
+            .toHaveBeenCalledWith({
+                digitalriver: {
+                    configuration: {
+                        button: {
+                            type: 'submitOrder',
+                        },
+                        flow: 'checkout',
+                        paymentMethodConfiguration: {
+                            classes: {
+                                base: 'form-input optimizedCheckout-form-input',
+                            },
+                        },
+                        showComplianceSection: true,
+                        showSavePaymentAgreement: false,
+                        showTermsOfSaleDisclosure: true,
+                        usage: 'unscheduled',
+                    },
+                    containerId: `${method}-component-field`,
+                    onError: expect.any(Function),
+                    onRenderButton: expect.any(Function),
+                    onSubmitForm: expect.any(Function),
+                },
+                gatewayId: undefined,
+                methodId: 'digitalriver',
+            });
+    });
+});

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback, useContext, FunctionComponent } from 'react';
+import { Omit } from 'utility-types';
+
+import { connectFormik, ConnectFormikProps } from '../../common/form';
+import { FormContext } from '../../ui/form';
+import PaymentContext from '../PaymentContext';
+import { PaymentFormValues } from '../PaymentForm';
+
+import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+
+export type DigitalRiverPaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'containerId'> & ConnectFormikProps<PaymentFormValues>;
+
+export enum DigitalRiverClasses {
+    base =  'form-input optimizedCheckout-form-input',
+}
+
+const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProps> = ({
+    initializePayment,
+    onUnhandledError,
+    formik: { submitForm },
+    ...rest
+}) => {
+    const paymentContext = useContext(PaymentContext);
+    const { setSubmitted } = useContext(FormContext);
+    const containerId = `${rest.method}-component-field`;
+    const initializeDigitalRiverPayment = useCallback(options => initializePayment({
+        ...options,
+        digitalriver: {
+            containerId,
+            configuration: {
+                flow: 'checkout',
+                showSavePaymentAgreement: false,
+                showComplianceSection: true,
+                button: {
+                    type: 'submitOrder',
+                },
+                usage: 'unscheduled',
+                showTermsOfSaleDisclosure: true,
+                paymentMethodConfiguration: {
+                    classes: DigitalRiverClasses,
+                },
+            },
+            onRenderButton: () => {
+                paymentContext?.hidePaymentSubmitButton?.(rest.method, true);
+            },
+            onSubmitForm: () => {
+                setSubmitted(true);
+                submitForm();
+            },
+            onError: (error: Error) => {
+                onUnhandledError?.(error);
+            },
+        },
+    }), [containerId, initializePayment, submitForm, paymentContext, rest.method, setSubmitted, onUnhandledError]);
+
+    return <HostedWidgetPaymentMethod
+        { ...rest }
+        containerId={ containerId }
+        initializePayment={ initializeDigitalRiverPayment }
+    />;
+};
+
+export default connectFormik(DigitalRiverPaymentMethod);

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -14,6 +14,7 @@ import BraintreeCreditCardPaymentMethod from './BraintreeCreditCardPaymentMethod
 import ChasePayPaymentMethod from './ChasePayPaymentMethod';
 import CheckoutCustomPaymentMethod from './CheckoutcomCustomPaymentMethod';
 import CCAvenueMarsPaymentMethod from './CCAvenueMarsPaymentMethod';
+import DigitalRiverPaymentMethod from './DigitalRiverPaymentMethod';
 import GooglePayPaymentMethod from './GooglePayPaymentMethod';
 import HostedCreditCardPaymentMethod from './HostedCreditCardPaymentMethod';
 import HostedPaymentMethod from './HostedPaymentMethod';
@@ -88,6 +89,10 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.gateway === PaymentMethodId.BlueSnapV2) {
         return <BlueSnapV2PaymentMethod { ...props } />;
+    }
+
+    if (method.id === PaymentMethodId.DigitalRiver) {
+        return <DigitalRiverPaymentMethod { ...props } />;
     }
 
     if (method.gateway === PaymentMethodId.Klarna) {

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -20,6 +20,7 @@ enum PaymentMethodId {
     CheckoutcomGooglePay = 'googlepaycheckoutcom',
     Converge = 'converge',
     CybersourceV2GooglePay = 'googlepaycybersourcev2',
+    DigitalRiver = 'digitalriver',
     Ideal = 'ideal',
     Klarna = 'klarna',
     Laybuy = 'laybuy',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -81,6 +81,10 @@ function getPaymentMethodTitle(
                 logoUrl: cdnPath('/img/payment-providers/google-pay.png'),
                 titleText: '',
             },
+            [PaymentMethodId.DigitalRiver]: {
+                logoUrl: cdnPath('/img/payment-providers/digital-river-header.png'),
+                titleText: '',
+            },
             [PaymentMethodId.Klarna]: {
                 logoUrl: cdnPath('/img/payment-providers/klarna-header.png'),
                 titleText: method.config && method.config.displayName || '',


### PR DESCRIPTION
## What? [INT-3840](https://jira.bigcommerce.com/browse/INT-3840)

- Create the Digital River payment strategy and make it available on the checkout page. 
- Removes the general place order button to Digital River.
- Add events such as errors and submit to control it on the SDK.

## Why?
A new payment method is required to support Digital River which will only be displayed when there is no other payment provider configured.

## Testing / Proof
<img width="757" alt="Screen Shot 2021-03-03 at 1 56 23 PM" src="https://user-images.githubusercontent.com/42154828/109864346-54e8a180-7c28-11eb-9282-741dd858afe1.png">

## Siblings Prs
https://github.com/bigcommerce/checkout-sdk-js/pull/1076
**must be merged first** 


@bigcommerce/checkout @bigcommerce/apex-integrations
