### PR TITLE
made taxes field customizable and fixed language error in de.json

### DIFF
--- a/src/app/locale/translations/de.json
+++ b/src/app/locale/translations/de.json
@@ -71,7 +71,7 @@
             "gift_wrapping_text": "Geschenkverpackung",
             "show_details_action": "Details anzeigen",
             "store_credit_text": "Shop-Guthaben",
-            "subtotal_text": "Gesamtbetrag (netto)",
+            "subtotal_text": "Zwischensumme",
             "taxes_text": "Steuern",
             "total_text": "Summe",
             "empty_cart_message": "Ihr Warenkorb ist leer, Sie werden weitergeleitet. Bitte klicken Sie <a href=\"{url}\" target=\"_top\">hier</a>, wenn Ihr Browser Sie nicht weiterleitet."

--- a/src/app/order/__snapshots__/OrderSummarySubtotals.spec.tsx.snap
+++ b/src/app/order/__snapshots__/OrderSummarySubtotals.spec.tsx.snap
@@ -73,7 +73,11 @@ exports[`OrderSummarySubtotals renders component 1`] = `
   <OrderSummaryPrice
     amount={3}
     key="0"
-    label="Tax"
+    label={
+      <WithLanguage(TranslatedString)
+        id="cart.taxes_text"
+      />
+    }
     testId="cart-taxes"
   />
 </Fragment>


### PR DESCRIPTION
## What?
PR for customizable taxes field by language json files.

## Why?
Closes: https://github.com/bigcommerce/checkout-js/issues/885

## Testing / Proof
No need because few changes of strings

@bigcommerce/checkout
