### PR TITLE
feat(checkout): CHECKOUT-0000 Update e2e tests local env entry point

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,5 @@
-import dotenv from 'dotenv';
+import 'dotenv/config'
 import { devices, PlaywrightTestConfig } from '@playwright/test';
-
-dotenv.config();
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/tests/fixture/pageObject/playwright/PlaywrightHelper.ts
+++ b/tests/fixture/pageObject/playwright/PlaywrightHelper.ts
@@ -31,7 +31,7 @@ export class PlaywrightHelper {
 
     async goto(): Promise<void> {
         if (this.isReplay) {
-            await this.page.goto('/');
+            await this.page.goto('/checkout');
         } else {
             await this.page.goto(this.storeUrl + '/checkout');
         }
@@ -53,7 +53,7 @@ export class PlaywrightHelper {
             // creating local checkout environment during replay
             this.polly.enableReplay(this.storeUrl);
             const { checkoutId, orderId } = this.polly.getCartAndOrderIDs();
-            await this.renderAndRoute('/', './tests/support/checkout.ejs', { checkoutId });
+            await this.renderAndRoute('/checkout', './tests/support/checkout.ejs', { checkoutId });
             await this.renderAndRoute(/order-confirmation.*/, './tests/support/orderConfirmation.ejs', { orderId });
         }
     }
@@ -75,7 +75,7 @@ export class PlaywrightHelper {
         if (includes(filePath, 'ejs')) {
             const localhostUrl = 'http://localhost:' + process.env.PORT;
             const storeUrl = this.isReplay ? localhostUrl : this.storeUrl;
-            const checkoutUrl = this.isReplay ? localhostUrl : storeUrl + '/checkout';
+            const checkoutUrl = this.isReplay ? localhostUrl + '/checkout' : storeUrl + '/checkout';
             const htmlStr = await this.server.renderFile(filePath, { ...data, localhostUrl, storeUrl, checkoutUrl });
             await this.page.route(url, route => route.fulfill({
                 status: 200,


### PR DESCRIPTION
## What?
Change local e2e testing environment entry point from `http://localhost:port` to `http://localhost:port/checkout`.

## Why?
The local testing environment is more in line with a dev store environment.
Checkout page always has a path name, `checkout`.

## Testing / Proof
https://user-images.githubusercontent.com/88361607/179891322-fd310ea4-da9f-4580-b18a-86dfa19ac375.mov