### PR TITLE
feat(payment): INT-4342 added Google Pay for Orbital

### DIFF
--- a/src/app/customer/CheckoutButtonList.tsx
+++ b/src/app/customer/CheckoutButtonList.tsx
@@ -17,6 +17,7 @@ export const SUPPORTED_METHODS: string[] = [
     'googlepaybraintree',
     'googlepaycheckoutcom',
     'googlepaycybersourcev2',
+    'googlepayorbital',
     'googlepaystripe',
 ];
 

--- a/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
@@ -32,6 +32,10 @@ const GooglePayPaymentMethod: FunctionComponent<GooglePayPaymentMethodProps> = (
             walletButton: 'walletButton',
             onError: onUnhandledError,
         },
+        googlepayorbital: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+        },
         googlepaycheckoutcom: {
             walletButton: 'walletButton',
             onError: onUnhandledError,

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -146,6 +146,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
         method.id === PaymentMethodId.BraintreeGooglePay ||
         method.id === PaymentMethodId.CheckoutcomGooglePay ||
         method.id === PaymentMethodId.CybersourceV2GooglePay ||
+        method.id === PaymentMethodId.OrbitalGooglePay ||
         method.id === PaymentMethodId.StripeGooglePay) {
         return <GooglePayPaymentMethod { ...props } />;
     }

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -30,6 +30,7 @@ enum PaymentMethodId {
     Mollie = 'mollie',
     Moneris = 'moneris',
     Oxxo = 'oxxo',
+    OrbitalGooglePay = 'googlepayorbital',
     PaypalExpress = 'paypalexpress',
     PaypalPaymentsPro = 'paypal',
     PaypalCommerce = 'paypalcommerce',


### PR DESCRIPTION
## What? [INT-4342](https://jira.bigcommerce.com/browse/INT-4342)
Added Google Pay on Orbital

## Why?
So that merchants can offer Google Pay as Payment Method using Orbital (CMS) integration

## Testing / Proof

<img width="790" alt="INT-4342 Payment Step" src="https://user-images.githubusercontent.com/61981535/122312546-078ff780-ceda-11eb-9cbd-4759a17fdd0a.png">

## Depends on
[SDK 1154](https://github.com/bigcommerce/checkout-sdk-js/pull/1154)


bigcommerce/checkout
