### PR TITLE
fix(payment): INT-5854 [Mollie] Klarna is not available if cart contains digital products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.278.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.278.1.tgz",
-      "integrity": "sha512-Ruk6muMgzFvtpluuZwnPm7DPYUaNcFwNXxibZzlgBMiVWksrl/4/BqQkzzXu8sLW3JEt2n0s6nh6OV4876XPlA==",
+      "version": "1.279.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.279.0.tgz",
+      "integrity": "sha512-Gik4pyXqb6RCAcbi2Zktanf+yGdmuR2xt0SJvANsEGpyuG8VUpqAa7WgSWAxYAaiEyGBRdxzmYbe1YbAr1GnNw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.278.1",
+    "@bigcommerce/checkout-sdk": "^1.279.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/locale/translations/da.json
+++ b/packages/core/src/app/locale/translations/da.json
@@ -239,6 +239,7 @@
             "klarna_continue_action": "Fortsæt med Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Denne betalingsmetode kan ikke bruges til køb af digitale produkter. Kontakt kundeservice eller prøv igen.",
             "opy_continue_action": "Fortsæt med {methodName}",
             "opy_widget_slogan": "Køb nu. Betal smartere.",
             "opy_widget_info": "Du vil blive omdirigeret til {methodName}s websted for at fuldføre din ordre, når du klikker på \"Fortsæt med {methodName}\"",

--- a/packages/core/src/app/locale/translations/de.json
+++ b/packages/core/src/app/locale/translations/de.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Weiter mit Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Diese Zahlungsmethode kann nicht für den Kauf von digitalen Produkten verwendet werden. Bitte kontaktieren Sie den Kundendienst oder versuchen Sie es erneut.",
             "opy_continue_action": "Weiter mit Openpay",
             "orbital_continue_action": "Bestellung aufgeben",
             "orbital_description_text": "Mit Ihrem ChasePay-Konto bezahlen",

--- a/packages/core/src/app/locale/translations/en.json
+++ b/packages/core/src/app/locale/translations/en.json
@@ -241,6 +241,7 @@
             "klarna_continue_action": "Continue with Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "This payment method cannot be used towards the purchase of digital products. Please contact customer support or try again.",
             "opy_continue_action": "Continue with {methodName}",
             "opy_widget_slogan": "Buy now. Pay smarter.",
             "opy_widget_info": "You will be redirected to {methodName}'s website to complete your order when you click \"Continue with {methodName}\"",

--- a/packages/core/src/app/locale/translations/es-419.json
+++ b/packages/core/src/app/locale/translations/es-419.json
@@ -239,6 +239,7 @@
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pago no puede utilizarse para la compra de productos digitales. Ponte en contacto con el servicio de atención al cliente o inténtalo de nuevo.",
             "opy_continue_action": "Continuar con {methodName}",
             "opy_widget_slogan": "Compra ahora. Paga de manera más inteligente.",
             "opy_widget_info": "Se te redirigirá al sitio web de {methodName} para que completes tu pedido cuando hagas clic en “Continuar con {methodName}“",

--- a/packages/core/src/app/locale/translations/es-AR.json
+++ b/packages/core/src/app/locale/translations/es-AR.json
@@ -239,6 +239,7 @@
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pago no puede utilizarse para la compra de productos digitales. Ponte en contacto con el servicio de atención al cliente o inténtalo de nuevo.",
             "opy_continue_action": "Continuar con {methodName}",
             "opy_widget_slogan": "Compra ahora. Paga de manera más inteligente.",
             "opy_widget_info": "Se te redirigirá al sitio web de {methodName} para que completes tu pedido cuando hagas clic en “Continuar con {methodName}“",

--- a/packages/core/src/app/locale/translations/es-CL.json
+++ b/packages/core/src/app/locale/translations/es-CL.json
@@ -239,6 +239,7 @@
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pago no puede utilizarse para la compra de productos digitales. Ponte en contacto con el servicio de atención al cliente o inténtalo de nuevo.",
             "opy_continue_action": "Continuar con {methodName}",
             "opy_widget_slogan": "Compra ahora. Paga de manera más inteligente.",
             "opy_widget_info": "Se te redirigirá al sitio web de {methodName} para que completes tu pedido cuando hagas clic en “Continuar con {methodName}“",

--- a/packages/core/src/app/locale/translations/es-CO.json
+++ b/packages/core/src/app/locale/translations/es-CO.json
@@ -239,6 +239,7 @@
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pago no puede utilizarse para la compra de productos digitales. Ponte en contacto con el servicio de atención al cliente o inténtalo de nuevo.",
             "opy_continue_action": "Continuar con {methodName}",
             "opy_widget_slogan": "Compra ahora. Paga de manera más inteligente.",
             "opy_widget_info": "Se te redirigirá al sitio web de {methodName} para que completes tu pedido cuando hagas clic en “Continuar con {methodName}“",

--- a/packages/core/src/app/locale/translations/es-MX.json
+++ b/packages/core/src/app/locale/translations/es-MX.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pago no puede utilizarse para la compra de productos digitales. Ponte en contacto con el servicio de atención al cliente o inténtalo de nuevo.",
             "opy_continue_action": "Continuar con Openpay",
             "orbital_continue_action": "Realizar pedido",
             "orbital_description_text": "Paga con tu cuenta de ChasePay",

--- a/packages/core/src/app/locale/translations/es-PE.json
+++ b/packages/core/src/app/locale/translations/es-PE.json
@@ -239,6 +239,7 @@
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pago no puede utilizarse para la compra de productos digitales. Ponte en contacto con el servicio de atención al cliente o inténtalo de nuevo.",
             "opy_continue_action": "Continuar con {methodName}",
             "opy_widget_slogan": "Compra ahora. Paga de manera más inteligente.",
             "opy_widget_info": "Se te redirigirá al sitio web de {methodName} para que completes tu pedido cuando hagas clic en “Continuar con {methodName}“",

--- a/packages/core/src/app/locale/translations/es.json
+++ b/packages/core/src/app/locale/translations/es.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Continuar con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pago no puede utilizarse para la compra de productos digitales. Ponte en contacto con el servicio de atención al cliente o inténtalo de nuevo.",
             "opy_continue_action": "Continuar con Openpay",
             "orbital_continue_action": "Realizar pedido",
             "orbital_description_text": "Pagar con su cuenta de ChasePay",

--- a/packages/core/src/app/locale/translations/fr.json
+++ b/packages/core/src/app/locale/translations/fr.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Poursuivre avec Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Ce mode de paiement ne peut pas être utilisé pour l'achat de produits numériques. Veuillez contacter le service clientèle ou réessayer.",
             "opy_continue_action": "Continuer avec Openpay",
             "orbital_continue_action": "Passer commande",
             "orbital_description_text": "Payer avec mon compte Chase Pay",

--- a/packages/core/src/app/locale/translations/it.json
+++ b/packages/core/src/app/locale/translations/it.json
@@ -236,6 +236,7 @@
             "klarna_continue_action": "Prosegui con Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Questo metodo di pagamento non può essere utilizzato per l'acquisto di prodotti digitali. Contattare l'assistenza clienti o riprovare.",
             "opy_continue_action": "Continua con Openpay",
             "orbital_continue_action": "Effettua ordine",
             "orbital_description_text": "Paga dal tuo conto ChasePay",

--- a/packages/core/src/app/locale/translations/nl.json
+++ b/packages/core/src/app/locale/translations/nl.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Doorgaan met Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Deze betaalmethode kan niet worden gebruikt voor de aankoop van digitale producten. Neem contact op met de klantenservice of probeer het opnieuw.",
             "opy_continue_action": "Doorgaan met Openpay",
             "orbital_continue_action": "Bestelling plaatsen",
             "orbital_description_text": "Betalen met uw ChasePay-account",

--- a/packages/core/src/app/locale/translations/no.json
+++ b/packages/core/src/app/locale/translations/no.json
@@ -239,6 +239,7 @@
             "klarna_continue_action": "Fortsett med Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Denne betalingsmåten kan ikke brukes til kjøp av digitale produkter. Kontakt kundestøtte eller prøv igjen.",
             "opy_continue_action": "Fortsett med {methodName}",
             "opy_widget_slogan": "Kjøp nå. Betal smartere.",
             "opy_widget_info": "Du vil bli omdirigert til nettstedet til {methodName} for å fullføre bestillingen når du klikker på «Fortsett med {methodName}»",

--- a/packages/core/src/app/locale/translations/pt-BR.json
+++ b/packages/core/src/app/locale/translations/pt-BR.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Continuar com o Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Esta forma de pagamento não pode ser utilizada para a compra de produtos digitais. Favor entrar em contato com o suporte ao cliente ou tente novamente.",
             "opy_continue_action": "Continuar com o Openpay",
             "orbital_continue_action": "Comprar",
             "orbital_description_text": "Pague com a sua conta do ChasePay",

--- a/packages/core/src/app/locale/translations/pt.json
+++ b/packages/core/src/app/locale/translations/pt.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Continuar com o Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Este método de pagamento não pode ser utilizado para a compra de produtos digitais. Por favor contacte o apoio ao cliente ou tente novamente.",
             "opy_continue_action": "Continuar com o Openpay",
             "orbital_continue_action": "Comprar",
             "orbital_description_text": "Pague com a sua conta do ChasePay",

--- a/packages/core/src/app/locale/translations/sv.json
+++ b/packages/core/src/app/locale/translations/sv.json
@@ -237,6 +237,7 @@
             "klarna_continue_action": "Fortsätt med Klarna",
             "klarna_name_text": "Klarna",
             "masterpass_name_text": "Masterpass",
+            "mollie_unsupported_method_error": "Denna betalningsmetod kan inte användas för att köpa digitala produkter. Kontakta kundtjänst eller försök igen.",
             "opy_continue_action": "Fortsätt med Openpay",
             "orbital_continue_action": "Beställ",
             "orbital_description_text": "Betala med ditt ChasePay-konto",

--- a/packages/core/src/app/payment/paymentMethod/MolliePaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/MolliePaymentMethod.spec.tsx
@@ -198,6 +198,8 @@ describe('MolliePaymentMethod', () => {
                              },
                         },
                     },
+                    unsupportedMethodMessage: "This payment method cannot be used towards the purchase of digital products. Please contact customer support or try again.",
+                    disableButton: expect.any(Function)
                 },
             }));
     });


### PR DESCRIPTION
## What? [INT-5854](https://bigcommercecloud.atlassian.net/browse/INT-5854)
I want to hide any Klarna Pay Later and Klarna Slice It from shoppers if their cart contains digital products

## Why?
So that I can prevent shoppers from trying to pay for an ineligible cart and getting an error

## Testing / Proof

Before
https://user-images.githubusercontent.com/104527753/180102690-63e27651-3e1d-466b-bc3d-24f71aaf2b78.mov

After
https://user-images.githubusercontent.com/104527753/180099759-592b8826-6aea-4258-a53c-4835332259d4.mov

Dependency of 

- https://github.com/bigcommerce/checkout-js/pull/969

@bigcommerce/checkout @bigcommerce/apex-integrations 