### PR TITLE
fix(checkout): CHECKOUT-4936 Display shipping step with custom item c…

### DIFF
--- a/src/app/shipping/index.ts
+++ b/src/app/shipping/index.ts
@@ -4,3 +4,4 @@ export { default as getShippableItemsCount } from './getShippableItemsCount';
 export { default as hasSelectedShippingOptions } from './hasSelectedShippingOptions';
 export { default as hasUnassignedLineItems } from './hasUnassignedLineItems';
 export { default as isUsingMultiShipping } from './isUsingMultiShipping';
+export { default as itemsRequireShipping } from './itemsRequireShipping';

--- a/src/app/shipping/itemsRequireShipping.spec.ts
+++ b/src/app/shipping/itemsRequireShipping.spec.ts
@@ -1,0 +1,43 @@
+import { Cart, StoreConfig } from '@bigcommerce/checkout-sdk';
+
+import { getCart } from '../cart/carts.mock';
+import { getCustomItem } from '../cart/lineItem.mock';
+import { getStoreConfig } from '../config/config.mock';
+
+import itemsRequireShipping from './itemsRequireShipping';
+
+describe('itemsRequireShipping()', () => {
+    let cart: Cart;
+    let config: StoreConfig;
+
+    beforeEach(() => {
+        cart = getCart();
+        config = getStoreConfig();
+        config.checkoutSettings.features['CHECKOUT-4936.enable_custom_item_shipping'] = true;
+    });
+
+    it('returns false if there are no physical items or custom items', () => {
+        cart.lineItems.physicalItems = [];
+        cart.lineItems.customItems = [];
+        expect(itemsRequireShipping(cart, config))
+            .toBe(false);
+    });
+
+    it('returns false if there is no cart', () => {
+        expect(itemsRequireShipping(undefined, config))
+            .toBe(false);
+    });
+
+    it('returns true if there are physical items', () => {
+        expect(itemsRequireShipping(cart, config))
+            .toBe(true);
+    });
+
+    it('returns true if there are only custom items', () => {
+        cart.lineItems.physicalItems = [];
+        cart.lineItems.customItems = [getCustomItem()];
+        expect(itemsRequireShipping(cart, config))
+            .toBe(true);
+    });
+
+});

--- a/src/app/shipping/itemsRequireShipping.ts
+++ b/src/app/shipping/itemsRequireShipping.ts
@@ -1,0 +1,19 @@
+import { Cart, StoreConfig } from '@bigcommerce/checkout-sdk';
+
+const itemsRequireShipping = (cart?: Cart, config?: StoreConfig) => {
+    if (!cart) {
+        return false;
+    }
+
+    if (cart.lineItems.physicalItems.some(lineItem => lineItem.isShippingRequired)) {
+        return true;
+    }
+
+    if (config && config.checkoutSettings.features['CHECKOUT-4936.enable_custom_item_shipping'] && cart.lineItems.customItems) {
+        return cart.lineItems.customItems.length > 0;
+    }
+
+    return false;
+};
+
+export default itemsRequireShipping;


### PR DESCRIPTION
…arts

## What?
Displaying the shipping step if a cart only has custom items.

## Why?
Custom items are pseudo-physical items per our existing functionality in manual orders and LCO. 

Currently draft orders with only custom items can't adjust a shipping address adjusted in checkout, and S2S carts consisting of only custom items cannot complete a checkout due to a missing shipping method error.

By surfacing the shipping step when custom items are present, draft orders can have their shipping address adjusted by shoppers, and checkout can be completed when carts created via S2S API only have custom items.


## Testing / Proof
Before:
![image](https://user-images.githubusercontent.com/16565458/109365242-5562f000-7856-11eb-911c-653dcb06939f.png)

After:
![image](https://user-images.githubusercontent.com/16565458/109365312-7c212680-7856-11eb-993f-83ec31f997bd.png)



@bigcommerce/checkout
