### PR TITLE
feat(payment): INT-5460 Remove the word Payment from error title

### DIFF
--- a/src/app/locale/translations/de.json
+++ b/src/app/locale/translations/de.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "Kreditkartennummer erforderlich",
             "credit_card_number_mismatch_error": "Die eingegebene Kartennummer entspricht nicht der in Ihrem Konto gespeicherten Karte",
             "digitalriver_dropin_error": "Bei der Verarbeitung Ihrer Zahlung ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut oder nehmen Sie Kontakt zu uns auf.",
+            "digitalriver_checkout_error": "Es gab ein Problem mit Ihrem Checkout, bitte überprüfen Sie Ihre Daten und versuchen Sie es erneut oder wenden Sie sich an den Kundenservice",
+            "digitalriver_checkout_error_title": "Fehler beim Verarbeiten der Anfrage.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Weiter mit Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -230,6 +230,7 @@
             "credit_card_number_mismatch_error": "The card number entered does not match the card stored in your account",
             "digitalriver_dropin_error": "There was an error while processing your payment. Please try again or contact us.",
             "digitalriver_checkout_error": "There was a problem with your checkout, please check your details and try again or contact customer service",
+            "digitalriver_checkout_error_title": "Error while processing request.",
             "digitalriver_display_name_text": "Please select your payment method",
             "google_pay_name_text": "Google Pay",
             "humm_not_processable_error": "Humm cannot process your payment for this order, please select another payment method.",

--- a/src/app/locale/translations/es-MX.json
+++ b/src/app/locale/translations/es-MX.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "Se requiere el número de tarjeta de crédito",
             "credit_card_number_mismatch_error": "El número de tarjeta introducido no coincide con la tarjeta guardada en su cuenta",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
+            "digitalriver_checkout_error": "Hubo un problema con su pago, verifique sus datos e intente nuevamente o comuníquese con el servicio al cliente",
+            "digitalriver_checkout_error_title": "Error al procesar la solicitud.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/es.json
+++ b/src/app/locale/translations/es.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "Se requiere el número de tarjeta de crédito",
             "credit_card_number_mismatch_error": "El número de tarjeta introducido no coincide con la tarjeta guardada en su cuenta",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
+            "digitalriver_checkout_error": "Hubo un problema con su pago, verifique sus datos e intente nuevamente o comuníquese con el servicio al cliente",
+            "digitalriver_checkout_error_title": "Error al procesar la solicitud.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/fr.json
+++ b/src/app/locale/translations/fr.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "Numéro de carte bancaire requis",
             "credit_card_number_mismatch_error": "Le numéro de carte saisi ne correspond pas à celui de la carte enregistrée dans votre compte",
             "digitalriver_dropin_error": "Une erreur s'est produite lors du traitement de votre paiement. Veuillez réessayer, ou contactez-nous.",
+            "digitalriver_checkout_error": "Il y a eu un problème avec votre paiement, veuillez vérifier vos coordonnées et réessayer ou contacter le service client",
+            "digitalriver_checkout_error_title": "Erreur lors du traitement de la demande.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Poursuivre avec Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/it.json
+++ b/src/app/locale/translations/it.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "Il numero della carta di credito è obbligatorio",
             "credit_card_number_mismatch_error": "Il numero di carta inserito non corrisponde a quello memorizzato nel tuo account",
             "digitalriver_dropin_error": "Si è verificato un problema durante l'elaborazione del pagamento. Riprova o contattaci.",
+            "digitalriver_checkout_error": "Si è verificato un problema con il pagamento, controlla i tuoi dati e riprova o contatta il servizio clienti",
+            "digitalriver_checkout_error_title": "Errore durante l'elaborazione della richiesta.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Prosegui con Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/nl.json
+++ b/src/app/locale/translations/nl.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "Creditcardnummer is vereist",
             "credit_card_number_mismatch_error": "Het ingevoerde kaartnummer komt niet overeen met de kaart die in uw account is opgeslagen",
             "digitalriver_dropin_error": "Er is een fout opgetreden bij het verwerken van uw betaling. Probeer het opnieuw of neem contact met ons op.",
+            "digitalriver_checkout_error": "Er is een probleem opgetreden bij het afrekenen, controleer uw gegevens en probeer het opnieuw of neem contact op met de klantenservice",
+            "digitalriver_checkout_error_title": "Fout tijdens het verwerken van het verzoek.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Doorgaan met Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/pt-BR.json
+++ b/src/app/locale/translations/pt-BR.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "O número de cartão de crédito é obrigatório",
             "credit_card_number_mismatch_error": "O número do cartão inserido não corresponde ao cartão armazenado na sua conta",
             "digitalriver_dropin_error": "Ocorreu um erro no processamento do seu pagamento. Tente novamente ou entre em contato conosco.",
+            "digitalriver_checkout_error": "Ocorreu um problema com seu checkout, verifique seus dados e tente novamente ou entre em contato com o atendimento ao cliente",
+            "digitalriver_checkout_error_title": "Erro ao processar a solicitação.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Continuar com o Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/pt.json
+++ b/src/app/locale/translations/pt.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "O número de cartão de crédito é obrigatório",
             "credit_card_number_mismatch_error": "O número do cartão inserido não corresponde ao cartão armazenado na sua conta",
             "digitalriver_dropin_error": "Ocorreu um erro no processamento do seu pagamento. Tente novamente ou entre em contato conosco.",
+            "digitalriver_checkout_error": "Ocorreu um problema com seu checkout, verifique seus dados e tente novamente ou entre em contato com o atendimento ao cliente",
+            "digitalriver_checkout_error_title": "Erro ao processar a solicitação.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Continuar com o Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/locale/translations/sv.json
+++ b/src/app/locale/translations/sv.json
@@ -230,6 +230,8 @@
             "credit_card_number_required_error": "Kreditkortsnummer är obligatoriskt",
             "credit_card_number_mismatch_error": "Det angivna kortnumret matchar inte det kort som är lagrat på ditt konto",
             "digitalriver_dropin_error": "Det uppstod ett fel när betalningen bearbetades. Försök igen eller kontakta oss.",
+            "digitalriver_checkout_error": "Det uppstod ett problem med din kassa, kontrollera dina uppgifter och försök igen eller kontakta kundtjänst",
+            "digitalriver_checkout_error_title": "Fel vid bearbetning av begäran.",
             "google_pay_name_text": "Google Pay",
             "klarna_continue_action": "Fortsätt med Klarna",
             "klarna_name_text": "Klarna",

--- a/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/DigitalRiverPaymentMethod.tsx
@@ -58,7 +58,7 @@ const DigitalRiverPaymentMethod: FunctionComponent<DigitalRiverPaymentMethodProp
     const onError = (error: CustomError) => {
         if (error.name === 'digitalRiverCheckoutError') {
             error = new CustomError({
-                title: language.translate('payment.errors.general_error'),
+                title: language.translate('payment.digitalriver_checkout_error_title'),
                 message: language.translate(error.type),
                 data: {},
                 name: 'digitalRiverCheckoutError',


### PR DESCRIPTION
## What?
When DR dropin doesn't load because zip code on shipping step is invalid, for the error displayed to the shopper, remove the word "payment" in the title of the error

## Why?
Digital River requested
![image](https://user-images.githubusercontent.com/35146660/150860703-491d5206-db51-4861-a256-aef7966e1e75.png)


## Testing / Proof
Before: 
![image](https://user-images.githubusercontent.com/35146660/150860737-27ab97a4-b32a-48fc-a262-e856907d2d07.png)

After: 
![image](https://user-images.githubusercontent.com/35146660/150860775-a4e27acb-4564-4ce1-af0d-cdb91c21ee10.png)


@bigcommerce/checkout @bigcommerce/apex-integrations 
