### PR TITLE
fix(checkout): CHECKOUT-5980 invalid aria-labelledby values

### DIFF
--- a/src/app/address/getAddressFormFieldInputId.ts
+++ b/src/app/address/getAddressFormFieldInputId.ts
@@ -15,3 +15,6 @@ export function getAddressFormFieldLegacyName(name: string): string {
 export function getAddressFormFieldInputId(name: string): string {
     return `${getAddressFormFieldLegacyName(name)}Input`;
 }
+export function getAddressFormFieldLabelId(name: string): string {
+    return `${getAddressFormFieldLegacyName(name)}Label`;
+}

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
@@ -5,7 +5,7 @@ import React, { memo, useCallback, useMemo, FunctionComponent } from 'react';
 import { TranslatedString } from '../../locale';
 import { AutocompleteItem } from '../../ui/autocomplete';
 import { FormField } from '../../ui/form';
-import { getAddressFormFieldInputId } from '../getAddressFormFieldInputId';
+import { getAddressFormFieldInputId, getAddressFormFieldLabelId } from '../getAddressFormFieldInputId';
 
 import GoogleAutocomplete from './GoogleAutocomplete';
 
@@ -40,10 +40,13 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         <TranslatedString id="address.address_line_1_label" />
     ), []);
 
+    const labelID = getAddressFormFieldLabelId(name);
+
     const inputProps = useMemo(() => ({
         className: 'form-input optimizedCheckout-form-input',
         id: getAddressFormFieldInputId(name),
-    }), [name]);
+        'aria-labelledby': labelID,
+    }), [name, labelID]);
 
     const renderInput = useCallback(({ field }: FieldProps) => (
         <GoogleAutocomplete
@@ -76,7 +79,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         <div className={ `dynamic-form-field dynamic-form-field--addressLineAutocomplete` }>
             <FormField
                 input={ renderInput }
-                labelContent={ labelContent }
+                label={ <label className="form-label optimizedCheckout-form-label" htmlFor={ inputProps.id } id={ labelID }>{ labelContent }</label> }
                 name={ fieldName }
             />
         </div>

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
@@ -4,7 +4,7 @@ import React, { memo, useCallback, useMemo, FunctionComponent } from 'react';
 
 import { TranslatedString } from '../../locale';
 import { AutocompleteItem } from '../../ui/autocomplete';
-import { FormField } from '../../ui/form';
+import { FormField, Label } from '../../ui/form';
 import { getAddressFormFieldInputId, getAddressFormFieldLabelId } from '../getAddressFormFieldInputId';
 
 import GoogleAutocomplete from './GoogleAutocomplete';
@@ -79,7 +79,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         <div className={ `dynamic-form-field dynamic-form-field--addressLineAutocomplete` }>
             <FormField
                 input={ renderInput }
-                label={ <label className="form-label optimizedCheckout-form-label" htmlFor={ inputProps.id } id={ labelID }>{ labelContent }</label> }
+                label={ <Label htmlFor={ inputProps.id } id={ labelID }>{ labelContent }</Label> }
                 name={ fieldName }
             />
         </div>

--- a/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
+++ b/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
@@ -40,13 +40,13 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         <TranslatedString id="address.address_line_1_label" />
     ), []);
 
-    const labelID = getAddressFormFieldLabelId(name);
+    const labelId = getAddressFormFieldLabelId(name);
 
     const inputProps = useMemo(() => ({
         className: 'form-input optimizedCheckout-form-input',
         id: getAddressFormFieldInputId(name),
-        'aria-labelledby': labelID,
-    }), [name, labelID]);
+        'aria-labelledby': labelId,
+    }), [name, labelId]);
 
     const renderInput = useCallback(({ field }: FieldProps) => (
         <GoogleAutocomplete
@@ -79,7 +79,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
         <div className={ `dynamic-form-field dynamic-form-field--addressLineAutocomplete` }>
             <FormField
                 input={ renderInput }
-                label={ <Label htmlFor={ inputProps.id } id={ labelID }>{ labelContent }</Label> }
+                label={ <Label htmlFor={ inputProps.id } id={ labelId }>{ labelContent }</Label> }
                 name={ fieldName }
             />
         </div>

--- a/src/app/ui/autocomplete/Autocomplete.tsx
+++ b/src/app/ui/autocomplete/Autocomplete.tsx
@@ -36,6 +36,7 @@ class Autocomplete extends PureComponent<AutocompleteProps> {
                 initialHighlightedIndex={ initialHighlightedIndex }
                 initialInputValue={ initialValue }
                 itemToString={ this.itemToString }
+                labelId={ inputProps && inputProps['aria-labelledby'] ? inputProps['aria-labelledby'] : null }
                 onChange={ onSelect }
                 onStateChange={ this.handleStateChange }
                 stateReducer={ this.stateReducer }


### PR DESCRIPTION
## What? 
- Calculate an `id` value for a `<label>`, and pass it to `<Downshift>` as the value of `aria-labelledby`, so that a screen reader can pick up an autocomplete input field's name.
-  No modification on tests.
## Why?
- As stated in [CHECKOUT-5980](https://jira.bigcommerce.com/browse/CHECKOUT-5980), a screen reader software fails now because the autocomplete address input does not have a matching `id` attribute.

## Testing / Proof
HTML code before:
```
<div class="dynamic-form-field dynamic-form-field--addressLineAutocomplete">
  <div class="form-field">
    <label
      for="shippingAddress.address1"
      class="form-label optimizedCheckout-form-label"
      >Address</label
    >
    <div
      role="combobox"
      aria-expanded="false"
      aria-haspopup="listbox"
      aria-labelledby="downshift-0-label"
    >
      <input
        aria-autocomplete="list"
        aria-labelledby="downshift-0-label"
        autocomplete="off"
        id="addressLine1Input"
        class="form-input optimizedCheckout-form-input"
        value=""
      />
    </div>
  </div>
</div>
```

After:
```
<div class="dynamic-form-field dynamic-form-field--addressLineAutocomplete">
  <div class="form-field">
    <label
      for="addressLine1Input"
      id="addressLine1Label"
      class="form-label optimizedCheckout-form-label"
      >Address</label
    >
    <div
      role="combobox"
      aria-expanded="false"
      aria-haspopup="listbox"
      aria-labelledby="addressLine1Label"
    >
      <input
        aria-autocomplete="list"
        aria-labelledby="addressLine1Label"
        autocomplete="off"
        id="addressLine1Input"
        class="form-input optimizedCheckout-form-input"
        value=""
      />
    </div>
  </div>
</div>

```

- An alpha release of `checkout-js` has been tested on Launchbay at:
https://app.circleci.com/pipelines/github/bigcommerce/bigcommerce?branch=pull%2F42735
All Google address autocomplete tests passed.