### PR TITLE
feat(payment): PAYMENTS-6899 add ppsdk payment method submit button text

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -204,6 +204,7 @@
             "checkoutcom_sepa_debtor_title": "Debtor",
             "checkoutcom_sepa_mandate_disclaimer": "By accepting this mandate form, you authorize {creditorName} to send instructions to your bank to debit your account, and your bank to debit your account in accordance with those instructions. You are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited.",
             "checkoutcom_sepa_payment_type": "Payment type: one-off (non-recurring)",
+            "continue_with_action": "Continue with {methodName}",
             "credit_card_text": "Credit card",
             "credit_card_customer_code_label": "Customer Code",
             "credit_card_cvv_help_text": "For VISA and Mastercard, the CVV is a three-digit code printed on the back. For American Express it is the four-digit code printed on the front. The CVV is a security measure to ensure that you are in possession of the card.",

--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -359,5 +359,28 @@ describe('PaymentForm', () => {
                     methodType: 'bar',
                 }));
         });
+
+        describe('with a no UI, PPSDK payment method', () => {
+            it('passes a continueWith value to the submitButton', () => {
+                selectedMethod = {
+                    ...selectedMethod,
+                    initializationStrategy: { type: 'NONE' },
+                    config: { displayName: 'Some Method' },
+                };
+
+                defaultProps = { ...defaultProps, selectedMethod };
+                const container = mount(<PaymentFormTest { ...defaultProps } />);
+                const submitButton = container.find(PaymentSubmitButton);
+
+                expect(submitButton)
+                    .toHaveLength(1);
+
+                expect(submitButton.props())
+                    .toEqual(expect.objectContaining({
+                        continueWith: 'Some Method',
+                    }));
+            });
+        });
+
     });
 });

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -12,7 +12,7 @@ import { DocumentOnlyCustomFormFieldsetValues, FawryCustomFormFieldsetValues, Id
 import { CreditCardFieldsetValues } from './creditCard';
 import getPaymentValidationSchema from './getPaymentValidationSchema';
 import { HostedCreditCardFieldsetValues } from './hostedCreditCard';
-import { getUniquePaymentMethodId, PaymentMethodId, PaymentMethodList } from './paymentMethod';
+import { getPaymentMethodName, getUniquePaymentMethodId, PaymentMethodId, PaymentMethodList } from './paymentMethod';
 import { CardInstrumentFieldsetValues } from './storedInstrument';
 import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
 import PaymentRedeemables from './PaymentRedeemables';
@@ -76,6 +76,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     isTermsConditionsRequired,
     isStoreCreditApplied,
     isUsingMultiShipping,
+    language,
     methods,
     onMethodSelect,
     onStoreCreditChange,
@@ -115,6 +116,9 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
         />;
     }
 
+    const selectedMethodName = selectedMethod && getPaymentMethodName(language)(selectedMethod);
+    const continueWith = selectedMethod?.initializationStrategy?.type === 'NONE' ? selectedMethodName : undefined;
+
     return (
         <Form
             className="checkout-form"
@@ -151,6 +155,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
                 { shouldHidePaymentSubmitButton ?
                     <PaymentMethodSubmitButtonContainer /> :
                     <PaymentSubmitButton
+                        continueWith={ continueWith }
                         isDisabled={ shouldDisableSubmit }
                         methodGateway={ selectedMethod && selectedMethod.gateway }
                         methodId={ selectedMethodId }

--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -1,5 +1,6 @@
-import { createCheckoutService, CheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, CheckoutSelectors, CheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { mount, render } from 'enzyme';
+import { set } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 import { CheckoutProvider } from '../checkout';
@@ -7,11 +8,13 @@ import { getStoreConfig } from '../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
 import { Button } from '../ui/button';
 
+import { PaymentMethodProviderType } from './paymentMethod';
 import PaymentSubmitButton, { PaymentSubmitButtonProps } from './PaymentSubmitButton';
 
 describe('PaymentSubmitButton', () => {
     let PaymentSubmitButtonTest: FunctionComponent<PaymentSubmitButtonProps>;
     let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
     let languageService: LanguageService;
     let localeContext: LocaleContextType;
 
@@ -19,6 +22,7 @@ describe('PaymentSubmitButton', () => {
         checkoutService = createCheckoutService();
         localeContext = createLocaleContext(getStoreConfig());
         languageService = localeContext.language;
+        checkoutState = checkoutService.getState();
 
         PaymentSubmitButtonTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
@@ -128,5 +132,43 @@ describe('PaymentSubmitButton', () => {
 
         expect(component.text())
             .toEqual(languageService.translate('payment.paypal_credit_continue_action'));
+    });
+
+    describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is off', () => {
+        beforeEach(() => {
+            const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': false };
+            const storeConfig = set(getStoreConfig(), 'checkoutSettings.features', flagValues);
+
+            jest.spyOn(checkoutState.data, 'getConfig')
+                .mockReturnValue(storeConfig);
+        });
+
+        it('does not render button with label of "Continue with ${methodName}"', () => {
+            const component = mount(
+                <PaymentSubmitButtonTest continueWith="Foo" />
+            );
+
+            expect(component.text())
+                .not.toEqual(languageService.translate('payment.ppsdk_continue_action', { methodName: 'Foo' }));
+        });
+    });
+
+    describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is on', () => {
+        beforeEach(() => {
+            const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': true };
+            const storeConfig = set(getStoreConfig(), 'checkoutSettings.features', flagValues);
+
+            jest.spyOn(checkoutState.data, 'getConfig')
+                .mockReturnValue(storeConfig);
+        });
+
+        it('renders button with label of "Continue with ${methodName}" when continueWith prop is set', () => {
+            const component = mount(
+                <PaymentSubmitButtonTest continueWith="Foo" />
+            );
+
+            expect(component.text())
+                .toEqual(languageService.translate('payment.continue_with_action', { methodName: 'Foo' }));
+        });
     });
 });


### PR DESCRIPTION
## What?

- Add logic to set the Submit button label to `Continue with {methodName}` when a no UI PPSDK payment method is selected
- Guard the above with a experiment feature toggle which maintains current functionality when off

## Why?
- To convey to consumers that more steps are required with that payment method prior to submitting the order

## Testing / Proof
- New tests

https://user-images.githubusercontent.com/56807262/119301209-7300f380-bca5-11eb-8753-a1604cd8194b.mov



@bigcommerce/checkout
