### PR TITLE
chore(checkout): INT-6276 bump checkout-sdk-js version 1.265.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.264.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.264.1.tgz",
-      "integrity": "sha512-7CorQcHVITf/DONzEHx9dBEnhZSryEGUgCJEff8qDdkwd/cDagPPFbrHLZvndKkJrzRbzSS10U2XVaEbhVtzLg==",
+      "version": "1.265.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.265.0.tgz",
+      "integrity": "sha512-XOCaBaqb/DxeprpU+LMfYaEzsldnDXdZLjhM2ZwA+Jo0C+2Ls8dFvlk9hUkslBTNI6xqE49Zq1tZg31O0nUJFA==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.259.0",
+    "@bigcommerce/checkout-sdk": "^1.265.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
Release the change: https://github.com/bigcommerce/checkout-sdk-js/releases/tag/v1.265.0

## Testing / Proof


@bigcommerce/checkout @bigcommerce/apex-integrations 
