### PR TITLE
fix(payment): PAYMENTS-7169 fix broken UI post finalization error

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -105,7 +105,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             onFinalize();
         } catch (error) {
             if (error.type !== 'order_finalization_not_required') {
-                return onFinalizeError(error);
+                onFinalizeError(error);
             }
         }
 


### PR DESCRIPTION
## What?

- Allow the Payments UI to present payment options after a finalization error (i.e. when a payment method returns to the checkout, but the payment failed for some reason)

## Why?

- Current UI shows payment methods as perpetually loading in this scenario
- Allow customers to try paying again to continue their checkout
- The removed `return` did not seem to offer any functionality, React does not consume returned values from `componentDidMount` methods and the early return only served to stop the component reaching an otherwise valid `ready` state

## Testing / Proof

**Before:**

https://user-images.githubusercontent.com/56807262/127413506-3d146f3f-9cad-456b-8112-02625b2bc6f7.mov

**After**

https://user-images.githubusercontent.com/56807262/127413537-f675ba85-9e0a-437e-9212-ee1944c5ed5a.mov


@bigcommerce/checkout
