### PR TITLE
fix(payment): INT-4709 Display "place order button" when payment is not required

### DIFF
--- a/src/app/payment/paymentMethod/HostedDropInPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/HostedDropInPaymentMethod.spec.tsx
@@ -207,6 +207,34 @@ describe('HostedDropInPaymentMethod', () =>  {
                 .toHaveBeenCalledWith(defaultProps.method, false);
         });
 
+        it('shows the payment submit button when payment data is not required', () => {
+            jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+                .mockReturnValue(false);
+
+            const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            component.find(CardInstrumentFieldset)
+                .prop('onUseNewInstrument')();
+            component.update();
+
+            expect(paymentContext.hidePaymentSubmitButton)
+                .toHaveBeenCalledWith(defaultProps.method, false);
+        });
+
+        it('shows the payment submit button when payment data is required', () => {
+            jest.spyOn(checkoutState.data, 'isPaymentDataRequired')
+                .mockReturnValue(true);
+
+            const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
+
+            component.find(CardInstrumentFieldset)
+                .prop('onUseNewInstrument')();
+            component.update();
+
+            expect(paymentContext.hidePaymentSubmitButton)
+                .toHaveBeenCalledWith(defaultProps.method, true);
+        });
+
         it('hides the payment submit button when a vaulted instrument is not selected', () => {
             const component = mount(<HostedDropInPaymentMethodTest { ...defaultProps } />);
 

--- a/src/app/payment/paymentMethod/HostedDropInPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedDropInPaymentMethod.tsx
@@ -91,6 +91,7 @@ class HostedDropInPaymentMethod extends Component<
             method,
             onUnhandledError = noop,
             hidePaymentSubmitButton,
+            isPaymentDataRequired,
         } = this.props;
 
         const {
@@ -99,7 +100,7 @@ class HostedDropInPaymentMethod extends Component<
         } = this.state;
         const selectedInstrument = this.getDefaultInstrumentId();
 
-        hidePaymentSubmitButton(method, !selectedInstrument);
+        hidePaymentSubmitButton(method, (!selectedInstrument && isPaymentDataRequired));
 
         if (selectedInstrumentId !== prevState.selectedInstrumentId ||
             (prevProps.instruments.length > 0 && instruments.length === 0) ||
@@ -254,12 +255,14 @@ class HostedDropInPaymentMethod extends Component<
             method,
             setSubmit,
             signInCustomer = noop,
+            hidePaymentSubmitButton,
         } = this.props;
 
         const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
 
         if (!isPaymentDataRequired) {
             setSubmit(method, null);
+            hidePaymentSubmitButton(method, false);
 
             return Promise.resolve();
         }


### PR DESCRIPTION
## What? [INT-4709](https://jira.bigcommerce.com/browse/INT-4709)
Fix logic to render on submit button when a discount is applied and the total is 0.

## Why?
we detected this scenario in our QE phase and was necessary to fix it.

## Testing / Proof
**BEFORE:**
<img width="909" alt="Screen Shot 2021-08-06 at 10 26 27 AM" src="https://user-images.githubusercontent.com/42154828/128534983-bb0c2da1-3b19-42dd-a78e-4d003764ab0b.png">
**AFTER:**
<img width="1211" alt="Screen Shot 2021-08-06 at 10 29 40 AM" src="https://user-images.githubusercontent.com/42154828/128534989-bf96df6b-cc2b-4284-9096-6dec392efc8a.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
