### PR TITLE
fix(payment): INT-5645 Openpay: Localized message for invalid cart error

### DIFF
--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -242,6 +242,7 @@
             "opy_continue_action": "Continue with {methodName}",
             "opy_widget_slogan": "Buy now. Pay smarter.",
             "opy_widget_info": "You will be redirected to {methodName}'s website to complete your order when you click \"Continue with {methodName}\"",
+            "opy_invalid_cart_error": "Cart price is different to {methodName} plan amount.",
             "orbital_continue_action": "Place Order",
             "orbital_description_text": "Pay using your ChasePay Account",
             "payment_cancelled": "Payment was cancelled",

--- a/src/app/payment/paymentMethod/OpyPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/OpyPaymentMethod.spec.tsx
@@ -43,6 +43,7 @@ describe('when using Opy payment', () => {
             deinitializePayment: jest.fn(),
             initializePayment: jest.fn(),
             method,
+            onUnhandledError: jest.fn(),
         };
 
         OpyPaymentMethodTest = props => (
@@ -96,6 +97,7 @@ describe('when using Opy payment', () => {
                 hideWidget: false,
                 initializePayment: expect.any(Function),
                 method,
+                onUnhandledError: expect.any(Function),
             }));
     });
 
@@ -121,6 +123,28 @@ describe('when using Opy payment', () => {
         expect(container.text().includes(text1)).toBe(true);
         expect(container.text().includes(text2)).toBe(true);
         expect(container.text().includes(text3)).toBe(true);
+    });
+
+    it('returns correct message when cart is not valid', () => {
+        defaultProps.method.config.displayName = 'Foo Payment Method';
+
+        const opyError = Object.create(new Error('Something went wrong.'));
+        opyError.name = 'OpyError';
+        opyError.type = 'opy_error';
+        opyError.subtype = 'invalid_cart';
+
+        mount(<OpyPaymentMethodTest />)
+          .find(HostedWidgetPaymentMethod)
+          .props()
+          .onUnhandledError(opyError);
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(
+          new Error(
+            localeContext.language.translate('payment.opy_invalid_cart_error', {
+                methodName: 'Foo Payment Method',
+            })
+          )
+        );
     });
 
     it('matches snapshot with rendered output', () => {

--- a/src/app/payment/paymentMethod/OpyPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/OpyPaymentMethod.tsx
@@ -36,27 +36,29 @@ const OpyPaymentMethod: FunctionComponent<OpyPaymentMethodProps & WithLanguagePr
     }, [language, methodName, onUnhandledError]);
 
     return (
-      <LoadingOverlay hideContentWhenLoading isLoading={ isInitializing }>
-        <strong>
-            <TranslatedString id="payment.opy_widget_slogan" />
-        </strong>
-        <div style={ { display: 'inline-block', marginLeft: '0.5rem' } }>
-            <HostedWidgetPaymentMethod
-                { ...rest }
-                containerId={ containerId }
-                hideWidget={ isInitializing }
-                initializePayment={ initializeOpyPayment }
-                method={ method }
-                onUnhandledError={ onUnhandledOpyError }
-            />
-        </div>
-        <p>
-            <TranslatedString
-                data={ { methodName } }
-                id="payment.opy_widget_info"
-            />
-        </p>
-      </LoadingOverlay>
+        <LoadingOverlay hideContentWhenLoading isLoading={ isInitializing }>
+            <div style={ { overflow: 'auto' } }>
+                <strong>
+                    <TranslatedString id="payment.opy_widget_slogan" />
+                </strong>
+                <div style={ { display: 'inline-block', marginLeft: '0.5rem' } }>
+                    <HostedWidgetPaymentMethod
+                        { ...rest }
+                        containerId={ containerId }
+                        hideWidget={ isInitializing }
+                        initializePayment={ initializeOpyPayment }
+                        method={ method }
+                        onUnhandledError={ onUnhandledOpyError }
+                    />
+                </div>
+                <p>
+                    <TranslatedString
+                        data={ { methodName } }
+                        id="payment.opy_widget_info"
+                    />
+                </p>
+            </div>
+        </LoadingOverlay>
     );
 };
 

--- a/src/app/payment/paymentMethod/__snapshots__/OpyPaymentMethod.spec.tsx.snap
+++ b/src/app/payment/paymentMethod/__snapshots__/OpyPaymentMethod.spec.tsx.snap
@@ -2,26 +2,30 @@
 
 exports[`when using Opy payment matches snapshot with rendered output 1`] = `
 <div>
-  <strong>
-    Buy now. Pay smarter.
-  </strong>
   <div
-    style="display:inline-block;margin-left:0.5rem"
+    style="overflow:auto"
   >
-    <div>
-      <div
-        class="paymentMethod--hosted"
-      >
+    <strong>
+      Buy now. Pay smarter.
+    </strong>
+    <div
+      style="display:inline-block;margin-left:0.5rem"
+    >
+      <div>
         <div
-          class="widget widget--opy payment-widget"
-          id="learnMoreButton"
-          tabindex="-1"
-        />
+          class="paymentMethod--hosted"
+        >
+          <div
+            class="widget widget--opy payment-widget"
+            id="learnMoreButton"
+            tabindex="-1"
+          />
+        </div>
       </div>
     </div>
+    <p>
+      You will be redirected to Opy's website to complete your order when you click "Continue with Opy"
+    </p>
   </div>
-  <p>
-    You will be redirected to Opy's website to complete your order when you click "Continue with Opy"
-  </p>
 </div>
 `;


### PR DESCRIPTION
## What? [INT-5645](https://jira.bigcommerce.com/browse/INT-5645)
- Display a localized error message for an invalid cart error.
- Also, fixes the widget's overflow. 😁

## Why?
To display a custom error message based on location. The Openpay team wants us to use the following messages:
- For AU/UK/NZ: "Cart price is different to Openpay plan amount."
- For US merchants: "Cart price is different to Opy plan amount."

## Testing / Proof

### Error message

_Before:_
<img width="708" alt="before" src="https://user-images.githubusercontent.com/4843328/157351780-6ba9b72b-8e1b-40e2-8752-0b23d4db67df.png">

_Now:_
<img width="708" alt="now" src="https://user-images.githubusercontent.com/4843328/157351397-36a8938e-36c0-43c9-a431-7ea1d7f32f9f.png">

### Widget's overflow

_Before:_
<img width="645" alt="overflow-before" src="https://user-images.githubusercontent.com/4843328/157945259-7fdd28c8-bea6-4d9b-a785-3f6f2c912523.png">

_Now:_
<img width="648" alt="overflow-now" src="https://user-images.githubusercontent.com/4843328/157945291-8a3aca09-4501-40a2-ae8b-6827a96a1769.png">

## Depends on
👉 https://github.com/bigcommerce/checkout-sdk-js/pull/1367

@bigcommerce/checkout
