### PR TITLE
chore(payment): PAYMENTS-7187 remove WIP feature toggle for PPSDK strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.190.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.190.0.tgz",
-      "integrity": "sha512-RTrUjU5CTXJPFtCESS6XKGGln1Q+UgCvozegiz0YryIf6+pV6KC4Uh+Clm/uhXnmLZpUSMD3MpZvRByfmzaIgg==",
+      "version": "1.190.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.190.1.tgz",
+      "integrity": "sha512-/zbgUS1DaOj7GkuHW6XnAo2QgCVJugEHcx2Wop6r2DLKvAyaRmaWS09gZ28WEETgFcwDO3EnL0kan89aJP4XkQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.190.0",
+    "@bigcommerce/checkout-sdk": "^1.190.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -163,41 +163,12 @@ describe('PaymentSubmitButton', () => {
             .toEqual(languageService.translate('payment.zip_continue_action'));
     });
 
-    describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is off', () => {
-        beforeEach(() => {
-            const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': false };
-            const storeConfig = set(getStoreConfig(), 'checkoutSettings.features', flagValues);
+    it('renders button with label of "Continue with ${methodName}"', () => {
+        const component = mount(
+            <PaymentSubmitButtonTest initialisationStrategyType="none" methodName="Foo" />
+        );
 
-            jest.spyOn(checkoutState.data, 'getConfig')
-                .mockReturnValue(storeConfig);
-        });
-
-        it('does not render button with label of "Continue with ${methodName}"', () => {
-            const component = mount(
-                <PaymentSubmitButtonTest initialisationStrategyType="none" methodName="Foo" />
-            );
-
-            expect(component.text())
-                .not.toEqual(languageService.translate('payment.ppsdk_continue_action', { methodName: 'Foo' }));
-        });
-    });
-
-    describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is on', () => {
-        beforeEach(() => {
-            const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': true };
-            const storeConfig = set(getStoreConfig(), 'checkoutSettings.features', flagValues);
-
-            jest.spyOn(checkoutState.data, 'getConfig')
-                .mockReturnValue(storeConfig);
-        });
-
-        it('renders button with label of "Continue with ${methodName}"', () => {
-            const component = mount(
-                <PaymentSubmitButtonTest initialisationStrategyType="none" methodName="Foo" />
-            );
-
-            expect(component.text())
-                .toEqual(languageService.translate('payment.ppsdk_continue_action', { methodName: 'Foo' }));
-        });
+        expect(component.text())
+            .toEqual(languageService.translate('payment.ppsdk_continue_action', { methodName: 'Foo' }));
     });
 });

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -13,14 +13,13 @@ interface PaymentSubmitButtonTextProps {
     methodType?: string;
     methodName?: string;
     initialisationStrategyType?: string;
-    isPpsdkEnabled?: boolean;
 }
 
 const providersWithCustomClasses = [PaymentMethodId.Bolt];
 
-const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> = memo(({ methodId, methodName, methodType, methodGateway, isPpsdkEnabled = false, initialisationStrategyType }) => {
+const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> = memo(({ methodId, methodName, methodType, methodGateway, initialisationStrategyType }) => {
 
-    if (isPpsdkEnabled && methodName && initialisationStrategyType === 'none') {
+    if (methodName && initialisationStrategyType === 'none') {
         return <TranslatedString data={ { methodName } } id="payment.ppsdk_continue_action" />;
     }
 
@@ -94,7 +93,6 @@ export interface PaymentSubmitButtonProps {
 interface WithCheckoutPaymentSubmitButtonProps {
     isInitializing?: boolean;
     isSubmitting?: boolean;
-    isPpsdkEnabled: boolean;
 }
 
 const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithCheckoutPaymentSubmitButtonProps> = ({
@@ -105,7 +103,6 @@ const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithChec
     methodId,
     methodName,
     methodType,
-    isPpsdkEnabled,
     initialisationStrategyType,
 }) => (
         <Button
@@ -120,7 +117,6 @@ const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithChec
         >
             <PaymentSubmitButtonText
                 initialisationStrategyType={ initialisationStrategyType }
-                isPpsdkEnabled={ isPpsdkEnabled }
                 methodGateway={ methodGateway }
                 methodId={ methodId }
                 methodName={ methodName }
@@ -129,7 +125,7 @@ const PaymentSubmitButton: FunctionComponent<PaymentSubmitButtonProps & WithChec
         </Button>
     );
 
-export default withCheckout(({ checkoutState, checkoutService }) => {
+export default withCheckout(({ checkoutState }) => {
     const {
         statuses: {
             isInitializingCustomer,
@@ -138,15 +134,8 @@ export default withCheckout(({ checkoutState, checkoutService }) => {
         },
     } = checkoutState;
 
-    const isPpsdkEnabled = Boolean(
-        checkoutService.getState()
-            .data.getConfig()
-            ?.checkoutSettings.features['PAYMENTS-6806.enable_ppsdk_strategy']
-    );
-
     return {
         isInitializing: isInitializingCustomer() || isInitializingPayment(),
         isSubmitting: isSubmittingOrder(),
-        isPpsdkEnabled,
     };
 })(memo(PaymentSubmitButton));

--- a/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
@@ -1,7 +1,7 @@
 import { createCheckoutService, CheckoutSelectors, CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import { Formik } from 'formik';
-import { noop, set } from 'lodash';
+import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 import { getBillingAddress } from '../../billing/billingAddresses.mock';
@@ -426,53 +426,31 @@ describe('PaymentMethod', () => {
             };
         });
 
-        describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is off', () => {
-            beforeEach(() => {
-                const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': false };
-                const storeConfig = set(getStoreConfigMock(), 'checkoutSettings.features', flagValues);
-                getStoreConfigMock.mockReturnValue(storeConfig);
-            });
+        it('renders as a PPSDK payment method', () => {
+            const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
 
-            it('does not render as a PPSDK payment method', () => {
-                const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
-
-                expect(container.find(PPSDKPaymentMethod).exists()).toBe(false);
-            });
+            expect(container.find(PPSDKPaymentMethod).props())
+                .toEqual(expect.objectContaining({
+                    deinitializePayment: expect.any(Function),
+                    initializePayment: expect.any(Function),
+                    method,
+                }));
         });
 
-        describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is on', () => {
-            beforeEach(() => {
-                const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': true };
-                const storeConfig = set(getStoreConfigMock(), 'checkoutSettings.features', flagValues);
-                getStoreConfigMock.mockReturnValue(storeConfig);
+        it('initializes method with required config', () => {
+            const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+            const component = container.find(PPSDKPaymentMethod);
+
+            component.prop('initializePayment')({
+                methodId: defaultProps.method.id,
+                gatewayId: defaultProps.method.gateway,
             });
 
-            it('renders as a PPSDK payment method', () => {
-                const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
-
-                expect(container.find(PPSDKPaymentMethod).props())
-                    .toEqual(expect.objectContaining({
-                        deinitializePayment: expect.any(Function),
-                        initializePayment: expect.any(Function),
-                        method,
-                    }));
-            });
-
-            it('initializes method with required config', () => {
-                const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
-                const component = container.find(PPSDKPaymentMethod);
-
-                component.prop('initializePayment')({
-                    methodId: defaultProps.method.id,
-                    gatewayId: defaultProps.method.gateway,
-                });
-
-                expect(checkoutService.initializePayment)
-                    .toHaveBeenCalledWith(expect.objectContaining({
-                        methodId: method.id,
-                        gatewayId: method.gateway,
-                    }));
-            });
+            expect(checkoutService.initializePayment)
+                .toHaveBeenCalledWith(expect.objectContaining({
+                    methodId: method.id,
+                    gatewayId: method.gateway,
+                }));
         });
     });
 });

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -46,7 +46,6 @@ export interface PaymentMethodProps {
 }
 
 export interface WithCheckoutPaymentMethodProps {
-    isPpsdkEnabled: boolean;
     isInitializing: boolean;
     deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
@@ -65,9 +64,9 @@ export interface WithCheckoutPaymentMethodProps {
  */
 // tslint:disable:cyclomatic-complexity
 const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckoutPaymentMethodProps> = props => {
-    const { method, isPpsdkEnabled } = props;
+    const { method } = props;
 
-    if (isPpsdkEnabled && method.type === PaymentMethodProviderType.PPSDK) {
+    if (method.type === PaymentMethodProviderType.PPSDK) {
         return <PPSDKPaymentMethod { ...props } />;
     }
 
@@ -233,19 +232,12 @@ function mapToWithCheckoutPaymentMethodProps(
         statuses: { isInitializingPayment },
     } = checkoutState;
 
-    const isPpsdkEnabled = Boolean(
-        checkoutService.getState()
-            .data.getConfig()
-            ?.checkoutSettings.features['PAYMENTS-6806.enable_ppsdk_strategy']
-    );
-
     return {
         deinitializeCustomer: checkoutService.deinitializeCustomer,
         deinitializePayment: checkoutService.deinitializePayment,
         initializeCustomer: checkoutService.initializeCustomer,
         initializePayment: checkoutService.initializePayment,
         isInitializing: isInitializingPayment(method.id),
-        isPpsdkEnabled,
     };
 }
 


### PR DESCRIPTION
## What?

- Remove WIP feature toggle which enables/disables the new PPSSDK strategy

## Why?

- Now that contracts have solidified, we can safely remove this WIP toggle
- Should we want to disable PPSDK functionality on the view, we can do this by stopping PPSDK methods coming from the BE 

## Testing / Proof

- Updated tests

@bigcommerce/checkout
