### PR TITLE
feat(order): INT-4776 Create a new field for the mandate reference ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
-      "integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
@@ -145,9 +145,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001310",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001310.tgz",
-          "integrity": "sha512-cb9xTV8k9HTIUA3GnPUJCk0meUnrHL5gy5QePfDjxHyNBcnzPzrHFv5GqfP7ue5b1ZyzZL0RJboD6hQlPXjhjg=="
+          "version": "1.0.30001312",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+          "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
         }
       }
     },
@@ -1071,9 +1071,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
-          "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+          "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
           "requires": {
             "@babel/types": "^7.17.0",
             "jsesc": "^2.5.1",
@@ -1219,9 +1219,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-          "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw=="
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+          "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA=="
         },
         "@babel/template": {
           "version": "7.16.7",
@@ -1234,17 +1234,17 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
-          "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
           "requires": {
             "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.0",
+            "@babel/generator": "^7.17.3",
             "@babel/helper-environment-visitor": "^7.16.7",
             "@babel/helper-function-name": "^7.16.7",
             "@babel/helper-hoist-variables": "^7.16.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
-            "@babel/parser": "^7.17.0",
+            "@babel/parser": "^7.17.3",
             "@babel/types": "^7.17.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
@@ -1480,19 +1480,19 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.17.2",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.2.tgz",
-              "integrity": "sha512-R3VH5G42VSDolRHyUO4V2cfag8WHcZyxdq5Z/m8Xyb92lW/Erm/6kM+XtRFGf3Mulre3mveni2NHfEUws8wSvw==",
+              "version": "7.17.4",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
+              "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
               "requires": {
-                "@ampproject/remapping": "^2.0.0",
+                "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.17.0",
+                "@babel/generator": "^7.17.3",
                 "@babel/helper-compilation-targets": "^7.16.7",
                 "@babel/helper-module-transforms": "^7.16.7",
                 "@babel/helpers": "^7.17.2",
-                "@babel/parser": "^7.17.0",
+                "@babel/parser": "^7.17.3",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.17.0",
+                "@babel/traverse": "^7.17.3",
                 "@babel/types": "^7.17.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
@@ -1684,9 +1684,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.215.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.215.1.tgz",
-      "integrity": "sha512-p9bwwO2E9wDHySrnFxC+ROyBGZpbcKZHobnKnPN8YGHU0TYHh3NckPuwTMAHe0a4OSMI5zOiq2h2VJ0SPF4Myw==",
+      "version": "1.217.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.217.0.tgz",
+      "integrity": "sha512-i+5PRdR6dJrCt/UFobivey2qKZxtkImSEW9kK/oxLA5kR/Uy3Vd3JxzE3RBzyNRIc+DCwEs/aA0h8EXxPQiSIw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.15.1",
@@ -2221,14 +2221,14 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg=="
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew=="
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
-      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg=="
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.4",
@@ -7448,9 +7448,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.68",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.68.tgz",
-      "integrity": "sha512-cId+QwWrV8R1UawO6b9BR1hnkJ4EJPCPAr4h315vliHUtVUJDk39Sg1PMNnaWKfj5x+93ssjeJ9LKL6r8LaMiA=="
+      "version": "1.4.71",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
+      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.215.1",
+    "@bigcommerce/checkout-sdk": "^1.217.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -454,6 +454,20 @@
             "terms_and_conditions_heading": "Terms and Conditions"
         },
         "order_confirmation": {
+            "mandate": {
+                "checkoutcom": {
+                    "boleto": "Boleto Bancário Ticket",
+                    "oxxo": "OXXO Ticket",
+                    "sepa": "SEPA Direct Debit (via Checkout.com) Mandate Reference: {mandate}"
+                },
+                "stripev3": {
+                    "iban": "SEPA Direct Debit Mandate"
+                },
+                "stripe_upe": {
+                    "boleto": "Boleto Bancário Ticket",
+                    "oxxo": "OXXO Ticket"
+                }
+            },
             "order_number_text": "Your order number is <strong>{orderNumber}</strong>",
             "order_pending_review_text": "Your order was sent to us but is currently awaiting payment. Once we receive the payment for your order, it will be completed. If you've already provided payment details then we will process your order manually and send you an email when it's completed.",
             "order_pending_status_text": "We've received your order and are processing your payment. Once the payment is verified, your order will be completed. We will send you an email when it's completed. Please note, this process may take a few minutes depending on the processing times of your chosen method. If you have any questions about your purchase, email us at <a href=\"mailto:{supportEmail}?Subject=Order {orderNumber}\" target=\"_top\">{supportEmail}</a>.",
@@ -465,11 +479,7 @@
             "thank_you_customer_heading": "Thank you {name}!",
             "thank_you_heading": "Thank you!",
             "continue_shopping": "Continue Shopping »",
-            "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger",
-            "mandate_link_text": "{provider} Mandate",
-            "boleto_link_text": "Boleto Bancário Ticket",
-            "oxxo_link_text": "OXXO Ticket",
-            "sepa_link_text": "SEPA Direct Debit Mandate"
+            "order_status_update_facebook_messenger_heading": "Get instant updates of your order to Messenger"
         }
     }
 }

--- a/src/app/order/orders.mock.ts
+++ b/src/app/order/orders.mock.ts
@@ -55,6 +55,26 @@ export function getOrder(): Order {
     };
 }
 
+export function getOrderWithMandateId(): Order {
+    const order = getOrder();
+    order.payments = [
+        getGatewayOrderPaymentWithMandateId(),
+        getGiftCertificateOrderPayment(),
+    ];
+
+    return order;
+}
+
+export function getOrderWithMandateURL(): Order {
+    const order = getOrder();
+    order.payments = [
+        getGatewayOrderPaymentWithMandateURL(),
+        getGiftCertificateOrderPayment(),
+    ];
+
+    return order;
+}
+
 export function getGatewayOrderPayment(): GatewayOrderPayment {
     return {
         providerId: 'authorizenet',
@@ -63,6 +83,39 @@ export function getGatewayOrderPayment(): GatewayOrderPayment {
         detail: {
             step: 'FINALIZE',
             instructions: '<strong>295</strong> something',
+        },
+    };
+}
+
+export function getGatewayOrderPaymentWithMandateId(): GatewayOrderPayment {
+    return {
+        providerId: 'checkoutcom',
+        description: 'SEPA Direct Debit (via Checkout.com)',
+        amount: 190,
+        methodId: 'sepa',
+        detail: {
+            step: 'FINALIZE',
+            instructions: '<strong>295</strong> something',
+        },
+        mandate: {
+            id: 'ABC12345',
+        },
+    };
+}
+
+export function getGatewayOrderPaymentWithMandateURL(): GatewayOrderPayment {
+    return {
+        providerId: 'checkoutcom',
+        description: 'SEPA Direct Debit (via Checkout.com)',
+        amount: 190,
+        methodId: 'sepa',
+        detail: {
+            step: 'FINALIZE',
+            instructions: '<strong>295</strong> something',
+        },
+        mandate: {
+            id: '',
+            url: 'https://www.test.com/mandate',
         },
     };
 }


### PR DESCRIPTION
## What?
Display mandate reference ID  as text only when mandate url is empty.

Also remove the part of the code that searched for the mandate text and used it to build the mandate text, instead use the new method Id to use it as a key and map it to the correct mandate text.

## Why?
So the mandate link does not redirect to a 404 page.

Also the translation of the mandate text is done properly and not built into the code.

## Testing / Proof
[Demo Videos](https://drive.google.com/drive/folders/1VcyX_5nMpL3Ri0nMPOcgDqWWBq0Kmzvx?usp=sharing)
<img width="716" alt="Screen Shot 2021-08-23 at 3 41 02 PM" src="https://user-images.githubusercontent.com/35502707/130525591-aac7e1ea-dc02-4b9c-89c1-d6c3e5b0fb0b.png">

## Sibling PRs
https://github.com/bigcommerce/bigcommerce/pull/42364
https://github.com/bigcommerce/bigpay/pull/4234

https://github.com/bigcommerce/checkout-sdk-js/pull/1220

## Merge Order
1) https://github.com/bigcommerce/checkout-sdk-js/pull/1220

2) https://github.com/bigcommerce/bigcommerce/pull/42364
https://github.com/bigcommerce/bigpay/pull/4234
https://github.com/bigcommerce/checkout-js/pull/674

@bigcommerce/checkout @bigcommerce/apex-integrations 
