### PR TITLE
fix(shipping): CHECKOUT-5895 Keep billingSameAsShipping state when navigating through steps

### DIFF
--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -66,6 +66,7 @@ export interface CheckoutProps {
 
 export interface CheckoutState {
     activeStepType?: CheckoutStepType;
+    isBillingSameAsShipping: boolean;
     customerViewType?: CustomerViewType;
     defaultStepType?: CheckoutStepType;
     error?: Error;
@@ -100,6 +101,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
     stepTracker: StepTracker | undefined;
 
     state: CheckoutState = {
+        isBillingSameAsShipping: true,
         isCartEmpty: false,
         isRedirecting: false,
         isMultiShippingMode: false,
@@ -319,7 +321,10 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
             consignments = [],
         } = this.props;
 
-        const { isMultiShippingMode } = this.state;
+        const {
+            isBillingSameAsShipping,
+            isMultiShippingMode,
+        } = this.state;
 
         if (!cart) {
             return;
@@ -344,6 +349,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 <LazyContainer>
                     <Shipping
                         cartHasChanged={ hasCartChanged }
+                        isBillingSameAsShipping={ isBillingSameAsShipping }
                         isMultiShippingMode={ isMultiShippingMode }
                         navigateNextStep={ this.handleShippingNextStep }
                         onCreateAccount={ this.handleShippingCreateAccount }
@@ -584,8 +590,10 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         this.navigateToStep(CheckoutStepType.Customer);
     };
 
-    private handleShippingNextStep: (billingSameAsShipping: boolean) => void = billingSameAsShipping => {
-        if (billingSameAsShipping) {
+    private handleShippingNextStep: (isBillingSameAsShipping: boolean) => void = isBillingSameAsShipping => {
+        this.setState({ isBillingSameAsShipping });
+
+        if (isBillingSameAsShipping) {
             this.navigateToNextIncompleteStep();
         } else {
             this.navigateToStep(CheckoutStepType.Billing);

--- a/src/app/shipping/Shipping.spec.tsx
+++ b/src/app/shipping/Shipping.spec.tsx
@@ -31,6 +31,7 @@ describe('Shipping Component', () => {
         checkoutState = checkoutService.getState();
 
         defaultProps = {
+            isBillingSameAsShipping: true,
             isMultiShippingMode: false,
             onToggleMultiShipping: jest.fn(),
             cartHasChanged: false,
@@ -260,7 +261,7 @@ describe('Shipping Component', () => {
         expect(checkoutService.deleteConsignment).toHaveBeenCalled();
     });
 
-    it('does not Call delete consignment if consignment doesnot exist when adding a new address', async () => {
+    it('does not call delete consignment if consignment doesnot exist when adding a new address', async () => {
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
             ...getCustomer(),
         });

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -17,6 +17,7 @@ import ShippingHeader from './ShippingHeader';
 import { SingleShippingFormValues } from './SingleShippingForm';
 
 export interface ShippingProps {
+    isBillingSameAsShipping: boolean;
     cartHasChanged: boolean;
     isMultiShippingMode: boolean;
     onCreateAccount(): void;
@@ -24,7 +25,7 @@ export interface ShippingProps {
     onReady?(): void;
     onUnhandledError(error: Error): void;
     onSignIn(): void;
-    navigateNextStep(billingSameAsShipping: boolean): void;
+    navigateNextStep(isBillingSameAsShipping: boolean): void;
 }
 
 export interface WithCheckoutShippingProps {
@@ -97,6 +98,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
 
     render(): ReactNode {
         const {
+            isBillingSameAsShipping,
             isGuest,
             shouldShowMultiShipping,
             customer,
@@ -131,6 +133,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         addresses={ customer.addresses }
                         deinitialize={ deinitializeShippingMethod }
                         initialize={ initializeShippingMethod }
+                        isBillingSameAsShipping = { isBillingSameAsShipping }
                         isGuest={ isGuest }
                         isMultiShippingMode={ isMultiShippingMode }
                         onMultiShippingSubmit={ this.handleMultiShippingSubmit }

--- a/src/app/shipping/ShippingForm.spec.tsx
+++ b/src/app/shipping/ShippingForm.spec.tsx
@@ -26,6 +26,7 @@ describe('ShippingForm Component', () => {
         localeContext = createLocaleContext(getStoreConfig());
 
         defaultProps = {
+            isBillingSameAsShipping: true,
             cart: {
                 ...getCart(),
                 lineItems: {

--- a/src/app/shipping/ShippingForm.tsx
+++ b/src/app/shipping/ShippingForm.tsx
@@ -15,6 +15,7 @@ export interface ShippingFormProps {
     countriesWithAutocomplete: string[];
     customerMessage: string;
     googleMapsApiKey?: string;
+    isBillingSameAsShipping: boolean;
     isGuest: boolean;
     isLoading: boolean;
     isShippingStepPending: boolean;
@@ -58,6 +59,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
             getFields,
             googleMapsApiKey,
             initialize,
+            isBillingSameAsShipping,
             isGuest,
             isLoading,
             isMultiShippingMode,
@@ -112,6 +114,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
                 getFields={ getFields }
                 googleMapsApiKey={ googleMapsApiKey }
                 initialize={ initialize }
+                isBillingSameAsShipping={ isBillingSameAsShipping }
                 isLoading={ isLoading }
                 isMultiShippingMode={ isMultiShippingMode }
                 isShippingStepPending={ isShippingStepPending }

--- a/src/app/shipping/SingleShippingForm.tsx
+++ b/src/app/shipping/SingleShippingForm.tsx
@@ -17,6 +17,7 @@ import ShippingFormFooter from './ShippingFormFooter';
 
 export interface SingleShippingFormProps {
     addresses: CustomerAddress[];
+    isBillingSameAsShipping: boolean;
     cartHasChanged: boolean;
     consignments: Consignment[];
     countries: Country[];
@@ -288,8 +289,8 @@ export default withLanguage(withFormik<SingleShippingFormProps & WithLanguagePro
     handleSubmit: (values, { props: { onSubmit } }) => {
         onSubmit(values);
     },
-    mapPropsToValues: ({ getFields, shippingAddress,  customerMessage }) => ({
-        billingSameAsShipping: true,
+    mapPropsToValues: ({ getFields, shippingAddress, isBillingSameAsShipping, customerMessage }) => ({
+        billingSameAsShipping: isBillingSameAsShipping,
         orderComment: customerMessage,
         shippingAddress: mapAddressToFormValues(
             getFields(shippingAddress && shippingAddress.countryCode),


### PR DESCRIPTION
## What?
When navigating to billing/payment step and back to shipping step, the "My billing address is the same as my shipping address" checkbox always default to `true` 

## Why?
The state of the checkbox is not saved

## Testing / Proof

https://user-images.githubusercontent.com/22089936/124700192-e17cd680-df1e-11eb-818a-e58fbe3d8233.mov



@bigcommerce/checkout
