### PR TITLE
fix(payment): INT-4184 Add missing payment type to SEPA

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -203,6 +203,7 @@
             "checkoutcom_sepa_creditor_id": "Creditor ID: {creditorId}",
             "checkoutcom_sepa_debtor_title": "Debtor",
             "checkoutcom_sepa_mandate_disclaimer": "By accepting this mandate form, you authorize {creditorName} to send instructions to your bank to debit your account, and your bank to debit your account in accordance with those instructions. You are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited.",
+            "checkoutcom_sepa_payment_type": "Payment type: one-off (non-recurring)",
             "credit_card_text": "Credit card",
             "credit_card_customer_code_label": "Customer Code",
             "credit_card_cvv_help_text": "For VISA and Mastercard, the CVV is a three-digit code printed on the back. For American Express it is the four-digit code printed on the front. The CVV is a security measure to ensure that you are in possession of the card.",

--- a/src/app/payment/paymentMethod/CheckoutcomCustomFormFields.tsx
+++ b/src/app/payment/paymentMethod/CheckoutcomCustomFormFields.tsx
@@ -76,6 +76,11 @@ const Sepa: FunctionComponent<CheckoutcomAPMFormProps> = ({method, debtor}) => {
                 <p className="checkoutcom-sepa-line">{ debtor.countryCode }</p>
             </div>
         </div>
+        <p className="checkoutcom-sepa-line">
+            <TranslatedString id="payment.checkoutcom_sepa_payment_type" />
+        </p>
+        <br />
+
         <TextFieldForm
             additionalClassName="form-field--iban"
             autoComplete="iban"

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -91,7 +91,7 @@ body.klarna-payments-fso-open {
     flex-basis: 100%;
     flex-direction: row;
     margin-bottom: 0;
-    padding-bottom: remCalc(20px);
+    padding-bottom: remCalc(5px);
 }
 
 .checkoutcom-sepa-column-content {


### PR DESCRIPTION
## What?
Add the missing payment type line to SEPA on checkout.com

## Why?
These changes were missing on https://github.com/bigcommerce/checkout-js/pull/571

## Testing / Proof
<img width="669" alt="Screen Shot 2021-05-05 at 12 31 43 PM" src="https://user-images.githubusercontent.com/35502707/117191608-5d836280-ada6-11eb-8fd1-3a2ecc12f397.png">

@bigcommerce/checkout @bigcommerce/apex-integrations 
