### PR TITLE
chore(checkout): ADYEN-320 bump sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001283",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
-          "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg=="
+          "version": "1.0.30001284",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001284.tgz",
+          "integrity": "sha512-t28SKa7g6kiIQi6NHeOcKrOrGMzCRrXvlasPwWC26TH2QNdglgzQIRUuJ0cR3NeQPH+5jpuveeeSFDLm2zbkEw=="
         }
       }
     },
@@ -1655,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.200.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.200.0.tgz",
-      "integrity": "sha512-zKVd8kFfoVd65klmYhJzUzYGjkWnDTNXO/M4LHUQ7fK4SxxBtgpHTlhRj4hffibP7QIE482lVrC15wQ5uPd9Gw==",
+      "version": "1.201.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.201.2.tgz",
+      "integrity": "sha512-IAC0KFBnLJ7sHZxRmORGDNUgCtWiRPMZac5eUHXK0yqLH0NVO5yDiVJyKA86SfpuabSA5howPTYYkBBSsYfpsA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -7355,9 +7355,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.6.tgz",
-      "integrity": "sha512-YDZAXP0P8USm0YoyIXWijxFT3tJHbt3WwY7CTQiK3+Ad6Ai/b9N4GqfDR107jfGilAfxl7Gkhb+h0KPoKXAgqw=="
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.10.tgz",
+      "integrity": "sha512-tFgA40Iq2oy4k2PnZrLJowbgpij+lD6ZLxkw8Ht1NKTYyN8dvSvC5xlo8X0WW2jqhKSzITrbr5mpB4/AZ/8OUA=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.200.0",
+    "@bigcommerce/checkout-sdk": "^1.201.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
Due to the release of https://jira.bigcommerce.com/browse/ADYEN-320
https://github.com/bigcommerce/checkout-sdk-js/pull/1298

## Testing / Proof
Tested manually

@bigcommerce/checkout
