### PR TITLE
feat(checkout): CHECKOUT-6711 Add buy now cart experiment

### DIFF
--- a/src/app/checkout/Checkout.tsx
+++ b/src/app/checkout/Checkout.tsx
@@ -75,6 +75,7 @@ export interface CheckoutState {
     isCartEmpty: boolean;
     isRedirecting: boolean;
     hasSelectedShippingOptions: boolean;
+    isBuyNowCartEnabled: boolean;
 }
 
 export interface WithCheckoutProps {
@@ -106,6 +107,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         isRedirecting: false,
         isMultiShippingMode: false,
         hasSelectedShippingOptions: false,
+        isBuyNowCartEnabled: false,
     };
 
     private embeddedMessenger?: EmbeddedCheckoutMessenger;
@@ -170,12 +172,13 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
             const hasMultiShippingEnabled = data.getConfig()?.checkoutSettings?.hasMultiShippingEnabled;
             const checkoutBillingSameAsShippingEnabled = data.getConfig()?.checkoutSettings?.checkoutBillingSameAsShippingEnabled ?? true;
+            const buyNowCartFlag = data.getConfig()?.checkoutSettings?.features['CHECKOUT-3190.enable_buy_now_cart'] ?? false;
             const isMultiShippingMode = !!cart &&
                 !!consignments &&
                 hasMultiShippingEnabled &&
                 isUsingMultiShipping(consignments, cart.lineItems);
 
-            this.setState({ isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled });
+            this.setState({ isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled, isBuyNowCartEnabled: buyNowCartFlag });
 
             if (isMultiShippingMode) {
                 this.setState({ isMultiShippingMode }, this.handleReady);
@@ -492,6 +495,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
     private navigateToOrderConfirmation: (orderId?: number) => void = orderId => {
         const { steps } = this.props;
+        const { isBuyNowCartEnabled } = this.state;
 
         if (this.stepTracker) {
             this.stepTracker.trackStepCompleted(steps[steps.length - 1].type);
@@ -502,7 +506,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         }
 
         this.setState({ isRedirecting: true }, () => {
-            navigateToOrderConfirmation(window.location, orderId);
+            navigateToOrderConfirmation(isBuyNowCartEnabled, orderId);
         });
     };
 

--- a/src/app/checkout/navigateToOrderConfirmation.spec.tsx
+++ b/src/app/checkout/navigateToOrderConfirmation.spec.tsx
@@ -1,43 +1,39 @@
 import navigateToOrderConfirmation from './navigateToOrderConfirmation';
 
 describe('navigateToOrderConfirmation', () => {
-    let locationMock: Pick<Location, 'pathname' | 'href' | 'replace'>;
-
     beforeEach(() => {
-        locationMock = {
-            href: 'https://store.com/checkout',
-            pathname: '/checkout',
-            replace: jest.fn(),
-        };
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: 'https://store.com/checkout',
+                pathname: '/checkout',
+                replace: jest.fn(),
+            },
+            writable: true,
+        });
     });
 
     it('navigates to order confirmation page based on its current path', () => {
-        navigateToOrderConfirmation(locationMock as Location);
+        navigateToOrderConfirmation(true);
 
-        expect(locationMock.replace)
+        expect(window.location.replace)
             .toHaveBeenCalledWith('/checkout/order-confirmation');
     });
 
     it('navigates to order confirmation page with orderId in the URL when it is a buy now cart checkout', () => {
-        locationMock = {
-            ...locationMock,
-            pathname: '/checkout/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
-        };
-        jest.spyOn(window, 'window', 'get').mockImplementation(() => ({ location: locationMock }) as any);
+        window.location.pathname = '/checkout/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
+        navigateToOrderConfirmation(true, 100);
 
-        navigateToOrderConfirmation(locationMock as Location, 100);
-
-        expect(locationMock.replace)
+        expect(window.location.replace)
             .toHaveBeenCalledWith('/checkout/order-confirmation/100');
     });
 
     it('discards any query params when navigating to order confirmation page', () => {
-        locationMock.href = 'https://store.com/embedded-checkout?setCurrencyId=1';
-        locationMock.pathname = '/embedded-checkout';
+        window.location.href = 'https://store.com/embedded-checkout?setCurrencyId=1';
+        window.location.pathname = '/embedded-checkout';
 
-        navigateToOrderConfirmation(locationMock as Location);
+        navigateToOrderConfirmation(true);
 
-        expect(locationMock.replace)
+        expect(window.location.replace)
             .toHaveBeenCalledWith('/embedded-checkout/order-confirmation');
     });
 });

--- a/src/app/checkout/navigateToOrderConfirmation.tsx
+++ b/src/app/checkout/navigateToOrderConfirmation.tsx
@@ -2,16 +2,22 @@ import { noop } from 'lodash';
 
 import { isBuyNowCart } from '../common/utility';
 
-export default function navigateToOrderConfirmation(location = window.location, orderId?: number): Promise<never> {
+export default function navigateToOrderConfirmation(isBuyNowCartEnabled: boolean = false, orderId?: number): Promise<never> {
     let url: string;
 
-    if (orderId && isBuyNowCart()) {
-        url = `/checkout/order-confirmation/${orderId.toString()}`;
-    } else {
-        url = `${location.pathname.replace(/\/$/, '')}/order-confirmation`;
+    if (isBuyNowCartEnabled) {
+        if (orderId && isBuyNowCart()) {
+            url = `/checkout/order-confirmation/${orderId.toString()}`;
+        } else {
+            url = `${window.location.pathname.replace(/\/$/, '')}/order-confirmation`;
+        }
+        window.location.replace(url);
+
+        return new Promise(noop);
     }
 
-    location.replace(url);
+    url = `${window.location.pathname.replace(/\/$/, '')}/order-confirmation`;
+    window.location.replace(url);
 
     return new Promise(noop);
 }


### PR DESCRIPTION
## What?
Add buy now cart experiment to wrap up the related changes.

## Why?
To control the risk of rolling out buy now cart.

## Testing / Proof
- Circle
- When `CHECKOUT-3190.enable_buy_now_cart` is on and a shopper is signed-in, the order confirmation page will be `/checkout/order-confirmation/:id/`.

https://user-images.githubusercontent.com/88361607/175231095-613295b7-8690-4fdd-b034-fd6400fad4df.mov



@bigcommerce/checkout
