### PR TITLE
feat(payment): PAYMENTS-7524 Bump checkout-sdk version to 1.254.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw=="
+      "version": "7.18.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.5.tgz",
+      "integrity": "sha512-BxhE40PVCBxVEJsSBhB6UWyAuqJRxGsAw8BdHMJ3AKGydcwuWW4kOO3HmqBQAdcq/OP+/DlTVxLvsCzRTnZuGg=="
     },
     "@babel/core": {
       "version": "7.5.5",
@@ -122,6 +122,36 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-compilation-targets": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
+      "integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
+      "requires": {
+        "@babel/compat-data": "^7.17.10",
+        "@babel/helper-validator-option": "^7.16.7",
+        "browserslist": "^4.20.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.20.4",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
+          "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001349",
+            "electron-to-chromium": "^1.4.147",
+            "escalade": "^3.1.1",
+            "node-releases": "^2.0.5",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001355",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001355.tgz",
+          "integrity": "sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g=="
+        }
+      }
+    },
     "@babel/helper-define-map": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
@@ -134,23 +164,9 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "requires": {
-        "@babel/types": "^7.16.7"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.17.10",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
-          "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.16.7",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
+      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ=="
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.1.0",
@@ -484,9 +500,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+          "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA=="
         }
       }
     },
@@ -499,9 +515,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+          "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA=="
         }
       }
     },
@@ -514,9 +530,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+          "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA=="
         }
       }
     },
@@ -547,9 +563,9 @@
       },
       "dependencies": {
         "@babel/helper-plugin-utils": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-          "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+          "version": "7.17.12",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+          "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA=="
         }
       }
     },
@@ -1023,9 +1039,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.17.0.tgz",
-      "integrity": "sha512-S3ps6C59JB/VrAIWluz4F0Us/JTi5S6yRnwF+zHLO4OpNU3dBIYytLTs/q7eXwCe5CkOeZXVx9mspItV97c13g==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.18.0.tgz",
+      "integrity": "sha512-nUHsJxeVySZEpzbPqcV20eunJKOCVOnV9BGuy29TedekqB6LXz4pu040PrZpoMNONnojJBuNkIot9TExqENGeA==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^27.4.6",
@@ -1049,17 +1065,6 @@
             "@babel/types": "^7.18.2",
             "@jridgewell/gen-mapping": "^0.3.0",
             "jsesc": "^2.5.1"
-          }
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.18.2",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.2.tgz",
-          "integrity": "sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==",
-          "requires": {
-            "@babel/compat-data": "^7.17.10",
-            "@babel/helper-validator-option": "^7.16.7",
-            "browserslist": "^4.20.2",
-            "semver": "^6.3.0"
           }
         },
         "@babel/helper-function-name": {
@@ -1167,12 +1172,12 @@
             "color-name": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+              "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
             },
             "has-flag": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+              "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
             },
             "supports-color": {
               "version": "5.5.0",
@@ -1185,9 +1190,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.18.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
-          "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow=="
+          "version": "7.18.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
+          "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw=="
         },
         "@babel/template": {
           "version": "7.16.7",
@@ -1200,9 +1205,9 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.18.2",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.2.tgz",
-          "integrity": "sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==",
+          "version": "7.18.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
+          "integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
           "requires": {
             "@babel/code-frame": "^7.16.7",
             "@babel/generator": "^7.18.2",
@@ -1210,17 +1215,10 @@
             "@babel/helper-function-name": "^7.17.9",
             "@babel/helper-hoist-variables": "^7.16.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
-            "@babel/parser": "^7.18.0",
-            "@babel/types": "^7.18.2",
+            "@babel/parser": "^7.18.5",
+            "@babel/types": "^7.18.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
-          },
-          "dependencies": {
-            "@babel/helper-environment-visitor": {
-              "version": "7.18.2",
-              "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-              "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ=="
-            }
           }
         },
         "@babel/types": {
@@ -1381,23 +1379,6 @@
             "fill-range": "^7.0.1"
           }
         },
-        "browserslist": {
-          "version": "4.20.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-          "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
-          "requires": {
-            "caniuse-lite": "^1.0.30001332",
-            "electron-to-chromium": "^1.4.118",
-            "escalade": "^3.1.1",
-            "node-releases": "^2.0.3",
-            "picocolors": "^1.0.0"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001346",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-          "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ=="
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1408,9 +1389,9 @@
           }
         },
         "ci-info": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-          "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg=="
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
+          "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg=="
         },
         "color-convert": {
           "version": "2.0.1",
@@ -1503,9 +1484,9 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.18.2",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.2.tgz",
-              "integrity": "sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==",
+              "version": "7.18.5",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
+              "integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
               "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
@@ -1513,10 +1494,10 @@
                 "@babel/helper-compilation-targets": "^7.18.2",
                 "@babel/helper-module-transforms": "^7.18.0",
                 "@babel/helpers": "^7.18.2",
-                "@babel/parser": "^7.18.0",
+                "@babel/parser": "^7.18.5",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.18.2",
-                "@babel/types": "^7.18.2",
+                "@babel/traverse": "^7.18.5",
+                "@babel/types": "^7.18.4",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1699,12 +1680,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.249.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.249.0.tgz",
-      "integrity": "sha512-LIEbzhlB9WebxqYtFh3EIdofn5SNI0VUNVwxncncCTjol0px36efCFmllmV7UPIuTdx8yZrukZqcal9dwj1+3w==",
+      "version": "1.254.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.254.0.tgz",
+      "integrity": "sha512-gU/YyWESeisrzeii9Ed+wBZptLl/6s2XB72J8os6vYzGkJbxBrzxKvfUPUDjVGtz96lnsgL1QlInGFR1oG4oOg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
-        "@bigcommerce/bigpay-client": "^5.17.0",
+        "@bigcommerce/bigpay-client": "^5.18.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,32 +1759,14 @@
           "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A=="
         },
         "core-js": {
-          "version": "3.22.8",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.8.tgz",
-          "integrity": "sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA=="
-        },
-        "query-string": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
-          "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "filter-obj": "^1.1.0",
-            "split-on-first": "^1.0.0",
-            "strict-uri-encode": "^2.0.0"
-          },
-          "dependencies": {
-            "strict-uri-encode": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-              "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
-            }
-          }
+          "version": "3.23.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.1.tgz",
+          "integrity": "sha512-wfMYHWi1WQjpgZNC9kAlN4ut04TM9fUTdi7CqIoTVM7yaiOUQTklOzfb+oWH3r9edQcT3F887swuVmxrV+CC8w=="
         },
         "reselect": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
-          "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
+          "version": "4.1.6",
+          "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+          "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
         },
         "rxjs": {
           "version": "6.6.7",
@@ -6800,7 +6763,7 @@
     "current-script-polyfill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/current-script-polyfill/-/current-script-polyfill-1.0.0.tgz",
-      "integrity": "sha1-8xz35PPiGLBybnOMqSoC00iO9hU="
+      "integrity": "sha512-qv8s+G47V6Hq+g2kRE5th+ASzzrL7b6l+tap1DHKK25ZQJv3yIFhH96XaQ7NGL+zRW3t/RDbweJf/dJDe5Z5KA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -7432,9 +7395,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
+      "version": "1.4.158",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.158.tgz",
+      "integrity": "sha512-gppO3/+Y6sP432HtvwvuU8S+YYYLH4PmAYvQwqUtt9HDOmEsBwQfLnK9T8+1NIKwAS1BEygIjTaATC4H5EzvxQ=="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -8711,7 +8674,7 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -13601,9 +13564,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
+      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q=="
     },
     "node-sass": {
       "version": "4.14.1",
@@ -14842,6 +14805,24 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "query-string": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
+      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "dependencies": {
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
+        }
+      }
     },
     "querystringify": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.248.2",
+    "@bigcommerce/checkout-sdk": "^1.254.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version to 1.254.0 to apply [those changes](https://github.com/bigcommerce/checkout-sdk-js/commit/bfedf7c42dd913fc5f155425d82d678880950862).

## Why?
To support human verification for PPSDK card payment.

## Testing / Proof
Unit tests.
Manual tests.

@bigcommerce/checkout @bigcommerce/payments 
