### PR TITLE
docs(checkout): CHECKOUT-0000 Update requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Checkout JS is a browser-based application providing a seamless UI for BigCommer
 
 In order to build from the source code, you must have the following set up in your development environment.
 
-* Node >= v10.
-* NPM >= v3.
+* Node >= v14.
+* NPM >= v6.
 * Unix-based operating system.
 
 One of the simplest ways to install Node is using [NVM](https://github.com/nvm-sh/nvm#installation-and-update). You can follow their instructions to set up your environment if it is not already set up.


### PR DESCRIPTION
## What?
Update `Node` and `npm` requirements documentation.

## Why?
The current description is inaccurate and out of date, which may confuse developers.