### PR TITLE
fix(payment): CHECKOUT-6549 Add check if window has apple pay supported

### DIFF
--- a/src/app/common/utility/index.ts
+++ b/src/app/common/utility/index.ts
@@ -5,3 +5,4 @@ export { default as parseAnchor } from './parseAnchor';
 export { default as isRecord } from './isRecord';
 export { default as isRecordContainingKey } from './isRecordContainingKey';
 export { default as isMobile } from './isMobile';
+export { default as isApplePayWindow } from './is-apple-pay-window';

--- a/src/app/common/utility/is-apple-pay-window.ts
+++ b/src/app/common/utility/is-apple-pay-window.ts
@@ -1,0 +1,7 @@
+interface ApplePayWindow extends Window {
+    ApplePaySession: void;
+}
+
+export default function isApplePayWindow(window: Window): window is ApplePayWindow {
+    return 'ApplePaySession' in window;
+}

--- a/src/app/customer/CheckoutButtonList.tsx
+++ b/src/app/customer/CheckoutButtonList.tsx
@@ -1,16 +1,19 @@
 import { CustomerInitializeOptions, CustomerRequestOptions } from '@bigcommerce/checkout-sdk';
 import React, { memo, Fragment, FunctionComponent } from 'react';
 
+import { isApplePayWindow } from '../common/utility';
 import { TranslatedString } from '../locale';
 
 import { ApplePayButton } from './customWalletButton';
 import CheckoutButton from './CheckoutButton';
 
+const APPLE_PAY = 'applepay';
+
 // TODO: The API should tell UI which payment method offers its own checkout button
 export const SUPPORTED_METHODS: string[] = [
     'amazon',
     'amazonpay',
-    'applepay',
+    APPLE_PAY,
     'braintreevisacheckout',
     'chasepay',
     'masterpass',
@@ -41,8 +44,13 @@ const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
     methodIds,
     ...rest
 }) => {
-    const supportedMethodIds = (methodIds ?? [])
-        .filter(methodId => SUPPORTED_METHODS.indexOf(methodId) !== -1);
+    const supportedMethodIds = (methodIds ?? []).filter(methodId => {
+        if (methodId === APPLE_PAY && !isApplePayWindow(window)) {
+            return false;
+        }
+
+        return SUPPORTED_METHODS.indexOf(methodId) !== -1;
+    });
 
     if (supportedMethodIds.length === 0) {
         return null;

--- a/src/app/customer/customWalletButton/ApplePayButton.tsx
+++ b/src/app/customer/customWalletButton/ApplePayButton.tsx
@@ -2,6 +2,7 @@ import { CustomerInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { useCallback, useContext, FunctionComponent } from 'react';
 
 import { navigateToOrderConfirmation } from '../../checkout';
+import { isApplePayWindow } from '../../common/utility';
 import { LocaleContext } from '../../locale';
 import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
 
@@ -21,6 +22,10 @@ const ApplePayButton: FunctionComponent<CheckoutButtonProps> = ({
             onPaymentAuthorize: navigateToOrderConfirmation,
         },
     }), [initialize, localeContext, onError, rest.containerId]);
+
+    if (!isApplePayWindow(window)) {
+        return null;
+    }
 
     return <CheckoutButton initialize={ initializeOptions } { ...rest } />;
 };

--- a/src/app/customer/customWalletButton/ApplePayButton.tsx
+++ b/src/app/customer/customWalletButton/ApplePayButton.tsx
@@ -2,7 +2,6 @@ import { CustomerInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { useCallback, useContext, FunctionComponent } from 'react';
 
 import { navigateToOrderConfirmation } from '../../checkout';
-import { isApplePayWindow } from '../../common/utility';
 import { LocaleContext } from '../../locale';
 import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
 
@@ -22,10 +21,6 @@ const ApplePayButton: FunctionComponent<CheckoutButtonProps> = ({
             onPaymentAuthorize: navigateToOrderConfirmation,
         },
     }), [initialize, localeContext, onError, rest.containerId]);
-
-    if (!isApplePayWindow(window)) {
-        return null;
-    }
 
     return <CheckoutButton initialize={ initializeOptions } { ...rest } />;
 };


### PR DESCRIPTION
## What?
- Add check before rendering component if apple pay is supported in the browser or not
- Bump checkout-sdk to get apple pay shipping fix

## Why?
If a browser doesn't support apple pay, at the moment there is an empty container rendered, therefore return nothing from the component if apple pay is not supported 

Also bump SDK https://github.com/bigcommerce/checkout-sdk-js/commit/e79f27b7727222b155677b84541926aff4859529

## Testing / Proof
- Tests

@bigcommerce/checkout
