### PR TITLE
feat(payment): INT-4289 Suppress payment methods out of scope on Digital River

### DIFF
--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -85,10 +85,17 @@ describe('when using Digital River payment', () => {
                         flow: 'checkout',
                         paymentMethodConfiguration: {
                             disabledPaymentMethods: [
+                                'alipay',
+                                'bPay',
+                                'codJapan',
                                 'klarnaCredit',
+                                'konbini',
+                                'msts',
+                                'payco',
                                 'payPal',
                                 'payPalCredit',
                                 'payPalBilling',
+                                'wireTransfer',
                             ],
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -38,10 +38,17 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 showTermsOfSaleDisclosure: true,
                 paymentMethodConfiguration: {
                     disabledPaymentMethods: [
+                        'alipay',
+                        'bPay',
+                        'codJapan',
                         'klarnaCredit',
+                        'konbini',
+                        'msts',
+                        'payco',
                         'payPal',
                         'payPalCredit',
                         'payPalBilling',
+                        'wireTransfer',
                     ],
                     classes: DigitalRiverClasses,
                 },


### PR DESCRIPTION
## What?
[INT-4289](https://jira.bigcommerce.com/browse/INT-4289): Suppress payment methods out of scope on Digital River.

## Why?
On BigCommerce we will not be supporting all the alternative [payment methods provided by Digital River](https://jira.bigcommerce.com/browse/INT-4289) by default.

## Testing / Proof
Checkout screen without unsupported methods as Alipay and Wire Transfer:
![image](https://user-images.githubusercontent.com/46331158/119040388-f86d6680-b97a-11eb-860f-2fc5769f05ff.png)

@bigcommerce/checkout @bigcommerce/apex-integrations 
