### PR TITLE
chore(checkout): CHECKOUT-6765 bump checkout-sdk-js version 1.259.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,21 +134,20 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.20.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
-          "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
+          "version": "4.21.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
+          "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
           "requires": {
-            "caniuse-lite": "^1.0.30001349",
-            "electron-to-chromium": "^1.4.147",
-            "escalade": "^3.1.1",
+            "caniuse-lite": "^1.0.30001358",
+            "electron-to-chromium": "^1.4.164",
             "node-releases": "^2.0.5",
-            "picocolors": "^1.0.0"
+            "update-browserslist-db": "^1.0.0"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001355",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001355.tgz",
-          "integrity": "sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g=="
+          "version": "1.0.30001358",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+          "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw=="
         }
       }
     },
@@ -1680,9 +1679,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.256.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.256.0.tgz",
-      "integrity": "sha512-VSMTq9Foqlr5Eef60nAcWwTLqT7FW8obBynjoVBv02D9AcW1Wi7Bgt+0cqbvYQZ7fXUiNESUoOVDdI5D9LiTKQ==",
+      "version": "1.259.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.259.0.tgz",
+      "integrity": "sha512-Nb0S3KNKwnYMjZnBubqewcQ2URuVQ2HA21f6+UWTI9xl7JuAMMp44Mo+wiQgK3zr7MxwGFIkYiyW0Lr+PU4Rbg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.19.0",
@@ -1759,9 +1758,9 @@
           "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A=="
         },
         "core-js": {
-          "version": "3.23.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.1.tgz",
-          "integrity": "sha512-wfMYHWi1WQjpgZNC9kAlN4ut04TM9fUTdi7CqIoTVM7yaiOUQTklOzfb+oWH3r9edQcT3F887swuVmxrV+CC8w=="
+          "version": "3.23.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.2.tgz",
+          "integrity": "sha512-ELJOWxNrJfOH/WK4VJ3Qd+fOqZuOuDNDJz0xG6Bt4mGg2eO/UT9CljCrbqDGovjLKUrGajEEBcoTOc0w+yBYeQ=="
         },
         "reselect": {
           "version": "4.1.6",
@@ -7395,9 +7394,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.158",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.158.tgz",
-      "integrity": "sha512-gppO3/+Y6sP432HtvwvuU8S+YYYLH4PmAYvQwqUtt9HDOmEsBwQfLnK9T8+1NIKwAS1BEygIjTaATC4H5EzvxQ=="
+      "version": "1.4.165",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.165.tgz",
+      "integrity": "sha512-DKQW1lqUSAYQvn9dnpK7mWaDpWbNOXQLXhfCi7Iwx0BKxdZOxkKcCyKw1l3ihWWW5iWSxKKbhEUoNRoHvl/hbA=="
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -18659,6 +18658,15 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
+      }
+    },
+    "update-browserslist-db": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz",
+      "integrity": "sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
       }
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.256.0",
+    "@bigcommerce/checkout-sdk": "^1.259.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

Release the change of checkout SDK
https://github.com/bigcommerce/checkout-sdk-js/pull/1477

## Testing / Proof

@bigcommerce/checkout
