### PR TITLE
CHECKOUT-6265: Add build script to generate export file that can automatically surface new payment integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 coverage
 tests/_report/
 tests/_screenshots/
+src/app/generated/
+__temp__

--- a/auto-export.config.json
+++ b/auto-export.config.json
@@ -1,0 +1,9 @@
+{
+    "entries": [
+        {
+            "inputPath": "src/app/paymentIntegration/**/index.ts",
+            "outputPath": "src/app/generated/paymentIntegrations/index.ts",
+            "memberPattern": ".+PaymentMethod$"
+        }
+    ]
+}

--- a/bin/auto-export.js
+++ b/bin/auto-export.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const yargs = require('yargs');
+const autoExport = require('../scripts/webpack/auto-export');
+
+(async function() {
+    const argv = yargs
+        .option('config', {
+            describe: 'The config file specifying which files to re-export and to where',
+            default: '../auto-export.config.json'
+        })
+        .argv;
+
+    try {
+        const config = require(argv.config);
+
+        await Promise.all(
+            config.entries.map(async entry => {
+                await autoExport(entry);
+                console.log(`Modules are exported at '${entry.outputPath}'`);
+            })
+        );
+
+        process.exit(0);
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,6 +2147,21 @@
             "@istanbuljs/schema": "^0.1.2",
             "glob": "^7.1.4",
             "minimatch": "^3.0.4"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+              "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
           }
         },
         "to-regex-range": {
@@ -2597,6 +2612,20 @@
         "string-length": "^2.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "slash": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -3468,6 +3497,22 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+              "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
           }
         },
         "slash": {
@@ -6032,6 +6077,20 @@
         "unique-filename": "^1.1.1"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
@@ -11740,16 +11799,37 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.1.tgz",
+      "integrity": "sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^5.0.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -11834,6 +11914,20 @@
         "slash": "^1.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -11857,6 +11951,22 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "gonzales-pe": {
@@ -13472,6 +13582,22 @@
         "micromatch": "^3.1.10",
         "pretty-format": "^24.8.0",
         "realpath-native": "^1.1.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -13763,6 +13889,20 @@
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
           "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "require-main-filename": {
           "version": "1.0.1",
@@ -15160,6 +15300,20 @@
         "which": "1"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -15302,6 +15456,20 @@
           "requires": {
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
+          }
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lru-cache": {
@@ -17370,6 +17538,22 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -17486,6 +17670,20 @@
         "yargs": "^13.3.2"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "yargs": {
           "version": "13.3.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
@@ -17802,6 +18000,22 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "shellwords": {
@@ -19156,6 +19370,20 @@
             "slash": "^2.0.0"
           },
           "dependencies": {
+            "glob": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+              "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
             "ignore": {
               "version": "4.0.6",
               "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -19749,6 +19977,20 @@
         "require-main-filename": "^2.0.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -20034,6 +20276,22 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ts-jest": {
@@ -20175,6 +20433,20 @@
         "tsutils": "^2.29.0"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -20884,6 +21156,22 @@
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+              "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
           }
         },
         "enhanced-resolve": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:alpha": "npm run lint && npm run test -- --coverage && npm run build -- --prerelease && npm run release:version",
     "release:version": "git add dist && standard-version -a",
+    "auto-export": "bin/auto-export.js",
+    "prelint": "npm run auto-export",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "pretest": "bin/auto-export.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },
@@ -107,6 +110,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^1.7.0",
     "file-loader": "^4.1.0",
+    "glob": "^8.0.1",
     "http-server": "^0.11.1",
     "image-webpack-loader": "^5.0.0",
     "jest": "^24.8.0",

--- a/scripts/webpack/__fixtures__/auto-export/componentA/ComponentA.tsx
+++ b/scripts/webpack/__fixtures__/auto-export/componentA/ComponentA.tsx
@@ -1,0 +1,5 @@
+import React, { FunctionComponent } from 'react';
+
+const ComponentA: FunctionComponent<{ title: string }> = ({ title }) => <div>{ title }</div>;
+
+export default ComponentA;

--- a/scripts/webpack/__fixtures__/auto-export/componentA/index.ts
+++ b/scripts/webpack/__fixtures__/auto-export/componentA/index.ts
@@ -1,0 +1,1 @@
+export { default as ComponentA } from './ComponentA';

--- a/scripts/webpack/__fixtures__/auto-export/componentB/ComponentB.tsx
+++ b/scripts/webpack/__fixtures__/auto-export/componentB/ComponentB.tsx
@@ -1,0 +1,5 @@
+import React, { FunctionComponent } from 'react';
+
+const ComponentB: FunctionComponent<{ title: string }> = ({ title }) => <div>{ title }</div>;
+
+export default ComponentB;

--- a/scripts/webpack/__fixtures__/auto-export/componentB/index.ts
+++ b/scripts/webpack/__fixtures__/auto-export/componentB/index.ts
@@ -1,0 +1,1 @@
+export { default as ComponentB } from './ComponentB';

--- a/scripts/webpack/__fixtures__/auto-export/functionA/functionA.ts
+++ b/scripts/webpack/__fixtures__/auto-export/functionA/functionA.ts
@@ -1,0 +1,3 @@
+export default function functionA() {
+    return true;
+}

--- a/scripts/webpack/__fixtures__/auto-export/functionA/index.ts
+++ b/scripts/webpack/__fixtures__/auto-export/functionA/index.ts
@@ -1,0 +1,1 @@
+export { default as functionA } from './functionA';

--- a/scripts/webpack/auto-export.js
+++ b/scripts/webpack/auto-export.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const ts = require('typescript');
+const { promisify } = require('util');
+const glob = promisify(require('glob'));
+const path = require('path');
+
+async function autoExport({ inputPath, outputPath, memberPattern }) {
+    const filePaths = await glob(inputPath);
+    const exportDeclarations = await Promise.all(
+        filePaths.map(filePath => createExportDeclaration(filePath, outputPath, memberPattern))
+    );
+    const content = ts.createPrinter()
+        .printList(
+            ts.ListFormat.MultiLine, 
+            exportDeclarations.filter(Boolean), 
+            outputPath
+        );
+
+    await writeFile(outputPath, content);
+}
+
+async function createExportDeclaration(filePath, outputPath, memberPattern) {
+    const readFile = promisify(fs.readFile);
+    const source = await readFile(filePath, { encoding: 'utf8' });
+    const root = ts.createSourceFile(
+        path.parse(filePath).name,
+        source,
+        ts.ScriptTarget.Latest
+    );
+
+    const memberNames = root.statements
+        .filter(statement =>
+            statement.kind === ts.SyntaxKind.ExportDeclaration &&
+            statement.exportClause.kind === ts.SyntaxKind.NamedExports
+        )
+        .flatMap(statement =>
+            statement.exportClause.elements.filter(element => element.kind === ts.SyntaxKind.ExportSpecifier)
+        )
+        .filter(element => element.name.escapedText.match(new RegExp(memberPattern)))
+        .map(element => element.name.escapedText);
+
+    if (memberNames.length === 0) {
+        return;
+    }
+
+    return ts.createExportDeclaration(
+        undefined,
+        undefined,
+        ts.createNamedExports(
+            memberNames.map(memberName =>
+                ts.createExportSpecifier(
+                    undefined,
+                    ts.createIdentifier(memberName)
+                )
+            )),
+        createStringLiteral(getImportPath(filePath, outputPath)),
+        false
+    );
+}
+
+function createStringLiteral(value) {
+    const stringLiteral = ts.createStringLiteral(value);
+
+    // Newer version of TS allows you to specify the use of single quote directly
+    // e.g.: ts.createStringLiteral(value, true)
+    stringLiteral.singleQuote = true;
+
+    return stringLiteral;
+}
+
+function getImportPath(filePath, outputPath) {
+    const fileName = path.parse(filePath).name;
+    const outputFolder = path.parse(outputPath).dir;
+    const importFolder = path.parse(path.relative(outputFolder, filePath)).dir;
+
+    return fileName === 'index' ?
+        importFolder :
+        path.join(importFolder, fileName);
+}
+
+async function writeFile(outputPath, content) {
+    const mkdir = promisify(fs.mkdir);
+    const writeFile = promisify(fs.writeFile);
+
+    try {
+        await mkdir(path.parse(outputPath).dir, { recursive: true });
+    } catch (error) {
+        if (error && error.code !== 'EEXIST') {
+            throw error;
+        }
+    }
+
+    await writeFile(outputPath, content, { encoding: 'utf-8' });
+}
+
+module.exports = autoExport;

--- a/scripts/webpack/auto-export.spec.ts
+++ b/scripts/webpack/auto-export.spec.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import { EOL } from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+import autoExport from './auto-export';
+
+describe('autoExport()', () => {
+    it('export matching members from files to another file', async () => {
+        const options = {
+            inputPath: path.join(__dirname, '/__fixtures__/**/index.ts'),
+            outputPath: path.join(__dirname, '/__temp__/output.ts'),
+            memberPattern: '^Component',
+        };
+
+        await autoExport(options);
+        const output = await promisify(fs.readFile)(options.outputPath, { encoding: 'utf8' });
+
+        expect(output)
+            .toEqual(
+                "export { ComponentA } from '../__fixtures__/auto-export/componentA';" + EOL +
+                "export { ComponentB } from '../__fixtures__/auto-export/componentB';" + EOL
+            );
+
+        await promisify(fs.unlink)(options.outputPath);
+    });
+
+    it('handles scenario where no matching member is found', async () => {
+        const options = {
+            inputPath: path.join(__dirname, '/__fixtures__/**/index.ts'),
+            outputPath: path.join(__dirname, '/__temp__/output.ts'),
+            memberPattern: '^Test',
+        };
+
+        await autoExport(options);
+        const output = await promisify(fs.readFile)(options.outputPath, { encoding: 'utf8' });
+
+        expect(output)
+            .toEqual('');
+
+        await promisify(fs.unlink)(options.outputPath);
+    });
+});

--- a/scripts/webpack/build-hook-plugin.js
+++ b/scripts/webpack/build-hook-plugin.js
@@ -2,10 +2,11 @@ const { noop } = require('lodash');
 const { exec } = require('child_process');
 
 class BuildHookPlugin {
-    constructor({ onDone = noop, onSuccess = noop, onError = noop } = {}) {
+    constructor({ onDone = noop, onSuccess = noop, onError = noop, onBeforeCompile } = {}) {
         this.onDone = onDone;
         this.onError = onError;
         this.onSuccess = onSuccess;
+        this.onBeforeCompile = onBeforeCompile;
     }
 
     apply(compiler) {
@@ -22,6 +23,10 @@ class BuildHookPlugin {
 
             this.onDone();
         });
+
+        if (this.onBeforeCompile) {
+            compiler.hooks.beforeCompile.tapPromise('BuildHooks', this.onBeforeCompile);
+        }
     }
 
     process(command) {

--- a/scripts/webpack/index.js
+++ b/scripts/webpack/index.js
@@ -1,6 +1,7 @@
 module.exports = {
     AsyncHookPlugin: require('./async-hook-plugin'),
     BuildHookPlugin: require('./build-hook-plugin'),
+    autoExport: require('./auto-export'),
     getNextVersion: require('./get-next-version'),
     transformManifest: require('./transform-manifest'),
 };

--- a/src/app/checkout/index.ts
+++ b/src/app/checkout/index.ts
@@ -1,7 +1,7 @@
 export { RenderCheckout, RenderCheckoutOptions } from './renderCheckout';
 export { default as CheckoutContext, CheckoutContextProps } from './CheckoutContext';
 export { default as CheckoutProvider, CheckoutProviderProps, CheckoutProviderState } from './CheckoutProvider';
-export { default as withCheckout } from './withCheckout';
+export { default as withCheckout, WithCheckoutProps } from './withCheckout';
 export { default as CheckoutSupport } from './CheckoutSupport';
 export { default as NoopCheckoutSupport } from './NoopCheckoutSupport';
 export { default as navigateToOrderConfirmation } from './navigateToOrderConfirmation';

--- a/src/app/checkout/withCheckout.tsx
+++ b/src/app/checkout/withCheckout.tsx
@@ -1,6 +1,8 @@
 import { createMappableInjectHoc } from '../common/hoc';
 
-import CheckoutContext from './CheckoutContext';
+import CheckoutContext, { CheckoutContextProps } from './CheckoutContext';
+
+export type WithCheckoutProps = CheckoutContextProps;
 
 const withCheckout = createMappableInjectHoc(CheckoutContext, { displayNamePrefix: 'WithCheckout' });
 

--- a/src/app/common/form/ConnectFormikProps.ts
+++ b/src/app/common/form/ConnectFormikProps.ts
@@ -3,3 +3,5 @@ import { FormikContext } from 'formik';
 export default interface ConnectFormikProps<TValues> {
     formik: FormikContext<TValues>;
 }
+
+export type WithFormikProps<TValues> = ConnectFormikProps<TValues>;

--- a/src/app/common/form/index.ts
+++ b/src/app/common/form/index.ts
@@ -1,2 +1,2 @@
 export { default as connectFormik } from './connectFormik';
-export { default as ConnectFormikProps } from './ConnectFormikProps';
+export { default as ConnectFormikProps, WithFormikProps } from './ConnectFormikProps';

--- a/src/app/common/types/RequireAtLeastOne.ts
+++ b/src/app/common/types/RequireAtLeastOne.ts
@@ -1,0 +1,7 @@
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
+    Pick<T, Exclude<keyof T, Keys>>
+    & {
+        [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+    }[Keys];
+
+export default RequireAtLeastOne;

--- a/src/app/common/types/index.ts
+++ b/src/app/common/types/index.ts
@@ -1,0 +1,1 @@
+export { default as RequireAtLeastOne } from './RequireAtLeastOne';

--- a/src/app/core/paymentIntegration/PaymentMethodProps.tsx
+++ b/src/app/core/paymentIntegration/PaymentMethodProps.tsx
@@ -1,0 +1,12 @@
+import { CheckoutSelectors, CheckoutService, LanguageService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { PaymentFormService } from '../../payment';
+
+export default interface PaymentMethodProps {
+    method: PaymentMethod;
+    checkoutService: CheckoutService;
+    checkoutState: CheckoutSelectors;
+    paymentForm: PaymentFormService;
+    language: LanguageService;
+    onUnhandledError(error: Error): void;
+}

--- a/src/app/core/paymentIntegration/ResolvableComponent.ts
+++ b/src/app/core/paymentIntegration/ResolvableComponent.ts
@@ -1,0 +1,7 @@
+import { ComponentType } from 'react';
+
+type ResolvableComponent<TProps, TIdentifier> = ComponentType<TProps> & {
+    resolveIds: TIdentifier[];
+};
+
+export default ResolvableComponent;

--- a/src/app/core/paymentIntegration/index.ts
+++ b/src/app/core/paymentIntegration/index.ts
@@ -1,0 +1,4 @@
+export { default as PaymentMethodProps } from './PaymentMethodProps';
+export { default as ResolvableComponent } from './ResolvableComponent';
+export { default as toResolvableComponent } from './toResolvableComponent';
+export { default as resolvePaymentMethod, PaymentMethodResolveId } from './resolvePaymentMethod';

--- a/src/app/core/paymentIntegration/isResolvableComponent.ts
+++ b/src/app/core/paymentIntegration/isResolvableComponent.ts
@@ -1,0 +1,9 @@
+import { ComponentType } from 'react';
+
+import ResolvableComponent from './ResolvableComponent';
+
+export default function isResolvableComponent<TProps, TIdentifier>(
+    Component: ComponentType<TProps>
+): Component is ResolvableComponent<TProps, TIdentifier> {
+    return 'resolveIds' in Component;
+}

--- a/src/app/core/paymentIntegration/resolvePaymentMethod.spec.tsx
+++ b/src/app/core/paymentIntegration/resolvePaymentMethod.spec.tsx
@@ -1,0 +1,70 @@
+import { render } from 'enzyme';
+import React from 'react';
+
+import { getPaymentMethod } from '../../payment/payment-methods.mock';
+
+import resolvePaymentMethod from './resolvePaymentMethod';
+import PaymentMethodProps from './PaymentMethodProps';
+
+jest.mock('../../generated/paymentIntegrations', () => {
+    const { default: toResolvableComponent } = jest.requireActual('./toResolvableComponent');
+
+    const Foo = toResolvableComponent(
+        () => <div>Foo</div>,
+        [{ id: 'foo', gateway: null, type: 'api' }]
+    );
+
+    const Bar = toResolvableComponent(
+        () => <div>Bar</div>,
+        [{ id: 'bar', gateway: null, type: 'hosted' }]
+    );
+
+    const Foobar = toResolvableComponent(
+        () => <div>Foobar</div>,
+        [{ id: 'foo', gateway: 'bar', type: 'hosted' }]
+    );
+
+    return { Foo, Bar, Foobar };
+});
+
+describe('resolvePaymentMethod()', () => {
+    let props: PaymentMethodProps;
+
+    beforeEach(() => {
+        props = {
+            method: getPaymentMethod(),
+        } as PaymentMethodProps;
+    });
+
+    it('returns component if able to resolve to one by id', () => {
+        const Foo = resolvePaymentMethod({ id: 'foo' });
+
+        expect(Foo)
+            .toBeDefined();
+        expect(render(<Foo { ...props } />).text())
+            .toEqual('Foo');
+    });
+
+    it('returns component if able to resolve to one by type', () => {
+        const Bar = resolvePaymentMethod({ type: 'hosted' });
+
+        expect(Bar)
+            .toBeDefined();
+        expect(render(<Bar { ...props } />).text())
+            .toEqual('Bar');
+    });
+
+    it('returns component if able to resolve to one by id and gateway', () => {
+        const Foobar = resolvePaymentMethod({ id: 'foo', gateway: 'bar' });
+
+        expect(Foobar)
+            .toBeDefined();
+        expect(render(<Foobar { ...props } />).text())
+            .toEqual('Foobar');
+    });
+
+    it('throws error if unable to resolve to one', () => {
+        expect(() => resolvePaymentMethod({ type: 'hello' }))
+            .toThrowError();
+    });
+});

--- a/src/app/core/paymentIntegration/resolvePaymentMethod.ts
+++ b/src/app/core/paymentIntegration/resolvePaymentMethod.ts
@@ -1,0 +1,50 @@
+import { ComponentType } from 'react';
+
+import { RequireAtLeastOne } from '../../common/types';
+import * as paymentMethods from '../../generated/paymentIntegrations';
+
+import isResolvableComponent from './isResolvableComponent';
+import PaymentMethodProps from './PaymentMethodProps';
+
+export type PaymentMethodResolveId = RequireAtLeastOne<{
+    id?: string;
+    gateway?: string;
+    type?: string;
+}>;
+
+export default function resolvePaymentMethod(
+    query: PaymentMethodResolveId
+): ComponentType<PaymentMethodProps> {
+    const results: Array<{ component: ComponentType<PaymentMethodProps>; matches: number }> = [];
+
+    for (const [_, PaymentMethod] of Object.entries(paymentMethods)) {
+        if (!isResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(PaymentMethod)) {
+            continue;
+        }
+
+        for (const resolverId of PaymentMethod.resolveIds) {
+            const result = { component: PaymentMethod, matches: 0 };
+
+            for (const [key, value] of Object.entries(resolverId)) {
+                if (isKeyOfPaymentMethodResolveId(key) && query[key] === value) {
+                    result.matches++;
+                }
+            }
+
+            results.push(result);
+        }
+    }
+
+    const matched = results.sort((a, b) => b.matches - a.matches)
+        .filter(result => result.matches > 0)[0];
+
+    if (matched?.component) {
+        return matched.component;
+    }
+
+    throw new Error('Unable to resolve to a component with the provided id.');
+}
+
+function isKeyOfPaymentMethodResolveId(key: string): key is keyof PaymentMethodResolveId {
+    return ['id', 'gateway', 'type'].includes(key);
+}

--- a/src/app/core/paymentIntegration/toResolvableComponent.tsx
+++ b/src/app/core/paymentIntegration/toResolvableComponent.tsx
@@ -1,0 +1,13 @@
+import React, { ComponentType } from 'react';
+
+import ResolvableComponent from './ResolvableComponent';
+
+export default function toResolvableComponent<TProps, TIdentifier>(
+    Component: ComponentType<TProps>,
+    resolveIds: TIdentifier[]
+): ResolvableComponent<TProps, TIdentifier> {
+    return Object.assign(
+        (props: TProps) => <Component { ...props } />,
+        { resolveIds }
+    );
+}

--- a/src/app/payment/PaymentFormService.ts
+++ b/src/app/payment/PaymentFormService.ts
@@ -1,0 +1,17 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { ObjectSchema } from 'yup';
+
+import { PaymentFormValues } from './PaymentForm';
+
+export default interface PaymentFormService {
+    disableSubmit(method: PaymentMethod, disabled?: boolean): void;
+    hidePaymentSubmitButton(method: PaymentMethod, hidden?: boolean): void;
+    isSubmitted(): boolean;
+    setFieldTouched<TField extends keyof PaymentFormValues>(field: TField, touched?: boolean): void;
+    setFieldValue<TField extends keyof PaymentFormValues>(field: TField, value: PaymentFormValues[TField]): void;
+    setSubmit(method: PaymentMethod, fn: ((values: PaymentFormValues) => void) | null): void;
+    setSubmitted(isSubmitted: boolean): void;
+    setValidationSchema(method: PaymentMethod, schema: ObjectSchema<Partial<PaymentFormValues>> | null): void;
+    submitForm(): void;
+    validateForm(): void;
+}

--- a/src/app/payment/createPaymentFormService.ts
+++ b/src/app/payment/createPaymentFormService.ts
@@ -1,0 +1,45 @@
+import { FormikContext } from 'formik';
+
+import { FormContextType } from '../ui/form';
+
+import { PaymentContextProps } from './PaymentContext';
+import { PaymentFormValues } from './PaymentForm';
+import PaymentFormService from './PaymentFormService';
+
+export default function createPaymentFormService(
+    formikContext: FormikContext<PaymentFormValues>,
+    formContext: FormContextType,
+    paymentContext: PaymentContextProps
+): PaymentFormService {
+    const {
+        setFieldTouched,
+        setFieldValue,
+        submitForm,
+        validateForm,
+    } = formikContext;
+
+    const {
+        isSubmitted,
+        setSubmitted,
+    } = formContext;
+
+    const {
+        disableSubmit,
+        setSubmit,
+        setValidationSchema,
+        hidePaymentSubmitButton,
+    } = paymentContext;
+
+    return {
+        disableSubmit,
+        hidePaymentSubmitButton,
+        isSubmitted: () => isSubmitted,
+        setFieldTouched,
+        setFieldValue,
+        setSubmit,
+        setSubmitted,
+        setValidationSchema,
+        submitForm,
+        validateForm,
+    };
+}

--- a/src/app/payment/index.ts
+++ b/src/app/payment/index.ts
@@ -1,2 +1,3 @@
 export { PaymentProps } from './Payment';
+export { default as PaymentFormService } from './PaymentFormService';
 export { default as getPreselectedPayment } from './getPreselectedPayment';

--- a/src/app/payment/paymentMethod/PaymentMethodV2.spec.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodV2.spec.tsx
@@ -1,0 +1,85 @@
+import { createCheckoutService, CheckoutService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import { Formik } from 'formik';
+import React, { FunctionComponent, ReactNode } from 'react';
+
+import { CheckoutProvider } from '../../checkout';
+import { PaymentMethodProps } from '../../core/paymentIntegration';
+import { LocaleProvider } from '../../locale';
+import { FormProvider } from '../../ui/form';
+import { getPaymentMethod } from '../payment-methods.mock';
+import PaymentContext, { PaymentContextProps } from '../PaymentContext';
+
+import { default as PaymentMethodComponent } from './PaymentMethodV2';
+
+describe('PaymentMethod', () => {
+    let checkoutService: CheckoutService;
+    let paymentContext: PaymentContextProps;
+    let ContextProvider: FunctionComponent<{ children: ReactNode }>;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        paymentContext = {
+            disableSubmit: jest.fn(),
+            setSubmit: jest.fn(),
+            setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
+        };
+
+        ContextProvider = ({ children }) => (
+            <CheckoutProvider checkoutService={ checkoutService }>
+                <LocaleProvider checkoutService={ checkoutService }>
+                    <PaymentContext.Provider value={ paymentContext }>
+                        <FormProvider>
+                            <Formik
+                                initialValues={ {} }
+                                onSubmit={ jest.fn() }
+                            >
+                                { children }
+                            </Formik>
+                        </FormProvider>
+                    </PaymentContext.Provider>
+                </LocaleProvider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('renders component by payment method', () => {
+        const Foo: FunctionComponent<PaymentMethodProps> = ({ method }) => <div>{ method.id }</div>;
+        const Bar: FunctionComponent<PaymentMethodProps> = ({ method }) => <div>{ method.id }</div>;
+
+        const resolver = (method: PaymentMethod) => {
+            return method.id === 'foo' ? Foo : Bar;
+        };
+
+        const componentA = mount(
+            <ContextProvider>
+                <PaymentMethodComponent
+                    method={ {
+                        ...getPaymentMethod(),
+                        id: 'foo',
+                    } }
+                    onUnhandledError={ jest.fn() }
+                    resolveComponent={ resolver }
+                />
+            </ContextProvider>
+        );
+        const componentB = mount(
+            <ContextProvider>
+                <PaymentMethodComponent
+                    method={ {
+                        ...getPaymentMethod(),
+                        id: 'bar',
+                    } }
+                    onUnhandledError={ jest.fn() }
+                    resolveComponent={ resolver }
+                />
+            </ContextProvider>
+        );
+
+        expect(componentA.find(Foo))
+            .toBeDefined();
+        expect(componentB.find(Bar))
+            .toBeDefined();
+    });
+});

--- a/src/app/payment/paymentMethod/PaymentMethodV2.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodV2.tsx
@@ -1,0 +1,81 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk';
+import React, { ComponentType } from 'react';
+
+import { withCheckout, WithCheckoutProps } from '../../checkout';
+import { connectFormik, WithFormikProps } from '../../common/form';
+import { resolvePaymentMethod, PaymentMethodProps as ResolvedPaymentMethodProps, PaymentMethodResolveId } from '../../core/paymentIntegration';
+import { withLanguage, WithLanguageProps } from '../../locale';
+import { withForm, WithFormProps } from '../../ui/form';
+import createPaymentFormService from '../createPaymentFormService';
+import withPayment, { WithPaymentProps } from '../withPayment';
+import { PaymentFormValues } from '../PaymentForm';
+
+export interface PaymentMethodProps {
+    method: PaymentMethod;
+    resolveComponent?(query: PaymentMethodResolveId): ComponentType<ResolvedPaymentMethodProps>;
+    onUnhandledError(error: Error): void;
+}
+
+const PaymentMethodContainer: ComponentType<
+    PaymentMethodProps &
+    WithCheckoutProps &
+    WithLanguageProps &
+    WithPaymentProps &
+    WithFormProps &
+    WithFormikProps<PaymentFormValues>
+> = ({
+    formik: formikContext,
+    checkoutService,
+    checkoutState,
+    disableSubmit,
+    hidePaymentSubmitButton,
+    isSubmitted,
+    language,
+    method,
+    onUnhandledError,
+    resolveComponent = resolvePaymentMethod,
+    setSubmit,
+    setSubmitted,
+    setValidationSchema,
+}) => {
+    const formContext = {
+        isSubmitted,
+        setSubmitted,
+    };
+
+    const paymentContext = {
+        disableSubmit,
+        hidePaymentSubmitButton,
+        setSubmit,
+        setValidationSchema,
+    };
+
+    const ResolvedPaymentMethod = resolveComponent({
+        id: method.id,
+        gateway: method.gateway,
+        type: method.type,
+    });
+
+    return <ResolvedPaymentMethod
+        checkoutService={ checkoutService }
+        checkoutState={ checkoutState }
+        language={ language }
+        method={ method }
+        onUnhandledError={ onUnhandledError }
+        paymentForm={ createPaymentFormService(
+            formikContext,
+            formContext,
+            paymentContext
+        ) }
+    />;
+};
+
+export default withCheckout(props => props)(
+    withLanguage(
+        withPayment(
+            withForm(
+                connectFormik(PaymentMethodContainer)
+            )
+        )
+    )
+) as ComponentType<PaymentMethodProps>;

--- a/src/app/paymentIntegration/anotherSample/AnotherSamplePaymentMethod.tsx
+++ b/src/app/paymentIntegration/anotherSample/AnotherSamplePaymentMethod.tsx
@@ -1,0 +1,10 @@
+import React, { FunctionComponent } from 'react';
+
+import { toResolvableComponent, PaymentMethodProps } from '../../core/paymentIntegration';
+
+const AnotherSamplePaymentMethod: FunctionComponent<PaymentMethodProps> = () => <></>;
+
+export default toResolvableComponent(
+    AnotherSamplePaymentMethod,
+    [{ type: 'anotherSample' }]
+);

--- a/src/app/paymentIntegration/anotherSample/index.ts
+++ b/src/app/paymentIntegration/anotherSample/index.ts
@@ -1,0 +1,1 @@
+export { default as AnotherSamplePaymentMethod } from './AnotherSamplePaymentMethod';

--- a/src/app/paymentIntegration/sample/SamplePaymentMethod.tsx
+++ b/src/app/paymentIntegration/sample/SamplePaymentMethod.tsx
@@ -1,0 +1,10 @@
+import React, { FunctionComponent } from 'react';
+
+import { toResolvableComponent, PaymentMethodProps } from '../../core/paymentIntegration';
+
+const SamplePaymentMethod: FunctionComponent<PaymentMethodProps> = () => <></>;
+
+export default toResolvableComponent(
+    SamplePaymentMethod,
+    [{ id: 'sample' }]
+);

--- a/src/app/paymentIntegration/sample/index.ts
+++ b/src/app/paymentIntegration/sample/index.ts
@@ -1,0 +1,1 @@
+export { default as SamplePaymentMethod } from './SamplePaymentMethod';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,8 @@ const TerserPlugin = require('terser-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
-const { AsyncHookPlugin, BuildHookPlugin, getNextVersion, transformManifest } = require('./scripts/webpack');
+const { AsyncHookPlugin, BuildHookPlugin, autoExport, getNextVersion, transformManifest } = require('./scripts/webpack');
+const autoExportConfig = require('./auto-export.config.json');
 
 const ENTRY_NAME = 'checkout';
 const LIBRARY_NAME = 'checkout';
@@ -127,6 +128,9 @@ function appConfig(options, argv) {
                         },
                         onError(errors) {
                             eventEmitter.emit('app:error', errors);
+                        },
+                        onBeforeCompile() {
+                            return Promise.all(autoExportConfig.entries.map(autoExport));
                         },
                     }),
                 ].filter(Boolean),


### PR DESCRIPTION
## What?
* Added a build task that automatically generates an index file, re-exporting members matching a particular pattern from index files in another location.
* Added a function that can resolve to a React component by `id`, `gateway` and/or `type` property of a payment method object. Components that are resolvable must be exported with an additional property named `resolveIds`, indicating what properties to match against.
* Implemented an interface where dependencies can be injected to payment method components from their parent when they are loaded and rendered.

## Why?
* This will allow checkout team to auto-load new payment method components written by payment integration teams. This means in the future once the repo is restructured as a monorepo, there's no need for the payment integration teams to make a change to the `core` repo in order to integrate a new payment method into checkout, as long as it conforms to the predefined interface.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team 
