### PR TITLE
fix(checkout): CHECKOUT-5322 scroll to earliest error on iOS

### DIFF
--- a/src/app/ui/form/Form.tsx
+++ b/src/app/ui/form/Form.tsx
@@ -32,7 +32,8 @@ const Form: FunctionComponent<FormProps> = ({
         const erroredFormField = current.querySelector<HTMLElement>(errorInputSelectors.join(', '));
 
         if (erroredFormField) {
-            erroredFormField.focus();
+            erroredFormField.focus({preventScroll: true});
+            erroredFormField.offsetParent?.scrollIntoView({behavior: 'smooth', block: 'center', inline: 'center'});
         }
     };
 


### PR DESCRIPTION
## What?
…
When focusing on form errors, prevent the default scrolling behavior from focus, and specify a configuration for the scrolling behavior. 

## Why?
…
CHECKOUT-5322 

This will make the form error scrolling behavior on iOS more consistent with other devices. 

On iOS using Safari or Chrome, the default scrolling behavior differs from other browsers and creates a potentially confusing situation for the shopper. 

-It will scroll to the latest error in the form, rather than the earliest error in the form. Other browsers/devices will take the user to the earliest place in the form, so that all errors will be reviewed by the user. 

-Only the initial submit initiates any action. If the user happens to scroll back down without noticing/correcting an error, they may perceive the checkout as not working as they hit the submit button repeatedly within the shipping step. 

Notice that if the keyboard is pulled up, then the focus() behavior is the same as other browsers. This issue seems to be due to iOS devices requiring direct user action to open the keyboard or focus on an input element.

Klarna and Braintree have run into similar issues in the past around iOS and HTMLElement.focus()

https://github.com/klarna/ui/commit/749a5978f1d7428045dcd41998182ede505dbb12

https://github.com/braintree/braintree-web/issues/490#issuecomment-658361207 
https://github.com/braintree/braintree-web/commit/7cb84433f0d83f528a0f1663d1a3e7c3888e1891 

scrollIntoView options are marked as not supported in Safari / iOS, but this appears to have been updated:

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
https://github.com/mdn/browser-compat-data/issues/9055
https://bugs.webkit.org/show_bug.cgi?id=161611


## Testing / Proof
…

### Before

Unexpected (iOS)
https://user-images.githubusercontent.com/5630999/137813435-15745e20-40d5-43c6-8bb9-116ff5852dcf.mov

https://user-images.githubusercontent.com/5630999/137813417-710ef5af-b59e-435b-86c7-94530d5bab4a.mov

Expected (Android)

https://user-images.githubusercontent.com/5630999/137813485-e02772b4-10fb-4655-bb7c-212748ac653d.mov

### After

https://user-images.githubusercontent.com/5630999/137813588-3cc02c7b-df04-4b75-8a0e-3278cd5aee0a.mov

https://user-images.githubusercontent.com/5630999/137813602-39987ba5-68fe-4440-b0c2-e94ac9e367cb.mov

https://user-images.githubusercontent.com/5630999/137813541-f926039f-42de-4bc0-90f0-a90d5a0163f4.mov

https://user-images.githubusercontent.com/5630999/137813555-a3f550bd-d452-4287-87d9-d77da7ffa0bb.mov

https://user-images.githubusercontent.com/5630999/137813576-3556d893-e99b-41f9-bbba-595a9d3831a2.mov

https://user-images.githubusercontent.com/5630999/137813621-784c39d7-eba9-4703-9e20-e0662ef719a7.mov

@bigcommerce/checkout
