### PR TITLE
chore(payment): PAYMENTS-7215 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.174.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.174.0.tgz",
-      "integrity": "sha512-ZEWm2oisKJfXo2+JAWHL85NfQLPF1Mpn4jgryhHisMmKMBUnIFRDS457PuToXdbBjs+YFbGz9kIWUnMliHlJmQ==",
+      "version": "1.175.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.1.tgz",
+      "integrity": "sha512-IbYWfeh+xSg4L460Vb6PsqQkcFlY+0TTUpxontcLipiiJeb1kxo2cwAdaR9Tqq+qpvw/0gR237RjSksQii3K9g==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.174.0",
+    "@bigcommerce/checkout-sdk": "^1.175.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
**N.B.** The PPSDK is behind a work in progress feature toggle

## What?

- Bump `checkout-sdk` to `1.175.1`

## Why?

- To inherit the PPSDK fix: https://jira.bigcommerce.com/browse/PAYMENTS-7215

## Testing / Proof

- Passing tests

@bigcommerce/checkout
