### PR TITLE
feat(payment): BOLT-95 changed PaymentSubmitButtonText for Bolt payment provider

### DIFF
--- a/src/app/locale/translations/de.json
+++ b/src/app/locale/translations/de.json
@@ -181,7 +181,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Fortfahren",
             "bluesnap_v2_continue_action": "Fortfahren",
-            "bolt_continue_action": "Mit Bolt fortfahren",
             "braintreevisacheckout_continue_action": "Mit Visa Checkout fortfahren",
             "ccavenuemars_description_text": "Bezahlvorgang mit CCAvenue abschließen",
             "chasepay_continue_action": "Mit Chase Pay fortfahren",

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -184,7 +184,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Continue",
             "bluesnap_v2_continue_action": "Continue",
-            "bolt_continue_action": "Continue with Bolt",
             "bolt_create_account_label": "Remember my information with Bolt",
             "bolt_create_account_disclaimer": "By checking above, you are agreeing to create a Bolt Account under <a href=\"{termsUrl}\" target=\"_blank\">terms</a> and <a href=\"{privacyPolicyUrl}\" target=\"_blank\">privacy policy</a>.",
             "bolt_name_text": "Bolt",

--- a/src/app/locale/translations/fr.json
+++ b/src/app/locale/translations/fr.json
@@ -181,7 +181,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Continuer",
             "bluesnap_v2_continue_action": "Continuer",
-            "bolt_continue_action": "Continuer avec Bolt",
             "braintreevisacheckout_continue_action": "Continuer avec Visa Checkout",
             "ccavenuemars_description_text": "Continuer avec CCAvenue",
             "chasepay_continue_action": "Continuer avec Chase Pay",

--- a/src/app/locale/translations/it.json
+++ b/src/app/locale/translations/it.json
@@ -181,7 +181,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Continua",
             "bluesnap_v2_continue_action": "Continua",
-            "bolt_continue_action": "Continua con Bolt",
             "braintreevisacheckout_continue_action": "Continua con Visa Checkout",
             "ccavenuemars_description_text": "Checkout con CCAvenue",
             "chasepay_continue_action": "Continua con Chase Pay",

--- a/src/app/locale/translations/nl.json
+++ b/src/app/locale/translations/nl.json
@@ -181,7 +181,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Doorgaan",
             "bluesnap_v2_continue_action": "Doorgaan",
-            "bolt_continue_action": "Doorgaan met Bolt",
             "braintreevisacheckout_continue_action": "Doorgaan met Visa Checkout",
             "ccavenuemars_description_text": "Afrekenen met CCAvenue",
             "chasepay_continue_action": "Doorgaan met Chase Pay",

--- a/src/app/locale/translations/pt-BR.json
+++ b/src/app/locale/translations/pt-BR.json
@@ -181,7 +181,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Continuar",
             "bluesnap_v2_continue_action": "Continuar",
-            "bolt_continue_action": "Prosseguir com o Bolt",
             "braintreevisacheckout_continue_action": "Prosseguir com o Visa Checkout",
             "ccavenuemars_description_text": "Finalizar a compra com o CCAvenue",
             "chasepay_continue_action": "Prosseguir com o Chase Pay",

--- a/src/app/locale/translations/pt.json
+++ b/src/app/locale/translations/pt.json
@@ -181,7 +181,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Continuar",
             "bluesnap_v2_continue_action": "Continuar",
-            "bolt_continue_action": "Prosseguir com o Bolt",
             "braintreevisacheckout_continue_action": "Prosseguir com o Visa Checkout",
             "ccavenuemars_description_text": "Finalizar a compra com o CCAvenue",
             "chasepay_continue_action": "Prosseguir com o Chase Pay",

--- a/src/app/locale/translations/sv.json
+++ b/src/app/locale/translations/sv.json
@@ -181,7 +181,6 @@
             "amazon_name_text": "Amazon Pay",
             "barclaycard_continue_action": "Fortsätt",
             "bluesnap_v2_continue_action": "Fortsätt",
-            "bolt_continue_action": "Fortsätt med Bolt",
             "braintreevisacheckout_continue_action": "Fortsätt med Visa Checkout",
             "ccavenuemars_description_text": "Fortsätt med CCAvenue",
             "chasepay_continue_action": "Fortsätt med Chase Pay",

--- a/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -1,6 +1,5 @@
-import { createCheckoutService, CheckoutSelectors, CheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, CheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { mount, render } from 'enzyme';
-import { set } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 import { CheckoutProvider } from '../checkout';
@@ -14,7 +13,6 @@ import PaymentSubmitButton, { PaymentSubmitButtonProps } from './PaymentSubmitBu
 describe('PaymentSubmitButton', () => {
     let PaymentSubmitButtonTest: FunctionComponent<PaymentSubmitButtonProps>;
     let checkoutService: CheckoutService;
-    let checkoutState: CheckoutSelectors;
     let languageService: LanguageService;
     let localeContext: LocaleContextType;
 
@@ -22,7 +20,6 @@ describe('PaymentSubmitButton', () => {
         checkoutService = createCheckoutService();
         localeContext = createLocaleContext(getStoreConfig());
         languageService = localeContext.language;
-        checkoutState = checkoutService.getState();
 
         PaymentSubmitButtonTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
@@ -86,7 +83,7 @@ describe('PaymentSubmitButton', () => {
         );
 
         expect(component.text())
-            .toEqual('Bolt' + languageService.translate('payment.bolt_continue_action'));
+            .toEqual('Bolt' + languageService.translate('payment.place_order_action'));
         expect(component.find(IconBolt).length)
             .toEqual(1);
     });

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -34,7 +34,7 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
     if (methodId === PaymentMethodId.Bolt) {
         return (<Fragment>
             <IconBolt additionalClassName="payment-submit-button-bolt-icon" />
-            <TranslatedString id="payment.bolt_continue_action" />
+            <TranslatedString id="payment.place_order_action" />
         </Fragment>);
     }
 


### PR DESCRIPTION
## What?
Changed PaymentSubmitButtonText for Bolt payment provider

## Why?
Because of the task: https://jira.bigcommerce.com/browse/BOLT-95

## Testing / Proof
Unit tests
Manual tests
<img width="359" alt="Screenshot 2021-11-10 at 09 59 24" src="https://user-images.githubusercontent.com/25133454/141073153-72dcf86c-54f4-4be1-9a17-6741748aff82.png">

Here is a screenshot:
<img width="1182" alt="Screenshot 2021-11-10 at 09 52 33" src="https://user-images.githubusercontent.com/25133454/141072791-0c8b0a49-6229-4a52-b025-57d2142dd2be.png">

@bigcommerce/checkout
