### PR TITLE
fix(checkout): INT-4229 Fix checkout.com logo for credit card on phase 1

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -301,5 +301,13 @@ describe('PaymentMethodTitle', () => {
         component = checkoutcomTitleComponent('qpay');
         expect(component.find('[data-test="payment-method-logo"]').prop('src'))
             .toEqual(`${config.cdnPath}${baseURL('qpay')}`);
+
+        component = checkoutcomTitleComponent('credit_card');
+        expect(component.find('[data-test="payment-method-name"]').text())
+            .toEqual(defaultProps.method.config.displayName);
+
+        component = checkoutcomTitleComponent('checkoutcom');
+        expect(component.find('[data-test="payment-method-name"]').text())
+            .toEqual(defaultProps.method.config.displayName);
     });
 });

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -122,7 +122,7 @@ function getPaymentMethodTitle(
                 titleText: methodName,
             },
             [PaymentMethodId.Checkoutcom]: {
-                logoUrl: method.id === 'credit_card' ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.svg`),
+                logoUrl: ['credit_card', 'checkoutcom'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.svg`),
                 titleText: methodName,
             },
             [PaymentMethodId.StripeV3]: {


### PR DESCRIPTION
## What?
Add 'checkoutcom' validation for the payment method logo

## Why?
So credit card method does not display logo when on phase 1.

## Sibling PRs
Requires https://github.com/bigcommerce/checkout-js/pull/552 to be merged

## Testing / Proof
With Phase 2 disabled
<img width="633" alt="Screen Shot 2021-04-21 at 5 11 25 PM" src="https://user-images.githubusercontent.com/35502707/115627482-b5a96780-a2c4-11eb-81c5-17b849b6b5f3.png">

With Phase 2 enabled
<img width="721" alt="Screen Shot 2021-04-21 at 5 09 33 PM" src="https://user-images.githubusercontent.com/35502707/115627484-b641fe00-a2c4-11eb-9263-f52c69218bfc.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
