### PR TITLE
feat(payment): INT-4893 Add translations for errors from SDK - Humm

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -232,6 +232,7 @@
             "digitalriver_checkout_error": "There was a problem with your checkout, please check your details and try again or contact customer service",
             "digitalriver_display_name_text": "Please select your payment method",
             "google_pay_name_text": "Google Pay",
+            "humm_not_processable_error": "Humm cannot process your payment for this order, please select another payment method.",
             "klarna_continue_action": "Continue with Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",

--- a/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
+++ b/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
@@ -213,6 +213,16 @@ describe('mapSubmitOrderErrorMessage()', () => {
 
             expect(message).toEqual(translate('payment.place_order_error'));
         });
+
+        it('returns correct translated message when payment_execute_error', () => {
+            const error = {
+                type: 'custom_provider_execute_error',
+                subtype: 'payment.humm_not_processable_error',
+            };
+            const message = mapSubmitOrderErrorMessage(error, translate, false);
+
+            expect(message).toEqual(translate('payment.humm_not_processable_error'));
+        });
     });
 });
 

--- a/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -10,6 +10,9 @@ export default function mapSubmitOrderErrorMessage(
         case 'not_initialized':
             return translate('payment.payment_error');
 
+        case 'custom_provider_execute_error':
+            return translate(error.subtype);
+
         case 'payment_cancelled':
             return translate('payment.payment_cancelled');
 


### PR DESCRIPTION
## What?  [INT-4893](https://jira.bigcommerce.com/browse/INT-4893)
Add support to translate, if necessary, error messages from the execute step in the payment strategy

## Why?
We need to translate the messages that are shown to customer to achieve a successful internationalization

## Testing / Proof
![image](https://user-images.githubusercontent.com/36899206/146252619-f0722b9e-514c-4e7f-8cd8-b9cf4ac5eb05.png)

@bigcommerce/apex-integrations 
