### PR TITLE
feat(payments): INT-4237 Added select your bank to json

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -277,6 +277,7 @@
             "quadpay_continue_action": "Continue with Quadpay",
             "quadpay_display_name_text": "Pay in 4 installments",
             "ppsdk_continue_action": "Continue with {methodName}",
+            "select_your_bank": "Select your bank",
             "sepa_account_number": "Account Number (IBAN)",
             "sepa_account_number_required": "You must enter your account number (IBAN)",
             "sepa_bic": "BIC",

--- a/src/app/payment/paymentMethod/MollieAPMCustomForm.spec.tsx
+++ b/src/app/payment/paymentMethod/MollieAPMCustomForm.spec.tsx
@@ -4,11 +4,14 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
 import { DropdownTrigger } from '../../ui/dropdown';
 
 import MollieAPMCustomForm, { Issuer, IssuerSelectButton, MollieCustomCardFormProps, OptionButton } from './MollieAPMCustomForm';
 
 describe('MollieAPMCustomForm', () => {
+    let localeContext: LocaleContextType;
     const issuer: Issuer = {
         id: 'kbc',
         name: 'kbc',
@@ -38,14 +41,17 @@ describe('MollieAPMCustomForm', () => {
     let MollieAPMCustomFormTest: FunctionComponent<MollieCustomCardFormProps> ;
 
     beforeEach(() => {
-        MollieAPMCustomFormTest = (props: MollieCustomCardFormProps) => (
-            <Formik
-                initialValues={ {} }
-                onSubmit={ noop }
+        localeContext = createLocaleContext(getStoreConfig());
 
-            >
-                <MollieAPMCustomForm { ...props } />
-            </Formik>
+        MollieAPMCustomFormTest = (props: MollieCustomCardFormProps) => (
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <MollieAPMCustomForm { ...props } />
+                </Formik>
+            </LocaleContext.Provider>
         );
     });
 

--- a/src/app/payment/paymentMethod/MollieAPMCustomForm.tsx
+++ b/src/app/payment/paymentMethod/MollieAPMCustomForm.tsx
@@ -3,6 +3,7 @@ import { FieldProps } from 'formik';
 import React, { useCallback, useEffect, useState, FunctionComponent, SyntheticEvent } from 'react';
 
 import { preventDefault } from '../../common/dom';
+import { withLanguage, WithLanguageProps } from '../../locale';
 import { DropdownTrigger } from '../../ui/dropdown';
 import { FormField } from '../../ui/form';
 
@@ -32,10 +33,10 @@ interface OptionButtonProps {
     onClick?(event: SyntheticEvent<EventTarget>): void;
 }
 
-const MollieAPMCustomForm: FunctionComponent<MollieCustomCardFormProps> = ({ method }) => {
+const MollieAPMCustomForm: FunctionComponent<MollieCustomCardFormProps & WithLanguageProps> = ({ method, language }) => {
     const issuers: Issuer[] = method.initializationData?.paymentMethodsResponse;
 
-    const [ selectedIssuer, setSelectedIssuer ] = useState<Issuer>({ name: 'Select your bank', id: '', image: { size1x: '' } });
+    const [ selectedIssuer, setSelectedIssuer ] = useState<Issuer>({ name: language.translate('payment.select_your_bank') , id: '', image: { size1x: '' } });
     const render = useCallback((props: FieldProps) => <HiddenInput { ...props } selectedIssuer={ selectedIssuer } />, [ selectedIssuer ]);
 
     if (!issuers || issuers.length === 0) {
@@ -120,4 +121,4 @@ export const OptionButton: FunctionComponent<OptionButtonProps> = ({ issuer, ...
     );
 };
 
-export default MollieAPMCustomForm;
+export default withLanguage(MollieAPMCustomForm);


### PR DESCRIPTION
## What? [INT-4237](https://jira.bigcommerce.com/browse/INT-4237)

Add Select your bank to the en.json as part of [INT-4237](https://jira.bigcommerce.com/browse/INT-4237)

## Why?
Its a good practice to have these copies in a translatable file

## Testing / Proof
![Screen Shot 2021-06-30 at 10 56 57](https://user-images.githubusercontent.com/69221626/123993266-e75c4000-d991-11eb-964f-bd5db7feabcd.png)

@bigcommerce/checkout @bigcommerce/apex-integrations
