### PR TITLE
chore(payment): INT-4893 INT-4926 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,12 +125,12 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.18.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
-          "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
+          "version": "4.19.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+          "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
           "requires": {
-            "caniuse-lite": "^1.0.30001280",
-            "electron-to-chromium": "^1.3.896",
+            "caniuse-lite": "^1.0.30001286",
+            "electron-to-chromium": "^1.4.17",
             "escalade": "^3.1.1",
             "node-releases": "^2.0.1",
             "picocolors": "^1.0.0"
@@ -152,6 +152,25 @@
         "@babel/helper-function-name": "^7.1.0",
         "@babel/types": "^7.5.5",
         "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.5.tgz",
+      "integrity": "sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==",
+      "requires": {
+        "@babel/types": "^7.16.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+          "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -423,9 +442,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         }
       }
     },
@@ -438,9 +457,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         }
       }
     },
@@ -462,9 +481,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         }
       }
     },
@@ -486,9 +505,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         }
       }
     },
@@ -501,9 +520,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         }
       }
     },
@@ -516,9 +535,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         }
       }
     },
@@ -549,9 +568,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         }
       }
     },
@@ -1029,9 +1048,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-          "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.5.tgz",
+          "integrity": "sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==",
           "requires": {
             "@babel/types": "^7.16.0",
             "jsesc": "^2.5.1",
@@ -1071,14 +1090,6 @@
             "@babel/types": "^7.16.0"
           }
         },
-        "@babel/helper-member-expression-to-functions": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-          "integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
-          "requires": {
-            "@babel/types": "^7.16.0"
-          }
-        },
         "@babel/helper-module-imports": {
           "version": "7.16.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
@@ -1088,36 +1099,17 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
-          "integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.5.tgz",
+          "integrity": "sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==",
           "requires": {
+            "@babel/helper-environment-visitor": "^7.16.5",
             "@babel/helper-module-imports": "^7.16.0",
-            "@babel/helper-replace-supers": "^7.16.0",
             "@babel/helper-simple-access": "^7.16.0",
             "@babel/helper-split-export-declaration": "^7.16.0",
             "@babel/helper-validator-identifier": "^7.15.7",
             "@babel/template": "^7.16.0",
-            "@babel/traverse": "^7.16.0",
-            "@babel/types": "^7.16.0"
-          }
-        },
-        "@babel/helper-optimise-call-expression": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-          "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
-          "requires": {
-            "@babel/types": "^7.16.0"
-          }
-        },
-        "@babel/helper-replace-supers": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-          "integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
-          "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.16.0",
-            "@babel/helper-optimise-call-expression": "^7.16.0",
-            "@babel/traverse": "^7.16.0",
+            "@babel/traverse": "^7.16.5",
             "@babel/types": "^7.16.0"
           }
         },
@@ -1138,12 +1130,12 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.16.3",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
-          "integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.5.tgz",
+          "integrity": "sha512-TLgi6Lh71vvMZGEkFuIxzaPsyeYCHQ5jJOOX1f0xXn0uciFuE8cEk0wyBquMcCxBXZ5BJhE2aUB7pnWTD150Tw==",
           "requires": {
             "@babel/template": "^7.16.0",
-            "@babel/traverse": "^7.16.3",
+            "@babel/traverse": "^7.16.5",
             "@babel/types": "^7.16.0"
           }
         },
@@ -1204,9 +1196,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.16.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng=="
+          "version": "7.16.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.6.tgz",
+          "integrity": "sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ=="
         },
         "@babel/template": {
           "version": "7.16.0",
@@ -1219,16 +1211,17 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.16.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
-          "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.5.tgz",
+          "integrity": "sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==",
           "requires": {
             "@babel/code-frame": "^7.16.0",
-            "@babel/generator": "^7.16.0",
+            "@babel/generator": "^7.16.5",
+            "@babel/helper-environment-visitor": "^7.16.5",
             "@babel/helper-function-name": "^7.16.0",
             "@babel/helper-hoist-variables": "^7.16.0",
             "@babel/helper-split-export-declaration": "^7.16.0",
-            "@babel/parser": "^7.16.3",
+            "@babel/parser": "^7.16.5",
             "@babel/types": "^7.16.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
@@ -1450,18 +1443,18 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.16.0",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
-              "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+              "version": "7.16.5",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.5.tgz",
+              "integrity": "sha512-wUcenlLzuWMZ9Zt8S0KmFwGlH6QKRh3vsm/dhDA3CHkiTA45YuG1XkHRcNRl73EFPXDp/d5kVOU0/y7x2w6OaQ==",
               "requires": {
                 "@babel/code-frame": "^7.16.0",
-                "@babel/generator": "^7.16.0",
-                "@babel/helper-compilation-targets": "^7.16.0",
-                "@babel/helper-module-transforms": "^7.16.0",
-                "@babel/helpers": "^7.16.0",
-                "@babel/parser": "^7.16.0",
+                "@babel/generator": "^7.16.5",
+                "@babel/helper-compilation-targets": "^7.16.3",
+                "@babel/helper-module-transforms": "^7.16.5",
+                "@babel/helpers": "^7.16.5",
+                "@babel/parser": "^7.16.5",
                 "@babel/template": "^7.16.0",
-                "@babel/traverse": "^7.16.0",
+                "@babel/traverse": "^7.16.5",
                 "@babel/types": "^7.16.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
@@ -1655,9 +1648,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.204.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.204.0.tgz",
-      "integrity": "sha512-xoJRUN8vevxQaZLY3CC5oRbM4hSv2BpPy5I+iJdstJBvmY0qNYW1dR7IoGCh/HrVt1HGlq3RJb0Xevk6SuXUWg==",
+      "version": "1.205.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.205.0.tgz",
+      "integrity": "sha512-h5dB6JpogxXtEZ1EIJQQ941o9cSGcWstRhPkrvXKwAbYyxg0btPTQHp5cDRfu1lvdwNLkQXkq2jN5LLDD4/ZvA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.14.0",
@@ -3621,9 +3614,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
+          "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ=="
         },
         "@babel/plugin-syntax-async-generators": {
           "version": "7.8.4",
@@ -7355,9 +7348,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.16.tgz",
-      "integrity": "sha512-BQb7FgYwnu6haWLU63/CdVW+9xhmHls3RCQUFiV4lvw3wimEHTVcUk2hkuZo76QhR8nnDdfZE7evJIZqijwPdA=="
+      "version": "1.4.19",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.19.tgz",
+      "integrity": "sha512-TeAjwsC/vhvxEtX/xN1JQUMkl+UrwKXlB4rwLyuLYVuBuRtqJJrU4Jy5pCVihMQg4m1ceZ3MEJ0yYuxHj8vC+w=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.204.0",
+    "@bigcommerce/checkout-sdk": "^1.205.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to 1.205.0

## Why?
To get the following changes released:
- https://github.com/bigcommerce/checkout-sdk-js/pull/1287
- https://github.com/bigcommerce/checkout-sdk-js/pull/1288

## Testing / Proof
See videos on the above PRs

@bigcommerce/checkout @bigcommerce/apex-integrations