### PR TITLE
fix(checkout): ADYEN-0000 fixed payment provider title css

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -230,20 +230,21 @@ const PaymentMethodTitle: FunctionComponent<PaymentMethodTitleProps & WithLangua
 
     return (
         <div className="paymentProviderHeader-container">
-            { logoUrl && <img
-                alt={ methodName }
-                className="paymentProviderHeader-img"
-                data-test="payment-method-logo"
-                src={ logoUrl }
-            /> }
+            <div className="paymentProviderHeader-nameContainer">
+                { logoUrl && <img
+                    alt={ methodName }
+                    className="paymentProviderHeader-img"
+                    data-test="payment-method-logo"
+                    src={ logoUrl }
+                /> }
 
-            { titleText && <div
-                className="paymentProviderHeader-name"
-                data-test="payment-method-name"
-            >
-                { titleText }
-            </div> }
-
+                { titleText && <div
+                    className="paymentProviderHeader-name"
+                    data-test="payment-method-name"
+                >
+                    { titleText }
+                </div> }
+            </div>
             <div className="paymentProviderHeader-cc">
                 <CreditCardIconList
                     cardTypes={ compact(method.supportedCards.map(mapFromPaymentMethodCardType)) }

--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -2,6 +2,12 @@
 // PAYMENT PROVIDER (Component)
 // =============================================================================
 .paymentProviderHeader-container {
+    align-items: start;
+    display: flex;
+    justify-content: space-between;
+}
+
+.paymentProviderHeader-nameContainer {
     display: flex;
     justify-content: space-between;
 }


### PR DESCRIPTION
## What?
Fixed styles for the payment provider title.
Markup breaks when there are multiple rows of accepted cards 

## Why?
Markup breaks when there are multiple rows of accepted cards 

## Testing / Proof
before
![image](https://user-images.githubusercontent.com/79574476/180025381-a44e5d52-bd85-481e-aa9a-10c2c0eb5138.png)
after
![image](https://user-images.githubusercontent.com/79574476/180025501-1692c0e4-ca38-4a01-b199-ca0d5d02a512.png)

@bigcommerce/checkout
