### PR TITLE
feat(payment): INT-4897 Humm - Show Humm as payment method

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -287,6 +287,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.AmazonPay ||
             selectedMethod.id === PaymentMethodId.Checkoutcom ||
             selectedMethod.id === PaymentMethodId.Converge ||
+            selectedMethod.id === PaymentMethodId.Humm ||
             selectedMethod.id === PaymentMethodId.Laybuy ||
             selectedMethod.id === PaymentMethodId.Opy ||
             selectedMethod.id === PaymentMethodId.Quadpay ||

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -199,6 +199,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.gateway === PaymentMethodId.Afterpay ||
         method.gateway === PaymentMethodId.Clearpay ||
+        method.id === PaymentMethodId.Humm ||
         method.id === PaymentMethodId.Laybuy ||
         method.id === PaymentMethodId.Opy ||
         method.id === PaymentMethodId.Quadpay ||

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -24,6 +24,7 @@ enum PaymentMethodId {
     CybersourceV2GooglePay = 'googlepaycybersourcev2',
     DigitalRiver = 'digitalriver',
     Fawry = 'fawry',
+    Humm = 'humm',
     Ideal = 'ideal',
     Klarna = 'klarna',
     Laybuy = 'laybuy',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -31,6 +31,7 @@ describe('PaymentMethodTitle', () => {
         applepay: '/modules/checkout/applepay/images/applepay-header@2x.png',
         chasepay: '/img/payment-providers/chase-pay.png',
         googlepay: '/img/payment-providers/google-pay.png',
+        humm: '/img/payment-providers/humm-checkout-header.png',
         klarna: '/img/payment-providers/klarna-header.png',
         laybuy: '/img/payment-providers/laybuy-checkout-header.png',
         masterpass: 'https://masterpass.com/dyn/img/acc/global/mp_mark_hor_blk.svg',
@@ -211,6 +212,7 @@ describe('PaymentMethodTitle', () => {
         const methodIds = [
             PaymentMethodId.Amazon,
             PaymentMethodId.ChasePay,
+            PaymentMethodId.Humm,
             PaymentMethodId.Opy,
             PaymentMethodId.PaypalCommerce,
             PaymentMethodType.Barclaycard,

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -97,6 +97,10 @@ function getPaymentMethodTitle(
                 logoUrl: '',
                 titleText: language.translate('payment.digitalriver_display_name_text'),
             },
+            [PaymentMethodId.Humm]: {
+                logoUrl: cdnPath('/img/payment-providers/humm-checkout-header.png'),
+                titleText: '',
+            },
             [PaymentMethodId.Klarna]: {
                 logoUrl: cdnPath('/img/payment-providers/klarna-header.png'),
                 titleText: method.config && method.config.displayName || '',


### PR DESCRIPTION
## What? [INT-4897](https://jira.bigcommerce.com/browse/INT-4897)
Adding humm as payment method, specifying the logo, humm is a external payment method then we going to redirect the pay.

## Why?
it's need it to support it when we want to pay.

## Testing / Proof
![image](https://user-images.githubusercontent.com/4907027/140761022-5dfac835-fa74-4d8a-819e-1b555163d20c.png)


@bigcommerce/checkout 
