### PR TITLE
feat(checkout): CHECKOUT-6643 add checkoutBillingSameAsShipping check for checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
-      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
-      "dev": true
+      "version": "7.17.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
+      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw=="
     },
     "@babel/core": {
       "version": "7.5.5",
@@ -124,48 +123,45 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
-      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
-      "dev": true,
+      "version": "7.17.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
+      "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
       "requires": {
-        "@babel/compat-data": "^7.17.7",
+        "@babel/compat-data": "^7.17.10",
         "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
+        "browserslist": "^4.20.2",
         "semver": "^6.3.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.20.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-          "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
-          "dev": true,
+          "version": "4.20.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+          "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
           "requires": {
-            "caniuse-lite": "^1.0.30001317",
-            "electron-to-chromium": "^1.4.84",
+            "caniuse-lite": "^1.0.30001332",
+            "electron-to-chromium": "^1.4.118",
             "escalade": "^3.1.1",
-            "node-releases": "^2.0.2",
+            "node-releases": "^2.0.3",
             "picocolors": "^1.0.0"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001332",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-          "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
-          "dev": true
+          "version": "1.0.30001341",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+          "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA=="
         }
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.17.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz",
-      "integrity": "sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz",
+      "integrity": "sha512-kUjip3gruz6AJKOq5i3nC6CoCEEF/oHH3cp6tOZhB+IyyyPyW0g1Gfsxn3mkk6S08pIA2y8GQh609v9G/5sHVQ==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.7",
         "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-member-expression-to-functions": "^7.16.7",
+        "@babel/helper-function-name": "^7.17.9",
+        "@babel/helper-member-expression-to-functions": "^7.17.7",
         "@babel/helper-optimise-call-expression": "^7.16.7",
         "@babel/helper-replace-supers": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7"
@@ -181,14 +177,14 @@
           }
         },
         "@babel/generator": {
-          "version": "7.17.7",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
+          "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.17.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
+            "@babel/types": "^7.17.10",
+            "@jridgewell/gen-mapping": "^0.1.0",
+            "jsesc": "^2.5.1"
           }
         },
         "@babel/helper-annotate-as-pure": {
@@ -201,23 +197,13 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-          "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+          "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.16.7",
             "@babel/template": "^7.16.7",
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-          "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.16.7"
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/helper-hoist-variables": {
@@ -270,9 +256,9 @@
           }
         },
         "@babel/highlight": {
-          "version": "7.16.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+          "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
@@ -281,9 +267,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.17.8",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
-          "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
+          "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
           "dev": true
         },
         "@babel/template": {
@@ -298,27 +284,27 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
+          "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.3",
+            "@babel/generator": "^7.17.10",
             "@babel/helper-environment-visitor": "^7.16.7",
-            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-function-name": "^7.17.9",
             "@babel/helper-hoist-variables": "^7.16.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
-            "@babel/parser": "^7.17.3",
-            "@babel/types": "^7.17.0",
+            "@babel/parser": "^7.17.10",
+            "@babel/types": "^7.17.10",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+          "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
@@ -368,9 +354,9 @@
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "version": "7.17.10",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+          "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
@@ -1558,17 +1544,6 @@
             "jsesc": "^2.5.1"
           }
         },
-        "@babel/helper-compilation-targets": {
-          "version": "7.17.10",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
-          "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
-          "requires": {
-            "@babel/compat-data": "^7.17.10",
-            "@babel/helper-validator-option": "^7.16.7",
-            "browserslist": "^4.20.2",
-            "semver": "^6.3.0"
-          }
-        },
         "@babel/helper-function-name": {
           "version": "7.17.9",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
@@ -2171,9 +2146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.244.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.244.0.tgz",
-      "integrity": "sha512-0qL9FK2C+QAQTwjiIXbEYpRlg7mMSI0CG24iVegtrpirZRe7hJ4XIwkSZdbaDLahzMShUdQV7vTStxPCxzfXIQ==",
+      "version": "1.244.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.244.1.tgz",
+      "integrity": "sha512-qbjGXymj97gBncOu/V5NUrBUsEQq8ZLdq98B9WW79Of1y/O9aDLhPSrJeRyaC/qCGCbO4NHB2ffhFCCij6WAIw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.17.0",
@@ -4028,7 +4003,7 @@
     "@types/reselect": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/reselect/-/reselect-2.2.0.tgz",
-      "integrity": "sha1-xmcgbP3DgZDh03m6vgiGWyKIV18=",
+      "integrity": "sha512-wRzxD+878qxC1h3ZMkEl/smBluwVeuVxhjhwM1/ZLQ6+hgl5gPQp2mZQSjRppwAyyR+Ul3JIaiObAd7mD4QT3w==",
       "requires": {
         "reselect": "*"
       }
@@ -9035,10 +9010,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.111",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
-      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw==",
-      "dev": true
+      "version": "1.4.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
+      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -15240,9 +15214,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
     },
     "node-sass": {
       "version": "4.14.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.244.0",
+    "@bigcommerce/checkout-sdk": "^1.244.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -167,11 +167,15 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
             const consignments = data.getConsignments();
             const cart = data.getCart();
+
             const hasMultiShippingEnabled = data.getConfig()?.checkoutSettings?.hasMultiShippingEnabled;
+            const checkoutBillingSameAsShippingEnabled = data.getConfig()?.checkoutSettings?.checkoutBillingSameAsShippingEnabled;
             const isMultiShippingMode = !!cart &&
                 !!consignments &&
                 hasMultiShippingEnabled &&
                 isUsingMultiShipping(consignments, cart.lineItems);
+
+            this.setState({ isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled || true });
 
             if (isMultiShippingMode) {
                 this.setState({ isMultiShippingMode }, this.handleReady);

--- a/src/app/config/config.mock.ts
+++ b/src/app/config/config.mock.ts
@@ -10,6 +10,7 @@ export function getStoreConfig(): StoreConfig {
             billingAddressFields: [],
         },
         checkoutSettings: {
+            checkoutBillingSameAsShippingEnabled: true,
             enableOrderComments: true,
             enableTermsAndConditions: false,
             googleRecaptchaSitekey: 'sitekey',


### PR DESCRIPTION
## What?
Allows store admin to enable/disable "Billing Address same as Shipping Address" check when a shopper is using checkout process. This can be checked within the admin panel of the store under the Checkout Settings.

## Why?
Store admin suggestion to BC as the customer would sometimes skip or ignore the check where it could be incorrect

## Testing / Proof

![Screen Shot 2022-05-13 at 9 54 48 am](https://user-images.githubusercontent.com/9646373/168513934-b01a25d1-0652-45fa-8e4
![Screen Shot 2022-05-13 at 9 54 53 am](https://user-images.githubusercontent.com/9646373/168513944-9001b62c-f2c3-49df-8c30-5d52cc39a583.png)
8-7316e97b9f82.png)

ping @bigcommerce/checkout
