### PR TITLE
fix(checkout): PAYPAL-1118 removed unnecessary collapsing of checkout list elements for APMs without widget

### DIFF
--- a/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaypalCommercePaymentMethod.tsx
@@ -25,6 +25,10 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
     const paymentContext = useContext(PaymentContext);
     const { setSubmitted } = useContext(FormContext);
     const paymentUniqueId = `${uniqueId}-paymentWidget`;
+    const paymentMethodsWithoutWidget = ['venmo'];
+    const { method: { id } } = rest;
+
+    const shouldShowWidget = isAPM && !paymentMethodsWithoutWidget.includes(id);
 
     const initializePayPalCommercePayment = useCallback(options => initializePayment({
         ...options,
@@ -92,7 +96,7 @@ const PaypalCommercePaymentMethod: FunctionComponent<PaypalCommercePaymentMethod
         containerId={ paymentUniqueId }
         initializePayment={ initializePayPalCommercePayment }
         onUnhandledError={ onError }
-        shouldShow={ isAPM }
+        shouldShow={ shouldShowWidget }
     />;
 };
 


### PR DESCRIPTION

## What?
Removed unnecessary collapsing of checkout list elements for APMs without widget

## Why?
Due to the https://jira.bigcommerce.com/browse/PAYPAL-1118 PayPal commerce APMs without additional fields(widget) have more padding. When user selects APM without widgets, useless loader appears.

Created separate list of APMs that don't use widget to prevent this unnecessary collapsing and loader appearing.

## Testing / Proof
**Before:**
![Screenshot 2021-08-19 at 17 07 48](https://user-images.githubusercontent.com/79574476/130086126-22ac17c7-6ec6-40fd-9752-6de11bd7bab5.png)
**After:**
![Screenshot 2021-08-19 at 17 18 48](https://user-images.githubusercontent.com/79574476/130086174-5162a4e4-7c2f-428b-b0ad-726da33ec61c.png)


@bigcommerce/checkout
