### PR TITLE
feat(payment): INT-6055 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1885,9 +1885,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001344",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-          "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g=="
+          "version": "1.0.30001346",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
+          "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -2190,9 +2190,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.248.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.248.0.tgz",
-      "integrity": "sha512-g8JJUn0hCnwIvtVpbwPaPgCAqd8NlmJenKWl82FW8lo5OGOoDFm353/raduOOw+BITDtlknu4Pos8R+bIkQlOg==",
+      "version": "1.249.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.249.0.tgz",
+      "integrity": "sha512-LIEbzhlB9WebxqYtFh3EIdofn5SNI0VUNVwxncncCTjol0px36efCFmllmV7UPIuTdx8yZrukZqcal9dwj1+3w==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.17.0",
@@ -2269,9 +2269,9 @@
           "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A=="
         },
         "core-js": {
-          "version": "3.22.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.7.tgz",
-          "integrity": "sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg=="
+          "version": "3.22.8",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.8.tgz",
+          "integrity": "sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA=="
         },
         "query-string": {
           "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.248.0",
+    "@bigcommerce/checkout-sdk": "^1.248.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What? [INT-6055](https://bigcommercecloud.atlassian.net/browse/INT-6055)
Bump checkout-sdk-js version

## Why?
To update the checkout-sdk-js verion that include the fix of the next PR
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1459

## Testing / Proof


@bigcommerce/checkout
