### PR TITLE
feat(checkout): CHECKOUT-6032 Assert error banners on checkout page

### DIFF
--- a/src/app/ui/alert/Alert.tsx
+++ b/src/app/ui/alert/Alert.tsx
@@ -54,7 +54,7 @@ const Alert: FunctionComponent<AlertProps> = ({
             { icon ? icon : renderDefaultIcon(type) }
         </div>
 
-        <div className="alertBox-column alertBox-message">
+        <div aria-live="assertive" className="alertBox-column alertBox-message" role="alert">
             { children }
         </div>
     </div>

--- a/src/app/ui/alert/__snapshots__/Alert.spec.tsx.snap
+++ b/src/app/ui/alert/__snapshots__/Alert.spec.tsx.snap
@@ -10,7 +10,9 @@ exports[`Alert matches snapshot 1`] = `
     <Memo() />
   </div>
   <div
+    aria-live="assertive"
     className="alertBox-column alertBox-message"
+    role="alert"
   >
     Hello world
   </div>


### PR DESCRIPTION
## What
- Add attributes `role="alert"`, `aria-live="assertive"` to alert text.

## Why
- With these two attributes, a screen reader can announce error messages on Checkout page automatically and immediately.  [Checkout-6032](https://jira.bigcommerce.com/browse/Checkout-5928)
- `role="alert"` : https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
- `aria-live="assertive"`: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions

## Testing / Proof
Tested on MAC's voice over. The alert message will be read out as soon as it appears.
Also, it is mentioned on [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) that using `role="alert"` and `aria-live="assertive"` together may cause double speaking on iOS. Can confirm it is no longer an issue on iOS 15.

https://user-images.githubusercontent.com/88361607/135219219-a11946cf-84b9-4064-bbf1-68cc258c7b58.mov

@bigcommerce/checkout