### PR TITLE
feat(payment): INT-3946 added locale from browser on masterpass SRC

### DIFF
--- a/src/app/payment/paymentMethod/MasterpassPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/MasterpassPaymentMethod.tsx
@@ -2,7 +2,7 @@ import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { useCallback, useMemo, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
-import { withLanguage, WithLanguageProps } from '../../locale';
+import { getLanguageService, withLanguage, WithLanguageProps } from '../../locale';
 
 import WalletButtonPaymentMethod, { WalletButtonPaymentMethodProps } from './WalletButtonPaymentMethod';
 
@@ -20,8 +20,17 @@ const MasterpassPaymentMethod: FunctionComponent<MasterpassPaymentMethodProps & 
         },
     }), [initializePayment]);
 
+    const formatLocale = useCallback((localeLanguage: string) => {
+        const auxLocale = localeLanguage.replace(/[-_]/g, '_');
+        const formatedLocale = auxLocale.includes('_') ? `${auxLocale}` : `${auxLocale}_${auxLocale}`;
+
+        return formatedLocale.toLowerCase();
+    }, []);
+
     const { config: { testMode }, initializationData: { checkoutId, isMasterpassSrcEnabled } } = rest.method;
-    const locale = navigator.language.replace('-', '_');
+
+    const locale = formatLocale(getLanguageService().getLocale());
+
     const signInButtonLabel = useMemo(() => (
         <img
             alt={ language.translate('payment.masterpass_name_text') }


### PR DESCRIPTION
## What? [INT-3946](https://jira.bigcommerce.com/browse/INT-3946)
Added locale from browser on masterpass SRC.

## Why?
In order to be able to see masterpass or SRC button based on shopper locale.

## Testing / Proof
<img width="672" alt="Screen Shot 2021-06-30 at 6 53 52 PM" src="https://user-images.githubusercontent.com/61981535/124045106-96ba0680-d9d4-11eb-8e38-1a8569a4a977.png">


@bigcommerce/checkout
