### PR TITLE
feat(payment): STRIPE-82 Add code to show images on the list

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -30,6 +30,7 @@ function getPaymentMethodTitle(
     const cdnPath = (path: string) => `${basePath}${path}`;
 
     return method => {
+        const paymentWithLogo = method.initializationData?.methodsWithLogo ? method.initializationData.methodsWithLogo : [];
         const methodName = getPaymentMethodName(language)(method);
         const methodDisplayName = getPaymentMethodDisplayName(language)(method);
         // TODO: API could provide the data below so UI can read simply read it.
@@ -165,11 +166,11 @@ function getPaymentMethodTitle(
                 titleText: methodName,
             },
             [PaymentMethodId.StripeV3]: {
-                logoUrl: ['credit_card', 'card'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/stripe-${method.id.toLowerCase()}.svg`),
+                logoUrl: paymentWithLogo.includes(method.id) ? cdnPath(`/img/payment-providers/stripe-${method.id.toLowerCase()}.svg`) : '',
                 titleText: method.method === 'iban' ? language.translate('payment.stripe_sepa_display_name_text') : methodName,
             },
             [PaymentMethodId.StripeUPE]: {
-                logoUrl: ['credit_card', 'card'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/stripe-${method.id.toLowerCase()}.svg`),
+                logoUrl: paymentWithLogo.includes(method.id) ? cdnPath(`/img/payment-providers/stripe-${method.id.toLowerCase()}.svg`) : '',
                 titleText: method.method === 'iban' ? language.translate('payment.stripe_sepa_display_name_text') : methodName,
             },
             [PaymentMethodId.WorldpayAccess]: {

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -165,11 +165,11 @@ function getPaymentMethodTitle(
                 titleText: methodName,
             },
             [PaymentMethodId.StripeV3]: {
-                logoUrl: '',
+                logoUrl: ['credit_card', 'card'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/stripe-${method.id.toLowerCase()}.svg`),
                 titleText: method.method === 'iban' ? language.translate('payment.stripe_sepa_display_name_text') : methodName,
             },
             [PaymentMethodId.StripeUPE]: {
-                logoUrl: '',
+                logoUrl: ['credit_card', 'card'].includes(method.id) ? '' : cdnPath(`/img/payment-providers/stripe-${method.id.toLowerCase()}.svg`),
                 titleText: method.method === 'iban' ? language.translate('payment.stripe_sepa_display_name_text') : methodName,
             },
             [PaymentMethodId.WorldpayAccess]: {


### PR DESCRIPTION
## What? [STRIPE-82](https://bigcommercecloud.atlassian.net/browse/STRIPE-82)

Add images between list for payments providers

## Why?

Display the payment method’s logo next the payment method radio selector label for the following payment methods

## Testing / Proof

<img width="584" alt="Screen Shot 2022-07-22 at 15 49 17" src="https://user-images.githubusercontent.com/25911489/180575137-df8738c8-ea74-4b49-b104-be3baedc7e2b.png">

<img width="571" alt="Screen Shot 2022-07-22 at 16 06 32" src="https://user-images.githubusercontent.com/25911489/180575152-754a9329-0384-4ec4-9e64-56a580b23287.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
