### PR TITLE
fix(payment): BOLT-203 Bump checkout-sdk v1.237.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,9 +1667,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.237.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.237.0.tgz",
-      "integrity": "sha512-1KPWRmFngCFPiSbYmg/njhm7zB/z6zFI7dZGq6EK4H6TO5MpB6HaujQd2hBLk5S/vvTDt+vl0umifGCipw9DiQ==",
+      "version": "1.237.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.237.1.tgz",
+      "integrity": "sha512-w1J4v1GOea7QJnoPucMCOzxQbnpANzS42cQwNXaN57mXXnmo09017Quc6J+CQ81Xt51A2nE3mZMbIpl4bjLOXg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.237.0",
+    "@bigcommerce/checkout-sdk": "^1.237.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Change the card number data type to avoid skipping digits after converting a string to a number

## Why?
Because of task: [https://jira.bigcommerce.com/browse/BOLT-203](https://jira.bigcommerce.com/browse/BOLT-203)

## Testing / Proof


https://user-images.githubusercontent.com/9430298/161246306-b2950358-ba05-457c-8677-6fc8878d64ee.mov


![Screenshot 2022-04-01 at 11 40 56](https://user-images.githubusercontent.com/9430298/161246092-fc961fa1-6469-40b7-a9ec-226d8d65cf44.png)
<img width="385" alt="Screenshot 2022-03-31 at 18 40 21" src="https://user-images.githubusercontent.com/9430298/161246108-5bec26ba-5d40-458d-b646-224fbd9d8998.png">


@bigcommerce/checkout
