### PR TITLE
[draft, wip] feat(payment): BOLT-19 added new BoltCheckout implementation to custo…

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -100,7 +100,7 @@
         },
         "customer": {
             "checkout_as_guest_text": "Checking out as a <strong>Guest</strong>? You'll be able to save your details to create an account with us later.",
-            "continue_as_guest_action": "Continue as guest",
+            "continue_as_guest_action": "Continue",
             "create_account_action": "Create Account",
             "set_password_action": "Save Password",
             "required_error": "{label} is required",


### PR DESCRIPTION
…mer step

## What?
Added extra 'sign in', 'sign up' and 'continue as customer' handler to open BoltCheckout modal (with new sdk strategy) before passing customer step.

## Why?
Because of the task: https://jira.bigcommerce.com/browse/BOLT-19

## Sibling pull-request
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1158

## Testing / Proof
Some gifs to figure out how it looks like:
![continue_as_customer](https://user-images.githubusercontent.com/25133454/122948894-eb7dd180-d383-11eb-81bf-6e1be142deaf.gif)
![sign_in](https://user-images.githubusercontent.com/25133454/122948927-f0db1c00-d383-11eb-92cd-faa159989147.gif)
![sign_up](https://user-images.githubusercontent.com/25133454/122948951-f59fd000-d383-11eb-9a3a-0da28878f1b4.gif)


@bigcommerce/checkout @BC-ACherednichenko 
