### PR TITLE
feat(payment): INT-4828 Adding custom error message for all dropin error

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -224,6 +224,7 @@
             "credit_card_number_last_four": "Enter card number for {cardType} ending in {lastFour}",
             "credit_card_number_required_error": "Credit Card Number is required",
             "credit_card_number_mismatch_error": "The card number entered does not match the card stored in your account",
+            "digitalriver_dropin_error": "There was an error while processing your payment. Please try again or contact us.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Continue with Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useContext, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
 import { connectFormik, ConnectFormikProps } from '../../common/form';
+import { withLanguage, WithLanguageProps } from '../../locale';
 import { FormContext } from '../../ui/form';
 import { PaymentFormValues } from '../PaymentForm';
 
@@ -14,8 +15,9 @@ export enum DigitalRiverClasses {
     base =  'form-input optimizedCheckout-form-input',
 }
 
-const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProps> = ({
+const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProps & WithLanguageProps> = ({
     initializePayment,
+    language,
     onUnhandledError,
     formik: { submitForm },
     ...rest
@@ -45,11 +47,11 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
                 setSubmitted(true);
                 submitForm();
             },
-            onError: (error: Error) => {
-                onUnhandledError?.(error);
+            onError: () => {
+                onUnhandledError?.(new Error(language.translate('payment.digitalriver_dropin_error')));
             },
         },
-    }), [initializePayment, containerId, isVaultingEnabled, setSubmitted, submitForm, onUnhandledError]);
+    }), [initializePayment, containerId, isVaultingEnabled, setSubmitted, submitForm, onUnhandledError, language]);
 
     return <HostedDropInPaymentMethod
         { ...rest }
@@ -59,4 +61,4 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
     />;
 };
 
-export default connectFormik(DigitalRiverPaymentMethod);
+export default connectFormik(withLanguage(DigitalRiverPaymentMethod));


### PR DESCRIPTION
## What? [INT-4828](https://jira.bigcommerce.com/browse/INT-4828)
Add custom error message for all drop-in errors using Digital River

## Why?
Digital River requested this message "There was an error while processing your payment. Please try again or contact us." should be displayed for all cases that DR drop-in send an error
![image (2)](https://user-images.githubusercontent.com/42154828/132415763-c24031f2-19c2-4559-b507-f8f300e26436.png)

## Testing / Proof
<img width="1076" alt="Screen Shot 2021-08-31 at 2 37 08 PM" src="https://user-images.githubusercontent.com/42154828/132414316-1fd85cf2-9c04-4739-85a0-186817b94774.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
