### PR TITLE
feat(payment): INT-4141 Bump SDK.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.164.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.164.0.tgz",
-      "integrity": "sha512-JuSVJGfAE7x2gyvSFzvEEVR7l2kRUe4d2zN1MI/tHtx54AxeBQ+nT30WnBH1TLjPWu4iS1kxPayUKLD7sKdnQA==",
+      "version": "1.165.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.165.0.tgz",
+      "integrity": "sha512-7nKrytmJybYKI3R0qKKwfNLJSxOJDaodSoQUTOMTPsNecc616V1kyOrpP4W5CDcMheLvjBaHlAqMNbmoHh9Vwg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.164.0",
+    "@bigcommerce/checkout-sdk": "^1.165.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Raise the active SDK version.

## Why?
Releasing https://github.com/bigcommerce/checkout-sdk-js/pull/1171

## Testing / Proof
Circle, see linked PR.

@bigcommerce/checkout
