### PR TITLE
feat(payment): BOLT-238 Card method swap

### DIFF
--- a/src/app/payment/Payment.tsx
+++ b/src/app/payment/Payment.tsx
@@ -1,4 +1,4 @@
-import { CartChangedError, CheckoutSelectors, CheckoutSettings, OrderRequestBody, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { CartChangedError, CheckoutSelectors, CheckoutSettings, OrderRequestBody, PaymentMethod, PaymentMethodsWithConflicts } from '@bigcommerce/checkout-sdk';
 import { memoizeOne } from '@bigcommerce/memoize';
 import { compact, find, isEmpty, noop } from 'lodash';
 import React, { Component, ReactNode } from 'react';
@@ -46,6 +46,7 @@ interface WithCheckoutPaymentProps {
     termsConditionsText?: string;
     termsConditionsUrl?: string;
     usableStoreCredit: number;
+    paymentMethodsWithCreditCardConflicts?: PaymentMethodsWithConflicts[];
     applyStoreCredit(useStoreCredit: boolean): Promise<CheckoutSelectors>;
     clearError(error: Error): void;
     finalizeOrderIfNeeded(): Promise<CheckoutSelectors>;
@@ -134,6 +135,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             isInitializingPayment,
             isUsingMultiShipping,
             methods,
+            paymentMethodsWithCreditCardConflicts,
             applyStoreCredit,
             ...rest
         } = this.props;
@@ -169,6 +171,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
                         onMethodSelect={ this.setSelectedMethod }
                         onStoreCreditChange={ this.handleStoreCreditChange }
                         onSubmit={ this.handleSubmit }
+                        paymentMethodsWithCreditCardConflicts={ paymentMethodsWithCreditCardConflicts }
                         selectedMethod={ selectedMethod }
                         shouldDisableSubmit={ uniqueSelectedMethodId && shouldDisableSubmit[uniqueSelectedMethodId] || undefined }
                         shouldHidePaymentSubmitButton={ uniqueSelectedMethodId && shouldHidePaymentSubmitButton[uniqueSelectedMethodId] || undefined }
@@ -566,6 +569,7 @@ export function mapToPaymentProps({
             undefined,
         usableStoreCredit: checkout.grandTotal > 0 ?
             Math.min(checkout.grandTotal, customer.storeCredit || 0) : 0,
+        paymentMethodsWithCreditCardConflicts: config.checkoutSettings.paymentMethodsWithCreditCardConflicts,
     };
 }
 

--- a/src/app/payment/PaymentForm.tsx
+++ b/src/app/payment/PaymentForm.tsx
@@ -1,4 +1,4 @@
-import { PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { PaymentMethod, PaymentMethodsWithConflicts } from '@bigcommerce/checkout-sdk';
 import { withFormik, FormikProps, WithFormikConfig } from 'formik';
 import { isNil, noop, omitBy } from 'lodash';
 import React, { memo, useCallback, useContext, useMemo, FunctionComponent } from 'react';
@@ -39,6 +39,7 @@ export interface PaymentFormProps {
     termsConditionsUrl?: string;
     usableStoreCredit?: number;
     validationSchema?: ObjectSchema<Partial<PaymentFormValues>>;
+    paymentMethodsWithCreditCardConflicts?: PaymentMethodsWithConflicts[];
     isPaymentDataRequired(): boolean;
     onMethodSelect?(method: PaymentMethod): void;
     onStoreCreditChange?(useStoreCredit?: boolean): void;
@@ -83,6 +84,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
     isUsingMultiShipping,
     language,
     methods,
+    paymentMethodsWithCreditCardConflicts,
     onMethodSelect,
     onStoreCreditChange,
     onUnhandledError,
@@ -150,6 +152,7 @@ const PaymentForm: FunctionComponent<PaymentFormProps & FormikProps<PaymentFormV
                 methods={ methods }
                 onMethodSelect={ onMethodSelect }
                 onUnhandledError={ onUnhandledError }
+                paymentMethodsWithCreditCardConflicts={ paymentMethodsWithCreditCardConflicts }
                 resetForm={ resetForm }
                 values={ values }
             />
@@ -188,6 +191,7 @@ interface PaymentMethodListFieldsetProps {
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
     values: PaymentFormValues;
+    paymentMethodsWithCreditCardConflicts?: PaymentMethodsWithConflicts[];
     isPaymentDataRequired(): boolean;
     onMethodSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
@@ -202,6 +206,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     methods,
     onMethodSelect = noop,
     onUnhandledError,
+    paymentMethodsWithCreditCardConflicts,
     resetForm,
     values,
 }) => {
@@ -249,6 +254,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
                 methods={ methods }
                 onSelect={ handlePaymentMethodSelect }
                 onUnhandledError={ onUnhandledError }
+                paymentMethodsWithCreditCardConflicts={ paymentMethodsWithCreditCardConflicts }
             />
         </Fieldset>
     );


### PR DESCRIPTION
## What?
Conflict payment methods hiding on Checkout payment step.

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-235](https://bigcommercecloud.atlassian.net/browse/BOLT-235)
For cases when merchant setup multiple payment providers and this providers has similar payment methods, we should hide this conflicts methods. 
For example:
Merchant setup Braintree and Bolt (with Braintree as payment system)
So customers will see two Credit card fields in payment section. And both of them will be processed by Braintree.
For this cases we need to hide similar fields and show only one Credit card field.
And we should keep workable all other payment methods for this providers, like embedded forms and other.
Video example of solution:

https://user-images.githubusercontent.com/9430298/169863639-332380e1-c125-45de-9d87-c101240ee023.mov



## Testing / Proof
...

@bigcommerce/checkout
