### PR TITLE
feat(payment): INT-3700 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,9 +114,9 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
-      "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
       "requires": {
         "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
@@ -137,14 +137,14 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001194",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
-          "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA=="
+          "version": "1.0.30001197",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
+          "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw=="
         },
         "electron-to-chromium": {
-          "version": "1.3.678",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.678.tgz",
-          "integrity": "sha512-E5ha1pE9+aWWrT2fUD5wdPBWUnYtKnEnloewbtVyrkAs79HvodOiNO4rMR94+hKbxgMFQG4fnPQACOc1cfMfBg=="
+          "version": "1.3.684",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz",
+          "integrity": "sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w=="
         },
         "node-releases": {
           "version": "1.1.71",
@@ -1141,9 +1141,9 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-          "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+          "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
           "requires": {
             "@babel/template": "^7.12.13",
             "@babel/traverse": "^7.13.0",
@@ -1151,9 +1151,9 @@
           }
         },
         "@babel/highlight": {
-          "version": "7.13.8",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-          "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
             "chalk": "^2.0.0",
@@ -1207,9 +1207,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
-          "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw=="
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
+          "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -1453,16 +1453,16 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.13.8",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
-              "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
+              "version": "7.13.10",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
+              "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
               "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.0",
-                "@babel/helper-compilation-targets": "^7.13.8",
+                "@babel/generator": "^7.13.9",
+                "@babel/helper-compilation-targets": "^7.13.10",
                 "@babel/helper-module-transforms": "^7.13.0",
-                "@babel/helpers": "^7.13.0",
-                "@babel/parser": "^7.13.4",
+                "@babel/helpers": "^7.13.10",
+                "@babel/parser": "^7.13.10",
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.13.0",
                 "@babel/types": "^7.13.0",
@@ -1652,9 +1652,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.132.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.132.0.tgz",
-      "integrity": "sha512-EaY4Ow8TGUO+mA3aTUzbS0wIrBZBnXrK/Vh/dxHZtZxPWrN+BB5rJfRjeTNwExEWRgsLQ5lDbxfO0Nj4qEYT5w==",
+      "version": "1.133.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.133.0.tgz",
+      "integrity": "sha512-hFqUYlo/xwg1POWL91iWfI9nWxhzw4p+4LN5xqNExpwciCH23z4f3jSPaoSCqDlM+yNe3EM2R1L4IbVjbZzwxg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.132.0",
+    "@bigcommerce/checkout-sdk": "^1.133.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump the version of Checkout SDK in use.

## Why?
Releasing https://github.com/bigcommerce/checkout-sdk-js/pull/1066

## Testing / Proof
Circle, performed manually.

@bigcommerce/checkout
