### PR TITLE
fix(payment): INT-4598 handle vaulting Enable checkbox for Digital River

### DIFF
--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -20,16 +20,18 @@ describe('when using Digital River payment', () => {
     let defaultProps: PaymentMethodProps;
     let localeContext: LocaleContextType;
     let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
+    const digitalRiverMethod = getPaymentMethod();
+    digitalRiverMethod.config.isVaultingEnabled = true;
 
     beforeEach(() => {
         defaultProps = {
-            method: getPaymentMethod(),
+            method: digitalRiverMethod,
             onUnhandledError: jest.fn(),
         };
         checkoutService = createCheckoutService();
         checkoutState = checkoutService.getState();
         localeContext = createLocaleContext(getStoreConfig());
-        method = { ...getPaymentMethod(), id: PaymentMethodId.DigitalRiver };
+        method = { ...digitalRiverMethod, id: PaymentMethodId.DigitalRiver };
 
         jest.spyOn(checkoutState.data, 'getConfig')
             .mockReturnValue(getStoreConfig());
@@ -103,7 +105,7 @@ describe('when using Digital River payment', () => {
                             },
                         },
                         showComplianceSection: true,
-                        showSavePaymentAgreement: false,
+                        showSavePaymentAgreement: true,
                         showTermsOfSaleDisclosure: true,
                         usage: 'unscheduled',
                     },
@@ -140,7 +142,7 @@ describe('when using Digital River payment', () => {
                             },
                         },
                         showComplianceSection: true,
-                        showSavePaymentAgreement: false,
+                        showSavePaymentAgreement: true,
                         showTermsOfSaleDisclosure: true,
                         usage: 'unscheduled',
                     },

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -23,6 +23,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
     const { setSubmitted } = useContext(FormContext);
     const containerId = `${rest.method.id}-component-field`;
     const disabledPaymentMethods = rest.method.initializationData?.disabledPaymentMethods ?? [];
+    const isVaultingEnabled = rest.method.config.isVaultingEnabled;
 
     const initializeDigitalRiverPayment = useCallback(options => initializePayment({
         ...options,
@@ -30,7 +31,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
             containerId,
             configuration: {
                 flow: 'checkout',
-                showSavePaymentAgreement: false,
+                showSavePaymentAgreement: isVaultingEnabled,
                 showComplianceSection: true,
                 button: {
                     type: 'submitOrder',
@@ -50,7 +51,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 onUnhandledError?.(error);
             },
         },
-    }), [initializePayment, containerId, disabledPaymentMethods, setSubmitted, submitForm, onUnhandledError]);
+    }), [initializePayment, containerId, isVaultingEnabled, disabledPaymentMethods, setSubmitted, submitForm, onUnhandledError]);
 
     return <HostedDropInPaymentMethod
         { ...rest }


### PR DESCRIPTION
## What? [INT-4598](https://jira.bigcommerce.com/browse/INT-4598)
added showSavePaymentAgreement dynamically instead of hardcoded

## Why?
It's a bug that could affect future DigitalRiver users

## Testing / Proof
![image](https://user-images.githubusercontent.com/42154828/125129489-28a4cc00-e0c5-11eb-95d8-583f288e2603.png)

## Dependency of
https://github.com/bigcommerce/checkout-sdk-js/pull/1178

@bigcommerce/checkout @bigcommerce/apex-integrations 
