### PR TITLE
PAYMENTS-6899 add ppsdk payment method submit button text

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -276,6 +276,7 @@
             "instrument_trusted_shipping_address_title_text": "Please re-enter your card number to authorize this transaction.",
             "quadpay_continue_action": "Continue with Quadpay",
             "quadpay_display_name_text": "Pay in 4 installments",
+            "ppsdk_continue_action": "Continue with {methodName}",
             "sepa_account_number": "Account Number (IBAN)",
             "sepa_account_number_required": "You must enter your account number (IBAN)",
             "sepa_bic": "BIC",

--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -323,6 +323,7 @@ describe('PaymentForm', () => {
                     methodGateway: 'baz',
                     methodId: 'foo',
                     methodType: 'bar',
+                    methodName: 'Authorizenet',
                 }));
         });
 
@@ -340,6 +341,7 @@ describe('PaymentForm', () => {
                     methodGateway: 'baz',
                     methodId: undefined,
                     methodType: 'bar',
+                    methodName: 'Amazon Pay',
                 }));
         });
 
@@ -357,6 +359,7 @@ describe('PaymentForm', () => {
                     methodGateway: 'baz',
                     methodId: 'amazonpay',
                     methodType: 'bar',
+                    methodName: 'Amazon Pay',
                 }));
         });
     });

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -12,7 +12,7 @@ import { DocumentOnlyCustomFormFieldsetValues, FawryCustomFormFieldsetValues, Id
 import { CreditCardFieldsetValues } from './creditCard';
 import getPaymentValidationSchema from './getPaymentValidationSchema';
 import { HostedCreditCardFieldsetValues } from './hostedCreditCard';
-import { getUniquePaymentMethodId, PaymentMethodId, PaymentMethodList } from './paymentMethod';
+import { getPaymentMethodName, getUniquePaymentMethodId, PaymentMethodId, PaymentMethodList } from './paymentMethod';
 import { CardInstrumentFieldsetValues } from './storedInstrument';
 import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
 import PaymentRedeemables from './PaymentRedeemables';
@@ -76,6 +76,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     isTermsConditionsRequired,
     isStoreCreditApplied,
     isUsingMultiShipping,
+    language,
     methods,
     onMethodSelect,
     onStoreCreditChange,
@@ -151,9 +152,11 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
                 { shouldHidePaymentSubmitButton ?
                     <PaymentMethodSubmitButtonContainer /> :
                     <PaymentSubmitButton
+                        initialisationStrategyType={ selectedMethod && selectedMethod.initializationStrategy?.type }
                         isDisabled={ shouldDisableSubmit }
                         methodGateway={ selectedMethod && selectedMethod.gateway }
                         methodId={ selectedMethodId }
+                        methodName={ selectedMethod && getPaymentMethodName(language)(selectedMethod) }
                         methodType={ selectedMethod && selectedMethod.method }
                     /> }
             </div>

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -45,7 +45,7 @@ export interface PaymentMethodProps {
 }
 
 export interface WithCheckoutPaymentMethodProps {
-    ppsdkFeatureOn: boolean;
+    isPpsdkEnabled: boolean;
     isInitializing: boolean;
     deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
@@ -64,9 +64,9 @@ export interface WithCheckoutPaymentMethodProps {
  */
 // tslint:disable:cyclomatic-complexity
 const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckoutPaymentMethodProps> = props => {
-    const { method, ppsdkFeatureOn } = props;
+    const { method, isPpsdkEnabled } = props;
 
-    if (ppsdkFeatureOn && method.type === PaymentMethodProviderType.PPSDK) {
+    if (isPpsdkEnabled && method.type === PaymentMethodProviderType.PPSDK) {
         return <PPSDKPaymentMethod { ...props } />;
     }
 
@@ -226,7 +226,7 @@ function mapToWithCheckoutPaymentMethodProps(
         statuses: { isInitializingPayment },
     } = checkoutState;
 
-    const ppsdkFeatureOn = Boolean(
+    const isPpsdkEnabled = Boolean(
         checkoutService.getState()
             .data.getConfig()
             ?.checkoutSettings.features['PAYMENTS-6806.enable_ppsdk_strategy']
@@ -238,7 +238,7 @@ function mapToWithCheckoutPaymentMethodProps(
         initializeCustomer: checkoutService.initializeCustomer,
         initializePayment: checkoutService.initializePayment,
         isInitializing: isInitializingPayment(method.id),
-        ppsdkFeatureOn,
+        isPpsdkEnabled,
     };
 }
 


### PR DESCRIPTION
Supersedes: https://github.com/bigcommerce/checkout-js/pull/594

## What?

- Add logic to set the Submit button label to `Continue with {methodName}` when a no UI PPSDK payment method is selected
- Guard the above with a experiment feature toggle which maintains current functionality when off

## Why?
- To convey to consumers that more steps are required with that payment method prior to submitting the order

## Testing / Proof
- New tests

https://user-images.githubusercontent.com/56807262/119301209-7300f380-bca5-11eb-8753-a1604cd8194b.mov



@bigcommerce/checkout
