### PR TITLE
chore(payment): PAYMENTS-7252 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,9 +114,9 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
       "requires": {
         "@babel/compat-data": "^7.15.0",
         "@babel/helper-validator-option": "^7.14.5",
@@ -1010,11 +1010,11 @@
           }
         },
         "@babel/generator": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+          "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
           "requires": {
-            "@babel/types": "^7.15.0",
+            "@babel/types": "^7.15.4",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           },
@@ -1027,105 +1027,105 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.14.5",
-            "@babel/template": "^7.14.5",
-            "@babel/types": "^7.14.5"
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-          "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-hoist-variables": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-          "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+          "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
           "requires": {
-            "@babel/types": "^7.15.0"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-          "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-          "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz",
+          "integrity": "sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==",
           "requires": {
-            "@babel/helper-module-imports": "^7.14.5",
-            "@babel/helper-replace-supers": "^7.15.0",
-            "@babel/helper-simple-access": "^7.14.8",
-            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/helper-module-imports": "^7.15.4",
+            "@babel/helper-replace-supers": "^7.15.4",
+            "@babel/helper-simple-access": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
             "@babel/helper-validator-identifier": "^7.14.9",
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.15.0",
-            "@babel/types": "^7.15.0"
+            "@babel/template": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-optimise-call-expression": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-          "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+          "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+          "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.15.0",
-            "@babel/helper-optimise-call-expression": "^7.14.5",
-            "@babel/traverse": "^7.15.0",
-            "@babel/types": "^7.15.0"
+            "@babel/helper-member-expression-to-functions": "^7.15.4",
+            "@babel/helper-optimise-call-expression": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-          "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+          "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
           "requires": {
-            "@babel/types": "^7.14.8"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helpers": {
-          "version": "7.15.3",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.3.tgz",
-          "integrity": "sha512-HwJiz52XaS96lX+28Tnbu31VeFSQJGOeKHJeaEPQlTl7PnlhFElWPj8tUXtqFIzeN86XxXoBr+WFAyK2PPVz6g==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+          "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
           "requires": {
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.15.0",
-            "@babel/types": "^7.15.0"
+            "@babel/template": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/highlight": {
@@ -1185,40 +1185,40 @@
           }
         },
         "@babel/parser": {
-          "version": "7.15.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
-          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA=="
+          "version": "7.15.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.5.tgz",
+          "integrity": "sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg=="
         },
         "@babel/template": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
           "requires": {
             "@babel/code-frame": "^7.14.5",
-            "@babel/parser": "^7.14.5",
-            "@babel/types": "^7.14.5"
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/traverse": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
           "requires": {
             "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.15.0",
-            "@babel/helper-function-name": "^7.14.5",
-            "@babel/helper-hoist-variables": "^7.14.5",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.15.0",
-            "@babel/types": "^7.15.0",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.4.tgz",
+          "integrity": "sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
@@ -1264,9 +1264,9 @@
           }
         },
         "@types/babel__core": {
-          "version": "7.1.15",
-          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-          "integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+          "version": "7.1.16",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+          "integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0",
@@ -1430,19 +1430,19 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.15.0",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-              "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+              "version": "7.15.5",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+              "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
               "requires": {
                 "@babel/code-frame": "^7.14.5",
-                "@babel/generator": "^7.15.0",
-                "@babel/helper-compilation-targets": "^7.15.0",
-                "@babel/helper-module-transforms": "^7.15.0",
-                "@babel/helpers": "^7.14.8",
-                "@babel/parser": "^7.15.0",
-                "@babel/template": "^7.14.5",
-                "@babel/traverse": "^7.15.0",
-                "@babel/types": "^7.15.0",
+                "@babel/generator": "^7.15.4",
+                "@babel/helper-compilation-targets": "^7.15.4",
+                "@babel/helper-module-transforms": "^7.15.4",
+                "@babel/helpers": "^7.15.4",
+                "@babel/parser": "^7.15.5",
+                "@babel/template": "^7.15.4",
+                "@babel/traverse": "^7.15.4",
+                "@babel/types": "^7.15.4",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.180.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.180.0.tgz",
-      "integrity": "sha512-WAjFE2e4q3QT5BDUCWv8zCBseADcWOnCaSg5rujgRzPQkHsE8tLBREStPg+7zS0yPk2798glVTP7076fSeeJKg==",
+      "version": "1.180.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.180.1.tgz",
+      "integrity": "sha512-HcC7rffj1+Hgw/wWcXPASU99fcM+l92YKbtbV6vNflTjbQPFGmSB1b5RnbdjU/J7rZCa4SWvL12/79D7nDZxcA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.180.0",
+    "@bigcommerce/checkout-sdk": "^1.180.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
**N.B.** The PPSDK is behind a work in progress feature toggle

## What?

- Bump `checkout-sdk` to `1.180.1`

## Why?

- To inherit the PPSDK fix: https://jira.bigcommerce.com/browse/PAYMENTS-7252

## Testing / Proof

- Passing tests

@bigcommerce/checkout
