### PR TITLE
feat(payment): INT-4605 Zip: Display special text for PaymentSubmitButton

### DIFF
--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -145,6 +145,15 @@ describe('PaymentSubmitButton', () => {
             .toEqual(languageService.translate('payment.quadpay_continue_action'));
     });
 
+    it('renders button with special label for Zip', () => {
+        const component = mount(
+            <PaymentSubmitButtonTest methodId="zip" />
+        );
+
+        expect(component.text())
+            .toEqual(languageService.translate('payment.zip_continue_action'));
+    });
+
     describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is off', () => {
         beforeEach(() => {
             const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': false };

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -67,6 +67,10 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
         return <TranslatedString id="payment.quadpay_continue_action" />;
     }
 
+    if (methodId === PaymentMethodId.Zip) {
+        return <TranslatedString id="payment.zip_continue_action" />;
+    }
+
     return <TranslatedString id="payment.place_order_action" />;
 });
 


### PR DESCRIPTION
## What? [INT-4605](https://jira.bigcommerce.com/browse/INT-4605)
Display `Continue with Zip` instead of `Place Order`

## Why?
It's more accurate since the shopper is redirected to Zip's page.

## Testing / Proof
_Before:_
<img width="640" alt="Screen Shot 2021-07-15 at 1 08 05 PM" src="https://user-images.githubusercontent.com/4843328/125838632-55912572-7cb0-4c5a-846f-88760424b01a.png">
_After:_
<img width="643" alt="Screen Shot 2021-07-15 at 1 12 56 PM" src="https://user-images.githubusercontent.com/4843328/125838640-1371c967-f4e5-450a-bde9-d902ecc30202.png">

@bigcommerce/apex-integrations  @bigcommerce/checkout
