### PR TITLE
chore(payment): PAYPAL-1508 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,9 +1680,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.255.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.255.0.tgz",
-      "integrity": "sha512-qVhWCwbDLvRbjH9uVRfQ60pbpxBC3zS/zAVdQrk1asV6Wn5b4nCQnPwP4lKSlQtJsWomKZnSIx5vG4pZ+yh2jw==",
+      "version": "1.256.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.256.0.tgz",
+      "integrity": "sha512-VSMTq9Foqlr5Eef60nAcWwTLqT7FW8obBynjoVBv02D9AcW1Wi7Bgt+0cqbvYQZ7fXUiNESUoOVDdI5D9LiTKQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.255.0",
+    "@bigcommerce/checkout-sdk": "^1.256.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To release checkout sdk changes due the task: 
https://bigcommercecloud.atlassian.net/browse/PAYPAL-1508

## Testing / Proof
Unit tests
Manual tests

@bigcommerce/checkout
