### PR TITLE
fix(checkout): CHECKOUT-6657 Ensure pages reflow without requiring two-dimensional scrolling without loss of  content or functionality

### DIFF
--- a/packages/core/src/scss/settings/checkout/customer/_settings.scss
+++ b/packages/core/src/scss/settings/checkout/customer/_settings.scss
@@ -5,4 +5,4 @@
 $customerEmail-action-margin: spacing("single") + spacing("fifth") 0 0 0;
 $customerEmail-button-padding: spacing("half") + spacing("sixth") spacing("third");
 $customerView-actions-marginTop: remCalc(-5px);
-$customerView-actions-marginTop--large: remCalc(-40px);
+$customerView-actions-marginTop--large: 0;


### PR DESCRIPTION
## What?
Setting margin-top to 0 and removing the `$customerView-actions-marginTop--large` variable since it will no longer be used.

## Why?
Users with low vision who require zoom in order to view page content will have the sign out button overlap content on the checkout page.

## Testing / Proof
Before:
![Screen Shot 2022-06-06 at 4 10 12 PM](https://user-images.githubusercontent.com/20911717/172259396-b52d495b-d6f5-42aa-8bc9-afa9c8046166.png)

After:
![Screen Shot 2022-06-06 at 4 09 49 PM](https://user-images.githubusercontent.com/20911717/172259407-d521e592-ad46-4e80-9ac3-014594a4aeda.png)

I am not sure that this is the best way to resolve this. We could add more breakpoints but I did not see `$customerView-actions-marginTop--large` being used anywhere else in checkout.

@bigcommerce/checkout
