### PR TITLE
fix(common): PAYMENTS-6799 Add missing mapSubmitOrderErrorMessage unit tests…

### DIFF
--- a/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
+++ b/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
@@ -1,0 +1,233 @@
+import { getLanguageService } from '../locale';
+
+import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
+
+const translate = getLanguageService().translate;
+
+describe('mapSubmitOrderErrorMessage()', () => {
+    it('returns correct message when payment is cancelled', () => {
+        const message = mapSubmitOrderErrorMessage({ type: 'payment_cancelled' }, translate, false);
+
+        expect(message).toEqual(translate('payment.payment_cancelled'));
+    });
+
+    it('returns correct message when payment method is not valid', () => {
+        const message = mapSubmitOrderErrorMessage({ type: 'payment_method_invalid' }, translate, false);
+
+        expect(message).toEqual(translate('payment.payment_method_disabled_error'));
+    });
+
+    it('returns correct message when shopping cart changed', () => {
+        const message = mapSubmitOrderErrorMessage({ type: 'cart_changed' }, translate, false);
+
+        expect(message).toEqual(translate('shipping.cart_change_error'));
+    });
+
+    it('returns correct message when payment error order_could_not_be_finalized_error', () => {
+        const message = mapSubmitOrderErrorMessage(
+            {
+                body: {
+                    type: 'order_could_not_be_finalized_error',
+                },
+                message: 'payment error message',
+            },
+            translate,
+            false);
+
+        expect(message).toEqual(translate('payment.payment_method_error', { message: 'payment error message' }));
+    });
+
+    it('returns correct message when payment error provider_fatal_error', () => {
+        const message = mapSubmitOrderErrorMessage(
+            {
+                body: {
+                    type: 'provider_fatal_error',
+                },
+                message: 'payment error message',
+            },
+            translate,
+            false);
+
+        expect(message).toEqual(translate('payment.payment_method_error', { message: 'payment error message' }));
+    });
+
+    it('returns correct message when payment error payment_invalid', () => {
+        const message = mapSubmitOrderErrorMessage(
+            {
+                body: {
+                    type: 'payment_invalid',
+                },
+                message: 'payment error message',
+            },
+            translate,
+            false);
+
+        expect(message).toEqual(translate('payment.payment_method_error', { message: 'payment error message' }));
+    });
+
+    it('returns correct message when payment error provider_error', () => {
+        const message = mapSubmitOrderErrorMessage(
+            {
+                body: {
+                    type: 'provider_error',
+                },
+                message: 'payment error message',
+            },
+            translate,
+            false);
+
+        expect(message).toEqual(translate('payment.payment_method_error', { message: 'payment error message' }));
+    });
+
+    it('returns correct message when payment error provider_widget_error', () => {
+        const message = mapSubmitOrderErrorMessage(
+            {
+                body: {
+                    type: 'provider_widget_error',
+                },
+                message: 'payment error message',
+            },
+            translate,
+            false);
+
+        expect(message).toEqual(translate('payment.payment_method_error', { message: 'payment error message' }));
+    });
+
+    it('returns correct message when payment error user_payment_error', () => {
+        const message = mapSubmitOrderErrorMessage(
+            {
+                body: {
+                    type: 'user_payment_error',
+                },
+                message: 'payment error message',
+            },
+            translate,
+            false);
+
+        expect(message).toEqual(translate('payment.payment_method_error', { message: 'payment error message' }));
+    });
+
+    describe('When bigpay request error and localization enabled,', () => {
+        it('returns correct translated message when one error is received', () => {
+            const message = mapSubmitOrderErrorMessage(
+                {
+                    body: {
+                        errors: [
+                            {
+                                code: 'incorrect_address',
+                                message: 'whatever message coming from bigpay',
+                            },
+                        ],
+                    },
+                },
+                translate,
+                true);
+
+            expect(message).toEqual(translate('payment.errors.incorrect_address'));
+        });
+
+        it('returns correct translated messages when multiple errors are received', () => {
+            const message = mapSubmitOrderErrorMessage(
+                {
+                    body: {
+                        errors: [
+                            {
+                                code: 'incorrect_address',
+                                message: 'whatever message coming from bigpay',
+                            },
+                            {
+                                code: 'incorrect_amount',
+                                message: 'whatever another message coming from bigpay',
+                            },
+                        ],
+                    },
+                },
+                translate,
+                true);
+
+            expect(message).toEqual(`${translate('payment.errors.incorrect_address')} ${translate('payment.errors.incorrect_amount')}`);
+        });
+
+        it('returns untranslated error message when errors array is empty', () => {
+            const message = mapSubmitOrderErrorMessage(
+                {
+                    body: {
+                        errors: [],
+                    },
+                    message: 'bigpay error message',
+                },
+                translate,
+                true);
+
+            expect(message).toEqual('bigpay error message');
+        });
+    });
+    it('returns untranslated error message when bigpay request error and localization disabled', () => {
+        const message = mapSubmitOrderErrorMessage(
+            {
+                body: {
+                    errors: [
+                        {
+                            code: 'incorrect_address',
+                            message: 'whatever message coming from bigpay',
+                        },
+                        {
+                            code: 'incorrect_amount',
+                            message: 'whatever another message coming from bigpay',
+                        },
+                    ],
+                },
+                message: 'bigpay error message',
+            },
+            translate,
+            false);
+
+        expect(message).toEqual('bigpay error message');
+    });
+
+    describe('When not bigpay request error and no error message exists,', () => {
+        it('returns correct default translated message when error type is "unrecoverable"', () => {
+            const message = mapSubmitOrderErrorMessage(
+                {
+                    type: 'unrecoverable',
+                },
+                translate,
+                false);
+
+            expect(message).toEqual(translate('common.unavailable_error'));
+        });
+
+        it('returns correct default translated message when error type is not "unrecoverable"', () => {
+            const message = mapSubmitOrderErrorMessage(
+                {
+                    type: 'some_type',
+                },
+                translate,
+                false);
+
+            expect(message).toEqual(translate('payment.place_order_error'));
+        });
+    });
+});
+
+describe('mapSubmitOrderErrorTitle()', () => {
+    it('returns correct title when error type is "unrecoverable"', () => {
+        const title = mapSubmitOrderErrorTitle(
+            {
+                type: 'unrecoverable',
+            },
+            translate);
+
+        expect(title).toEqual(translate('common.unavailable_heading'));
+    });
+
+    it('returns correct title when error type is not "unrecoverable"', () => {
+        const title = mapSubmitOrderErrorTitle(
+            {
+                type: 'some_type',
+            },
+            translate);
+
+        expect(title).toEqual(translate('common.error_heading'));
+    });
+});

--- a/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -28,12 +28,10 @@ export default function mapSubmitOrderErrorMessage(
                 return translate('payment.payment_method_error', { message: error.message });
             }
 
-            if (shouldLocalise && error.body && error.body.errors) {
+            if (shouldLocalise && error.body && error.body.errors && error.body.errors.length) {
                 const messages = error.body.errors.map((err: { code: any }) => translate(`payment.errors.${err.code}`));
 
-                if (messages.length) {
-                    return messages.join(' ');
-                }
+                return messages.join(' ');
             }
 
             if (error.message) {


### PR DESCRIPTION
… to fix test coverage release issue

## What?
Added unit tests for `mapSubmitOrderErrorMessage` and `mapSubmitOrderErrorTitle` functions.

## Why?
No unit tests was available for these functions. Repo test coverage was below 80% which prevented release.

## Testing / Proof
Unit tests
Screenshots
<img width="929" alt="Screen Shot 2021-05-24 at 7 46 38 pm" src="https://user-images.githubusercontent.com/36555311/119331506-c5084000-bcca-11eb-994e-c93d1d75d27e.png">
<img width="974" alt="Screen Shot 2021-05-24 at 7 50 45 pm" src="https://user-images.githubusercontent.com/36555311/119331513-c76a9a00-bcca-11eb-82c3-761acf5a5ad7.png">

@bigcommerce/checkout
