### PR TITLE
feat(checkout): STRF-9829 Redirect to cart on sign-out if prices are hidden from guests

### DIFF
--- a/packages/core/src/app/checkout/Checkout.spec.tsx
+++ b/packages/core/src/app/checkout/Checkout.spec.tsx
@@ -462,6 +462,41 @@ describe('Checkout', () => {
                 .toHaveBeenCalled();
         });
 
+        it('navigates to cart page after sign out if prices are restricted to login', () => {
+            checkoutState = { ...checkoutState };
+
+            Object.defineProperty(window, 'top', {
+                value: {
+                    location: {
+                        assign: jest.fn(),
+                    },
+                },
+                writable: true,
+            });
+
+            jest.spyOn(checkoutState.data, 'getCustomer')
+                .mockReturnValue(getCustomer());
+
+            jest.spyOn(checkoutState.data, 'getConfig')
+                .mockReturnValue({
+                    ...getStoreConfig(),
+                    displaySettings: {
+                        hidePriceFromGuests: true,
+                    },
+                });
+
+            container = mount(<CheckoutTest { ...defaultProps } />);
+
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            (container.find(CustomerInfo) as ReactWrapper<CustomerInfoProps>)
+                .prop('onSignOut')!({ isCartEmpty: false });
+            
+            const cartUrl = getStoreConfig().links.cartLink;
+
+            expect(window.top.location.href)
+                .toEqual(cartUrl);
+        });
+
         it('logs unhandled error', () => {
             const error = new Error();
 

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -88,7 +88,9 @@ export interface WithCheckoutProps {
     isGuestEnabled: boolean;
     isLoadingCheckout: boolean;
     isPending: boolean;
+    isPriceHiddenFromGuests: boolean;
     loginUrl: string;
+    cartUrl: string;
     createAccountUrl: string;
     canCreateAccountInCheckout: boolean;
     promotions?: Promotion[];
@@ -580,7 +582,11 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
     };
 
     private handleSignOut: (event: CustomerSignOutEvent) => void = ({ isCartEmpty }) => {
-        const { loginUrl, isGuestEnabled } = this.props;
+        const { loginUrl, cartUrl, isPriceHiddenFromGuests, isGuestEnabled } = this.props;
+
+        if (isPriceHiddenFromGuests) {
+            return window.top.location.href = cartUrl;
+        }
 
         if (this.embeddedMessenger) {
             this.embeddedMessenger.postSignedOut();

--- a/packages/core/src/app/checkout/mapToCheckoutProps.ts
+++ b/packages/core/src/app/checkout/mapToCheckoutProps.ts
@@ -21,7 +21,11 @@ export default function mapToCheckoutProps(
         links: {
             loginLink: loginUrl = '',
             createAccountLink: createAccountUrl = '',
+            cartLink: cartUrl = '',
         } = {},
+        displaySettings: {
+            hidePriceFromGuests: isPriceHiddenFromGuests = false,
+        } = {}
     } = data.getConfig() || {};
 
     const subscribeToConsignmentsSelector = createSelector(
@@ -40,8 +44,10 @@ export default function mapToCheckoutProps(
         isGuestEnabled,
         isLoadingCheckout: statuses.isLoadingCheckout(),
         isPending: statuses.isPending(),
+        isPriceHiddenFromGuests,
         loadCheckout: checkoutService.loadCheckout,
         loginUrl,
+        cartUrl,
         createAccountUrl,
         canCreateAccountInCheckout: features['CHECKOUT-4941.account_creation_in_checkout'],
         promotions,

--- a/packages/core/src/app/config/config.mock.ts
+++ b/packages/core/src/app/config/config.mock.ts
@@ -6,8 +6,9 @@ export function getStoreConfig(): StoreConfig {
         inputDateFormat: 'dd/MM/yyyy',
         displayDateFormat: 'dd/MM/yyyy',
         formFields: {
-            shippingAddressFields: [],
-            billingAddressFields: [],
+            shippingAddress: [],
+            billingAddress: [],
+            customerAccount: [],
         },
         checkoutSettings: {
             checkoutBillingSameAsShippingEnabled: true,
@@ -18,12 +19,15 @@ export function getStoreConfig(): StoreConfig {
             hasMultiShippingEnabled: true,
             guestCheckoutEnabled: true,
             isAnalyticsEnabled: true,
+            isAccountCreationEnabled: true,
             isCardVaultingEnabled: true,
             isPaymentRequestEnabled: false,
             isPaymentRequestCanMakePaymentEnabled: false,
             isSpamProtectionEnabled: false,
+            isStorefrontSpamProtectionEnabled: false,
             isCouponCodeCollapsed: true,
             isTrustedShippingAddressEnabled: true,
+            isSignInEmailEnabled: false,
             orderTermsAndConditions: '',
             orderTermsAndConditionsLink: '',
             orderTermsAndConditionsType: '',
@@ -95,6 +99,7 @@ export function getStoreConfig(): StoreConfig {
             orderEmail: 's1504098821@example.com',
             shopPath: 'https://store-k1drp8k8.bcapp.dev',
             storeCountry: 'United States',
+            storeCountryCode: 'US',
             storeHash: 'k1drp8k8',
             storeId: '1504098821',
             storeName: 's1504098821',
@@ -112,6 +117,9 @@ export function getStoreConfig(): StoreConfig {
             isTransactional: true,
             thousandsSeparator: ',',
             exchangeRate: 1.12,
+        },
+        displaySettings: {
+            hidePriceFromGuests: false,
         },
     };
 }


### PR DESCRIPTION
### JIRA: [STRF-9829](https://bigcommercecloud.atlassian.net/browse/STRF-9829)

### Depends on:
- https://github.com/bigcommerce/checkout-sdk-js/pull/1521

## What?
When a user clicks the "Sign Out" button during checkout while the "HidePriceFromGuests" configuration is turned on, they will be redirected to the cart page.

## Why?
**STRF-9829** will move the "Hide pricing for guests" functionality into store/channel configuration. While prices are restricted to login, we should redirect a user to the cart page if the log out during the checkout. This ensures stability and will prevent prices from being exposed if a customer signs out during the checkout.

Typically, a merchant would use the checkout setting to require an account. However, if prices should be hidden for guests, we should redirect back to the cart page on sign-out to ensure prices are not visible to the guest.

## Testing / Proof
- Added Unit Tests
- Video proof below

**BigCommerce Storefront:**


https://user-images.githubusercontent.com/19815878/181115867-441cfd19-2984-448d-bd74-ce77036896c8.mov

**Headless Embedded Checkout with HidePriceFromGuests enabled on the channel (redirects to channel cart route):**


https://user-images.githubusercontent.com/19815878/181116393-b7199a4f-cea4-4f65-998a-e11ad59ba6fa.mov

**Headless Redirected Checkout with HidePriceFromGuests enabled on the channel:**


https://user-images.githubusercontent.com/19815878/181116703-74c1df59-046e-4a6b-9445-39329922f024.mov



@bigcommerce/checkout
