### PR TITLE
feat(payment): INT-4310 Create HostedDropInPaymentMethod

### DIFF
--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -9,7 +9,7 @@ import { getStoreConfig } from '../../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
 import { getPaymentMethod } from '../payment-methods.mock';
 
-import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+import HostedDropInPaymentMethod, { HostedDropInPaymentMethodProps } from './HostedDropInPaymentMethod';
 import { default as PaymentMethodComponent, PaymentMethodProps } from './PaymentMethod';
 import PaymentMethodId from './PaymentMethodId';
 
@@ -54,9 +54,9 @@ describe('when using Digital River payment', () => {
         );
     });
 
-    it('renders as hosted widget method', () => {
+    it('renders as hosted drop in method', () => {
         const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
-        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+        const component: ReactWrapper<HostedDropInPaymentMethodProps> = container.find(HostedDropInPaymentMethod);
 
         expect(component.props())
             .toEqual(expect.objectContaining({
@@ -68,7 +68,7 @@ describe('when using Digital River payment', () => {
 
     it('initializes method with required config', () => {
         const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
-        const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
+        const component: ReactWrapper<HostedDropInPaymentMethodProps> = container.find(HostedDropInPaymentMethod);
 
         component.prop('initializePayment')({
             methodId: method.id,
@@ -108,7 +108,6 @@ describe('when using Digital River payment', () => {
                     },
                     containerId: `${method}-component-field`,
                     onError: expect.any(Function),
-                    onRenderButton: expect.any(Function),
                     onSubmitForm: expect.any(Function),
                 },
                 gatewayId: undefined,

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -3,10 +3,10 @@ import { Omit } from 'utility-types';
 
 import { connectFormik, ConnectFormikProps } from '../../common/form';
 import { FormContext } from '../../ui/form';
-import PaymentContext from '../PaymentContext';
 import { PaymentFormValues } from '../PaymentForm';
 
-import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
+import HostedDropInPaymentMethod from './HostedDropInPaymentMethod';
+import { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
 
 export type DigitalRiverPaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'containerId'> & ConnectFormikProps<PaymentFormValues>;
 
@@ -20,7 +20,6 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
     formik: { submitForm },
     ...rest
 }) => {
-    const paymentContext = useContext(PaymentContext);
     const { setSubmitted } = useContext(FormContext);
     const containerId = `${rest.method}-component-field`;
     const initializeDigitalRiverPayment = useCallback(options => initializePayment({
@@ -53,9 +52,6 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                     classes: DigitalRiverClasses,
                 },
             },
-            onRenderButton: () => {
-                paymentContext?.hidePaymentSubmitButton?.(rest.method, true);
-            },
             onSubmitForm: () => {
                 setSubmitted(true);
                 submitForm();
@@ -64,11 +60,12 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 onUnhandledError?.(error);
             },
         },
-    }), [containerId, initializePayment, submitForm, paymentContext, rest.method, setSubmitted, onUnhandledError]);
+    }), [initializePayment, containerId, setSubmitted, submitForm, onUnhandledError]);
 
-    return <HostedWidgetPaymentMethod
+    return <HostedDropInPaymentMethod
         { ...rest }
         containerId={ containerId }
+        hideVerificationFields
         initializePayment={ initializeDigitalRiverPayment }
     />;
 };

--- a/src/app/payment/paymentMethod/HostedDropInPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedDropInPaymentMethod.spec.tsx
@@ -1,0 +1,259 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount, ReactWrapper } from 'enzyme';
+import { EventEmitter } from 'events';
+import { Formik } from 'formik';
+import { merge, noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { getCart } from '../../cart/carts.mock';
+import { CheckoutProvider } from '../../checkout';
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getCustomer } from '../../customer/customers.mock';
+import { createLocaleContext, LocaleContext } from '../../locale';
+import { getConsignment } from '../../shipping/consignment.mock';
+import { LoadingOverlay } from '../../ui/loading';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { CardInstrumentFieldset } from '../storedInstrument';
+import { getInstruments } from '../storedInstrument/instruments.mock';
+import PaymentContext, { PaymentContextProps } from '../PaymentContext';
+
+import HostedDropInPaymentMethod, { HostedDropInPaymentMethodProps } from './HostedDropInPaymentMethod';
+
+describe('HostedDropInPaymentMethod', () =>  {
+    let HostedDropInPaymentMethodTest: FunctionComponent<HostedDropInPaymentMethodProps>;
+    let defaultProps: HostedDropInPaymentMethodProps;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let paymentContext: PaymentContextProps;
+    let subscribeEventEmitter: EventEmitter;
+
+    beforeEach(() => {
+        defaultProps = {
+            containerId: 'widget-container',
+            deinitializePayment: jest.fn(),
+            initializePayment: jest.fn(),
+            method: getPaymentMethod(),
+        };
+
+        defaultProps.method.id = 'digitalriver';
+
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        paymentContext = {
+            disableSubmit: jest.fn(),
+            setSubmit: jest.fn(),
+            setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
+        };
+        subscribeEventEmitter = new EventEmitter();
+
+        jest.spyOn(checkoutService, 'subscribe')
+            .mockImplementation(subscriber => {
+                subscribeEventEmitter.on('change', () => subscriber(checkoutState));
+                subscribeEventEmitter.emit('change');
+
+                return noop;
+            });
+
+        jest.spyOn(checkoutState.data, 'getCheckout')
+            .mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(true);
+
+        jest.spyOn(checkoutState.data, 'getCart')
+            .mockReturnValue(getCart());
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getConsignments')
+            .mockReturnValue([getConsignment()]);
+
+        jest.spyOn(checkoutState.data, 'getCustomer')
+            .mockReturnValue(getCustomer());
+
+        HostedDropInPaymentMethodTest = props => (
+            <LocaleContext.Provider value={ createLocaleContext(getStoreConfig()) }>
+                <CheckoutProvider checkoutService={ checkoutService }>
+                    <PaymentContext.Provider value={ paymentContext }>
+                        <Formik
+                            initialValues={ {} }
+                            onSubmit={ noop }
+                        >
+                            <HostedDropInPaymentMethod { ...props } />
+                        </Formik>
+                    </PaymentContext.Provider>
+                </CheckoutProvider>
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('initializes payment method when component mounts', () => {
+        mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+        expect(defaultProps.initializePayment)
+            .toHaveBeenCalled();
+        expect(paymentContext.setSubmit).toHaveBeenCalled();
+    });
+
+    it('deinitializes payment method when component unmounts', () => {
+        const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+        expect(defaultProps.deinitializePayment)
+            .not.toHaveBeenCalled();
+
+        component.unmount();
+
+        expect(defaultProps.deinitializePayment)
+            .toHaveBeenCalled();
+    });
+
+    it('does not initialize payment method if payment data is not required', () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+            .mockReturnValue(false);
+
+        mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+        expect(defaultProps.initializePayment)
+            .not.toHaveBeenCalled();
+    });
+
+    it('renders loading overlay while waiting for method to initialize', () => {
+        let component: ReactWrapper;
+
+        component = mount(<HostedDropInPaymentMethodTest
+            { ...defaultProps }
+            isInitializing
+        />);
+
+        expect(component.find(LoadingOverlay).prop('isLoading'))
+            .toEqual(true);
+
+        component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+        expect(component.find(LoadingOverlay).prop('isLoading'))
+            .toEqual(false);
+    });
+
+    it('hides content while loading', () => {
+        const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+        expect(component.find(LoadingOverlay).prop('hideContentWhenLoading'))
+            .toEqual(true);
+    });
+
+    it('renders placeholder container with provided ID', () => {
+        const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+        expect(component.exists(`#${defaultProps.containerId}`))
+            .toEqual(true);
+    });
+
+    it('deinitializes payment method when component unmounts', () => {
+        const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+        expect(defaultProps.deinitializePayment)
+            .not.toHaveBeenCalled();
+
+        component.unmount();
+
+        expect(defaultProps.deinitializePayment)
+            .toHaveBeenCalled();
+    });
+
+    describe('if stored instrument feature is available', () => {
+        beforeEach(() => {
+            defaultProps.method.config.isVaultingEnabled = true;
+
+            jest.spyOn(checkoutState.data, 'getInstruments')
+                .mockReturnValue(getInstruments());
+            jest.spyOn(checkoutService, 'loadInstruments')
+                .mockResolvedValue(checkoutState);
+            jest.spyOn(checkoutService, 'initializePayment')
+                .mockResolvedValue(checkoutState);
+        });
+
+        it('loads stored instruments when component mounts', () => {
+            mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            expect(checkoutService.loadInstruments)
+                .toHaveBeenCalled();
+        });
+
+        it('only shows instruments fieldset when there is at least one stored instrument', () => {
+            const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            expect(component.find(CardInstrumentFieldset))
+                .toHaveLength(1);
+        });
+
+        it('uses PaymentMethod to retrieve instruments', () => {
+            mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            expect(checkoutState.data.getInstruments)
+                .toHaveBeenCalledWith(defaultProps.method);
+        });
+
+        it('shows the payment submit button when a vaulted instrument is selected', () => {
+            const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            component.find(CardInstrumentFieldset)
+                .prop('onSelectInstrument')(getInstruments()[0].bigpayToken);
+            component.update();
+
+            expect(paymentContext.hidePaymentSubmitButton)
+                .toHaveBeenCalledWith(defaultProps.method, false);
+        });
+
+        it('hides the payment submit button when a vaulted instrument is not selected', () => {
+            const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            component.find(CardInstrumentFieldset)
+                .prop('onUseNewInstrument')();
+            component.update();
+
+            expect(paymentContext.hidePaymentSubmitButton)
+                .toHaveBeenCalledWith(defaultProps.method, true);
+        });
+
+        it('shows fields on the Widget when you click Use another payment form on the vaulted instruments dropdown', () => {
+            const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+            component.find(CardInstrumentFieldset)
+                .prop('onSelectInstrument')(getInstruments()[0].bigpayToken);
+            component.update();
+            component.find(CardInstrumentFieldset)
+                .prop('onUseNewInstrument')();
+            component.update();
+
+            expect(component.find(CardInstrumentFieldset).prop('selectedInstrumentId'))
+                .toEqual(undefined);
+        });
+
+        it('switches to "use new card" view if all instruments are deleted', () => {
+            const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            expect(component.find(CardInstrumentFieldset))
+                .toHaveLength(1);
+
+            // Update state
+            checkoutState = merge({}, checkoutState, {
+                data: {
+                    getInstruments: jest.fn(() => []),
+                },
+            });
+
+            subscribeEventEmitter.emit('change');
+
+            component.find(CardInstrumentFieldset)
+                // tslint:disable-next-line:no-non-null-assertion
+                .prop('onDeleteInstrument')!(getInstruments()[0].bigpayToken);
+
+            component.update();
+
+            expect(component.find('.paymentMethod--hosted'))
+                .toHaveLength(1);
+        });
+    });
+});

--- a/src/app/payment/paymentMethod/HostedDropInPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedDropInPaymentMethod.tsx
@@ -1,0 +1,388 @@
+import { CardInstrument, CheckoutSelectors, CustomerInitializeOptions,
+    CustomerRequestOptions,
+    Instrument, PaymentInitializeOptions,
+    PaymentInstrument,
+    PaymentMethod, PaymentRequestOptions } from '@bigcommerce/checkout-sdk';
+import { memoizeOne } from '@bigcommerce/memoize';
+import classNames from 'classnames';
+import { find, noop, some } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+
+import { withCheckout, CheckoutContextProps } from '../../checkout';
+import { connectFormik, ConnectFormikProps } from '../../common/form';
+import { MapToPropsFactory } from '../../common/hoc';
+import { LoadingOverlay } from '../../ui/loading';
+import { isBankAccountInstrument, isCardInstrument, isInstrumentCardCodeRequiredSelector,
+    isInstrumentCardNumberRequiredSelector,
+    isInstrumentFeatureAvailable,
+    CardInstrumentFieldset,
+    CreditCardValidation } from '../storedInstrument';
+import withPayment, { WithPaymentProps } from '../withPayment';
+import { PaymentFormValues } from '../PaymentForm';
+
+export interface HostedDropInPaymentMethodProps {
+    containerId: string;
+    method: PaymentMethod;
+    isUsingMultiShipping?: boolean;
+    isInitializing?: boolean;
+    hideWidget?: boolean;
+    shouldHideInstrumentExpiryDate?: boolean;
+    hideVerificationFields?: boolean;
+    isSignInRequired?: boolean;
+    validateInstrument?(shouldShowNumberField: boolean): React.ReactNode;
+    deinitializeCustomer?(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
+    deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
+    onUnhandledError?(error: Error): void;
+    initializeCustomer?(options: CustomerInitializeOptions): Promise<CheckoutSelectors>;
+    initializePayment(options: PaymentInitializeOptions, selectedInstrumentId?: string): Promise<CheckoutSelectors>;
+    signInCustomer?(): void;
+    onSignOut?(): void;
+    onSignOutError?(error: Error): void;
+}
+
+interface HostedDropInPaymentMethodState {
+    isAddingNewCard: boolean;
+    selectedInstrumentId?: string;
+}
+
+interface WithCheckoutHostedDropInPaymentMethodProps {
+    instruments: PaymentInstrument[];
+    isInstrumentFeatureAvailable: boolean;
+    isLoadingInstruments: boolean;
+    isPaymentDataRequired: boolean;
+    isSignedIn: boolean;
+    isInstrumentCardCodeRequired(instrument: Instrument, method: PaymentMethod): boolean;
+    isInstrumentCardNumberRequired(instrument: Instrument): boolean;
+    loadInstruments(): Promise<CheckoutSelectors>;
+    signOut(options: CustomerRequestOptions): void;
+}
+
+class HostedDropInPaymentMethod extends Component<
+    HostedDropInPaymentMethodProps &
+    WithCheckoutHostedDropInPaymentMethodProps &
+    ConnectFormikProps<PaymentFormValues> &
+    WithPaymentProps
+> {
+    state: HostedDropInPaymentMethodState = {
+        isAddingNewCard: false,
+    };
+    async componentDidMount(): Promise<void> {
+        const {
+            isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
+            loadInstruments,
+            onUnhandledError = noop,
+        } = this.props;
+
+        try {
+            if (isInstrumentFeatureAvailableProp) {
+                await loadInstruments();
+            }
+            await this.initializeMethod();
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    async componentDidUpdate(prevProps: Readonly<HostedDropInPaymentMethodProps & WithCheckoutHostedDropInPaymentMethodProps>,
+                             prevState: Readonly<HostedDropInPaymentMethodState>): Promise<void> {
+        const {
+            deinitializePayment = noop,
+            instruments,
+            method,
+            onUnhandledError = noop,
+            hidePaymentSubmitButton,
+        } = this.props;
+
+        const {
+            selectedInstrumentId,
+            isAddingNewCard,
+        } = this.state;
+        const selectedInstrument = this.getDefaultInstrumentId();
+
+        hidePaymentSubmitButton(method, !selectedInstrument);
+
+        if (selectedInstrumentId !== prevState.selectedInstrumentId ||
+            (prevProps.instruments.length > 0 && instruments.length === 0) ||
+            isAddingNewCard !== prevState.isAddingNewCard) {
+            try {
+                await deinitializePayment({
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                });
+                await this.initializeMethod();
+            } catch (error) {
+                onUnhandledError(error);
+            }
+        }
+    }
+
+    async componentWillUnmount(): Promise<void> {
+        const {
+            deinitializeCustomer = noop,
+            deinitializePayment = noop,
+            method,
+            onUnhandledError = noop,
+            setSubmit,
+            setValidationSchema,
+        } = this.props;
+
+        setValidationSchema(method, null);
+        setSubmit(method, null);
+
+        try {
+            await deinitializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+
+            await deinitializeCustomer({
+                methodId: method.id,
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    render(): ReactNode {
+        const {
+            instruments,
+            containerId,
+            method,
+            isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
+            isInitializing = false,
+            isLoadingInstruments,
+            hideWidget = false,
+            shouldHideInstrumentExpiryDate = false,
+        } = this.props;
+
+        const {
+            isAddingNewCard,
+            selectedInstrumentId = this.getDefaultInstrumentId(),
+        } = this.state;
+
+        const shouldShowInstrumentFieldset = isInstrumentFeatureAvailableProp && instruments.length > 0;
+        const shouldShowCreditCardFieldset = !shouldShowInstrumentFieldset || isAddingNewCard;
+        const isLoading = (isInitializing || isLoadingInstruments) && !hideWidget;
+
+        return (
+            <LoadingOverlay
+                hideContentWhenLoading
+                isLoading={ isLoading }
+            >
+                { shouldShowInstrumentFieldset && <CardInstrumentFieldset
+                    instruments={ instruments as CardInstrument[] }
+                    onDeleteInstrument={ this.handleDeleteInstrument }
+                    onSelectInstrument={ this.handleSelectInstrument }
+                    onUseNewInstrument={ this.handleUseNewCard }
+                    selectedInstrumentId={ selectedInstrumentId }
+                    shouldHideExpiryDate={ shouldHideInstrumentExpiryDate }
+                    validateInstrument={ this.getValidateInstrument() }
+                /> }
+
+                { shouldShowCreditCardFieldset && <div className="paymentMethod--hosted">
+                    <div
+                        className={ classNames(
+                            'widget',
+                            `widget--${method.id}`,
+                            'payment-widget'
+                        ) }
+                        id={ containerId }
+                        style={ {
+                            display: undefined,
+                        } }
+                        tabIndex={ -1 }
+                    />
+                </div> }
+            </LoadingOverlay>
+        );
+    }
+
+    private getDefaultInstrumentId(): string | undefined {
+        const { isAddingNewCard } = this.state;
+
+        if (isAddingNewCard) {
+            return;
+        }
+
+        const { instruments } = this.props;
+        const defaultInstrument = (
+            instruments.find(instrument => instrument.defaultInstrument) ||
+            instruments[0]
+        );
+
+        return defaultInstrument && defaultInstrument.bigpayToken;
+    }
+
+    private getValidateInstrument(): ReactNode {
+        const {
+            hideVerificationFields,
+            instruments,
+            isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
+            isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
+            method,
+            validateInstrument,
+        } = this.props;
+
+        const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
+        const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
+        const shouldShowNumberField = selectedInstrument ? isInstrumentCardNumberRequiredProp(selectedInstrument as CardInstrument) : false;
+        const shouldShowCardCodeField = selectedInstrument ? isInstrumentCardCodeRequiredProp(selectedInstrument as CardInstrument, method) : false;
+
+        if (hideVerificationFields) {
+            return;
+        }
+
+        if (validateInstrument) {
+            return validateInstrument(shouldShowNumberField);
+        }
+
+        return (
+            <CreditCardValidation
+                shouldShowCardCodeField={ shouldShowCardCodeField }
+                shouldShowNumberField={ shouldShowNumberField }
+            />
+        );
+    }
+
+    private async initializeMethod(): Promise<CheckoutSelectors | void> {
+        const {
+            isPaymentDataRequired,
+            isSignedIn,
+            isSignInRequired,
+            initializeCustomer = noop,
+            initializePayment = noop,
+            method,
+            setSubmit,
+            signInCustomer = noop,
+        } = this.props;
+
+        const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
+
+        if (!isPaymentDataRequired) {
+            setSubmit(method, null);
+
+            return Promise.resolve();
+        }
+
+        if (isSignInRequired && !isSignedIn) {
+            setSubmit(method, signInCustomer);
+
+            return initializeCustomer({
+                methodId: method.id,
+            });
+        }
+
+        setSubmit(method, null);
+
+        return initializePayment({
+            gatewayId: method.gateway,
+            methodId: method.id,
+        }, selectedInstrumentId);
+    }
+
+    private handleDeleteInstrument: (id: string) => void = id => {
+        const { instruments, formik: { setFieldValue } } = this.props;
+        const { selectedInstrumentId } = this.state;
+
+        if (instruments.length === 0) {
+            this.setState({
+                isAddingNewCard: true,
+                selectedInstrumentId: undefined,
+            });
+
+            setFieldValue('instrumentId', '');
+        } else if (selectedInstrumentId === id) {
+            this.setState({
+                selectedInstrumentId: this.getDefaultInstrumentId(),
+            });
+
+            setFieldValue('instrumentId', this.getDefaultInstrumentId());
+        }
+    };
+
+    private handleSelectInstrument: (id: string) => void = id => {
+        this.setState({
+            isAddingNewCard: false,
+            selectedInstrumentId: id,
+        });
+    };
+
+    private handleUseNewCard: () => void = async () => {
+        const {
+            deinitializePayment = noop,
+            initializePayment = noop,
+            method,
+        } = this.props;
+
+        this.setState({
+            isAddingNewCard: true,
+            selectedInstrumentId: undefined,
+        });
+
+        await deinitializePayment({
+            gatewayId: method.gateway,
+            methodId: method.id,
+        });
+
+        await initializePayment({
+            gatewayId: method.gateway,
+            methodId: method.id,
+        });
+    };
+}
+
+const mapFromCheckoutProps: MapToPropsFactory<CheckoutContextProps,
+    WithCheckoutHostedDropInPaymentMethodProps,
+    HostedDropInPaymentMethodProps & ConnectFormikProps<PaymentFormValues>> = () => {
+    const filterInstruments = memoizeOne((instruments: PaymentInstrument[] = []) => instruments.filter(instrument => isCardInstrument(instrument) || isBankAccountInstrument(instrument)));
+
+    return (context, props) => {
+
+        const {
+            isUsingMultiShipping = false,
+            method,
+        } = props;
+
+        const {checkoutService, checkoutState} = context;
+
+        const {
+            data: {
+                getCheckout,
+                getConfig,
+                getCustomer,
+                getInstruments,
+                isPaymentDataRequired,
+            },
+            statuses: {
+                isLoadingInstruments,
+            },
+        } = checkoutState;
+
+        const checkout = getCheckout();
+        const config = getConfig();
+        const customer = getCustomer();
+
+        if (!checkout || !config || !customer || !method) {
+            return null;
+        }
+
+        return {
+            instruments: filterInstruments(getInstruments(method)),
+            isLoadingInstruments: isLoadingInstruments(),
+            isPaymentDataRequired: isPaymentDataRequired(),
+            isSignedIn: some(checkout.payments, {providerId: method.id}),
+            isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredSelector(checkoutState),
+            isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredSelector(checkoutState),
+            isInstrumentFeatureAvailable: isInstrumentFeatureAvailable({
+                config,
+                customer,
+                isUsingMultiShipping,
+                paymentMethod: method,
+            }),
+            loadInstruments: checkoutService.loadInstruments,
+            signOut: checkoutService.signOutCustomer,
+        };
+    };
+};
+
+export default connectFormik(withPayment(withCheckout(mapFromCheckoutProps)(HostedDropInPaymentMethod)));


### PR DESCRIPTION
## What?
Proposal to create a HostedDropInPaymentMethod to support the Digital River Drop In component.

This new PaymentMethod allow us to hide the checkboxes to save cards since the drop in component have them in their own logic.

Also allow us to hide/show the submitPaymentButton depends on the element that is rendered (Drop In or CardInstrumentFieldset) using the paymentContext.

## Why?
Right now there isn't a payment method that supports this type of component and behavior.

## Testing / Proof
Demo: https://drive.google.com/file/d/1ws428vHXhPTeaIqy4PlDdiaxM3_sfLRr/view?usp=sharing

Note: Avoid Circle CI, I didn't complete the unit testing until get approval

@bigcommerce/checkout
