### PR TITLE
feat(payment): PAYMENTS-7403 Add PPSDK Credit Card payment method UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001328",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001328.tgz",
-          "integrity": "sha512-Ue55jHkR/s4r00FLNiX+hGMMuwml/QGqqzVeMQ5thUewznU2EdULFvI3JR7JJid6OrjJNfFvHY2G2dIjmRaDDQ=="
+          "version": "1.0.30001332",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+          "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
         }
       }
     },
@@ -1667,12 +1667,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.237.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.237.3.tgz",
-      "integrity": "sha512-NEwmUAiL6AQIet9zGKZQLepJqp+XPjwhqpIriQXVLfaeg45OrDynp4PDxj2YPXerx8G54lVn+1NGReI2ffImfg==",
+      "version": "1.239.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.239.0.tgz",
+      "integrity": "sha512-7vW7aqJ1we/GoTWHSTke4bVZURhRGIDBkLi0ZGFh4TFQufUrV52hyEbyGvIt3IOsK0qoTgrqJKQjp4TsFXzAUQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.16.0",
+        "@bigcommerce/bigpay-client": "^5.17.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1746,9 +1746,9 @@
           "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A=="
         },
         "core-js": {
-          "version": "3.21.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-          "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
+          "version": "3.22.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.0.tgz",
+          "integrity": "sha512-8h9jBweRjMiY+ORO7bdWSeWfHhLPO7whobj7Z2Bl0IDo00C228EdGgH7FE4jGumbEjzcFfkfW8bXgdkEDhnwHQ=="
         },
         "query-string": {
           "version": "7.1.1",
@@ -7439,9 +7439,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.107",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.107.tgz",
-      "integrity": "sha512-Huen6taaVrUrSy8o7mGStByba8PfOWWluHNxSHGBrCgEdFVLtvdQDBr9LBCF9Uci8SYxh28QNNMO0oC17wbGAg=="
+      "version": "1.4.111",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
+      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.237.3",
+    "@bigcommerce/checkout-sdk": "^1.239.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/NoUI.tsx
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/NoUI.tsx
@@ -1,1 +1,11 @@
-export const NoUI = () => null;
+import React from 'react';
+
+import { usePropsToOnMount } from './usePropsToOnMount';
+import { Props } from './PPSDKPaymentMethod';
+import { Wrapper } from './Wrapper';
+
+export const NoUI = (props: Props) => {
+    const onMount = usePropsToOnMount(props);
+
+    return (<Wrapper onMount={ onMount } />);
+};

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/PPSDKPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/PPSDKPaymentMethod.tsx
@@ -3,12 +3,10 @@ import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 import { initializationComponentMap } from './initializationComponentMap';
-import { usePropsToOnMount } from './usePropsToOnMount';
-import { Wrapper } from './Wrapper';
 
 type CheckoutServiceInstance = InstanceType<typeof CheckoutService>;
 
-interface Props {
+export interface Props {
     method: PaymentMethod;
     deinitializePayment: CheckoutServiceInstance['deinitializePayment'];
     initializePayment: CheckoutServiceInstance['initializePayment'];
@@ -17,8 +15,6 @@ interface Props {
 
 export const PPSDKPaymentMethod: FunctionComponent<Props> = props => {
     const { method, onUnhandledError = noop } = props;
-
-    const onMount = usePropsToOnMount(props);
 
     const componentKey = method?.initializationStrategy?.type || '';
     const Component = initializationComponentMap[componentKey];
@@ -30,8 +26,6 @@ export const PPSDKPaymentMethod: FunctionComponent<Props> = props => {
     }
 
     return (
-        <Wrapper onMount={ onMount }>
-            <Component { ...props } />
-        </Wrapper>
+        <Component { ...props } />
     );
 };

--- a/src/app/payment/paymentMethod/PPSDKPaymentMethod/initializationComponentMap.ts
+++ b/src/app/payment/paymentMethod/PPSDKPaymentMethod/initializationComponentMap.ts
@@ -1,9 +1,12 @@
-import { FunctionComponent } from 'react';
+import { ComponentType } from 'react';
+
+import HostedCreditCardPaymentMethod from '../HostedCreditCardPaymentMethod';
 
 import { NoUI } from './NoUI';
 
-type ComponentMap = Record<string, FunctionComponent>;
+type ComponentMap = Record<string, ComponentType<any>>;
 
 export const initializationComponentMap: ComponentMap = {
+    card_ui: HostedCreditCardPaymentMethod,
     none: NoUI,
 };


### PR DESCRIPTION
## What?
When a PPSDK card payment method is selected, we want the UI to load the PPSDK hosted fields credit card view of PPSDK that uses its own strategy instead of the generic `CreditCardPaymentStrategy`. 

## Why?
To allow handling of different credit card payment features that will be available via PPSDK, like human verification, 3D security check, vaulting credit cards, save as default payment method.

## Related PRs
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1396

## Testing / Proof
Unit tests
Screenshots
**Hosted form is rendered when PPSDK integration type experiment is turned on:**
<img width="1231" alt="Screen Shot 2022-04-05 at 11 06 49 am" src="https://user-images.githubusercontent.com/36555311/161658789-712742ce-359e-4ae0-9ed1-a9c534bbf39e.png">

**Method returns from bcapp as PAYMENT_TYPE_SDK:**
<img width="727" alt="Screen Shot 2022-04-05 at 11 08 11 am" src="https://user-images.githubusercontent.com/36555311/161679541-d8ea0691-e629-4466-bc0d-c9519cc675bb.png">

**The new payment endpoint is used:**
<img width="996" alt="Screen Shot 2022-04-05 at 11 10 08 am" src="https://user-images.githubusercontent.com/36555311/161658805-73e564bd-bdc8-4c6f-87cb-339c1907b298.png">

@bigcommerce/checkout @bigcommerce/payments
