### PR TITLE
chore(checkout): CHECKOUT-6631 Bump checkout-js v1.242.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
     "@babel/compat-data": {
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
-      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
+      "dev": true
     },
     "@babel/core": {
       "version": "7.5.5",
@@ -126,6 +127,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
       "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
@@ -137,6 +139,7 @@
           "version": "4.20.2",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
           "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+          "dev": true,
           "requires": {
             "caniuse-lite": "^1.0.30001317",
             "electron-to-chromium": "^1.4.84",
@@ -148,7 +151,8 @@
         "caniuse-lite": {
           "version": "1.0.30001332",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-          "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
+          "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+          "dev": true
         }
       }
     },
@@ -1539,21 +1543,30 @@
             "@babel/highlight": "^7.16.7"
           }
         },
+        "@babel/compat-data": {
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
+          "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw=="
+        },
         "@babel/generator": {
-          "version": "7.17.9",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
-          "integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
+          "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
           "requires": {
-            "@babel/types": "^7.17.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-            }
+            "@babel/types": "^7.17.10",
+            "@jridgewell/gen-mapping": "^0.1.0",
+            "jsesc": "^2.5.1"
+          }
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
+          "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
+          "requires": {
+            "@babel/compat-data": "^7.17.10",
+            "@babel/helper-validator-option": "^7.16.7",
+            "browserslist": "^4.20.2",
+            "semver": "^6.3.0"
           }
         },
         "@babel/helper-function-name": {
@@ -1679,9 +1692,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.17.9",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
-          "integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg=="
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
+          "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ=="
         },
         "@babel/template": {
           "version": "7.16.7",
@@ -1694,26 +1707,26 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.17.9",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
-          "integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
+          "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
           "requires": {
             "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.9",
+            "@babel/generator": "^7.17.10",
             "@babel/helper-environment-visitor": "^7.16.7",
             "@babel/helper-function-name": "^7.17.9",
             "@babel/helper-hoist-variables": "^7.16.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
-            "@babel/parser": "^7.17.9",
-            "@babel/types": "^7.17.0",
+            "@babel/parser": "^7.17.10",
+            "@babel/types": "^7.17.10",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+          "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
@@ -1858,6 +1871,23 @@
             "fill-range": "^7.0.1"
           }
         },
+        "browserslist": {
+          "version": "4.20.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+          "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001332",
+            "electron-to-chromium": "^1.4.118",
+            "escalade": "^3.1.1",
+            "node-releases": "^2.0.3",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001334",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+          "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw=="
+        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1892,6 +1922,11 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "electron-to-chromium": {
+          "version": "1.4.129",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
+          "integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ=="
         },
         "fill-range": {
           "version": "7.0.1",
@@ -1940,20 +1975,20 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.17.9",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
-              "integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
+              "version": "7.17.10",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
+              "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
               "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.17.9",
-                "@babel/helper-compilation-targets": "^7.17.7",
+                "@babel/generator": "^7.17.10",
+                "@babel/helper-compilation-targets": "^7.17.10",
                 "@babel/helper-module-transforms": "^7.17.7",
                 "@babel/helpers": "^7.17.9",
-                "@babel/parser": "^7.17.9",
+                "@babel/parser": "^7.17.10",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.17.9",
-                "@babel/types": "^7.17.0",
+                "@babel/traverse": "^7.17.10",
+                "@babel/types": "^7.17.10",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -2136,9 +2171,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.242.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.242.0.tgz",
-      "integrity": "sha512-yCZHDlajb0ittGMiBmq6eD4pbXhvsHaqtgg/X+Se825av+kLQJeOyjddPGpFkwVL1nqzV2J4Rvjl7QrWf6g11A==",
+      "version": "1.242.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.242.2.tgz",
+      "integrity": "sha512-pnmrIfP/dMc+o0agO7GHhkJKXFTchH8t+DVMahS/ElS3fDyiW78r4mSLd1EppNULH3zFokEAsjhercKxI/vMRw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.17.0",
@@ -2160,7 +2195,7 @@
         "iframe-resizer": "^3.6.2",
         "local-storage-fallback": "^4.1.1",
         "lodash": "^4.17.15",
-        "messageformat": "2.1.0",
+        "messageformat": "^2.3.0",
         "query-string": "^7.0.1",
         "reselect": "^4.1.5",
         "rxjs": "^6.5.3",
@@ -9002,7 +9037,8 @@
     "electron-to-chromium": {
       "version": "1.4.111",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
-      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw=="
+      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw==",
+      "dev": true
     },
     "elliptic": {
       "version": "6.5.4",
@@ -14694,14 +14730,19 @@
       "dev": true
     },
     "messageformat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.1.0.tgz",
-      "integrity": "sha512-AfH57I4eLJNtqpX7qlGfaWAQFjsImADhKzwJuNWJwjCQhWB7p4IgH8C5/Z9PUeRZsby3/lCPYJmVRYoXfi4Qbw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
+      "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
       "requires": {
         "make-plural": "^4.3.0",
-        "messageformat-parser": "^4.1.0",
-        "reserved-words": "^0.1.2"
+        "messageformat-formatters": "^2.0.1",
+        "messageformat-parser": "^4.1.2"
       }
+    },
+    "messageformat-formatters": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
     },
     "messageformat-parser": {
       "version": "4.1.3",
@@ -17237,11 +17278,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
       "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE="
     },
     "resolve": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.242.0",
+    "@bigcommerce/checkout-sdk": "^1.242.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk

## Why?
To get https://github.com/bigcommerce/checkout-sdk-js/pull/1425 out

## Testing / Proof
CircleCI + see the PR above.