### PR TITLE
chore(checkout): CHECKOUT-0000 Update Node Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ aliases:
   - &node_executor
       executor:
         name: node/node
-        node-version: "14"
+        node-version: "14.18"
 
   - &release_filter
       branches:


### PR DESCRIPTION
## What?
Update the node image, so Circle Ci can be back on track.

## Why?
Circle Ci is not working now due to missing the proper node image.