### PR TITLE
feat(payment): PAYPAL-863 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,9 +1626,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.154.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.154.0.tgz",
-      "integrity": "sha512-MY8FPJWZ3/D0XNIq4iy0FPVbG6IRVE8LuPMhL6fFhxWHoOXciuEIsbxjEMoSgYRb5RhOB+ITIRwl7QxExKZ5yg==",
+      "version": "1.155.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.155.0.tgz",
+      "integrity": "sha512-PXk8FmpLM3Dnke3iB43dStzGy5FsBbWgV5hZNvvl36r+CuGXd1FvPKG5mLjDkiWUe3iGE9m/ZiKEoYGuWdRdMg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.154.0",
+    "@bigcommerce/checkout-sdk": "^1.155.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js

## Why?
Getting the following change out:
https://github.com/bigcommerce/checkout-sdk-js/pull/1074

## Testing / Proof
before
<img width="476" alt="Screenshot 2021-05-27 at 19 09 11" src="https://user-images.githubusercontent.com/54856617/120300251-6c413480-c2d4-11eb-888a-cd84716155cc.png">
after
![Screenshot 2021-04-30 at 15 48 09](https://user-images.githubusercontent.com/54856617/120300334-811dc800-c2d4-11eb-9a88-7d5c0d4db4c8.png)


@bigcommerce/checkout

