### PR TITLE
feat(payment): INT-4242 Add Quadpay payment method

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -274,6 +274,8 @@
             "account_instrument_new_shipping_address": "<strong>We noticed this is a new shipping address.</strong><p>For security reasons, you will need to re-link your PayPal account when shipping to an address for the first time or if the shipping address was edited recently.</p>",
             "instrument_trusted_shipping_address_text": "This additional security step is applied to your card when shipping to an address for the first time or if the shipping address was edited recently.",
             "instrument_trusted_shipping_address_title_text": "Please re-enter your card number to authorize this transaction.",
+            "quadpay_continue_action": "Continue with Quadpay",
+            "quadpay_display_name_text": "Pay in 4 installments",
             "sepa_account_number": "Account Number (IBAN)",
             "sepa_account_number_required": "You must enter your account number (IBAN)",
             "sepa_bic": "BIC",

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -286,6 +286,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.Checkoutcom ||
             selectedMethod.id === PaymentMethodId.Converge ||
             selectedMethod.id === PaymentMethodId.Laybuy ||
+            selectedMethod.id === PaymentMethodId.Quadpay ||
             selectedMethod.id === PaymentMethodId.SagePay ||
             selectedMethod.id === PaymentMethodId.Sezzle ||
             selectedMethod.id === PaymentMethodId.Zip ||

--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -132,4 +132,13 @@ describe('PaymentSubmitButton', () => {
         expect(component.text())
             .toEqual(languageService.translate('payment.paypal_credit_continue_action'));
     });
+
+    it('renders button with special label for Quadpay', () => {
+        const component = mount(
+            <PaymentSubmitButtonTest methodId="quadpay" />
+        );
+
+        expect(component.text())
+            .toEqual(languageService.translate('payment.quadpay_continue_action'));
+    });
 });

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -55,6 +55,10 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
         return <TranslatedString id="payment.paypal_credit_continue_action" />;
     }
 
+    if (methodId === PaymentMethodId.Quadpay) {
+        return <TranslatedString id="payment.quadpay_continue_action" />;
+    }
+
     return <TranslatedString id="payment.place_order_action" />;
 });
 

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -191,6 +191,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
     if (method.gateway === PaymentMethodId.Afterpay ||
         method.gateway === PaymentMethodId.Clearpay ||
         method.id === PaymentMethodId.Laybuy ||
+        method.id === PaymentMethodId.Quadpay ||
         method.id === PaymentMethodId.Sezzle ||
         method.id === PaymentMethodId.Zip ||
         method.method === PaymentMethodType.Paypal ||

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -36,6 +36,7 @@ enum PaymentMethodId {
     PaypalCommerceCreditCards = 'paypalcommercecreditcards',
     PaypalCommerceAlternativeMethod = 'paypalcommercealternativemethods',
     Qpay = 'qpay',
+    Quadpay = 'quadpay',
     SagePay = 'sagepay',
     Sepa = 'sepa',
     Sezzle = 'sezzle',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -34,6 +34,7 @@ describe('PaymentMethodTitle', () => {
         laybuy: '/img/payment-providers/laybuy-checkout-header.png',
         masterpass: 'https://masterpass.com/dyn/img/acc/global/mp_mark_hor_blk.svg',
         paypal: '/img/payment-providers/paypalpaymentsprouk.png',
+        quadpay: '/img/payment-providers/quadpay.png',
         sezzle: '/img/payment-providers/sezzle-checkout-header.png',
         zip: '/img/payment-providers/zip.png',
         paypalcommerce: '/img/payment-providers/paypal_commerce_logo.svg',
@@ -160,6 +161,7 @@ describe('PaymentMethodTitle', () => {
             PaymentMethodId.Afterpay,
             PaymentMethodId.Clearpay,
             PaymentMethodId.Klarna,
+            PaymentMethodId.Quadpay,
             PaymentMethodId.Sezzle,
             PaymentMethodId.Zip,
         ];
@@ -185,6 +187,7 @@ describe('PaymentMethodTitle', () => {
         const methodIds = [
             PaymentMethodId.Affirm,
             PaymentMethodId.Klarna,
+            PaymentMethodId.Quadpay,
             PaymentMethodId.Sezzle,
             PaymentMethodId.Zip,
         ];

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -105,6 +105,10 @@ function getPaymentMethodTitle(
                 logoUrl: cdnPath('/img/payment-providers/paypalpaymentsprouk.png'),
                 titleText: '',
             },
+            [PaymentMethodId.Quadpay]: {
+                logoUrl: cdnPath('/img/payment-providers/quadpay.png'),
+                titleText: language.translate('payment.quadpay_display_name_text'),
+            },
             [PaymentMethodId.Sezzle]: {
                 logoUrl: cdnPath('/img/payment-providers/sezzle-checkout-header.png'),
                 titleText: language.translate('payment.sezzle_display_name_text'),


### PR DESCRIPTION
## What? [INT-4242](https://jira.bigcommerce.com/browse/INT-4242)
Add **Quadpay** payment method.

## Why?
To make **Quadpay** available at checkout.

## Testing / Proof
<img width="550" alt="Quadpay" src="https://user-images.githubusercontent.com/4843328/119195286-05a55680-ba4a-11eb-97fc-e549057a64b1.png">

## Sibling PR
This PR depends on https://github.com/bigcommerce/checkout-sdk-js/pull/1129 to pay.
This PR depends on https://github.com/bigcommerce/bigcommerce/pull/40762 to display the Quadpay logo.

@bigcommerce/apex-integrations  @bigcommerce/checkout
