### PR TITLE
feat(payment): PAYPAL-982 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1655,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.142.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.142.0.tgz",
-      "integrity": "sha512-iUMF6HQj5G0+gPuz99JOAv0rhHKxQy1cJkonbaZaF6fnRWCTpHUgG1D8Nx3ZHtJ9DJOlXFwzbN2dLNvCSdWrBA==",
+      "version": "1.143.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.143.0.tgz",
+      "integrity": "sha512-a2AMizPBsAM0Bb6emZYnfIKjRkjL1cVLpCzg37WYl/M8CdsnyqBCXR8Pw+5sKl+n/ALFM/UtxdnEOancLmng6Q==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.13.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.142.0",
+    "@bigcommerce/checkout-sdk": "^1.143.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task PAYPAL-982

tested on dev

@bigcommerce/checkout @davidchin @capsula4 
