### PR TITLE
chore(payment): ADYEN-253 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.187.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.187.1.tgz",
-      "integrity": "sha512-ATIah/tKGLfBv49XOHQ526N0+mg2nhi/2OEMwXRJMfycc9/rCtGjQftAlQodWzqzzbxG5RHSmbx1LHeGKP2PEA==",
+      "version": "1.188.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.188.1.tgz",
+      "integrity": "sha512-JjJx1XY9OLagQIieWWBsBkNjYXVKtpv1mcokfd8o9rl3NtPewXeVC6d0BOPDYywYj6fRWS1mQ5Bw7QrgrP4fTA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.187.1",
+    "@bigcommerce/checkout-sdk": "^1.188.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/1257

## Why?
Due to the https://jira.bigcommerce.com/browse/ADYEN-253

## Testing / Proof
Testing / Proof section here https://github.com/bigcommerce/checkout-sdk-js/pull/1257

@bigcommerce/checkout
