### PR TITLE
fix(checkout): INT-5543 [CKO] Update to 3DS on Google Pay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001322",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-          "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew=="
+          "version": "1.0.30001325",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
+          "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ=="
         }
       }
     },
@@ -1676,9 +1676,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.234.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.234.0.tgz",
-      "integrity": "sha512-5iymjvmKGlsou85+9c72gUORb10KSkwcph0vvH7eniL8rnfMHt8bNtnikaSHc3fqSamu7tp/yQ36C6c/cf+OdQ==",
+      "version": "1.235.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.235.0.tgz",
+      "integrity": "sha512-rA8GeBJnv1m2PHLPUh6KMM/0sbJWU23Y0nBl3jsK2NwxHHJdVE20XQBM1YP+Y2moPDsPL5W5QSqkmdb1ODI0/A==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.16.0",
@@ -7448,9 +7448,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.101",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.101.tgz",
-      "integrity": "sha512-XJH+XmJjACx1S7ASl/b//KePcda5ocPnFH2jErztXcIS8LpP0SE6rX8ZxiY5/RaDPnaF1rj0fPaHfppzb0e2Aw=="
+      "version": "1.4.103",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
+      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.234.0",
+    "@bigcommerce/checkout-sdk": "^1.235.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -286,6 +286,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.Amazon ||
             selectedMethod.id === PaymentMethodId.AmazonPay ||
             selectedMethod.id === PaymentMethodId.Checkoutcom ||
+            selectedMethod.id === PaymentMethodId.CheckoutcomGooglePay ||
             selectedMethod.id === PaymentMethodId.Converge ||
             selectedMethod.id === PaymentMethodId.Humm ||
             selectedMethod.id === PaymentMethodId.Laybuy ||


### PR DESCRIPTION
## What? [INT-5543](https://jira.bigcommerce.com/browse/INT-5543)
Add Checkout.com's GooglePay to the list of providers that require a redirect but are not a Hosted Payment Method.

## Why?
So the Prompt for leaving the page does not interfere with the offsite redirection that Google Pay requires.

## Testing / Proof
[Demo Video](https://drive.google.com/file/d/1FTuDYjBL7YUgdXZWVCeLN4lxuASvZEqz/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/apex-integrations 
