### PR TITLE
fix(shipping): CHECKOUT-6773 Fix bug with address auto complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/report/
 tests/screenshots/
 packages/core/src/app/generated/
 __temp__
+.idea
+.vscode

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint 'packages/**/*.{ts,tsx}'",
     "pretest": "bin/auto-export.js",
     "test": "npx nx run-many --target=test --all",
-    "test:watch": "jest --watch"
+    "test:watch": "npx nx run-many --target=test --all --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
@@ -29,6 +29,13 @@ describe('AddressSelector', () => {
         });
     });
 
+    describe('#getStreet2()', () => {
+        it('returns the correct street2 value', () => {
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+            expect(accessor.getStreet2()).toBe('unit 6');
+        });
+    });
+
     describe('#getCountry()', () => {
         it('returns the correct country', () => {
             const accessor = new AddressSelector(googleAutoCompleteResponseMock);

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelector.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelector.ts
@@ -22,7 +22,7 @@ export default class AddressSelector {
     }
 
     getStreet2(): string {
-        return '';
+        return this._get('subpremise', 'short_name');
     }
 
     getCity(): string {

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
@@ -3,6 +3,13 @@ export function getGoogleAutocompletePlaceMock(): google.maps.places.PlaceResult
         name: '1-3 Smail St',
         address_components: [
             {
+                long_name: 'unit 6',
+                short_name: 'unit 6',
+                types: [
+                    'subpremise',
+                ],
+            },
+            {
                 long_name: '1-3 (l)',
                 short_name: '1-3 (s)',
                 types: [

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
@@ -49,4 +49,5 @@ export type GoogleAddressFieldType =
     'street_number' |
     'route' |
     'political' |
-    'country';
+    'country' |
+    'subpremise';


### PR DESCRIPTION
## What?
Fix issue with google address auto complete

## Why?
As of now if an address with a subpremise is returned we don't map it to the shipping address form. Hence we need to add subpremise to address mapper that can place the form value correctly.

## Testing / Proof
- Circle
- Screencast


https://user-images.githubusercontent.com/7134802/177555440-d3a97b46-7cf9-46c7-a5f5-98ebfdd9e8f7.mov


@bigcommerce/checkout
