### PR TITLE
chore(payment): INT-4438 INT-4480 INT-4584 INT-4585 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.169.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.169.3.tgz",
-      "integrity": "sha512-vbXdXfNYmZr3ktE/bAsASWs20/B2Q8T2elD5cpezV5xQWblZIsltFJ4+0fBzOWD7qLoGeLuCd28UXdLt/wmkbg==",
+      "version": "1.170.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.170.0.tgz",
+      "integrity": "sha512-wVx3o6thgtb37nuaFAdYgQ36CaTYkMuXHT27gctJfjYO+snw4ZFztpJDWFV5+HFtbY+m9/12iKhCy/+6uSNEAQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -1693,9 +1693,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.171",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
-          "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg=="
+          "version": "4.14.172",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+          "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
         },
         "@types/yup": {
           "version": "0.26.37",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.169.3",
+    "@bigcommerce/checkout-sdk": "^1.170.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk

## Why?
To get 1.170.0 out. See https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md#11700-2021-08-04

## Testing / Proof
See screenshots on these PRs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1165
https://github.com/bigcommerce/checkout-sdk-js/pull/1185
https://github.com/bigcommerce/checkout-sdk-js/pull/1187
https://github.com/bigcommerce/checkout-sdk-js/pull/1194

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations