### PR TITLE
[POC] feat(payment): PAYPAL-1406 POC added smartButtonsList component to place smart buttons on the top of checkout page

### DIFF
--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -13,6 +13,7 @@ import { withLanguage, TranslatedString, WithLanguageProps } from '../locale';
 import { PromotionBannerList } from '../promotion';
 import { hasSelectedShippingOptions, isUsingMultiShipping, StaticConsignment } from '../shipping';
 import { ShippingOptionExpiredError } from '../shipping/shippingOption';
+import { SmartButtonsList } from '../smartButtons';
 import { LazyContainer, LoadingNotification, LoadingOverlay } from '../ui/loading';
 import { MobileView } from '../ui/responsive';
 
@@ -239,6 +240,8 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                     <LoadingNotification isLoading={ isPending } />
 
                     <PromotionBannerList promotions={ promotions } />
+
+                    <SmartButtonsList />
 
                     <ol className="checkout-steps">
                         { steps

--- a/src/app/smartButtons/SmartButton.tsx
+++ b/src/app/smartButtons/SmartButton.tsx
@@ -1,0 +1,38 @@
+import { CheckoutButtonInitializeOptions, CheckoutButtonOptions } from '@bigcommerce/checkout-sdk';
+import React, { useEffect, ReactElement } from 'react';
+
+import { SmartButtonProvider } from './SmartButtonsList';
+
+export interface SmartButtonProps {
+    containerId: string;
+    smartButtonProvider: SmartButtonProvider;
+    deinitializeSmartButton(options: CheckoutButtonOptions): void;
+    initializeSmartButton(options: CheckoutButtonInitializeOptions): void;
+}
+
+const SmartButton = ({
+    containerId,
+    smartButtonProvider,
+    initializeSmartButton,
+    deinitializeSmartButton,
+}: SmartButtonProps): ReactElement => {
+    const { methodId, initializationOptions } = smartButtonProvider;
+
+    useEffect(() => {
+        initializeSmartButton({
+            containerId,
+            methodId,
+            [methodId]: {
+                ...initializationOptions,
+            },
+        });
+
+        return () => deinitializeSmartButton({ methodId });
+    }, []);
+
+    return (
+        <div id={ containerId } />
+    );
+};
+
+export default SmartButton;

--- a/src/app/smartButtons/SmartButtonsList.tsx
+++ b/src/app/smartButtons/SmartButtonsList.tsx
@@ -1,0 +1,95 @@
+import { CheckoutButtonInitializeOptions, CheckoutButtonMethodType, CheckoutButtonOptions } from '@bigcommerce/checkout-sdk';
+
+import React, { FunctionComponent } from 'react';
+
+import { withCheckout, CheckoutContextProps } from '../checkout';
+
+import SmartButton from './SmartButton';
+
+export interface WithCheckoutSmartButtonsProps {
+    smartButtonProviders: SmartButtonProvider[];
+    isInitializing?: boolean;
+    deinitializeSmartButton(options: CheckoutButtonOptions): void;
+    initializeSmartButton(options: CheckoutButtonInitializeOptions): void;
+}
+
+export interface SmartButtonProvider {
+    gatewayId?: string;
+    methodId: CheckoutButtonMethodType;
+    sortOrder: number;
+    initializationOptions?: {
+        style?: any;
+        // ...other
+    };
+}
+
+export type SmartButtonsListProps= WithCheckoutSmartButtonsProps;
+
+const SmartButtonsList: FunctionComponent<SmartButtonsListProps> | null = ({
+    isInitializing,
+    smartButtonProviders,
+    ...rest
+}) => {
+    if (!smartButtonProviders?.length) {
+        return null;
+    }
+
+    const sortedSmartButtonsProviders = smartButtonProviders.sort((current, next) => current.sortOrder - next.sortOrder);
+
+    return (
+        <>
+            { !isInitializing && <h2>Smart buttons / External checkout</h2> }
+
+            <ul className="smartButtonsList">
+                { sortedSmartButtonsProviders.map((smartButtonProvider, index) => {
+                    const { methodId } = smartButtonProvider;
+
+                    return <SmartButton
+                        containerId={ `${methodId}SmartButton` }
+                        key={ index }
+                        smartButtonProvider={ smartButtonProvider }
+                        { ...rest }
+                    />;
+                }) }
+            </ul>
+        </>
+    );
+};
+
+export function mapToWithCheckoutCustomerProps(
+    { checkoutService, checkoutState }: CheckoutContextProps
+): WithCheckoutSmartButtonsProps | null {
+    const {
+        data: { getCheckout, getConfig },
+        statuses: { isInitializingCheckoutButton },
+    } = checkoutState;
+
+    const checkout = getCheckout();
+    const config = getConfig();
+
+    if (!checkout || !config) {
+        return null;
+    }
+
+    const methodId = 'braintreepaypal' as CheckoutButtonMethodType.BRAINTREE_PAYPAL;
+
+    const smartButtonProviders = config.checkoutSettings.smartButtonsProviders || [
+        {
+            gatewayId: null,
+            methodId,
+            sortOrder: 0,
+            initializationOptions: {
+                style: {},
+            },
+        },
+    ];
+
+    return {
+        deinitializeSmartButton: checkoutService.deinitializeSmartButton,
+        initializeSmartButton: checkoutService.initializeSmartButton,
+        isInitializing:  isInitializingCheckoutButton(), // Info: we might use this variable in the future
+        smartButtonProviders,
+    };
+}
+
+export default withCheckout(mapToWithCheckoutCustomerProps)(SmartButtonsList);

--- a/src/app/smartButtons/index.ts
+++ b/src/app/smartButtons/index.ts
@@ -1,0 +1,1 @@
+export { default as SmartButtonsList } from './SmartButtonsList';


### PR DESCRIPTION
## What?
Added SmartButtonsList and SmartButton components to initialise and display smart buttons on the top of Checkout page (before Customer step)

## Why?
Due the initiative: https://jira.bigcommerce.com/browse/PAYPAL-1379

## Testing / Proof
I didn't finish unit tests to save some time due the POC, but will add them after feature approve from Checkout team.

Here is a screenshot of braintree paypal smart button integration:
<img width="1137" alt="Screenshot 2022-04-15 at 12 13 42" src="https://user-images.githubusercontent.com/25133454/163565041-61447696-4962-4915-bf69-f50bedc3b3e9.png">

P.S.: don't pay attention to the style of the implementation, it will looks better in the end

