### PR TITLE
chore(checkout): PAYPAL-1111 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.177.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.177.1.tgz",
-      "integrity": "sha512-mCiK2BKmlDlwmw48PPkhITLuAjdVUqNYZDu4rOJQ32rgYFBK0P904sRD4cwiSGEZdPMkdiPAzxHipbjP0dOrKg==",
+      "version": "1.178.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.178.0.tgz",
+      "integrity": "sha512-SZECPtzpUOHH6W8FPNNaad/QnF+Ybaaz509gAJsr0bGVRi/DjGGunWnVxG+DRGVfx5Vz0+WzdpwpyELnbazqaw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.177.1",
+    "@bigcommerce/checkout-sdk": "^1.178.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-js version
SDK PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1217

## Why?
Release of PAYPAL-1111

## Testing / Proof
Tested manually

@bigcommerce/checkout
