### PR TITLE
fix(checkout): CHECKOUT-6756 fix up alignment for paymentProviders

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -1,7 +1,7 @@
 import { LanguageService, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { number } from 'card-validator';
 import { compact } from 'lodash';
-import React, { memo, Fragment, FunctionComponent } from 'react';
+import React, { memo, FunctionComponent } from 'react';
 
 import { withCheckout, CheckoutContextProps } from '../../checkout';
 import { connectFormik, ConnectFormikProps } from '../../common/form';
@@ -229,7 +229,7 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
     };
 
     return (
-        <Fragment>
+        <div className="paymentProviderHeader-container">
             { logoUrl && <img
                 alt={ methodName }
                 className="paymentProviderHeader-img"
@@ -237,12 +237,12 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
                 src={ logoUrl }
             /> }
 
-            { titleText && <span
+            { titleText && <div
                 className="paymentProviderHeader-name"
                 data-test="payment-method-name"
             >
                 { titleText }
-            </span> }
+            </div> }
 
             <div className="paymentProviderHeader-cc">
                 <CreditCardIconList
@@ -250,7 +250,7 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
                     selectedCardType={ getSelectedCardType() }
                 />
             </div>
-        </Fragment>
+        </div>
     );
 };
 

--- a/packages/core/src/scss/components/bigcommerce/credit-card-types/_credit-card-types.scss
+++ b/packages/core/src/scss/components/bigcommerce/credit-card-types/_credit-card-types.scss
@@ -13,9 +13,20 @@
 // -----------------------------------------------------------------------------
 
 @if $exportCSS--credit-card-types {
+    .creditCardTypes-list {
+        align-content: flex-end;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: end;
+        margin-left: spacing("single");
+        max-width: $credit-card-items-max-width;
+    }
+
     .creditCardTypes-list-item {
         opacity: 1;
         transition: all 0.6s ease-out;
+        width: $credit-card-items-width;
 
         &.not-active {
             filter: grayscale(100%);

--- a/packages/core/src/scss/components/checkout/checklist/_checklist.scss
+++ b/packages/core/src/scss/components/checkout/checklist/_checklist.scss
@@ -66,12 +66,11 @@
 
         background-color: $input-bg-color;
         border-radius: 100%;
-        bottom: 0;
         content: "";
         left: $checklist-pip-spacing--small;
         margin: auto;
         position: absolute;
-        top: 0;
+        top: $checklist-pip-spacing-top;
 
         @include breakpoint("small") {
             left: $checklist-pip-spacing;

--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -1,8 +1,14 @@
 // =============================================================================
 // PAYMENT PROVIDER (Component)
 // =============================================================================
+.paymentProviderHeader-container {
+    display: flex;
+    justify-content: space-between;
+}
 
 .paymentProviderHeader-img {
+    align-self: center;
+    display: flex;
     height: fontSize("large");
 
     + .paymentProviderHeader-name {
@@ -16,8 +22,19 @@
 
 .paymentProviderHeader-cc {
     @include breakpoint("small") {
-        float: right;
+        align-items: flex-end;
+        display: flex;
+        flex-grow: 0;
+        flex-shrink: 2;
     }
+}
+
+.paymentProviderHeader-name {
+    align-items: flex-end;
+    align-self: start;
+    display: flex;
+    flex-grow: 1;
+    flex-shrink: 1;
 }
 
 .paymentMethod--creditCard,

--- a/packages/core/src/scss/settings/bigcommerce/credit-card-types/_settings.scss
+++ b/packages/core/src/scss/settings/bigcommerce/credit-card-types/_settings.scss
@@ -13,3 +13,5 @@
 // -----------------------------------------------------------------------------
 
 $exportCSS--credit-card-types: true;
+$credit-card-items-max-width: 17rem;
+$credit-card-items-width: 3rem;

--- a/packages/core/src/scss/settings/checkout/checklist/_settings.scss
+++ b/packages/core/src/scss/settings/checkout/checklist/_settings.scss
@@ -15,3 +15,4 @@ $checklist-pip-backgroundImage:         url("data:image/svg+xml;utf8, %3Csvg%20w
 $checklist-pip-spacing:                 spacing("base") + spacing("third");
 $checklist-pip-spacing--small:          $checklist-pip-spacing / 1.5;
 $checklist-pip-spacingVertical:         remCalc(20px);
+$checklist-pip-spacing-top:             remCalc(19px);


### PR DESCRIPTION
## What?
Fix up alignment for payment logos

## Why?
The credit card icons in the payment step are misaligned when there are many icons. This is creating a poor shopper experience at the checkout. Merchants have reported that this UX is underwhelming.

## Testing / Proof

![Screen Shot 2022-07-07 at 4 44 09 pm](https://user-images.githubusercontent.com/9646373/177893940-559b333f-8e0a-4739-9dde-c266bdc8f6fe.png)
![Screen Shot 2022-07-07 at 12 12 15 pm](https://user-images.githubusercontent.com/9646373/177893944-033f6cf9-cd80-4979-8ee6-c64e4b2e7365.png)


@bigcommerce/checkout
