### PR TITLE
fix(CHECKOUT) : CHECKOUT-5322 - Sentry CHECKOUT-JS-4VG

### DIFF
--- a/src/app/ui/form/Form.tsx
+++ b/src/app/ui/form/Form.tsx
@@ -33,7 +33,11 @@ const Form: FunctionComponent<FormProps> = ({
 
         if (erroredFormField) {
             erroredFormField.focus({preventScroll: true});
-            erroredFormField.offsetParent?.scrollIntoView({behavior: 'smooth', block: 'center', inline: 'center'});
+            try {
+                erroredFormField.offsetParent?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center'});
+            } catch {
+                erroredFormField.offsetParent?.scrollIntoView();
+            }
         }
     };
 


### PR DESCRIPTION
## What?
...
Add a try... catch... to handle this error produced in Sentry - "Error:” 'block' member of ScrollIntoViewOptions 'center' is not a valid value for enumeration ScrollLogicalPosition.“ - https://sentry.io/organizations/bigcommerce/issues/2751428755/events/10bc9b4d64254fc79a96615bb7adca79/events/?cursor=0%3A0%3A1&project=1542560

This error began after - https://github.com/bigcommerce/checkout-js/pull/732/commits/d5455c92cdff412d3249bf075b4ed0d056f6629f

This error seems to occur in older versions of Chrome, Firefox, and Safari. I've been able to replicate the error in Firefox 57. The error does not replicate in Firefox 58. I could not replicate the issue on Safari 13.1.2.  The issue replicated once on 85.0.4103 but not after. 

3% - Chrome <= 85.0.4103 OR Firefox <= 57.0 OR Safari <= 13.1.2

https://browserslist.dev/?q=Q2hyb21lIDw9IDg1LjAuNDEwMyBPUiBGaXJlZm94IDw9IDU3LjAgT1IgU2FmYXJpIDw9IDEzLjEuMg%3D%3D

## Why?
...
When replicating this issue, it does not disrupt the user. It just produces an error in the console, then does the default ScrollIntoView() behavior. 

This PR would allow us to catch this error if we feel it's necessary. I will defer to whatever the Checkout Team thinks is best. 

## Testing / Proof
...

before:

https://user-images.githubusercontent.com/5630999/140664236-a1a74bbe-bf4e-46e2-9c03-a5130e4eb451.mov

after:

https://user-images.githubusercontent.com/5630999/140664242-79d800e1-56dd-4830-ad15-6a5ebc9f2d0a.mov


