### PR TITLE
fix(shipping): CHECKOUT-6370 Trim address field value before validating

### DIFF
--- a/src/app/formFields/getFormFieldsValidationSchema.ts
+++ b/src/app/formFields/getFormFieldsValidationSchema.ts
@@ -20,7 +20,7 @@ export default memoize(function getFormFieldsValidationSchema({
                 schema[name] = string();
 
                 if (required) {
-                    schema[name] = schema[name].required(translate('required', { label, name }));
+                    schema[name] = schema[name].trim().required(translate('required', { label, name }));
                 }
 
                 schema[name] = schema[name].matches(


### PR DESCRIPTION
## What?
Trim address field values before validating

## Why?
At the moment we don't trim values entered in required string fields for shipping form. So we need to trim the input field for whitespaces before validating.

## Testing / Proof
- Screenshot

Before
![Screen Shot 2022-03-10 at 4 21 00 pm (2)](https://user-images.githubusercontent.com/7134802/157594940-fb26d9cf-635f-4ff0-9a13-4edab7b76486.png)

After
![Screen Shot 2022-03-10 at 4 18 26 pm (2)](https://user-images.githubusercontent.com/7134802/157594695-f7f5972a-26e3-4751-9a21-4e1ba4cd1d06.png)


@bigcommerce/checkout
