### PR TITLE
feat(payment): PAYPAL-1057 added check of showOnlyOnMobileDevices APM…

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -24,6 +24,11 @@ window.matchMedia = jest.fn(() => ({
     removeEventListener: noop,
 } as MediaQueryList));
 
+Object.defineProperty(window.navigator, "userAgent", ((value) => ({
+    get() { return value; },
+    set(v) { value = v; }
+}))(window.navigator["userAgent"]));
+
 (global as any).__webpack_public_path__ = undefined;
 
 beforeAll(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -859,9 +859,9 @@
           "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         }
       }
     },
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.167.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.167.0.tgz",
-      "integrity": "sha512-ScMQPxltIBMvtIhByKiKmgftR0q8McEmDNURv+FTKvvIWVo+qoTDGIDG+BU/X5CMvxWSaIviJ7LSKJOpB7iMww==",
+      "version": "1.168.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.168.0.tgz",
+      "integrity": "sha512-b+NTd79w3jXlvtTZ49+6Pqo/l0GTtYq9Syv6FVoGhR//UaJy4enPD+PZ7H8ncAkdr/P0l4/GlPcfM5LdBmnp8g==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.167.0",
+    "@bigcommerce/checkout-sdk": "^1.168.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/common/utility/index.ts
+++ b/src/app/common/utility/index.ts
@@ -4,3 +4,4 @@ export { default as retry, RetryOptions } from './retry';
 export { default as parseAnchor } from './parseAnchor';
 export { default as isRecord } from './isRecord';
 export { default as isRecordContainingKey } from './isRecordContainingKey';
+export { default as isMobile } from './isMobile';

--- a/src/app/common/utility/isMobile.spec.ts
+++ b/src/app/common/utility/isMobile.spec.ts
@@ -1,0 +1,21 @@
+import isMobile from './isMobile';
+
+describe('isMobile()', () => {
+    it('returns true on iPhones', () => {
+        // @ts-ignore: setter for userAgent is defined in jest-setup.ts
+        window.navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1';
+        expect(isMobile()).toBeTruthy();
+    });
+
+    it('returns true on Android devices', () => {
+        // @ts-ignore: setter for userAgent is defined in jest-setup.ts
+        window.navigator.userAgent = 'Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36';
+        expect(isMobile()).toBeTruthy();
+    });
+
+    it('returns false for the desktop devices', () => {
+        // @ts-ignore: setter for userAgent is defined in jest-setup.ts
+        window.navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
+        expect(isMobile()).toBeFalsy();
+    });
+});

--- a/src/app/common/utility/isMobile.ts
+++ b/src/app/common/utility/isMobile.ts
@@ -1,0 +1,3 @@
+export default function isMobile(): boolean {
+  return /Android|iPhone|iPad|iPod/i.test(window.navigator.userAgent);
+}

--- a/src/app/payment/payment-methods.mock.ts
+++ b/src/app/payment/payment-methods.mock.ts
@@ -25,3 +25,32 @@ export function getPaymentMethod(): PaymentMethod {
         type: 'PAYMENT_TYPE_API',
     };
 }
+
+export function getMobilePaymentMethod(): PaymentMethod {
+    return {
+        id: 'authorizenetMobile',
+        gateway: undefined,
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [
+            'VISA',
+            'AMEX',
+            'MC',
+        ],
+        initializationData: {
+            showOnlyOnMobileDevices: true,
+        },
+        config: {
+            displayName: 'Authorizenet',
+            cardCode: true,
+            enablePaypal: undefined,
+            hasDefaultStoredInstrument: false,
+            helpText: '',
+            is3dsEnabled: undefined,
+            isVisaCheckoutEnabled: undefined,
+            merchantId: undefined,
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+    };
+}

--- a/src/app/payment/paymentMethod/PaymentMethodList.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.spec.tsx
@@ -5,7 +5,7 @@ import { noop, range } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 import { Checklist, ChecklistItem } from '../../ui/form';
-import { getPaymentMethod } from '../payment-methods.mock';
+import { getMobilePaymentMethod, getPaymentMethod } from '../payment-methods.mock';
 
 import PaymentMethodList, { PaymentMethodListProps } from './PaymentMethodList';
 
@@ -34,6 +34,28 @@ describe('PaymentMethodList', () => {
 
         expect(component.find(ChecklistItem))
             .toHaveLength(methods.length);
+    });
+
+    it('renders mobile payment methods as checklist on mobile device', () => {
+        methods = [getMobilePaymentMethod(), getPaymentMethod()];
+
+        // @ts-ignore: setter for userAgent is defined in jest-setup.ts
+        window.navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1';
+        const component = mount(<PaymentMethodListTest methods={ methods } />);
+
+        expect(component.find(ChecklistItem))
+            .toHaveLength(2);
+    });
+
+    it('does not renders mobile payment methods as checklist on desktop', () => {
+        methods = [getMobilePaymentMethod(), getPaymentMethod()];
+
+        // @ts-ignore: setter for userAgent is defined in jest-setup.ts
+        window.navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
+        const component = mount(<PaymentMethodListTest methods={ methods } />);
+
+        expect(component.find(ChecklistItem))
+            .toHaveLength(1);
     });
 
     it('configures each item in list with value', () => {

--- a/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -1,8 +1,9 @@
 import { PaymentMethod } from '@bigcommerce/checkout-sdk';
-import { find, noop } from 'lodash';
+import { find, get, noop } from 'lodash';
 import React, { memo, useCallback, useMemo, FunctionComponent } from 'react';
 
 import { connectFormik, ConnectFormikProps } from '../../common/form';
+import { isMobile } from '../../common/utility';
 import { Checklist, ChecklistItem } from '../../ui/form';
 
 import getUniquePaymentMethodId, { parseUniquePaymentMethodId } from './getUniquePaymentMethodId';
@@ -56,6 +57,11 @@ const PaymentMethodList: FunctionComponent<
     >
         { methods.map(method => {
             const value = getUniquePaymentMethodId(method.id, method.gateway);
+            const showOnlyOnMobileDevices = get(method, 'initializationData.showOnlyOnMobileDevices', false);
+
+            if (showOnlyOnMobileDevices && !isMobile()) {
+                return;
+            }
 
             return (
                 <PaymentMethodListItem


### PR DESCRIPTION
## What?

- Added Venmo payment method to paypal commerce integration.
- Added shouldRenderFields flag on APM initialization to prevent apm fields render for Venmo. It doesn't need apm fields.
- Added isMobile utility src/app/common/utility/isMobile.ts for checking mobile devices. For rendering Venmo only on mobile devices.


connected PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1184
## Why?
Due to the https://jira.bigcommerce.com/browse/PAYPAL-1057

## Testing / Proof
tested manually, units
![image](https://user-images.githubusercontent.com/79574476/126478563-3a8b9ab6-68f0-41a5-9154-1dd490444ae2.png)


@bigcommerce/checkout @bigcommerce/payments
