### PR TITLE
fix(checkout): CHECKOUT-5037 Fix mailto: links on order confirmation page if payment is still pending or when order is incomplete

### DIFF
--- a/src/app/order/OrderStatus.spec.tsx
+++ b/src/app/order/OrderStatus.spec.tsx
@@ -141,7 +141,7 @@ describe('OrderStatus', () => {
                 />
             );
             const translationProps = orderStatus.find('[data-test="order-confirmation-order-status-text"]')
-                .find(TranslatedString)
+                .find(TranslatedHtml)
                 .props();
 
             expect(translationProps)
@@ -171,7 +171,7 @@ describe('OrderStatus', () => {
                 />
             );
             const translationProps = orderStatus.find('[data-test="order-confirmation-order-status-text"]')
-                .find(TranslatedString)
+                .find(TranslatedHtml)
                 .props();
 
             expect(translationProps)

--- a/src/app/order/OrderStatus.tsx
+++ b/src/app/order/OrderStatus.tsx
@@ -90,13 +90,13 @@ const OrderStatusMessage: FunctionComponent<OrderStatusMessageProps> = ({
         />;
 
     case 'PENDING':
-        return <TranslatedString
+        return <TranslatedHtml
             data={ { orderNumber, supportEmail } }
             id="order_confirmation.order_pending_status_text"
         />;
 
     case 'INCOMPLETE':
-        return <TranslatedString
+        return <TranslatedHtml
             data={ { orderNumber, supportEmail } }
             id="order_confirmation.order_incomplete_status_text"
         />;


### PR DESCRIPTION
## What?
Fix mailto: links on order confirmation page if payment is still pending or order is incomplete

## Why?
There's HTML in these strings which is being escaped

## Testing / Proof
Before
<img width="675" alt="Screen Shot 2021-05-18 at 6 01 13 pm" src="https://user-images.githubusercontent.com/1606901/118615837-7bb87c00-b804-11eb-9e11-082c171c98d7.png">

After
<img width="681" alt="Screen Shot 2021-05-18 at 6 02 03 pm" src="https://user-images.githubusercontent.com/1606901/118615832-7a874f00-b804-11eb-99d5-470b9fc256d8.png">

@bigcommerce/checkout