### PR TITLE
chore(checkout): INT-5031 Bump checkout-sdk v1.207.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.206.2",
+    "@bigcommerce/checkout-sdk": "^1.207.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk.

## Why?
To get https://github.com/bigcommerce/checkout-sdk-js/pull/1295 out

## Testing / Proof
CircleCI + see the videos on above PR