### PR TITLE
chore(common): CHECKOUT-0000 Update circle config for sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
             SENTRY_COMMIT=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME@$RELEASE_REVISION
             sentry-cli releases --project $SENTRY_PROJECT --org $SENTRY_ORG new $SENTRY_RELEASE
             sentry-cli releases --project $SENTRY_PROJECT --org $SENTRY_ORG set-commits $SENTRY_RELEASE --commit $SENTRY_COMMIT
-            sentry-cli releases --project $SENTRY_PROJECT --org $SENTRY_ORG files $SENTRY_RELEASE upload-sourcemaps --rewrite dist
+            sentry-cli releases --project $SENTRY_PROJECT --org $SENTRY_ORG files $SENTRY_RELEASE upload-sourcemaps dist
             sentry-cli releases --project $SENTRY_PROJECT --org $SENTRY_ORG finalize $SENTRY_RELEASE
 
 workflows:


### PR DESCRIPTION
## What?
Update circle config for sentry

## Why?
We always pull the latest sentry CLI. There is an update for cli where the default behaviour will be to rewrite source maps before uploading.

<img width="1322" alt="Screen Shot 2022-04-13 at 3 05 25 pm" src="https://user-images.githubusercontent.com/7134802/163104221-b73322f1-5d21-4415-80b6-b133091e6c4e.png">


## Testing / Proof
- Circle

@bigcommerce/checkout
