### PR TITLE
test(payment): INT-4853 increase code coverage on BarclaycardPaymentMethod

### DIFF
--- a/src/app/payment/paymentMethod/BarclaycardPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/BarclaycardPaymentMethod.spec.tsx
@@ -1,73 +1,28 @@
-import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
-import { Formik } from 'formik';
-import { noop } from 'lodash';
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
-import { CheckoutProvider } from '../../checkout';
-import { getStoreConfig } from '../../config/config.mock';
-import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
-
+import BarclaycardPaymentMethod, { BarclaycardPaymentMethodProps } from './BarclaycardPaymentMethod';
 import HostedWidgetPaymentMethod, { HostedWidgetPaymentMethodProps } from './HostedWidgetPaymentMethod';
-import { default as PaymentMethodComponent, PaymentMethodProps } from './PaymentMethod';
 
 describe('when using Barclaycard payment', () => {
-    let checkoutService: CheckoutService;
-    let checkoutState: CheckoutSelectors;
-    let defaultProps: PaymentMethodProps;
-    let localeContext: LocaleContextType;
-    let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
-
-    beforeEach(() => {
-        defaultProps = {
-            method: {
-                id: 'barclaycard',
-                method: 'barclaycard',
-                supportedCards: [],
-                config: {},
-                type: 'card',
-                gateway: 'barclaycard',
-            },
-            onUnhandledError: jest.fn(),
-            isEmbedded: true,
-        };
-
-        checkoutService = createCheckoutService();
-        checkoutState = checkoutService.getState();
-        localeContext = createLocaleContext(getStoreConfig());
-
-        jest.spyOn(checkoutState.data, 'getConfig')
-            .mockReturnValue(getStoreConfig());
-
-        jest.spyOn(checkoutService, 'deinitializePayment')
-            .mockResolvedValue(checkoutState);
-
-        jest.spyOn(checkoutService, 'initializePayment')
-            .mockResolvedValue(checkoutState);
-
-        PaymentMethodTest = props => (
-            <CheckoutProvider checkoutService={ checkoutService }>
-                <LocaleContext.Provider value={ localeContext }>
-                    <Formik
-                        initialValues={ {} }
-                        onSubmit={ noop }
-                    >
-                        <PaymentMethodComponent { ...props } />
-                    </Formik>
-                </LocaleContext.Provider>
-            </CheckoutProvider>
-        );
-    });
+    const defaultProps: BarclaycardPaymentMethodProps = {
+        method: {
+            id: 'barclaycard',
+            method: 'barclaycard',
+            supportedCards: [],
+            config: {},
+            type: 'card',
+            gateway: 'barclaycard',
+        },
+        deinitializePayment: jest.fn(),
+        initializePayment: jest.fn(),
+    };
 
     it('should mount Barclaycard', () => {
-        const container = mount(<PaymentMethodTest { ...defaultProps } />);
+        const container = mount(<BarclaycardPaymentMethod { ...defaultProps } />);
         const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);
-        expect(component.prop('containerId')).toBe('barclaycard-container');
-    });
-
-    it('renders as hosted widget method', () => {
-        const container = mount(<PaymentMethodTest { ...defaultProps } />);
 
         expect(container.find(HostedWidgetPaymentMethod)).toBeTruthy();
+        expect(component.prop('containerId')).toBe('barclaycard-container');
     });
 });

--- a/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.spec.tsx
@@ -13,6 +13,7 @@ import { createLocaleContext, LocaleContext, LocaleContextType } from '../../loc
 import { getPaymentMethod } from '../payment-methods.mock';
 import PaymentContext, { PaymentContextProps } from '../PaymentContext';
 
+import BarclaycardPaymentMethod from './BarclaycardPaymentMethod';
 import CheckoutcomCustomPaymentMethod, { CheckoutcomCustomPaymentMethodProps } from './CheckoutcomCustomPaymentMethod';
 import CreditCardPaymentMethod, { CreditCardPaymentMethodProps } from './CreditCardPaymentMethod';
 import HostedPaymentMethod, { HostedPaymentMethodProps } from './HostedPaymentMethod';
@@ -451,6 +452,27 @@ describe('PaymentMethod', () => {
                     methodId: method.id,
                     gatewayId: method.gateway,
                 }));
+        });
+    });
+
+    describe('when using barclaycard payment method', () => {
+        let method: PaymentMethod;
+
+        beforeEach(() => {
+            method = {
+                id: 'barclaycard',
+                method: 'barclaycard',
+                supportedCards: [],
+                config: {},
+                type: 'card',
+                gateway: 'barclaycard',
+            };
+        });
+
+        it('should render barclay PaymentMethod', () => {
+            const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+
+            expect(container.find(BarclaycardPaymentMethod)).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
## What? [INT-4853](https://jira.bigcommerce.com/browse/INT-4853)
Increase BarclaycardPaymentMethod code coverage

## Why?

To increase code coverage

## Testing / Proof

### Before

![Screen Shot 2021-10-28 at 15 23 03](https://user-images.githubusercontent.com/69221626/139329944-70826527-0808-435e-a2eb-a1f1f7f6630b.png)

### Now 

![Screen Shot 2021-10-28 at 15 25 18](https://user-images.githubusercontent.com/69221626/139330284-eeb0ad91-3119-44b5-be07-863ddcb63210.png)

![Screen Shot 2021-10-28 at 15 19 12](https://user-images.githubusercontent.com/69221626/139329393-4d98104d-3ab1-482e-81da-62c7c56a259c.png)


@bigcommerce/checkout @bigcommerce/apex-integrations
