### PR TITLE
feat(payment): PAYPAL-1445 fixed storeCredit checkbox

### DIFF
--- a/packages/core/src/app/payment/Payment.spec.tsx
+++ b/packages/core/src/app/payment/Payment.spec.tsx
@@ -243,6 +243,23 @@ describe('Payment', () => {
             .toHaveBeenCalledWith(false);
     });
 
+    it('calls handleStoreCreditChange when component did mount', async () => {
+        jest.spyOn(checkoutService, 'applyStoreCredit')
+            .mockResolvedValue(checkoutState);
+        const defaultProps = {
+            onSubmit: jest.fn(),
+            onSubmitError: jest.fn(),
+            onUnhandledError: jest.fn(),
+            usableStoreCredit: 10,
+        }
+        mount(<PaymentTest { ...defaultProps } />);
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutService.applyStoreCredit)
+            .toHaveBeenCalledWith(true);
+    });
+
     it('sets default selected payment method', async () => {
         const container = mount(<PaymentTest { ...defaultProps } />);
 

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -93,7 +93,12 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             onFinalizeError = noop,
             onReady = noop,
             onUnhandledError = noop,
+            usableStoreCredit,
         } = this.props;
+
+        if (usableStoreCredit) {
+            this.handleStoreCreditChange(true);
+        }
 
         try {
             await loadPaymentMethods();


### PR DESCRIPTION
## What?
Fixed storeCredit checkbox behaviour

## Why?
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1445

## Testing / Proof

https://user-images.githubusercontent.com/56301104/180470438-a24fd5a7-6158-4433-bd2a-d3f4bb746d7f.mov



@bigcommerce/checkout
