### PR TITLE
feat(payment): INT-5481 Worldpay component

### DIFF
--- a/src/app/locale/translations/da.json
+++ b/src/app/locale/translations/da.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Følgende betalingsmetoder understøttes ikke af Embedded Checkout: {methods}. Kontakt os for at få hjælp."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Betalingskort",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Betal over tid",
             "affirm_body_text": "Du vil blive omdirigeret til Affirm for at gennemføre dit køb på sikker vis. Du skal bare udfylde lidt grundlæggende oplysninger og få en beslutning i realtid. Det påvirker ikke din kreditværdighed, at vi kontrollerer din berettigelse.",
@@ -230,6 +229,7 @@
             "credit_card_number_last_four": "Indtast kortnummer for {cardType}, der ender på {lastFour}",
             "credit_card_number_required_error": "Kreditkortnummeret er påkrævet",
             "credit_card_number_mismatch_error": "Det indtastede kortnummer stemmer ikke overens med det kort, der er gemt på din konto",
+            "credit_debit_card_text": "Betalingskort",
             "digitalriver_dropin_error": "Der opstod en fejl under behandlingen af din betaling. Prøv igen, eller kontakt os.",
             "digitalriver_checkout_error": "Der var et problem med din betaling. Tjek dine oplysninger, og prøv igen, eller kontakt kundeservice",
             "digitalriver_checkout_error_title": "Fejl under behandling af anmodningen.",

--- a/src/app/locale/translations/de.json
+++ b/src/app/locale/translations/de.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Die folgenden Zahlungsmethoden werden von Embedded Checkout nicht unterstützt: {methods}. Bitte wenden Sie sich an uns, um Hilfe zu erhalten."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Kredit-/Debitkarte",
             "affirm_name_text": "Bestätigen",
             "affirm_display_name_text": "Im Laufe der Zeit bezahlen",
             "affirm_body_text": "Sie werden zu Affirm weitergeleitet, um Ihren Kauf sicher abzuschließen. Füllen Sie einfach ein paar grundlegende Informationen aus und Sie erhalten eine Entscheidung in Echtzeit. Die Überprüfung Ihrer Berechtigung wirkt sich nicht auf Ihre Bonität aus.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Geben Sie die Kartennummer für {cardType} mit den Endziffern {lastFour} ein",
             "credit_card_number_required_error": "Kreditkartennummer erforderlich",
             "credit_card_number_mismatch_error": "Die eingegebene Kartennummer entspricht nicht der in Ihrem Konto gespeicherten Karte",
+            "credit_debit_card_text": "Kredit-/Debitkarte",
             "digitalriver_dropin_error": "Bei der Verarbeitung Ihrer Zahlung ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut oder nehmen Sie Kontakt zu uns auf.",
             "digitalriver_checkout_error": "Es gab ein Problem mit Ihrem Bezahlvorgang, bitte prüfen Sie Ihre Details und versuchen Sie es erneut oder kontaktieren Sie den Kundendienst.",
             "digitalriver_checkout_error_title": "Fehler beim Verarbeiten der Anfrage.",

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -173,7 +173,6 @@
             "unsupported_error": "The following payment methods are not supported by Embedded Checkout: {methods}. Please contact us for assistance."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Credit/Debit Card",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Pay over time",
             "affirm_body_text": "You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.",
@@ -231,6 +230,7 @@
             "credit_card_number_last_four": "Enter card number for {cardType} ending in {lastFour}",
             "credit_card_number_required_error": "Credit Card Number is required",
             "credit_card_number_mismatch_error": "The card number entered does not match the card stored in your account",
+            "credit_debit_card_text": "Credit/Debit Card",
             "digitalriver_dropin_error": "There was an error while processing your payment. Please try again or contact us.",
             "digitalriver_checkout_error": "There was a problem with your checkout, please check your details and try again or contact customer service",
             "digitalriver_checkout_error_title": "Error while processing request.",

--- a/src/app/locale/translations/es-419.json
+++ b/src/app/locale/translations/es-419.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Los siguientes métodos de pago no son compatibles con el pago integrado: {methods}. Comunícate con nosotros para obtener ayuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Tarjeta de débito/crédito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Paga después",
             "affirm_body_text": "Se te redirigirá a Affirm para completar de forma segura tu compra. Simplemente, proporciona algunos datos básicos y obtén una decisión en tiempo real. La verificación de tu elegibilidad no afectará tu puntaje crediticio.",
@@ -230,6 +229,7 @@
             "credit_card_number_last_four": "Ingresa el número de la tarjeta de {cardType} con terminación en {lastFour}",
             "credit_card_number_required_error": "El número de tarjeta de crédito es obligatorio",
             "credit_card_number_mismatch_error": "El número de tarjeta que se ingresó no coincide con la tarjeta guardada en tu cuenta",
+            "credit_debit_card_text": "Tarjeta de débito/crédito",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
             "digitalriver_checkout_error": "Hubo un problema con tu proceso de pago; revisa tus datos e inténtalo de nuevo o ponte en contacto con el servicio de atención al cliente",
             "digitalriver_checkout_error_title": "Error al procesar la solicitud.",

--- a/src/app/locale/translations/es-AR.json
+++ b/src/app/locale/translations/es-AR.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Los siguientes métodos de pago no son compatibles con el pago integrado: {methods}. Comunícate con nosotros para obtener ayuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Tarjeta de débito/crédito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Paga después",
             "affirm_body_text": "Se te redirigirá a Affirm para completar de forma segura tu compra. Simplemente, proporciona algunos datos básicos y obtén una decisión en tiempo real. La verificación de tu elegibilidad no afectará tu puntaje crediticio.",
@@ -230,6 +229,7 @@
             "credit_card_number_last_four": "Ingresa el número de la tarjeta de {cardType} con terminación en {lastFour}",
             "credit_card_number_required_error": "El número de tarjeta de crédito es obligatorio",
             "credit_card_number_mismatch_error": "El número de tarjeta que se ingresó no coincide con la tarjeta guardada en tu cuenta",
+            "credit_debit_card_text": "Tarjeta de débito/crédito",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
             "digitalriver_checkout_error": "Hubo un problema con tu proceso de pago; revisa tus datos e inténtalo de nuevo o ponte en contacto con el servicio de atención al cliente",
             "digitalriver_checkout_error_title": "Error al procesar la solicitud.",

--- a/src/app/locale/translations/es-CL.json
+++ b/src/app/locale/translations/es-CL.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Los siguientes métodos de pago no son compatibles con el pago integrado: {methods}. Comunícate con nosotros para obtener ayuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Tarjeta de débito/crédito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Paga después",
             "affirm_body_text": "Se te redirigirá a Affirm para completar de forma segura tu compra. Simplemente, proporciona algunos datos básicos y obtén una decisión en tiempo real. La verificación de tu elegibilidad no afectará tu puntaje crediticio.",
@@ -230,6 +229,7 @@
             "credit_card_number_last_four": "Ingresa el número de la tarjeta de {cardType} con terminación en {lastFour}",
             "credit_card_number_required_error": "El número de tarjeta de crédito es obligatorio",
             "credit_card_number_mismatch_error": "El número de tarjeta que se ingresó no coincide con la tarjeta guardada en tu cuenta",
+            "credit_debit_card_text": "Tarjeta de débito/crédito",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
             "digitalriver_checkout_error": "Hubo un problema con tu proceso de pago; revisa tus datos e inténtalo de nuevo o ponte en contacto con el servicio de atención al cliente",
             "digitalriver_checkout_error_title": "Error al procesar la solicitud.",

--- a/src/app/locale/translations/es-CO.json
+++ b/src/app/locale/translations/es-CO.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Los siguientes métodos de pago no son compatibles con el pago integrado: {methods}. Comunícate con nosotros para obtener ayuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Tarjeta de débito/crédito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Paga después",
             "affirm_body_text": "Se te redirigirá a Affirm para completar de forma segura tu compra. Simplemente, proporciona algunos datos básicos y obtén una decisión en tiempo real. La verificación de tu elegibilidad no afectará tu puntaje crediticio.",
@@ -230,6 +229,7 @@
             "credit_card_number_last_four": "Ingresa el número de la tarjeta de {cardType} con terminación en {lastFour}",
             "credit_card_number_required_error": "El número de tarjeta de crédito es obligatorio",
             "credit_card_number_mismatch_error": "El número de tarjeta que se ingresó no coincide con la tarjeta guardada en tu cuenta",
+            "credit_debit_card_text": "Tarjeta de débito/crédito",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
             "digitalriver_checkout_error": "Hubo un problema con tu proceso de pago; revisa tus datos e inténtalo de nuevo o ponte en contacto con el servicio de atención al cliente",
             "digitalriver_checkout_error_title": "Error al procesar la solicitud.",

--- a/src/app/locale/translations/es-MX.json
+++ b/src/app/locale/translations/es-MX.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Los siguientes métodos de pago no son compatibles con el pago integrado: {methods}. Comunícate con nosotros para obtener ayuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Tarjeta de débito/crédito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Paga después",
             "affirm_body_text": "Se te redirigirá a Affirm para completar de forma segura tu compra. Simplemente, proporciona algunos datos básicos y obtén una decisión en tiempo real. La verificación de tu elegibilidad no afectará tu puntaje crediticio.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Ingresa el número de la tarjeta de {cardType} con terminación en {lastFour}",
             "credit_card_number_required_error": "El número de tarjeta de crédito es obligatorio",
             "credit_card_number_mismatch_error": "El número de tarjeta que se ingresó no coincide con la tarjeta guardada en tu cuenta",
+            "credit_debit_card_text": "Tarjeta de débito/crédito",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
             "digitalriver_checkout_error": "Hubo un problema con tu proceso de pago; revisa tus datos e inténtalo de nuevo o ponte en contacto con el servicio de atención al cliente",
             "digitalriver_checkout_error_title": "Error al procesar la solicitud.",

--- a/src/app/locale/translations/es-PE.json
+++ b/src/app/locale/translations/es-PE.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Los siguientes métodos de pago no son compatibles con el pago integrado: {methods}. Comunícate con nosotros para obtener ayuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Tarjeta de débito/crédito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Paga después",
             "affirm_body_text": "Se te redirigirá a Affirm para completar de forma segura tu compra. Simplemente, proporciona algunos datos básicos y obtén una decisión en tiempo real. La verificación de tu elegibilidad no afectará tu puntaje crediticio.",
@@ -230,6 +229,7 @@
             "credit_card_number_last_four": "Ingresa el número de la tarjeta de {cardType} con terminación en {lastFour}",
             "credit_card_number_required_error": "El número de tarjeta de crédito es obligatorio",
             "credit_card_number_mismatch_error": "El número de tarjeta que se ingresó no coincide con la tarjeta guardada en tu cuenta",
+            "credit_debit_card_text": "Tarjeta de débito/crédito",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
             "digitalriver_checkout_error": "Hubo un problema con tu proceso de pago; revisa tus datos e inténtalo de nuevo o ponte en contacto con el servicio de atención al cliente",
             "digitalriver_checkout_error_title": "Error al procesar la solicitud.",

--- a/src/app/locale/translations/es.json
+++ b/src/app/locale/translations/es.json
@@ -173,7 +173,6 @@
             "unsupported_error": "El proceso de pago integrado no admite los siguientes métodos de pago: {methods}. Póngase en contacto con nosotros para obtener ayuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Tarjeta de crédito/débito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Pago aplazado",
             "affirm_body_text": "Se le redirigirá a Affirm para completar su compra de forma segura. Solo hay que rellenar unos pocos datos básicos y obtendrá una decisión en tiempo real. Verificar su elegibilidad no afectará su puntuación crediticia.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Introduzca el número de la tarjeta {cardType} que termina en {lastFour}",
             "credit_card_number_required_error": "Se requiere el número de tarjeta de crédito",
             "credit_card_number_mismatch_error": "El número de tarjeta introducido no coincide con la tarjeta guardada en su cuenta",
+            "credit_debit_card_text": "Tarjeta de crédito/débito",
             "digitalriver_dropin_error": "Hubo un error al procesar su pago. Inténtelo de nuevo o póngase en contacto con nosotros.",
             "digitalriver_checkout_error": "Ha habido un problema con su compra; compruebe sus datos e inténtelo de nuevo o póngase en contacto con el servicio de Atención al Cliente",
             "digitalriver_checkout_error_title": "Error al procesar la solicitud.",

--- a/src/app/locale/translations/fr.json
+++ b/src/app/locale/translations/fr.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Les modes de paiement suivants ne sont pas pris en charge par Embedded Checkout : {methods}. Veuillez nous contacter pour obtenir de l'aide."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Carte de crédit/débit",
             "affirm_name_text": "Confirmer",
             "affirm_display_name_text": "Payer en plusieurs fois",
             "affirm_body_text": "Vous allez être redirigé·e vers Affirm afin de finaliser votre achat en toute sécurité. Il vous suffira de renseigner certaines informations de base pour obtenir une réponse en temps réel. La vérification de votre éligibilité n'affectera en rien votre fiabilité.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Saisissez le numéro de la carte {cardType} se terminant par {lastFour}",
             "credit_card_number_required_error": "Numéro de carte bancaire requis",
             "credit_card_number_mismatch_error": "Le numéro de carte saisi ne correspond pas à celui de la carte enregistrée dans votre compte",
+            "credit_debit_card_text": "Carte de crédit/débit",
             "digitalriver_dropin_error": "Une erreur s'est produite lors du traitement de votre paiement. Veuillez réessayer, ou contactez-nous.",
             "digitalriver_checkout_error": "Un problème est survenu lors de votre paiement, veuillez vérifier vos informations et réessayer, ou contacter le service client",
             "digitalriver_checkout_error_title": "Erreur lors du traitement de la demande.",

--- a/src/app/locale/translations/it.json
+++ b/src/app/locale/translations/it.json
@@ -173,7 +173,6 @@
             "unsupported_error": "I seguenti metodi di pagamento non sono supportati dal Checkout incorporato: {methods}. Contattaci per ricevere assistenza."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Carta di credito/debito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Pagamento nel tempo",
             "affirm_body_text": "Verrai reindirizzato su Affirm per completare il tuo acquisto in modo sicuro. Da lì ti basterà inserire alcune informazioni di base e prendere una decisione in tempo reale. Verificare la tua idoneità non influirà sul tuo punteggio di credito.",
@@ -229,6 +228,7 @@
             "credit_card_number_last_four": "Inserisci il numero di carta della {cardType} che termina con {lastFour}",
             "credit_card_number_required_error": "Il numero della carta di credito è obbligatorio",
             "credit_card_number_mismatch_error": "Il numero di carta inserito non corrisponde a quello memorizzato nel tuo account",
+            "credit_debit_card_text": "Carta di credito/debito",
             "digitalriver_dropin_error": "Si è verificato un problema durante l'elaborazione del pagamento. Riprova o contattaci.",
             "digitalriver_checkout_error": "Si è verificato un problema con il pagamento, controlla i tuoi dati e riprova o contatta il servizio clienti",
             "digitalriver_checkout_error_title": "Errore durante l'elaborazione della richiesta.",

--- a/src/app/locale/translations/nl.json
+++ b/src/app/locale/translations/nl.json
@@ -173,7 +173,6 @@
             "unsupported_error": "De volgende betaalmethoden worden niet ondersteund door Embedded Checkout: {methods}. Neem voor hulp contact met ons op."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Creditcard/betaalpas",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Later betalen",
             "affirm_body_text": "U wordt omgeleid naar Affirm om uw aankoop veilig te voltooien. Als u enkele basisgegevens invult, krijgt u in real time een beslissing. Het controleren van uw geschiktheid heeft geen invloed op uw creditscore.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Voer het kaartnummer in voor {cardType} eindigend op {lastFour}",
             "credit_card_number_required_error": "Creditcardnummer is vereist",
             "credit_card_number_mismatch_error": "Het ingevoerde kaartnummer komt niet overeen met de kaart die in uw account is opgeslagen",
+            "credit_debit_card_text": "Creditcard/betaalpas",
             "digitalriver_dropin_error": "Er is een fout opgetreden bij het verwerken van uw betaling. Probeer het opnieuw of neem contact met ons op.",
             "digitalriver_checkout_error": "Er is iets fout gegaan bij het afrekenen: controleer uw gegevens en probeer het opnieuw, of neem contact op met de klantenservice",
             "digitalriver_checkout_error_title": "Fout tijdens het verwerken van het verzoek.",

--- a/src/app/locale/translations/pt-BR.json
+++ b/src/app/locale/translations/pt-BR.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Os métodos de pagamento a seguir não são aceitos na finalização de compra integrada: {methods}. Entre em contato conosco para receber ajuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Cartão de crédito/débito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Pagar ao longo do tempo",
             "affirm_body_text": "Você será redirecionado para o Affirm para concluir a sua compra com segurança. Basta preencher algumas informações básicas e tomar uma decisão em tempo real. Verificar sua qualificação não afetará sua pontuação de crédito.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Insira o número do cartão {cardType} terminando em {lastFour}",
             "credit_card_number_required_error": "O número de cartão de crédito é obrigatório",
             "credit_card_number_mismatch_error": "O número do cartão inserido não corresponde ao cartão armazenado na sua conta",
+            "credit_debit_card_text": "Cartão de crédito/débito",
             "digitalriver_dropin_error": "Ocorreu um erro no processamento do seu pagamento. Tente novamente ou entre em contato conosco.",
             "digitalriver_checkout_error": "Ocorreu um problema na finalização da compra; confira os dados e tente novamente; ou procure o atendimento ao cliente",
             "digitalriver_checkout_error_title": "Erro ao processar a solicitação.",

--- a/src/app/locale/translations/pt.json
+++ b/src/app/locale/translations/pt.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Os métodos de pagamento a seguir não são aceitos na finalização de compra integrada: {methods}. Entre em contato conosco para receber ajuda."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Cartão de crédito/débito",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Pagar ao longo do tempo",
             "affirm_body_text": "Você será redirecionado para o Affirm para concluir a sua compra com segurança. Basta preencher algumas informações básicas e tomar uma decisão em tempo real. Verificar sua qualificação não afetará sua pontuação de crédito.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Insira o número do cartão {cardType} terminando em {lastFour}",
             "credit_card_number_required_error": "O número de cartão de crédito é obrigatório",
             "credit_card_number_mismatch_error": "O número do cartão inserido não corresponde ao cartão armazenado na sua conta",
+            "credit_debit_card_text": "Cartão de crédito/débito",
             "digitalriver_dropin_error": "Ocorreu um erro no processamento do seu pagamento. Tente novamente ou entre em contato conosco.",
             "digitalriver_checkout_error": "Ocorreu um problema na finalização da compra; confira os dados e tente novamente; ou procure o atendimento ao cliente",
             "digitalriver_checkout_error_title": "Erro ao processar a solicitação.",

--- a/src/app/locale/translations/sv.json
+++ b/src/app/locale/translations/sv.json
@@ -173,7 +173,6 @@
             "unsupported_error": "Följande betalningsmetoder stöds inte av inbyggd kassa: {methods}. Kontakta oss för att få hjälp."
         },
         "payment": {
-            "adyen_credit_debit_card_text": "Kredit-/betalkort",
             "affirm_name_text": "Bekräfta",
             "affirm_display_name_text": "Betala med tiden",
             "affirm_body_text": "Du kommer att omdirigeras till Affirm för att slutföra ditt köp på ett säkert sätt. Fyll i grundläggande information och få ett beslut i realtid. Din kreditvärdighet påverkas inte när du kontrollerar din behörighet.",
@@ -228,6 +227,7 @@
             "credit_card_number_last_four": "Ange kortnummer för {cardType} som slutar på {lastFour}",
             "credit_card_number_required_error": "Kreditkortsnummer är obligatoriskt",
             "credit_card_number_mismatch_error": "Det angivna kortnumret matchar inte det kort som är lagrat på ditt konto",
+            "credit_debit_card_text": "Kredit-/betalkort",
             "digitalriver_dropin_error": "Det uppstod ett fel när betalningen bearbetades. Försök igen eller kontakta oss.",
             "digitalriver_checkout_error": "Ett fel uppstod i kassan. Vänligen kontrollera dina uppgifter och försök igen, eller kontakta kundtjänst.",
             "digitalriver_checkout_error_title": "Fel vid bearbetning av begäran.",

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -40,6 +40,7 @@ import SquarePaymentMethod from './SquarePaymentMethod';
 import StripePaymentMethod from './StripePaymentMethod';
 import StripeUPEPaymentMethod from './StripeUPEPaymentMethod';
 import VisaCheckoutPaymentMethod from './VisaCheckoutPaymentMethod';
+import WorldpayCreditCardPaymentMethod from './WorldpayCreditCardPaymentMethod';
 
 export interface PaymentMethodProps {
     method: PaymentMethod;
@@ -209,6 +210,10 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.id === PaymentMethodId.Moneris) {
         return <MonerisPaymentMethod { ...props } />;
+    }
+
+    if (method.id === PaymentMethodId.WorldpayAccess) {
+        return <WorldpayCreditCardPaymentMethod { ...props } />;
     }
 
     if (method.gateway === PaymentMethodId.Afterpay ||

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -55,6 +55,7 @@ enum PaymentMethodId {
     StripeUPEGooglePay = 'googlepaystripeupe',
     StripeV3 = 'stripev3',
     StripeUPE = 'stripeupe',
+    WorldpayAccess = 'worldpayaccess',
     Zip = 'zip',
 }
 

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -163,6 +163,10 @@ function getPaymentMethodTitle(
                 logoUrl: '',
                 titleText: method.method === 'iban' ? language.translate('payment.stripe_sepa_display_name_text') : methodName,
             },
+            [PaymentMethodId.WorldpayAccess]: {
+                logoUrl: '',
+                titleText: language.translate('payment.credit_debit_card_text'),
+            },
         };
 
         // KLUDGE: 'paypal' is actually a credit card method. It is the only

--- a/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.spec.tsx
+++ b/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.spec.tsx
@@ -1,0 +1,166 @@
+import { createCheckoutService, CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { useEffect, FunctionComponent } from 'react';
+import { object } from 'yup';
+
+import { getCart } from '../../cart/carts.mock';
+import { CheckoutProvider } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { getCustomer } from '../../customer/customers.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { withHostedCreditCardFieldset, WithInjectedHostedCreditCardFieldsetProps } from '../hostedCreditCard';
+import { getPaymentMethod } from '../payment-methods.mock';
+import PaymentContext, { PaymentContextProps } from '../PaymentContext';
+
+import CreditCardPaymentMethod from './CreditCardPaymentMethod';
+import PaymentMethodId from './PaymentMethodId';
+import WorldpayCreditCardPaymentMethod, { WorldpayCreditCardPaymentMethodProps } from './WorldpayCreditCardPaymentMethod';
+
+const hostedFormOptions = {
+    fields: {
+        cardCode: { containerId: 'cardCode', placeholder: 'Card code' },
+        cardName: { containerId: 'cardName', placeholder: 'Card name' },
+        cardNumber: { containerId: 'cardNumber', placeholder: 'Card number' },
+        cardExpiry: { containerId: 'cardExpiry', placeholder: 'Card expiry' },
+    },
+};
+
+const injectedProps: WithInjectedHostedCreditCardFieldsetProps = {
+    getHostedFormOptions: () => Promise.resolve(hostedFormOptions),
+    getHostedStoredCardValidationFieldset: () => <div />,
+    hostedFieldset: <div />,
+    hostedStoredCardValidationSchema: object(),
+    hostedValidationSchema: object(),
+};
+
+jest.mock('../hostedCreditCard', () => ({
+    ...jest.requireActual('../hostedCreditCard'),
+    withHostedCreditCardFieldset: jest.fn(
+        Component => (props: any) => <Component
+            { ...props }
+            { ...injectedProps }
+        />
+    ) as jest.Mocked<typeof withHostedCreditCardFieldset>,
+}));
+
+jest.mock('./CreditCardPaymentMethod', () =>
+    jest.fn(({
+        initializePayment,
+        method,
+    }) => {
+        useEffect(() => {
+            initializePayment({
+                methodId: method.id,
+                gatewayId: method.gateway,
+            });
+        });
+
+        return <div />;
+    }) as jest.Mocked<typeof CreditCardPaymentMethod>
+);
+
+describe('when using Worldpay payment', () => {
+    let WorldpayCreditCardPaymentMethodTest: FunctionComponent<WorldpayCreditCardPaymentMethodProps>;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: WorldpayCreditCardPaymentMethodProps;
+    let localeContext: LocaleContextType;
+    let paymentContext: PaymentContextProps;
+
+    beforeEach(() => {
+        defaultProps = {
+            deinitializePayment: jest.fn(),
+            initializePayment: jest.fn(),
+            isInitializing: false,
+            method: {
+                ...getPaymentMethod(),
+                id: PaymentMethodId.Worldpay,
+            },
+            onUnhandledError: jest.fn(),
+        };
+
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+        paymentContext = {
+            disableSubmit: jest.fn(),
+            setSubmit: jest.fn(),
+            setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
+        };
+
+        jest.spyOn(checkoutState.data, 'getCart')
+            .mockReturnValue(getCart());
+
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getCustomer')
+            .mockReturnValue(getCustomer());
+
+        jest.spyOn(checkoutService, 'deinitializePayment')
+            .mockResolvedValue(checkoutState);
+
+        jest.spyOn(checkoutService, 'initializePayment')
+            .mockResolvedValue(checkoutState);
+
+        WorldpayCreditCardPaymentMethodTest = props => (
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <PaymentContext.Provider value={ paymentContext }>
+                    <LocaleContext.Provider value={ localeContext }>
+                        <Formik
+                            initialValues={ {} }
+                            onSubmit={ noop }
+                        >
+                            <WorldpayCreditCardPaymentMethod { ...props } />
+                        </Formik>
+                    </LocaleContext.Provider>
+                </PaymentContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('renders as credit card payment method', async () => {
+        const container = mount(<WorldpayCreditCardPaymentMethodTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(container.find(CreditCardPaymentMethod).props())
+            .toEqual(expect.objectContaining({
+                deinitializePayment: expect.any(Function),
+                initializePayment: expect.any(Function),
+                method: defaultProps.method,
+            }));
+    });
+
+    it('initializes method with required config', async () => {
+        mount(<WorldpayCreditCardPaymentMethodTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(defaultProps.initializePayment)
+            .toHaveBeenCalledWith(expect.objectContaining({
+                methodId: defaultProps.method.id,
+                gatewayId: defaultProps.method.gateway,
+            }));
+    });
+
+    it('injects hosted form properties to credit card payment method component', async () => {
+        const component = mount(<WorldpayCreditCardPaymentMethodTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        const decoratedComponent = component.find(CreditCardPaymentMethod);
+
+        expect(decoratedComponent.prop('cardFieldset'))
+            .toEqual(injectedProps.hostedFieldset);
+        expect(decoratedComponent.prop('cardValidationSchema'))
+            .toEqual(injectedProps.hostedValidationSchema);
+        expect(decoratedComponent.prop('getStoredCardValidationFieldset'))
+            .toEqual(injectedProps.getHostedStoredCardValidationFieldset);
+        expect(decoratedComponent.prop('storedCardValidationSchema'))
+            .toEqual(injectedProps.hostedStoredCardValidationSchema);
+    });
+});

--- a/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.tsx
@@ -1,0 +1,77 @@
+import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import React, { createRef, useCallback, useRef, useState, FunctionComponent, RefObject } from 'react';
+
+import { Modal } from '../../ui/modal';
+
+import HostedCreditCardPaymentMethod, { HostedCreditCardPaymentMethodProps } from './HostedCreditCardPaymentMethod';
+
+export type WorldpayCreditCardPaymentMethodProps = HostedCreditCardPaymentMethodProps;
+
+interface WorldpayPaymentMethodRef {
+    paymentPageContentRef: RefObject<HTMLDivElement>;
+    paymentPageContentMetaDataRef: RefObject<HTMLDivElement>;
+    cancelThreeDSecureVerification?(): void;
+}
+
+const WorldpayCreditCardPaymentMethod: FunctionComponent<WorldpayCreditCardPaymentMethodProps> = ({
+    initializePayment,
+    ...rest
+}) => {
+    const [threeDSecureVerification, setThreeDSecureVerification] = useState<HTMLElement>();
+    const [metadata, setMetadata] = useState<HTMLElement>();
+
+    const ref = useRef<WorldpayPaymentMethodRef>({
+        paymentPageContentRef: createRef(),
+        paymentPageContentMetaDataRef: createRef(),
+    });
+
+    const cancelWorldpayModalFlow = useCallback(() => {
+        setThreeDSecureVerification(undefined);
+
+        if (ref.current.cancelThreeDSecureVerification) {
+            ref.current.cancelThreeDSecureVerification();
+            ref.current.cancelThreeDSecureVerification = undefined;
+        }
+    }, []);
+
+    const initializeWorldpayPayment = useCallback((options: PaymentInitializeOptions) => {
+        return initializePayment({
+            ...options,
+            worldpay: {
+                onLoad(content: HTMLIFrameElement, cancel: () => void) {
+                    setThreeDSecureVerification(content);
+                    setMetadata(content);
+                    ref.current.cancelThreeDSecureVerification = cancel;
+                },
+            },
+        });
+    }, [initializePayment]);
+
+    const appendPaymentPageContent = useCallback(() => {
+        if (ref.current.paymentPageContentRef.current && threeDSecureVerification) {
+            ref.current.paymentPageContentRef.current.appendChild(threeDSecureVerification);
+        }
+    }, [threeDSecureVerification]);
+
+    if (metadata) {
+        ref.current.paymentPageContentMetaDataRef.current?.appendChild(metadata);
+    }
+
+    return <>
+        <HostedCreditCardPaymentMethod
+            { ...rest }
+            initializePayment={ initializeWorldpayPayment }
+        />
+        <Modal
+            isOpen={ !!threeDSecureVerification }
+            onAfterOpen={ appendPaymentPageContent }
+            onRequestClose={ cancelWorldpayModalFlow }
+            shouldShowCloseButton={ true }
+        >
+            <div ref={ ref.current.paymentPageContentRef } />
+        </Modal>
+        <div hidden ref={ ref.current.paymentPageContentMetaDataRef } />
+    </>;
+};
+
+export default WorldpayCreditCardPaymentMethod;

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.spec.tsx
@@ -38,6 +38,6 @@ describe('getPaymentMethodDisplayName()', () => {
         const method = { ...getPaymentMethod(), id: PaymentMethodId.AdyenV2, config: { displayName: 'Credit Card' } };
 
         expect(getPaymentMethodDisplayName(language)(method))
-            .toEqual(language.translate('payment.adyen_credit_debit_card_text'));
+            .toEqual(language.translate('payment.credit_debit_card_text'));
     });
 });

--- a/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
+++ b/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
@@ -19,7 +19,7 @@ export default function getPaymentMethodDisplayName(
         }
 
         if (isCreditCard && method.id === PaymentMethodId.AdyenV2 || method.id === PaymentMethodId.AdyenV3) {
-            return language.translate('payment.adyen_credit_debit_card_text');
+            return language.translate('payment.credit_debit_card_text');
         }
 
         if (isCreditCard) {


### PR DESCRIPTION
## What?  [INT-5481](https://bigcommercecloud.atlassian.net/browse/INT-5481)
adds worldpay as payment method in the checkout and a div tag later we could add 3ds section

## Why?
we need to allow pay as a credit card

## Testing / Proof
<img width="639" alt="image" src="https://user-images.githubusercontent.com/4907027/165628486-15fe2c8b-fc78-4872-9f73-5e364834cff9.png">

## Depends of
https://github.com/bigcommerce/checkout-sdk-js/pull/1424

@bigcommerce/checkout @bigcommerce/apex-integrations 
