### PR TITLE
feat(payment): PAYPAL-1298 added branding names logic for BT

### DIFF
--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
@@ -9,7 +9,7 @@ export default function getPaymentMethodDisplayName(
         const { displayName } = method.config;
 
         const isCreditCard = displayName?.toLowerCase() === 'credit card';
-        if (method.id === PaymentMethodId.PaypalCommerceCredit) {
+        if (method.id === PaymentMethodId.PaypalCommerceCredit || method.id === PaymentMethodId.Braintree) {
             const { payPalCreditProductBrandName } = method.initializationData;
 
             return payPalCreditProductBrandName && payPalCreditProductBrandName.credit ? payPalCreditProductBrandName.credit : 'Pay Later';


### PR DESCRIPTION
## What?
Added branding name logic for BT

## Why?
According to task https://jira.bigcommerce.com/browse/PAYPAL-1298

## Testing / Proof

<img width="1680" alt="Screenshot 2022-02-11 at 19 39 26" src="https://user-images.githubusercontent.com/56301104/156776929-b7020ce5-937a-4c7b-986e-3b855322e4b5.png">



@bigcommerce/checkout
