### PR TITLE
feat(payment): CHECKOUT-6067 Display applepay in payment step of checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1185,9 +1185,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.0.tgz",
-          "integrity": "sha512-TEHWXf0xxpi9wKVyBCmRcSSDjbJ/cl6LUdlbYUHEaNQUJGhreJbZrXT6sR4+fZLxVUJqNRB4KyOvjuy/D9009A=="
+          "version": "7.16.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
+          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw=="
         },
         "@babel/template": {
           "version": "7.16.0",
@@ -1636,9 +1636,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.195.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.195.0.tgz",
-      "integrity": "sha512-7mZ8LfKfY4KV6V4h864bYiOIwAESGC9U5Y2mSF0+irUQSQwAHJcBrkB8nJUaNeqGlSq039WArw2TKXJWn+I37g==",
+      "version": "1.196.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.196.0.tgz",
+      "integrity": "sha512-HcagoL6v/QtsvvppoZqWi9QFlmpHq3rOf18IpcAtaMedOL2AtSuDR8Bb4DfT6d1BYR6z3C64Uc7sVpTR47vsGg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.195.0",
+    "@bigcommerce/checkout-sdk": "^1.196.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -74,6 +74,10 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
         return <AdyenV2PaymentMethod { ...props } />;
     }
 
+    if (method.id === PaymentMethodId.ApplePay) {
+        return null;
+    }
+
     if (method.id === PaymentMethodId.SquareV2) {
         return <SquarePaymentMethod { ...props } />;
     }

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -6,6 +6,7 @@ enum PaymentMethodId {
     Afterpay = 'afterpay',
     Amazon = 'amazon',
     AmazonPay = 'amazonpay',
+    ApplePay = 'applepay',
     Barclaycard = 'barclaycard',
     BlueSnapV2 = 'bluesnapv2',
     Boleto = 'boleto',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -28,6 +28,7 @@ describe('PaymentMethodTitle', () => {
         'visa-checkout': '/img/payment-providers/visa-checkout.png',
         afterpay: '/img/payment-providers/afterpay-badge-blackonmint.png',
         amazon: '/img/payment-providers/amazon-header.png',
+        applepay: '/modules/checkout/applepay/images/applepay-header@2x.png',
         chasepay: '/img/payment-providers/chase-pay.png',
         googlepay: '/img/payment-providers/google-pay.png',
         klarna: '/img/payment-providers/klarna-header.png',
@@ -94,6 +95,7 @@ describe('PaymentMethodTitle', () => {
 
     it('renders logo based on their method type', () => {
         const methodTypes = [
+            PaymentMethodType.ApplePay,
             PaymentMethodType.Chasepay,
             PaymentMethodType.GooglePay,
             PaymentMethodType.Masterpass,

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -73,6 +73,10 @@ function getPaymentMethodTitle(
                 logoUrl: cdnPath('/img/payment-providers/amazon-header.png'),
                 titleText: '',
             },
+            [PaymentMethodId.ApplePay]: {
+                logoUrl: cdnPath('/modules/checkout/applepay/images/applepay-header@2x.png'),
+                titleText: '',
+            },
             [PaymentMethodId.Bolt]: {
                 logoUrl: '',
                 titleText: language.translate('payment.credit_card_text'),

--- a/src/app/payment/paymentMethod/PaymentMethodType.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodType.ts
@@ -1,4 +1,5 @@
 enum PaymentMethodType {
+    ApplePay = 'applepay',
     Barclaycard = 'barclaycard',
     Chasepay = 'chasepay',
     CreditCard = 'credit-card',


### PR DESCRIPTION
## What?
Display applepay in payment step of checkout

## Why?
Support apple pay in checkout payment steps.

## Testing / Proof
- Tests
- Screenshots

## Safari
<img width="1680" alt="Screen Shot 2021-11-03 at 3 34 40 pm" src="https://user-images.githubusercontent.com/7134802/140010443-dd38bb1f-e7b7-4551-aa44-d0f56b05120b.png">

## Chrome
![Screen Shot 2021-11-03 at 3 36 55 pm (2)](https://user-images.githubusercontent.com/7134802/140010545-2cdcc979-9b3e-4fdc-9590-e91acafa7817.png)

@bigcommerce/checkout
