### PR TITLE
feat(payment): PAYPAL-972 bump checkout sdk js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.183.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.183.2.tgz",
-      "integrity": "sha512-YwqQCvFDash5pAM0ZkEMOdUeY74yK9C+TKCzWlGlGDXuUuBpNjFP0WcsLHeRQTND+ip9N5DiqkaXOnIcbV7mfQ==",
+      "version": "1.185.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.185.0.tgz",
+      "integrity": "sha512-ye4oriCPlxj32hfKfXfK1XTOX+NyBwUHbZbYCZz//izoQoaESDJjyybZHnZnqBvSF1SOaA+TssAhjRYY9L0M3g==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -1693,9 +1693,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.173",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
-          "integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg=="
+          "version": "4.14.175",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+          "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
         },
         "@types/yup": {
           "version": "0.26.37",
@@ -1850,9 +1850,9 @@
       "dev": true
     },
     "@braintree/browser-detection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.12.0.tgz",
-      "integrity": "sha512-fmZcaXYkXr9b0J+3HwXLQogIYV+xSS6aBG7LGu0OjLkSD/k62EAu2xLGEDFHUu6siH/I7vvGoC0/Ds3f3RnS6g=="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.12.1.tgz",
+      "integrity": "sha512-i/54qrax5o/WbJJhsE/7qqKE594/kGhR+xSu/w13rT7Mlr/uITkWDXzxffcKQ6l6FQxK0IG0EfgT6TJpWgZcUQ=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.183.2",
+    "@bigcommerce/checkout-sdk": "^1.185.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task https://jira.bigcommerce.com/browse/PAYPAL-972
SDK PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1240

## Testing / Proof
<img width="998" alt="Screenshot 2021-09-14 at 16 37 12" src="https://user-images.githubusercontent.com/56301104/135231427-b1d353a1-45d1-4d5f-88b7-24dbafba0816.png">


@bigcommerce/checkout
