### PR TITLE
fix(payment): INT-4674 GooglePay: reinitialize payment on payment select

### DIFF
--- a/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
@@ -89,6 +89,7 @@ describe('when using Google Pay payment', () => {
                 [method.id]: {
                     walletButton: 'walletButton',
                     onError: defaultProps.onUnhandledError,
+                    onPaymentSelect: expect.any(Function),
                 },
             }));
     });

--- a/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
@@ -1,4 +1,4 @@
-import { createCheckoutService, CheckoutSelectors, CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, CheckoutSelectors, CheckoutService, PaymentInitializeOptions, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
@@ -92,5 +92,34 @@ describe('when using Google Pay payment', () => {
                     onPaymentSelect: expect.any(Function),
                 },
             }));
+    });
+
+    it('reinitializes method once payment option is selected', async () => {
+        const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
+        const component: ReactWrapper<WalletButtonPaymentMethodProps> = container.find(WalletButtonPaymentMethod);
+
+        component.prop('initializePayment')({
+            methodId: method.id,
+            gatewayId: method.gateway,
+        });
+
+        const options: PaymentInitializeOptions = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        const paymentSelectHandler = options.googlepaybraintree?.onPaymentSelect;
+        if (paymentSelectHandler) {
+            paymentSelectHandler();
+        }
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.deinitializePayment)
+            .toHaveBeenCalledWith({ methodId: method.id });
+        expect(checkoutService.initializePayment)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                methodId: method.id,
+                [method.id]: expect.any(Object),
+            }));
+        expect(checkoutService.initializePayment)
+            .toHaveBeenCalledTimes(2);
     });
 });

--- a/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
@@ -1,53 +1,99 @@
+import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
 import React, { useCallback, FunctionComponent } from 'react';
 import { Omit } from 'utility-types';
 
 import WalletButtonPaymentMethod, { WalletButtonPaymentMethodProps } from './WalletButtonPaymentMethod';
 
-export type GooglePayPaymentMethodProps = Omit<WalletButtonPaymentMethodProps, 'buttonId' | 'shouldShowEditButton'>;
+export type GooglePayPaymentMethodProps = Omit<
+  WalletButtonPaymentMethodProps,
+  'buttonId' | 'shouldShowEditButton'
+>;
 
-const GooglePayPaymentMethod: FunctionComponent<GooglePayPaymentMethodProps> = ({
+const GooglePayPaymentMethod: FunctionComponent<GooglePayPaymentMethodProps> =
+  ({
+    deinitializePayment,
     initializePayment,
-    onUnhandledError,
+    method,
+    onUnhandledError = noop,
     ...rest
-}) => {
-    const initializeGooglePayPayment = useCallback(options => initializePayment({
-        ...options,
-        googlepayadyenv2: {
-            walletButton: 'walletButton',
-            onError: onUnhandledError,
-        },
-        googlepayauthorizenet: {
-            walletButton: 'walletButton',
-            onError: onUnhandledError,
-        },
-        googlepaybraintree: {
-            walletButton: 'walletButton',
-            onError: onUnhandledError,
-        },
-        googlepaystripe: {
-            walletButton: 'walletButton',
-            onError: onUnhandledError,
-        },
-        googlepaycybersourcev2: {
-            walletButton: 'walletButton',
-            onError: onUnhandledError,
-        },
-        googlepayorbital: {
-            walletButton: 'walletButton',
-            onError: onUnhandledError,
-        },
-        googlepaycheckoutcom: {
-            walletButton: 'walletButton',
-            onError: onUnhandledError,
-        },
-    }), [initializePayment, onUnhandledError]);
+  }) => {
+    const initializeGooglePayPayment = useCallback((defaultOptions: PaymentInitializeOptions) => {
+        const reinitializePayment = async (options: PaymentInitializeOptions) => {
+          try {
+            await deinitializePayment({
+              gatewayId: method.gateway,
+              methodId: method.id,
+            });
 
-    return <WalletButtonPaymentMethod
-        { ...rest }
-        buttonId="walletButton"
-        initializePayment={ initializeGooglePayPayment }
-        shouldShowEditButton
-    />;
-};
+            await initializePayment({
+              ...options,
+              gatewayId: method.gateway,
+              methodId: method.id,
+            });
+          } catch (error) {
+            onUnhandledError(error);
+          }
+        };
+
+        const mergedOptions = {
+          ...defaultOptions,
+          googlepayadyenv2: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
+          googlepayauthorizenet: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
+          googlepaybraintree: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
+          googlepaystripe: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
+          googlepaycybersourcev2: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
+          googlepayorbital: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
+          googlepaycheckoutcom: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
+        };
+
+        return initializePayment(mergedOptions);
+      },
+      [
+        deinitializePayment,
+        initializePayment,
+        method,
+        onUnhandledError,
+    ]);
+
+    return (
+        <WalletButtonPaymentMethod
+            { ...rest }
+            buttonId="walletButton"
+            deinitializePayment={ deinitializePayment }
+            initializePayment={ initializeGooglePayPayment }
+            method={ method }
+            shouldShowEditButton
+        />
+    );
+  };
 
 export default GooglePayPaymentMethod;


### PR DESCRIPTION
## What? [INT-4674](https://jira.bigcommerce.com/browse/INT-4674)
Added a reinitialize function when Google Pay payment is selected

## Why?
So the wallet button works for changing the selected card when Google pay is selected

## Testing / Proof
https://drive.google.com/file/d/1rsx-TU__hCeUxXce05YdYAGXLqXBP1D8/view?usp=sharing

@bigcommerce/checkout
