### PR TITLE
feat(payment): BOLT-19 added BoltCheckout implementation for customer…

### DIFF
--- a/src/app/config/config.mock.ts
+++ b/src/app/config/config.mock.ts
@@ -10,6 +10,7 @@ export function getStoreConfig(): StoreConfig {
             billingAddressFields: [],
         },
         checkoutSettings: {
+            customContinueFlowProviderId: undefined,
             enableOrderComments: true,
             enableTermsAndConditions: false,
             googleRecaptchaSitekey: 'sitekey',

--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -1,5 +1,5 @@
 import { createCheckoutService, BillingAddress, Checkout, CheckoutService, Customer as CustomerData, StoreConfig } from '@bigcommerce/checkout-sdk';
-import { mount, render, ReactWrapper } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 
 import { getBillingAddress } from '../billing/billingAddresses.mock';
@@ -45,6 +45,15 @@ describe('Customer', () => {
         jest.spyOn(checkoutService.getState().data, 'getConfig')
             .mockReturnValue(config);
 
+        jest.spyOn(checkoutService, 'loadPaymentMethods')
+            .mockResolvedValue(checkoutService.getState());
+
+        jest.spyOn(checkoutService, 'initializeCustomer')
+            .mockResolvedValue(checkoutService.getState());
+
+        jest.spyOn(checkoutService.getState().data, 'getPaymentMethods')
+            .mockReturnValue([]);
+
         localeContext = createLocaleContext(getStoreConfig());
 
         CustomerTest = props => (
@@ -57,23 +66,31 @@ describe('Customer', () => {
     });
 
     describe('when view type is "guest"', () => {
-        it('matches snapshot', () => {
-            expect(render(
-                <CustomerTest viewType={ CustomerViewType.Guest } />
-            ))
-                .toMatchSnapshot();
-        });
-
-        it('renders guest form by default', () => {
+        it('matches snapshot', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
+            expect(component.render())
+                .toMatchSnapshot();
+        });
+
+        it('renders guest form by default', async () => {
+            const component = mount(
+                <CustomerTest viewType={ CustomerViewType.Guest } />
+            );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(GuestForm).exists())
                 .toEqual(true);
         });
 
-        it('renders guest form if billing address is undefined', () => {
+        it('renders guest form if billing address is undefined', async () => {
             jest.spyOn(checkoutService.getState().data, 'getBillingAddress')
                 .mockReturnValue(undefined);
 
@@ -81,11 +98,14 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(GuestForm).exists())
                 .toEqual(true);
         });
 
-        it('renders guest form if customer is undefined', () => {
+        it('renders guest form if customer is undefined', async () => {
             jest.spyOn(checkoutService.getState().data, 'getCustomer')
                 .mockReturnValue(undefined);
 
@@ -93,11 +113,14 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(GuestForm).exists())
                 .toEqual(true);
         });
 
-        it('renders create account form if type is create account', () => {
+        it('renders create account form if type is create account', async () => {
             jest.spyOn(checkoutService.getState().data, 'getCustomer')
                 .mockReturnValue(undefined);
 
@@ -116,14 +139,20 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.CreateAccount } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(CreateAccountForm).exists())
                 .toEqual(true);
         });
 
-        it('passes data to guest form', () => {
+        it('passes data to guest form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(GuestForm).props())
                 .toMatchObject({
@@ -133,15 +162,19 @@ describe('Customer', () => {
                 });
         });
 
-        it('continues checkout as guest and does not send consent if not required', () => {
+        it('continues checkout as guest and does not send consent if not required', async () => {
             jest.spyOn(checkoutService, 'continueAsGuest')
                 .mockReturnValue(Promise.resolve(checkoutService.getState()));
 
+            const defaultOptions = { methodId: undefined };
             const component = mount(
                 <CustomerTest
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -154,19 +187,23 @@ describe('Customer', () => {
                     email: 'test@bigcommerce.com',
                     acceptsMarketingNewsletter: true,
                     acceptsAbandonedCartEmails: true,
-                });
+                }, defaultOptions);
         });
 
-        it('only subscribes to newsletter if allowed by customer', () => {
+        it('only subscribes to newsletter if allowed by customer', async () => {
             jest.spyOn(checkoutService, 'continueAsGuest')
                 .mockReturnValue(Promise.resolve(checkoutService.getState()));
 
+            const defaultOptions = { methodId: undefined };
             const subscribeToNewsletter = jest.fn();
             const component = mount(
                 <CustomerTest
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -179,13 +216,13 @@ describe('Customer', () => {
                     email: 'test@bigcommerce.com',
                     acceptsMarketingNewsletter: undefined,
                     acceptsAbandonedCartEmails: undefined,
-                });
+                }, defaultOptions);
 
             expect(subscribeToNewsletter)
                 .not.toHaveBeenCalled();
         });
 
-        it('changes to login view when "show login" event is received', () => {
+        it('changes to login view when "show login" event is received', async () => {
             const handleChangeViewType = jest.fn();
             const component = mount(
                 <CustomerTest
@@ -193,6 +230,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onShowLogin')();
@@ -212,6 +252,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -237,6 +280,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -260,6 +306,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -292,6 +341,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -319,6 +371,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -343,6 +398,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -355,10 +413,13 @@ describe('Customer', () => {
                 .toHaveBeenCalled();
         });
 
-        it('retains draft email address when switching to login view', () => {
+        it('retains draft email address when switching to login view', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onChangeEmail')('test@bigcommerce.com');
@@ -372,7 +433,7 @@ describe('Customer', () => {
     });
 
     describe('when view type is "login"', () => {
-        it('matches snapshot', () => {
+        it('matches snapshot', async () => {
             const component = mount(
                 <CustomerTest
                     isAccountCreationEnabled={ true }
@@ -380,14 +441,20 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.render())
                 .toMatchSnapshot();
         });
 
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).exists())
                 .toEqual(true);
@@ -400,6 +467,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Login }
                 />);
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(EmailLoginForm).exists())
                 .toEqual(false);
 
@@ -410,13 +480,16 @@ describe('Customer', () => {
                 .toEqual(false);
         });
 
-        it('does not render sign-in email link when is embedded checkout', () => {
+        it('does not render sign-in email link when is embedded checkout', async () => {
             const component = mount(
                 <CustomerTest
                     isEmbedded={ true }
                     isSignInEmailEnabled={ true }
                     viewType={ CustomerViewType.Login }
                 />);
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(EmailLoginForm).exists())
                 .toEqual(false);
@@ -425,10 +498,13 @@ describe('Customer', () => {
                 .toEqual(false);
         });
 
-        it('passes data to login form', () => {
+        it('passes data to login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).props())
                 .toMatchObject({
@@ -438,13 +514,17 @@ describe('Customer', () => {
                 });
         });
 
-        it('handles "sign in" event', () => {
+        it('handles "sign in" event', async () => {
             jest.spyOn(checkoutService, 'signInCustomer')
                 .mockReturnValue(Promise.resolve(checkoutService.getState()));
 
+            const defaultOptions = { methodId: undefined };
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 .prop('onSignIn')({
@@ -456,7 +536,7 @@ describe('Customer', () => {
                 .toHaveBeenCalledWith({
                     email: 'test@bigcommerce.com',
                     password: 'password1',
-                });
+                }, defaultOptions);
         });
 
         it('triggers completion callback if customer is successfully signed in', async () => {
@@ -470,6 +550,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Login }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 .prop('onSignIn')({
@@ -495,6 +578,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 .prop('onSignIn')({
                     email: 'test@bigcommerce.com',
@@ -507,7 +593,7 @@ describe('Customer', () => {
                 .toHaveBeenCalled();
         });
 
-        it('clears error when "cancel" event is triggered', () => {
+        it('clears error when "cancel" event is triggered', async () => {
             const error = new Error();
 
             jest.spyOn(checkoutService.getState().errors, 'getSignInError')
@@ -520,6 +606,9 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 // tslint:disable-next-line:no-non-null-assertion
                 .prop('onCancel')!();
@@ -528,7 +617,7 @@ describe('Customer', () => {
                 .toHaveBeenCalledWith(error);
         });
 
-        it('changes to guest view when "cancel" event is triggered', () => {
+        it('changes to guest view when "cancel" event is triggered', async () => {
             const handleChangeViewType = jest.fn();
             const component = mount(
                 <CustomerTest
@@ -536,6 +625,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Login }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 // tslint:disable-next-line:no-non-null-assertion
@@ -545,10 +637,13 @@ describe('Customer', () => {
                 .toHaveBeenCalledWith(CustomerViewType.Guest);
         });
 
-        it('retains draft email address when switching to guest view', () => {
+        it('retains draft email address when switching to guest view', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 // tslint:disable-next-line:no-non-null-assertion
@@ -563,10 +658,13 @@ describe('Customer', () => {
     });
 
     describe('when view type is "cancellable_enforced_login"', () => {
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.CancellableEnforcedLogin } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).prop('viewType'))
                 .toEqual(CustomerViewType.CancellableEnforcedLogin);
@@ -574,10 +672,13 @@ describe('Customer', () => {
     });
 
     describe('when view type is "suggested_login"', () => {
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.SuggestedLogin } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).prop('viewType'))
                 .toEqual(CustomerViewType.SuggestedLogin);
@@ -585,10 +686,13 @@ describe('Customer', () => {
     });
 
     describe('when view type is "enforced_login"', () => {
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.EnforcedLogin } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).prop('viewType'))
                 .toEqual(CustomerViewType.EnforcedLogin);
@@ -604,7 +708,11 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.EnforcedLogin }
                 />);
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             component.find('[data-test="customer-signin-link"]').simulate('click');
+
             component.update();
             await new Promise(resolve => process.nextTick(resolve));
             component.update();
@@ -625,8 +733,12 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.EnforcedLogin }
                 />);
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             component.find('[data-test="customer-signin-link"]').simulate('click');
             component.update();
+
             await new Promise(resolve => process.nextTick(resolve));
             component.update();
 

--- a/src/app/customer/GuestForm.spec.tsx
+++ b/src/app/customer/GuestForm.spec.tsx
@@ -15,6 +15,7 @@ describe('GuestForm', () => {
     beforeEach(() => {
         defaultProps = {
             canSubscribe: true,
+            customContinueAsGuestButtonLabelId: '',
             defaultShouldSubscribe: false,
             isLoading: false,
             onChangeEmail: jest.fn(),

--- a/src/app/customer/GuestForm.tsx
+++ b/src/app/customer/GuestForm.tsx
@@ -13,6 +13,7 @@ import SubscribeField from './SubscribeField';
 export interface GuestFormProps {
     canSubscribe: boolean;
     checkoutButtons?: ReactNode;
+    customContinueAsGuestButtonLabelId?: string;
     requiresMarketingConsent: boolean;
     defaultShouldSubscribe: boolean;
     email?: string;
@@ -31,6 +32,7 @@ export interface GuestFormValues {
 const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikProps<GuestFormValues>> = ({
     canSubscribe,
     checkoutButtons,
+    customContinueAsGuestButtonLabelId,
     isLoading,
     onChangeEmail,
     onShowLogin,
@@ -86,7 +88,7 @@ const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikPr
                             type="submit"
                             variant={ ButtonVariant.Primary }
                         >
-                            <TranslatedString id="customer.continue_as_guest_action" />
+                            <TranslatedString id={ customContinueAsGuestButtonLabelId || 'customer.continue_as_guest_action' } />
                         </Button>
                     </div>
                 </div>

--- a/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -2,216 +2,220 @@
 
 exports[`Customer when view type is "guest" matches snapshot 1`] = `
 <div>
-  <form
-    class="checkout-form"
-    data-test="checkout-customer-guest"
-    id="checkout-customer-guest"
-    novalidate=""
-  >
-    <fieldset
-      class="form-fieldset"
+  <div>
+    <form
+      class="checkout-form"
+      data-test="checkout-customer-guest"
+      id="checkout-customer-guest"
+      novalidate=""
     >
-      <legend
-        class="form-legend is-srOnly"
+      <fieldset
+        class="form-fieldset"
       >
-        Guest Customer
-      </legend>
-      <div
-        class="form-body"
-      >
-        <p>
-          <span>
-            Checking out as a 
-            <strong>
-              Guest
-            </strong>
-            ? You'll be able to save your details to create an account with us later.
-          </span>
-        </p>
-        <div
-          class="customerEmail-container"
+        <legend
+          class="form-legend is-srOnly"
         >
+          Guest Customer
+        </legend>
+        <div
+          class="form-body"
+        >
+          <p>
+            <span>
+              Checking out as a 
+              <strong>
+                Guest
+              </strong>
+              ? You'll be able to save your details to create an account with us later.
+            </span>
+          </p>
           <div
-            class="customerEmail-body"
+            class="customerEmail-container"
           >
             <div
-              class="form-field"
+              class="customerEmail-body"
             >
-              <label
-                class="form-label optimizedCheckout-form-label"
-                for="email"
+              <div
+                class="form-field"
               >
-                Email Address
-              </label>
-              <input
-                autocomplete="email"
-                class="form-input optimizedCheckout-form-input"
-                id="email"
-                name="email"
-                type="email"
-                value="test@bigcommerce.com"
-              />
+                <label
+                  class="form-label optimizedCheckout-form-label"
+                  for="email"
+                >
+                  Email Address
+                </label>
+                <input
+                  autocomplete="email"
+                  class="form-input optimizedCheckout-form-input"
+                  id="email"
+                  name="email"
+                  type="email"
+                  value="test@bigcommerce.com"
+                />
+              </div>
+              <div
+                class="form-field"
+              >
+                <input
+                  class="form-checkbox"
+                  id="shouldSubscribe"
+                  name="shouldSubscribe"
+                  type="checkbox"
+                  value="false"
+                />
+                <label
+                  class="form-label optimizedCheckout-form-label"
+                  for="shouldSubscribe"
+                >
+                  Subscribe to our newsletter.
+                </label>
+              </div>
             </div>
             <div
-              class="form-field"
+              class="form-actions customerEmail-action"
             >
-              <input
-                class="form-checkbox"
-                id="shouldSubscribe"
-                name="shouldSubscribe"
-                type="checkbox"
-                value="false"
-              />
-              <label
-                class="form-label optimizedCheckout-form-label"
-                for="shouldSubscribe"
+              <button
+                class="button customerEmail-button button--primary optimizedCheckout-buttonPrimary"
+                data-test="customer-continue-as-guest-button"
+                id="checkout-customer-continue"
+                type="submit"
               >
-                Subscribe to our newsletter.
-              </label>
+                Continue as guest
+              </button>
             </div>
           </div>
-          <div
-            class="form-actions customerEmail-action"
-          >
-            <button
-              class="button customerEmail-button button--primary optimizedCheckout-buttonPrimary"
-              data-test="customer-continue-as-guest-button"
-              id="checkout-customer-continue"
-              type="submit"
+          <p>
+            Already have an account? 
+            <a
+              data-test="customer-continue-button"
+              id="checkout-customer-login"
             >
-              Continue as guest
-            </button>
-          </div>
+              Sign in now
+            </a>
+          </p>
         </div>
-        <p>
-          Already have an account? 
-          <a
-            data-test="customer-continue-button"
-            id="checkout-customer-login"
-          >
-            Sign in now
-          </a>
-        </p>
-      </div>
-    </fieldset>
-  </form>
+      </fieldset>
+    </form>
+  </div>
 </div>
 `;
 
 exports[`Customer when view type is "login" matches snapshot 1`] = `
 <div>
-  <form
-    class="checkout-form"
-    data-test="checkout-customer-returning"
-    id="checkout-customer-returning"
-    novalidate=""
-  >
-    <fieldset
-      class="form-fieldset"
+  <div>
+    <form
+      class="checkout-form"
+      data-test="checkout-customer-returning"
+      id="checkout-customer-returning"
+      novalidate=""
     >
-      <legend
-        class="form-legend is-srOnly"
+      <fieldset
+        class="form-fieldset"
       >
-        Returning Customer
-      </legend>
-      <div
-        class="form-body"
-      >
-        <p>
-          Don't have an account? 
-          <a
-            href="#"
-          >
-            Create an account
-          </a>
-           to continue.
-        </p>
-        <div
-          class="form-field"
+        <legend
+          class="form-legend is-srOnly"
         >
-          <label
-            class="form-label optimizedCheckout-form-label"
-            for="email"
-          >
-            Email Address
-          </label>
-          <input
-            autocomplete="email"
-            class="form-input optimizedCheckout-form-input"
-            id="email"
-            name="email"
-            type="email"
-            value="test@bigcommerce.com"
-          />
-        </div>
+          Returning Customer
+        </legend>
         <div
-          class="form-field"
+          class="form-body"
         >
-          <label
-            class="form-label optimizedCheckout-form-label"
-            for="password"
-          >
-            Password
-          </label>
-          <div
-            class="form-field-password"
-          >
-            <input
-              class="form-input optimizedCheckout-form-input form-input--withIcon"
-              id="password"
-              name="password"
-              type="password"
-              value=""
-            />
+          <p>
+            Don't have an account? 
             <a
-              class="form-toggle-password form-input-icon"
               href="#"
             >
-              <div
-                class="icon"
+              Create an account
+            </a>
+             to continue.
+          </p>
+          <div
+            class="form-field"
+          >
+            <label
+              class="form-label optimizedCheckout-form-label"
+              for="email"
+            >
+              Email Address
+            </label>
+            <input
+              autocomplete="email"
+              class="form-input optimizedCheckout-form-input"
+              id="email"
+              name="email"
+              type="email"
+              value="test@bigcommerce.com"
+            />
+          </div>
+          <div
+            class="form-field"
+          >
+            <label
+              class="form-label optimizedCheckout-form-label"
+              for="password"
+            >
+              Password
+            </label>
+            <div
+              class="form-field-password"
+            >
+              <input
+                class="form-input optimizedCheckout-form-input form-input--withIcon"
+                id="password"
+                name="password"
+                type="password"
+                value=""
+              />
+              <a
+                class="form-toggle-password form-input-icon"
+                href="#"
               >
-                <svg
-                  viewBox="0 0 640 512"
-                  xmlns="http://www.w3.org/2000/svg"
+                <div
+                  class="icon"
                 >
-                  <path
-                    d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
-                  />
-                </svg>
-              </div>
+                  <svg
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                    />
+                  </svg>
+                </div>
+              </a>
+            </div>
+            <a
+              data-test="forgot-password-link"
+              href="https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Forgot password?
             </a>
           </div>
-          <a
-            data-test="forgot-password-link"
-            href="https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password"
-            rel="noopener noreferrer"
-            target="_blank"
+          <div
+            class="form-actions"
           >
-            Forgot password?
-          </a>
+            <button
+              class="button button--primary optimizedCheckout-buttonPrimary"
+              data-test="customer-continue-button"
+              id="checkout-customer-continue"
+              type="submit"
+            >
+              Sign In
+            </button>
+            <a
+              class="button optimizedCheckout-buttonSecondary"
+              data-test="customer-cancel-button"
+              href="#"
+              id="checkout-customer-cancel"
+            >
+              Cancel
+            </a>
+          </div>
         </div>
-        <div
-          class="form-actions"
-        >
-          <button
-            class="button button--primary optimizedCheckout-buttonPrimary"
-            data-test="customer-continue-button"
-            id="checkout-customer-continue"
-            type="submit"
-          >
-            Sign In
-          </button>
-          <a
-            class="button optimizedCheckout-buttonSecondary"
-            data-test="customer-cancel-button"
-            href="#"
-            id="checkout-customer-cancel"
-          >
-            Cancel
-          </a>
-        </div>
-      </div>
-    </fieldset>
-  </form>
+      </fieldset>
+    </form>
+  </div>
 </div>
 `;

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -101,6 +101,7 @@
         "customer": {
             "checkout_as_guest_text": "Checking out as a <strong>Guest</strong>? You'll be able to save your details to create an account with us later.",
             "continue_as_guest_action": "Continue as guest",
+            "continue": "Continue",
             "create_account_action": "Create Account",
             "set_password_action": "Save Password",
             "required_error": "{label} is required",


### PR DESCRIPTION
…s with bolt account

## What?
Added BoltCheckout implementation for customers with bolt account.

## Why?
We need to add custom flow for _continue as guest_, _sign in_ and  _sign up_ events, to show BoltCheckout modal if the customer has BoltAccount

Task: https://jira.bigcommerce.com/browse/BOLT-19

## Sibling pull-request
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1163

## Testing / Proof
Some gifs to figure out how it looks like:
![continue_as_customer](https://user-images.githubusercontent.com/25133454/122948894-eb7dd180-d383-11eb-81bf-6e1be142deaf.gif)
![sign_in](https://user-images.githubusercontent.com/25133454/122948927-f0db1c00-d383-11eb-92cd-faa159989147.gif)
![sign_up](https://user-images.githubusercontent.com/25133454/122948951-f59fd000-d383-11eb-9a3a-0da28878f1b4.gif)

There how it will looks like if the user have default flow or customer hasn't bolt account:
![continue_as_guest_without_bolt_account](https://user-images.githubusercontent.com/25133454/124246107-4b653c80-db29-11eb-8501-3405fd6f4e36.gif)

@bigcommerce/checkout @bigcommerce/payments
