### PR TITLE
chore(payment): ADYEN-260 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.186.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.186.0.tgz",
-      "integrity": "sha512-9pUfh7s4hlIXWk6pPc0VjyXnbj0hhcsyY60Do9ZXubKWFUM/UB58zzPQ0MAKfZ4b/ptRS9fMBsurvWyXWuDP5w==",
+      "version": "1.186.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.186.1.tgz",
+      "integrity": "sha512-TFI4pF2lUb6iEdDRQyNsOEtswjLteUJ9iKVUiRWHTJAVJIz1ab6QsBjHuLY2tEVuy2HGZ89KIVJ2T5rZdMt4bw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.186.0",
+    "@bigcommerce/checkout-sdk": "^1.186.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of https://jira.bigcommerce.com/browse/ADYEN-260
SDK PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1251

## Why?
Due to the https://github.com/bigcommerce/checkout-sdk-js/pull/1251

## Testing / Proof
Look for testing / proof section at this PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/1251

@bigcommerce/checkout
