### PR TITLE
fix(checkout): PAYPAL-1055 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,9 +1626,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.155.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.155.0.tgz",
-      "integrity": "sha512-PXk8FmpLM3Dnke3iB43dStzGy5FsBbWgV5hZNvvl36r+CuGXd1FvPKG5mLjDkiWUe3iGE9m/ZiKEoYGuWdRdMg==",
+      "version": "1.155.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.155.1.tgz",
+      "integrity": "sha512-GZl0b1Q8JAX4/QliCh1rREnnZoF307GItqF9labdCqZWoDfRyszDYPx7BWaxKvfXk/nRwEZPXLL2m5ybVgRoZw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.155.0",
+    "@bigcommerce/checkout-sdk": "^1.155.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump Checkout-sdk version 
checkout-sdk-js [PR](https://jira.bigcommerce.com/browse/PAYPAL-1055)

## Why?
Due to https://jira.bigcommerce.com/browse/PAYPAL-1055

## Testing / Proof
Tested manually

@bigcommerce/checkout
