### PR TITLE
feat(payment): INT-4170 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,9 +1626,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.155.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.155.1.tgz",
-      "integrity": "sha512-GZl0b1Q8JAX4/QliCh1rREnnZoF307GItqF9labdCqZWoDfRyszDYPx7BWaxKvfXk/nRwEZPXLL2m5ybVgRoZw==",
+      "version": "1.156.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.156.0.tgz",
+      "integrity": "sha512-Dl8nDxlNAPpnHhOEWSdvuOQhTPtL1SeUD/6aYEBrYtZJzXjPTn6964hqkKlEEkpO74b7LZJcgNjDG13e/Hewdw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -1840,9 +1840,9 @@
       "dev": true
     },
     "@braintree/browser-detection": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.11.1.tgz",
-      "integrity": "sha512-jE5GRXNT2Ey3itbR7uTYdzbiLs9CP0kCInjTJFItApMFPj6F2Dm0Yb56C/69f7BL282gcCRqwhXVgaTeVwTWbw=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.12.0.tgz",
+      "integrity": "sha512-fmZcaXYkXr9b0J+3HwXLQogIYV+xSS6aBG7LGu0OjLkSD/k62EAu2xLGEDFHUu6siH/I7vvGoC0/Ds3f3RnS6g=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.155.1",
+    "@bigcommerce/checkout-sdk": "^1.156.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Raise the active SDK version.

## Why?
Releasing https://github.com/bigcommerce/checkout-sdk-js/pull/1140

## Testing / Proof
Circle, see linked PR.

@bigcommerce/checkout
