### PR TITLE
chore(checkout): CHECKOUT-6703 bump checkout-sdk-js version 1.248.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1658,12 +1658,12 @@
             "color-name": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+              "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
             },
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+              "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
             },
             "supports-color": {
               "version": "5.5.0",
@@ -1676,9 +1676,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.0.tgz",
-          "integrity": "sha512-AqDccGC+m5O/iUStSJy3DGRIUFu7WbY/CppZYwrEUB4N0tZlnI8CSTsgL7v5fHVFmUbRv2sd+yy27o8Ydt4MGg=="
+          "version": "7.18.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
+          "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow=="
         },
         "@babel/template": {
           "version": "7.16.7",
@@ -1715,9 +1715,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.18.2",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.2.tgz",
-          "integrity": "sha512-0On6B8A4/+mFUto5WERt3EEuG1NznDirvwca1O8UwXQHVY8g3R7OzYgxXdOfMwLO08UrpUD/2+3Bclyq+/C94Q==",
+          "version": "7.18.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
+          "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "to-fast-properties": "^2.0.0"
@@ -1885,9 +1885,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001342",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz",
-          "integrity": "sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA=="
+          "version": "1.0.30001344",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+          "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -2190,9 +2190,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.247.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.247.0.tgz",
-      "integrity": "sha512-fp2aXC2ssw2wBIZcMNK6RXq8fCKvoO68eRDgy0s872FyJXx3RmhmCLTAKF38jAkfhsdHfwnCVHjyErVZoZg7yw==",
+      "version": "1.248.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.248.0.tgz",
+      "integrity": "sha512-g8JJUn0hCnwIvtVpbwPaPgCAqd8NlmJenKWl82FW8lo5OGOoDFm353/raduOOw+BITDtlknu4Pos8R+bIkQlOg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.17.0",
@@ -4077,7 +4077,7 @@
     "@types/reselect": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/reselect/-/reselect-2.2.0.tgz",
-      "integrity": "sha1-xmcgbP3DgZDh03m6vgiGWyKIV18=",
+      "integrity": "sha512-wRzxD+878qxC1h3ZMkEl/smBluwVeuVxhjhwM1/ZLQ6+hgl5gPQp2mZQSjRppwAyyR+Ul3JIaiObAd7mD4QT3w==",
       "requires": {
         "reselect": "*"
       }
@@ -8410,7 +8410,7 @@
     "current-script-polyfill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/current-script-polyfill/-/current-script-polyfill-1.0.0.tgz",
-      "integrity": "sha1-8xz35PPiGLBybnOMqSoC00iO9hU="
+      "integrity": "sha512-qv8s+G47V6Hq+g2kRE5th+ASzzrL7b6l+tap1DHKK25ZQJv3yIFhH96XaQ7NGL+zRW3t/RDbweJf/dJDe5Z5KA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -10382,7 +10382,7 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.247.0",
+    "@bigcommerce/checkout-sdk": "^1.248.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task [CHECKOUT-6679](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-6679)
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1457

## Testing / Proof


@bigcommerce/checkout
