### PR TITLE
fix(checkout): INT-4180 Display method name along with the icon for checkout.com

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -284,7 +284,7 @@ describe('PaymentMethodTitle', () => {
                 } }
             />
         );
-        const baseURL = (id: string) => `/img/payment-providers/checkoutcom_${id}.png`;
+        const baseURL = (id: string) => `/img/payment-providers/checkoutcom_${id}.svg`;
 
         let component = checkoutcomTitleComponent('sepa');
         expect(component.find('[data-test="payment-method-logo"]').prop('src'))

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -122,8 +122,8 @@ function getPaymentMethodTitle(
                 titleText: methodName,
             },
             [PaymentMethodId.Checkoutcom]: {
-                logoUrl: method.id === 'credit_card' ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.png`),
-                titleText: method.id === 'credit_card' ? methodName : '',
+                logoUrl: method.id === 'credit_card' ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.svg`),
+                titleText: methodName,
             },
         };
 


### PR DESCRIPTION
## What? [INT-4081](https://jira.bigcommerce.com/browse/INT-4180)
Change logo file extension to `*.svg` instead of `*.png` and use method name in all cases.

## Why?
As requested by checkout.com on JIRA issue [INT-4180](https://jira.bigcommerce.com/browse/INT-4180)

## Testing / Proof
<img width="700" alt="Screen Shot 2021-04-13 at 4 26 16 PM" src="https://user-images.githubusercontent.com/35502707/114625627-25da3c80-9c78-11eb-8c9d-ac9db4c46e5d.png">
<img width="712" alt="Screen Shot 2021-04-13 at 4 46 15 PM" src="https://user-images.githubusercontent.com/35502707/114625630-270b6980-9c78-11eb-96db-af63c8756ed3.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
