### PR TITLE
fix(checkout): CHECKOUT-6760 [Accessibility] - simplymedical.com - Ensure color is not the sole means of indicating error messages

### DIFF
--- a/packages/core/src/app/customer/CreateAccountForm.spec.tsx
+++ b/packages/core/src/app/customer/CreateAccountForm.spec.tsx
@@ -71,6 +71,33 @@ describe('CreateAccountForm Component', () => {
         });
     });
 
+    it.each([['Password needs to contain a letter', '1234567'], ['Password needs to contain a number', 'abcdefg'], ['Password is too short', '1a']]) ('renders correct error when %s', async (expected, passwordCase) => {
+        const onSubmit = jest.fn();
+
+        component = mount(
+            <LocaleContext.Provider value={ localeContext }>
+                <CreateAccountForm
+                    formFields={ formFields }
+                    onSubmit={ onSubmit }
+                    requiresMarketingConsent={ false }
+                />
+            </LocaleContext.Provider>
+        );
+
+        component.find('input[name="password"]')
+            .simulate('change', { target: { value: passwordCase, name: 'password' } });
+
+        component.find('form')
+            .simulate('submit');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        component.update();
+
+        expect(component.find('#password-field-error-message').text())
+            .toEqual(expected);
+    });
+
     it('calls onCancel', () => {
         const onCancel = jest.fn();
 

--- a/packages/core/src/app/customer/getCreateCustomerValidationSchema.ts
+++ b/packages/core/src/app/customer/getCreateCustomerValidationSchema.ts
@@ -57,10 +57,10 @@ export default memoize(function getCreateCustomerValidationSchema({
             firstName: string().required(language.translate('address.first_name_required_error')),
             lastName: string().required(language.translate('address.last_name_required_error')),
             password: string()
-                .required(description || language.translate('customer.password_required_error'))
-                .matches(numeric, description || language.translate('customer.password_number_required_error'))
-                .matches(alpha, description || language.translate('customer.password_letter_required_error'))
-                .min(minLength, description || language.translate('customer.password_under_minimum_length_error'))
+                .required(language.translate('customer.password_required_error') || description)
+                .matches(numeric, language.translate('customer.password_number_required_error') || description)
+                .matches(alpha, language.translate('customer.password_letter_required_error') || description)
+                .min(minLength, language.translate('customer.password_under_minimum_length_error' || description))
                 .max(100, language.translate('customer.password_over_maximum_length_error')),
         })
         .concat(getEmailValidationSchema({ language }))


### PR DESCRIPTION
## What?
Reversing order for description and custom errors for password related error messages in the create customer form validation.

## Why?
Currently custom password related errors are not rendered on the create customer form during checkout. This is because the default description is evaluated and used first. This change will first check for a custom error message instead.

## Testing / Proof
Before:
![Screen Shot 2022-07-19 at 3 24 08 PM](https://user-images.githubusercontent.com/20911717/179843126-2945e2ae-c8b3-4279-a73a-30ba0a44efe2.png)
(note that the password error message is the default one)
After:
![Screen Shot 2022-07-19 at 3 10 15 PM](https://user-images.githubusercontent.com/20911717/179843083-5361a374-f327-45e6-b39b-0e47342f6b61.png)
(password error message is now read from the locale language file and updates based on what condition is failing)

@bigcommerce/checkout
