### PR TITLE
fix(checkout): ADYEN-497 Googlepay icon fix

### DIFF
--- a/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -99,6 +99,10 @@ function getPaymentMethodTitle(
                 logoUrl: cdnPath('/img/payment-providers/google-pay.png'),
                 titleText: '',
             },
+            [PaymentMethodType.PayWithGoogle]: {
+                logoUrl: cdnPath('/img/payment-providers/google-pay.png'),
+                titleText: '',
+            },
             [PaymentMethodId.DigitalRiver]: {
                 logoUrl: '',
                 titleText: language.translate('payment.digitalriver_display_name_text'),

--- a/src/app/payment/paymentMethod/PaymentMethodType.ts
+++ b/src/app/payment/paymentMethod/PaymentMethodType.ts
@@ -4,6 +4,7 @@ enum PaymentMethodType {
     Chasepay = 'chasepay',
     CreditCard = 'credit-card',
     GooglePay = 'googlepay',
+    PayWithGoogle = 'paywithgoogle',
     Masterpass = 'masterpass',
     MultiOption = 'multi-option',
     Paypal = 'paypal',

--- a/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -6,8 +6,6 @@
     height: fontSize("large");
 
     + .paymentProviderHeader-name {
-        font-size: 18px;
-        font-weight: bold;
         margin-left: spacing("half");
     }
 }


### PR DESCRIPTION
## What?
ADYEN-497 Googlepay icon fix

## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-497
And added fix for the font weight https://bigcommercecloud.atlassian.net/browse/ADYEN-434

## Testing / Proof
Before fix:
![image](https://user-images.githubusercontent.com/79574476/175532066-da2325e1-bde8-43e9-9ba1-7cf3f2cf6646.png)

After fix:
![image](https://user-images.githubusercontent.com/79574476/175563096-8afd4411-c2df-4444-aea2-3b43316668b4.png)


@bigcommerce/checkout
