### PR TITLE
fix(payment): INT-4489 cko add method supported 'card'

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -120,7 +120,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
     }
 
     if (method.gateway === PaymentMethodId.Checkoutcom) {
-        if (method.id === 'credit_card') {
+        if (method.id === 'credit_card' || method.id === 'card') {
             return <HostedCreditCardPaymentMethod { ...props } />;
         }
 

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -130,7 +130,7 @@ function getPaymentMethodTitle(
                 titleText: method.method === 'credit_card' ? startCase(methodName) : methodName,
             },
             [PaymentMethodId.Checkoutcom]: {
-                logoUrl: ['credit_card', 'checkoutcom'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.svg`),
+                logoUrl: ['credit_card', 'card', 'checkoutcom'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.svg`),
                 titleText: methodName,
             },
             [PaymentMethodId.StripeV3]: {


### PR DESCRIPTION
## What? [INT-4489](https://jira.bigcommerce.com/browse/INT-4489)
Add alias mapping for credit_card as card

## Why?
Because method will change name from credit_card to card on Bigpay, both names will be keep to be able to merge without issues

## Testing / Proof
[Demo](https://drive.google.com/file/d/1EmTIw2wTqmYpYERm_a4GIWqjivYbNlt6/view?usp=sharing)

## Dependency of
https://github.com/bigcommerce/bigpay/pull/4051

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1202

@bigcommerce/checkout @bigcommerce/apex-integrations 
