### PR TITLE
feat(payment): BOLT-19 added Bolt Embedded One Click Checkout implementation

### DIFF
--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -7,7 +7,7 @@ import { StaticBillingAddress } from '../billing';
 import { EmptyCartMessage } from '../cart';
 import { isCustomError, CustomError, ErrorLogger, ErrorModal } from '../common/error';
 import { retry } from '../common/utility';
-import { CustomerInfo, CustomerSignOutEvent, CustomerViewType } from '../customer';
+import { CheckoutSuggestion, CustomerInfo, CustomerSignOutEvent, CustomerViewType } from '../customer';
 import { isEmbedded, EmbeddedCheckoutStylesheet } from '../embeddedCheckout';
 import { withLanguage, TranslatedString, WithLanguageProps } from '../locale';
 import { PromotionBannerList } from '../promotion';
@@ -288,6 +288,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 key={ step.type }
                 onEdit={ this.handleEditStep }
                 onExpanded={ this.handleExpanded }
+                suggestion={ <CheckoutSuggestion /> }
                 summary={
                     <CustomerInfo
                         onSignOut={ this.handleSignOut }

--- a/src/app/checkout/CheckoutStep.spec.tsx
+++ b/src/app/checkout/CheckoutStep.spec.tsx
@@ -120,9 +120,11 @@ describe('CheckoutStep', () => {
             heading: 'Billing',
             summary: 'Billing summary',
             type: CheckoutStepType.Billing,
+            isActive: true,
             isComplete: true,
             isEditable: true,
-            isActive: true,
+            onEdit: undefined,
+            suggestion: undefined,
         };
 
         const component = mount(
@@ -136,7 +138,7 @@ describe('CheckoutStep', () => {
             .toHaveLength(1);
 
         expect(component.find(CheckoutStepHeader).props())
-            .toEqual(headerProps);
+            .toEqual({ ...headerProps, isClosed: false });
     });
 
     it('renders content if step is active', () => {

--- a/src/app/checkout/CheckoutStep.tsx
+++ b/src/app/checkout/CheckoutStep.tsx
@@ -13,13 +13,22 @@ export interface CheckoutStepProps {
     isActive?: boolean;
     isComplete?: boolean;
     isEditable?: boolean;
+    suggestion?: ReactNode;
     summary?: ReactNode;
     type: CheckoutStepType;
     onExpanded?(step: CheckoutStepType): void;
     onEdit?(step: CheckoutStepType): void;
 }
 
-export default class CheckoutStep extends Component<CheckoutStepProps> {
+export interface CheckoutStepState {
+    isClosed: boolean;
+}
+
+export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutStepState> {
+    state = {
+        isClosed: true,
+    };
+
     private containerRef = createRef<HTMLLIElement>();
     private contentRef = createRef<HTMLDivElement>();
     private timeoutRef?: number;
@@ -56,9 +65,12 @@ export default class CheckoutStep extends Component<CheckoutStepProps> {
             isComplete,
             isEditable,
             onEdit,
+            suggestion,
             summary,
             type,
         } = this.props;
+
+        const { isClosed } = this.state;
 
         return (
             <li
@@ -73,9 +85,11 @@ export default class CheckoutStep extends Component<CheckoutStepProps> {
                     <CheckoutStepHeader
                         heading={ heading }
                         isActive={ isActive }
+                        isClosed={ isClosed }
                         isComplete={ isComplete }
                         isEditable={ isEditable }
                         onEdit={ onEdit }
+                        suggestion={ suggestion }
                         summary={ summary }
                         type={ type }
                     />
@@ -120,6 +134,8 @@ export default class CheckoutStep extends Component<CheckoutStepProps> {
 
     private focusStep(): void {
         const delay = isMobileView() ? 0 : this.getTransitionDelay();
+
+        this.setState({ isClosed: false });
 
         this.timeoutRef = window.setTimeout(() => {
             const input = this.getChildInput();
@@ -195,9 +211,15 @@ export default class CheckoutStep extends Component<CheckoutStepProps> {
     }
 
     private handleTransitionEnd: (node: HTMLElement, done: () => void) => void = (node, done) => {
+        const { isActive } = this.props;
+
         node.addEventListener('transitionend', ({ target }) => {
             if (target === node) {
                 done();
+
+                if (!isActive) {
+                    this.setState({ isClosed: true });
+                }
             }
         });
     };

--- a/src/app/checkout/CheckoutStepHeader.spec.tsx
+++ b/src/app/checkout/CheckoutStepHeader.spec.tsx
@@ -13,6 +13,7 @@ describe('CheckoutStepHeader', () => {
     beforeEach(() => {
         defaultProps = {
             heading: 'Billing',
+            suggestion: 'Billing suggestion',
             summary: 'Billing summary',
             type: CheckoutStepType.Billing,
         };
@@ -49,6 +50,44 @@ describe('CheckoutStepHeader', () => {
 
         expect(component.find('[data-test="step-info"]').text())
             .toEqual('');
+    });
+
+    it('renders suggestion if step is inactive', () => {
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isClosed
+                isComplete
+            />
+        );
+
+        expect(component.find('[data-test="step-suggestion"]').text())
+            .toEqual('Billing suggestion');
+    });
+
+    it('does not render suggestion if step is active', () => {
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isActive
+            />
+        );
+
+        expect(component.exists('[data-test="step-suggestion"]'))
+            .toEqual(false);
+    });
+
+    it('does not render suggestion if its not provided', () => {
+        const component = shallow(
+            <CheckoutStepHeader
+                { ...defaultProps }
+                isComplete
+                suggestion={ undefined }
+            />
+        );
+
+        expect(component.exists('[data-test="step-suggestion"]'))
+            .toEqual(false);
     });
 
     it('renders edit button if it is editable', () => {

--- a/src/app/checkout/CheckoutStepHeader.tsx
+++ b/src/app/checkout/CheckoutStepHeader.tsx
@@ -12,8 +12,10 @@ import CheckoutStepType from './CheckoutStepType';
 export interface CheckoutStepHeaderProps {
     heading: ReactNode;
     isActive?: boolean;
+    isClosed?: boolean;
     isComplete?: boolean;
     isEditable?: boolean;
+    suggestion?: ReactNode;
     summary?: ReactNode;
     type: CheckoutStepType;
     onEdit?(type: CheckoutStepType): void;
@@ -22,9 +24,11 @@ export interface CheckoutStepHeaderProps {
 const CheckoutStepHeader: FunctionComponent<CheckoutStepHeaderProps> = ({
     heading,
     isActive,
+    isClosed,
     isComplete,
     isEditable,
     onEdit,
+    suggestion,
     summary,
     type,
 }) => {
@@ -36,35 +40,41 @@ const CheckoutStepHeader: FunctionComponent<CheckoutStepHeaderProps> = ({
             ) }
             onClick={ preventDefault(isEditable && onEdit ? () => onEdit(type) : noop) }
         >
-            <div className="stepHeader-figure stepHeader-column">
-                <IconCheck
-                    additionalClassName={ classNames(
-                        'stepHeader-counter',
-                        'optimizedCheckout-step',
-                        { 'stepHeader-counter--complete': isComplete }
-                    ) }
-                />
+            <div className="stepHeader-row">
+                <div className="stepHeader-figure stepHeader-column">
+                    <IconCheck
+                        additionalClassName={ classNames(
+                            'stepHeader-counter',
+                            'optimizedCheckout-step',
+                            { 'stepHeader-counter--complete': isComplete }
+                        ) }
+                    />
 
-                <h2 className="stepHeader-title optimizedCheckout-headingPrimary">
-                    { heading }
-                </h2>
-            </div>
+                    <h2 className="stepHeader-title optimizedCheckout-headingPrimary">
+                        { heading }
+                    </h2>
+                </div>
 
-            <div
-                className="stepHeader-body stepHeader-column optimizedCheckout-contentPrimary"
-                data-test="step-info"
-            >
-                { !isActive && isComplete && summary }
-            </div>
-
-            { isEditable && !isActive && <div className="stepHeader-actions stepHeader-column">
-                <Button
-                    size={ ButtonSize.Tiny }
-                    testId="step-edit-button"
-                    variant={ ButtonVariant.Secondary }
+                <div
+                    className="stepHeader-body stepHeader-column optimizedCheckout-contentPrimary"
+                    data-test="step-info"
                 >
-                    <TranslatedString id="common.edit_action" />
-                </Button>
+                    { !isActive && isComplete && summary }
+                </div>
+
+                { isEditable && !isActive && <div className="stepHeader-actions stepHeader-column">
+                    <Button
+                        size={ ButtonSize.Tiny }
+                        testId="step-edit-button"
+                        variant={ ButtonVariant.Secondary }
+                    >
+                        <TranslatedString id="common.edit_action" />
+                    </Button>
+                </div> }
+            </div>
+
+            { suggestion && isClosed && !isActive && <div className="stepHeader-row stepHeader-suggestion" data-test="step-suggestion">
+                { suggestion }
             </div> }
         </a>
     );

--- a/src/app/common/dom/index.ts
+++ b/src/app/common/dom/index.ts
@@ -1,4 +1,5 @@
 export { default as appendStylesheet } from './appendStylesheet';
 export { default as getAppliedStyles } from './getAppliedStyles';
 export { default as preventDefault } from './preventDefault';
+export { default as stopPropagation } from './stopPropagation';
 export { default as toCSSRule } from './toCssRule';

--- a/src/app/common/dom/stopPropagation.ts
+++ b/src/app/common/dom/stopPropagation.ts
@@ -1,0 +1,13 @@
+import { SyntheticEvent } from 'react';
+
+export default function stopPropagation<TFunc extends (event: TEvent, ...args: any[]) => any, TEvent extends SyntheticEvent>(
+    fn?: TFunc
+): (event: TEvent) => void {
+    return event => {
+        event.stopPropagation();
+
+        if (fn) {
+            fn(event);
+        }
+    };
+}

--- a/src/app/config/config.mock.ts
+++ b/src/app/config/config.mock.ts
@@ -27,6 +27,7 @@ export function getStoreConfig(): StoreConfig {
             orderTermsAndConditionsLink: '',
             orderTermsAndConditionsType: '',
             privacyPolicyUrl: '',
+            providerWithCustomCheckout: null,
             shippingQuoteFailedMessage: 'Unfortunately one or more items in your cart can\'t be shipped to your \
             location.Please choose a different delivery address.',
             realtimeShippingProviders: [

--- a/src/app/customer/Customer.spec.tsx
+++ b/src/app/customer/Customer.spec.tsx
@@ -1,5 +1,5 @@
 import { createCheckoutService, BillingAddress, Checkout, CheckoutService, Customer as CustomerData, StoreConfig } from '@bigcommerce/checkout-sdk';
-import { mount, render, ReactWrapper } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 
 import { getBillingAddress } from '../billing/billingAddresses.mock';
@@ -45,6 +45,15 @@ describe('Customer', () => {
         jest.spyOn(checkoutService.getState().data, 'getConfig')
             .mockReturnValue(config);
 
+        jest.spyOn(checkoutService, 'loadPaymentMethods')
+            .mockResolvedValue(checkoutService.getState());
+
+        jest.spyOn(checkoutService, 'initializeCustomer')
+            .mockResolvedValue(checkoutService.getState());
+
+        jest.spyOn(checkoutService.getState().data, 'getPaymentMethods')
+            .mockReturnValue([]);
+
         localeContext = createLocaleContext(getStoreConfig());
 
         CustomerTest = props => (
@@ -57,23 +66,31 @@ describe('Customer', () => {
     });
 
     describe('when view type is "guest"', () => {
-        it('matches snapshot', () => {
-            expect(render(
-                <CustomerTest viewType={ CustomerViewType.Guest } />
-            ))
-                .toMatchSnapshot();
-        });
-
-        it('renders guest form by default', () => {
+        it('matches snapshot', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
+            expect(component.render())
+                .toMatchSnapshot();
+        });
+
+        it('renders guest form by default', async () => {
+            const component = mount(
+                <CustomerTest viewType={ CustomerViewType.Guest } />
+            );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(GuestForm).exists())
                 .toEqual(true);
         });
 
-        it('renders guest form if billing address is undefined', () => {
+        it('renders guest form if billing address is undefined', async () => {
             jest.spyOn(checkoutService.getState().data, 'getBillingAddress')
                 .mockReturnValue(undefined);
 
@@ -81,11 +98,14 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(GuestForm).exists())
                 .toEqual(true);
         });
 
-        it('renders guest form if customer is undefined', () => {
+        it('renders guest form if customer is undefined', async () => {
             jest.spyOn(checkoutService.getState().data, 'getCustomer')
                 .mockReturnValue(undefined);
 
@@ -93,11 +113,14 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(GuestForm).exists())
                 .toEqual(true);
         });
 
-        it('renders create account form if type is create account', () => {
+        it('renders create account form if type is create account', async () => {
             jest.spyOn(checkoutService.getState().data, 'getCustomer')
                 .mockReturnValue(undefined);
 
@@ -116,14 +139,20 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.CreateAccount } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(CreateAccountForm).exists())
                 .toEqual(true);
         });
 
-        it('passes data to guest form', () => {
+        it('passes data to guest form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(GuestForm).props())
                 .toMatchObject({
@@ -133,7 +162,7 @@ describe('Customer', () => {
                 });
         });
 
-        it('continues checkout as guest and does not send consent if not required', () => {
+        it('continues checkout as guest and does not send consent if not required', async () => {
             jest.spyOn(checkoutService, 'continueAsGuest')
                 .mockReturnValue(Promise.resolve(checkoutService.getState()));
 
@@ -142,6 +171,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -157,7 +189,7 @@ describe('Customer', () => {
                 });
         });
 
-        it('only subscribes to newsletter if allowed by customer', () => {
+        it('only subscribes to newsletter if allowed by customer', async () => {
             jest.spyOn(checkoutService, 'continueAsGuest')
                 .mockReturnValue(Promise.resolve(checkoutService.getState()));
 
@@ -167,6 +199,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -185,7 +220,7 @@ describe('Customer', () => {
                 .not.toHaveBeenCalled();
         });
 
-        it('changes to login view when "show login" event is received', () => {
+        it('changes to login view when "show login" event is received', async () => {
             const handleChangeViewType = jest.fn();
             const component = mount(
                 <CustomerTest
@@ -193,6 +228,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onShowLogin')();
@@ -212,6 +250,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -237,6 +278,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -260,6 +304,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Guest }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
@@ -292,6 +339,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -319,6 +369,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -343,6 +396,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onContinueAsGuest')({
                     email: 'test@bigcommerce.com',
@@ -355,10 +411,13 @@ describe('Customer', () => {
                 .toHaveBeenCalled();
         });
 
-        it('retains draft email address when switching to login view', () => {
+        it('retains draft email address when switching to login view', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Guest } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(GuestForm) as ReactWrapper<GuestFormProps>)
                 .prop('onChangeEmail')('test@bigcommerce.com');
@@ -372,7 +431,7 @@ describe('Customer', () => {
     });
 
     describe('when view type is "login"', () => {
-        it('matches snapshot', () => {
+        it('matches snapshot', async () => {
             const component = mount(
                 <CustomerTest
                     isAccountCreationEnabled={ true }
@@ -380,14 +439,20 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.render())
                 .toMatchSnapshot();
         });
 
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).exists())
                 .toEqual(true);
@@ -400,6 +465,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Login }
                 />);
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             expect(component.find(EmailLoginForm).exists())
                 .toEqual(false);
 
@@ -410,13 +478,16 @@ describe('Customer', () => {
                 .toEqual(false);
         });
 
-        it('does not render sign-in email link when is embedded checkout', () => {
+        it('does not render sign-in email link when is embedded checkout', async () => {
             const component = mount(
                 <CustomerTest
                     isEmbedded={ true }
                     isSignInEmailEnabled={ true }
                     viewType={ CustomerViewType.Login }
                 />);
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(EmailLoginForm).exists())
                 .toEqual(false);
@@ -425,10 +496,13 @@ describe('Customer', () => {
                 .toEqual(false);
         });
 
-        it('passes data to login form', () => {
+        it('passes data to login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).props())
                 .toMatchObject({
@@ -438,13 +512,16 @@ describe('Customer', () => {
                 });
         });
 
-        it('handles "sign in" event', () => {
+        it('handles "sign in" event', async () => {
             jest.spyOn(checkoutService, 'signInCustomer')
                 .mockReturnValue(Promise.resolve(checkoutService.getState()));
 
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 .prop('onSignIn')({
@@ -471,6 +548,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 .prop('onSignIn')({
                     email: 'test@bigcommerce.com',
@@ -495,6 +575,9 @@ describe('Customer', () => {
                 />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 .prop('onSignIn')({
                     email: 'test@bigcommerce.com',
@@ -507,7 +590,7 @@ describe('Customer', () => {
                 .toHaveBeenCalled();
         });
 
-        it('clears error when "cancel" event is triggered', () => {
+        it('clears error when "cancel" event is triggered', async () => {
             const error = new Error();
 
             jest.spyOn(checkoutService.getState().errors, 'getSignInError')
@@ -520,6 +603,9 @@ describe('Customer', () => {
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
 
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 // tslint:disable-next-line:no-non-null-assertion
                 .prop('onCancel')!();
@@ -528,7 +614,7 @@ describe('Customer', () => {
                 .toHaveBeenCalledWith(error);
         });
 
-        it('changes to guest view when "cancel" event is triggered', () => {
+        it('changes to guest view when "cancel" event is triggered', async () => {
             const handleChangeViewType = jest.fn();
             const component = mount(
                 <CustomerTest
@@ -536,6 +622,9 @@ describe('Customer', () => {
                     viewType={ CustomerViewType.Login }
                 />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 // tslint:disable-next-line:no-non-null-assertion
@@ -545,10 +634,13 @@ describe('Customer', () => {
                 .toHaveBeenCalledWith(CustomerViewType.Guest);
         });
 
-        it('retains draft email address when switching to guest view', () => {
+        it('retains draft email address when switching to guest view', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.Login } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>)
                 // tslint:disable-next-line:no-non-null-assertion
@@ -563,10 +655,13 @@ describe('Customer', () => {
     });
 
     describe('when view type is "cancellable_enforced_login"', () => {
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.CancellableEnforcedLogin } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).prop('viewType'))
                 .toEqual(CustomerViewType.CancellableEnforcedLogin);
@@ -574,10 +669,13 @@ describe('Customer', () => {
     });
 
     describe('when view type is "suggested_login"', () => {
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.SuggestedLogin } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).prop('viewType'))
                 .toEqual(CustomerViewType.SuggestedLogin);
@@ -585,10 +683,13 @@ describe('Customer', () => {
     });
 
     describe('when view type is "enforced_login"', () => {
-        it('renders login form', () => {
+        it('renders login form', async () => {
             const component = mount(
                 <CustomerTest viewType={ CustomerViewType.EnforcedLogin } />
             );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             expect(component.find(LoginForm).prop('viewType'))
                 .toEqual(CustomerViewType.EnforcedLogin);
@@ -603,6 +704,9 @@ describe('Customer', () => {
                     sendLoginEmail={ sendLoginEmail }
                     viewType={ CustomerViewType.EnforcedLogin }
                 />);
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             component.find('[data-test="customer-signin-link"]').simulate('click');
             component.update();
@@ -624,6 +728,9 @@ describe('Customer', () => {
                     sendLoginEmail={ sendLoginEmail }
                     viewType={ CustomerViewType.EnforcedLogin }
                 />);
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
 
             component.find('[data-test="customer-signin-link"]').simulate('click');
             component.update();

--- a/src/app/customer/Customer.tsx
+++ b/src/app/customer/Customer.tsx
@@ -1,8 +1,9 @@
-import { CheckoutSelectors, CustomerAccountRequestBody, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, FormField, GuestCredentials, SignInEmail, StoreConfig } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, CustomerAccountRequestBody, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions, FormField, GuestCredentials, SignInEmail, StoreConfig } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
-import React, { Component, Fragment, ReactNode } from 'react';
+import React, { Component, ReactNode } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../checkout';
+import { LoadingOverlay } from '../ui/loading';
 
 import { CreateAccountFormValues } from './getCreateCustomerValidationSchema';
 import mapCreateAccountFromFormValues from './mapCreateAccountFromFormValues';
@@ -37,12 +38,14 @@ export interface WithCheckoutCustomerProps {
     forgotPasswordUrl: string;
     isContinuingAsGuest: boolean;
     isCreatingAccount: boolean;
+    isExecutingPaymentMethodCheckout: boolean;
     isGuestEnabled: boolean;
     isInitializing: boolean;
     isSendingSignInEmail: boolean;
     isSignInEmailEnabled: boolean;
     isSigningIn: boolean;
     privacyPolicyUrl?: string;
+    providerWithCustomCheckout?: string;
     requiresMarketingConsent: boolean;
     signInEmail?: SignInEmail;
     signInEmailError?: Error;
@@ -52,6 +55,7 @@ export interface WithCheckoutCustomerProps {
     clearError(error: Error): Promise<CheckoutSelectors>;
     continueAsGuest(credentials: GuestCredentials): Promise<CheckoutSelectors>;
     deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
+    executePaymentMethodCheckout(options: ExecutePaymentMethodCheckoutOptions): Promise<CheckoutSelectors>;
     initializeCustomer(options: CustomerInitializeOptions): Promise<CheckoutSelectors>;
     sendLoginEmail(params: { email: string }): Promise<CheckoutSelectors>;
     signIn(credentials: CustomerCredentials): Promise<CheckoutSelectors>;
@@ -60,42 +64,72 @@ export interface WithCheckoutCustomerProps {
 
 export interface CustomerState {
     isEmailLoginFormOpen: boolean;
+    isReady: boolean;
     hasRequestedLoginEmail: boolean;
 }
 
 class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, CustomerState> {
     state: CustomerState = {
         isEmailLoginFormOpen: false,
+        isReady: false,
         hasRequestedLoginEmail: false,
     };
 
     private draftEmail?: string;
 
-    componentDidMount(): void {
+    async componentDidMount(): Promise<void> {
         const {
-            onReady = noop,
+            initializeCustomer,
             email,
+            onReady = noop,
+            onUnhandledError = noop,
+            providerWithCustomCheckout,
         } = this.props;
 
         this.draftEmail = email;
 
+        try {
+            await initializeCustomer({ methodId: providerWithCustomCheckout });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+
+        this.setState({ isReady: true });
+
         onReady();
+    }
+
+    async componentWillUnmount(): Promise<void> {
+        const {
+            deinitializeCustomer = noop,
+            providerWithCustomCheckout,
+            onUnhandledError = noop,
+        } = this.props;
+
+        try {
+            await deinitializeCustomer({ methodId: providerWithCustomCheckout });
+        } catch (error) {
+            onUnhandledError(error);
+        }
     }
 
     render(): ReactNode {
         const { viewType } = this.props;
-        const { isEmailLoginFormOpen } = this.state;
+        const { isEmailLoginFormOpen, isReady } = this.state;
         const shouldRenderGuestForm = viewType === CustomerViewType.Guest;
         const shouldRenderCreateAccountForm = viewType === CustomerViewType.CreateAccount;
         const shouldRenderLoginForm = !shouldRenderGuestForm && !shouldRenderCreateAccountForm;
 
         return (
-            <Fragment>
+            <LoadingOverlay
+                isLoading={ !isReady }
+                unmountContentWhenLoading
+            >
                 { isEmailLoginFormOpen && this.renderEmailLoginLinkForm() }
                 { shouldRenderLoginForm && this.renderLoginForm() }
                 { shouldRenderGuestForm && this.renderGuestForm() }
                 { shouldRenderCreateAccountForm && this.renderCreateAccountForm() }
-            </Fragment>
+            </LoadingOverlay>
         );
     }
 
@@ -109,8 +143,10 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             email,
             initializeCustomer,
             isContinuingAsGuest = false,
+            isExecutingPaymentMethodCheckout = false,
             isInitializing = false,
             privacyPolicyUrl,
+            providerWithCustomCheckout,
             requiresMarketingConsent,
             onUnhandledError = noop,
         } = this.props;
@@ -128,9 +164,10 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
                         onError={ onUnhandledError }
                     />
                 }
+                continueAsGuestButtonLabelId={ !!providerWithCustomCheckout ? 'customer.continue' : 'customer.continue_as_guest_action' }
                 defaultShouldSubscribe={ defaultShouldSubscribe }
                 email={ this.draftEmail || email }
-                isLoading={ isContinuingAsGuest || isInitializing }
+                isLoading={ isContinuingAsGuest || isInitializing || isExecutingPaymentMethodCheckout }
                 onChangeEmail={ this.handleChangeEmail }
                 onContinueAsGuest={ this.handleContinueAsGuest }
                 onShowLogin={ this.handleShowLogin }
@@ -203,7 +240,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             isSendingSignInEmail,
             isSigningIn,
             isAccountCreationEnabled,
-            onContinueAsGuest,
+            providerWithCustomCheckout,
             signInError,
             viewType,
         } = this.props;
@@ -211,6 +248,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
         return (
             <LoginForm
                 canCancel={ isGuestEnabled }
+                continueAsGuestButtonLabelId={ !!providerWithCustomCheckout ? 'customer.continue' : 'customer.continue_as_guest_action' }
                 email={ this.draftEmail || email }
                 forgotPasswordUrl={ forgotPasswordUrl }
                 isSendingSignInEmail={ isSendingSignInEmail }
@@ -218,7 +256,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
                 isSigningIn={ isSigningIn }
                 onCancel={ this.handleCancelSignIn }
                 onChangeEmail={ this.handleChangeEmail }
-                onContinueAsGuest={ onContinueAsGuest }
+                onContinueAsGuest={ this.executePaymentMethodCheckoutOrContinue }
                 onCreateAccount={ this.showCreateAccount }
                 onSendLoginEmail={ this.handleEmailLoginClicked }
                 onSignIn={ this.handleSignIn }
@@ -277,17 +315,17 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             const customer = data.getCustomer();
 
             if (customer && customer.shouldEncourageSignIn && customer.isGuest) {
-                return onChangeViewType(CustomerViewType.SuggestedLogin);
+               return onChangeViewType(CustomerViewType.SuggestedLogin);
             }
 
-            onContinueAsGuest();
+            await this.executePaymentMethodCheckoutOrContinue();
 
             this.draftEmail = undefined;
         } catch (error) {
-            if (error.type === 'update_subscriptions') {
+            if (error.type === 'update_subscriptions' || error.type === 'payment_method_client_invalid') {
                 this.draftEmail = undefined;
 
-                return onContinueAsGuest();
+                onContinueAsGuest();
             }
 
             if (error.status === 429) {
@@ -375,6 +413,20 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
 
         onChangeViewType(CustomerViewType.Login);
     };
+
+    private executePaymentMethodCheckoutOrContinue: () => void = async () => {
+        const {
+            executePaymentMethodCheckout,
+            onContinueAsGuest = noop,
+            providerWithCustomCheckout,
+        } = this.props;
+
+        if (providerWithCustomCheckout) {
+            await executePaymentMethodCheckout({ methodId: providerWithCustomCheckout, continueWithCheckoutCallback: onContinueAsGuest });
+        } else {
+            onContinueAsGuest();
+        }
+    };
 }
 
 export function mapToWithCheckoutCustomerProps(
@@ -383,7 +435,7 @@ export function mapToWithCheckoutCustomerProps(
     const {
         data: { getBillingAddress, getCustomerAccountFields, getCheckout, getCustomer, getSignInEmail, getConfig },
         errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
-        statuses: { isContinuingAsGuest, isInitializingCustomer, isSigningIn, isSendingSignInEmail, isCreatingCustomerAccount },
+        statuses: { isContinuingAsGuest, isExecutingPaymentMethodCheckout, isInitializingCustomer, isSigningIn, isSendingSignInEmail, isCreatingCustomerAccount },
     } = checkoutState;
 
     const billingAddress = getBillingAddress();
@@ -415,13 +467,15 @@ export function mapToWithCheckoutCustomerProps(
         sendLoginEmail: checkoutService.sendSignInEmail,
         defaultShouldSubscribe: config.shopperConfig.defaultNewsletterSignup,
         deinitializeCustomer: checkoutService.deinitializeCustomer,
-        email: (billingAddress && billingAddress.email) || (customer && customer.email),
-        firstName: customer && customer.firstName,
+        executePaymentMethodCheckout: checkoutService.executePaymentMethodCheckout,
+        email: billingAddress?.email || customer?.email,
+        firstName: customer?.firstName,
         forgotPasswordUrl: config.links.forgotPasswordLink,
         initializeCustomer: checkoutService.initializeCustomer,
         isCreatingAccount: isCreatingCustomerAccount(),
         createAccountError: getCreateCustomerAccountError(),
         isContinuingAsGuest: isContinuingAsGuest(),
+        isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
         isInitializing:  isInitializingCustomer(),
         isSignInEmailEnabled,
         isAccountCreationEnabled,
@@ -431,6 +485,7 @@ export function mapToWithCheckoutCustomerProps(
         signInEmail,
         signInEmailError: getSignInEmailError(),
         privacyPolicyUrl,
+        providerWithCustomCheckout: config.checkoutSettings.providerWithCustomCheckout || undefined,
         requiresMarketingConsent,
         signIn: checkoutService.signInCustomer,
         signInError: getSignInError(),

--- a/src/app/customer/GuestForm.spec.tsx
+++ b/src/app/customer/GuestForm.spec.tsx
@@ -15,6 +15,7 @@ describe('GuestForm', () => {
     beforeEach(() => {
         defaultProps = {
             canSubscribe: true,
+            continueAsGuestButtonLabelId: 'customer.continue_as_guest_action',
             defaultShouldSubscribe: false,
             isLoading: false,
             onChangeEmail: jest.fn(),
@@ -265,5 +266,15 @@ describe('GuestForm', () => {
         );
 
         expect(component.find('[data-test="customer-continue-button"]').length).toEqual(0);
+    });
+
+    it('shows different action button label if another label id was provided', () => {
+        const component = mount(
+            <TestComponent
+                continueAsGuestButtonLabelId="customer.continue"
+            />
+        );
+
+        expect(component.find('[data-test="customer-continue-button"]').text()).not.toEqual('Continue as guest');
     });
 });

--- a/src/app/customer/GuestForm.tsx
+++ b/src/app/customer/GuestForm.tsx
@@ -13,6 +13,7 @@ import SubscribeField from './SubscribeField';
 export interface GuestFormProps {
     canSubscribe: boolean;
     checkoutButtons?: ReactNode;
+    continueAsGuestButtonLabelId: string;
     requiresMarketingConsent: boolean;
     defaultShouldSubscribe: boolean;
     email?: string;
@@ -31,6 +32,7 @@ export interface GuestFormValues {
 const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikProps<GuestFormValues>> = ({
     canSubscribe,
     checkoutButtons,
+    continueAsGuestButtonLabelId,
     isLoading,
     onChangeEmail,
     onShowLogin,
@@ -86,7 +88,7 @@ const GuestForm: FunctionComponent<GuestFormProps & WithLanguageProps & FormikPr
                             type="submit"
                             variant={ ButtonVariant.Primary }
                         >
-                            <TranslatedString id="customer.continue_as_guest_action" />
+                            <TranslatedString id={ continueAsGuestButtonLabelId } />
                         </Button>
                     </div>
                 </div>

--- a/src/app/customer/LoginForm.spec.tsx
+++ b/src/app/customer/LoginForm.spec.tsx
@@ -1,29 +1,40 @@
 import { mount, render } from 'enzyme';
-import { noop } from 'lodash';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 
 import { getStoreConfig } from '../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedHtml, TranslatedLink } from '../locale';
 import { Alert } from '../ui/alert';
 
 import CustomerViewType from './CustomerViewType';
-import LoginForm from './LoginForm';
+import LoginForm, { LoginFormProps } from './LoginForm';
 
 describe('LoginForm', () => {
+    let defaultProps: LoginFormProps;
     let localeContext: LocaleContextType;
+    let TestComponent: FunctionComponent<Partial<LoginFormProps>>;
 
     beforeEach(() => {
+        defaultProps = {
+            continueAsGuestButtonLabelId: 'customer.continue_as_guest_action',
+            forgotPasswordUrl: '/forgot-password',
+            onSignIn: jest.fn(),
+        };
+
         localeContext = createLocaleContext(getStoreConfig());
+
+        TestComponent = props => (
+            <LocaleContext.Provider value={ localeContext }>
+                <LoginForm
+                    { ...defaultProps }
+                    { ...props }
+                />
+            </LocaleContext.Provider>
+        );
     });
 
     it('matches snapshot', () => {
         const component = render(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                />
-            </LocaleContext.Provider>
+            <TestComponent />
         );
 
         expect(component)
@@ -32,13 +43,7 @@ describe('LoginForm', () => {
 
     it('renders form with initial values', () => {
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    email={ 'test@bigcommerce.com' }
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                />
-            </LocaleContext.Provider>
+            <TestComponent email={ 'test@bigcommerce.com' } />
         );
 
         expect(component.find('input[name="email"]').prop('value'))
@@ -48,12 +53,7 @@ describe('LoginForm', () => {
     it('notifies when user clicks on "sign in" button', async () => {
         const handleSignIn = jest.fn();
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ handleSignIn }
-                />
-            </LocaleContext.Provider>
+            <TestComponent onSignIn={ handleSignIn } />
         );
 
         component.find('input[name="email"]')
@@ -74,16 +74,11 @@ describe('LoginForm', () => {
     it('displays error message if email is not valid', () => {
         async function getEmailError(value: string): Promise<string> {
             const component = mount(
-                <LocaleContext.Provider value={ localeContext }>
-                    <LoginForm
-                        forgotPasswordUrl={ '/forgot-password' }
-                        onSignIn={ noop }
-                    />
-                </LocaleContext.Provider>
+                <TestComponent />
             );
 
             component.find('input[name="email"]')
-            .simulate('change', { target: { value, name: 'email' } });
+                .simulate('change', { target: { value, name: 'email' } });
 
             component.find('form')
                 .simulate('submit');
@@ -109,12 +104,7 @@ describe('LoginForm', () => {
 
     it('displays error message if password is missing', async () => {
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                />
-            </LocaleContext.Provider>
+            <TestComponent />
         );
 
         component.find('input[name="email"]')
@@ -134,16 +124,12 @@ describe('LoginForm', () => {
     it('renders SuggestedLogin (no email input, suggestion, continue as guest) and ignores canCancel flag', () => {
         const onCancel = jest.fn();
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    canCancel
-                    email="foo@bar.com"
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onCancel={ onCancel }
-                    onSignIn={ noop }
-                    viewType={ CustomerViewType.SuggestedLogin }
-                />
-            </LocaleContext.Provider>
+            <TestComponent
+                canCancel
+                email="foo@bar.com"
+                onCancel={ onCancel }
+                viewType={ CustomerViewType.SuggestedLogin }
+            />
         );
 
         expect(component.find(Alert).prop('type'))
@@ -170,15 +156,11 @@ describe('LoginForm', () => {
 
     it('renders info alert if CancellableEnforcedLogin, and hides email input', () => {
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    canCancel
-                    email="foo@bar.com"
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                    viewType={ CustomerViewType.CancellableEnforcedLogin }
-                />
-            </LocaleContext.Provider>
+            <TestComponent
+                canCancel
+                email="foo@bar.com"
+                viewType={ CustomerViewType.CancellableEnforcedLogin }
+            />
         );
 
         expect(component.find(Alert).prop('type'))
@@ -196,15 +178,11 @@ describe('LoginForm', () => {
 
     it('renders guest is temporary disabled alert if EnforcedLogin, and ignores canCancel flag', () => {
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    canCancel
-                    email="foo@bar.com"
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                    viewType={ CustomerViewType.EnforcedLogin }
-                />
-            </LocaleContext.Provider>
+            <TestComponent
+                canCancel
+                email="foo@bar.com"
+                viewType={ CustomerViewType.EnforcedLogin }
+            />
         );
 
         expect(component.find(Alert).prop('type'))
@@ -223,14 +201,10 @@ describe('LoginForm', () => {
     it('renders error as alert if password is incorrect', () => {
         const error = Object.assign(new Error(), { body: { type: 'invalid login' } });
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    canCancel
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                    signInError={ error }
-                />
-            </LocaleContext.Provider>
+            <TestComponent
+                canCancel
+                signInError={ error }
+            />
         );
 
         expect(component.find('[data-test="customer-login-error-message"]').text())
@@ -239,13 +213,7 @@ describe('LoginForm', () => {
 
     it('renders cancel button if able to cancel', () => {
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    canCancel
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                />
-            </LocaleContext.Provider>
+            <TestComponent canCancel />
         );
 
         expect(component.exists('[data-test="customer-cancel-button"]'))
@@ -254,12 +222,7 @@ describe('LoginForm', () => {
 
     it('does not render cancel button by default', () => {
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onSignIn={ noop }
-                />
-            </LocaleContext.Provider>
+            <TestComponent />
         );
 
         expect(component.exists('[data-test="customer-cancel-button"]'))
@@ -269,13 +232,7 @@ describe('LoginForm', () => {
     it('notifies when user changes email address', () => {
         const handleChangeEmail = jest.fn();
         const component = mount(
-            <LocaleContext.Provider value={ localeContext }>
-                <LoginForm
-                    forgotPasswordUrl={ '/forgot-password' }
-                    onChangeEmail={ handleChangeEmail }
-                    onSignIn={ noop }
-                />
-            </LocaleContext.Provider>
+            <TestComponent onChangeEmail={ handleChangeEmail } />
         );
 
         component.find('input[name="email"]')
@@ -283,5 +240,16 @@ describe('LoginForm', () => {
 
         expect(handleChangeEmail)
             .toHaveBeenCalledWith('test@bigcommerce.com');
+    });
+
+    it('shows different "Continue as guest" button label if another label id was provided', () => {
+        const component = mount(
+            <TestComponent
+                continueAsGuestButtonLabelId="customer.continue"
+                viewType={ CustomerViewType.SuggestedLogin }
+            />
+        );
+
+        expect(component.find('[data-test="customer-guest-continue"]').text()).not.toEqual('Continue as guest');
     });
 });

--- a/src/app/customer/LoginForm.tsx
+++ b/src/app/customer/LoginForm.tsx
@@ -17,6 +17,7 @@ import PasswordField from './PasswordField';
 
 export interface LoginFormProps {
     canCancel?: boolean;
+    continueAsGuestButtonLabelId: string;
     email?: string;
     forgotPasswordUrl: string;
     isSignInEmailEnabled?: boolean;
@@ -42,6 +43,7 @@ export interface LoginFormValues {
 
 const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikProps<LoginFormValues>> = ({
     canCancel,
+    continueAsGuestButtonLabelId,
     forgotPasswordUrl,
     email,
     isSignInEmailEnabled,
@@ -154,7 +156,7 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
                         id="checkout-guest-continue"
                         onClick={ preventDefault(onContinueAsGuest) }
                     >
-                        <TranslatedString id="customer.continue_as_guest_action" />
+                        <TranslatedString id={ continueAsGuestButtonLabelId } />
                     </a> }
 
                     { canCancel &&

--- a/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -2,216 +2,220 @@
 
 exports[`Customer when view type is "guest" matches snapshot 1`] = `
 <div>
-  <form
-    class="checkout-form"
-    data-test="checkout-customer-guest"
-    id="checkout-customer-guest"
-    novalidate=""
-  >
-    <fieldset
-      class="form-fieldset"
+  <div>
+    <form
+      class="checkout-form"
+      data-test="checkout-customer-guest"
+      id="checkout-customer-guest"
+      novalidate=""
     >
-      <legend
-        class="form-legend is-srOnly"
+      <fieldset
+        class="form-fieldset"
       >
-        Guest Customer
-      </legend>
-      <div
-        class="form-body"
-      >
-        <p>
-          <span>
-            Checking out as a 
-            <strong>
-              Guest
-            </strong>
-            ? You'll be able to save your details to create an account with us later.
-          </span>
-        </p>
-        <div
-          class="customerEmail-container"
+        <legend
+          class="form-legend is-srOnly"
         >
+          Guest Customer
+        </legend>
+        <div
+          class="form-body"
+        >
+          <p>
+            <span>
+              Checking out as a 
+              <strong>
+                Guest
+              </strong>
+              ? You'll be able to save your details to create an account with us later.
+            </span>
+          </p>
           <div
-            class="customerEmail-body"
+            class="customerEmail-container"
           >
             <div
-              class="form-field"
+              class="customerEmail-body"
             >
-              <label
-                class="form-label optimizedCheckout-form-label"
-                for="email"
+              <div
+                class="form-field"
               >
-                Email Address
-              </label>
-              <input
-                autocomplete="email"
-                class="form-input optimizedCheckout-form-input"
-                id="email"
-                name="email"
-                type="email"
-                value="test@bigcommerce.com"
-              />
+                <label
+                  class="form-label optimizedCheckout-form-label"
+                  for="email"
+                >
+                  Email Address
+                </label>
+                <input
+                  autocomplete="email"
+                  class="form-input optimizedCheckout-form-input"
+                  id="email"
+                  name="email"
+                  type="email"
+                  value="test@bigcommerce.com"
+                />
+              </div>
+              <div
+                class="form-field"
+              >
+                <input
+                  class="form-checkbox"
+                  id="shouldSubscribe"
+                  name="shouldSubscribe"
+                  type="checkbox"
+                  value="false"
+                />
+                <label
+                  class="form-label optimizedCheckout-form-label"
+                  for="shouldSubscribe"
+                >
+                  Subscribe to our newsletter.
+                </label>
+              </div>
             </div>
             <div
-              class="form-field"
+              class="form-actions customerEmail-action"
             >
-              <input
-                class="form-checkbox"
-                id="shouldSubscribe"
-                name="shouldSubscribe"
-                type="checkbox"
-                value="false"
-              />
-              <label
-                class="form-label optimizedCheckout-form-label"
-                for="shouldSubscribe"
+              <button
+                class="button customerEmail-button button--primary optimizedCheckout-buttonPrimary"
+                data-test="customer-continue-as-guest-button"
+                id="checkout-customer-continue"
+                type="submit"
               >
-                Subscribe to our newsletter.
-              </label>
+                Continue as guest
+              </button>
             </div>
           </div>
-          <div
-            class="form-actions customerEmail-action"
-          >
-            <button
-              class="button customerEmail-button button--primary optimizedCheckout-buttonPrimary"
-              data-test="customer-continue-as-guest-button"
-              id="checkout-customer-continue"
-              type="submit"
+          <p>
+            Already have an account? 
+            <a
+              data-test="customer-continue-button"
+              id="checkout-customer-login"
             >
-              Continue as guest
-            </button>
-          </div>
+              Sign in now
+            </a>
+          </p>
         </div>
-        <p>
-          Already have an account? 
-          <a
-            data-test="customer-continue-button"
-            id="checkout-customer-login"
-          >
-            Sign in now
-          </a>
-        </p>
-      </div>
-    </fieldset>
-  </form>
+      </fieldset>
+    </form>
+  </div>
 </div>
 `;
 
 exports[`Customer when view type is "login" matches snapshot 1`] = `
 <div>
-  <form
-    class="checkout-form"
-    data-test="checkout-customer-returning"
-    id="checkout-customer-returning"
-    novalidate=""
-  >
-    <fieldset
-      class="form-fieldset"
+  <div>
+    <form
+      class="checkout-form"
+      data-test="checkout-customer-returning"
+      id="checkout-customer-returning"
+      novalidate=""
     >
-      <legend
-        class="form-legend is-srOnly"
+      <fieldset
+        class="form-fieldset"
       >
-        Returning Customer
-      </legend>
-      <div
-        class="form-body"
-      >
-        <p>
-          Don't have an account? 
-          <a
-            href="#"
-          >
-            Create an account
-          </a>
-           to continue.
-        </p>
-        <div
-          class="form-field"
+        <legend
+          class="form-legend is-srOnly"
         >
-          <label
-            class="form-label optimizedCheckout-form-label"
-            for="email"
-          >
-            Email Address
-          </label>
-          <input
-            autocomplete="email"
-            class="form-input optimizedCheckout-form-input"
-            id="email"
-            name="email"
-            type="email"
-            value="test@bigcommerce.com"
-          />
-        </div>
+          Returning Customer
+        </legend>
         <div
-          class="form-field"
+          class="form-body"
         >
-          <label
-            class="form-label optimizedCheckout-form-label"
-            for="password"
-          >
-            Password
-          </label>
-          <div
-            class="form-field-password"
-          >
-            <input
-              class="form-input optimizedCheckout-form-input form-input--withIcon"
-              id="password"
-              name="password"
-              type="password"
-              value=""
-            />
+          <p>
+            Don't have an account? 
             <a
-              class="form-toggle-password form-input-icon"
               href="#"
             >
-              <div
-                class="icon"
+              Create an account
+            </a>
+             to continue.
+          </p>
+          <div
+            class="form-field"
+          >
+            <label
+              class="form-label optimizedCheckout-form-label"
+              for="email"
+            >
+              Email Address
+            </label>
+            <input
+              autocomplete="email"
+              class="form-input optimizedCheckout-form-input"
+              id="email"
+              name="email"
+              type="email"
+              value="test@bigcommerce.com"
+            />
+          </div>
+          <div
+            class="form-field"
+          >
+            <label
+              class="form-label optimizedCheckout-form-label"
+              for="password"
+            >
+              Password
+            </label>
+            <div
+              class="form-field-password"
+            >
+              <input
+                class="form-input optimizedCheckout-form-input form-input--withIcon"
+                id="password"
+                name="password"
+                type="password"
+                value=""
+              />
+              <a
+                class="form-toggle-password form-input-icon"
+                href="#"
               >
-                <svg
-                  viewBox="0 0 640 512"
-                  xmlns="http://www.w3.org/2000/svg"
+                <div
+                  class="icon"
                 >
-                  <path
-                    d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
-                  />
-                </svg>
-              </div>
+                  <svg
+                    viewBox="0 0 640 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"
+                    />
+                  </svg>
+                </div>
+              </a>
+            </div>
+            <a
+              data-test="forgot-password-link"
+              href="https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Forgot password?
             </a>
           </div>
-          <a
-            data-test="forgot-password-link"
-            href="https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password"
-            rel="noopener noreferrer"
-            target="_blank"
+          <div
+            class="form-actions"
           >
-            Forgot password?
-          </a>
+            <button
+              class="button button--primary optimizedCheckout-buttonPrimary"
+              data-test="customer-continue-button"
+              id="checkout-customer-continue"
+              type="submit"
+            >
+              Sign In
+            </button>
+            <a
+              class="button optimizedCheckout-buttonSecondary"
+              data-test="customer-cancel-button"
+              href="#"
+              id="checkout-customer-cancel"
+            >
+              Cancel
+            </a>
+          </div>
         </div>
-        <div
-          class="form-actions"
-        >
-          <button
-            class="button button--primary optimizedCheckout-buttonPrimary"
-            data-test="customer-continue-button"
-            id="checkout-customer-continue"
-            type="submit"
-          >
-            Sign In
-          </button>
-          <a
-            class="button optimizedCheckout-buttonSecondary"
-            data-test="customer-cancel-button"
-            href="#"
-            id="checkout-customer-cancel"
-          >
-            Cancel
-          </a>
-        </div>
-      </div>
-    </fieldset>
-  </form>
+      </fieldset>
+    </form>
+  </div>
 </div>
 `;

--- a/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.spec.tsx
+++ b/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.spec.tsx
@@ -1,0 +1,108 @@
+import { mount } from 'enzyme';
+import React, { FunctionComponent } from 'react';
+import { act } from 'react-dom/test-utils';
+
+import BoltCheckoutSuggestion, { BoltCheckoutSuggestionProps } from './BoltCheckoutSuggestion';
+
+describe('BoltCheckoutSuggestion', () => {
+    let defaultProps: BoltCheckoutSuggestionProps;
+    let TestComponent: FunctionComponent<Partial<BoltCheckoutSuggestionProps>>;
+
+    beforeEach(() => {
+        defaultProps = {
+            deinitializeCustomer: jest.fn(),
+            executePaymentMethodCheckout: jest.fn(),
+            initializeCustomer: jest.fn(),
+            onUnhandledError: jest.fn(),
+            isExecutingPaymentMethodCheckout: false,
+            methodId: 'bolt',
+        };
+
+        TestComponent = props => (
+            <BoltCheckoutSuggestion
+                { ...defaultProps }
+                { ...props }
+            />
+        );
+    });
+
+    it('deinitializes previous Bolt customer strategy before initialisation', () => {
+        mount(<TestComponent />);
+
+        expect(defaultProps.deinitializeCustomer).toHaveBeenCalledWith({ methodId: 'bolt' });
+    });
+
+    it('initialises Bolt customer strategy with required options', () => {
+        mount(<TestComponent />);
+
+        const deinitializeOptions = { methodId: 'bolt' };
+        const initializeOptions = {
+            methodId: 'bolt',
+            bolt: {
+                onInit: expect.any(Function),
+            },
+        };
+
+        expect(defaultProps.deinitializeCustomer).toHaveBeenCalledWith(deinitializeOptions);
+        expect(defaultProps.initializeCustomer).toHaveBeenCalledWith(initializeOptions);
+    });
+
+    it('calls onUnhandledError if initialization was failed', () => {
+        defaultProps.initializeCustomer = jest.fn(() => { throw new Error(); });
+
+        mount(<TestComponent />);
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    it('do not render Bolt suggestion block if the customer has not bolt account', async () => {
+        const component = mount(<TestComponent />);
+        const customerHasBoltAccount = false;
+        const initializeOptions = (defaultProps.initializeCustomer as jest.Mock).mock.calls[0][0];
+
+        act(() => {
+            initializeOptions.bolt.onInit(customerHasBoltAccount);
+        });
+
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        expect(component.find('[data-test="suggestion-action-button"]')).toHaveLength(0);
+    });
+
+    it('renders Bolt suggestion block if the customer has bolt account', async () => {
+        const component = mount(<TestComponent />);
+        const customerHasBoltAccount = true;
+        const initializeOptions = (defaultProps.initializeCustomer as jest.Mock).mock.calls[0][0];
+
+        act(() => {
+            initializeOptions.bolt.onInit(customerHasBoltAccount);
+        });
+
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        expect(component.find('[data-test="suggestion-action-button"]')).toHaveLength(1);
+    });
+
+    it('executes Bolt Checkout', async () => {
+        const component = mount(<TestComponent />);
+        const customerHasBoltAccount = true;
+        const initializeOptions = (defaultProps.initializeCustomer as jest.Mock).mock.calls[0][0];
+
+        act(() => initializeOptions.bolt.onInit(customerHasBoltAccount));
+
+        await new Promise(resolve => process.nextTick(resolve));
+        component.update();
+
+        const actionButton = component.find('[data-test="suggestion-action-button"]');
+
+        expect(actionButton).toHaveLength(1);
+
+        actionButton.simulate('click');
+
+        expect(defaultProps.executePaymentMethodCheckout).toHaveBeenCalledWith({
+            methodId: defaultProps.methodId,
+        });
+    });
+});

--- a/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
+++ b/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
@@ -1,0 +1,90 @@
+import { CheckoutSelectors, CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import React, { memo, useEffect, useState, FunctionComponent } from 'react';
+
+import { stopPropagation } from '../../common/dom';
+import { TranslatedString } from '../../locale';
+import { Button } from '../../ui/button';
+import { IconBolt } from '../../ui/icon';
+
+export interface BoltCheckoutSuggestionProps {
+    isExecutingPaymentMethodCheckout: boolean;
+    methodId: string;
+    deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
+    executePaymentMethodCheckout(options: ExecutePaymentMethodCheckoutOptions): Promise<CheckoutSelectors>;
+    initializeCustomer(options: CustomerInitializeOptions): Promise<CheckoutSelectors>;
+    onUnhandledError?(error: Error): void;
+}
+
+const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = ({
+    isExecutingPaymentMethodCheckout,
+    methodId,
+    deinitializeCustomer,
+    executePaymentMethodCheckout,
+    initializeCustomer,
+    onUnhandledError = noop,
+}) => {
+    const [ showSuggestion, setShowSuggestion ] = useState<boolean>(false);
+
+    useEffect(() => {
+        deinitializeCustomer({ methodId });
+
+        try {
+            initializeCustomer({
+                methodId,
+                bolt: {
+                    onInit: hasBoltAccount => {
+                        setShowSuggestion(hasBoltAccount);
+                    },
+                },
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+
+        return () => {
+            deinitializeCustomer({ methodId });
+        };
+    }, [initializeCustomer, deinitializeCustomer, methodId, onUnhandledError]);
+
+    if (!showSuggestion) {
+        return null;
+    }
+
+    const handleActionClick = async () => {
+        await executePaymentMethodCheckout({ methodId });
+    };
+
+    return (
+        <div
+            className="checkoutSuggestion"
+            onClick={ stopPropagation() }
+        >
+            <p className="checkoutSuggestion-message">
+                <TranslatedString
+                    data={ {
+                        provider: 'Bolt',
+                        providerFlow: 'Bolt Checkout',
+                    } }
+                    id="customer.suggestion_text"
+                />
+            </p>
+            <Button
+                className="checkoutSuggestion-button checkoutSuggestion-button--bolt"
+                data-test="suggestion-action-button"
+                isLoading={ isExecutingPaymentMethodCheckout }
+                onClick={ handleActionClick }
+            >
+                <IconBolt
+                    additionalClassName="checkoutSuggestion-button-icon--bolt"
+                />
+                <TranslatedString
+                    data={ { providerFlow: 'Bolt Checkout' } }
+                    id="customer.suggestion_action"
+                />
+            </Button>
+        </div>
+    );
+};
+
+export default memo(BoltCheckoutSuggestion);

--- a/src/app/customer/checkoutSuggestion/CheckoutSuggestion.spec.tsx
+++ b/src/app/customer/checkoutSuggestion/CheckoutSuggestion.spec.tsx
@@ -1,0 +1,74 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount, render } from 'enzyme';
+import React, { FunctionComponent } from 'react';
+
+import { CheckoutProvider } from '../../checkout';
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { LocaleProvider } from '../../locale';
+
+import BoltCheckoutSuggestion from './BoltCheckoutSuggestion';
+import CheckoutSuggestion, { CheckoutSuggestionProps, WithCheckoutSuggestionsProps } from './CheckoutSuggestion';
+
+describe('CheckoutSuggestion', () => {
+    let defaultProps: WithCheckoutSuggestionsProps & CheckoutSuggestionProps;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let TestComponent: FunctionComponent<WithCheckoutSuggestionsProps & CheckoutSuggestionProps>;
+
+    beforeEach(() => {
+        defaultProps = {
+            deinitializeCustomer: jest.fn(),
+            executePaymentMethodCheckout: jest.fn(),
+            initializeCustomer: jest.fn(),
+            isExecutingPaymentMethodCheckout: false,
+            providerWithCustomCheckout: null,
+            onUnhandledError: jest.fn(),
+        };
+
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+
+        jest.spyOn(checkoutState.data, 'getCheckout')
+            .mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        TestComponent = props => (
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleProvider checkoutService={ checkoutService }>
+                    <CheckoutSuggestion { ...props } />
+                </LocaleProvider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('does not render anything if method id is not provided', () => {
+        const component = render(<TestComponent { ...defaultProps } />);
+
+        expect(component.get(0)).toBeFalsy();
+    });
+
+    it('initializes Bolt Checkout suggestion block', () => {
+        const container = mount(<TestComponent { ...defaultProps } providerWithCustomCheckout="bolt" />);
+        const component = container.find(BoltCheckoutSuggestion);
+
+        expect(component.props())
+            .toEqual(expect.objectContaining({
+                deinitializeCustomer: expect.any(Function),
+                executePaymentMethodCheckout: expect.any(Function),
+                initializeCustomer: expect.any(Function),
+                isExecutingPaymentMethodCheckout: false,
+                methodId: 'bolt',
+                onUnhandledError: expect.any(Function),
+            }));
+
+        expect(defaultProps.initializeCustomer).toHaveBeenCalledWith({
+            methodId: 'bolt',
+            bolt: {
+                onInit: expect.any(Function),
+            },
+        });
+    });
+});

--- a/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
+++ b/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
@@ -1,0 +1,57 @@
+import { CheckoutSelectors, CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '@bigcommerce/checkout-sdk';
+import React, { memo, FunctionComponent } from 'react';
+
+import { withCheckout, CheckoutContextProps } from '../../checkout';
+import { PaymentMethodId } from '../../payment/paymentMethod';
+
+import BoltCheckoutSuggestion from './BoltCheckoutSuggestion';
+
+export interface CheckoutSuggestionProps {
+    onUnhandledError?(error: Error): void;
+}
+
+export interface WithCheckoutSuggestionsProps {
+    isExecutingPaymentMethodCheckout: boolean;
+    providerWithCustomCheckout?: string;
+    deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
+    executePaymentMethodCheckout(options: ExecutePaymentMethodCheckoutOptions): Promise<CheckoutSelectors>;
+    initializeCustomer(options: CustomerInitializeOptions): Promise<CheckoutSelectors>;
+}
+
+const CheckoutSuggestion: FunctionComponent<WithCheckoutSuggestionsProps & CheckoutSuggestionProps> = ({
+   providerWithCustomCheckout,
+   ...rest
+}) => {
+    if (providerWithCustomCheckout === PaymentMethodId.Bolt) {
+        return <BoltCheckoutSuggestion methodId={ providerWithCustomCheckout } { ...rest } />;
+    }
+
+    return null;
+};
+
+const mapToCheckoutSuggestionProps = (
+    { checkoutService, checkoutState }: CheckoutContextProps
+): WithCheckoutSuggestionsProps | null => {
+    const {
+        data: { getCheckout, getConfig },
+        errors: {},
+        statuses: { isExecutingPaymentMethodCheckout },
+    } = checkoutState;
+
+    const checkout = getCheckout();
+    const config = getConfig();
+
+    if (!checkout || !config) {
+        return null;
+    }
+
+    return {
+        deinitializeCustomer: checkoutService.deinitializeCustomer,
+        executePaymentMethodCheckout: checkoutService.executePaymentMethodCheckout,
+        initializeCustomer: checkoutService.initializeCustomer,
+        isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+        providerWithCustomCheckout: config.checkoutSettings.providerWithCustomCheckout || undefined,
+    };
+};
+
+export default withCheckout(mapToCheckoutSuggestionProps)(memo(CheckoutSuggestion));

--- a/src/app/customer/checkoutSuggestion/index.tsx
+++ b/src/app/customer/checkoutSuggestion/index.tsx
@@ -1,0 +1,1 @@
+export { default as CheckoutSuggestion } from './CheckoutSuggestion';

--- a/src/app/customer/index.ts
+++ b/src/app/customer/index.ts
@@ -1,6 +1,7 @@
 export { CustomerProps } from './Customer';
 export { default as CustomerViewType } from './CustomerViewType';
 export { default as CustomerInfo, CustomerInfoProps, CustomerSignOutEvent } from './CustomerInfo';
+export { default as CheckoutSuggestion } from './checkoutSuggestion/CheckoutSuggestion';
 export { default as GuestForm, GuestFormProps, GuestFormValues } from './GuestForm';
 export { default as LoginForm, LoginFormProps, LoginFormValues } from './LoginForm';
 export { default as getPasswordRequirements, getPasswordRequirementsFromConfig, PasswordRequirements } from './getPasswordRequirements';

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -102,6 +102,7 @@
             "checkout_as_guest_text": "Checking out as a <strong>Guest</strong>? You'll be able to save your details to create an account with us later.",
             "continue_as_guest_action": "Continue as guest",
             "create_account_action": "Create Account",
+            "continue": "Continue",
             "set_password_action": "Save Password",
             "required_error": "{label} is required",
             "min_error": "{label} should be bigger than {min}",
@@ -149,7 +150,9 @@
             "sign_in_throttled_error": "Due to excessive login attempts, please wait 10 seconds before attempting to log in again.",
             "sign_out_action": "Sign Out",
             "sign_out_error": "An error occurred while signing out. Please try again.",
-            "subscribe_to_newsletter_text": "Yes, I'd like to receive updates."
+            "subscribe_to_newsletter_text": "Yes, I'd like to receive updates.",
+            "suggestion_text": "Looks like you have an account with {provider}. For fast checkout, continue with {providerFlow}.",
+            "suggestion_action": "{providerFlow}"
         },
         "login_email": {
             "error_server": "We couldn't send you a sign-in link. Please try again.",

--- a/src/scss/components/_components.scss
+++ b/src/scss/components/_components.scss
@@ -85,6 +85,9 @@
 // Checkout Steps
 @import "checkout/checkoutSteps/component";
 
+// Checkout Customer Suggestion
+@import "checkout/checkoutSuggestion/component";
+
 // GenericModal
 @import "checkout/genericModal/component";
 

--- a/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -99,10 +99,17 @@
 // Checkout Step Header
 // -----------------------------------------------------------------------------
 .stepHeader {
-    align-items: top;
+    padding: spacing("single") 0;
+
+    &.is-readonly {
+        cursor: default;
+    }
+}
+
+.stepHeader-row {
+    align-items: flex-start;
     display: flex;
     flex-wrap: wrap;
-    padding: spacing("single") 0;
 
     @include breakpoint("small") {
         flex-wrap: nowrap;
@@ -110,10 +117,6 @@
 
     @include breakpoint("large") {
         flex-wrap: nowrap;
-    }
-
-    &.is-readonly {
-        cursor: default;
     }
 }
 
@@ -163,5 +166,21 @@
 
     .button {
         margin-bottom: 0;
+    }
+}
+
+.stepHeader-suggestion {
+    margin: 0;
+
+    @include breakpoint("small") {
+        margin-left: remCalc($checkoutStep-counter-size) + $checkoutStep-header-figure-margin;
+    }
+
+    @include breakpoint("large") {
+        margin-left: 0;
+    }
+
+    @include breakpoint(1080px) {
+        margin-left: remCalc($checkoutStep-counter-size) + $checkoutStep-header-figure-margin;
     }
 }

--- a/src/scss/components/checkout/checkoutSuggestion/_checkoutSuggestion.scss
+++ b/src/scss/components/checkout/checkoutSuggestion/_checkoutSuggestion.scss
@@ -1,0 +1,61 @@
+.checkoutSuggestion {
+    align-items: center;
+    border: 1px solid $color-greyMedium;
+    border-radius: $global-radius;
+    cursor: default;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin: spacing("single") 0 0 0;
+    padding: spacing("single");
+    width: 100%;
+
+    @include breakpoint("medium") {
+        flex-direction: row;
+    }
+}
+
+.checkoutSuggestion-message {
+    color: $color-greyDarker;
+    font-weight: 400;
+    margin: 0 0 spacing("single") 0;
+    width: 100%;
+
+    @include breakpoint("medium") {
+        margin: 0 spacing("single") 0 0;
+        width: auto;
+    }
+}
+
+.checkoutSuggestion-button {
+    color: $buttonStyle-action-color;
+    margin: 0;
+    text-transform: initial;
+    white-space: nowrap;
+    width: 100%;
+
+    @include breakpoint("medium") {
+        width: auto;
+    }
+
+    &:hover {
+        color: $buttonStyle-action-color;
+    }
+
+    &--bolt {
+        background-color: $bolt-action-color;
+        border-color: $bolt-action-color;
+
+        &:hover {
+            background-color: $bolt-action-color-hover;
+            border-color: $bolt-action-color-hover;
+        }
+    }
+}
+
+.checkoutSuggestion-button-icon {
+    &--bolt {
+        height: 1rem;
+        margin-right: spacing("quarter");
+    }
+}

--- a/src/scss/components/checkout/checkoutSuggestion/_component.scss
+++ b/src/scss/components/checkout/checkoutSuggestion/_component.scss
@@ -1,6 +1,5 @@
 // =============================================================================
-// PAYMENT PROVIDER (Settings)
+// CHECKOUT SUGGESTION
 // =============================================================================
 
-$bolt-action-color: #006cff;
-$bolt-action-color-hover: #005ad5;
+@import "checkoutSuggestion";


### PR DESCRIPTION
feat(payment): BOLT-19 added Bolt Embedded One Click Checkout implementation and new generic CheckoutSuggestion component

## What?
Add Bolt Embedded One Click Checkout implementation.

<img width="1440" alt="screenshot_2021-07-30_at_18 19 19" src="https://user-images.githubusercontent.com/25133454/128998351-2f287341-15fe-4f47-931d-1604ba5223b0.png">

## Why?
Because of the task: https://jira.bigcommerce.com/browse/BOLT-19

## What was done?
- Extracted `CheckoutStep` component with `suggestion` prop to render `BoltCheckoutSuggestion` in collapsed Customer step;
- Changed 'Continue as guest' click handler to execute priority payment provider checkout;
- Created new generic `CheckoutSuggestion` component;
- Created new `BoltCheckoutSuggestion` component;
- Changed 'Continue as guest' button label to 'Continue' for cases if the shop has enabled interaction with provider's checkout.

To add Bolt Embedded One Click Checkout implementation I needed to handle next cases:
- customer should not interact with Bolt Embedded One Click Checkout, if 'Embedded one click' configuration mode is not enabled. 

_In this case Continue as guest has its own default flow, BoltCheckoutSuggestion will not be rendered and 'Continue as guest' button has default label_

https://user-images.githubusercontent.com/25133454/129000314-1349820d-da25-4934-a9bb-e39190022431.mov

- those customers who have Bolt account but _don't have BC account_, will have Bolt Checkout Modal opened on 'Continue' click, and if the customer close Bolt Checkout Modal he should have an ability to interact with Bolt Checkout Modal again through `BoltCheckoutSuggestion` component

https://user-images.githubusercontent.com/25133454/129001617-2dac5a6b-39e3-4dfc-bd88-f0247b1a421f.mov

- those customers who have Bolt account and _have BC account_, Login form will be shown by clicking on 'Continue' button. And if the customer wants to continue as guest he will have Bolt Checkout Modal opened on 'Continue' click. If the customer close Bolt Checkout Modal he should have an ability to interact with Bolt Checkout Modal again through `BoltCheckoutSuggestion` component

https://user-images.githubusercontent.com/25133454/129002011-a75eee89-fdf8-4e41-94ae-fc8678949bde.mov

- logged in customer should see BoltCheckoutSuggestion if 'Embedded one click' configuration mode is enabled and the customer has Bolt account

https://user-images.githubusercontent.com/25133454/129000783-343e9b31-c67e-41b5-b9ac-99cfbd3c9e58.mov

- customer should have an ability to interact with Bolt Embedded One Click Checkout any time when customer wants

https://user-images.githubusercontent.com/25133454/129000783-343e9b31-c67e-41b5-b9ac-99cfbd3c9e58.mov

## Testing / Proof
All unit tests passed locally and all the flows were tested couple times.

<img width="313" alt="Screenshot 2021-08-11 at 12 22 43" src="https://user-images.githubusercontent.com/25133454/129004312-a4e9cf90-4b08-49cb-94f8-991b4719e826.png">

## Sibling pull-requests
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1208

@bigcommerce/checkout
