### PR TITLE
feat(payment): INT-4237 Add issuer for Mollie APMs

### DIFF
--- a/src/app/payment/paymentMethod/MollieAPMCustomForm.spec.tsx
+++ b/src/app/payment/paymentMethod/MollieAPMCustomForm.spec.tsx
@@ -1,0 +1,55 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { DropdownTrigger } from '../../ui/dropdown';
+
+import MollieAPMCustomForm, { MollieCustomCardFormProps } from './MollieAPMCustomForm';
+
+describe('MollieAPMCustomForm', () => {
+    const method: PaymentMethod = {
+        id: 'mollie',
+        method: 'kbc/cbc',
+        supportedCards: [],
+        config: {},
+        type: 'card',
+        initializationData: {
+            paymentMethodsResponse: [
+                {
+                    resource: 'kbc',
+                    id: 'kbc',
+                    name: 'kbc',
+                    image: {
+                        size1x: 'logo.png',
+                    },
+                },
+            ],
+        },
+    };
+    let MollieAPMCustomFormTest: FunctionComponent<MollieCustomCardFormProps> ;
+
+    beforeEach(() => {
+        MollieAPMCustomFormTest = (props: MollieCustomCardFormProps) => (
+            <Formik
+                initialValues={ {} }
+                onSubmit={ noop }
+            >
+                <MollieAPMCustomForm { ...props } />
+            </Formik>
+        );
+    });
+
+    it('should empty render', () => {
+        const container = mount(<MollieAPMCustomFormTest method={ { ...method, initializationData: {} } } />);
+
+        expect(container.isEmptyRender()).toBe(true);
+    });
+
+    it('should render MollieAPMCustomForm', () => {
+        const container = mount(<MollieAPMCustomFormTest method={ method } />);
+
+        expect(container.find(DropdownTrigger)).toHaveLength(1);
+    });
+});

--- a/src/app/payment/paymentMethod/MollieAPMCustomForm.tsx
+++ b/src/app/payment/paymentMethod/MollieAPMCustomForm.tsx
@@ -1,0 +1,123 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { FieldProps } from 'formik';
+import React, { useCallback, useEffect, useState, FunctionComponent, SyntheticEvent } from 'react';
+
+import { preventDefault } from '../../common/dom';
+import { DropdownTrigger } from '../../ui/dropdown';
+import { FormField } from '../../ui/form';
+
+export interface MollieCustomCardFormProps {
+    method: PaymentMethod;
+}
+
+interface Issuer {
+    name: string;
+    image: {
+        size1x: string;
+    };
+    id: string;
+}
+
+interface HiddenInputProps extends FieldProps {
+    selectedIssuer?: Issuer;
+}
+
+interface SelecteIssuerProp {
+    selectedIssuer: Issuer;
+}
+
+interface OptionButtonProps {
+    issuer: Issuer;
+    className?: string;
+    onClick?(event: SyntheticEvent<EventTarget>): void;
+}
+
+const MollieAPMCustomForm: FunctionComponent<MollieCustomCardFormProps> = ({ method }) => {
+    const issuers: Issuer[] = method.initializationData?.paymentMethodsResponse;
+
+    const [ selectedIssuer, setSelectedIssuer ] = useState<Issuer>({ name: 'Select your bank', id: '', image: { size1x: '' } });
+    const render = useCallback((props: FieldProps) => <HiddenInput { ...props } selectedIssuer={ selectedIssuer } />, [ selectedIssuer ]);
+
+    if (!issuers || issuers.length === 0) {
+        return <></>;
+    }
+
+    const handleClick = ({ currentTarget }: SyntheticEvent<HTMLButtonElement>) => {
+        const _selectedIssuer = issuers.find(({ id }) => id === currentTarget?.dataset.id);
+
+        if (!_selectedIssuer) {
+            return;
+        }
+
+        setSelectedIssuer(_selectedIssuer);
+    };
+
+    const issuersList = (
+        <ul
+            className="dropdown-menu instrumentSelect-dropdownMenu mollie-instrument-card"
+            id="issuersDropdown"
+        >
+            { issuers.map(issuer =>
+                <li
+                    className="dropdown-menu-item dropdown-menu-item--select"
+                    key={ issuer.id }
+                >
+                    <OptionButton issuer={ issuer } onClick={ handleClick } />
+                </li>
+            ) }
+        </ul>
+    );
+
+    return (<>
+        <DropdownTrigger dropdown={ issuersList }>
+            <IssuerSelectButton selectedIssuer={ selectedIssuer } />
+        </DropdownTrigger>
+        <FormField input={ render } name="issuer" />
+    </>);
+};
+
+const HiddenInput: FunctionComponent<HiddenInputProps> = ({ field: { value, ...restField }, form, selectedIssuer}) => {
+    const Input = useCallback(() => <input { ...restField } type="hidden" />, [restField]);
+
+    useEffect(() => {
+        if (value === selectedIssuer) {
+            return;
+        }
+
+        form.setFieldValue(restField.name, selectedIssuer?.id);
+    }, [value, form, selectedIssuer, restField.name]);
+
+    return <Input />;
+};
+
+const IssuerSelectButton: FunctionComponent<SelecteIssuerProp> = ({ selectedIssuer }) => (
+    <a
+        className="instrumentSelect instrumentSelect-card button dropdown-button dropdown-toogle--select"
+        href="#"
+        id="issuerToggle"
+        onClick={ preventDefault() }
+    >
+        { selectedIssuer.name }
+    </a>
+);
+
+const OptionButton: FunctionComponent<OptionButtonProps> = ({ issuer, ...props }) => {
+    const { name, image, id } = issuer;
+
+    return (
+        <a
+            className="instrumentSelect-details mollie-instrument-list"
+            { ...props }
+            data-id={ id }
+        >
+            <label className="mollie-instrument-left">{ name }</label>
+            <img
+                alt={ name }
+                data-test="cart-item-image"
+                src={ image.size1x }
+            />
+        </a>
+    );
+};
+
+export default MollieAPMCustomForm;

--- a/src/app/payment/paymentMethod/MollieCustomCardForm.spec.tsx
+++ b/src/app/payment/paymentMethod/MollieCustomCardForm.spec.tsx
@@ -1,0 +1,77 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import MollieAPMCustomForm from './MollieAPMCustomForm';
+import MollieCustomCardForm, { MollieCustomCardFormProps } from './MollieCustomCardForm';
+
+describe('MollieCustomForm', () => {
+    const method: PaymentMethod = {
+        id: 'mollie',
+        method: 'kbc/cbc',
+        supportedCards: [],
+        config: {},
+        type: 'card',
+        initializationData: {
+            paymentMethodsResponse: [
+                {
+                    resource: 'kbc',
+                    id: 'kbc',
+                    name: 'kbc',
+                    image: {
+                        size1x: 'logo.png',
+                    },
+                },
+            ],
+        },
+    };
+    const options = {
+        cardNumberElementOptions: {
+            containerId: 'cnumber_containerId',
+        },
+        cardExpiryElementOptions: {
+            containerId: 'expiry_containerId',
+        },
+        cardCvcElementOptions: {
+            containerId: 'ccvc_containerId',
+        },
+        cardHolderElementOptions: {
+            containerId: 'cholder_containerId',
+        },
+    };
+    let MollieCustomFormTest: FunctionComponent<MollieCustomCardFormProps> ;
+
+    beforeEach(() => {
+        MollieCustomFormTest = (props: MollieCustomCardFormProps) => (
+            <Formik
+                initialValues={ {} }
+                onSubmit={ noop }
+            >
+                <MollieCustomCardForm { ...props } />
+            </Formik>
+        );
+    });
+
+    it('should render cc options', () => {
+        const container = mount(<MollieCustomFormTest isCreditCard={ true } method={ method } options={ options } />);
+
+        expect(container.find('[id="cnumber_containerId"]')).toHaveLength(1);
+        expect(container.find('[id="expiry_containerId"]')).toHaveLength(1);
+        expect(container.find('[id="ccvc_containerId"]')).toHaveLength(1);
+        expect(container.find('[id="cholder_containerId"]')).toHaveLength(1);
+    });
+
+    it('should empty render', () => {
+        const container = mount(<MollieCustomFormTest isCreditCard={ false } method={ { ...method, initializationData: {} } } options={ options } />);
+
+        expect(container.isEmptyRender()).toBe(true);
+    });
+
+    it('should render MollieAPMCustomForm', () => {
+        const container = mount(<MollieCustomFormTest isCreditCard={ false } method={ method } options={ options } />);
+
+        expect(container.find(MollieAPMCustomForm)).toHaveLength(1);
+    });
+});

--- a/src/app/payment/paymentMethod/MollieCustomCardForm.tsx
+++ b/src/app/payment/paymentMethod/MollieCustomCardForm.tsx
@@ -1,3 +1,4 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -5,6 +6,8 @@ import { TranslatedString } from '../../locale';
 import { IconHelp } from '../../ui/icon';
 import { TooltipTrigger } from '../../ui/tooltip';
 import { CreditCardCodeTooltip } from '../creditCard';
+
+import MollieAPMCustomForm from './MollieAPMCustomForm';
 
 export interface MollieCustomCardFormProps {
     options: {
@@ -21,12 +24,12 @@ export interface MollieCustomCardFormProps {
             containerId: string;
         };
     };
-
     isCreditCard: boolean;
+    method: PaymentMethod;
 }
 
-const MollieCustomCardForm: React.FunctionComponent<MollieCustomCardFormProps> = ({ options, isCreditCard }) => (
-    !isCreditCard ? <div /> :
+const MollieCustomCardForm: React.FunctionComponent<MollieCustomCardFormProps> = ({ options, isCreditCard, method }) => (
+    !isCreditCard ? <MollieAPMCustomForm method={ method } /> :
     <div className="form-ccFields">
         <div className={ classNames('form-field', 'mollie-full') }>
             <label

--- a/src/app/payment/paymentMethod/MolliePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/MolliePaymentMethod.tsx
@@ -62,7 +62,7 @@ const MolliePaymentMethod: FunctionComponent<MolliePaymentMethodsProps> = ({ ini
     function renderCustomPaymentForm() {
         const options = getMolliesElementOptions();
 
-        return <MollieCustomCardForm isCreditCard={ isCreditCard() } options={ options } />;
+        return <MollieCustomCardForm isCreditCard={ isCreditCard() } method={ method } options={ options } />;
     }
 
     function isCreditCard(): boolean {

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -1,6 +1,6 @@
 import { LanguageService, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { number } from 'card-validator';
-import { compact } from 'lodash';
+import { compact, startCase } from 'lodash';
 import React, { memo, Fragment, FunctionComponent } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
@@ -119,7 +119,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.Mollie]: {
                 logoUrl: method.method === 'credit_card' ? '' : cdnPath(`/img/payment-providers/${method.method}.svg`),
-                titleText: methodName,
+                titleText: startCase(methodName),
             },
             [PaymentMethodId.Checkoutcom]: {
                 logoUrl: ['credit_card', 'checkoutcom'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.svg`),

--- a/src/scss/components/checkout/instrumentSelect/_instrumentSelect.scss
+++ b/src/scss/components/checkout/instrumentSelect/_instrumentSelect.scss
@@ -88,3 +88,21 @@
         margin-bottom: 0;
     }
 }
+
+.mollie {
+    &-instrument-card {
+        margin-left: remCalc(9px);
+        margin-top: remCalc(-20px);
+        overflow: auto;
+        width: 80%;
+    }
+
+    &-instrument-list {
+        display: flex !important;
+        justify-content: flex-end;
+    }
+
+    &-instrument-left {
+        margin-right: auto;
+    }
+}


### PR DESCRIPTION
## What? [INT-4237](https://jira.bigcommerce.com/browse/INT-4237)
 List Issuing Banks In Dropdown on Payment Step, adding a component for APMs where this issuers are listed in a dropdown

## Why?
Some APMs such as Ideal have bank from where to choose, 

## Testing / Proof
![Screen Shot 2021-04-28 at 15 17 34](https://user-images.githubusercontent.com/69221626/116467058-e04f6f00-a834-11eb-91a2-f1a7ad56b553.png)

## Siblings
[SDK](https://github.com/bigcommerce/checkout-sdk-js/pull/1126)
[BCAPP](https://github.com/bigcommerce/bigcommerce/pull/40630)
[BIGPAY](https://github.com/bigcommerce/bigpay/pull/3748)


ping @bigcommerce/payments @bigcommerce/apex-integrations @bigcommerce/checkout

