### PR TITLE
Fix(payment): STRIPE-53 Give more information on payment authentication with 3ds failure error message

### DIFF
--- a/packages/core/src/app/locale/translations/en.json
+++ b/packages/core/src/app/locale/translations/en.json
@@ -232,6 +232,7 @@
             "credit_card_number_required_error": "Credit Card Number is required",
             "credit_card_number_mismatch_error": "The card number entered does not match the card stored in your account",
             "credit_debit_card_text": "Credit/Debit Card",
+            "stripev3_auth_3ds_fail": "User did not authenticate",
             "digitalriver_dropin_error": "There was an error while processing your payment. Please try again or contact us.",
             "digitalriver_checkout_error": "There was a problem with your checkout, please check your details and try again or contact customer service",
             "digitalriver_checkout_error_title": "Error while processing request.",

--- a/packages/core/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripePaymentMethod.spec.tsx
@@ -102,6 +102,26 @@ describe('when using Stripe payment', () => {
                 }));
         });
 
+        it('return stripe v3 3ds auth failure', () => {
+
+            const authFail3ds = Object.create(new Error('Something went wrong.'));
+            authFail3ds.name = 'StripeV3Error';
+            authFail3ds.type = 'stripev3_error';
+            authFail3ds.subtype = 'auth_failure';
+
+
+            mount(<PaymentMethodTest { ...defaultProps } method={ method } />)
+                .find(HostedWidgetPaymentMethod)
+                .props()
+                .onUnhandledError(authFail3ds);
+
+            expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(
+                new Error(
+                    localeContext.language.translate('payment.stripev3_auth_3ds_fail')
+                )
+            );
+        });
+
         it('initializes method with required config', () => {
             const container = mount(<PaymentMethodTest { ...defaultProps } method={ method } />);
             const component: ReactWrapper<HostedWidgetPaymentMethodProps> = container.find(HostedWidgetPaymentMethod);


### PR DESCRIPTION
## What?
Alteration of error message when stripe 3DS auth fails

## Why?
To give more information to the user about the failure


## Testing / Proof
<img width="755" alt="Screen Shot 2022-07-21 at 15 07 03" src="https://user-images.githubusercontent.com/106765049/180305882-7e0ed984-43b6-4fda-b456-e6d7705a4be8.png">


@bigcommerce/checkout 

## Dependency of  
https://github.com/bigcommerce/checkout-sdk-js/pull/1488