### PR TITLE
feat(payment): INT-5000 DigitalRiver: populate onUnhandledError correctly

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -229,6 +229,7 @@
             "credit_card_number_required_error": "Credit Card Number is required",
             "credit_card_number_mismatch_error": "The card number entered does not match the card stored in your account",
             "digitalriver_dropin_error": "There was an error while processing your payment. Please try again or contact us.",
+            "digitalriver_checkout_error": "There was a problem with your checkout, please check your details and try again or contact customer service",
             "digitalriver_display_name_text": "Please select your payment method",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Continue with Klarna",

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.spec.tsx
@@ -65,6 +65,7 @@ describe('when using Digital River payment', () => {
                 containerId: `${method.id}-component-field`,
                 initializePayment: expect.any(Function),
                 method,
+                onUnhandledError: expect.any(Function),
             }));
     });
 

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -2,6 +2,7 @@ import { noop } from 'lodash';
 import React, { useCallback, useContext, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
+import { CustomError } from '../../common/error';
 import { connectFormik, ConnectFormikProps } from '../../common/form';
 import { withLanguage, WithLanguageProps } from '../../locale';
 import { FormContext } from '../../ui/form';
@@ -54,7 +55,16 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
         },
     }), [initializePayment, containerId, isVaultingEnabled, setSubmitted, submitForm, onUnhandledError, language]);
 
-    const onError = (error: Error) => {
+    const onError = (error: CustomError) => {
+        if (error.name === 'digitalRiverCheckoutError') {
+            error = new CustomError({
+                title: language.translate('payment.errors.general_error'),
+                message: language.translate(error.type),
+                data: {},
+                name: 'digitalRiverCheckoutError',
+            });
+        }
+
         onUnhandledError?.(error);
     };
 

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -1,3 +1,4 @@
+import { noop } from 'lodash';
 import React, { useCallback, useContext, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
@@ -18,7 +19,7 @@ export enum DigitalRiverClasses {
 const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProps & WithLanguageProps> = ({
     initializePayment,
     language,
-    onUnhandledError,
+    onUnhandledError = noop,
     formik: { submitForm },
     ...rest
 }) => {
@@ -53,11 +54,16 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
         },
     }), [initializePayment, containerId, isVaultingEnabled, setSubmitted, submitForm, onUnhandledError, language]);
 
+    const onError = (error: Error) => {
+        onUnhandledError?.(error);
+    };
+
     return <HostedDropInPaymentMethod
         { ...rest }
         containerId={ containerId }
         hideVerificationFields
         initializePayment={ initializeDigitalRiverPayment }
+        onUnhandledError={ onError }
     />;
 };
 


### PR DESCRIPTION
## What?
Populate onUnhandledError correctly to show up the error message we sent from the strategy when the payment method isn't available.

## Why?
Digital River requested it because the shopper doesn't know what happened if the drop in element isn't rendered
![image](https://user-images.githubusercontent.com/35146660/140789462-89b14ae8-00e1-4265-b308-06eb892cf356.png)

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/140583027-d2070255-296d-4d60-8f7e-36b19ef20000.png)
![image](https://user-images.githubusercontent.com/35146660/140789241-9675dad3-6741-4b15-bf25-dec1d779cb91.png)

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1286


@bigcommerce/checkout @bigcommerce/apex-integrations 
