### PR TITLE
feat(checkout): CHECKOUT-6653 make cart drawer interactable via keyboard

### DIFF
--- a/src/app/order/OrderSummaryDrawer.spec.tsx
+++ b/src/app/order/OrderSummaryDrawer.spec.tsx
@@ -100,4 +100,28 @@ describe('OrderSummaryDrawer', () => {
                 });
         });
     });
+
+    describe('when active and enter is pressed', () => {
+        beforeEach(() => {
+            orderSummary.find('.cartDrawer').simulate('keypress', {key: 'Enter'});
+        });
+
+        it('renders order summary modal with the right props', () => {
+            expect(orderSummary.find(OrderSummaryModal).length)
+                .toEqual(1);
+
+            expect(orderSummary.find(OrderSummaryModal).find('#cart-print-link').length)
+                .toEqual(1);
+
+            expect(orderSummary.find(OrderSummaryModal).props())
+                .toMatchObject({
+                    ...mapToOrderSummarySubtotalsProps(getOrder()),
+                    lineItems: getOrder().lineItems,
+                    total: getOrder().orderAmount,
+                    storeCurrency: getStoreConfig().currency,
+                    shopperCurrency: getStoreConfig().shopperCurrency,
+                    additionalLineItems: 'foo',
+                });
+        });
+    });
 });

--- a/src/app/order/OrderSummaryDrawer.tsx
+++ b/src/app/order/OrderSummaryDrawer.tsx
@@ -82,9 +82,11 @@ const OrderSummaryDrawer: FunctionComponent<OrderSummaryDrawerProps & OrderSumma
     ]);
 
     return <ModalTrigger modal={ renderModal }>
-        { ({ onClick }) => <div
+        { ({ onClick, onKeyPress }) => <div
             className="cartDrawer optimizedCheckout-orderSummary"
             onClick={ onClick }
+            onKeyPress= { onKeyPress }
+            tabIndex= { 0 }
         >
             <figure
                 className={ classNames(

--- a/src/app/ui/modal/Modal.tsx
+++ b/src/app/ui/modal/Modal.tsx
@@ -56,6 +56,7 @@ const Modal: FunctionComponent<ModalProps> = ({
             afterOpen: 'modalOverlay--afterOpen',
             beforeClose: 'modalOverlay--beforeClose',
         } }
+        shouldCloseOnEsc={ true }
         shouldCloseOnOverlayClick={ false }
     >
         <div

--- a/src/app/ui/modal/ModalTrigger.spec.tsx
+++ b/src/app/ui/modal/ModalTrigger.spec.tsx
@@ -43,4 +43,21 @@ describe('ModalTrigger', () => {
         expect(component.find('#modal'))
             .toHaveLength(0);
     });
+
+    it('opens modal window when focused and enter is pressed', () => {
+        const component = mount(
+            <ModalTrigger modal={ Modal }>
+                { ({ onKeyPress }) => <button id="openButton" onKeyPress={ onKeyPress }>Open</button> }
+            </ModalTrigger>
+        );
+
+        expect(component.find('#modal'))
+            .toHaveLength(0);
+
+        component.find('#openButton')
+            .simulate('keypress', {key: 'Enter'});
+
+        expect(component.find('#modal'))
+            .toHaveLength(1);
+    });
 });

--- a/src/app/ui/modal/ModalTrigger.tsx
+++ b/src/app/ui/modal/ModalTrigger.tsx
@@ -1,7 +1,7 @@
-import React, { Component, Fragment, MouseEventHandler, ReactNode } from 'react';
+import React, { Component, Fragment, KeyboardEvent, KeyboardEventHandler, MouseEventHandler, ReactNode } from 'react';
 
 export interface ModalTriggerProps {
-    children(props: { onClick: MouseEventHandler }): ReactNode;
+    children(props: { onClick: MouseEventHandler; onKeyPress: KeyboardEventHandler}): ReactNode;
     modal(props: ModalTriggerModalProps): ReactNode;
 }
 
@@ -35,7 +35,10 @@ export default class ModalTrigger extends Component<ModalTriggerProps, ModalTrig
 
         return (
             <Fragment>
-                { children({ onClick: this.handleOpen }) }
+                { children({
+                    onClick: this.handleOpen,
+                    onKeyPress: this.handleKeyOpen,
+                }) }
 
                 { modal({
                     isOpen,
@@ -63,5 +66,11 @@ export default class ModalTrigger extends Component<ModalTriggerProps, ModalTrig
         this.setState({
             isOpen: false,
         });
+    };
+
+    private handleKeyOpen: (keyboardEvent: KeyboardEvent<HTMLElement>) => void = keyboardEvent => {
+        if (keyboardEvent.key === 'Enter') {
+            this.handleOpen();
+        }
     };
 }


### PR DESCRIPTION
## What?
...
When screen width is narrowed, it moves to the cart summary to the bottom of the page. For accessibility purposes, this should be accessible with the 'tab' key, and the modal should display when clicking the "enter" key.  

## Why?
...
For better accessibility for screen reader users
https://bigcommercecloud.atlassian.net/browse/CHECKOUT-6653

## Testing / Proof

Before:
(cannot tab to modal trigger)

https://user-images.githubusercontent.com/5630999/171290143-94c10a7e-e581-4543-8c73-fb906fc89442.mp4


After: 
(tab to modal trigger, press enter to open modal)

https://user-images.githubusercontent.com/5630999/171289101-00569788-6324-41e0-8da4-cd44ad311d6e.mp4




...
POC for now (5/25) , will need to update this to only use the enter key to bring up the modal. With these immediate changes it becomes accessible via the tab key, but it should only react to the 'enter' key and right now it opens with any key. 

(5/27) Updated so that only the Enter key will open the modal when tabbed to. The focus is trapped once the users tabs into the modal, but it still need to update this so that the modal traps the focus without requiring hitting tab the first time.

(5/31) It is not clear if autofocus on the modal is desirable from an accessibility perspective. Upon hitting tab once the modal is opened, the user will be able to tab around the modal. Trapping the tab into the modal without the possibility of shift-tab should probably be handled in a separate PR.  For now this PR will make the modal accessible via tab and the enter button on the keyboard. 

@bigcommerce/checkout
