### PR TITLE
chore(payment): BOLT-109 bump up checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001285",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
-          "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q=="
+          "version": "1.0.30001286",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
+          "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ=="
         }
       }
     },
@@ -1655,9 +1655,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.203.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.203.0.tgz",
-      "integrity": "sha512-4nNBw5vpIoQNc65otTdrodXRYDPVDNaSiZOLFEso6Go7gM6vVxY2AdSIA10RTD9DaWs3dP8PUsSjy78lK994/A==",
+      "version": "1.204.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.204.0.tgz",
+      "integrity": "sha512-xoJRUN8vevxQaZLY3CC5oRbM4hSv2BpPy5I+iJdstJBvmY0qNYW1dR7IoGCh/HrVt1HGlq3RJb0Xevk6SuXUWg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -1724,9 +1724,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.177",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
-          "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
+          "version": "4.14.178",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
+          "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
         },
         "@types/yup": {
           "version": "0.26.37",
@@ -7355,9 +7355,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.13.tgz",
-      "integrity": "sha512-ih5tIhzEuf78pBY70FXLo+Pw73R5MPPPcXb4CGBMJaCQt/qo/IGIesKXmswpemVCKSE2Bulr5FslUv7gAWJoOw=="
+      "version": "1.4.16",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.16.tgz",
+      "integrity": "sha512-BQb7FgYwnu6haWLU63/CdVW+9xhmHls3RCQUFiV4lvw3wimEHTVcUk2hkuZo76QhR8nnDdfZE7evJIZqijwPdA=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.203.0",
+    "@bigcommerce/checkout-sdk": "^1.204.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump up checkout-sdk-js version

## Why?
To release the task: https://jira.bigcommerce.com/browse/BOLT-109

## Testing / Proof
All tests and proofs available here: https://github.com/bigcommerce/checkout-sdk-js/pull/1304
