### PR TITLE
CHECKOUT-5872: Handle locale with region identifier

### DIFF
--- a/src/app/locale/getDefaultTranslations.spec.ts
+++ b/src/app/locale/getDefaultTranslations.spec.ts
@@ -1,0 +1,27 @@
+import getDefaultTranslations from './getDefaultTranslations';
+
+describe('getDefaultTranslations', () => {
+    it('returns French translations when fr locale is specified', async () => {
+        expect(await getDefaultTranslations('fr'))
+            // eslint-disable-next-line import/no-internal-modules
+            .toEqual(require('./translations/fr.json'));
+    });
+
+    it('returns French translations when fr-CA locale is specified', async () => {
+        expect(await getDefaultTranslations('fr-CA'))
+            // eslint-disable-next-line import/no-internal-modules
+            .toEqual(require('./translations/fr.json'));
+    });
+
+    it('returns Portuguese translations when pt locale is specified', async () => {
+        expect(await getDefaultTranslations('pt'))
+            // eslint-disable-next-line import/no-internal-modules
+            .toEqual(require('./translations/pt.json'));
+    });
+
+    it('returns Brazilian Portuguese translations when pt-BR locale is specified', async () => {
+        expect(await getDefaultTranslations('pt-BR'))
+            // eslint-disable-next-line import/no-internal-modules
+            .toEqual(require('./translations/pt-BR.json'));
+    });
+});

--- a/src/app/locale/getDefaultTranslations.ts
+++ b/src/app/locale/getDefaultTranslations.ts
@@ -2,56 +2,42 @@ import { Translations } from '@bigcommerce/checkout-sdk';
 
 import { FALLBACK_TRANSLATIONS } from './translations';
 
-export default async function getDefaultTranslations(locale: string): Promise<Translations> {
-    switch (locale) {
-        case 'de':
-            return asTranslations((await import(
-                /* webpackChunkName: "translations-de" */
-                './translations/de.json'
-            )).default);
+const AVAILABLE_TRANSLATIONS: Record<string, () => Promise<{ default: unknown }>> = {
+    de: () => import(
+        /* webpackChunkName: "translations-de" */
+        './translations/de.json'
+    ),
+    fr: () => import(
+        /* webpackChunkName: "translations-fr" */
+        './translations/fr.json'
+    ),
+    it: () => import(
+        /* webpackChunkName: "translations-it" */
+        './translations/it.json'
+    ),
+    nl: () => import(
+        /* webpackChunkName: "translations-nl" */
+        './translations/nl.json'
+    ),
+    'pt-BR': () => import(
+        /* webpackChunkName: "translations-pt-br" */
+        './translations/pt-BR.json'
+    ),
+    pt: () => import(
+        /* webpackChunkName: "translations-pt" */
+        './translations/pt.json'
+    ),
+    sv: () => import(
+        /* webpackChunkName: "translations-sv" */
+        './translations/sv.json'
+    ),
+    en: () => Promise.resolve(({ default: FALLBACK_TRANSLATIONS })),
+};
 
-        case 'fr':
-            return asTranslations((await import(
-                /* webpackChunkName: "translations-fr" */
-                './translations/fr.json'
-            )).default);
+export default async function getDefaultTranslations(requestedLocale: string): Promise<Translations> {
+    const loadTranslations = AVAILABLE_TRANSLATIONS[requestedLocale] ?? AVAILABLE_TRANSLATIONS[requestedLocale.split('-')[0]];
 
-        case 'it':
-            return asTranslations((await import(
-                /* webpackChunkName: "translations-it" */
-                './translations/it.json'
-            )).default);
-
-        case 'nl':
-            return asTranslations((await import(
-                /* webpackChunkName: "translations-nl" */
-                './translations/nl.json'
-            )).default);
-
-        case 'pt-BR':
-            return asTranslations((await import(
-                /* webpackChunkName: "translations-pt-br" */
-                './translations/pt-BR.json'
-            )).default);
-
-        case 'pt':
-            return asTranslations((await import(
-                /* webpackChunkName: "translations-pt" */
-                './translations/pt.json'
-            )).default);
-
-        case 'sv':
-            return asTranslations((await import(
-                /* webpackChunkName: "translations-sv" */
-                './translations/sv.json'
-            )).default);
-
-        case 'en':
-            return FALLBACK_TRANSLATIONS;
-
-        default:
-            return {};
-    }
+    return loadTranslations ? asTranslations((await loadTranslations()).default) : {};
 }
 
 function asTranslations(translations: unknown): Translations {


### PR DESCRIPTION
## What?
Ignore the region identifier if only the language identifier matches with the value inherited from storefront.

## Why?
For example, if `fr-CA` is the preferred locale, display `fr` instead of `en`.

## Testing / Proof
Unit

@bigcommerce/checkout
