### PR TITLE
feat(payment): PAYPAL-1466 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2190,9 +2190,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.246.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.246.5.tgz",
-      "integrity": "sha512-8qZ5BvHwuj3dV/ekjJzsbvza6C1u8P/Og42z84/s/TTcxd8YAbjV9k1Ib8SCDE3Jz7RaJS5eKNkEy1eFd9oxeA==",
+      "version": "1.247.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.247.0.tgz",
+      "integrity": "sha512-fp2aXC2ssw2wBIZcMNK6RXq8fCKvoO68eRDgy0s872FyJXx3RmhmCLTAKF38jAkfhsdHfwnCVHjyErVZoZg7yw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.17.0",
@@ -4077,7 +4077,7 @@
     "@types/reselect": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/reselect/-/reselect-2.2.0.tgz",
-      "integrity": "sha512-wRzxD+878qxC1h3ZMkEl/smBluwVeuVxhjhwM1/ZLQ6+hgl5gPQp2mZQSjRppwAyyR+Ul3JIaiObAd7mD4QT3w==",
+      "integrity": "sha1-xmcgbP3DgZDh03m6vgiGWyKIV18=",
       "requires": {
         "reselect": "*"
       }
@@ -10825,6 +10825,12 @@
         },
         "inherits": {
           "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
           "bundled": true,
           "dev": true,
           "optional": true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.246.5",
+    "@bigcommerce/checkout-sdk": "^1.247.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1466
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1457

## Testing / Proof


@bigcommerce/checkout
