### PR TITLE
feat(checkout): CHECKOUT-6340 Configure Jest to Ignore Integration Tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
             statements: 90,
         },
     },
+    testPathIgnorePatterns: ["<rootDir>/tests"],
     preset: 'ts-jest',
     setupFilesAfterEnv: [
         '<rootDir>/jest-setup.ts',


### PR DESCRIPTION
## What?
Configure Jest to Ignore the `tests` folder which is suppose to be run by `Playwright`.

Related doc: https://jestjs.io/docs/configuration#testpathignorepatterns-arraystring

> testPathIgnorePatterns [array<string>]
>
> An array of regexp pattern strings that are matched against all test paths before executing the test. If the test path matches any of the patterns, it will be skipped.

## Why?
Unblock `checkout-js` CI pipeline.

## Testing / Proof
CI checks of this PR.