### PR TITLE
fix(payment): INT-4672 Add support for new error type

### DIFF
--- a/src/app/payment/Payment.spec.tsx
+++ b/src/app/payment/Payment.spec.tsx
@@ -408,6 +408,23 @@ describe('Payment', () => {
             .not.toHaveBeenCalled();
     });
 
+    it('does not trigger error handler if finalization was not successful', async () => {
+        jest.spyOn(checkoutService, 'finalizeOrderIfNeeded')
+            .mockRejectedValue({ type: 'order_finalization_not_completed' });
+
+        const handleFinalizeError = jest.fn();
+
+        mount(<PaymentTest
+            { ...defaultProps }
+            onFinalizeError={ handleFinalizeError }
+        />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(handleFinalizeError)
+            .not.toHaveBeenCalled();
+    });
+
     it('checks if available payment methods are supported in embedded mode', () => {
         const checkEmbeddedSupport = jest.fn();
 

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -104,8 +104,10 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             await finalizeOrderIfNeeded();
             onFinalize();
         } catch (error) {
-            if (error.type !== 'order_finalization_not_required') {
-                onFinalizeError(error);
+            if (error.type === 'order_finalization_not_completed') {
+                this.renderOrderErrorModal();
+            } else if (error.type !== 'order_finalization_not_required') {
+                return onFinalizeError(error);
             }
         }
 


### PR DESCRIPTION
## What? [INT-4672](https://jira.bigcommerce.com/browse/INT-4672)
Add support for the **order_finalization_not_completed** error and modify the existing code to catch this error and display the error modal instead of re-throwing the exception

## Why?
Currently if we get an error after calling the **finalize** method in the strategy and the error is other than **OrderFinalizationNotRequiredError** then shoppers see a modal informing them that their payment was declined but at this point the payment methods list do not load again and the "loading" animation spin indefinitely, so shoppers cannot select another payment method or retry the payment.

We found that the issue is shared with all the providers that implemented the offsite flow (like BluesnapV2, AdyenV1, Afterpay and others), the problem occurs when, for some reason, the **finalize** step of the strategy cannot be completed correctly, for example when the provider returns that the payment validation was not valid, if something like this happens then shoppers see the error informing them that their payment was declined but the payment methods do not load again and the "loading" animation spin indefinitely.

Here are some videos showing the issue (Bluesnap and Adyen):
https://drive.google.com/file/d/1bbtOiL3-3qxV1487k1v5iAxug9DT483E/view?usp=sharing
https://drive.google.com/file/d/1pBDl0t3Hh9pfcr5HnVq--C4fUivLO4oj/view?usp=sharing

## Testing / Proof
https://drive.google.com/file/d/15aMngXeY-Rq1oA3iE4kh0hjxBz5g6BQF/view?usp=sharing

## Dependency of
[checkout-sdk](https://github.com/bigcommerce/checkout-sdk-js/pull/1192)

@bigcommerce/checkout
