### PR TITLE
fix(common): CHECKOUT-6674 Fix issue with alpha prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "webpack --mode development --watch",
     "dev:server": "http-server build",
     "release": "echo 'Please do not release locally, use CircleCi'",
-    "release:alpha": "npm run lint && npm run test -- --coverage && npm run build -- --prerelease && npm run release:version",
+    "release:alpha": "npm run lint && npm run test -- --coverage && npm run build -- --env prerelease=prerelease && npm run release:version",
     "release:version": "git add dist && standard-version -a",
     "auto-export": "bin/auto-export.js",
     "prelint": "npm run auto-export",

--- a/scripts/webpack/get-next-version.js
+++ b/scripts/webpack/get-next-version.js
@@ -6,6 +6,25 @@ const packageJson = require('../../package.json');
 
 let nextVersion;
 
+function getEnvArgsMap() {
+    const obj = {};
+
+    console.log(argv);
+
+    const args = argv.env && argv.env.split(' ');
+
+    if (!args) {
+        return obj;
+    }
+
+    args.split(' ').forEach(arg => {
+        const argArray = arg.split('=');
+        obj[argArray[0]] = argArray[1];
+    });
+
+    return obj;
+}
+
 function getNextVersion() {
     if (!nextVersion) {
         nextVersion = new Promise((resolve, reject) => {
@@ -14,12 +33,14 @@ function getNextVersion() {
             }
 
             conventionalRecommendedBump({ preset: 'angular' }, (err, release) => {
+                const argsObject = getEnvArgsMap();
+
                 if (err) {
                     return reject(err);
                 }
 
-                if (argv.prerelease) {
-                    const prereleaseType = typeof argv.prerelease === 'string' ? argv.prerelease : 'alpha';
+                if (argsObject.prerelease) {
+                    const prereleaseType = typeof argsObject.prerelease === 'string' ? argsObject.prerelease : 'alpha';
 
                     return resolve(semver.inc(packageJson.version, 'prerelease', prereleaseType).replace(/\.\d+$/, `.${Date.now()}`));
                 }


### PR DESCRIPTION
## What?
Fix issue with creating alpha prerelease

## Why?
As part of webpack upgrade, alpha prerelease is broken.  Which is an important part of dev cycle. Hence fix it so we can test changes in functional tests before releasing code.

https://webpack.js.org/guides/environment-variables/

## Testing / Proof
- Screenshot
![Screen Shot 2022-06-20 at 11 05 53 pm](https://user-images.githubusercontent.com/7134802/174609014-2dd522b2-0a7e-4ead-a17a-40f941dacecc.png)

@bigcommerce/checkout
