### PR TITLE
fix(shipping): CHECKOUT-6643 Remove or check for billingSameAsShipping Flag

### DIFF
--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -169,13 +169,13 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
             const cart = data.getCart();
 
             const hasMultiShippingEnabled = data.getConfig()?.checkoutSettings?.hasMultiShippingEnabled;
-            const checkoutBillingSameAsShippingEnabled = data.getConfig()?.checkoutSettings?.checkoutBillingSameAsShippingEnabled;
+            const checkoutBillingSameAsShippingEnabled = data.getConfig()?.checkoutSettings?.checkoutBillingSameAsShippingEnabled ?? true;
             const isMultiShippingMode = !!cart &&
                 !!consignments &&
                 hasMultiShippingEnabled &&
                 isUsingMultiShipping(consignments, cart.lineItems);
 
-            this.setState({ isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled || true });
+            this.setState({ isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled });
 
             if (isMultiShippingMode) {
                 this.setState({ isMultiShippingMode }, this.handleReady);


### PR DESCRIPTION
## What?
Remove `||` check for billing same as shipping flag

## Why?
The `||` check disrespects the value of the store setting and always defaults to true.

## Testing / Proof
- Tests

@bigcommerce/checkout
