### PR TITLE
fix(checkout): INT-4504 Fix 404 on mandate link for SEPA

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -451,6 +451,7 @@
             "continue_shopping": "Continue Shopping »",
             "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger",
             "mandate_link_text": "{provider} Mandate",
+            "mandate_text_only": "{provider} Mandate Reference: {mandate}",
             "boleto_link_text": "Boleto Bancário Ticket",
             "oxxo_link_text": "OXXO Ticket",
             "sepa_link_text": "SEPA Direct Debit Mandate"

--- a/src/app/order/OrderStatus.spec.tsx
+++ b/src/app/order/OrderStatus.spec.tsx
@@ -272,6 +272,30 @@ describe('OrderStatus', () => {
                 .text())
                 .toEqual('SEPA Direct Debit Mandate');
         });
+
+        it('renders "SEPA Direct Debit (via Checkout.com)" mandate text without link when provider description is Checkout.com (SEPA)', () => {
+            const orderStatus = mount(
+                <OrderStatusTest
+                    { ...defaultProps }
+                    order={ {
+                        ...order,
+                        payments: [{
+                            providerId: 'checkoutcom',
+                            description: 'SEPA Direct Debit (via Checkout.com)',
+                            amount: 190,
+                            detail: {
+                                step: 'FINALIZE',
+                                instructions: '<strong>295</strong> something',
+                            },
+                        }],
+                    } }
+                />
+            );
+
+            expect(orderStatus.find('[data-test="order-confirmation-mandate-text-only"]')
+                .text())
+                .toEqual('SEPA Direct Debit (via Checkout.com) Mandate Reference: mandateLink');
+        });
     });
 
 });

--- a/src/app/order/OrderStatus.tsx
+++ b/src/app/order/OrderStatus.tsx
@@ -11,6 +11,8 @@ export interface OrderStatusProps {
     order: Order;
 }
 
+const checkoutcomSEPAMethod = 'SEPA Direct Debit (via Checkout.com)';
+
 const OrderStatus: FunctionComponent<OrderStatusProps> = ({
     order,
     supportEmail,
@@ -26,11 +28,22 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
             { method: 'Stripe (SEPA)', value: 'sepa_link_text' },
             { method: 'OXXO (via Checkout.com)', value: 'oxxo_link_text' },
             { method: 'Boleto Bancário (via Checkout.com)', value: 'boleto_link_text' },
+            { method: checkoutcomSEPAMethod, value: 'mandate_text_only' },
         ];
 
         const mandateText = Mandates.find(pair => pair.method === order?.payments?.[0].description);
 
         return mandateText ? mandateText.value : 'mandate_link_text';
+    }, [order]);
+
+    const showMandateAsTextOnly = useCallback(() => {
+        const methods = [
+            { method: checkoutcomSEPAMethod },
+        ];
+
+        const mandateText = methods.find(pair => pair.method === order?.payments?.[0].description);
+
+        return !!mandateText;
     }, [order]);
 
     return <OrderConfirmationSection>
@@ -51,12 +64,20 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
             />
         </p>
 
-        { order.mandateUrl && <a data-test="order-confirmation-mandate-link-text" href={ order.mandateUrl } rel="noopener noreferrer" target="_blank">
+        { showMandateAsTextOnly() ?
+            <div data-test="order-confirmation-mandate-text-only">
+                <br />
+                <TranslatedString
+                    data={ { provider : getMandateProvider(), mandate: order.mandateUrl } }
+                    id={ 'order_confirmation.' + getMandateTextId() }
+                />
+            </div> :
+            order.mandateUrl && <a data-test="order-confirmation-mandate-link-text" href={ order.mandateUrl } rel="noopener noreferrer" target="_blank">
                 <TranslatedString
                     data={ { provider : getMandateProvider() } }
                     id={ 'order_confirmation.' + getMandateTextId() }
                 />
-        </a> }
+            </a> }
 
         { order.hasDigitalItems &&
         <p data-test="order-confirmation-digital-items-text">


### PR DESCRIPTION
## What?
Render Mandate as plaint text for SEPA on Checkout.com

## Why?
currently SEPA on Checkout.com returns a Mandate Reference only which is treated as a link which causes a 404 error when clicking on it.

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/apex-integrations 
