### PR TITLE
feat(payment): INT-5331 Remove validation for Amazon Pay and all the time show an specific label

### DIFF
--- a/src/app/billing/StaticBillingAddress.spec.tsx
+++ b/src/app/billing/StaticBillingAddress.spec.tsx
@@ -76,7 +76,6 @@ describe('StaticBillingAddress', () => {
 
         const addressData = {
             ...getAddress(),
-            firstName: '',
         };
 
         const container = mount(<StaticBillingAddressTest address={ addressData } />);
@@ -86,24 +85,5 @@ describe('StaticBillingAddress', () => {
 
         expect(container.text())
             .toEqual(getLanguageService().translate('billing.billing_address_amazonpay'));
-    });
-
-    it('renders address when using Amazon Pay V2 when full address is provided', () => {
-        jest.spyOn(checkoutState.data, 'getCheckout')
-            .mockReturnValue({
-                ...getCheckout(),
-                payments: [
-                    { ...getCheckoutPayment(), providerId: 'amazonpay' },
-                ],
-            });
-
-        const addressData = {
-            ...getAddress(),
-        };
-
-        const container = mount(<StaticBillingAddressTest address={ addressData } />);
-
-        expect(container.find(StaticAddress).length)
-            .toEqual(1);
     });
 });

--- a/src/app/billing/StaticBillingAddress.tsx
+++ b/src/app/billing/StaticBillingAddress.tsx
@@ -28,7 +28,7 @@ const StaticBillingAddress: FunctionComponent<
         );
     }
 
-    if (payments.find(payment => payment.providerId === 'amazonpay' && address.firstName === '')) {
+    if (payments.find(payment => payment.providerId === 'amazonpay')) {
         return (
             <p><TranslatedString id="billing.billing_address_amazonpay" /></p>
         );


### PR DESCRIPTION
## What?
[INT-5331](https://jira.bigcommerce.com/browse/INT-5331): Remove validation for Amazon Pay and all the time show an specific label

## Why?
Amazon requested to use shipping address when billing address is empty, however the shipping address was displaying as billing address an address is provided. The `Managed by Amazon` legend should be displayed in all cases in the billing address space instead.

## Testing / Proof
![INT-5331 Amazon Pay](https://user-images.githubusercontent.com/46331158/148439842-729a2e3e-0056-4491-9ad6-5b44e18892b8.gif)

## Dependency of
- https://github.com/bigcommerce/bigcommerce/pull/44369

@bigcommerce/checkout @bigcommerce/apex-integrations 