### PR TITLE
feat(checkout): CHECKOUT-6652 provide accessibility label for Address…

### DIFF
--- a/src/app/address/AddressSelect.tsx
+++ b/src/app/address/AddressSelect.tsx
@@ -7,6 +7,7 @@ import { DropdownTrigger } from '../ui/dropdown';
 
 import isEqualAddress from './isEqualAddress';
 import './AddressSelect.scss';
+import AddressSelectButton from './AddressSelectButton';
 import StaticAddress from './StaticAddress';
 
 export interface AddressSelectProps {
@@ -25,7 +26,7 @@ class AddressSelect extends PureComponent<AddressSelectProps> {
 
         return (
             <div className="form-field">
-                <div className="dropdown--select" role="combobox">
+                <div className="dropdown--select">
                     <DropdownTrigger
                         dropdown={
                             <AddressSelectMenu
@@ -97,23 +98,6 @@ const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({
             </li>
         )) }
     </ul>
-);
-
-type AddressSelectButtonProps = Pick<AddressSelectProps, 'selectedAddress' | 'addresses'>;
-
-const AddressSelectButton: FunctionComponent<AddressSelectButtonProps> = ({
-    selectedAddress,
-}) => (
-    <a
-        className="button dropdown-button dropdown-toggle--select"
-        href="#"
-        id="addressToggle"
-        onClick={ preventDefault() }
-    >
-        { selectedAddress ?
-            <StaticAddress address={ selectedAddress } /> :
-            <TranslatedString id="address.enter_address_action" /> }
-    </a>
 );
 
 export default memo(AddressSelect);

--- a/src/app/address/AddressSelectButton.tsx
+++ b/src/app/address/AddressSelectButton.tsx
@@ -1,0 +1,28 @@
+import React, { FunctionComponent } from 'react';
+
+import { preventDefault } from '../common/dom';
+import { withLanguage, TranslatedString, WithLanguageProps } from '../locale';
+
+import { AddressSelectProps } from './AddressSelect';
+import StaticAddress from './StaticAddress';
+
+type AddressSelectButtonProps = Pick<AddressSelectProps, 'selectedAddress' | 'addresses'>;
+
+const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLanguageProps> = ({
+    selectedAddress,
+    language,
+}) => (
+    <a
+        aria-description={ language.translate('address.enter_or_select_address_action') }
+        className="button dropdown-button dropdown-toggle--select"
+        href="#"
+        id="addressToggle"
+        onClick={ preventDefault() }
+    >
+        { selectedAddress ?
+            <StaticAddress address={ selectedAddress } /> :
+            <TranslatedString id="address.enter_address_action" /> }
+    </a>
+);
+
+export default withLanguage(AddressSelectButton);

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -22,6 +22,7 @@
             "custom_valid_error": "{label} is not valid",
             "edit_address_action": "Edit address",
             "enter_address_action": "Enter a new address",
+            "enter_or_select_address_action": "Enter or select a different address",
             "add_address_heading": "Add Address",
             "save_address_action": "Save Address",
             "first_name_label": "First Name",


### PR DESCRIPTION
## What?

Add aria-labelledby attribute to class name "dropdown--select" and added an ID to the a tag link to which the aria-labelledby can be pointed. 

“Some elements get their accessible name from their inner content. For example, the accessible name for a <button>, <a>, or <td> comes from the text between the opening and closing tags.”

“… All interactive elements must have an accessible name. aria-labelledby can be used to reference another element to define its accessible name, when an element's accessible name needs to use content from elsewhere in the DOM.”

Based on this I’ve gone with using aria-labelledby within the element with class name "dropdown--select" directed at the <a> tag link containing the text “Enter a new address”  - 

[aria-labelledby - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)

...

## Why?

CHECKOUT-6652
https://bigcommercecloud.atlassian.net/browse/CHECKOUT-6652 
...

## Testing / Proof
BEFORE:
<img width="2326" alt="Screen Shot 2022-05-05 at 12 01 32 PM" src="https://user-images.githubusercontent.com/5630999/167783244-320cf1a2-8c97-44fa-8295-9fb1d5a21640.png">

AFTER:
<img width="1493" alt="Screen Shot 2022-05-11 at 1 09 21 AM" src="https://user-images.githubusercontent.com/5630999/167783280-68c60b4f-35c6-4613-8a8b-1ae08fc5ee8b.png">

<img width="661" alt="Screen Shot 2022-05-11 at 1 30 39 AM" src="https://user-images.githubusercontent.com/5630999/167783367-f6eb7f17-2721-4244-88bb-ce109680b3e8.png">

...

@bigcommerce/checkout
