### PR TITLE
chore(payment): INT-5384 Bump checkout-sdk from 1.217.0 to 1.219.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,9 +1480,9 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.17.4",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
-              "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
+              "version": "7.17.5",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+              "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
               "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
@@ -1684,9 +1684,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.217.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.217.0.tgz",
-      "integrity": "sha512-i+5PRdR6dJrCt/UFobivey2qKZxtkImSEW9kK/oxLA5kR/Uy3Vd3JxzE3RBzyNRIc+DCwEs/aA0h8EXxPQiSIw==",
+      "version": "1.219.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.219.0.tgz",
+      "integrity": "sha512-m6t3MOPKJmfKmO5hbmm0Nxs8CSO8IvYANht6cIM656HuXHF8Nr5vYmdCze8r1p1HSoMhJ3ATYq4/mN1qxJOkjw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.15.1",
@@ -1763,9 +1763,9 @@
           "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A=="
         },
         "core-js": {
-          "version": "3.21.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-          "integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ=="
+          "version": "3.21.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
+          "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
         },
         "query-string": {
           "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.217.0",
+    "@bigcommerce/checkout-sdk": "^1.219.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from 1.217.0 to 1.219.0

## Why?
To release https://github.com/bigcommerce/checkout-sdk-js/pull/1344

## Testing / Proof
CircleCI + testing section on the above PR

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
