### PR TITLE
CHECKOUT-5740: Bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,9 @@
           "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw=="
         },
         "electron-to-chromium": {
-          "version": "1.3.707",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz",
-          "integrity": "sha512-BqddgxNPrcWnbDdJw7SzXVzPmp+oiyjVrc7tkQVaznPGSS9SKZatw6qxoP857M+HbOyyqJQwYQtsuFIMSTNSZA=="
+          "version": "1.3.710",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.710.tgz",
+          "integrity": "sha512-b3r0E2o4yc7mNmBeJviejF1rEx49PUBi+2NPa7jHEX3arkAXnVgLhR0YmV8oi6/Qf3HH2a8xzQmCjHNH0IpXWQ=="
         },
         "node-releases": {
           "version": "1.1.71",
@@ -1313,9 +1313,9 @@
           }
         },
         "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
@@ -1649,9 +1649,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.136.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.136.2.tgz",
-      "integrity": "sha512-vw0l5/tm0stAv7sgxUz222KJ19YPAeKJ/RMIfo2v7Q2XRCHALJGo3CLDoFbzb9qVm9TYMXoJaO8XQVwBO7uCuQ==",
+      "version": "1.137.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.137.1.tgz",
+      "integrity": "sha512-W6qAAz0Mm8HQQCUcwguzblYztCR+JdeY4FCYXVkP0Gaulz9MKB5wU9VjW8cUGDC8oqyULx+Sj4a8hPXmt5CpHA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.2",
@@ -1863,9 +1863,9 @@
       "dev": true
     },
     "@braintree/browser-detection": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.11.0.tgz",
-      "integrity": "sha512-A6G4DDygjLskhJkQvb6sURWSqL2sCkjKgnL6Pi2ZhiqOffiyyETmUpUSquCGthD8BKLGqVPpwHT4t883B9iZxw=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.11.1.tgz",
+      "integrity": "sha512-jE5GRXNT2Ey3itbR7uTYdzbiLs9CP0kCInjTJFItApMFPj6F2Dm0Yb56C/69f7BL282gcCRqwhXVgaTeVwTWbw=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.136.2",
+    "@bigcommerce/checkout-sdk": "^1.137.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version

## Why?
https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md

## Testing / Proof
See above

@bigcommerce/checkout
