### PR TITLE
feat(payment): INT-5060 Stripe UPE Look and Feel - Get styles from store theme styles

### DIFF
--- a/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
@@ -37,6 +37,11 @@ jest.mock('../hostedCreditCard', () => ({
         />
     ) as jest.Mocked<typeof withHostedCreditCardFieldset>,
 }));
+jest.mock('../../common/dom', () => ({
+    getAppliedStyles: () => {
+        return { color: '#cccccc' };
+    },
+}));
 describe('when using Stripe payment', () => {
     let method: PaymentMethod;
     let checkoutService: CheckoutService;
@@ -46,6 +51,7 @@ describe('when using Stripe payment', () => {
     let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
 
     beforeEach(() => {
+        const dummyElement = document.createElement('div');
         defaultProps = {
             method: getPaymentMethod(),
             onUnhandledError: jest.fn(),
@@ -63,6 +69,9 @@ describe('when using Stripe payment', () => {
 
         jest.spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
+
+        jest.spyOn(document, 'getElementById')
+            .mockReturnValue(dummyElement);
 
         PaymentMethodTest = props => (
             <CheckoutProvider checkoutService={ checkoutService }>
@@ -116,6 +125,9 @@ describe('when using Stripe payment', () => {
                     methodId: method.id,
                     stripeupe: {
                         containerId: 'stripe-alipay-component-field',
+                        style: expect.objectContaining({
+                            fieldText: '#cccccc',
+                        }),
                     },
                 }));
         });
@@ -159,6 +171,9 @@ describe('when using Stripe payment', () => {
                     methodId: method.id,
                     stripeupe: {
                         containerId: 'stripe-card-component-field',
+                        style: expect.objectContaining({
+                            fieldText: '#cccccc',
+                        }),
                     },
                 }));
         });
@@ -202,6 +217,9 @@ describe('when using Stripe payment', () => {
                         methodId: method.id,
                         stripeupe: {
                             containerId: 'stripe-idealBank-component-field',
+                            style: expect.objectContaining({
+                                fieldText: '#cccccc',
+                            }),
                         },
                     })
                 );
@@ -246,6 +264,9 @@ describe('when using Stripe payment', () => {
                     methodId: method.id,
                     stripeupe: {
                         containerId: 'stripe-iban-component-field',
+                        style: expect.objectContaining({
+                            fieldText: '#cccccc',
+                        }),
                     },
                 }));
         });


### PR DESCRIPTION
## What? [INT-5060](https://jira.bigcommerce.com/browse/INT-5060)
Gets the store theme checkout styles to change the appearance of the Stripe UPE

## Why?
To have the payment element style match with the store style

## Testing / Proof
![Screen Shot 2022-03-22 at 12 01 10](https://user-images.githubusercontent.com/87149598/159610656-6468906c-6942-4bf0-a249-d4726dbb6f90.png)
![image](https://user-images.githubusercontent.com/87149598/159610784-8cfbdd52-3710-417f-9553-14ec1f0a105c.png)


## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1382

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 
