### PR TITLE
fix(checkout): ADYEN-480 bump checkout-sdk for the Adyen vaulting fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,7 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
       "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.17.10",
         "@babel/helper-validator-option": "^7.16.7",
@@ -137,6 +138,7 @@
           "version": "4.20.3",
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
           "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+          "dev": true,
           "requires": {
             "caniuse-lite": "^1.0.30001332",
             "electron-to-chromium": "^1.4.118",
@@ -148,7 +150,8 @@
         "caniuse-lite": {
           "version": "1.0.30001341",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
-          "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA=="
+          "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
+          "dev": true
         }
       }
     },
@@ -1530,13 +1533,24 @@
           }
         },
         "@babel/generator": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.0.tgz",
-          "integrity": "sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==",
+          "version": "7.18.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
+          "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
           "requires": {
-            "@babel/types": "^7.18.0",
+            "@babel/types": "^7.18.2",
             "@jridgewell/gen-mapping": "^0.3.0",
             "jsesc": "^2.5.1"
+          }
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.18.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
+          "integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
+          "requires": {
+            "@babel/compat-data": "^7.17.10",
+            "@babel/helper-validator-option": "^7.16.7",
+            "browserslist": "^4.20.2",
+            "semver": "^6.3.0"
           }
         },
         "@babel/helper-function-name": {
@@ -1580,11 +1594,11 @@
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.17.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-          "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+          "version": "7.18.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
+          "integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
           "requires": {
-            "@babel/types": "^7.17.0"
+            "@babel/types": "^7.18.2"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -1596,13 +1610,13 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.0.tgz",
-          "integrity": "sha512-AE+HMYhmlMIbho9nbvicHyxFwhrO+xhKB6AhRxzl8w46Yj0VXTZjEsAoBVC7rB2I0jzX+yWyVybnO08qkfx6kg==",
+          "version": "7.18.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
+          "integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
           "requires": {
             "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.18.0",
-            "@babel/types": "^7.18.0"
+            "@babel/traverse": "^7.18.2",
+            "@babel/types": "^7.18.2"
           }
         },
         "@babel/highlight": {
@@ -1677,26 +1691,33 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.0.tgz",
-          "integrity": "sha512-oNOO4vaoIQoGjDQ84LgtF/IAlxlyqL4TUuoQ7xLkQETFaHkY1F7yazhB4Kt3VcZGL0ZF/jhrEpnXqUb0M7V3sw==",
+          "version": "7.18.2",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
+          "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
           "requires": {
             "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.18.0",
-            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/generator": "^7.18.2",
+            "@babel/helper-environment-visitor": "^7.18.2",
             "@babel/helper-function-name": "^7.17.9",
             "@babel/helper-hoist-variables": "^7.16.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
             "@babel/parser": "^7.18.0",
-            "@babel/types": "^7.18.0",
+            "@babel/types": "^7.18.2",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
+          },
+          "dependencies": {
+            "@babel/helper-environment-visitor": {
+              "version": "7.18.2",
+              "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
+              "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ=="
+            }
           }
         },
         "@babel/types": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.0.tgz",
-          "integrity": "sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==",
+          "version": "7.18.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.2.tgz",
+          "integrity": "sha512-0On6B8A4/+mFUto5WERt3EEuG1NznDirvwca1O8UwXQHVY8g3R7OzYgxXdOfMwLO08UrpUD/2+3Bclyq+/C94Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
@@ -1851,6 +1872,23 @@
             "fill-range": "^7.0.1"
           }
         },
+        "browserslist": {
+          "version": "4.20.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+          "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001332",
+            "electron-to-chromium": "^1.4.118",
+            "escalade": "^3.1.1",
+            "node-releases": "^2.0.3",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001342",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
+          "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA=="
+        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1956,20 +1994,20 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.18.0",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.0.tgz",
-              "integrity": "sha512-Xyw74OlJwDijToNi0+6BBI5mLLR5+5R3bcSH80LXzjzEGEUlvNzujEE71BaD/ApEZHAvFI/Mlmp4M5lIkdeeWw==",
+              "version": "7.18.2",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
+              "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
               "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.18.0",
-                "@babel/helper-compilation-targets": "^7.17.10",
+                "@babel/generator": "^7.18.2",
+                "@babel/helper-compilation-targets": "^7.18.2",
                 "@babel/helper-module-transforms": "^7.18.0",
-                "@babel/helpers": "^7.18.0",
+                "@babel/helpers": "^7.18.2",
                 "@babel/parser": "^7.18.0",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.18.0",
-                "@babel/types": "^7.18.0",
+                "@babel/traverse": "^7.18.2",
+                "@babel/types": "^7.18.2",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -2152,9 +2190,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.246.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.246.4.tgz",
-      "integrity": "sha512-BZ1vKpvUT8kK5ch8zXMlKMtY4HfEgOt+8288+syhEwskNDIS9L6nrxBs/B8bcgZZ+A/ehD0/XqZx56+7MJ7rsQ==",
+      "version": "1.246.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.246.5.tgz",
+      "integrity": "sha512-8qZ5BvHwuj3dV/ekjJzsbvza6C1u8P/Og42z84/s/TTcxd8YAbjV9k1Ib8SCDE3Jz7RaJS5eKNkEy1eFd9oxeA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.246.4",
+    "@bigcommerce/checkout-sdk": "^1.246.5",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Update checkout-sdk version due to the deploy of https://github.com/bigcommerce/checkout-sdk-js/pull/1449

## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-480

## Testing / Proof
Tested Manually

@bigcommerce/checkout
