### PR TITLE
feat(checkout): PAYPAL-1024 bump chechkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,9 @@
           "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
         },
         "electron-to-chromium": {
-          "version": "1.3.730",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.730.tgz",
-          "integrity": "sha512-1Tr3h09wXhmqXnvDyrRe6MFgTeU0ZXy3+rMJWTrOHh/HNesWwBBrKnMxRJWZ86dzs8qQdw2c7ZE1/qeGHygImA=="
+          "version": "1.3.734",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.734.tgz",
+          "integrity": "sha512-iQF2mjPZ6zNNq45kbJ6MYZYCBNdv2JpGiJC/lVx4tGJWi9MNg73KkL9sWGN4X4I/CP2SBLWsT8nPADZZpAHIyw=="
         },
         "node-releases": {
           "version": "1.1.72",
@@ -1655,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.149.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.149.0.tgz",
-      "integrity": "sha512-qsgDDdrC38xrfM3gfy/XCobxZhtL5IAE4M/Tovk9MXToQpid9KY8vAISyWBrsZcVGXu2Axj8TsWSWnoB1ogf7w==",
+      "version": "1.150.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.150.0.tgz",
+      "integrity": "sha512-OScEGHM5n3kONKDtQt1qEHvhwhTQGlomx4WUEEA1J0Z1OCEwhYvetFvP951puaUsmpzKFpIsMpScIueiqwC5Ww==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.149.0",
+    "@bigcommerce/checkout-sdk": "^1.150.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Update checkout-sdk-js version
[checkout-sdk-js PR](https://github.com/bigcommerce/checkout-sdk-js/pull/1142)

## Why?
Due to https://jira.bigcommerce.com/browse/PAYPAL-1024

## Testing / Proof
Tested manually

@bigcommerce/checkout
