### PR TITLE
feat(payment): BOLT-92 shows 'display name' value from method config

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -9,6 +9,7 @@ import { withLanguage, WithLanguageProps } from '../../locale';
 import { mapFromPaymentMethodCardType, CreditCardIconList } from '../creditCard';
 import { PaymentFormValues } from '../PaymentForm';
 
+import getPaymentMethodDisplayName from './getPaymentMethodDisplayName';
 import getPaymentMethodName from './getPaymentMethodName';
 import PaymentMethodId from './PaymentMethodId';
 import PaymentMethodType from './PaymentMethodType';
@@ -30,6 +31,7 @@ function getPaymentMethodTitle(
 
     return method => {
         const methodName = getPaymentMethodName(language)(method);
+        const methodDisplayName = getPaymentMethodDisplayName(language)(method);
         // TODO: API could provide the data below so UI can read simply read it.
         // However, I'm not sure how we deal with translation yet. TBC.
         const customTitles: { [key: string]: { logoUrl: string; titleText: string } } = {
@@ -51,7 +53,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.PaypalCommerceAlternativeMethod]: {
                 logoUrl: method.logoUrl || '',
-                titleText: (method.logoUrl ? '' : method.config.displayName) || '',
+                titleText: method.logoUrl ? '' : methodDisplayName,
             },
             [PaymentMethodType.VisaCheckout]: {
                 logoUrl: cdnPath('/img/payment-providers/visa-checkout.png'),
@@ -79,7 +81,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.Bolt]: {
                 logoUrl: '',
-                titleText: language.translate('payment.credit_card_text'),
+                titleText: methodDisplayName,
             },
             [PaymentMethodId.ChasePay]: {
                 logoUrl: cdnPath('/img/payment-providers/chase-pay.png'),
@@ -99,7 +101,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.Klarna]: {
                 logoUrl: cdnPath('/img/payment-providers/klarna-header.png'),
-                titleText: method.config && method.config.displayName || '',
+                titleText: methodDisplayName,
             },
             [PaymentMethodId.Laybuy]: {
                 logoUrl: cdnPath('/img/payment-providers/laybuy-checkout-header.png'),
@@ -135,7 +137,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.AdyenV2]: {
                 logoUrl: `https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/${(method.method === 'scheme') ? 'card' : method.method}.svg`,
-                titleText: (method.config.displayName === 'Credit Card' ? language.translate('payment.adyen_credit_debit_card_text') : method.config.displayName) || '',
+                titleText: methodDisplayName,
             },
             [PaymentMethodId.Mollie]: {
                 logoUrl: method.method === 'credit_card' ? '' : cdnPath(`/img/payment-providers/mollie_${method.method}.svg`),

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
@@ -1,0 +1,36 @@
+import { createLanguageService, LanguageService } from '@bigcommerce/checkout-sdk';
+
+import { FALLBACK_TRANSLATIONS } from '../../locale/translations';
+import { getPaymentMethod } from '../payment-methods.mock';
+
+import getPaymentMethodDisplayName from './getPaymentMethodDisplayName';
+import PaymentMethodId from './PaymentMethodId';
+
+describe('getPaymentMethodDisplayName()', () => {
+    let language: LanguageService;
+
+    beforeEach(() => {
+        language = createLanguageService({ defaultTranslations: FALLBACK_TRANSLATIONS });
+    });
+
+    it('returns configured display name', () => {
+        const method = getPaymentMethod();
+
+        expect(getPaymentMethodDisplayName(language)(method))
+            .toEqual(method.config.displayName);
+    });
+
+    it('returns translated "Credit card" display name', () => {
+        const method = { ...getPaymentMethod(), config: { displayName: 'Credit Card' } };
+
+        expect(getPaymentMethodDisplayName(language)(method))
+            .toEqual(language.translate('payment.credit_card_text'));
+    });
+
+    it('returns translated display name for AdyenV2 if the value is "Credit card"', () => {
+        const method = { ...getPaymentMethod(), id: PaymentMethodId.AdyenV2, config: { displayName: 'Credit Card' } };
+
+        expect(getPaymentMethodDisplayName(language)(method))
+            .toEqual(language.translate('payment.adyen_credit_debit_card_text'));
+    });
+});

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
@@ -1,0 +1,23 @@
+import { LanguageService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import PaymentMethodId from './PaymentMethodId';
+
+export default function getPaymentMethodDisplayName(
+    language: LanguageService
+): (method: PaymentMethod) => string {
+    return method => {
+        const { displayName } = method.config;
+
+        const isCreditCard = displayName?.toLowerCase() === 'credit card';
+
+        if (isCreditCard && method.id === PaymentMethodId.AdyenV2) {
+            return language.translate('payment.adyen_credit_debit_card_text');
+        }
+
+        if (isCreditCard) {
+            return language.translate('payment.credit_card_text');
+        }
+
+        return displayName || '';
+    };
+}

--- a/src/app/payment/paymentMethod/index.ts
+++ b/src/app/payment/paymentMethod/index.ts
@@ -6,3 +6,4 @@ export { default as PaymentMethodList, PaymentMethodListProps } from './PaymentM
 export { default as SignOutLink } from './SignOutLink';
 export { default as getUniquePaymentMethodId, parseUniquePaymentMethodId } from './getUniquePaymentMethodId';
 export { default as getPaymentMethodName } from './getPaymentMethodName';
+export { default as getPaymentMethodDisplayName } from './getPaymentMethodDisplayName';


### PR DESCRIPTION
## What?
When merchant changes display name in Control Panel, the display name doesn't show

## Why?
Because we need to add an ability to chose what payment title will be shown on Checkout page

## Testing / Proof
Manual tests
Unit tests

Tests:
<img width="319" alt="Screenshot 2021-11-05 at 10 33 11" src="https://user-images.githubusercontent.com/25133454/140481593-be49d8bf-131b-41ea-b22b-64e280fd2ec8.png">

Screenshots of the changes:
<img width="1128" alt="Screenshot 2021-11-05 at 10 30 45" src="https://user-images.githubusercontent.com/25133454/140481431-6a8a481d-623c-4076-9617-640a8a6abbb8.png">

<img width="641" alt="Screenshot 2021-11-05 at 10 03 26" src="https://user-images.githubusercontent.com/25133454/140481523-8978fb0a-30cc-4476-b7c3-87bcb0f31c1b.png">

<img width="1122" alt="Screenshot 2021-11-05 at 10 30 55" src="https://user-images.githubusercontent.com/25133454/140481440-8825a924-7f1c-471b-a756-0d2d26723e7b.png">

<img width="628" alt="Screenshot 2021-11-05 at 10 07 33" src="https://user-images.githubusercontent.com/25133454/140481539-3eff0092-aa85-4092-821b-dd5f283d45d3.png">

<img width="1118" alt="Screenshot 2021-11-05 at 10 31 06" src="https://user-images.githubusercontent.com/25133454/140481453-93543be2-2278-496c-9ec5-ed0cef3f22f3.png">

<img width="637" alt="Screenshot 2021-11-05 at 10 04 08" src="https://user-images.githubusercontent.com/25133454/140481551-a0ecc4ae-3a18-4d9e-afe8-b9ed6e77ca97.png">

@bigcommerce/checkout
