### PR TITLE
feat(checkout): CHECKOUT-6595 remove the edit cart button for buy now carts

### DIFF
--- a/src/app/cart/CartSummary.spec.tsx
+++ b/src/app/cart/CartSummary.spec.tsx
@@ -37,4 +37,14 @@ describe('CartSummary Component', () => {
         expect(component.find(OrderSummary).prop('headerLink'))
             .toMatchSnapshot();
     });
+
+    it('renders OrderSummary without the Edit Cart link for Buy Now carts', () => {
+        jest.spyOn(window, 'window', 'get').mockImplementation(() => ({
+            location: {
+                pathname: '/checkout/buy-now-checkout-id',
+            },
+        }) as any);
+
+        expect(component.find(OrderSummary).prop('headerLink')).not.toBeTruthy();
+    });
 });

--- a/src/app/cart/CartSummary.tsx
+++ b/src/app/cart/CartSummary.tsx
@@ -20,14 +20,18 @@ export type WithCheckoutCartSummaryProps = {
 const CartSummary: FunctionComponent<WithCheckoutCartSummaryProps> = ({
     cartUrl,
     ...props
-}) => (
-    withRedeemable(OrderSummary)({
-        ...props,
-        cartUrl,
-        headerLink: (
-            <EditLink url={ cartUrl } />
-        ),
-    })
-);
+}) => {
+    const isBuyNowCart = window.location.pathname.replace('/checkout', '').replace('/embedded-checkout', '').length > 0;
+
+    const headerLink = isBuyNowCart ? null : <EditLink url={ cartUrl } />;
+
+    return (
+        withRedeemable(OrderSummary)({
+            ...props,
+            cartUrl,
+            headerLink,
+        })
+    );
+};
 
 export default withCheckout(mapToCartSummaryProps)(CartSummary);

--- a/src/app/cart/__snapshots__/CartSummary.spec.tsx.snap
+++ b/src/app/cart/__snapshots__/CartSummary.spec.tsx.snap
@@ -1,7 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CartSummary Component renders OrderSummary with Edit Cart link 1`] = `
-<Memo(EditLink)
-  url="https://store-k1drp8k8.bcapp.dev/cart.php"
-/>
-`;
+exports[`CartSummary Component renders OrderSummary with Edit Cart link 1`] = `null`;


### PR DESCRIPTION
## What?
Remove the edit cart button on the checkout page for buy now carts

## Why?
Shoppers shouldn't need to edit the cart if they use the buy now button for items

## Testing / Proof
![Screen Shot 2022-06-14 at 3 55 08 pm](https://user-images.githubusercontent.com/9646373/173503535-7b3ab77d-a6cc-492b-bf1e-8964840d6b88.png)


@bigcommerce/checkout
