### PR TITLE
feat(payment): PAYPAL-965 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,14 +137,14 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001205",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-          "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og=="
+          "version": "1.0.30001207",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+          "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw=="
         },
         "electron-to-chromium": {
-          "version": "1.3.704",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.704.tgz",
-          "integrity": "sha512-6cz0jvawlUe4h5AbfQWxPzb+8LzVyswGAWiGc32EJEmfj39HTQyNPkLXirc7+L4x5I6RgRkzua8Ryu5QZqc8cA=="
+          "version": "1.3.707",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz",
+          "integrity": "sha512-BqddgxNPrcWnbDdJw7SzXVzPmp+oiyjVrc7tkQVaznPGSS9SKZatw6qxoP857M+HbOyyqJQwYQtsuFIMSTNSZA=="
         },
         "node-releases": {
           "version": "1.1.71",
@@ -1649,9 +1649,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.136.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.136.1.tgz",
-      "integrity": "sha512-PcyQ237qvylWmRBfmsLtbvnO2lWPwDIxTQZe4XuEQje5/c+A2sNXLjX+B7UGO8Qce41NaFK4yrW14l67fM/CFw==",
+      "version": "1.136.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.136.2.tgz",
+      "integrity": "sha512-vw0l5/tm0stAv7sgxUz222KJ19YPAeKJ/RMIfo2v7Q2XRCHALJGo3CLDoFbzb9qVm9TYMXoJaO8XQVwBO7uCuQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.136.1",
+    "@bigcommerce/checkout-sdk": "^1.136.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Raise the version of the SDK in use.

## Why?
Releasing [checkout-sdk-js/pull/1097](https://github.com/bigcommerce/checkout-sdk-js/pull/1097)

## Testing / Proof
Circle

@bigcommerce/checkout
