### PR TITLE
feat(payment): BOLT-69 set create_account checkbox checked by default for Bolt Embedded payment form

### DIFF
--- a/src/app/payment/PaymentForm.spec.tsx
+++ b/src/app/payment/PaymentForm.spec.tsx
@@ -238,7 +238,7 @@ describe('PaymentForm', () => {
                 ccName: 'Foo Bar',
                 ccExpiry: '10 / 22',
                 paymentProviderRadio: defaultProps.defaultMethodId,
-                shouldCreateAccount: false,
+                shouldCreateAccount: true,
                 shouldSaveInstrument: false,
                 terms: false,
             });

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -254,7 +254,7 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
         ccNumber: '',
         paymentProviderRadio: getUniquePaymentMethodId(defaultMethodId, defaultGatewayId),
         instrumentId: '',
-        shouldCreateAccount: false,
+        shouldCreateAccount: true,
         shouldSaveInstrument: false,
         terms: false,
         hostedForm: {

--- a/src/app/payment/paymentMethod/BoltCustomForm.spec.tsx
+++ b/src/app/payment/paymentMethod/BoltCustomForm.spec.tsx
@@ -43,7 +43,7 @@ describe('BoltCustomForm', () => {
         );
 
         expect(container.find('[id="boltEmbeddedOneClick"]').exists()).toEqual(true);
-        expect(container.find('[name="shouldCreateAccount"]').exists()).toEqual(true);
+        expect(container.find('[id="shouldCreateAccount"]').exists()).toEqual(true);
     });
 
     it('renders bolt embedded field without showing create account checkbox', () => {
@@ -56,6 +56,18 @@ describe('BoltCustomForm', () => {
         );
 
         expect(container.find('[id="boltEmbeddedOneClick"]').exists()).toEqual(true);
-        expect(container.find('[name="shouldCreateAccount"]').exists()).toEqual(false);
+        expect(container.find('[id="shouldCreateAccount"]').exists()).toEqual(false);
+    });
+
+    it('renders bolt embedded field with checked account creation checkbox by default', () => {
+        const container = mount(
+            <Formik
+                initialValues={ { shouldCreateAccount: true } }
+                onSubmit={ noop }
+                render={ () => <BoltCustomFormTest { ...defaultProps } showCreateAccountCheckbox /> }
+            />
+        );
+
+        expect(container.find('[id="shouldCreateAccount"]').hostNodes().props().checked).toEqual(true);
     });
 });


### PR DESCRIPTION
## What?
Made shouldCreateAccount checkbox in Bolt Embedded Payment form checked by default

## Why?
Because of the task: https://jira.bigcommerce.com/browse/BOLT-69

## Testing / Proof
Manual tests
Unit tests

Screenshot of test result:
<img width="348" alt="Screenshot 2021-10-06 at 10 45 03" src="https://user-images.githubusercontent.com/25133454/136161664-4d19e453-53e4-4761-b6bd-73dbf63e8268.png">

Video of the flow:
https://user-images.githubusercontent.com/25133454/136161706-72ce1bde-1dcc-4827-8c96-d3a71357dcba.mov


@bigcommerce/checkout
