### PR TITLE
chore(checkout): ADYEN-231 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.179.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.179.0.tgz",
-      "integrity": "sha512-N6sBldplxoQR/J3AHIajsXgkdhW3U2KWIjAVxBH2P6WN+kPFIWiT2Jp5hRhWhtFhtMGKjb4dKVmIbg2o+qdc/Q==",
+      "version": "1.179.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.179.1.tgz",
+      "integrity": "sha512-He+IxGSQ22as2AiqxHFpYcyCfIXIJZrpLthF2vqVVliT1Wn84vr98mEQ3IiiUN3ob9xw2bofW4opMrNuh/Jpeg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.179.0",
+    "@bigcommerce/checkout-sdk": "^1.179.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
Due release of [ADYEN-231](https://jira.bigcommerce.com/browse/ADYEN-231)
https://github.com/bigcommerce/checkout-sdk-js/pull/1230

## Testing / Proof
Tested Manually

@bigcommerce/checkout
