### PR TITLE
feat(payment): INT-4193 Add ticket url for OXXO/Boleto on checkout.com

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -372,7 +372,10 @@
             "thank_you_heading": "Thank you!",
             "continue_shopping": "Continue Shopping »",
             "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger",
-            "mandate_link_text": "{provider} Mandate"
+            "mandate_link_text": "{provider} Mandate",
+            "boleto_link_text": "Boleto Bancário Ticket",
+            "oxxo_link_text": "OXXO Ticket",
+            "sepa_link_text": "SEPA Direct Debit Mandate"
         }
     }
 }

--- a/src/app/order/OrderStatus.tsx
+++ b/src/app/order/OrderStatus.tsx
@@ -18,7 +18,19 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
 }) => {
 
     const getMandateProvider = useCallback(() => {
-        return order?.payments?.[0].description === 'Stripe (SEPA)' ? 'SEPA Direct Debit' : order?.payments?.[0].description;
+        return order?.payments?.[0].description;
+    }, [order]);
+
+    const getMandateTextId = useCallback(() => {
+        const Mandates = [
+            { method: 'Stripe (SEPA)', value: 'sepa_link_text' },
+            { method: 'OXXO (via Checkout.com)', value: 'oxxo_link_text' },
+            { method: 'Boleto Bancário (via Checkout.com)', value: 'boleto_link_text' },
+        ];
+
+        const mandateText = Mandates.find(pair => pair.method === order?.payments?.[0].description);
+
+        return mandateText ? mandateText.value : 'mandate_link_text';
     }, [order]);
 
     return <OrderConfirmationSection>
@@ -42,7 +54,7 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
         { order.mandateUrl && <a data-test="order-confirmation-mandate-link-text" href={ order.mandateUrl } rel="noopener noreferrer" target="_blank">
                 <TranslatedString
                     data={ { provider : getMandateProvider() } }
-                    id="order_confirmation.mandate_link_text"
+                    id={ 'order_confirmation.' + getMandateTextId() }
                 />
         </a> }
 


### PR DESCRIPTION
[INT-4193](https://jira.bigcommerce.com/browse/INT-4193)

## What?
Add Url for OXXO/Boleto ticket for checkout.com

## Why?
So customer can check its ticket through order confirmation and email

## Sibling PR's
[BCAPP](https://github.com/bigcommerce/bigcommerce/pull/40524)
~~[BIGPAY](https://github.com/bigcommerce/bigpay/pull/3700)~~

## Testing / Proof
[Demo](https://drive.google.com/file/d/1ZbjvnviN8GF_kbzWDLF-hsHSTG7EzatK/view?usp=sharing)
![Screen Shot 2021-04-20 at 16 49 09](https://user-images.githubusercontent.com/8669574/115759467-e2618b80-a365-11eb-9aeb-e9a82b8ad500.png)

@bigcommerce/checkout @bigcommerce/apex-integrations 
