### PR TITLE
fix(payment): PAYMENTS-7221 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.175.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.175.6.tgz",
-      "integrity": "sha512-HdbJOR6UBLBpCQZk316JBR3e6MtugZ0mbe2DNuMMiqTUUjHp+OT4f/sRomPeCm9MsZ2May0QorXMLd9YYtun1g==",
+      "version": "1.177.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.177.1.tgz",
+      "integrity": "sha512-mCiK2BKmlDlwmw48PPkhITLuAjdVUqNYZDu4rOJQ32rgYFBK0P904sRD4cwiSGEZdPMkdiPAzxHipbjP0dOrKg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.175.6",
+    "@bigcommerce/checkout-sdk": "^1.177.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
**N.B.** The PPSDK is behind a work in progress feature toggle

## What?

- Bump `checkout-sdk` to `1.177.1`

## Why?

- To inherit the PPSDK fix: https://jira.bigcommerce.com/browse/PAYMENTS-7221

## Testing / Proof

- Passing tests

@bigcommerce/checkout
