### PR TITLE
feat(payment): CHECKOUT-6070 Add applepay button component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,9 +1196,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.16.10",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
-          "integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ=="
+          "version": "7.16.12",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+          "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
         },
         "@babel/template": {
           "version": "7.16.7",
@@ -1443,16 +1443,16 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.16.10",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.10.tgz",
-              "integrity": "sha512-pbiIdZbCiMx/MM6toR+OfXarYix3uz0oVsnNtfdAGTcCTu3w/JGF8JhirevXLBJUu0WguSZI12qpKnx7EeMyLA==",
+              "version": "7.16.12",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
+              "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
               "requires": {
                 "@babel/code-frame": "^7.16.7",
                 "@babel/generator": "^7.16.8",
                 "@babel/helper-compilation-targets": "^7.16.7",
                 "@babel/helper-module-transforms": "^7.16.7",
                 "@babel/helpers": "^7.16.7",
-                "@babel/parser": "^7.16.10",
+                "@babel/parser": "^7.16.12",
                 "@babel/template": "^7.16.7",
                 "@babel/traverse": "^7.16.10",
                 "@babel/types": "^7.16.8",
@@ -7348,9 +7348,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.49",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.49.tgz",
-      "integrity": "sha512-k/0t1TRfonHIp8TJKfjBu2cKj8MqYTiEpOhci+q7CVEE5xnCQnx1pTa+V8b/sdhe4S3PR4p4iceEQWhGrKQORQ=="
+      "version": "1.4.51",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.51.tgz",
+      "integrity": "sha512-JNEmcYl3mk1tGQmy0EvL5eik/CKSBuzAyGP0QFdG6LIgxQe3II0BL1m2zKc2MZMf3uGqHWE1TFddJML0RpjSHQ=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.210.0",
+    "@bigcommerce/checkout-sdk": "^1.211.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/checkout/index.ts
+++ b/src/app/checkout/index.ts
@@ -4,3 +4,4 @@ export { default as CheckoutProvider, CheckoutProviderProps, CheckoutProviderSta
 export { default as withCheckout } from './withCheckout';
 export { default as CheckoutSupport } from './CheckoutSupport';
 export { default as NoopCheckoutSupport } from './NoopCheckoutSupport';
+export { default as navigateToOrderConfirmation } from './navigateToOrderConfirmation';

--- a/src/app/customer/CheckoutButtonList.tsx
+++ b/src/app/customer/CheckoutButtonList.tsx
@@ -3,12 +3,14 @@ import React, { memo, Fragment, FunctionComponent } from 'react';
 
 import { TranslatedString } from '../locale';
 
+import { ApplePayButton } from './customWalletButton';
 import CheckoutButton from './CheckoutButton';
 
 // TODO: The API should tell UI which payment method offers its own checkout button
 export const SUPPORTED_METHODS: string[] = [
     'amazon',
     'amazonpay',
+    'applepay',
     'braintreevisacheckout',
     'chasepay',
     'masterpass',
@@ -64,13 +66,21 @@ const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
 
             <div className="checkoutRemote">
                 { supportedMethodIds.map(methodId =>
-                    <CheckoutButton
-                        containerId={ `${methodId}CheckoutButton` }
-                        key={ methodId }
-                        methodId={ methodId }
-                        onError={ onError }
-                        { ...rest }
-                    />
+                    methodId === 'applepay' ?
+                        <ApplePayButton
+                            containerId={ `${methodId}CheckoutButton` }
+                            key={ methodId }
+                            methodId={ methodId }
+                            onError={ onError }
+                            { ...rest }
+                        /> :
+                        <CheckoutButton
+                            containerId={ `${methodId}CheckoutButton` }
+                            key={ methodId }
+                            methodId={ methodId }
+                            onError={ onError }
+                            { ...rest }
+                        />
                 ) }
             </div>
         </Fragment>

--- a/src/app/customer/customWalletButton/ApplePayButton.spec.tsx
+++ b/src/app/customer/customWalletButton/ApplePayButton.spec.tsx
@@ -41,6 +41,7 @@ describe('ApplePayButton', () => {
         expect(initialize).toHaveBeenCalledWith({
             methodId: 'applepay',
             applepay: {
+                container: 'test',
                 shippingLabel: 'Shipping',
                 subtotalLabel: 'Subtotal',
                 onError: error,

--- a/src/app/customer/customWalletButton/ApplePayButton.spec.tsx
+++ b/src/app/customer/customWalletButton/ApplePayButton.spec.tsx
@@ -1,0 +1,51 @@
+import { mount } from 'enzyme';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { navigateToOrderConfirmation } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import CheckoutButton from '../CheckoutButton';
+
+import ApplePayButton from './ApplePayButton';
+
+describe('ApplePayButton', () => {
+    let localeContext: LocaleContextType;
+    let ButtonTest: FunctionComponent;
+    const initialize = jest.fn();
+    const error = jest.fn();
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        ButtonTest = () => (
+            <LocaleContext.Provider value={ localeContext }>
+                <ApplePayButton
+                    containerId={ 'test' }
+                    deinitialize={ noop }
+                    initialize={ initialize }
+                    methodId={ 'applepay' }
+                    onError={ error }
+                />
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('renders as CheckoutButton', () => {
+        const container = mount(<ButtonTest />);
+
+        expect(container.find(CheckoutButton).length).toEqual(1);
+    });
+
+    it('initializes the button correctly', () => {
+        mount(<ButtonTest />);
+        expect(initialize).toHaveBeenCalledWith({
+            methodId: 'applepay',
+            applepay: {
+                shippingLabel: 'Shipping',
+                subtotalLabel: 'Subtotal',
+                onError: error,
+                onPaymentAuthorize: navigateToOrderConfirmation,
+            },
+        });
+    });
+});

--- a/src/app/customer/customWalletButton/ApplePayButton.tsx
+++ b/src/app/customer/customWalletButton/ApplePayButton.tsx
@@ -1,0 +1,27 @@
+import { CustomerInitializeOptions } from '@bigcommerce/checkout-sdk';
+import React, { useCallback, useContext, FunctionComponent } from 'react';
+
+import { navigateToOrderConfirmation } from '../../checkout';
+import { LocaleContext } from '../../locale';
+import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
+
+const ApplePayButton: FunctionComponent<CheckoutButtonProps> = ({
+    initialize,
+    onError,
+    ...rest
+}) => {
+    const localeContext = useContext(LocaleContext);
+    const initializeOptions = useCallback((options: CustomerInitializeOptions) => initialize({
+        ...options,
+        applepay: {
+            shippingLabel: localeContext?.language.translate('cart.shipping_text'),
+            subtotalLabel: localeContext?.language.translate('cart.subtotal_text'),
+            onError,
+            onPaymentAuthorize: navigateToOrderConfirmation,
+        },
+    }), [initialize, localeContext, onError]);
+
+    return <CheckoutButton initialize={ initializeOptions } { ...rest } />;
+};
+
+export default ApplePayButton;

--- a/src/app/customer/customWalletButton/ApplePayButton.tsx
+++ b/src/app/customer/customWalletButton/ApplePayButton.tsx
@@ -14,12 +14,13 @@ const ApplePayButton: FunctionComponent<CheckoutButtonProps> = ({
     const initializeOptions = useCallback((options: CustomerInitializeOptions) => initialize({
         ...options,
         applepay: {
+            container: rest.containerId,
             shippingLabel: localeContext?.language.translate('cart.shipping_text'),
             subtotalLabel: localeContext?.language.translate('cart.subtotal_text'),
             onError,
             onPaymentAuthorize: navigateToOrderConfirmation,
         },
-    }), [initialize, localeContext, onError]);
+    }), [initialize, localeContext, onError, rest.containerId]);
 
     return <CheckoutButton initialize={ initializeOptions } { ...rest } />;
 };

--- a/src/app/customer/customWalletButton/index.ts
+++ b/src/app/customer/customWalletButton/index.ts
@@ -1,0 +1,1 @@
+export { default as ApplePayButton } from './ApplePayButton';


### PR DESCRIPTION
## What?
Add apple pay wallet method component

## Why?
In order to complete payment via apple pay as a wallet button, we need to create a component to render apple pay with it's extra config.

## Testing / Proof
- Screencast
- Test

https://user-images.githubusercontent.com/7134802/146874158-8d39a584-d572-4f9f-b4e5-77117ee67673.mov

@bigcommerce/checkout
