### PR TITLE
fix(checkout): CHECKOUT-6082 localized message for the payment step initialization failure

### DIFF
--- a/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
+++ b/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
@@ -5,6 +5,12 @@ import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmi
 const translate = getLanguageService().translate;
 
 describe('mapSubmitOrderErrorMessage()', () => {
+    it('returns generic message when payment method is not initialized', () => {
+        const message = mapSubmitOrderErrorMessage({ type: 'not_initialized' }, translate, false);
+
+        expect(message).toEqual(translate('payment.payment_error'));
+    });
+
     it('returns correct message when payment is cancelled', () => {
         const message = mapSubmitOrderErrorMessage({ type: 'payment_cancelled' }, translate, false);
 

--- a/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -7,6 +7,9 @@ export default function mapSubmitOrderErrorMessage(
     shouldLocalise: boolean
 ): string {
     switch (error.type) {
+        case 'not_initialized':
+            return translate('payment.payment_error');
+
         case 'payment_cancelled':
             return translate('payment.payment_cancelled');
 


### PR DESCRIPTION
## What?
For Ayden V2,  when a shopper clicks "Place order" without card details, UCO will provide a localised user-friendly message,  `An error occurred while processing your payment. Please try again`.

## Why? 
Before, the error message was `Unable to proceed because the payment step of checkout has not been initialized`, which was not for a shopper([CHECKOUT-6082](https://jira.bigcommerce.com/browse/CHECKOUT-6082)).

UCO payment step has a mechanism to catch and display any errors thrown by SDK at [Payment.tsx#L179](https://github.com/bigcommerce/checkout-js/blob/95dde2b82caf07ed99f44d4dc23514ee956274a5/src/app/payment/Payment.tsx#L179). The missing part here is mapping error type `not_initialized` to a localised message in `mapSubmitOrderErrorMessage.ts`.

## Testing / Proof

https://user-images.githubusercontent.com/88361607/139607218-ea08e38d-d72a-48df-b8e1-7210d89cb3ec.mov



@bigcommerce/checkout
