### PR TITLE
feat(payment): PAYPAL-954 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.180.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.180.1.tgz",
-      "integrity": "sha512-HcC7rffj1+Hgw/wWcXPASU99fcM+l92YKbtbV6vNflTjbQPFGmSB1b5RnbdjU/J7rZCa4SWvL12/79D7nDZxcA==",
+      "version": "1.181.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.181.0.tgz",
+      "integrity": "sha512-KSaJvMwkpIbH3CpTmQy7zGnWvXuX/dDiMdkFWDsMY9nJuXsWUVI3r7aYlKG+vDNuitmhPKnDq/Wt78f5HIIpFw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.180.1",
+    "@bigcommerce/checkout-sdk": "^1.181.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to https://jira.bigcommerce.com/browse/PAYPAL-954

## Testing / Proof
Tested on dev and int

@bigcommerce/checkout
