### PR TITLE
INT-5036 Enable to show oxxo ticket and boleto ticket link for StripeUPE

### DIFF
--- a/src/app/order/OrderStatus.tsx
+++ b/src/app/order/OrderStatus.tsx
@@ -25,7 +25,9 @@ const OrderStatus: FunctionComponent<OrderStatusProps> = ({
         const Mandates = [
             { method: 'Stripe (SEPA)', value: 'sepa_link_text' },
             { method: 'OXXO (via Checkout.com)', value: 'oxxo_link_text' },
+            { method: 'OXXO (via Stripe)', value: 'oxxo_link_text'},
             { method: 'Boleto Bancário (via Checkout.com)', value: 'boleto_link_text' },
+            { method: 'Boleto (via Stripe)', value: 'boleto_link_text'},
         ];
 
         const mandateText = Mandates.find(pair => pair.method === order?.payments?.[0].description);


### PR DESCRIPTION


## What? [INT-5036](https://jira.bigcommerce.com/browse/INT-5036)
- Add option to display OXXO Ticket and Boleto Ticket links on confirmation pago for Stripe UPE

## Why?
- Display the link for the OXXO ticket and Boleto ticket to the shopper

## Testing / Proof
![image](https://user-images.githubusercontent.com/45854000/151199004-319ff45d-6def-4508-aa05-0a147b8a38c3.png)


@bigcommerce/checkout
