### PR TITLE
fix(customer): Disable continue as guest button when loading

### DIFF
--- a/src/app/customer/CheckoutButtonList.spec.tsx
+++ b/src/app/customer/CheckoutButtonList.spec.tsx
@@ -3,7 +3,7 @@ import { noop } from 'lodash';
 import React from 'react';
 
 import { getStoreConfig } from '../config/config.mock';
-import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedString } from '../locale';
 
 import CheckoutButton from './CheckoutButton';
 import CheckoutButtonList from './CheckoutButtonList';
@@ -72,6 +72,22 @@ describe('CheckoutButtonList', () => {
 
         expect(component.html())
             .toBeFalsy();
+    });
+
+    it('does not render the translated string when initializing', () => {
+        const component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <CheckoutButtonList
+                    deinitialize={ noop }
+                    initialize={ noop }
+                    isInitializing={ true }
+                    methodIds={ ['amazon', 'braintreevisacheckout'] }
+                />
+            </LocaleContext.Provider>
+        );
+
+        expect(component.find(TranslatedString))
+            .toHaveLength(0);
     });
 
     it('passes data to every checkout button', () => {

--- a/src/app/customer/CheckoutButtonList.tsx
+++ b/src/app/customer/CheckoutButtonList.tsx
@@ -22,6 +22,7 @@ export const SUPPORTED_METHODS: string[] = [
 
 export interface CheckoutButtonListProps {
     methodIds?: string[];
+    isInitializing?: boolean;
     checkEmbeddedSupport?(methodIds: string[]): void;
     deinitialize(options: CustomerRequestOptions): void;
     initialize(options: CustomerInitializeOptions): void;
@@ -31,6 +32,7 @@ export interface CheckoutButtonListProps {
 const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
     checkEmbeddedSupport,
     onError,
+    isInitializing = false,
     methodIds,
     ...rest
 }) => {
@@ -57,7 +59,7 @@ const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
 
     return (
         <Fragment>
-            <p><TranslatedString id="remote.continue_with_text" /></p>
+            { !isInitializing && <p><TranslatedString id="remote.continue_with_text" /></p> }
 
             <div className="checkoutRemote">
                 { supportedMethodIds.map(methodId =>

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -38,6 +38,7 @@ export interface WithCheckoutCustomerProps {
     isContinuingAsGuest: boolean;
     isCreatingAccount: boolean;
     isGuestEnabled: boolean;
+    isInitializing: boolean;
     isSendingSignInEmail: boolean;
     isSignInEmailEnabled: boolean;
     isSigningIn: boolean;
@@ -108,6 +109,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             email,
             initializeCustomer,
             isContinuingAsGuest = false,
+            isInitializing = false,
             privacyPolicyUrl,
             requiresMarketingConsent,
             onUnhandledError = noop,
@@ -121,13 +123,14 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
                         checkEmbeddedSupport={ checkEmbeddedSupport }
                         deinitialize={ deinitializeCustomer }
                         initialize={ initializeCustomer }
+                        isInitializing={ isInitializing }
                         methodIds={ checkoutButtonIds }
                         onError={ onUnhandledError }
                     />
                 }
                 defaultShouldSubscribe={ defaultShouldSubscribe }
                 email={ this.draftEmail || email }
-                isContinuingAsGuest={ isContinuingAsGuest }
+                isLoading={ isContinuingAsGuest || isInitializing }
                 onChangeEmail={ this.handleChangeEmail }
                 onContinueAsGuest={ this.handleContinueAsGuest }
                 onShowLogin={ this.handleShowLogin }
@@ -378,7 +381,7 @@ export function mapToWithCheckoutCustomerProps(
     const {
         data: { getBillingAddress, getCustomerAccountFields, getCheckout, getCustomer, getSignInEmail, getConfig },
         errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
-        statuses: { isContinuingAsGuest, isSigningIn, isSendingSignInEmail, isCreatingCustomerAccount },
+        statuses: { isContinuingAsGuest, isInitializingCustomer, isSigningIn, isSendingSignInEmail, isCreatingCustomerAccount },
     } = checkoutState;
 
     const billingAddress = getBillingAddress();
@@ -417,6 +420,7 @@ export function mapToWithCheckoutCustomerProps(
         isCreatingAccount: isCreatingCustomerAccount(),
         createAccountError: getCreateCustomerAccountError(),
         isContinuingAsGuest: isContinuingAsGuest(),
+        isInitializing:  isInitializingCustomer(),
         isSignInEmailEnabled,
         isAccountCreationEnabled,
         isGuestEnabled: config.checkoutSettings.guestCheckoutEnabled,

--- a/src/app/customer/GuestForm.spec.tsx
+++ b/src/app/customer/GuestForm.spec.tsx
@@ -16,7 +16,7 @@ describe('GuestForm', () => {
         defaultProps = {
             canSubscribe: true,
             defaultShouldSubscribe: false,
-            isContinuingAsGuest: false,
+            isLoading: false,
             onChangeEmail: jest.fn(),
             onContinueAsGuest: jest.fn(),
             onShowLogin: jest.fn(),
@@ -82,6 +82,20 @@ describe('GuestForm', () => {
                 privacyPolicy: false,
                 shouldSubscribe: true,
             });
+    });
+
+    it('disables "continue as guest" button when isLoading is true', () => {
+        const handleContinueAsGuest = jest.fn();
+        const component = mount(
+            <TestComponent
+                isLoading={ true }
+                onContinueAsGuest={ handleContinueAsGuest }
+            />
+        );
+
+        const button = component.find('[data-test="customer-continue-as-guest-button"]');
+
+        expect(button.prop('disabled')).toBeTruthy();
     });
 
     it('displays error message if email is not valid', () => {
@@ -241,5 +255,15 @@ describe('GuestForm', () => {
 
         expect(component.find('[data-test="privacy-policy-field-error-message"]').text())
             .toEqual('Please agree to the Privacy Policy.');
+    });
+
+    it('does not render "sign in" button when loading', () => {
+        const component = mount(
+            <TestComponent
+                isLoading={ true }
+            />
+        );
+
+        expect(component.find('[data-test="customer-continue-button"]').length).toEqual(0);
     });
 });

--- a/src/app/customer/GuestForm.tsx
+++ b/src/app/customer/GuestForm.tsx
@@ -16,7 +16,7 @@ export interface GuestFormProps {
     requiresMarketingConsent: boolean;
     defaultShouldSubscribe: boolean;
     email?: string;
-    isContinuingAsGuest: boolean;
+    isLoading: boolean;
     privacyPolicyUrl?: string;
     onChangeEmail(email: string): void;
     onContinueAsGuest(data: GuestFormValues): void;
@@ -31,7 +31,7 @@ export interface GuestFormValues {
 const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikProps<GuestFormValues>> = ({
     canSubscribe,
     checkoutButtons,
-    isContinuingAsGuest,
+    isLoading,
     onChangeEmail,
     onShowLogin,
     privacyPolicyUrl,
@@ -81,7 +81,7 @@ const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikPr
                         <Button
                             className="customerEmail-button"
                             id="checkout-customer-continue"
-                            isLoading={ isContinuingAsGuest }
+                            isLoading={ isLoading }
                             testId="customer-continue-as-guest-button"
                             type="submit"
                             variant={ ButtonVariant.Primary }
@@ -91,17 +91,19 @@ const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikPr
                     </div>
                 </div>
 
-                <p>
-                    <TranslatedString id="customer.login_text" />
-                    { ' ' }
-                    <a
-                        data-test="customer-continue-button"
-                        id="checkout-customer-login"
-                        onClick={ onShowLogin }
-                    >
-                        <TranslatedString id="customer.login_action" />
-                    </a>
-                </p>
+                {
+                    !isLoading && <p>
+                        <TranslatedString id="customer.login_text" />
+                        { ' ' }
+                        <a
+                            data-test="customer-continue-button"
+                            id="checkout-customer-login"
+                            onClick={ onShowLogin }
+                        >
+                            <TranslatedString id="customer.login_action" />
+                        </a>
+                    </p>
+                }
 
                 { checkoutButtons }
             </Fieldset>


### PR DESCRIPTION
## What? [INT-3604](https://jira.bigcommerce.com/browse/INT-3604) & [INT-3605](https://jira.bigcommerce.com/browse/INT-3605)
Pass the `isLoading` variable to the guest component and use it to validate the disabling of 'continue as Guest' button and also the "login" link to prevent it from being clickable when the checkout is loading

## Why?
As mentioned in the Jira Issues, when a customer clicks on the continue as guest button and the google pay / amazon pay scrips haven't finished loading it triggers an error only visible in the developer console which get logged into sentry.

By disabling the buttons until the scripts have finished loading this error is prevented.

## Testing / Proof
[Demo Video](https://drive.google.com/file/d/1dTN99MLiCYULoxVTJvuUQ5M4JeonLnCC/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
