### PR TITLE
feat(payment): INT-4310 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,23 +122,6 @@
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001228",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-          "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.736",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.736.tgz",
-          "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig=="
-        },
-        "node-releases": {
-          "version": "1.1.72",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
-          "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw=="
-        }
       }
     },
     "@babel/helper-define-map": {
@@ -1643,9 +1626,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.151.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.151.0.tgz",
-      "integrity": "sha512-000OHTd2JcVY+ub6444m/7SFrTFyIJGkjcUGysuEXfPU+Ca9omrCgI65sz3aDv16AxhYc70WsMgEhI3LyOslKw==",
+      "version": "1.152.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.152.0.tgz",
+      "integrity": "sha512-BSoBW0Dxt/oG4h9BZk6UhYYuGkaS54PlsGhkZEIQ863mSubYaMVln681Aas+7qWe5eDyd+KPPIXn/dlDnaJ3bQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.151.0",
+    "@bigcommerce/checkout-sdk": "^1.152.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Raise the active SDK version.

## Why?
Releasing https://github.com/bigcommerce/checkout-sdk-js/pull/1145

## Testing / Proof
Circle, linked PR.

@bigcommerce/checkout
