### PR TITLE
feat(payment): INT-3896 INT-3840 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,14 +137,14 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001197",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-          "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw=="
+          "version": "1.0.30001200",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
+          "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ=="
         },
         "electron-to-chromium": {
-          "version": "1.3.684",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz",
-          "integrity": "sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w=="
+          "version": "1.3.687",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+          "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ=="
         },
         "node-releases": {
           "version": "1.1.71",
@@ -1652,9 +1652,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.133.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.133.0.tgz",
-      "integrity": "sha512-hFqUYlo/xwg1POWL91iWfI9nWxhzw4p+4LN5xqNExpwciCH23z4f3jSPaoSCqDlM+yNe3EM2R1L4IbVjbZzwxg==",
+      "version": "1.134.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.134.0.tgz",
+      "integrity": "sha512-5aVMUwbA7u0g6FXvajmwBykx7wOyVKuqgLBQTjubJ4xkp4TAInKd4EiD2xOr5CGu8OkS0bcHvhjd3h9Jsiib6A==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.133.0",
+    "@bigcommerce/checkout-sdk": "^1.134.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump the version of the SDK in use.

## Why?
Releasing:
* https://github.com/bigcommerce/checkout-sdk-js/pull/1075
* https://github.com/bigcommerce/checkout-sdk-js/pull/1076

## Testing / Proof
See linked PRs.

@bigcommerce/checkout
