### PR TITLE
chore(payment): PAYPAL-1465 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2152,9 +2152,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.245.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.245.0.tgz",
-      "integrity": "sha512-svmn8jFiZ6SPfkqq5RTrd+5Owrx7wH3gSt1cUdaJeYy4YTu1kx0QfI/AN9T8VgADHiGiCc3/IVRWXt+F9fC/Sw==",
+      "version": "1.246.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.246.0.tgz",
+      "integrity": "sha512-hIq/+XXOAC4GcrZjh97eaxhSEemBduZj4vWhuXiDrLLhcN9NcyUc16wjIOJOnXLQChuZoJEqxncRpgDCkLtG+Q==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.245.0",
+    "@bigcommerce/checkout-sdk": "^1.246.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To release the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1465

## Testing / Proof
Unit tests
