### PR TITLE
feat(payment): PAYPAL-1487 Add paypal-venmo payment method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,9 +1039,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.18.0.tgz",
-      "integrity": "sha512-nUHsJxeVySZEpzbPqcV20eunJKOCVOnV9BGuy29TedekqB6LXz4pu040PrZpoMNONnojJBuNkIot9TExqENGeA==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.19.0.tgz",
+      "integrity": "sha512-iP9ztuU7kET5ppkfeFYW4P5RlG2El7KC66NGhpFD8p3Ww7KAihcQncwRtodLL5cEh6ndf8GeP6+XAuCPNJ7NTg==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^27.4.6",
@@ -1680,12 +1680,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.254.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.254.0.tgz",
-      "integrity": "sha512-gU/YyWESeisrzeii9Ed+wBZptLl/6s2XB72J8os6vYzGkJbxBrzxKvfUPUDjVGtz96lnsgL1QlInGFR1oG4oOg==",
+      "version": "1.255.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.255.0.tgz",
+      "integrity": "sha512-qVhWCwbDLvRbjH9uVRfQ60pbpxBC3zS/zAVdQrk1asV6Wn5b4nCQnPwP4lKSlQtJsWomKZnSIx5vG4pZ+yh2jw==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.18.0",
+        "@bigcommerce/bigpay-client": "^5.19.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.254.0",
+    "@bigcommerce/checkout-sdk": "^1.255.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/app/locale/translations/en.json
+++ b/src/app/locale/translations/en.json
@@ -259,6 +259,7 @@
             "payment_not_required_text": "Payment is not required for this order.",
             "paypal_continue_action": "Continue with PayPal",
             "paypal_pay_later_continue_action": "Continue with Pay Later",
+            "paypal_venmo_continue_action": "Continue with Venmo",
             "braintreevenmo_continue_action": "Continue with Venmo",
             "paypal_credit_continue_action": "Continue with PayPal Credit",
             "paypal_credit_description_text": "Buy Now, Pay Over Time",

--- a/src/app/payment/PaymentSubmitButton.tsx
+++ b/src/app/payment/PaymentSubmitButton.tsx
@@ -68,6 +68,10 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
         return <TranslatedString data={ { brandName } } id={ brandName ? 'payment.continue_with_brand' : 'payment.paypal_pay_later_continue_action' } />;
     }
 
+    if (methodType === PaymentMethodType.PaypalVenmo) {
+        return <TranslatedString id="payment.paypal_venmo_continue_action" />;
+    }
+
     if (methodId === PaymentMethodId.Opy) {
         return <TranslatedString data={ { methodName } } id="payment.opy_continue_action" />;
     }

--- a/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -183,6 +183,7 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.id === PaymentMethodId.PaypalCommerce ||
         method.id === PaymentMethodId.PaypalCommerceCredit ||
+        method.id === PaymentMethodId.PaypalCommerceVenmo ||
         method.gateway === PaymentMethodId.PaypalCommerceAlternativeMethod) {
         return <PaypalCommercePaymentMethod
             { ...props }

--- a/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -45,6 +45,7 @@ enum PaymentMethodId {
     PaypalCommerceCredit = 'paypalcommercecredit',
     PaypalCommerceCreditCards = 'paypalcommercecreditcards',
     PaypalCommerceAlternativeMethod = 'paypalcommercealternativemethods',
+    PaypalCommerceVenmo = 'paypalcommercevenmo',
     Qpay = 'qpay',
     Quadpay = 'quadpay',
     SagePay = 'sagepay',

--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -174,6 +174,10 @@ function getPaymentMethodTitle(
             },
         };
 
+        if (method.id === PaymentMethodId.PaypalCommerceVenmo) {
+            return customTitles[PaymentMethodId.PaypalCommerceAlternativeMethod];
+        }
+
         // KLUDGE: 'paypal' is actually a credit card method. It is the only
         // exception to the rule below. We should probably fix it on API level,
         // but apparently it would break LCO if we are not careful.

--- a/src/app/payment/paymentMethod/PaymentMethodType.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodType.ts
@@ -8,6 +8,7 @@ enum PaymentMethodType {
     MultiOption = 'multi-option',
     Paypal = 'paypal',
     PaypalCredit = 'paypal-credit',
+    PaypalVenmo = 'paypal-venmo',
     VisaCheckout = 'visa-checkout',
 }
 


### PR DESCRIPTION
## What?
A separate module was created for the Venmo payment method on the backend side. The common button strategy for all PPCP SPBs has now been expanded. In the future, a separate strategy will be created for each spb, including for Venmo. These tasks are already planned.

## Why?
We need a module for the Venmo payment method to create separate button strategy for it

## Depends on
https://github.com/bigcommerce/bigpay/pull/5495
https://github.com/bigcommerce/bigcommerce/pull/46631
https://github.com/bigcommerce/bigpay-client-js/pull/132
https://github.com/bigcommerce/checkout-sdk-js/pull/1458

## Testing / Proof
New approach
![Screenshot 2022-06-08 at 10 55 56](https://user-images.githubusercontent.com/18176525/172564601-42ecc2f5-d2ad-4746-afee-bc5476962d12.png)

Old approach
![Screenshot 2022-06-08 at 11 01 03](https://user-images.githubusercontent.com/18176525/172564696-e14fa3db-089b-4e9d-8972-96f19d05fdc0.png)

@bigcommerce/checkout
