### PR TITLE
fix(checkout): CHECKOUT-5823 Add label attribute for screen readers on coupon/gift certificate input field in cart summary at checkout

### DIFF
--- a/src/app/cart/Redeemable.spec.tsx
+++ b/src/app/cart/Redeemable.spec.tsx
@@ -58,6 +58,11 @@ describe('CartSummary Component', () => {
                 .toEqual(1);
         });
 
+        it('renders aria-label attribute on coupon input field', () => {
+            expect(component.find('input[aria-label="Gift Certificate or Coupon Code"]').length)
+                .toEqual(1);
+        });
+
         it('adds disabled and loading state to input', () => {
             const submit = component.find('[data-test="redeemableEntry-submit"]');
 

--- a/src/app/cart/Redeemable.tsx
+++ b/src/app/cart/Redeemable.tsx
@@ -68,11 +68,12 @@ const Redeemable: FunctionComponent<RedeemableProps & WithLanguageProps & Formik
     </Toggle>
 );
 
-const RedeemableForm: FunctionComponent<Partial<RedeemableProps> & FormikProps<RedeemableFormValues>> = ({
+const RedeemableForm: FunctionComponent<Partial<RedeemableProps> & FormikProps<RedeemableFormValues> & WithLanguageProps> = ({
     appliedRedeemableError,
     isApplyingRedeemable,
     clearError = noop,
     submitForm,
+    language,
 }) => {
     const handleKeyDown = useCallback(memoizeOne((setSubmitted: FormContextType['setSubmitted']) => (
         (event: KeyboardEvent) => {
@@ -128,6 +129,7 @@ const RedeemableForm: FunctionComponent<Partial<RedeemableProps> & FormikProps<R
             <div className="form-prefixPostfix">
                 <TextInput
                     { ...field }
+                    aria-label={ language.translate('redeemable.code_label') }
                     className="form-input optimizedCheckout-form-input"
                     onKeyDown={ handleKeyDown(setSubmitted) }
                     testId="redeemableEntry-input"
@@ -145,13 +147,7 @@ const RedeemableForm: FunctionComponent<Partial<RedeemableProps> & FormikProps<R
                 </Button>
             </div>
         </Fragment>
-    ), [
-        appliedRedeemableError,
-        handleKeyDown,
-        handleSubmit,
-        isApplyingRedeemable,
-        renderErrorMessage,
-    ]);
+    ), [appliedRedeemableError, handleKeyDown, handleSubmit, isApplyingRedeemable, language, renderErrorMessage]);
 
     const renderContent = useCallback(memoizeOne(({ setSubmitted }: FormContextType) => (
         <FormField


### PR DESCRIPTION
## What?
Adding an aria-label attribute to the coupon/gift certificate input field. The value will be populated by existing language already being used as the label for coupon/gift certificate input.
## Why?
To allow customers using screen reader software to more accurately navigate and input gift certificates/coupon codes during checkout. 
## Testing / Proof
Before:
<img width="912" alt="Screen Shot 2021-08-12 at 3 41 38 PM" src="https://user-images.githubusercontent.com/20911717/129266818-ed5b77d4-a60c-45c5-b7a6-db576c651f86.png">

After:
<img width="1009" alt="Screen Shot 2021-08-11 at 3 31 52 PM" src="https://user-images.githubusercontent.com/20911717/129266126-a18ce6b9-fe92-4ff6-bf79-6865ad165b19.png">

@bigcommerce/checkout
