### PR TITLE
[DRAFT] PAYMENTS-6796 How we will localise payment error messages

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -282,7 +282,11 @@
             "visa_checkout_continue_action": "Continue with Visa Checkout",
             "zip_continue_action": "Continue with Zip",
             "zip_name_text": "Zip",
-            "zip_display_name_text": "Own it now, pay later"
+            "zip_display_name_text": "Own it now, pay later",
+            "errors": {
+                "incorrect_address": "Unable to process the payment because invalid data was supplied with the transaction. (translated)",
+                "transaction_declined": "Payment was declined. Please try again. (translated)"
+            }
         },
         "redeemable": {
             "applied_text": "Applied",

--- a/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -27,6 +27,19 @@ export default function mapSubmitOrderErrorMessage(
                 return translate('payment.payment_method_error', { message: error.message });
             }
 
+            // Checking here if the error is a RequestError, get the translated message(s) based on the error code (s).
+            // It's an array of errors, so there could be more than one message.
+            // If we are going to add all BigPay messages to the translation JSON file,
+            // it should be not possible to have a code that does not exit.
+            // However, we want this case to be handled.
+            if (error.body && error.body.errors) {
+                const messages = error.body.errors.map((error: { code: any; }) => translate(`payment.errors.${error.code}`));
+
+                if (messages.length) {
+                    return messages.join(' ');
+                }
+            }
+            
             if (error.message) {
                 return error.message;
             }


### PR DESCRIPTION
## What?
Currently, error messages coming from BigPay are displayed without being translated. Instead, we want to use translated messages based on the error codes.

**Open question**: How shall we handle non-existing error code?

## Why?
So shoppers read payment error messages in their own languages.

## Testing / Proof
<img width="1199" alt="Screen Shot 2021-05-12 at 10 59 45 am" src="https://user-images.githubusercontent.com/36555311/117908482-d1c88380-b31b-11eb-96c8-1f33472cb885.png">

<img width="1198" alt="Screen Shot 2021-05-12 at 10 57 30 am" src="https://user-images.githubusercontent.com/36555311/117908487-d3924700-b31b-11eb-8743-e9d9c53cb94f.png">

@bigcommerce/checkout @bigcommerce/payments
