### PR TITLE
fix(payment): INT-4100 added ability to translate SEPA display name

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -272,6 +272,7 @@
             "sepa_bic": "BIC",
             "sepa_mandate_required": "You must accept the mandate form",
             "sezzle_display_name_text": "Pay Later. 0% Interest.",
+            "stripe_sepa_display_name_text": "Sepa Direct Debit.",
             "stripe_sepa_mandate_disclaimer": "By providing your IBAN and confirming this payment, you authorise (A) {storeUrl} and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. You are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within eight weeks starting from the date on which your account was debited.",
             "vco_name_text": "Visa Checkout",
             "visa_checkout_continue_action": "Continue with Visa Checkout",

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -125,6 +125,10 @@ function getPaymentMethodTitle(
                 logoUrl: method.id === 'credit_card' ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.png`),
                 titleText: method.id === 'credit_card' ? methodName : '',
             },
+            [PaymentMethodId.StripeV3]: {
+                logoUrl: '',
+                titleText: method.method === 'iban' ? language.translate('payment.stripe_sepa_display_name_text') : methodName,
+            },
         };
 
         // KLUDGE: 'paypal' is actually a credit card method. It is the only


### PR DESCRIPTION
## What? [INT-4100](https://jira.bigcommerce.com/browse/INT-4100)
Added ability to translate SEPA display name

## Why?
So that merchants are able to translate  SEPA checkout experience for their shoppers.

## Testing / Proof
![Screen Shot 2021-04-06 at 1 43 18 PM](https://user-images.githubusercontent.com/61981535/113763216-0cb51700-96df-11eb-8ec7-923f64325731.png)


@bigcommerce/checkout @bigcommerce/apex-integrations 
