### PR TITLE
fix(checkout): CUST-1572 accept marketing emails should be true when requires marketing consent is false

### DIFF
--- a/src/app/customer/CreateAccountForm.spec.tsx
+++ b/src/app/customer/CreateAccountForm.spec.tsx
@@ -31,6 +31,7 @@ describe('CreateAccountForm Component', () => {
                 >
                     <CreateAccountForm
                         formFields={ formFields }
+                        requiresMarketingConsent={ false }
                     />
                 </Formik>
             </LocaleContext.Provider>
@@ -59,6 +60,7 @@ describe('CreateAccountForm Component', () => {
                     createAccountError={ createAccountError }
                     formFields={ formFields }
                     onCancel={ onCancel }
+                    requiresMarketingConsent={ false }
                 />
             </LocaleContext.Provider>
         );
@@ -77,6 +79,7 @@ describe('CreateAccountForm Component', () => {
                 <CreateAccountForm
                     formFields={ formFields }
                     onCancel={ onCancel }
+                    requiresMarketingConsent={ false }
                 />
             </LocaleContext.Provider>
         );
@@ -95,6 +98,53 @@ describe('CreateAccountForm Component', () => {
                 <CreateAccountForm
                     formFields={ formFields }
                     onSubmit={ onSubmit }
+                    requiresMarketingConsent={ false }
+                />
+            </LocaleContext.Provider>
+        );
+
+        component.find('input[name="email"]')
+            .simulate('change', { target: { value: 'test@bigcommerce.com', name: 'email' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(onSubmit).not.toHaveBeenCalled();
+
+        component.find('input[name="password"]')
+            .simulate('change', { target: { value: 'Password1235+', name: 'password' } });
+
+        component.find('input[name="firstName"]')
+            .simulate('change', { target: { value: 'foo', name: 'firstName' } });
+
+        component.find('input[name="lastName"]')
+            .simulate('change', { target: { value: 'bar', name: 'lastName' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+            acceptsMarketingEmails: ['0'],
+            email: 'test@bigcommerce.com',
+            firstName: 'foo',
+            lastName: 'bar',
+            password: 'Password1235+',
+        }));
+    });
+
+    it('calls onSubmit when form is valid and requires consent', async () => {
+        const onSubmit = jest.fn();
+
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <CreateAccountForm
+                    formFields={ formFields }
+                    onSubmit={ onSubmit }
+                    requiresMarketingConsent={ true }
                 />
             </LocaleContext.Provider>
         );
@@ -128,6 +178,7 @@ describe('CreateAccountForm Component', () => {
             firstName: 'foo',
             lastName: 'bar',
             password: 'Password1235+',
+            acceptsMarketingEmails: [],
         }));
     });
 });

--- a/src/app/customer/CreateAccountForm.tsx
+++ b/src/app/customer/CreateAccountForm.tsx
@@ -18,6 +18,7 @@ export interface CreateAccountFormProps {
     formFields: FormField[];
     createAccountError?: Error;
     isCreatingAccount?: boolean;
+    requiresMarketingConsent: boolean;
     onCancel?(): void;
     onSubmit?(values: CreateAccountFormValues): void;
 }
@@ -103,13 +104,13 @@ export default withLanguage(withFormik<CreateAccountFormProps & WithLanguageProp
     handleSubmit: (values, { props: { onSubmit = noop } }) => {
         onSubmit(values);
     },
-    mapPropsToValues: () => ({
+    mapPropsToValues: ({requiresMarketingConsent}) => ({
         firstName: '',
         lastName: '',
         email: '',
         password: '',
         customFields: {},
-        acceptsMarketingEmails: [],
+        acceptsMarketingEmails: requiresMarketingConsent ? [] : ['0'],
     }),
     validationSchema: ({
         language,

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -178,6 +178,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             customerAccountFields,
             isCreatingAccount,
             createAccountError,
+            requiresMarketingConsent,
         } = this.props;
 
         return (
@@ -187,6 +188,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
                 isCreatingAccount={ isCreatingAccount }
                 onCancel={ this.handleCancelCreateAccount }
                 onSubmit={ this.handleCreateAccount }
+                requiresMarketingConsent={ requiresMarketingConsent }
             />
         );
     }


### PR DESCRIPTION
## What?
If the shopper doesn't require marketing consent, when a customer is created on checkout we should send the value to receive marketing emails

## Why?
Currently, that value is always false so even if the setting is off, customers won't receive marketing emails

## Testing / Proof
Update test 

@bigcommerce/checkout
### Require consent is false
![Screen Shot 2021-07-30 at 1 59 47 pm](https://user-images.githubusercontent.com/9570178/127598533-f44d2e07-59d1-44f8-9b57-18947960b343.png)
![Screen Shot 2021-07-30 at 1 59 05 pm](https://user-images.githubusercontent.com/9570178/127598535-c96179f3-e920-4107-8f97-f868fc74cff0.png)
### Require consent is true
![image](https://user-images.githubusercontent.com/9570178/127598564-1eb66e66-0c1b-4e7f-b78d-09b862b60677.png)
![Screen Shot 2021-07-30 at 2 01 37 pm](https://user-images.githubusercontent.com/9570178/127598569-1aeea95d-7979-4ea3-a2ab-f90ea4d622be.png)
