### PR TITLE
fix(checkout): CHECKOUT-6207 entered information lost after window resizing

### DIFF
--- a/src/app/checkout/CheckoutStep.spec.tsx
+++ b/src/app/checkout/CheckoutStep.spec.tsx
@@ -182,6 +182,8 @@ describe('CheckoutStep', () => {
 
         expect(component.find(CSSTransition))
             .toHaveLength(1);
+        expect(component.find(CSSTransition).prop('enter')).toBe(true);
+        expect(component.find(CSSTransition).prop('exit')).toBe(true);
     });
 
     it('does not animate using CSS transition in mobile view', () => {
@@ -189,8 +191,8 @@ describe('CheckoutStep', () => {
 
         const component = mount(<CheckoutStep { ...defaultProps } />);
 
-        expect(component.find(CSSTransition))
-            .toHaveLength(0);
+        expect(component.find(CSSTransition).prop('enter')).toBe(false);
+        expect(component.find(CSSTransition).prop('exit')).toBe(false);
     });
 
     it('changes isClosed for mobile', () => {

--- a/src/app/checkout/CheckoutStep.tsx
+++ b/src/app/checkout/CheckoutStep.tsx
@@ -112,16 +112,12 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
 
         return <>
             <MobileView>
-                { matched => {
-                    if (matched) {
-                        return !isActive ? null : <div className="checkout-view-content">
-                            { children }
-                        </div>;
-                    }
-
-                    return <CSSTransition
+                { matched =>
+                    <CSSTransition
                         addEndListener={ this.handleTransitionEnd }
                         classNames="checkout-view-content"
+                        enter={ !matched }
+                        exit={ !matched }
                         in={ isActive }
                         mountOnEnter
                         timeout={ {} }
@@ -133,8 +129,7 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
                         >
                             { children }
                         </div>
-                    </CSSTransition>;
-                } }
+                    </CSSTransition> }
             </MobileView>
         </>;
     }


### PR DESCRIPTION
## What?
Always return `<CSStransition>` to avoid rerendering the payment step when the window is resizing.

## Why?
Previously, when the window width is smaller than `968px`, `checkout-js` renders `<div>`; when the window gets bigger, `checkout-js` renders  `<CSStransition>`. 

This results in the loss of information entered for the payment step. This bugfix will always return `<CSStransition>` while keeping the same logic that we only present CSS effects on larger screens.

Related doc: `enter` and `exit` control whether the `<CSStransition>` displays animations ([link](http://reactcommunity.org/react-transition-group/transition#Transition-prop-enter)).

## Testing / Proof

https://user-images.githubusercontent.com/88361607/155924316-40d4a19b-66bb-4c8d-8f16-ab9620937061.mov
