### PR TITLE
fix(shipping): CHECKOUT-6607 Only mark the currently selected shipping option as valid if it is available for the current address

### DIFF
--- a/src/app/shipping/hasSelectedShippingOptions.spec.ts
+++ b/src/app/shipping/hasSelectedShippingOptions.spec.ts
@@ -1,5 +1,6 @@
 import { getConsignment } from './consignment.mock';
 import hasSelectedShippingOptions from './hasSelectedShippingOptions';
+import { getShippingOptionPickUpStore } from './shippingOption/shippingMethod.mock';
 
 describe('hasSelectedShippingOptions()', () => {
     it('returns false when has no consignments', () => {
@@ -24,5 +25,27 @@ describe('hasSelectedShippingOptions()', () => {
             getConsignment(),
         ]))
             .toEqual(true);
+    });
+
+    it('returns false when consignments have no shipping options', () => {
+        expect(hasSelectedShippingOptions([
+            getConsignment(),
+            {
+                ...getConsignment(),
+                availableShippingOptions: [],
+            },
+        ]))
+            .toEqual(false);
+    });
+
+    it('returns false when consignments have mismatched shipping options', () => {
+        expect(hasSelectedShippingOptions([
+            getConsignment(),
+            {
+                ...getConsignment(),
+                availableShippingOptions: [ getShippingOptionPickUpStore() ],
+            },
+        ]))
+            .toEqual(false);
     });
 });

--- a/src/app/shipping/hasSelectedShippingOptions.ts
+++ b/src/app/shipping/hasSelectedShippingOptions.ts
@@ -7,6 +7,13 @@ export default function hasSelectedShippingOptions(consignments: Consignment[]):
     }
 
     return every(consignments,
-        consignment => consignment.selectedShippingOption && consignment.selectedShippingOption.id
+        consignment => consignment.selectedShippingOption
+            && consignment.selectedShippingOption.id
+
+            // Selected option is available
+            && consignment.availableShippingOptions
+            && consignment.availableShippingOptions
+                .filter( ({id}) => id === consignment.selectedShippingOption?.id)
+                .length
     );
 }


### PR DESCRIPTION
## What?

Hello, during testing of our checkout we noticed that sometimes we could progress through checkout when there wasn't a shipping method selected.

On investigation, the checkout state persists the selected shipping method across address updates. Our configuration has different shipping options for different countries, and some countries with no options. We would expect these address to shipping method combinations to be recognised as invalid, and for the customer to be unable to progress.

## Why?

Currently, the customer will be able to progress beyond the shipping address stage. However, the final checkout submit will fail due to an invalid shipping option being selected. A local error is a better experience for the customer.


## Testing / Proof
Additional tests for hasSelectedShippingOptions.spec.ts. These fail against the master branch, and existing tests pass with this behaviour change.

## Before
https://user-images.githubusercontent.com/7134802/163550792-5cf59784-dd62-44ba-8f08-2d01290b4512.mov

## After
https://user-images.githubusercontent.com/7134802/163550460-2b8731ef-c3c7-4f93-91a9-d3c8761d39df.mov


@bigcommerce/checkout
