### PR TITLE
chore(payment): PAYMENTS-8045 Bump Checkout SDK release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.269.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.269.0.tgz",
-      "integrity": "sha512-5j+1bQDTq/uFkfxusvOyJTNnWIif63AzT0+7ok71SPzbt3xZoq1HgeaHwB72kt77EWxHCVYTSeeUQNj1yEbytg==",
+      "version": "1.272.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.272.1.tgz",
+      "integrity": "sha512-JXhrnVm1kORzyeWYNf7FyAp8Rd8DUN3ikA5g5Gom91PwfrxCGd9i6SKfjQZaNvXYoOCR/qsSFMauwU68B/N8wQ==",
       "requires": {
         "@babel/polyfill": "^7.4.4",
         "@bigcommerce/bigpay-client": "^5.19.0",
@@ -1321,9 +1321,9 @@
       }
     },
     "@braintree/browser-detection": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.13.0.tgz",
-      "integrity": "sha512-X5/M7jBpVHqqKl3ZKkk8aUvThtYGoEV4VRp0kP001/5cJsG/IzHTGnpolsrQKMhxPhDv63BPUzJzQCoVPshlrA=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.14.0.tgz",
+      "integrity": "sha512-OsqU+28RhNvSw8Y5JEiUHUrAyn4OpYazFkjSJe8ZVZfkAaRXQc6hsV38MMEpIlkPMig+A68buk/diY+0O8/dMQ=="
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.269.0",
+    "@bigcommerce/checkout-sdk": "^1.272.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk release to 1.272.1

## Why?
To apply this fix: https://github.com/bigcommerce/checkout-sdk-js/pull/1536

## Testing / Proof
Unit tests

@bigcommerce/checkout
