### PR TITLE
fix(payment): INT-4222 Fix Moneris payment method type issues

### DIFF
--- a/src/app/payment/paymentMethod/MonerisPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/MonerisPaymentMethod.tsx
@@ -1,4 +1,4 @@
-import { CardInstrument, PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import { CardInstrument, HostedFormValidationOptions, PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { useCallback, FunctionComponent } from 'react';
 
 import { withHostedCreditCardFieldset, WithInjectedHostedCreditCardFieldsetProps } from '../hostedCreditCard';
@@ -22,7 +22,7 @@ const MonerisPaymentMethod: FunctionComponent<MonerisPaymentMethodProps & WithIn
         ...options,
         moneris: {
             containerId,
-            ...(selectedInstrument && { form : await getHostedFormOptions(selectedInstrument) }),
+            ...(selectedInstrument && { form : await getHostedFormOptions(selectedInstrument) as HostedFormValidationOptions }),
         },
     }), [containerId, getHostedFormOptions, initializePayment]);
 


### PR DESCRIPTION
## What?
Use a type assertion to Moneris' `form` field  to `HostedFormValidationOptions`

## Why?
Moneris Vaulting SDK PR (https://github.com/bigcommerce/checkout-sdk-js/pull/1201) was just reverted due to a failing build, this PR should allow the build to succeed.

Due to the feedback that was given on how to create and use the interfaces in said PR, the `HostedFormValidationOptions` was created as a Weak Type (an interface in which all of its fields are optional, causing any type to satisfy this necessity [docs here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html#weak-type-detection)) that causes this error and this PR being the easiest fix.

Another way to fix this would be to dismiss the [feedback given on the original checkout-sdk PR](https://github.com/bigcommerce/checkout-sdk-js/pull/1151#discussion_r669353040) and use the default interface (`HostedFormOptions`) for the initialization options.

## Depends on 
Reverting https://github.com/bigcommerce/checkout-sdk-js/pull/1201

## Testing / Proof
[This same PR](https://github.com/bigcommerce/checkout-js/pull/659) but with the version that made the build fail

@bigcommerce/checkout @bigcommerce/apex-integrations 
 