### PR TITLE
feat(payment): PAYMENTS-6812 add PPSDK payment methods to the handleBeforeUnload exemption list

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -270,6 +270,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         });
     };
 
+    // tslint:disable:cyclomatic-complexity
     private handleBeforeUnload: (event: BeforeUnloadEvent) => string | undefined = event => {
         const { defaultMethod, isSubmittingOrder, language } = this.props;
         const { selectedMethod = defaultMethod } = this.state;
@@ -281,6 +282,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
         if (!isSubmittingOrder ||
             !selectedMethod ||
             selectedMethod.type === PaymentMethodProviderType.Hosted ||
+            selectedMethod.type === PaymentMethodProviderType.PPSDK ||
             selectedMethod.id === PaymentMethodId.Amazon ||
             selectedMethod.id === PaymentMethodId.AmazonPay ||
             selectedMethod.id === PaymentMethodId.Checkoutcom ||


### PR DESCRIPTION
## What?

- Add PPSDK methods to the before unload warning exemption list

## Why?

- So that redirect flows are not interrupted by the "Are you sure?" alert

## Testing / Proof

**Before**

![image](https://user-images.githubusercontent.com/56807262/124855360-2f134500-dfec-11eb-8cc1-66bebbe26f9a.png)

**After**


https://user-images.githubusercontent.com/56807262/124855426-43efd880-dfec-11eb-8dbd-61e9998becaa.mov



@bigcommerce/checkout
