### PR TITLE
fix(payment): BOLT-74 bolt checkout button on mobile

### DIFF
--- a/src/app/checkout/CheckoutStep.spec.tsx
+++ b/src/app/checkout/CheckoutStep.spec.tsx
@@ -3,13 +3,21 @@ import { noop } from 'lodash';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
 
-import { MOBILE_MAX_WIDTH } from '../ui/responsive';
+import { isMobileView, MOBILE_MAX_WIDTH } from '../ui/responsive';
 
 import CheckoutStep, { CheckoutStepProps } from './CheckoutStep';
 import CheckoutStepHeader from './CheckoutStepHeader';
 import CheckoutStepType from './CheckoutStepType';
 
 jest.useFakeTimers();
+jest.mock('../ui/responsive', () => {
+    const original = jest.requireActual('../ui/responsive');
+
+    return {
+        ...original,
+        isMobileView: jest.fn(),
+    };
+});
 
 describe('CheckoutStep', () => {
     let defaultProps: CheckoutStepProps;
@@ -183,5 +191,20 @@ describe('CheckoutStep', () => {
 
         expect(component.find(CSSTransition))
             .toHaveLength(0);
+    });
+
+    it('changes isClosed for mobile', () => {
+        isMobile = true;
+        isMobileView.mockImplementation(() => isMobile);
+
+        const component = mount(<CheckoutStep { ...defaultProps } />);
+
+        expect(component.state('isClosed')).toBe(false);
+
+        component
+            .setProps({ isActive: false })
+            .update();
+
+        expect(component.state('isClosed')).toBe(true);
     });
 });

--- a/src/app/checkout/CheckoutStep.tsx
+++ b/src/app/checkout/CheckoutStep.tsx
@@ -44,9 +44,14 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
 
     componentDidUpdate(prevProps: Readonly<CheckoutStepProps>): void {
         const { isActive } = this.props;
+        const { isClosed } = this.state;
 
         if (isActive && isActive !== prevProps.isActive) {
             this.focusStep();
+        }
+
+        if (!isActive && !isClosed && isMobileView()) {
+            this.setState({ isClosed: true });
         }
     }
 


### PR DESCRIPTION
## What?
Fix bug: [BOLT-74](https://jira.bigcommerce.com/browse/BOLT-74) Bolt checkout button doesn't appear on mobile

## Why?
Because of the task: [https://jira.bigcommerce.com/browse/BOLT-74](https://jira.bigcommerce.com/browse/BOLT-74)

## Testing / Proof
Before:
![Screenshot 2021-10-13 at 17 54 01](https://user-images.githubusercontent.com/9430298/137158457-133647a4-5d81-4910-9514-739fe5af1714.png)

After:
![Screenshot 2021-10-13 at 17 46 51](https://user-images.githubusercontent.com/9430298/137158026-3d27fc39-32cf-4fd3-905a-990fca7fb440.png)

Tests:
<img width="291" alt="Screenshot 2021-10-13 at 17 33 12" src="https://user-images.githubusercontent.com/9430298/137158107-9e06c3db-141e-4553-9896-32af73f314ef.png">


@bigcommerce/checkout
