### PR TITLE
feat(payment): PAYPAL-1123 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1316,14 +1316,14 @@
           }
         },
         "babel-plugin-istanbul": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
-          "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+          "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
             "@istanbuljs/load-nyc-config": "^1.0.0",
             "@istanbuljs/schema": "^0.1.2",
-            "istanbul-lib-instrument": "^4.0.0",
+            "istanbul-lib-instrument": "^5.0.4",
             "test-exclude": "^6.0.0"
           }
         },
@@ -1414,16 +1414,17 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "istanbul-lib-coverage": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.2.tgz",
-          "integrity": "sha512-o5+eTUYzCJ11/+JhW5/FUCdfsdoYVdQ/8I/OveE2XsjehYn5DdeSnNQAbjYaO8gQ6hvGTN6GM6ddQqpTVG5j8g=="
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+          "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw=="
         },
         "istanbul-lib-instrument": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-          "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.0.4.tgz",
+          "integrity": "sha512-W6jJF9rLGEISGoCyXRqa/JCGQGmmxPO10TMu7izaUTynxvBvTjqzAIIGCK9USBmIbQAaSWD6XJPrM9Pv5INknw==",
           "requires": {
-            "@babel/core": "^7.7.5",
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.14.7",
             "@istanbuljs/schema": "^0.1.2",
             "istanbul-lib-coverage": "^3.0.0",
             "semver": "^6.3.0"
@@ -1635,9 +1636,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.192.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.192.1.tgz",
-      "integrity": "sha512-WVl5z01wTSomYn+su9xp23iFJkuhmesTFgbJn4xExa7gJyGxHkHwPH6LCfvV5YlGNh1GiTC3FtVKP6F/xz0HTg==",
+      "version": "1.193.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.193.0.tgz",
+      "integrity": "sha512-JLoDOdTCxv3gW1TD7uMlsNUKRNxyiOQu0VVIoQJxOO7F8c4R15rq2TXOuJn802DNhWwYhNVuYQ56ISeCd5QCTQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -1693,9 +1694,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.175",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
-          "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw=="
+          "version": "4.14.176",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+          "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
         },
         "@types/yup": {
           "version": "0.26.37",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.192.1",
+    "@bigcommerce/checkout-sdk": "^1.193.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

According to task https://jira.bigcommerce.com/browse/PAYPAL-1123
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1271

## Testing / Proof
tested on dev and int

@bigcommerce/checkout
