### PR TITLE
feat(payment): CHECKOUT-6066 Add apple pay payment method component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.0.tgz",
-      "integrity": "sha512-DGjt2QZse5SGd9nfOSqO4WLJ8NN/oHkijbXbPrxuoJO3oIPJL3TciZs9FX+cOHNiY9E9l0opL8g7BmLe3T+9ew=="
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
+      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q=="
     },
     "@babel/core": {
       "version": "7.5.5",
@@ -125,9 +125,9 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.18.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.0.tgz",
-          "integrity": "sha512-ER2M0g5iAR84fS/zjBDqEgU6iO5fS9JI2EkHr5zxDxYEFk3LjhU9Vpp/INb6RMQphxko7PDV1FH38H/qVP5yCA==",
+          "version": "4.18.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+          "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
           "requires": {
             "caniuse-lite": "^1.0.30001280",
             "electron-to-chromium": "^1.3.896",
@@ -137,9 +137,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001280",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-          "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA=="
+          "version": "1.0.30001283",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+          "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg=="
         }
       }
     },
@@ -1204,9 +1204,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.16.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.3.tgz",
-          "integrity": "sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw=="
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng=="
         },
         "@babel/template": {
           "version": "7.16.0",
@@ -1396,9 +1396,9 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -1655,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.199.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.199.0.tgz",
-      "integrity": "sha512-y62M8fZkVBneCFONOs2PjxpR61U8Tq3PXAkKmBZD2W/U6xrOL6LA0zU9ffixJFyBZGzeINfyFoq/vXAfD4k3BA==",
+      "version": "1.200.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.200.0.tgz",
+      "integrity": "sha512-zKVd8kFfoVd65klmYhJzUzYGjkWnDTNXO/M4LHUQ7fK4SxxBtgpHTlhRj4hffibP7QIE482lVrC15wQ5uPd9Gw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -1724,9 +1724,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.176",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
-          "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+          "version": "4.14.177",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+          "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
         },
         "@types/yup": {
           "version": "0.26.37",
@@ -7355,9 +7355,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.896",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.896.tgz",
-      "integrity": "sha512-NcGkBVXePiuUrPLV8IxP43n1EOtdg+dudVjrfVEUd/bOqpQUFZ2diL5PPYzbgEhZFEltdXV3AcyKwGnEQ5lhMA=="
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.6.tgz",
+      "integrity": "sha512-YDZAXP0P8USm0YoyIXWijxFT3tJHbt3WwY7CTQiK3+Ad6Ai/b9N4GqfDR107jfGilAfxl7Gkhb+h0KPoKXAgqw=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.199.0",
+    "@bigcommerce/checkout-sdk": "^1.200.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/paymentMethod/ApplePayPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/ApplePayPaymentMethod.spec.tsx
@@ -1,0 +1,95 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { getCart } from '../../cart/carts.mock';
+import { CheckoutProvider } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { getCustomer } from '../../customer/customers.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { getPaymentMethod } from '../payment-methods.mock';
+import PaymentContext, { PaymentContextProps } from '../PaymentContext';
+
+import ApplePayPaymentMethod from './ApplePayPaymentMethod';
+import HostedPaymentMethod, { HostedPaymentMethodProps } from './HostedPaymentMethod';
+import PaymentMethodId from './PaymentMethodId';
+
+describe('ApplePayPaymentMethod', () => {
+    let defaultProps: HostedPaymentMethodProps;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let localeContext: LocaleContextType;
+    let paymentContext: PaymentContextProps;
+    let PaymentMethodTest: FunctionComponent;
+
+    beforeEach(() => {
+        defaultProps = {
+            initializePayment: jest.fn(),
+            deinitializePayment: jest.fn(),
+            method: {
+                ...getPaymentMethod(),
+                id: PaymentMethodId.ApplePay,
+                initializationData: {
+                    merchantCapabilities: [
+                        'supports3DS',
+                    ],
+                },
+            },
+        };
+
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+        paymentContext = {
+            disableSubmit: jest.fn(),
+            setSubmit: jest.fn(),
+            setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
+        };
+
+        jest.spyOn(checkoutState.data, 'getCart')
+            .mockReturnValue(getCart());
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getCustomer')
+            .mockReturnValue(getCustomer());
+
+        PaymentMethodTest = props => (
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <PaymentContext.Provider value={ paymentContext }>
+                    <LocaleContext.Provider value={ localeContext }>
+                        <Formik
+                            initialValues={ {} }
+                            onSubmit={ noop }
+                        >
+                            <ApplePayPaymentMethod { ...defaultProps } { ...props } />
+                        </Formik>
+                    </LocaleContext.Provider>
+                </PaymentContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('renders as hosted method', () => {
+        const container = mount(<PaymentMethodTest />);
+
+        expect(container.find(HostedPaymentMethod).length).toEqual(1);
+    });
+
+    it('initializes method with required config', () => {
+        mount(<PaymentMethodTest />);
+
+        expect(defaultProps.initializePayment)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                methodId: defaultProps.method.id,
+                [defaultProps.method.id]: {
+                    shippingLabel: 'Shipping',
+                    subtotalLabel: 'Subtotal',
+                },
+            }));
+    });
+});

--- a/src/app/payment/paymentMethod/ApplePayPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/ApplePayPaymentMethod.tsx
@@ -1,0 +1,30 @@
+import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import React, { useCallback, useContext, FunctionComponent } from 'react';
+
+import { LocaleContext } from '../../locale';
+
+import HostedPaymentMethod, { HostedPaymentMethodProps } from './HostedPaymentMethod';
+
+const ApplePayPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = ({
+    initializePayment,
+    method,
+    ...rest
+}) => {
+    const localeContext = useContext(LocaleContext);
+
+    const initializeApplePay = useCallback((options: PaymentInitializeOptions) => initializePayment({
+        ...options,
+        applepay: {
+            shippingLabel: localeContext?.language.translate('cart.shipping_text'),
+            subtotalLabel: localeContext?.language.translate('cart.subtotal_text'),
+        },
+    }), [initializePayment, localeContext]);
+
+    return <HostedPaymentMethod
+        { ...rest }
+        initializePayment={ initializeApplePay }
+        method={ method }
+    />;
+};
+
+export default ApplePayPaymentMethod;

--- a/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
@@ -99,6 +99,8 @@ class HostedPaymentMethod extends Component<
             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
         } = this.props;
 
+        console.log('hostedmethods', this.props);
+
         const {
             selectedInstrument = this.getDefaultInstrument(),
         } = this.state;

--- a/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/HostedPaymentMethod.tsx
@@ -99,8 +99,6 @@ class HostedPaymentMethod extends Component<
             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
         } = this.props;
 
-        console.log('hostedmethods', this.props);
-
         const {
             selectedInstrument = this.getDefaultInstrument(),
         } = this.state;

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -8,6 +8,7 @@ import AdyenV2PaymentMethod from './AdyenV2PaymentMethod';
 import AffirmPaymentMethod from './AffirmPaymentMethod';
 import AmazonPaymentMethod from './AmazonPaymentMethod';
 import AmazonPayV2PaymentMethod from './AmazonPayV2PaymentMethod';
+import ApplePayPaymentMethod from './ApplePayPaymentMethod';
 import BarclaycardPaymentMethod from './BarclaycardPaymentMethod';
 import BlueSnapV2PaymentMethod from './BlueSnapV2PaymentMethod';
 import BoltPaymentMethod from './BoltPaymentMethod';
@@ -75,7 +76,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
     }
 
     if (method.id === PaymentMethodId.ApplePay) {
-        return <HostedPaymentMethod { ...props } />
+        return <ApplePayPaymentMethod { ...props } />;
     }
 
     if (method.id === PaymentMethodId.SquareV2) {

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -75,7 +75,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
     }
 
     if (method.id === PaymentMethodId.ApplePay) {
-        return null;
+        return <HostedPaymentMethod { ...props } />
     }
 
     if (method.id === PaymentMethodId.SquareV2) {


### PR DESCRIPTION
## What?
Add apple pay payment method component

## Why?
In order to complete payment via apple pay we need to add a component that is responsible for initializing the apple pay payment method.

## Testing / Proof
- Screencast

https://user-images.githubusercontent.com/7134802/144144889-4f705c6d-6ae4-455e-b9f7-edc1f4fcea80.mov


@bigcommerce/checkout
