### PR TITLE
feat(payment): INT-4836 Openpay: New logo on checkout page

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -33,7 +33,7 @@ describe('PaymentMethodTitle', () => {
         klarna: '/img/payment-providers/klarna-header.png',
         laybuy: '/img/payment-providers/laybuy-checkout-header.png',
         masterpass: 'https://masterpass.com/dyn/img/acc/global/mp_mark_hor_blk.svg',
-        opy: '/img/payment-providers/opy.png',
+        opy: '/img/payment-providers/opy.svg',
         paypal: '/img/payment-providers/paypalpaymentsprouk.png',
         quadpay: '/img/payment-providers/quadpay.png',
         sezzle: '/img/payment-providers/sezzle-checkout-header.png',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -106,7 +106,7 @@ function getPaymentMethodTitle(
                 titleText: '',
             },
             [PaymentMethodId.Opy]: {
-                logoUrl: cdnPath('/img/payment-providers/opy.png'),
+                logoUrl: cdnPath('/img/payment-providers/opy.svg'),
                 titleText: '',
             },
             [PaymentMethodType.Paypal]: {


### PR DESCRIPTION
## What? [INT-4836](https://jira.bigcommerce.com/browse/INT-4836)
Update `PaymentMethodTitle` logo URL for Openpay.

## Why?
Openpay wants us to display this logo instead. 🤷🏻‍♂️

## Testing / Proof
**_Before:_**
<img width="550" alt="Openpay before" src="https://user-images.githubusercontent.com/4843328/132403575-63a08d94-eb40-4ef8-bdff-3e66b1a2b994.png">
**_After:_**
<img width="550" alt="Openpay after" src="https://user-images.githubusercontent.com/4843328/135358384-f86936ad-63fd-43f6-bfb2-9226c2f42ed7.png">

## Sibling PR:
☝️😅 This PR depends on https://github.com/bigcommerce/bigcommerce/pull/42979.

@bigcommerce/checkout
