### PR TITLE
feat(payment): PAYPAL-1103 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.185.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.185.1.tgz",
-      "integrity": "sha512-dr/SXVgnYe6UGiwHf2L9hzX8CW7q6WwPbZ0iyQbnt4hLV/7pGaH0F95AvND4X3vl9v2VvU6+APDMnl1phw/ZrQ==",
+      "version": "1.186.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.186.0.tgz",
+      "integrity": "sha512-9pUfh7s4hlIXWk6pPc0VjyXnbj0hhcsyY60Do9ZXubKWFUM/UB58zzPQ0MAKfZ4b/ptRS9fMBsurvWyXWuDP5w==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.185.1",
+    "@bigcommerce/checkout-sdk": "^1.186.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task https://jira.bigcommerce.com/browse/PAYPAL-1103
SDK PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1245

## Testing / Proof
Tested on integration

<img width="1157" alt="Screenshot 2021-09-21 at 21 08 46" src="https://user-images.githubusercontent.com/56301104/135428725-f6a8f4f1-417b-400b-a6d0-f5fbe75d8207.png">

@bigcommerce/checkout
