### PR TITLE
feat(payment): INT-4150 adding zip to handlebeforeunload function 

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -286,6 +286,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.Laybuy ||
             selectedMethod.id === PaymentMethodId.SagePay ||
             selectedMethod.id === PaymentMethodId.Sezzle ||
+            selectedMethod.id === PaymentMethodId.Zip ||
             selectedMethod.gateway === PaymentMethodId.AdyenV2 ||
             selectedMethod.gateway === PaymentMethodId.AdyenV2GooglePay ||
             selectedMethod.gateway === PaymentMethodId.Afterpay ||


### PR DESCRIPTION
Parent ticket: [INT-3825](https://jira.bigcommerce.com/browse/INT-3825)
[INT-4150](https://jira.bigcommerce.com/browse/INT-4150)

## What?
I added zip as an option within the handlebeforeunload function

## Why?
We're implementing a full redirect in new refactor for zip and during the redirect a `Leaving site` pop up alert was interrupting the redirection. 

## Testing / Proof
https://drive.google.com/file/d/1PsMQ111k9rtq6RjgBkdJcbeffcBln2yu/view?usp=sharing

@bigcommerce/checkout @bigcommerce/apex-integrations 

Sibling PR Sdk: https://github.com/bigcommerce/checkout-sdk-js/pull/1118