### PR TITLE
feat(payment): INT-4170 Stripe: use hosted fields for verification fields for stored instruments

### DIFF
--- a/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -3,15 +3,40 @@ import { mount, ReactWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
+import { object } from 'yup';
 
 import { CheckoutProvider } from '../../checkout';
 import { getStoreConfig } from '../../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { withHostedCreditCardFieldset, WithInjectedHostedCreditCardFieldsetProps } from '../hostedCreditCard';
 import { getPaymentMethod } from '../payment-methods.mock';
 
 import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
 import { default as PaymentMethodComponent, PaymentMethodProps } from './PaymentMethod';
 
+const hostedFormOptions = {
+    fields: {
+        cardCodeVerification: { containerId: 'card-code-verification', instrumentId: 'instrument-id' },
+        cardNumberVerification: { containerId: 'card-number-verification', instrumentId: 'instrument-id' },
+    },
+};
+
+const injectedProps: WithInjectedHostedCreditCardFieldsetProps = {
+    getHostedFormOptions: () => Promise.resolve(hostedFormOptions),
+    getHostedStoredCardValidationFieldset: () => <div />,
+    hostedFieldset: <div />,
+    hostedStoredCardValidationSchema: object(),
+    hostedValidationSchema: object(),
+};
+jest.mock('../hostedCreditCard', () => ({
+    ...jest.requireActual('../hostedCreditCard'),
+    withHostedCreditCardFieldset: jest.fn(
+        Component => (props: any) => <Component
+            { ...props }
+            { ...injectedProps }
+        />
+    ) as jest.Mocked<typeof withHostedCreditCardFieldset>,
+}));
 describe('when using Stripe payment', () => {
     let method: PaymentMethod;
     let checkoutService: CheckoutService;


### PR DESCRIPTION
## What? [INT-4170](https://jira.bigcommerce.com/browse/INT-4170)
Added hosted fields on verification fields on StripeV3

## Why?
Currently, we have some payment methods that are not using hosted credit card fields for stored instrument verifications (card number and CVV). This presents a security vulnerability as malicious JS can easily scrape credit card information.

## Dependencies
[SDK #1179](https://github.com/bigcommerce/checkout-sdk-js/pull/1179)

## Testing / Proof
- Manual
- Unit


@bigcommerce/apex-integrations @bigcommerce/checkout 
