### PR TITLE
fix(payment): PAYPAL-970 update version of checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1568,12 +1568,19 @@
           "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
           "requires": {
             "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
+            "picomatch": "^2.2.3"
+          },
+          "dependencies": {
+            "picomatch": {
+              "version": "2.2.3",
+              "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+              "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
+            }
           }
         },
         "minimist": {
@@ -1649,9 +1656,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.137.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.137.2.tgz",
-      "integrity": "sha512-7UG+wCF5j9LCPF3At0ovRAVx9aPuuf4Gg27Pn/ahWENsucG3FeqpqCj19EypJBZf9gZo+arx/EdrBW2aCZ36Zg==",
+      "version": "1.137.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.137.3.tgz",
+      "integrity": "sha512-nZ2TsOq8vzl5pymPy/BI+uuYerFt2xMnf1kxYRXsaYwwuGJ8xVTppq7Ztb4zlcYxHxSPM8TrwXcsd5VSLc26mA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.137.2",
+    "@bigcommerce/checkout-sdk": "^1.137.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of new version checkout-sdk 

## Why?
Due to https://jira.bigcommerce.com/browse/PAYPAL-970

## Testing / Proof
Tested manually

@bigcommerce/checkout
