### PR TITLE
chore(payment) PAYMENTS-7322 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.186.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.186.1.tgz",
-      "integrity": "sha512-TFI4pF2lUb6iEdDRQyNsOEtswjLteUJ9iKVUiRWHTJAVJIz1ab6QsBjHuLY2tEVuy2HGZ89KIVJ2T5rZdMt4bw==",
+      "version": "1.187.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.187.1.tgz",
+      "integrity": "sha512-ATIah/tKGLfBv49XOHQ526N0+mg2nhi/2OEMwXRJMfycc9/rCtGjQftAlQodWzqzzbxG5RHSmbx1LHeGKP2PEA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -5744,11 +5744,6 @@
             "yargs-parser": "^18.1.3"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
         "minimist-options": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
@@ -5850,11 +5845,6 @@
             "strip-indent": "^3.0.0"
           }
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
         "strip-indent": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -5885,11 +5875,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         },
         "yargs-parser": {
           "version": "18.1.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.186.1",
+    "@bigcommerce/checkout-sdk": "^1.187.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

- Bump checkout-sdk version to `1.187.1`

## Why?

- To release: https://jira.bigcommerce.com/browse/PAYMENTS-7322 -  an incremental change to the PPSDK strategy (itself behind a WIP feature toggle)

## Testing / Proof

- Passing tests

@bigcommerce/checkout
