### PR TITLE
feat(payment): PAYMENTS-6813 add wip ppsdk payment method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,9 @@
           "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
         },
         "electron-to-chromium": {
-          "version": "1.3.728",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz",
-          "integrity": "sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA=="
+          "version": "1.3.730",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.730.tgz",
+          "integrity": "sha512-1Tr3h09wXhmqXnvDyrRe6MFgTeU0ZXy3+rMJWTrOHh/HNesWwBBrKnMxRJWZ86dzs8qQdw2c7ZE1/qeGHygImA=="
         },
         "node-releases": {
           "version": "1.1.72",
@@ -1039,9 +1039,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.14.2",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.2.tgz",
-          "integrity": "sha512-OnADYbKrffDVai5qcpkMxQ7caomHOoEwjkouqnN2QhydAjowFAZcsdecFIRUBdb+ZcruwYE4ythYmF1UBZU5xQ==",
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+          "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
           "requires": {
             "@babel/types": "^7.14.2",
             "jsesc": "^2.5.1",
@@ -1113,14 +1113,14 @@
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.13.12",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-          "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+          "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
           "requires": {
             "@babel/helper-member-expression-to-functions": "^7.13.12",
             "@babel/helper-optimise-call-expression": "^7.12.13",
-            "@babel/traverse": "^7.13.0",
-            "@babel/types": "^7.13.12"
+            "@babel/traverse": "^7.14.2",
+            "@babel/types": "^7.14.2"
           }
         },
         "@babel/helper-simple-access": {
@@ -1206,9 +1206,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.14.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.2.tgz",
-          "integrity": "sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ=="
+          "version": "7.14.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+          "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ=="
         },
         "@babel/template": {
           "version": "7.12.13",
@@ -1450,16 +1450,16 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.14.2",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.2.tgz",
-              "integrity": "sha512-OgC1mON+l4U4B4wiohJlQNUU3H73mpTyYY3j/c8U9dr9UagGGSm+WFpzjy/YLdoyjiG++c1kIDgxCo/mLwQJeQ==",
+              "version": "7.14.3",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+              "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
               "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.14.2",
+                "@babel/generator": "^7.14.3",
                 "@babel/helper-compilation-targets": "^7.13.16",
                 "@babel/helper-module-transforms": "^7.14.2",
                 "@babel/helpers": "^7.14.0",
-                "@babel/parser": "^7.14.2",
+                "@babel/parser": "^7.14.3",
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.14.2",
                 "@babel/types": "^7.14.2",
@@ -1655,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.148.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.148.0.tgz",
-      "integrity": "sha512-GNqDQBYCOWNs7GTKYt6qOqYtnOnNf1SL98m4YyE8lZf4DFWN106sxwmxjWTwpgZgir3lh+m3QV40kk5Va4HQSw==",
+      "version": "1.149.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.149.0.tgz",
+      "integrity": "sha512-qsgDDdrC38xrfM3gfy/XCobxZhtL5IAE4M/Tovk9MXToQpid9KY8vAISyWBrsZcVGXu2Axj8TsWSWnoB1ogf7w==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.148.0",
+    "@bigcommerce/checkout-sdk": "^1.149.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/NoUI.tsx
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/NoUI.tsx
@@ -1,0 +1,1 @@
+export const NoUI = () => null;

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/PPSDKPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/PPSDKPaymentMethod.spec.tsx
@@ -1,0 +1,148 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { PPSDKPaymentMethod } from './PPSDKPaymentMethod';
+
+describe('when using a PPSDK payment method', () => {
+    describe('with an initialisation type of NONE', () => {
+        const method: PaymentMethod = {
+            id: 'someId',
+            gateway: 'someGateway',
+            config: {},
+            method: 'someMethod',
+            supportedCards: [],
+            type: 'PAYMENT_TYPE_SDK',
+            initializationStrategy: {
+                type: 'NONE',
+            },
+        };
+
+        it('renders empty', () => {
+            const container = mount(
+                <PPSDKPaymentMethod
+                    deinitializePayment={ jest.fn().mockResolvedValue(undefined) } initializePayment={ jest.fn().mockResolvedValue(undefined) } method={ method }
+                />
+            );
+
+            expect(container.isEmptyRender()).toBe(true);
+        });
+
+        it('invokes the initializePayment callback with an options argument on mount', () => {
+            const initializeMock = jest.fn().mockResolvedValue(undefined);
+
+            mount(
+                <PPSDKPaymentMethod
+                    deinitializePayment={ jest.fn().mockResolvedValue(undefined) } initializePayment={ initializeMock } method={ method }
+                />
+            );
+
+            expect(initializeMock).toHaveBeenCalledWith({
+                methodId: 'someId',
+                gatewayId: 'someGateway',
+            });
+        });
+
+        it('invokes the deinitializePayment callback with an options argument on unmount', () => {
+            const deinitializeMock = jest.fn().mockResolvedValue(undefined);
+
+            const container = mount(
+                <PPSDKPaymentMethod
+                    deinitializePayment={ deinitializeMock } initializePayment={ jest.fn().mockResolvedValue(undefined) } method={ method }
+                />
+            );
+
+            container.unmount();
+
+            expect(deinitializeMock).toHaveBeenCalledWith({
+                methodId: 'someId',
+                gatewayId: 'someGateway',
+            });
+        });
+
+        describe('with a failing initialization', () => {
+            it('invokes the error callback', async () => {
+                const errorHandlerMock = jest.fn();
+                const initializeMock = jest.fn().mockRejectedValue(new Error('Some error'));
+
+                mount(
+                    <PPSDKPaymentMethod
+                        deinitializePayment={ jest.fn().mockResolvedValue(undefined) } initializePayment={ initializeMock } method={ method } onUnhandledError={ errorHandlerMock }
+                    />
+                );
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(errorHandlerMock).toHaveBeenCalledWith(expect.any(Error));
+            });
+        });
+    });
+
+    describe('with an unsupported initialisation type', () => {
+        interface VagueMethod extends PaymentMethod {
+            initializationStrategy: any;
+        }
+
+        const unsupportedMethod: VagueMethod = {
+            id: 'someId',
+            gateway: 'someGateway',
+            config: {},
+            method: 'someMethod',
+            supportedCards: [],
+            type: 'PAYMENT_TYPE_SDK',
+            initializationStrategy: {
+                type: 'some-unsupported-type',
+            },
+        };
+
+        it('renders empty', () => {
+            const container = mount(
+                <PPSDKPaymentMethod
+                    deinitializePayment={ jest.fn().mockResolvedValue(undefined) } initializePayment={ jest.fn().mockResolvedValue(undefined) } method={ unsupportedMethod }
+                />
+            );
+
+            expect(container.isEmptyRender()).toBe(true);
+        });
+
+        it('invokes the error callback', async () => {
+            const errorHandlerMock = jest.fn();
+
+            mount(
+                <PPSDKPaymentMethod
+                    deinitializePayment={ jest.fn().mockResolvedValue(undefined) } initializePayment={ jest.fn().mockResolvedValue(undefined) } method={ unsupportedMethod } onUnhandledError={ errorHandlerMock }
+                />
+            );
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(errorHandlerMock).toHaveBeenCalledWith(expect.any(Error));
+        });
+
+        it('does not invoke the initializePayment callback on mount', () => {
+            const initializeMock = jest.fn().mockResolvedValue(undefined);
+
+            mount(
+                <PPSDKPaymentMethod
+                    deinitializePayment={ jest.fn().mockResolvedValue(undefined) } initializePayment={ initializeMock } method={ unsupportedMethod }
+                />
+            );
+
+            expect(initializeMock).not.toHaveBeenCalled();
+        });
+
+        it('does not invoke the deinitializePayment callback on unmount', () => {
+            const deinitializeMock = jest.fn().mockResolvedValue(undefined);
+
+            const container = mount(
+                <PPSDKPaymentMethod
+                    deinitializePayment={ deinitializeMock } initializePayment={ jest.fn().mockResolvedValue(undefined) } method={ unsupportedMethod }
+                />
+            );
+
+            container.unmount();
+
+            expect(deinitializeMock).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/PPSDKPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/PPSDKPaymentMethod.tsx
@@ -1,0 +1,37 @@
+import { CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { initializationComponentMap } from './initializationComponentMap';
+import { usePropsToOnMount } from './usePropsToOnMount';
+import { Wrapper } from './Wrapper';
+
+type CheckoutServiceInstance = InstanceType<typeof CheckoutService>;
+
+interface Props {
+    method: PaymentMethod;
+    deinitializePayment: CheckoutServiceInstance['deinitializePayment'];
+    initializePayment: CheckoutServiceInstance['initializePayment'];
+    onUnhandledError?(error: Error): void;
+}
+
+export const PPSDKPaymentMethod: FunctionComponent<Props> = props => {
+    const { method, onUnhandledError = noop } = props;
+
+    const onMount = usePropsToOnMount(props);
+
+    const componentKey = method?.initializationStrategy?.type || '';
+    const Component = initializationComponentMap[componentKey];
+
+    if (!Component) {
+        onUnhandledError(new Error('PPSDK initialization strategy not found'));
+
+        return null;
+    }
+
+    return (
+        <Wrapper onMount={ onMount }>
+            <Component { ...props } />
+        </Wrapper>
+    );
+};

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/Wrapper.tsx
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/Wrapper.tsx
@@ -1,0 +1,13 @@
+import React, { useEffect, FunctionComponent } from 'react';
+
+interface Props {
+    onMount(): () => void;
+}
+
+export const Wrapper: FunctionComponent<Props> = props => {
+    const { children, onMount } = props;
+
+    useEffect(onMount, [onMount]);
+
+    return <>{ children }</>;
+};

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/index.ts
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/index.ts
@@ -1,0 +1,1 @@
+export { PPSDKPaymentMethod as default } from './PPSDKPaymentMethod';

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/initializationComponentMap.ts
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/initializationComponentMap.ts
@@ -1,0 +1,9 @@
+import { FunctionComponent } from 'react';
+
+import { NoUI } from './NoUI';
+
+type ComponentMap = Record<string, FunctionComponent>;
+
+export const initializationComponentMap: ComponentMap = {
+    NONE: NoUI,
+};

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/usePropsToOnMount.ts
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/usePropsToOnMount.ts
@@ -1,0 +1,36 @@
+
+import { CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import { useCallback, useMemo } from 'react';
+
+type CheckoutServiceInstance = InstanceType<typeof CheckoutService>;
+
+interface Props {
+    method: PaymentMethod;
+    deinitializePayment: CheckoutServiceInstance['deinitializePayment'];
+    initializePayment: CheckoutServiceInstance['initializePayment'];
+    onUnhandledError?(error: Error): void;
+}
+
+export const usePropsToOnMount = (props: Props): () => () => void => {
+    const { initializePayment, deinitializePayment, method, onUnhandledError = noop } = props;
+
+    const options = useMemo(
+        () => ({
+            gatewayId: method.gateway,
+            methodId: method.id,
+        }),
+        [method.gateway, method.id]
+    );
+
+    const onInit = useCallback(() => initializePayment(options), [initializePayment, options]);
+    const onDeinit = useCallback(() => deinitializePayment(options), [deinitializePayment, options]);
+
+    return useCallback(() => {
+        onInit().catch(onUnhandledError);
+
+        return () => {
+            onDeinit().catch(onUnhandledError);
+        };
+    }, [onInit, onUnhandledError, onDeinit]);
+};

--- a/src/app/payment/paymentMethod/PaymentMethodProviderType.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodProviderType.ts
@@ -2,6 +2,7 @@ enum PaymentMethodProviderType {
     Api = 'PAYMENT_TYPE_API',
     Hosted = 'PAYMENT_TYPE_HOSTED',
     Offline = 'PAYMENT_TYPE_OFFLINE',
+    PPSDK = 'PAYMENT_TYPE_SDK',
 }
 
 export default PaymentMethodProviderType;


### PR DESCRIPTION
## What?

- Add a new `PPSDKPaymentMethod`
- Add a map of initialisation strategies to Functional Components which will render the UI
- Add mounting logic to call init/deinit strategy methods upon rendering a valid initialisation strategy
- Have the `PPSDKPaymentMethod` return no visuals and call the error handler on an initialisation strategy mismatch
- Add a `NoUI` component for PPSDK initialisation strategies that require no initial UI (e.g. payment methods which redirect offsite on a user click of "place order")
- Guard all the above with a experiment feature toggle which will not allow the selection of `PPSDKPaymentMethod` when off

## Why?

- To allow for correct rendering of new PPSDK Payment Methods (at first, ones with no visuals)

## Testing / Proof
- New tests

@bigcommerce/checkout
