### PR TITLE
chore(payment): PAYPAL-1567 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.267.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.267.0.tgz",
-      "integrity": "sha512-iaFN1ZOBibhYOeJR88nvcrvf00PZabM8Yz+T6aHwQa7svm6kFus0PTsI/ZC45aLeuzLyqeX1XSVnIZW5GLMuTA==",
+      "version": "1.269.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.269.0.tgz",
+      "integrity": "sha512-5j+1bQDTq/uFkfxusvOyJTNnWIif63AzT0+7ok71SPzbt3xZoq1HgeaHwB72kt77EWxHCVYTSeeUQNj1yEbytg==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.267.0",
+    "@bigcommerce/checkout-sdk": "^1.269.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump up checkout sdk version

## Why?
Due the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1567

## Testing / Proof
Unit tests
Manual tests
CI tests
