### PR TITLE
chore(payment): PAYMENTS-7390 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1636,9 +1636,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.194.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.194.0.tgz",
-      "integrity": "sha512-AjhK5tMyROVOcZnAtKEq/tNZ/3Tx2Do4y1DFcHzhutCUkIpdJxOc8WQHAc+RxbLsl1nWj+gSrk/yVlGUbQKALA==",
+      "version": "1.194.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.194.1.tgz",
+      "integrity": "sha512-35AtTNDuY59TtCgDhSQ2p6Y37cAKUXJn/5k8GHuKOmnRk8WJMgyDijVWN3bZW6quIRdjMciZEDE5Rbqhe+r0ww==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.194.0",
+    "@bigcommerce/checkout-sdk": "^1.194.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

- Bump Checkout-SDK from `1.194.0` to `1.194.1`

## Why?

- Deploy minor fix for PPSDK redirects: https://github.com/bigcommerce/checkout-sdk-js/pull/1278

## Testing / Proof

- Passing tests

@bigcommerce/checkout
