### PR TITLE
feat(checkout): CHECKOUT-6711 Update order confirmation redirect url

### DIFF
--- a/src/app/checkout/Checkout.spec.tsx
+++ b/src/app/checkout/Checkout.spec.tsx
@@ -715,7 +715,7 @@ describe('Checkout', () => {
                 .prop('onSubmit')!();
 
             expect(location.replace)
-                .toHaveBeenCalledWith('/order-confirmation');
+                .toHaveBeenCalledWith('/checkout/order-confirmation');
         });
 
         it('navigates to order confirmation page when order is finalized', () => {
@@ -724,7 +724,7 @@ describe('Checkout', () => {
                 .prop('onFinalize')!();
 
             expect(location.replace)
-                .toHaveBeenCalledWith('/order-confirmation');
+                .toHaveBeenCalledWith('/checkout/order-confirmation');
         });
 
         it('posts message to parent of embedded checkout when shopper completes checkout', () => {

--- a/src/app/checkout/navigateToOrderConfirmation.spec.tsx
+++ b/src/app/checkout/navigateToOrderConfirmation.spec.tsx
@@ -18,6 +18,16 @@ describe('navigateToOrderConfirmation', () => {
             .toHaveBeenCalledWith('/checkout/order-confirmation');
     });
 
+    it('navigates to order confirmation page without cart id in the path', () => {
+        locationMock.href = `https://store.com/checkout/checkout-id-abc/`;
+        locationMock.pathname = '/checkout/checkout-id-abc';
+
+        navigateToOrderConfirmation(locationMock as Location);
+
+        expect(locationMock.replace)
+            .toHaveBeenCalledWith('/checkout/order-confirmation');
+    });
+
     it('discards any query params when navigating to order confirmation page', () => {
         locationMock.href = 'https://store.com/embedded-checkout?setCurrencyId=1';
         locationMock.pathname = '/embedded-checkout';

--- a/src/app/checkout/navigateToOrderConfirmation.tsx
+++ b/src/app/checkout/navigateToOrderConfirmation.tsx
@@ -1,7 +1,7 @@
 import { noop } from 'lodash';
 
 export default function navigateToOrderConfirmation(location = window.location): Promise<never> {
-    const url = `${location.pathname.replace(/\/$/, '')}/order-confirmation`;
+    const url = `/${location.pathname.includes('embedded-checkout') ? 'embedded-checkout' : 'checkout'}/order-confirmation`;
 
     location.replace(url);
 


### PR DESCRIPTION
## What?
Change the navigating url of order confirmation for buy-now cart.

## Why?
Currently, the way to navigate to order confirmation page is appending `/order-confirmation` to the url. For buy-now cart, the url of order confirmation will be `/checkout/checkout-id-abc/order-confirmation`. To support buy-now cart, it should be navigating to `/checkout/order-confirmation`.

## Testing / Proof
Before - the order confirmation url contains checkout id for buy-now cart
![image](https://user-images.githubusercontent.com/84553389/172277942-f8e87168-d6c2-454a-ac2b-7583dd71cd6c.png)

After - checkout id will be removed in order confirmation url
![image](https://user-images.githubusercontent.com/84553389/172278107-4861c7d4-f24c-4d33-bc72-c0a958d9a81e.png)

### Buy-now cart

https://user-images.githubusercontent.com/84553389/172279170-3a6c0d6e-b716-4dec-9a12-1be3680fae0d.mov

### Normal checkout

https://user-images.githubusercontent.com/84553389/172278473-9d4e2ba9-ef8a-4b08-bdbc-7fd09a8a72d3.mov

### embedded checkout

https://user-images.githubusercontent.com/84553389/172279310-36dfa242-e1cf-414e-80ad-2135ac9957f5.mov


@bigcommerce/checkout
