### PR TITLE
fix(payment): INT-3941 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,14 +142,14 @@
           "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
         },
         "electron-to-chromium": {
-          "version": "1.3.727",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-          "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg=="
+          "version": "1.3.728",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz",
+          "integrity": "sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA=="
         },
         "node-releases": {
-          "version": "1.1.71",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-          "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+          "version": "1.1.72",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+          "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw=="
         }
       }
     },
@@ -1655,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.147.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.147.0.tgz",
-      "integrity": "sha512-3El4HCodHHjVwjo/jQ0HRtsKMHxaLznIoeTdTZofXk7TYR8d0S0Gn3Y2kbU6W9xHSM/dP1ooF8Zl1GvsWb8Yag==",
+      "version": "1.147.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.147.1.tgz",
+      "integrity": "sha512-qqz7Zfn27Wwua5hglg7jYsPyO47GjC8JI98YulKU+noSCncro4A0vDf/nNH1GxD+LZuCqlUPOGCKJ67GfqCFbA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.147.0",
+    "@bigcommerce/checkout-sdk": "^1.147.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Raise the active SDK version.

## Why?
Releasing https://github.com/bigcommerce/checkout-sdk-js/pull/1130

## Testing / Proof
Circle, see linked PR.

@bigcommerce/checkout
