### PR TITLE
feat(payment): INT-4917 Openpay: display the saved logo on the settin…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
-      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA=="
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
+      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew=="
     },
     "@babel/core": {
       "version": "7.5.5",
@@ -114,11 +114,11 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
-      "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
+      "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
       "requires": {
-        "@babel/compat-data": "^7.15.0",
+        "@babel/compat-data": "^7.16.0",
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
@@ -1002,19 +1002,19 @@
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
-          "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "@babel/generator": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.8.tgz",
-          "integrity": "sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+          "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
           "requires": {
-            "@babel/types": "^7.15.6",
+            "@babel/types": "^7.16.0",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           },
@@ -1027,113 +1027,113 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
-          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+          "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.15.4",
-            "@babel/template": "^7.15.4",
-            "@babel/types": "^7.15.4"
+            "@babel/helper-get-function-arity": "^7.16.0",
+            "@babel/template": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
-          "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+          "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-hoist-variables": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
-          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+          "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
-          "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
+          "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+          "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
-          "integrity": "sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
+          "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
           "requires": {
-            "@babel/helper-module-imports": "^7.15.4",
-            "@babel/helper-replace-supers": "^7.15.4",
-            "@babel/helper-simple-access": "^7.15.4",
-            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/helper-module-imports": "^7.16.0",
+            "@babel/helper-replace-supers": "^7.16.0",
+            "@babel/helper-simple-access": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
             "@babel/helper-validator-identifier": "^7.15.7",
-            "@babel/template": "^7.15.4",
-            "@babel/traverse": "^7.15.4",
-            "@babel/types": "^7.15.6"
+            "@babel/template": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-optimise-call-expression": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
-          "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
+          "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
-          "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
+          "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.15.4",
-            "@babel/helper-optimise-call-expression": "^7.15.4",
-            "@babel/traverse": "^7.15.4",
-            "@babel/types": "^7.15.4"
+            "@babel/helper-member-expression-to-functions": "^7.16.0",
+            "@babel/helper-optimise-call-expression": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
-          "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
+          "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
-          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+          "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
           "requires": {
-            "@babel/types": "^7.15.4"
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/helpers": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
-          "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.0.tgz",
+          "integrity": "sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==",
           "requires": {
-            "@babel/template": "^7.15.4",
-            "@babel/traverse": "^7.15.4",
-            "@babel/types": "^7.15.4"
+            "@babel/template": "^7.16.0",
+            "@babel/traverse": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           },
@@ -1185,42 +1185,42 @@
           }
         },
         "@babel/parser": {
-          "version": "7.15.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.8.tgz",
-          "integrity": "sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA=="
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.0.tgz",
+          "integrity": "sha512-TEHWXf0xxpi9wKVyBCmRcSSDjbJ/cl6LUdlbYUHEaNQUJGhreJbZrXT6sR4+fZLxVUJqNRB4KyOvjuy/D9009A=="
         },
         "@babel/template": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
-          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+          "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
           "requires": {
-            "@babel/code-frame": "^7.14.5",
-            "@babel/parser": "^7.15.4",
-            "@babel/types": "^7.15.4"
+            "@babel/code-frame": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0"
           }
         },
         "@babel/traverse": {
-          "version": "7.15.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
-          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
+          "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
           "requires": {
-            "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.15.4",
-            "@babel/helper-function-name": "^7.15.4",
-            "@babel/helper-hoist-variables": "^7.15.4",
-            "@babel/helper-split-export-declaration": "^7.15.4",
-            "@babel/parser": "^7.15.4",
-            "@babel/types": "^7.15.4",
+            "@babel/code-frame": "^7.16.0",
+            "@babel/generator": "^7.16.0",
+            "@babel/helper-function-name": "^7.16.0",
+            "@babel/helper-hoist-variables": "^7.16.0",
+            "@babel/helper-split-export-declaration": "^7.16.0",
+            "@babel/parser": "^7.16.0",
+            "@babel/types": "^7.16.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -1419,31 +1419,31 @@
           "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw=="
         },
         "istanbul-lib-instrument": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.0.4.tgz",
-          "integrity": "sha512-W6jJF9rLGEISGoCyXRqa/JCGQGmmxPO10TMu7izaUTynxvBvTjqzAIIGCK9USBmIbQAaSWD6XJPrM9Pv5INknw==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
+          "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
           "requires": {
             "@babel/core": "^7.12.3",
             "@babel/parser": "^7.14.7",
             "@istanbuljs/schema": "^0.1.2",
-            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-coverage": "^3.2.0",
             "semver": "^6.3.0"
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.15.8",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.8.tgz",
-              "integrity": "sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==",
+              "version": "7.16.0",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
+              "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
               "requires": {
-                "@babel/code-frame": "^7.15.8",
-                "@babel/generator": "^7.15.8",
-                "@babel/helper-compilation-targets": "^7.15.4",
-                "@babel/helper-module-transforms": "^7.15.8",
-                "@babel/helpers": "^7.15.4",
-                "@babel/parser": "^7.15.8",
-                "@babel/template": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.6",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-compilation-targets": "^7.16.0",
+                "@babel/helper-module-transforms": "^7.16.0",
+                "@babel/helpers": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/traverse": "^7.16.0",
+                "@babel/types": "^7.16.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1636,9 +1636,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.194.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.194.1.tgz",
-      "integrity": "sha512-35AtTNDuY59TtCgDhSQ2p6Y37cAKUXJn/5k8GHuKOmnRk8WJMgyDijVWN3bZW6quIRdjMciZEDE5Rbqhe+r0ww==",
+      "version": "1.195.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.195.0.tgz",
+      "integrity": "sha512-7mZ8LfKfY4KV6V4h864bYiOIwAESGC9U5Y2mSF0+irUQSQwAHJcBrkB8nJUaNeqGlSq039WArw2TKXJWn+I37g==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.194.1",
+    "@bigcommerce/checkout-sdk": "^1.195.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -33,7 +33,6 @@ describe('PaymentMethodTitle', () => {
         klarna: '/img/payment-providers/klarna-header.png',
         laybuy: '/img/payment-providers/laybuy-checkout-header.png',
         masterpass: 'https://masterpass.com/dyn/img/acc/global/mp_mark_hor_blk.svg',
-        opy: '/img/payment-providers/opy.svg',
         paypal: '/img/payment-providers/paypalpaymentsprouk.png',
         quadpay: '/img/payment-providers/quadpay.png',
         sezzle: '/img/payment-providers/sezzle-checkout-header.png',
@@ -125,7 +124,6 @@ describe('PaymentMethodTitle', () => {
         const methods = [
             { id: PaymentMethodId.Amazon, method: 'widget' },
             { id: PaymentMethodId.Klarna, method: 'widget' },
-            { id: PaymentMethodId.Opy, method: 'credit-card' },
             { id: PaymentMethodId.PaypalCommerce, method: 'widget' },
         ];
 
@@ -317,5 +315,38 @@ describe('PaymentMethodTitle', () => {
         component = checkoutcomTitleComponent('checkoutcom');
         expect(component.find('[data-test="payment-method-name"]').text())
             .toEqual(defaultProps.method.config.displayName);
+    });
+
+    it('renders logo based on provider\'s config', () => {
+        const methods = [
+          {
+            id: PaymentMethodId.Opy,
+            config: {
+              ...defaultProps.method.config,
+              logo: 'opy_gray.svg',
+            },
+          },
+        ];
+
+        methods.forEach(method => {
+            const component = mount(<PaymentMethodTitleTest
+                { ...defaultProps }
+                method={ {
+                    ...defaultProps.method,
+                    ...method,
+                } }
+            />);
+
+            expect(component.find('[data-test="payment-method-logo"]').prop('src'))
+                .toEqual(`${config.cdnPath}/img/payment-providers/${method.config.logo}`);
+        });
+    });
+
+    it('renders default logo for Openpay', () => {
+        defaultProps.method.id = PaymentMethodId.Opy;
+        const component = mount(<PaymentMethodTitleTest { ...defaultProps } />);
+
+        expect(component.find('[data-test="payment-method-logo"]').prop('src'))
+            .toEqual(`${config.cdnPath}/img/payment-providers/opy_default.svg`);
     });
 });

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -106,7 +106,7 @@ function getPaymentMethodTitle(
                 titleText: '',
             },
             [PaymentMethodId.Opy]: {
-                logoUrl: cdnPath('/img/payment-providers/opy.svg'),
+                logoUrl: cdnPath(`/img/payment-providers/${method.config.logo ?? 'opy_default.svg'}`),
                 titleText: '',
             },
             [PaymentMethodType.Paypal]: {


### PR DESCRIPTION
…gs page

## What? [INT-4917](https://jira.bigcommerce.com/browse/INT-4917)
1. Bump Checkout-SDK from `1.194.1` to `1.195.0`
2. Render the Openpay logo based on the payment method config.

## Why?
1. To get https://github.com/bigcommerce/checkout-sdk-js/pull/1272 released.
2. We need to display the saved logo from the Openpay settings page on the checkout page.

## Testing / Proof
<img width="456" alt="Screen Shot 2021-10-18 at 4 11 58 PM" src="https://user-images.githubusercontent.com/4843328/137815173-65eaeb51-c6b1-4049-8269-2292c3b118c8.png">
<img width="634" alt="Screen Shot 2021-10-18 at 4 12 06 PM" src="https://user-images.githubusercontent.com/4843328/137815175-7637848e-0ffd-4cf5-8efa-9ab7655757d5.png">

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1272 to recognize the new property.

@bigcommerce/apex-integrations  @bigcommerce/checkout
