### PR TITLE
fix(payment): BOLT-60 fixed an issue with checkout step header with large font-size

### DIFF
--- a/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -26,6 +26,14 @@
     }
 }
 
+.checkout-view-header {
+    margin-bottom: remCalc(10px);
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
 .checkout-view-content {
     @include breakpoint("large") {
         @include collapse;
@@ -107,7 +115,6 @@
 }
 
 .stepHeader-row {
-    align-items: flex-start;
     display: flex;
     flex-wrap: wrap;
 


### PR DESCRIPTION
## What?
Fixed an issue with checkout step header with large font-size

## Why?
Because of the task:
https://jira.bigcommerce.com/browse/BOLT-60

And because of the issue:
https://github.com/bigcommerce/checkout-js/issues/703

## Testing / Proof
Here are some screenshots of the result

Default title font size:
<img width="1176" alt="Screenshot 2021-09-23 at 17 14 28" src="https://user-images.githubusercontent.com/25133454/134523745-0ef69c0e-0c3f-45d3-9960-e18e40dfffd5.png">

Title font size 32px:
<img width="1177" alt="Screenshot 2021-09-23 at 17 15 57" src="https://user-images.githubusercontent.com/25133454/134523916-be222f04-7491-4b23-8acf-203915e0dc84.png">

Title font size 65px:
<img width="1429" alt="Screenshot 2021-09-23 at 16 40 52" src="https://user-images.githubusercontent.com/25133454/134521674-8a02e1b2-d8e7-4ca5-8461-c4b5025bb2e0.png">

