### PR TITLE
fix(payment): INT-6061 StripeUPE Vaulting selecting new card is failing

### DIFF
--- a/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -57,7 +57,7 @@ const StripeUPEPaymentMethod: FunctionComponent<StripePaymentMethodProps & WithI
         return getAppliedStyles(parentContainer, properties);
     };
 
-    const renderCustomPaymentForm = () => {
+    const renderCheckoutThemeStylesForStripeUPE = () => {
         return (
             <div
                 className={ 'optimizedCheckout-form-input' }
@@ -87,9 +87,8 @@ const StripeUPEPaymentMethod: FunctionComponent<StripePaymentMethodProps & WithI
             hideContentWhenSignedOut
             initializePayment={ initializeStripePayment }
             method={ method }
-            renderCustomPaymentForm={ renderCustomPaymentForm }
-            shouldRenderCustomInstrument={ true }
         />
+        { renderCheckoutThemeStylesForStripeUPE() }
     </>;
 };
 


### PR DESCRIPTION
## What? [INT-6061](https://bigcommercecloud.atlassian.net/browse/INT-6061)
Renders elements needed to get optimizedCheckout styles

## Why?
It's failing because renderContainer() function sets the display to none when certain conditions are met, and this elements need to always be rendered

## Testing / Proof
<img width="735" alt="image" src="https://user-images.githubusercontent.com/87149598/173173414-16f153f0-c99b-4a4b-94c3-a3c7ca7e0884.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 
