### PR TITLE
chore(checkout): CHECKOUT-6125 Bump checkout-sdk v1.227.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng=="
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
     },
     "@babel/core": {
       "version": "7.5.5",
@@ -122,32 +122,32 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
       "requires": {
-        "@babel/compat-data": "^7.16.4",
+        "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.20.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
-          "integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
+          "version": "4.20.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+          "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
           "requires": {
-            "caniuse-lite": "^1.0.30001313",
-            "electron-to-chromium": "^1.4.76",
+            "caniuse-lite": "^1.0.30001317",
+            "electron-to-chromium": "^1.4.84",
             "escalade": "^3.1.1",
             "node-releases": "^2.0.2",
             "picocolors": "^1.0.0"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001314",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
-          "integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw=="
+          "version": "1.0.30001319",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
+          "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw=="
         }
       }
     },
@@ -1071,9 +1071,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
-          "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
           "requires": {
             "@babel/types": "^7.17.0",
             "jsesc": "^2.5.1",
@@ -1122,13 +1122,13 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.17.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
-          "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+          "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
           "requires": {
             "@babel/helper-environment-visitor": "^7.16.7",
             "@babel/helper-module-imports": "^7.16.7",
-            "@babel/helper-simple-access": "^7.16.7",
+            "@babel/helper-simple-access": "^7.17.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
             "@babel/helper-validator-identifier": "^7.16.7",
             "@babel/template": "^7.16.7",
@@ -1137,11 +1137,11 @@
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-          "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+          "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
           "requires": {
-            "@babel/types": "^7.16.7"
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -1153,12 +1153,12 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-          "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
+          "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
           "requires": {
             "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.17.0",
+            "@babel/traverse": "^7.17.3",
             "@babel/types": "^7.17.0"
           }
         },
@@ -1219,9 +1219,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
-          "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA=="
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+          "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ=="
         },
         "@babel/template": {
           "version": "7.16.7",
@@ -1299,9 +1299,9 @@
           }
         },
         "@types/babel__core": {
-          "version": "7.1.18",
-          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
-          "integrity": "sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==",
+          "version": "7.1.19",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
+          "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0",
@@ -1426,9 +1426,9 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -1480,17 +1480,17 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.17.5",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
-              "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+              "version": "7.17.8",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+              "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
               "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.17.3",
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helpers": "^7.17.2",
-                "@babel/parser": "^7.17.3",
+                "@babel/generator": "^7.17.7",
+                "@babel/helper-compilation-targets": "^7.17.7",
+                "@babel/helper-module-transforms": "^7.17.7",
+                "@babel/helpers": "^7.17.8",
+                "@babel/parser": "^7.17.8",
                 "@babel/template": "^7.16.7",
                 "@babel/traverse": "^7.17.3",
                 "@babel/types": "^7.17.0",
@@ -1684,9 +1684,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.227.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.227.0.tgz",
-      "integrity": "sha512-GXtX/AFyCUEk9IWAurOxu/usxHCcFGuDtSVqHrWyr54ivgvauluKt45nSY+u8SucSAW1LFI4F8jPgwbsm1u+gw==",
+      "version": "1.227.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.227.2.tgz",
+      "integrity": "sha512-PvgmPY9UaOXI3D3xMzLnomr95cCgHHLy20mhXrS5GzLa13TH+/+Kjo6b5/ULp10YtCVqH9NM5Lcxvd/dj/sg9Q==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.16.0",
@@ -1753,9 +1753,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.179",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
-          "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w=="
+          "version": "4.14.180",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+          "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g=="
         },
         "@types/yup": {
           "version": "0.26.37",
@@ -7456,9 +7456,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.80",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.80.tgz",
-      "integrity": "sha512-COsbJCGVYCc/aAY4cd94x1Js3q0r406YKGbdL8LXHg0O9dEjuFEFU/vZneRxBxKo/f1lLHi0YyAR7sbFM+i8Bg=="
+      "version": "1.4.88",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.88.tgz",
+      "integrity": "sha512-oA7mzccefkvTNi9u7DXmT0LqvhnOiN2BhSrKerta7HeUC1cLoIwtbf2wL+Ah2ozh5KQd3/1njrGrwDBXx6d14Q=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.227.0",
+    "@bigcommerce/checkout-sdk": "^1.227.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
What?
Bump checkout-sdk.

## Why?
To get https://github.com/bigcommerce/checkout-sdk-js/pull/1373 out

## Testing / Proof
CircleCI + see the videos on above PR