### PR TITLE
chore(payment): INT-4891 Bump checkout-sdk to 1.192.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,9 +1414,9 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "istanbul-lib-coverage": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg=="
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.2.tgz",
+          "integrity": "sha512-o5+eTUYzCJ11/+JhW5/FUCdfsdoYVdQ/8I/OveE2XsjehYn5DdeSnNQAbjYaO8gQ6hvGTN6GM6ddQqpTVG5j8g=="
         },
         "istanbul-lib-instrument": {
           "version": "4.0.3",
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.190.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.190.1.tgz",
-      "integrity": "sha512-/zbgUS1DaOj7GkuHW6XnAo2QgCVJugEHcx2Wop6r2DLKvAyaRmaWS09gZ28WEETgFcwDO3EnL0kan89aJP4XkQ==",
+      "version": "1.192.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.192.0.tgz",
+      "integrity": "sha512-rARalCEsazuMcErx8RX9Y6YydSnUK+tN8n42c8HQSkFcKJ37YqThVQIB2O6Qp0weT0//NhZvZsNITUEgXt14+A==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.190.1",
+    "@bigcommerce/checkout-sdk": "^1.192.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to 1.192.0

## Why?
To get https://github.com/bigcommerce/checkout-sdk-js/pull/1249 released

## Testing / Proof
See proof on the above PR

@bigcommerce/checkout @bigcommerce/apex-integrations 
