### PR TITLE
fix(customer): CHECKOUT-5862 Fix create account flow from Checkout blocked due to cross origin frame

### DIFF
--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -617,7 +617,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         if (customerViewType === CustomerViewType.CreateAccount &&
             (!canCreateAccountInCheckout || isEmbedded())
         ) {
-            window.top.location.assign(createAccountUrl);
+            window.top.location.replace(createAccountUrl);
 
             return;
         }


### PR DESCRIPTION
## What?
Fix create account flow  from Checkout blocked due to cross origin frame in embedded checkouts.

## Why?
There is an issue where a CORS origin error happens when a user is redirected from checkout page to customer account creation.

## Testing / Proof
- Screencast

## Before
https://user-images.githubusercontent.com/7134802/126460870-ed4d3a2d-3b8b-403c-821d-ac886af83dc4.mov

## After
![Animated GIF-downsized (10)](https://user-images.githubusercontent.com/7134802/126461901-62b72a99-a6ac-4e59-98ce-8646c9b9c38b.gif)

@bigcommerce/checkout
