### PR TITLE
chore(checkout): ADYEN-260 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.183.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.183.0.tgz",
-      "integrity": "sha512-O0HclFuCf/XU03uyaKr/bZTkosV2xPWHIv++Ipx7jfmhInGETXUmlmpzSw34zHETGnagy0bwTt3dr1Vv40T4TQ==",
+      "version": "1.183.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.183.1.tgz",
+      "integrity": "sha512-zlykgxIaTz4gNm/I0YwNbF8WzL1WEF6nsK0HJCUgz06GWQ5rjhqShCCmQk6FbB+VxSR16dex8qZQDgHS85nERQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.183.0",
+    "@bigcommerce/checkout-sdk": "^1.183.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout-sdk version

## Why?
Due to the https://jira.bigcommerce.com/browse/ADYEN-260
SDK PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1244

## Testing / Proof
Tested manually. GooglePay didn't change customer email in checkout
![image](https://user-images.githubusercontent.com/79574476/134336917-ffa5b140-64c9-4470-a809-da039050cb35.png)


@bigcommerce/checkout
