### PR TITLE
chore(checkout): CHECKOUT-6563 Bump checkout-sdk v1.237.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,9 +145,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001327",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001327.tgz",
-          "integrity": "sha512-1/Cg4jlD9qjZzhbzkzEaAC2JHsP0WrOc8Rd/3a3LuajGzGWR/hD7TVyvq99VqmTy99eVh8Zkmdq213OgvgXx7w=="
+          "version": "1.0.30001328",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001328.tgz",
+          "integrity": "sha512-Ue55jHkR/s4r00FLNiX+hGMMuwml/QGqqzVeMQ5thUewznU2EdULFvI3JR7JJid6OrjJNfFvHY2G2dIjmRaDDQ=="
         }
       }
     },
@@ -1052,9 +1052,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.16.0.tgz",
-      "integrity": "sha512-aAU7LN0Ivayrk/JTg3wyTRyfMmKEJBeq1LSq4nBzAyvLhIsI18JWDd9fuS/pFuYXa5b9E2u5fXPnfadPHIGU1Q==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.17.0.tgz",
+      "integrity": "sha512-S3ps6C59JB/VrAIWluz4F0Us/JTi5S6yRnwF+zHLO4OpNU3dBIYytLTs/q7eXwCe5CkOeZXVx9mspItV97c13g==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^27.4.6",
@@ -1667,9 +1667,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.237.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.237.2.tgz",
-      "integrity": "sha512-EieKtwojpM9ijp6+s9mTzTV/mfn0swPe7qhNXyiW67YmeKTyCe8y84kQ3Gfw/N7bxvgGlWGF65b07C2fEXwsuA==",
+      "version": "1.237.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.237.3.tgz",
+      "integrity": "sha512-NEwmUAiL6AQIet9zGKZQLepJqp+XPjwhqpIriQXVLfaeg45OrDynp4PDxj2YPXerx8G54lVn+1NGReI2ffImfg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.16.0",
@@ -7439,9 +7439,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.106",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-      "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg=="
+      "version": "1.4.107",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.107.tgz",
+      "integrity": "sha512-Huen6taaVrUrSy8o7mGStByba8PfOWWluHNxSHGBrCgEdFVLtvdQDBr9LBCF9Uci8SYxh28QNNMO0oC17wbGAg=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -13296,9 +13296,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
     },
     "node-sass": {
       "version": "4.14.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.237.2",
+    "@bigcommerce/checkout-sdk": "^1.237.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk

## Why?
To get https://github.com/bigcommerce/checkout-sdk-js/pull/1402 out

## Testing / Proof
CircleCI + see the videos on above PR