### PR TITLE
feat(payment): PAYPAL-1180 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.192.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.192.0.tgz",
-      "integrity": "sha512-rARalCEsazuMcErx8RX9Y6YydSnUK+tN8n42c8HQSkFcKJ37YqThVQIB2O6Qp0weT0//NhZvZsNITUEgXt14+A==",
+      "version": "1.192.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.192.1.tgz",
+      "integrity": "sha512-WVl5z01wTSomYn+su9xp23iFJkuhmesTFgbJn4xExa7gJyGxHkHwPH6LCfvV5YlGNh1GiTC3FtVKP6F/xz0HTg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.192.0",
+    "@bigcommerce/checkout-sdk": "^1.192.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task https://jira.bigcommerce.com/browse/PAYPAL-1180
Checkout-sdk PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1269

## Testing / Proof
Tested on dev and Int

@bigcommerce/checkout
