### PR TITLE
fix(checkout): ADYEN-38 Fix Adyen icons on checkout page

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -123,8 +123,8 @@ function getPaymentMethodTitle(
         }
 
         return (
-            customTitles[method.id] ||
             customTitles[method.gateway || ''] ||
+            customTitles[method.id] ||
             customTitles[method.method] ||
             customTitles[PaymentMethodType.CreditCard]
         );


### PR DESCRIPTION
## What?
Made logos for Klarna methods on checkout consistent.

## Why?
According to task https://jira.bigcommerce.com/browse/ADYEN-38
Logos for Klarna methods on checkout seem inconsistent. 

## Testing / Proof
#### BEFORE:
![image](https://user-images.githubusercontent.com/79574476/110507528-c59c2c00-8108-11eb-9423-08024e21d563.png)

### AFTER:
![image](https://user-images.githubusercontent.com/79574476/110506877-2d9e4280-8108-11eb-852d-7d67ffecec4f.png)



@bigcommerce/checkout
