### PR TITLE
fix(checkout): CHECKOUT-6334 Restore Instructional Text in Country Dropdown Menu

### DIFF
--- a/src/app/address/AddressForm.spec.tsx
+++ b/src/app/address/AddressForm.spec.tsx
@@ -107,4 +107,31 @@ describe('AddressForm Component', () => {
 
         expect(onChange).toHaveBeenCalledWith('address1', 'foo bar');
     });
+
+    it('renders the same dropdown menu with different field.default values', () => {
+        const field = formFields.find(({ name }) => name === 'field_27') as FormFieldType;
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <AddressForm formFields={ [field] } />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+        const fieldChanged = {...field, default: 'new value'} as FormFieldType;
+        const componentChanged = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <AddressForm formFields={ [fieldChanged] } />
+                </Formik>
+            </LocaleContext.Provider>
+        );
+
+        expect(component.html()).toEqual(componentChanged.html());
+    });
 });

--- a/src/app/address/AddressForm.tsx
+++ b/src/app/address/AddressForm.tsx
@@ -82,7 +82,6 @@ class AddressForm extends Component<AddressFormProps & WithLanguageProps> {
         const {
             formFields,
             fieldName,
-            language,
             countriesWithAutocomplete,
             countryCode,
             googleMapsApiKey,
@@ -127,7 +126,7 @@ class AddressForm extends Component<AddressFormProps & WithLanguageProps> {
                                 parentFieldName={ field.custom ?
                                     (fieldName ? `${fieldName}.customFields` : 'customFields') :
                                     fieldName }
-                                placeholder={ field.default ? field.default : translatedPlaceholderId && language.translate(translatedPlaceholderId) }
+                                placeholder={ this.getPlaceholderValue(field, translatedPlaceholderId) }
                             />
                         );
                     }) }
@@ -139,6 +138,16 @@ class AddressForm extends Component<AddressFormProps & WithLanguageProps> {
                     name={ fieldName ? `${fieldName}.shouldSaveAddress` : 'shouldSaveAddress' }
                 /> }
         </>);
+    }
+
+    private getPlaceholderValue(field: FormField, translatedPlaceholderId: string): string {
+        const { language } = this.props;
+
+        if (field.default && field.fieldType !== 'dropdown') {
+            return field.default;
+        } else {
+            return translatedPlaceholderId && language.translate(translatedPlaceholderId);
+        }
     }
 
     private handleAutocompleteChange: (value: string, isOpen: boolean) => void = (value, isOpen) => {


### PR DESCRIPTION
## What?
This PR will restore a country dropdown menu's instructional text placeholder.

## Why?
In the previous PR, [CHECKOUT-6081](https://github.com/bigcommerce/checkout-js/pull/729), we have used the default value as an instructional message for a text input field and a dropdown menu.

It turns out that this does not work well for a dropdown menu, particularly a country menu. Because `checkout-sdk-js` updates the default value of the `countryCode` field every time a user makes a selection. 

## Testing / Proof

https://user-images.githubusercontent.com/88361607/155430516-c348ce48-0d9d-4dc0-b9d8-b0ae64b85b69.mov

There's also a new dropdown menu unit test.


