### PR TITLE
feat(shipping): CHECKOUT-6544 Update consignment methods to use address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,9 +1667,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.235.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.235.1.tgz",
-      "integrity": "sha512-jJKxMssh1wgITLWnZXdkaVTjKD4GPROPFdib0VnMpnef7eEeCwbtGk8JGBWUN1xxb3kKGezuvyg0yuM9URkg0Q==",
+      "version": "1.237.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.237.0.tgz",
+      "integrity": "sha512-1KPWRmFngCFPiSbYmg/njhm7zB/z6zFI7dZGq6EK4H6TO5MpB6HaujQd2hBLk5S/vvTDt+vl0umifGCipw9DiQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.16.0",
@@ -7439,9 +7439,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.104",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.104.tgz",
-      "integrity": "sha512-2kjoAyiG7uMyGRM9mx25s3HAzmQG2ayuYXxsFmYugHSDcwxREgLtscZvbL1JcW9S/OemeQ3f/SG6JhDwpnCclQ=="
+      "version": "1.4.105",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.105.tgz",
+      "integrity": "sha512-6w2bmoQBSUgCQjbSjiVv9IS1lXwW2aQABlUJ1vlE8Vci/sVXxUNQrHLQa5N1ioc82Py+a36DlUA5KvrAlHMMeA=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.235.1",
+    "@bigcommerce/checkout-sdk": "^1.237.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/shipping/MultiShippingForm.tsx
+++ b/src/app/shipping/MultiShippingForm.tsx
@@ -220,7 +220,7 @@ class MultiShippingForm extends PureComponent<MultiShippingFormProps & WithLangu
 
         try {
             const { data } = await assignItem({
-                shippingAddress: address,
+                address,
                 lineItems: [{
                     itemId,
                     quantity: 1,

--- a/src/app/shipping/Shipping.tsx
+++ b/src/app/shipping/Shipping.tsx
@@ -229,7 +229,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
 
         try {
             await unassignItem({
-                shippingAddress: address,
+                address,
                 lineItems: [{
                     quantity: 1,
                     itemId,


### PR DESCRIPTION
## What?
As above

## Why?
As part of refactoring for MLI we have updated the interface for consignment create to replace shippingAddress property with address property. 
[SDK PR ](https://github.com/bigcommerce/checkout-sdk-js/pull/1386)

## Testing / Proof
- Tests
- Screencast

https://user-images.githubusercontent.com/7134802/162135711-4dd6327b-4607-479d-8580-e515c3c25967.mov


@bigcommerce/checkout
