### PR TITLE
feat(payments): INT-4686 removing disabledPaymentMethods for digitalriver

### DIFF
--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -69,17 +69,7 @@ describe('when using Digital River payment', () => {
     });
 
     it('initializes method with required config including initializationData', () => {
-        const methodWithInitializationData = {
-            ...method,
-            initializationData: {
-                disabledPaymentMethods: [
-                    'googlePay',
-                    'alipay',
-                ],
-            },
-        };
-
-        const container = mount(<PaymentMethodTest { ...defaultProps } method={ methodWithInitializationData } />);
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
         const component: ReactWrapper<HostedDropInPaymentMethodProps> = container.find(HostedDropInPaymentMethod);
 
         component.prop('initializePayment')({
@@ -96,10 +86,6 @@ describe('when using Digital River payment', () => {
                         },
                         flow: 'checkout',
                         paymentMethodConfiguration: {
-                            disabledPaymentMethods: [
-                                'googlePay',
-                                'alipay',
-                            ],
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',
                             },
@@ -136,7 +122,6 @@ describe('when using Digital River payment', () => {
                         },
                         flow: 'checkout',
                         paymentMethodConfiguration: {
-                            disabledPaymentMethods: [],
                             classes: {
                                 base: 'form-input optimizedCheckout-form-input',
                             },

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -22,7 +22,6 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
 }) => {
     const { setSubmitted } = useContext(FormContext);
     const containerId = `${rest.method.id}-component-field`;
-    const disabledPaymentMethods = rest.method.initializationData?.disabledPaymentMethods ?? [];
     const isVaultingEnabled = rest.method.config.isVaultingEnabled;
 
     const initializeDigitalRiverPayment = useCallback(options => initializePayment({
@@ -39,7 +38,6 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 usage: 'unscheduled',
                 showTermsOfSaleDisclosure: true,
                 paymentMethodConfiguration: {
-                    disabledPaymentMethods,
                     classes: DigitalRiverClasses,
                 },
             },
@@ -51,7 +49,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 onUnhandledError?.(error);
             },
         },
-    }), [initializePayment, containerId, isVaultingEnabled, disabledPaymentMethods, setSubmitted, submitForm, onUnhandledError]);
+    }), [initializePayment, containerId, isVaultingEnabled, setSubmitted, submitForm, onUnhandledError]);
 
     return <HostedDropInPaymentMethod
         { ...rest }


### PR DESCRIPTION
## What? [INT-4686](https://jira.bigcommerce.com/browse/INT-4686)
Removing disabledPaymentMethods for digitalriver

## Why?
This functionality will be managed from the DigitalRiver dashboard 

## Testing / Proof
![image](https://user-images.githubusercontent.com/42154828/127232305-7b88937c-9b41-41d4-8ce3-3e322e9e8e3d.png)

## Dependency of
https://github.com/bigcommerce/checkout-sdk-js/pull/1198

@bigcommerce/checkout @bigcommerce/apex-integrations 
