### PR TITLE
feat(payment): INT-3792 Disabled payment method due to settings

### DIFF
--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -73,16 +73,6 @@ describe('when using Digital River payment', () => {
                 disabledPaymentMethods: [
                     'googlePay',
                     'alipay',
-                    'bPay',
-                    'codJapan',
-                    'klarnaCredit',
-                    'konbini',
-                    'msts',
-                    'payco',
-                    'payPal',
-                    'payPalCredit',
-                    'payPalBilling',
-                    'wireTransfer',
                 ],
             },
         };
@@ -107,16 +97,6 @@ describe('when using Digital River payment', () => {
                             disabledPaymentMethods: [
                                 'googlePay',
                                 'alipay',
-                                'bPay',
-                                'codJapan',
-                                'klarnaCredit',
-                                'konbini',
-                                'msts',
-                                'payco',
-                                'payPal',
-                                'payPalCredit',
-                                'payPalBilling',
-                                'wireTransfer',
                             ],
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -60,13 +60,72 @@ describe('when using Digital River payment', () => {
 
         expect(component.props())
             .toEqual(expect.objectContaining({
-                containerId: `${method}-component-field`,
+                containerId: `${method.id}-component-field`,
                 initializePayment: expect.any(Function),
                 method,
             }));
     });
 
     it('initializes method with required config', () => {
+        const methodWithInitializationData = {
+            ...method,
+            initializationData: {
+                disabledPaymentMethods: [
+                    'googlePay',
+                ],
+            },
+        };
+
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ methodWithInitializationData } />);
+        const component: ReactWrapper<HostedDropInPaymentMethodProps> = container.find(HostedDropInPaymentMethod);
+
+        component.prop('initializePayment')({
+            methodId: method.id,
+            gatewayId: method.gateway,
+        });
+
+        expect(checkoutService.initializePayment)
+            .toHaveBeenCalledWith({
+                digitalriver: {
+                    configuration: {
+                        button: {
+                            type: 'submitOrder',
+                        },
+                        flow: 'checkout',
+                        paymentMethodConfiguration: {
+                            disabledPaymentMethods: [
+                                'googlePay',
+                                'alipay',
+                                'bPay',
+                                'codJapan',
+                                'klarnaCredit',
+                                'konbini',
+                                'msts',
+                                'payco',
+                                'payPal',
+                                'payPalCredit',
+                                'payPalBilling',
+                                'wireTransfer',
+                            ],
+                            classes: {
+                                base: 'form-input optimizedCheckout-form-input',
+                            },
+                        },
+                        showComplianceSection: true,
+                        showSavePaymentAgreement: false,
+                        showTermsOfSaleDisclosure: true,
+                        usage: 'unscheduled',
+                    },
+                    containerId: `${method.id}-component-field`,
+                    onError: expect.any(Function),
+                    onSubmitForm: expect.any(Function),
+                },
+                gatewayId: undefined,
+                methodId: 'digitalriver',
+            });
+    });
+
+    it('initializes method with required config including initializationData', () => {
         const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
         const component: ReactWrapper<HostedDropInPaymentMethodProps> = container.find(HostedDropInPaymentMethod);
 
@@ -106,7 +165,7 @@ describe('when using Digital River payment', () => {
                         showTermsOfSaleDisclosure: true,
                         usage: 'unscheduled',
                     },
-                    containerId: `${method}-component-field`,
+                    containerId: `${method.id}-component-field`,
                     onError: expect.any(Function),
                     onSubmitForm: expect.any(Function),
                 },

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -66,12 +66,23 @@ describe('when using Digital River payment', () => {
             }));
     });
 
-    it('initializes method with required config', () => {
+    it('initializes method with required config including initializationData', () => {
         const methodWithInitializationData = {
             ...method,
             initializationData: {
                 disabledPaymentMethods: [
                     'googlePay',
+                    'alipay',
+                    'bPay',
+                    'codJapan',
+                    'klarnaCredit',
+                    'konbini',
+                    'msts',
+                    'payco',
+                    'payPal',
+                    'payPalCredit',
+                    'payPalBilling',
+                    'wireTransfer',
                 ],
             },
         };
@@ -125,7 +136,7 @@ describe('when using Digital River payment', () => {
             });
     });
 
-    it('initializes method with required config including initializationData', () => {
+    it('initializes method with required config and without initializationData', () => {
         const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
         const component: ReactWrapper<HostedDropInPaymentMethodProps> = container.find(HostedDropInPaymentMethod);
 
@@ -143,19 +154,7 @@ describe('when using Digital River payment', () => {
                         },
                         flow: 'checkout',
                         paymentMethodConfiguration: {
-                            disabledPaymentMethods: [
-                                'alipay',
-                                'bPay',
-                                'codJapan',
-                                'klarnaCredit',
-                                'konbini',
-                                'msts',
-                                'payco',
-                                'payPal',
-                                'payPalCredit',
-                                'payPalBilling',
-                                'wireTransfer',
-                            ],
+                            disabledPaymentMethods: [],
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',
                             },

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -21,7 +21,31 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
     ...rest
 }) => {
     const { setSubmitted } = useContext(FormContext);
-    const containerId = `${rest.method}-component-field`;
+    const containerId = `${rest.method.id}-component-field`;
+    let disabledPaymentMethodsFromSettings: string[] = [];
+    const { initializationData } = rest.method;
+    if (initializationData) {
+        const { disabledPaymentMethods } = initializationData;
+
+        if (disabledPaymentMethods) {
+            disabledPaymentMethodsFromSettings = disabledPaymentMethods;
+        }
+    }
+
+    const disabledPaymentMethodsData = [
+        ...disabledPaymentMethodsFromSettings,
+        'alipay',
+        'bPay',
+        'codJapan',
+        'klarnaCredit',
+        'konbini',
+        'msts',
+        'payco',
+        'payPal',
+        'payPalCredit',
+        'payPalBilling',
+        'wireTransfer',
+    ];
     const initializeDigitalRiverPayment = useCallback(options => initializePayment({
         ...options,
         digitalriver: {
@@ -36,19 +60,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 usage: 'unscheduled',
                 showTermsOfSaleDisclosure: true,
                 paymentMethodConfiguration: {
-                    disabledPaymentMethods: [
-                        'alipay',
-                        'bPay',
-                        'codJapan',
-                        'klarnaCredit',
-                        'konbini',
-                        'msts',
-                        'payco',
-                        'payPal',
-                        'payPalCredit',
-                        'payPalBilling',
-                        'wireTransfer',
-                    ],
+                    disabledPaymentMethods: disabledPaymentMethodsData,
                     classes: DigitalRiverClasses,
                 },
             },
@@ -60,7 +72,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 onUnhandledError?.(error);
             },
         },
-    }), [initializePayment, containerId, setSubmitted, submitForm, onUnhandledError]);
+    }), [initializePayment, containerId, disabledPaymentMethodsData, setSubmitted, submitForm, onUnhandledError]);
 
     return <HostedDropInPaymentMethod
         { ...rest }

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -22,15 +22,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
 }) => {
     const { setSubmitted } = useContext(FormContext);
     const containerId = `${rest.method.id}-component-field`;
-    let disabledPaymentMethodsFromSettings: string[] = [];
-    const { initializationData } = rest.method;
-    if (initializationData) {
-        const { disabledPaymentMethods } = initializationData;
-
-        if (disabledPaymentMethods) {
-            disabledPaymentMethodsFromSettings = disabledPaymentMethods;
-        }
-    }
+    const disabledPaymentMethods = rest.method.initializationData?.disabledPaymentMethods ?? [];
 
     const initializeDigitalRiverPayment = useCallback(options => initializePayment({
         ...options,
@@ -46,7 +38,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 usage: 'unscheduled',
                 showTermsOfSaleDisclosure: true,
                 paymentMethodConfiguration: {
-                    disabledPaymentMethods: disabledPaymentMethodsFromSettings,
+                    disabledPaymentMethods,
                     classes: DigitalRiverClasses,
                 },
             },
@@ -58,7 +50,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 onUnhandledError?.(error);
             },
         },
-    }), [initializePayment, containerId, disabledPaymentMethodsFromSettings, setSubmitted, submitForm, onUnhandledError]);
+    }), [initializePayment, containerId, disabledPaymentMethods, setSubmitted, submitForm, onUnhandledError]);
 
     return <HostedDropInPaymentMethod
         { ...rest }

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -32,20 +32,6 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
         }
     }
 
-    const disabledPaymentMethodsData = [
-        ...disabledPaymentMethodsFromSettings,
-        'alipay',
-        'bPay',
-        'codJapan',
-        'klarnaCredit',
-        'konbini',
-        'msts',
-        'payco',
-        'payPal',
-        'payPalCredit',
-        'payPalBilling',
-        'wireTransfer',
-    ];
     const initializeDigitalRiverPayment = useCallback(options => initializePayment({
         ...options,
         digitalriver: {
@@ -60,7 +46,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 usage: 'unscheduled',
                 showTermsOfSaleDisclosure: true,
                 paymentMethodConfiguration: {
-                    disabledPaymentMethods: disabledPaymentMethodsData,
+                    disabledPaymentMethods: disabledPaymentMethodsFromSettings,
                     classes: DigitalRiverClasses,
                 },
             },
@@ -72,7 +58,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 onUnhandledError?.(error);
             },
         },
-    }), [initializePayment, containerId, disabledPaymentMethodsData, setSubmitted, submitForm, onUnhandledError]);
+    }), [initializePayment, containerId, disabledPaymentMethodsFromSettings, setSubmitted, submitForm, onUnhandledError]);
 
     return <HostedDropInPaymentMethod
         { ...rest }


### PR DESCRIPTION
## What?
To disable the payment method depending from the settings we need to update the disabledPaymentMethods array that is sending as configuration to the Digital River JS in the strategy.

## Why?
To support the checkboxes in Digital River settings page.

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/120559847-62e4c480-c3c7-11eb-87bd-02a9db2e9904.png)


## Depends on: https://github.com/bigcommerce/bigcommerce/pull/41232

@bigcommerce/checkout @bigcommerce/apex-integrations 
