### PR TITLE
feat(payment): BOLT-24 added Bolt account creation checkbox into Bolt EmbeddedPaymentMethod component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.181.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.181.0.tgz",
-      "integrity": "sha512-KSaJvMwkpIbH3CpTmQy7zGnWvXuX/dDiMdkFWDsMY9nJuXsWUVI3r7aYlKG+vDNuitmhPKnDq/Wt78f5HIIpFw==",
+      "version": "1.182.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.182.0.tgz",
+      "integrity": "sha512-VM/i701uuIkllcPQTdX/Qvm+egpL0C2CqOqGGCtfX/yTwbRLDQo3AEAjknFjEbgDH6D0TJhwPFKKOIaPuK4QwQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.181.0",
+    "@bigcommerce/checkout-sdk": "^1.182.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -185,6 +185,8 @@
             "barclaycard_continue_action": "Continue",
             "bluesnap_v2_continue_action": "Continue",
             "bolt_continue_action": "Continue with Bolt",
+            "bolt_create_account_label": "Remember my information with Bolt",
+            "bolt_create_account_disclaimer": "By checking above, you are agreeing to create a Bolt Account under <a href=\"{termsUrl}\" target=\"_blank\">terms</a> and <a href=\"{privacyPolicyUrl}\" target=\"_blank\">privacy policy</a>.",
             "bolt_name_text": "Bolt",
             "braintreevisacheckout_continue_action": "Continue with Visa Checkout",
             "ccavenuemars_description_text": "Checkout with CCAvenue",

--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -238,6 +238,7 @@ describe('PaymentForm', () => {
                 ccName: 'Foo Bar',
                 ccExpiry: '10 / 22',
                 paymentProviderRadio: defaultProps.defaultMethodId,
+                shouldCreateAccount: false,
                 shouldSaveInstrument: false,
                 terms: false,
             });

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -243,7 +243,6 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
     mapPropsToValues: ({
         defaultGatewayId,
         defaultMethodId,
-
     }) => ({
         ccCustomerCode: '',
         ccCvv: '',
@@ -255,6 +254,7 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
         ccNumber: '',
         paymentProviderRadio: getUniquePaymentMethodId(defaultMethodId, defaultGatewayId),
         instrumentId: '',
+        shouldCreateAccount: false,
         shouldSaveInstrument: false,
         terms: false,
         hostedForm: {

--- a/src/app/payment/paymentMethod/BoltCustomForm.spec.tsx
+++ b/src/app/payment/paymentMethod/BoltCustomForm.spec.tsx
@@ -1,8 +1,11 @@
 import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 import BoltCustomForm, { BoltCustomFormProps } from './BoltCustomForm';
 
+/* eslint-disable react/jsx-no-bind */
 describe('BoltCustomForm', () => {
     let defaultProps: BoltCustomFormProps;
     let BoltCustomFormTest: FunctionComponent<BoltCustomFormProps>;
@@ -10,6 +13,7 @@ describe('BoltCustomForm', () => {
     beforeEach(() => {
         defaultProps = {
             containerId: 'boltEmbeddedOneClick',
+            showCreateAccountCheckbox: false,
         };
 
         BoltCustomFormTest = props => (
@@ -18,8 +22,40 @@ describe('BoltCustomForm', () => {
     });
 
     it('renders bolt embedded field', () => {
-        const container = mount(<BoltCustomFormTest { ...defaultProps }  />);
+        const container = mount(
+            <Formik
+                initialValues={ { shouldCreateAccount: true } }
+                onSubmit={ noop }
+                render={ () => <BoltCustomFormTest { ...defaultProps } /> }
+            />
+        );
 
-        expect(container.find('[id="boltEmbeddedOneClick"]')).toHaveLength(1);
+        expect(container.find('[id="boltEmbeddedOneClick"]').exists()).toEqual(true);
+    });
+
+    it('renders bolt embedded field and shows create account checkbox', () => {
+        const container = mount(
+            <Formik
+                initialValues={ { shouldCreateAccount: true } }
+                onSubmit={ noop }
+                render={ () => <BoltCustomFormTest { ...defaultProps } showCreateAccountCheckbox /> }
+            />
+        );
+
+        expect(container.find('[id="boltEmbeddedOneClick"]').exists()).toEqual(true);
+        expect(container.find('[name="shouldCreateAccount"]').exists()).toEqual(true);
+    });
+
+    it('renders bolt embedded field without showing create account checkbox', () => {
+        const container = mount(
+            <Formik
+                initialValues={ { shouldCreateAccount: false } }
+                onSubmit={ noop }
+                render={ () => <BoltCustomFormTest { ...defaultProps } /> }
+            />
+        );
+
+        expect(container.find('[id="boltEmbeddedOneClick"]').exists()).toEqual(true);
+        expect(container.find('[name="shouldCreateAccount"]').exists()).toEqual(false);
     });
 });

--- a/src/app/payment/paymentMethod/BoltCustomForm.tsx
+++ b/src/app/payment/paymentMethod/BoltCustomForm.tsx
@@ -1,16 +1,45 @@
 import React, { FunctionComponent } from 'react';
 
+import { TranslatedHtml, TranslatedString } from '../../locale';
+import { CheckboxFormField } from '../../ui/form';
+
 export interface BoltCustomFormProps {
     containerId: string;
+    showCreateAccountCheckbox: boolean;
 }
 
-const BoltCustomForm: FunctionComponent<BoltCustomFormProps> = ({ containerId }) => {
+const accountDisclaimerTranslationOptions = {
+    privacyPolicyUrl: 'https://www.bolt.com/privacy/',
+    termsUrl: 'https://www.bolt.com/end-user-terms/',
+};
+
+const BoltCreateAccountCheckbox: FunctionComponent = () => {
+    const labelContent = (
+        <>
+            <TranslatedString id="payment.bolt_create_account_label" />
+            <br />
+            <TranslatedHtml
+                data={ accountDisclaimerTranslationOptions }
+                id="payment.bolt_create_account_disclaimer"
+            />
+        </>
+    );
+
+    return <CheckboxFormField
+        additionalClassName="form-checkbox form-field--createAccount"
+        labelContent={ labelContent }
+        name="shouldCreateAccount"
+    />;
+};
+
+const BoltCustomForm: FunctionComponent<BoltCustomFormProps> = ({ containerId, showCreateAccountCheckbox }) => {
     return (
         <div className="form-ccFields">
             <div
                 className="form-field form-field--bolt-embed"
                 id={ containerId }
             />
+            { showCreateAccountCheckbox ? <BoltCreateAccountCheckbox /> : null }
         </div>
     );
 };

--- a/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.spec.tsx
@@ -91,6 +91,7 @@ describe('BoltEmbeddedPaymentMethod', () => {
                 bolt: {
                     containerId: 'bolt-embedded',
                     useBigCommerceCheckout: true,
+                    onPaymentSelect: expect.any(Function),
                 },
             }));
     });

--- a/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, FunctionComponent } from 'react';
+import React, { useCallback, useState, FunctionComponent } from 'react';
 
 import BoltCustomForm from './BoltCustomForm';
 import { HostedPaymentMethodProps } from './HostedPaymentMethod';
@@ -9,6 +9,8 @@ const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = (
     method,
     ...rest
 }) => {
+    const [ showCreateAccountCheckbox, setShowCreateAccountCheckbox ] = useState(false);
+
     const boltEmbeddedContainerId = 'bolt-embedded';
 
     const initializeBoltPayment = useCallback(options => initializePayment({
@@ -16,6 +18,9 @@ const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = (
             bolt: {
                 containerId: boltEmbeddedContainerId,
                 useBigCommerceCheckout: true,
+                onPaymentSelect: (hasBoltAccount: boolean) => {
+                    setShowCreateAccountCheckbox(!hasBoltAccount);
+                },
             },
         }
     ), [initializePayment, boltEmbeddedContainerId]);
@@ -23,8 +28,9 @@ const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = (
     const renderCustomPaymentForm = useCallback(() => (
         <BoltCustomForm
             containerId={ boltEmbeddedContainerId }
+            showCreateAccountCheckbox={ showCreateAccountCheckbox }
         />
-    ), [ boltEmbeddedContainerId ]);
+    ), [ boltEmbeddedContainerId, showCreateAccountCheckbox ]);
 
     return <HostedWidgetPaymentMethod
         { ...rest }

--- a/src/scss/components/bigcommerce/forms-ccFields/_forms-ccFields.scss
+++ b/src/scss/components/bigcommerce/forms-ccFields/_forms-ccFields.scss
@@ -34,6 +34,10 @@
     height: remCalc(56px);
 }
 
+.form-field--createAccount {
+    height: auto;
+}
+
 .mollie {
     &-full {
         flex-basis: 100%;


### PR DESCRIPTION
## What?
Added Bolt account creation checkbox under mounted Bolt filed in BoltEmbeddedPaymentMethod

## Why?
Because of the task: https://jira.bigcommerce.com/browse/BOLT-24

## Testing / Proof
Unit tests
Manual test

Here is a screenshot of the checkbox:
<img width="1300" alt="4 14 15 32" src="https://user-images.githubusercontent.com/25133454/132622550-2b5f649f-3867-4ac0-9290-a9b598d3a2d4.png">

## Sibling pull-request
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1235

@bigcommerce/checkout
