### PR TITLE
feat(checkout): CHECKOUT-6269 Use nx to run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "preinstall": "npx check-node-version --package",
     "prebuild": "rm -rf dist",
-    "build": "webpack --mode production",
+    "build": "nx run core:build",
     "build:server": "http-server dist",
     "dev": "nx run core:dev",
     "dev:server": "http-server build",


### PR DESCRIPTION
## What?
Use nx to build `checkout-js`.

## Why?
Improve building efficiency.

## Testing / Proof
CI.
