### PR TITLE
chore(checkout): BOLT-49 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.178.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.178.0.tgz",
-      "integrity": "sha512-SZECPtzpUOHH6W8FPNNaad/QnF+Ybaaz509gAJsr0bGVRi/DjGGunWnVxG+DRGVfx5Vz0+WzdpwpyELnbazqaw==",
+      "version": "1.179.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.179.0.tgz",
+      "integrity": "sha512-N6sBldplxoQR/J3AHIajsXgkdhW3U2KWIjAVxBH2P6WN+kPFIWiT2Jp5hRhWhtFhtMGKjb4dKVmIbg2o+qdc/Q==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.178.0",
+    "@bigcommerce/checkout-sdk": "^1.179.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-js version

## Why?
Release of BOLT-49

## Testing / Proof
Unit tests

## Sibling pull-request
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1229

@bigcommerce/checkout
