### PR TITLE
feat(payment): PAYPAL-1284 different naming for PPCP on checkout page

### DIFF
--- a/src/app/payment/payment-methods.mock.ts
+++ b/src/app/payment/payment-methods.mock.ts
@@ -12,7 +12,7 @@ export function getPaymentMethod(): PaymentMethod {
             'MC',
         ],
         initializationData: {
-            payPalCreditProductBrandName: '',
+            payPalCreditProductBrandName: {credit: ''},
         },
         config: {
             displayName: 'Authorizenet',
@@ -24,6 +24,21 @@ export function getPaymentMethod(): PaymentMethod {
             isVisaCheckoutEnabled: undefined,
             merchantId: undefined,
             testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+    };
+}
+
+export function getPaypalCreditPaymentMethod(): PaymentMethod {
+    return {
+        config: {},
+        supportedCards: [],
+        id: 'paypalcommercecredit',
+        gateway: undefined,
+        logoUrl: '',
+        method: 'paypal',
+        initializationData: {
+            payPalCreditProductBrandName: {credit: 'Pay in 3'},
         },
         type: 'PAYMENT_TYPE_API',
     };

--- a/src/app/payment/payment-methods.mock.ts
+++ b/src/app/payment/payment-methods.mock.ts
@@ -11,6 +11,9 @@ export function getPaymentMethod(): PaymentMethod {
             'AMEX',
             'MC',
         ],
+        initializationData: {
+            payPalCreditProductBrandName: '',
+        },
         config: {
             displayName: 'Authorizenet',
             cardCode: true,

--- a/src/app/payment/paymentMethod/MolliePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/MolliePaymentMethod.spec.tsx
@@ -118,7 +118,7 @@ describe('MolliePaymentMethod', () => {
                             testMode: false,
                         },
                         initializationData: {
-                            payPalCreditProductBrandName: '',
+                            payPalCreditProductBrandName: {credit: ''},
                         },
                         gateway: 'mollie',
                         id: 'mollie',

--- a/src/app/payment/paymentMethod/MolliePaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/MolliePaymentMethod.spec.tsx
@@ -117,6 +117,9 @@ describe('MolliePaymentMethod', () => {
                             merchantId: undefined,
                             testMode: false,
                         },
+                        initializationData: {
+                            payPalCreditProductBrandName: '',
+                        },
                         gateway: 'mollie',
                         id: 'mollie',
                         logoUrl: '',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -48,8 +48,8 @@ function getPaymentMethodTitle(
                 titleText: '',
             },
             [PaymentMethodId.PaypalCommerceCredit]: {
-                logoUrl: cdnPath('/img/payment-providers/paypal_commerce_pay_later.svg'),
-                titleText: '',
+                logoUrl: cdnPath('/img/payment-providers/paypal_commerce_logo_letter.svg'),
+                titleText: methodDisplayName,
             },
             [PaymentMethodId.PaypalCommerceAlternativeMethod]: {
                 logoUrl: method.logoUrl || '',

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
@@ -1,7 +1,7 @@
 import { createLanguageService, LanguageService } from '@bigcommerce/checkout-sdk';
 
 import { FALLBACK_TRANSLATIONS } from '../../locale/translations';
-import { getPaymentMethod } from '../payment-methods.mock';
+import { getPaymentMethod, getPaypalCreditPaymentMethod } from '../payment-methods.mock';
 
 import getPaymentMethodDisplayName from './getPaymentMethodDisplayName';
 import PaymentMethodId from './PaymentMethodId';
@@ -21,10 +21,10 @@ describe('getPaymentMethodDisplayName()', () => {
     });
 
     it('returns translated "Pay in 3" display name', () => {
-        const method = { ...getPaymentMethod(), initializationData: { payPalCreditProductBrandName: 'Pay in 3' } };
+        const method = { ...getPaypalCreditPaymentMethod() };
 
         expect(getPaymentMethodDisplayName(language)(method))
-            .toEqual(method.initializationData.payPalCreditProductBrandName);
+            .toEqual(method.initializationData.payPalCreditProductBrandName.credit);
     });
 
     it('returns translated "Credit card" display name', () => {

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
@@ -20,6 +20,13 @@ describe('getPaymentMethodDisplayName()', () => {
             .toEqual(method.config.displayName);
     });
 
+    it('returns translated "Pay in 3" display name', () => {
+        const method = { ...getPaymentMethod(), initializationData: { payPalCreditProductBrandName: 'Pay in 3' } };
+
+        expect(getPaymentMethodDisplayName(language)(method))
+            .toEqual(method.initializationData.payPalCreditProductBrandName);
+    });
+
     it('returns translated "Credit card" display name', () => {
         const method = { ...getPaymentMethod(), config: { displayName: 'Credit Card' } };
 

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
@@ -12,7 +12,7 @@ export default function getPaymentMethodDisplayName(
         if (method.id === PaymentMethodId.PaypalCommerceCredit) {
             const { payPalCreditProductBrandName } = method.initializationData;
 
-            return payPalCreditProductBrandName ? payPalCreditProductBrandName : 'Pay Later';
+            return payPalCreditProductBrandName && payPalCreditProductBrandName.credit ? payPalCreditProductBrandName.credit : 'Pay Later';
         }
 
         if (isCreditCard && method.id === PaymentMethodId.AdyenV2) {

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
@@ -9,6 +9,11 @@ export default function getPaymentMethodDisplayName(
         const { displayName } = method.config;
 
         const isCreditCard = displayName?.toLowerCase() === 'credit card';
+        if (method.id === PaymentMethodId.PaypalCommerceCredit) {
+            const { payPalCreditProductBrandName } = method.initializationData;
+
+            return payPalCreditProductBrandName ? payPalCreditProductBrandName : 'Pay Later';
+        }
 
         if (isCreditCard && method.id === PaymentMethodId.AdyenV2) {
             return language.translate('payment.adyen_credit_debit_card_text');

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -6,6 +6,8 @@
     height: fontSize("large");
 
     + .paymentProviderHeader-name {
+        font-size: 18px;
+        font-weight: bold;
         margin-left: spacing("half");
     }
 }


### PR DESCRIPTION
## What?
Different naming for PPCP on checkout page

## Why?
According to task https://jira.bigcommerce.com/browse/PAYPAL-1284

## Testing / Proof
<img width="1680" alt="Screenshot 2022-02-11 at 19 39 26" src="https://user-images.githubusercontent.com/56301104/153642840-d1c9fcff-c661-4b5d-b008-7535053b81e6.png">
<img width="1680" alt="Screenshot 2022-02-11 at 19 38 41" src="https://user-images.githubusercontent.com/56301104/153642856-4780bc5d-2cec-4785-8cc5-da0421405ee8.png">


@bigcommerce/checkout
