### PR TITLE
fix(checkout): CHECKOUT-6215 Display long descriptions of shipping methods properly

### DIFF
--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -69,9 +69,9 @@
         }
 
         .shippingOption-additionalDescription--collapsed {
-            height: 3rem;
+            height: 1.5rem;
             overflow: hidden;
-            width: 80%;
+            width: 65%;
         }
 
         .shippingOption-additionalDescription--expanded {

--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -69,7 +69,7 @@
         }
 
         .shippingOption-additionalDescription--collapsed {
-            height: 3.2rem;
+            height: 3rem;
             overflow: hidden;
             width: 80%;
         }

--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -33,6 +33,9 @@
 // ShippingOption Label
 // ---------------------------------------------------
 .shippingOptionLabel {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
     .shippingOption {
         align-items: center;
         display: flex;

--- a/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -33,9 +33,6 @@
 // ShippingOption Label
 // ---------------------------------------------------
 .shippingOptionLabel {
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-
     .shippingOption {
         align-items: center;
         display: flex;
@@ -72,9 +69,8 @@
         }
 
         .shippingOption-additionalDescription--collapsed {
-            height: 2.2rem;
+            height: 3.2rem;
             overflow: hidden;
-            white-space: nowrap;
             width: 80%;
         }
 


### PR DESCRIPTION
## What?
Wrap the long descriptions of shipping methods.

## Why? [CHECKOUT-6215](https://jira.bigcommerce.com/browse/CHECKOUT-6215)
Long texts in `ShippingOptionAdditionalDescription` component ([link](https://github.com/bigcommerce/checkout-js/blob/40e8b28cbdf55353e5887cb5267af8e85b83e926/src/app/shipping/shippingOption/ShippingOptionAdditionalDescription.tsx#L28
)) are breaking the checkout page now.

![k64M3ujqj2](https://user-images.githubusercontent.com/88361607/144773224-4a84d343-c19b-4e5c-a48c-94a687bf175d.png)

## Testing / Proof

Before:

https://user-images.githubusercontent.com/88361607/144783655-7b5dcacf-dd9d-4470-a051-3bd8c57de43d.mov

After:

https://user-images.githubusercontent.com/88361607/144943746-ee6b3740-060d-48a4-9b7f-8a5930007817.mov