### PR TITLE
chore(payment): PAYMENTS-7391 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,14 +114,33 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.0.tgz",
-      "integrity": "sha512-S7iaOT1SYlqK0sQaCi21RX4+13hmdmnxIEAnQUB/eh7GeAnRjOUgTYpLkUOiRXzD+yog1JxP0qyAQZ7ZxVxLVg==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
+      "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
       "requires": {
         "@babel/compat-data": "^7.16.0",
         "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.17.5",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.18.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.0.tgz",
+          "integrity": "sha512-ER2M0g5iAR84fS/zjBDqEgU6iO5fS9JI2EkHr5zxDxYEFk3LjhU9Vpp/INb6RMQphxko7PDV1FH38H/qVP5yCA==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001280",
+            "electron-to-chromium": "^1.3.896",
+            "escalade": "^3.1.1",
+            "node-releases": "^2.0.1",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001280",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
+          "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA=="
+        }
       }
     },
     "@babel/helper-define-map": {
@@ -1119,12 +1138,12 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.0.tgz",
-          "integrity": "sha512-dVRM0StFMdKlkt7cVcGgwD8UMaBfWJHl3A83Yfs8GQ3MO0LHIIIMvK7Fa0RGOGUQ10qikLaX6D7o5htcQWgTMQ==",
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
+          "integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
           "requires": {
             "@babel/template": "^7.16.0",
-            "@babel/traverse": "^7.16.0",
+            "@babel/traverse": "^7.16.3",
             "@babel/types": "^7.16.0"
           }
         },
@@ -1185,9 +1204,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.16.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-          "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw=="
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz",
+          "integrity": "sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw=="
         },
         "@babel/template": {
           "version": "7.16.0",
@@ -1200,16 +1219,16 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
-          "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+          "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
           "requires": {
             "@babel/code-frame": "^7.16.0",
             "@babel/generator": "^7.16.0",
             "@babel/helper-function-name": "^7.16.0",
             "@babel/helper-hoist-variables": "^7.16.0",
             "@babel/helper-split-export-declaration": "^7.16.0",
-            "@babel/parser": "^7.16.0",
+            "@babel/parser": "^7.16.3",
             "@babel/types": "^7.16.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
@@ -1636,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.196.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.196.0.tgz",
-      "integrity": "sha512-HcagoL6v/QtsvvppoZqWi9QFlmpHq3rOf18IpcAtaMedOL2AtSuDR8Bb4DfT6d1BYR6z3C64Uc7sVpTR47vsGg==",
+      "version": "1.199.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.199.0.tgz",
+      "integrity": "sha512-y62M8fZkVBneCFONOs2PjxpR61U8Tq3PXAkKmBZD2W/U6xrOL6LA0zU9ffixJFyBZGzeINfyFoq/vXAfD4k3BA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -1661,6 +1680,7 @@
         "local-storage-fallback": "^4.1.1",
         "lodash": "^4.17.15",
         "messageformat": "2.1.0",
+        "query-string": "^7.0.1",
         "reselect": "^4.0.0",
         "rxjs": "^6.5.3",
         "shallowequal": "^1.1.0",
@@ -1686,6 +1706,16 @@
             "tslib": "^1.11.0"
           },
           "dependencies": {
+            "query-string": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+              "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+              "requires": {
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -1704,13 +1734,21 @@
           "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A=="
         },
         "query-string": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+          "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
           "requires": {
             "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
+            "filter-obj": "^1.1.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          },
+          "dependencies": {
+            "strict-uri-encode": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+              "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+            }
           }
         },
         "rxjs": {
@@ -4253,6 +4291,7 @@
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
       "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
@@ -4264,17 +4303,20 @@
         "caniuse-lite": {
           "version": "1.0.30001228",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-          "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
+          "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.736",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.736.tgz",
-          "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig=="
+          "integrity": "sha512-DY8dA7gR51MSo66DqitEQoUMQ0Z+A2DSXFi7tK304bdTVqczCAfUuyQw6Wdg8hIoo5zIxkU1L24RQtUce1Ioig==",
+          "dev": true
         },
         "node-releases": {
           "version": "1.1.72",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
-          "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw=="
+          "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+          "dev": true
         }
       }
     },
@@ -4952,7 +4994,8 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
     },
     "colors": {
       "version": "1.0.3",
@@ -7311,6 +7354,11 @@
         }
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.896",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.896.tgz",
+      "integrity": "sha512-NcGkBVXePiuUrPLV8IxP43n1EOtdg+dudVjrfVEUd/bOqpQUFZ2diL5PPYzbgEhZFEltdXV3AcyKwGnEQ5lhMA=="
+    },
     "elliptic": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -8455,6 +8503,11 @@
           }
         }
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-cache-dir": {
       "version": "2.1.0",
@@ -13135,6 +13188,11 @@
         }
       }
     },
+    "node-releases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+    },
     "node-sass": {
       "version": "4.14.1",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
@@ -13890,6 +13948,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.0.7",
@@ -15690,6 +15753,11 @@
       "requires": {
         "through": "2"
       }
+    },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.196.0",
+    "@bigcommerce/checkout-sdk": "^1.199.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

- Bump checkout-sdk version from `^1.196.0` to `^1.199.0`

## Why?

- To release: https://github.com/bigcommerce/checkout-sdk-js/pull/1285 (the ability to cancel abandoned PPSDK redirects)

## Testing / Proof

- Passing tests

@bigcommerce/checkout
