### PR TITLE
fix(payment): BOLT-70 fixed Bolt Embedded Execution error after submit

### DIFF
--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -55,6 +55,7 @@ export type PaymentFormValues = (
     SepaCustomFormFieldsetValues & PaymentFormCommonValues |
     FawryCustomFormFieldsetValues & PaymentFormCommonValues |
     IdealCustomFormFieldsetValues & PaymentFormCommonValues |
+    AccountCreationValues & PaymentFormCommonValues |
     PaymentFormCommonValues
 );
 
@@ -65,6 +66,10 @@ export interface PaymentFormCommonValues {
 
 export interface HostedWidgetPaymentMethodValues {
     shouldSaveInstrument: boolean;
+}
+
+export interface AccountCreationValues {
+    shouldCreateAccount: boolean;
 }
 
 const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormValues> & WithLanguageProps> = ({
@@ -211,6 +216,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
             ccNumber: '',
             instrumentId: '',
             paymentProviderRadio: getUniquePaymentMethodId(method.id, method.gateway),
+            shouldCreateAccount: true,
             shouldSaveInstrument: false,
         });
 


### PR DESCRIPTION
## What?
Added `shouldCreateAccount` key to reset payment form method to have the same values as form has on initialisation.  

## Why?
When the customer switched between payment methods `shouldCreateAccount` disappear  from Formik values. Therefore when customer tries to submit form using Bolt payment method (after switching between payment methods), checkout-sdk-js throws an error because `shouldCreateAccount` is provided.

Here is a link to the task with video of the problem:
https://jira.bigcommerce.com/browse/BOLT-70

## Testing / Proof
Manual tests
Unit tests 

Screenshot of test results:
<img width="317" alt="Screenshot 2021-10-06 at 16 40 36" src="https://user-images.githubusercontent.com/25133454/136220514-7eef05a4-7be0-44ec-ae8a-5e57bf776aae.png">

Here is a video of the flow:
https://user-images.githubusercontent.com/25133454/136220715-c2980803-24ff-4b0d-8111-98f300c2adb4.mov


@bigcommerce/checkout
