### PR TITLE
chore(payment): INT-4672 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.175.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.1.tgz",
-      "integrity": "sha512-IbYWfeh+xSg4L460Vb6PsqQkcFlY+0TTUpxontcLipiiJeb1kxo2cwAdaR9Tqq+qpvw/0gR237RjSksQii3K9g==",
+      "version": "1.175.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.2.tgz",
+      "integrity": "sha512-zR4MIRC7OqGx3/K8Vt845K2Ny6V1uvVFdY7PNJfXYVlri04Hdmj6nZ+lXYvDdNLW7SRIZW0TRszvWaDa9QIncQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.175.1",
+    "@bigcommerce/checkout-sdk": "^1.175.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to 1.175.2

## Why?
We need to release changes from sdk https://github.com/bigcommerce/checkout-sdk-js/commit/9dfe1bdf9598c2acf8eb1ba0e5639b7adbe61d64

## Testing / Proof
Passing tests

@bigcommerce/checkout @bigcommerce/apex-integrations 
