### PR TITLE
chore(payment): PAYPAL-1555 bump up checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.266.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.266.0.tgz",
-      "integrity": "sha512-3HU5VCHV57o3Vk960hpj0pWiUMlksnD/KAoaggn0CX0sv37WQI1LvXKNM73vzDpGhS3y+4ySvHxx22GPBUhN/g==",
+      "version": "1.266.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.266.1.tgz",
+      "integrity": "sha512-QI7W+i3R25mPjENK9tw9+pZiUoVvysfX4Qvj6oSkGXfzOfVV37g03PO4eOttZCazhzdyPEElMfF3r4/IqptWzQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.266.0",
+    "@bigcommerce/checkout-sdk": "^1.266.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump up checkout-sdk-js version

## Why?
Due the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1555

## Testing / Proof
Unit tests
Manual tests
