### PR TITLE
feat(payment): INT-5754 Stripe UPE Added onError to initialize options

### DIFF
--- a/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
@@ -128,6 +128,7 @@ describe('when using Stripe payment', () => {
                         style: expect.objectContaining({
                             fieldText: '#cccccc',
                         }),
+                        onError: expect.any(Function),
                     },
                 }));
         });
@@ -174,6 +175,7 @@ describe('when using Stripe payment', () => {
                         style: expect.objectContaining({
                             fieldText: '#cccccc',
                         }),
+                        onError: expect.any(Function),
                     },
                 }));
         });
@@ -220,6 +222,7 @@ describe('when using Stripe payment', () => {
                             style: expect.objectContaining({
                                 fieldText: '#cccccc',
                             }),
+                            onError: expect.any(Function),
                         },
                     })
                 );
@@ -267,6 +270,7 @@ describe('when using Stripe payment', () => {
                         style: expect.objectContaining({
                             fieldText: '#cccccc',
                         }),
+                        onError: expect.any(Function),
                     },
                 }));
         });

--- a/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -1,4 +1,5 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
 import React, { useCallback, FunctionComponent } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
@@ -16,6 +17,7 @@ const StripeUPEPaymentMethod: FunctionComponent<StripePaymentMethodProps & WithI
     initializePayment,
     method,
     storeUrl,
+    onUnhandledError = noop,
     ...rest
     }) => {
     const containerId = `stripe-${method.id}-component-field`;
@@ -38,9 +40,10 @@ const StripeUPEPaymentMethod: FunctionComponent<StripePaymentMethodProps & WithI
                     fieldInnerShadow: formInput['box-shadow'],
                     fieldBorder: formInput['border-color'],
                 },
+                onError: onUnhandledError,
             },
         });
-    }, [initializePayment, containerId]);
+    }, [initializePayment, containerId, onUnhandledError]);
 
     const getStylesFromElement = (
         id: string,


### PR DESCRIPTION
## What? [INT-5754](https://jira.bigcommerce.com/browse/INT-5754)
Added onError so subscriber errors can be thrown

## Why?
So the customer sees error messages if adding coupons makes the order have an unsupported amount for stripe methods

## Testing / Proof
https://drive.google.com/file/d/1AAsEr5KsNoS6WgeY_fAvR-z43j6b_TSh/view?usp=sharing

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1385
https://github.com/bigcommerce/bigcommerce/pull/45506
https://github.com/bigcommerce/bigpay/pull/5145
https://github.com/bigcommerce/bigpay-client-php/pull/244

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 
