### PR TITLE
CHECKOUT-5618 Check also `stateOrProvinceCode` for address equality

### DIFF
--- a/src/app/address/isEqualAddress.spec.ts
+++ b/src/app/address/isEqualAddress.spec.ts
@@ -17,10 +17,57 @@ describe('isEqualAddress', () => {
         })).toBeTruthy();
     });
 
-    it('returns false when values are different', () => {
-        expect(isEqualAddress(getAddress(), {
+    it('returns true when stateOrProvinceCode matches stateOrProvince', () => {
+        expect(isEqualAddress({
             ...getAddress(),
-            stateOrProvince: 'Foo',
+            stateOrProvince: '',
+            stateOrProvinceCode: 'CA',
+        }, {
+            ...getAddress(),
+            stateOrProvince: 'California',
+            stateOrProvinceCode: 'CA',
+        })).toBeTruthy();
+
+        expect(isEqualAddress({
+            ...getAddress(),
+            stateOrProvince: 'California',
+            stateOrProvinceCode: '',
+        }, {
+            ...getAddress(),
+            stateOrProvince: 'California',
+            stateOrProvinceCode: 'CA',
+        })).toBeTruthy();
+
+        expect(isEqualAddress({
+            ...getAddress(),
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+        }, {
+            ...getAddress(),
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+        })).toBeTruthy();
+    });
+
+    it('returns false when values are different', () => {
+        expect(isEqualAddress({
+            ...getAddress(),
+            stateOrProvince: 'California',
+            stateOrProvinceCode: '',
+        }, {
+            ...getAddress(),
+            stateOrProvince: 'New York',
+            stateOrProvinceCode: '',
+        })).toBeFalsy();
+
+        expect(isEqualAddress({
+            ...getAddress(),
+            stateOrProvince: '',
+            stateOrProvinceCode: 'CA',
+        }, {
+            ...getAddress(),
+            stateOrProvince: '',
+            stateOrProvinceCode: 'NY',
         })).toBeFalsy();
     });
 

--- a/src/app/address/isEqualAddress.ts
+++ b/src/app/address/isEqualAddress.ts
@@ -12,13 +12,27 @@ export default function isEqualAddress(address1?: ComparableAddress, address2?: 
     return isEqual(
         normalizeAddress(address1),
         normalizeAddress(address2)
-    );
+    ) && isSameState(address1, address2);
+}
+
+function isSameState(address1: ComparableAddress, address2: ComparableAddress): boolean {
+    if (address1.stateOrProvince && address1.stateOrProvince === address2.stateOrProvince) {
+        return true;
+    }
+
+    if (address1.stateOrProvinceCode && address1.stateOrProvinceCode === address2.stateOrProvinceCode) {
+        return true;
+    }
+
+    return address1.stateOrProvince === address2.stateOrProvince &&
+        address1.stateOrProvinceCode === address2.stateOrProvinceCode;
 }
 
 function normalizeAddress(address: ComparableAddress) {
     const ignoredFields: ComparableAddressFields[] = [
         'id',
         'shouldSaveAddress',
+        'stateOrProvince',
         'stateOrProvinceCode',
         'type',
         'email',


### PR DESCRIPTION
## What?
Check state code for address equality, and any combination between `stateOrProvince` and `stateOrProvinceCode`

## Why?
Sometimes, when comparing if two addresses are equal, we might be comparing a request payload and a response payload. Request payloads may only contain `stateOrProvince` or `stateOrProvinceCode`, and for consignments, the `stateOrProvince` also accepts state codes as values.

## Testing / Proof
Unit

@bigcommerce/checkout
