### PR TITLE
feat(payment): INT-3946 added locale from browser on masterpass SRC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9397,6 +9397,14 @@
         "pump": "^3.0.0"
       }
     },
+    "get-user-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-1.4.0.tgz",
+      "integrity": "sha512-gQo03lP1OArHLKlnoglqrGGl7b04u2EP9Xutmp72cMdtrrSD7ZgIsCsUKZynYWLDkVJW33Cj3pliP7uP0UonHQ==",
+      "requires": {
+        "lodash.once": "^4.1.1"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -12387,6 +12395,11 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dompurify": "^2.0.7",
     "downshift": "^3.2.10",
     "formik": "^1.5.8",
+    "get-user-locale": "^1.4.0",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.21",
     "object-hash": "^1.3.0",

--- a/src/app/payment/paymentMethod/MasterpassPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/MasterpassPaymentMethod.tsx
@@ -1,4 +1,5 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import { getUserLocale } from 'get-user-locale';
 import React, { useCallback, useMemo, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
@@ -20,17 +21,19 @@ const MasterpassPaymentMethod: FunctionComponent<MasterpassPaymentMethodProps & 
         },
     }), [initializePayment]);
 
+    const userLocale = getUserLocale();
+
     const { config: { testMode }, initializationData: { checkoutId, isMasterpassSrcEnabled } } = rest.method;
-    const locale = navigator.language.replace('-', '_');
+
     const signInButtonLabel = useMemo(() => (
         <img
             alt={ language.translate('payment.masterpass_name_text') }
             id="mpbutton"
             src={ isMasterpassSrcEnabled ?
-                `https://${testMode ? 'sandbox.' : ''}src.mastercard.com/assets/img/btn/src_chk_btn_126x030px.svg?locale=${locale}&paymentmethod=master,visa,amex,discover&checkoutid=${checkoutId}` :
+                `https://${testMode ? 'sandbox.' : ''}src.mastercard.com/assets/img/btn/src_chk_btn_126x030px.svg?locale=${userLocale}&paymentmethod=master,visa,amex,discover&checkoutid=${checkoutId}` :
                 `https://masterpass.com/dyn/img/btn/global/mp_chk_btn_126x030px.svg` }
         />
-    ), [checkoutId, language, locale, testMode, isMasterpassSrcEnabled]);
+    ), [checkoutId, language, userLocale, testMode, isMasterpassSrcEnabled]);
 
     return <WalletButtonPaymentMethod
         { ...rest }


### PR DESCRIPTION
## What? [INT-3946](https://jira.bigcommerce.com/browse/INT-3946)
Added locale from browser on masterpass SRC.

## Why?
In order to be able to see masterpass or SRC button based on shopper locale.

## Testing / Proof
<img width="672" alt="Screen Shot 2021-06-30 at 6 53 52 PM" src="https://user-images.githubusercontent.com/61981535/124045106-96ba0680-d9d4-11eb-8e38-1a8569a4a977.png">


@bigcommerce/checkout
