### PR TITLE
feat(payment): INT-6115 Worldpay - remove unnecessary iframe

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -302,6 +302,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             selectedMethod.id === PaymentMethodId.Quadpay ||
             selectedMethod.id === PaymentMethodId.SagePay ||
             selectedMethod.id === PaymentMethodId.Sezzle ||
+            selectedMethod.id === PaymentMethodId.WorldpayAccess ||
             selectedMethod.id === PaymentMethodId.Zip ||
             selectedMethod.gateway === PaymentMethodId.AdyenV2 ||
             selectedMethod.gateway === PaymentMethodId.AdyenV2GooglePay ||

--- a/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.tsx
@@ -9,7 +9,6 @@ export type WorldpayCreditCardPaymentMethodProps = HostedCreditCardPaymentMethod
 
 interface WorldpayPaymentMethodRef {
     paymentPageContentRef: RefObject<HTMLDivElement>;
-    paymentPageContentMetaDataRef: RefObject<HTMLDivElement>;
     cancelThreeDSecureVerification?(): void;
 }
 
@@ -18,11 +17,9 @@ const WorldpayCreditCardPaymentMethod: FunctionComponent<WorldpayCreditCardPayme
     ...rest
 }) => {
     const [threeDSecureVerification, setThreeDSecureVerification] = useState<HTMLElement>();
-    const [metadata, setMetadata] = useState<HTMLElement>();
 
     const ref = useRef<WorldpayPaymentMethodRef>({
         paymentPageContentRef: createRef(),
-        paymentPageContentMetaDataRef: createRef(),
     });
 
     const cancelWorldpayModalFlow = useCallback(() => {
@@ -40,7 +37,6 @@ const WorldpayCreditCardPaymentMethod: FunctionComponent<WorldpayCreditCardPayme
             worldpay: {
                 onLoad(content: HTMLIFrameElement, cancel: () => void) {
                     setThreeDSecureVerification(content);
-                    setMetadata(content);
                     ref.current.cancelThreeDSecureVerification = cancel;
                 },
             },
@@ -48,14 +44,10 @@ const WorldpayCreditCardPaymentMethod: FunctionComponent<WorldpayCreditCardPayme
     }, [initializePayment]);
 
     const appendPaymentPageContent = useCallback(() => {
-        if (ref.current.paymentPageContentRef.current && threeDSecureVerification) {
-            ref.current.paymentPageContentRef.current.appendChild(threeDSecureVerification);
+        if (threeDSecureVerification) {
+            ref.current.paymentPageContentRef.current?.appendChild(threeDSecureVerification);
         }
     }, [threeDSecureVerification]);
-
-    if (metadata) {
-        ref.current.paymentPageContentMetaDataRef.current?.appendChild(metadata);
-    }
 
     return <>
         <HostedCreditCardPaymentMethod
@@ -70,7 +62,6 @@ const WorldpayCreditCardPaymentMethod: FunctionComponent<WorldpayCreditCardPayme
         >
             <div ref={ ref.current.paymentPageContentRef } />
         </Modal>
-        <div hidden ref={ ref.current.paymentPageContentMetaDataRef } />
     </>;
 };
 


### PR DESCRIPTION
## What? [INT-6115](https://bigcommercecloud.atlassian.net/browse/INT-6115)
Remove unecessary code to pay

## Why?
the iframe is going to be insert using sdk code

## Testing / Proof
https://drive.google.com/file/d/1zfe8vvwITn2uoZ-RKOjXuabQcnK2fpcf/view?usp=sharing

@bigcommerce/checkout
