### PR TITLE
fix(payment): BOLT-54 fixed an issue with customer strategy deinitialisation

### DIFF
--- a/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.tsx
@@ -5,9 +5,10 @@ import { HostedPaymentMethodProps } from './HostedPaymentMethod';
 import HostedWidgetPaymentMethod from './HostedWidgetPaymentMethod';
 
 const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = ({
+    isInitializing,
     initializePayment,
+    deinitializePayment,
     method,
-    ...rest
 }) => {
     const [ showCreateAccountCheckbox, setShowCreateAccountCheckbox ] = useState(false);
 
@@ -33,9 +34,10 @@ const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = (
     ), [ boltEmbeddedContainerId, showCreateAccountCheckbox ]);
 
     return <HostedWidgetPaymentMethod
-        { ...rest }
         containerId="boltEmbeddedOneClick"
+        deinitializePayment={ deinitializePayment }
         initializePayment={ initializeBoltPayment }
+        isInitializing={ isInitializing }
         method={ method }
         renderCustomPaymentForm={ renderCustomPaymentForm }
         shouldRenderCustomInstrument


### PR DESCRIPTION
## What?
Fixed an issue with Bolt customer strategy deinitialisation when closing payment step.

Videos of the problem:

The first one is about closing payment step by going to the billing tab and trying to use customer suggestion block.
https://user-images.githubusercontent.com/25133454/133968716-21927042-6a61-4e05-a9ce-00704fdc3ad2.mov

The second one is about closing payment step by opening customer step and trying to use customer strategy by click on 'Continue' button.
https://user-images.githubusercontent.com/25133454/133968737-28489066-bfbe-497d-90d3-3ffe8a572aa6.mov

## Why?
HostedWidgetPaymentMethod asynchronously deinitialize bolt customer strategy that was initialized in customer step. Deinitialize and initialize customer strategies unnecessary for Bolt payment provider in HostedWidgetPaymentMethod.

## Testing / Proof
Manual tests

Videos of the fixed issue:
https://user-images.githubusercontent.com/25133454/134030614-65f46e54-292a-4327-b2e8-30eb1fc7f75b.mov
https://user-images.githubusercontent.com/25133454/134030715-15af5b5d-a97f-4d68-8ba5-e32deb74a867.mov


@bigcommerce/checkout
