### PR TITLE
fix(payment): INT-5428 TypeError: i is not a function

### DIFF
--- a/src/app/payment/paymentMethod/StripePaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/StripePaymentMethod.tsx
@@ -113,6 +113,7 @@ const StripePaymentMethod: FunctionComponent<StripePaymentMethodProps & WithInje
     };
 
     function validateInstrument(_shouldShowNumber: boolean, selectedInstrument: CardInstrument) {
+        
         return getHostedStoredCardValidationFieldset(selectedInstrument);
     }
 


### PR DESCRIPTION
## What? [INT-5428](https://jira.bigcommerce.com/browse/INT-5428)

Sentry Issue: [CHECKOUT-JS-4S0](https://sentry.io/organizations/bigcommerce/issues/2693606697/?referrer=jira_integration)

## Why?
This issue has been detected after the merge of this PR https://github.com/bigcommerce/checkout-js/pull/637 where the selectedInstrument seems to be undefined some times.

This issue has been tracked for more than 1 month now but still is not reproducible.

## Testing / Proof
Since this is not reproducible, cannot produce a proof of the fix.

