### PR TITLE
chore(payment): BOLT-78 bump checkout-sdk-js version from 1.193.0 to 1.194.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1636,9 +1636,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.193.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.193.0.tgz",
-      "integrity": "sha512-JLoDOdTCxv3gW1TD7uMlsNUKRNxyiOQu0VVIoQJxOO7F8c4R15rq2TXOuJn802DNhWwYhNVuYQ56ISeCd5QCTQ==",
+      "version": "1.194.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.194.0.tgz",
+      "integrity": "sha512-AjhK5tMyROVOcZnAtKEq/tNZ/3Tx2Do4y1DFcHzhutCUkIpdJxOc8WQHAc+RxbLsl1nWj+gSrk/yVlGUbQKALA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.193.0",
+    "@bigcommerce/checkout-sdk": "^1.194.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version from 1.193.0 to 1.194.0

## Why?
Because of the task:
https://jira.bigcommerce.com/browse/BOLT-78

## Testing / Proof
Manual tests

@bigcommerce/checkout
