### PR TITLE
chore(payment): INT-4594 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.175.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.4.tgz",
-      "integrity": "sha512-sTMSFxf5IqjR19HOK0wSlWSdCyMaCBvtEmNGw+OOBm4IWLxqO9drnXViw8lQURPy8Ojrr5+OiH9lMMzNJBAwXg==",
+      "version": "1.175.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.5.tgz",
+      "integrity": "sha512-7w88GiXXQGprt4hmK5ZX38LhuapDwhaLHEGkYXsEFeWCP7IrD39uxWg9zDnv5bgK69SqXrz1u2R7QeBxitvyVA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.175.4",
+    "@bigcommerce/checkout-sdk": "^1.175.5",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to 1.175.5

## Why?
We need to release changes from sdk https://github.com/bigcommerce/checkout-sdk-js/commit/116a79c13b10b547000fb7599cd370afb8fbd6a8

## Testing / Proof
Passing tests

@bigcommerce/checkout @bigcommerce/apex-integrations 
