### PR TITLE
feat(payment): INT-5904 Remove formatting for payment method when Mollie

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -1,6 +1,6 @@
 import { LanguageService, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { number } from 'card-validator';
-import { compact, startCase } from 'lodash';
+import { compact } from 'lodash';
 import React, { memo, Fragment, FunctionComponent } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
@@ -149,7 +149,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.Mollie]: {
                 logoUrl: method.method === 'credit_card' ? '' : cdnPath(`/img/payment-providers/mollie_${method.method}.svg`),
-                titleText: method.method === 'credit_card' ? startCase(methodName) : methodName,
+                titleText: methodName,
             },
             [PaymentMethodId.Checkoutcom]: {
                 logoUrl: ['credit_card', 'card', 'checkoutcom'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/checkoutcom_${method.id.toLowerCase()}.svg`),


### PR DESCRIPTION
## What?
Remove startCase method of Lodash to avoid the formatting of payment method names.

## Why?
According with the last call with Mollie's team, we shouldn't modify the payment method name in any way, we need to trust the mollie api source.

## Testing / Proof
<img width="439" alt="image" src="https://user-images.githubusercontent.com/35146660/168680560-8d485772-71a9-49f1-b3bf-b0c53305856e.png">

@bigcommerce/checkout @bigcommerce/apex-integrations 
