### PR TITLE
fix(checkout): CHECKOUT-5980 invalid aria-labelledby values

### DIFF
--- a/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -9,6 +9,7 @@ import GoogleAutocompleteService from './GoogleAutocompleteService';
 
 interface GoogleAutocompleteProps {
     initialValue?: string;
+    labelContent: ReactNode;
     componentRestrictions?: google.maps.places.ComponentRestrictions;
     fields?: string[];
     apiKey: string;
@@ -40,6 +41,7 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
 
     render(): ReactNode {
         const {
+            labelContent,
             initialValue,
             onToggleOpen = noop,
             inputProps = {},
@@ -59,6 +61,7 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
                     autoComplete,
                 } }
                 items={ items }
+                labelContent={ labelContent }
                 listTestId="address-autocomplete-suggestions"
                 onChange={ this.onChange }
                 onSelect={ this.onSelect }

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
@@ -56,6 +56,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
             isAutocompleteEnabled={ countryCode ?
                 supportedCountries.indexOf(countryCode) > -1 :
                 false }
+            labelContent={ labelContent }
             nextElement={ nextElement }
             onChange={ onChange }
             onSelect={ onSelect }
@@ -65,6 +66,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         apiKey,
         countryCode,
         inputProps,
+        labelContent,
         nextElement,
         onChange,
         onSelect,
@@ -76,7 +78,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         <div className={ `dynamic-form-field dynamic-form-field--addressLineAutocomplete` }>
             <FormField
                 input={ renderInput }
-                labelContent={ labelContent }
+                labelContent={ null }
                 name={ fieldName }
             />
         </div>

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
@@ -78,7 +78,6 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         <div className={ `dynamic-form-field dynamic-form-field--addressLineAutocomplete` }>
             <FormField
                 input={ renderInput }
-                labelContent={ null }
                 name={ fieldName }
             />
         </div>

--- a/src/app/address/googleAutocomplete/__snapshots__/GoogleAutocomplete.spec.tsx.snap
+++ b/src/app/address/googleAutocomplete/__snapshots__/GoogleAutocomplete.spec.tsx.snap
@@ -7,6 +7,11 @@ exports[`GoogleAutocomplete Component renders input with initial value 1`] = `
   aria-labelledby="downshift-0-label"
   role="combobox"
 >
+  <label
+    class="form-label optimizedCheckout-form-label"
+    for="downshift-0-input"
+    id="downshift-0-label"
+  />
   <input
     aria-autocomplete="list"
     aria-labelledby="downshift-0-label"

--- a/src/app/ui/autocomplete/Autocomplete.tsx
+++ b/src/app/ui/autocomplete/Autocomplete.tsx
@@ -8,6 +8,7 @@ import AutocompleteItem from './autocomplete-item';
 
 export interface AutocompleteProps {
     initialValue?: string;
+    labelContent: ReactNode;
     initialHighlightedIndex?: number;
     children?: ReactNode;
     items: AutocompleteItem[];
@@ -21,6 +22,7 @@ export interface AutocompleteProps {
 class Autocomplete extends PureComponent<AutocompleteProps> {
     render(): ReactNode {
         const {
+            labelContent,
             inputProps,
             initialValue,
             initialHighlightedIndex,
@@ -46,11 +48,18 @@ class Autocomplete extends PureComponent<AutocompleteProps> {
                     getMenuProps,
                     getItemProps,
                     highlightedIndex,
+                       getLabelProps,
                 }) => (
                     <div>
+                        <label
+                            className="form-label optimizedCheckout-form-label"
+                            { ...getLabelProps() }
+                        >
+                            { labelContent }
+                        </label>
                         <input
-                            { ...getInputProps() }
                             { ...inputProps }
+                            { ...getInputProps() }
                         />
                         { isOpen && !!items.length &&
                             <Popover>

--- a/src/app/ui/autocomplete/Autocomplete.tsx
+++ b/src/app/ui/autocomplete/Autocomplete.tsx
@@ -48,7 +48,7 @@ class Autocomplete extends PureComponent<AutocompleteProps> {
                     getMenuProps,
                     getItemProps,
                     highlightedIndex,
-                       getLabelProps,
+                    getLabelProps,
                 }) => (
                     <div>
                         <label

--- a/src/app/ui/autocomplete/__snapshots__/Autocomplete.spec.tsx.snap
+++ b/src/app/ui/autocomplete/__snapshots__/Autocomplete.spec.tsx.snap
@@ -7,6 +7,11 @@ exports[`Autocomplete Component renders input with initial value 1`] = `
   aria-labelledby="downshift-0-label"
   role="combobox"
 >
+  <label
+    class="form-label optimizedCheckout-form-label"
+    for="downshift-0-input"
+    id="downshift-0-label"
+  />
   <input
     aria-autocomplete="list"
     aria-labelledby="downshift-0-label"


### PR DESCRIPTION
## What? [CHECKOUT-5980](https://jira.bigcommerce.com/browse/CHECKOUT-5980)
- Use `getLabelProps()` from [Downshift](https://www.downshift-js.com) to create a dynamic `id` attribute for an autocomplete input field's label, which aligns with the sample usage of [\<Downshift\> component](https://www.downshift-js.com/downshift).
- Update two snapshots to cover the code change.
## Why?
<img width="680" alt="_1__-_Hi__We_re_ready_right_now_to_provide_you_with_a_free_LIVE_face_to_face_personalized_skin_consultation_-2" src="https://user-images.githubusercontent.com/88361607/131297017-6844973c-b72a-4c46-990d-642983df3b3c.png">

As stated in [CHECKOUT-5980](https://jira.bigcommerce.com/browse/CHECKOUT-5980), the screen reader fails now because of  a label's missing dynamic `id` attribute(e.g., `id="downshift-0-label"`). Sometimes, the `id` can be `downshift-2-label`. Therefore,  this fix will create label `id` dynamically with Downshift.

## Testing / Proof
<img width="680" alt="Screen Shot 2021-08-30 at 10 48 23 am" src="https://user-images.githubusercontent.com/88361607/131297822-9001c3fd-4414-4a55-a48a-01a3e6367ce5.png">

Demo after code change.

https://user-images.githubusercontent.com/88361607/131297982-62e5efe3-3ca1-460c-a51d-99eeb893a2f2.mov

HTML of the address input field. Before:

```HTML
<div class="dynamic-form-field dynamic-form-field--addressLineAutocomplete">
    <div class="form-field">
        <label for="shippingAddress.address1" class="form-label optimizedCheckout-form-label">Address</label>
        <div role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-labelledby="downshift-0-label">
            <input aria-autocomplete="list" aria-labelledby="downshift-0-label" autocomplete="off"
                   id="addressLine1Input" class="form-input optimizedCheckout-form-input" value="">
        </div>
    </div>
</div>
```

After:
```HTML
<div class="dynamic-form-field dynamic-form-field--addressLineAutocomplete">
    <div class="form-field">
        <div role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-labelledby="downshift-0-label">
            <label
                    class="form-label optimizedCheckout-form-label" for="downshift-0-input"
                    id="downshift-0-label">Address</label>
            <input class="form-input optimizedCheckout-form-input"
                   id="downshift-0-input" autocomplete="off"
                   aria-autocomplete="list"
                   aria-labelledby="downshift-0-label" value="">
        </div>
    </div>
</div>
```

@bigcommerce/checkout