### PR TITLE
feat(payment): INT-3969 Use APMs logos instead names in checkout accordion for Checkout.com

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -272,4 +272,34 @@ describe('PaymentMethodTitle', () => {
         expect(component.find(CreditCardIconList).prop('selectedCardType'))
             .toEqual('visa');
     });
+
+    it('renders only Checkout.com APMs logos based on their gateway id', () => {
+        const checkoutcomTitleComponent = (id: string) => mount(
+            <PaymentMethodTitleTest
+                { ...defaultProps }
+                method={ {
+                    ...defaultProps.method,
+                    method: PaymentMethodId.Checkoutcom,
+                    id,
+                } }
+            />
+        );
+        const baseURL = (id: string) => `/img/payment-providers/checkoutcom_${id}.png`;
+
+        let component = checkoutcomTitleComponent('sepa');
+        expect(component.find('[data-test="payment-method-logo"]').prop('src'))
+            .toEqual(`${config.cdnPath}${baseURL('sepa')}`);
+
+        component = checkoutcomTitleComponent('oxxo');
+        expect(component.find('[data-test="payment-method-logo"]').prop('src'))
+            .toEqual(`${config.cdnPath}${baseURL('oxxo')}`);
+
+        component = checkoutcomTitleComponent('boleto');
+        expect(component.find('[data-test="payment-method-logo"]').prop('src'))
+            .toEqual(`${config.cdnPath}${baseURL('boleto')}`);
+
+        component = checkoutcomTitleComponent('qpay');
+        expect(component.find('[data-test="payment-method-logo"]').prop('src'))
+            .toEqual(`${config.cdnPath}${baseURL('qpay')}`);
+    });
 });

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -121,6 +121,10 @@ function getPaymentMethodTitle(
                 logoUrl: method.method === 'creditcard' ? '' : cdnPath(`/img/payment-providers/${method.method}.svg`),
                 titleText: methodName,
             },
+            [PaymentMethodId.Checkoutcom]: {
+                logoUrl: method.id === 'credit_card' ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.png`),
+                titleText: method.id === 'credit_card' ? methodName : '',
+            },
         };
 
         // KLUDGE: 'paypal' is actually a credit card method. It is the only


### PR DESCRIPTION
[INT-3969](https://jira.bigcommerce.com/browse/INT-3969)

## What?
Use logos for multiple APMs of checkout.com payment method instead of names

## Why?
In order to replace text and use the images for the multiple APMs that checkout.com let use

## Testing / Proof
<img width="539" alt="Screen Shot 2021-03-09 at 3 19 42 PM" src="https://user-images.githubusercontent.com/69487179/110542732-0e46eb80-80ef-11eb-8e30-4be12ed34632.png">
<img width="539" alt="Screen Shot 2021-03-09 at 3 20 09 PM" src="https://user-images.githubusercontent.com/69487179/110542734-0edf8200-80ef-11eb-9ff7-bd3ae667ccb5.png">
<img width="539" alt="Screen Shot 2021-03-09 at 3 20 25 PM" src="https://user-images.githubusercontent.com/69487179/110542735-0f781880-80ef-11eb-9b26-421f46d5ad5d.png">

## Depends on

- bigcommerce/bigcommerce#39812


@bigcommerce/checkout
