### PR TITLE
feat(payment): INT-4441 Update Mollie APMs logos

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -126,7 +126,7 @@ function getPaymentMethodTitle(
                 titleText: (method.config.displayName === 'Credit Card' ? language.translate('payment.adyen_credit_debit_card_text') : method.config.displayName) || '',
             },
             [PaymentMethodId.Mollie]: {
-                logoUrl: method.method === 'credit_card' ? '' : cdnPath(`/img/payment-providers/${method.method}.svg`),
+                logoUrl: method.method === 'credit_card' ? '' : cdnPath(`/img/payment-providers/mollie_${method.method}.svg`),
                 titleText: method.method === 'credit_card' ? startCase(methodName) : methodName,
             },
             [PaymentMethodId.Checkoutcom]: {


### PR DESCRIPTION
## What? [INT-4441](https://jira.bigcommerce.com/browse/INT-4441)

Update Mollie APMs Logos


## Why?

The Mollie APMs Logos were not the current ones 

## Testing / Proof

![Screen Shot 2021-06-15 at 13 29 08](https://user-images.githubusercontent.com/69221626/122105093-ffeb2880-cddd-11eb-9638-b7f996bf99dc.png)

## Dependency of 

[BCCAP](https://github.com/bigcommerce/bigcommerce/pull/41490)

## How can this change be undone in case of failure?
By Reverting this PR

ping @bigcommerce/apex-integrations @bigcommerce/checkout 
