### PR TITLE
feat(payment): INT-3947 Suppress PayPal and Klarna for DigitalRiver

### DIFF
--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -84,6 +84,12 @@ describe('when using Digital River payment', () => {
                         },
                         flow: 'checkout',
                         paymentMethodConfiguration: {
+                            disabledPaymentMethods: [
+                                'klarnaCredit',
+                                'payPal',
+                                'payPalCredit',
+                                'payPalBilling',
+                            ],
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',
                             },

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -37,6 +37,12 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 usage: 'unscheduled',
                 showTermsOfSaleDisclosure: true,
                 paymentMethodConfiguration: {
+                    disabledPaymentMethods: [
+                        'klarnaCredit',
+                        'payPal',
+                        'payPalCredit',
+                        'payPalBilling',
+                    ],
                     classes: DigitalRiverClasses,
                 },
             },


### PR DESCRIPTION
## What? [INT-3947](https://jira.bigcommerce.com/browse/INT-3947)
Suppress PayPal and Klarna for DigitalRiver from being renderer. Digital provides us a new param called `disabledPaymentMethods` to do that.

## Why?
Because Digital River needs to obtain permission from PayPal and Klarna before BigCommerce can support any of these payment methods within our Digital River integration

## Siblings Prs
 https://github.com/bigcommerce/checkout-sdk-js/pull/1086

## Testing / Proof
**Before:**
<img width="757" alt="Screen Shot 2021-03-03 at 1 56 23 PM" src="https://user-images.githubusercontent.com/42154828/111347738-1c43c180-8645-11eb-8746-1f42adba9fe7.png">
**After:**
<img width="1147" alt="Screen Shot 2021-03-08 at 12 03 26 PM" src="https://user-images.githubusercontent.com/42154828/111347769-249bfc80-8645-11eb-9546-c73a2c494c2a.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
