### PR TITLE
chore(checkout): CHECK-5757 bump up checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.175.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.5.tgz",
-      "integrity": "sha512-7w88GiXXQGprt4hmK5ZX38LhuapDwhaLHEGkYXsEFeWCP7IrD39uxWg9zDnv5bgK69SqXrz1u2R7QeBxitvyVA==",
+      "version": "1.175.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.6.tgz",
+      "integrity": "sha512-HdbJOR6UBLBpCQZk316JBR3e6MtugZ0mbe2DNuMMiqTUUjHp+OT4f/sRomPeCm9MsZ2May0QorXMLd9YYtun1g==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.175.5",
+    "@bigcommerce/checkout-sdk": "^1.175.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to 1.175.6

## Why?
We need to release changes from [SDK](https://github.com/bigcommerce/checkout-sdk-js/commit/e49795db4597f100ca3caa7f3bfd07e9f2481a55), which addresses [Checkout-5757](https://jira.bigcommerce.com/browse/CHECKOUT-5757).


## Testing / Proof
All tests passed.

@bigcommerce/checkout @bigcommerce/apex-integrations 
