### PR TITLE
CHECKOUT-6781: Move default checkout button into its own package and allow GooglePay to override

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -11,6 +11,11 @@ module.exports = {
             statements: 80,
         },
     },
+    transform: {
+        '^.+\\.(ts|tsx)?$': 'ts-jest',
+        '\\.(gif|png|jpe?g|svg)$': '../../scripts/jest/file-transformer',
+        '\\.scss$': '../../scripts/jest/style-transformer',
+    },
     moduleFileExtensions: [
         'ts',
         'tsx',

--- a/packages/checkout-button-integration/.eslintrc.json
+++ b/packages/checkout-button-integration/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../.eslintrc.json"
+  ]
+}

--- a/packages/checkout-button-integration/README.md
+++ b/packages/checkout-button-integration/README.md
@@ -1,0 +1,14 @@
+# checkout-button-integration
+
+This library was generated with [Nx](https://nx.dev).
+
+
+## Running unit tests
+
+Run `nx test checkout-button-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+
+## Running lint
+
+Run `nx lint checkout-button-integration` to execute the lint via [ESLint](https://eslint.org/).
+

--- a/packages/checkout-button-integration/jest.config.js
+++ b/packages/checkout-button-integration/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: 'checkout-button-integration',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        }
+    },
+    setupFilesAfterEnv: ['../../jest-setup.ts'],
+    coverageDirectory: '../../coverage/packages/checkout-button-integration'
+};

--- a/packages/checkout-button-integration/project.json
+++ b/packages/checkout-button-integration/project.json
@@ -1,0 +1,27 @@
+{
+  "root": "packages/checkout-button-integration",
+  "sourceRoot": "packages/checkout-button-integration/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/checkout-button-integration/**/*.{ts,tsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": [
+        "coverage/packages/checkout-button-integration"
+      ],
+      "options": {
+        "jestConfig": "packages/checkout-button-integration/jest.config.js"
+      }
+    }
+  },
+  "tags": [
+    "scope:integration",
+    "scope:shared"
+  ]
+}

--- a/packages/checkout-button-integration/src/CheckoutButton.spec.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.spec.tsx
@@ -3,7 +3,7 @@ import { createCheckoutService, createLanguageService } from '@bigcommerce/check
 import { mount } from 'enzyme';
 import React from 'react';
 
-import CheckoutButton from './CheckoutButtonV2';
+import CheckoutButton from './CheckoutButton';
 
 describe('CheckoutButton', () => {
     let defaultProps: CheckoutButtonProps;

--- a/packages/checkout-button-integration/src/CheckoutButton.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.tsx
@@ -1,4 +1,4 @@
-import { CheckoutButtonProps } from '@bigcommerce/checkout-js/payment-integration';
+import { CheckoutButtonProps, CheckoutButtonResolveId, toResolvableComponent } from '@bigcommerce/checkout-js/payment-integration';
 
 import React, { FunctionComponent, useEffect } from 'react';
 
@@ -22,11 +22,20 @@ const CheckoutButton: FunctionComponent<CheckoutButtonProps> = ({
             deinitializeCustomer({ methodId })
                 .catch(onUnhandledError);
         }
-    }, [containerId, methodId]);
+    }, [
+        containerId, 
+        deinitializeCustomer,
+        initializeCustomer, 
+        methodId,
+        onUnhandledError,
+    ]);
 
     return (
         <div id={ containerId } />
     );
 }
 
-export default CheckoutButton;
+export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(
+    CheckoutButton,
+    [{ default: true }]
+);

--- a/packages/checkout-button-integration/src/index.ts
+++ b/packages/checkout-button-integration/src/index.ts
@@ -1,0 +1,1 @@
+export { default as CheckoutButton } from './CheckoutButton';

--- a/packages/checkout-button-integration/tsconfig.json
+++ b/packages/checkout-button-integration/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/checkout-button-integration/tsconfig.lib.json
+++ b/packages/checkout-button-integration/tsconfig.lib.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
+}

--- a/packages/checkout-button-integration/tsconfig.spec.json
+++ b/packages/checkout-button-integration/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/core/src/app/common/resolver/resolveComponent.spec.tsx
+++ b/packages/core/src/app/common/resolver/resolveComponent.spec.tsx
@@ -66,4 +66,14 @@ describe('resolveComponent', () => {
         expect(resolveComponent({ type: 'hello' }, components))
             .toBeUndefined();
     });
+
+    it('returns default component if configured and unable to resolve by id', () => {
+        const Default = toResolvableComponent(
+            ({ message }: TestingProps) => <div>Default: { message }</div>,
+            [{ default: true }]
+        );
+
+        expect(resolveComponent({ id: 'hello_world' }, { ...components, Default }))
+            .toEqual(Default);
+    });
 });

--- a/packages/core/src/app/customer/CheckoutButtonListV2.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonListV2.spec.tsx
@@ -9,17 +9,22 @@ import { LocaleProvider } from '../locale';
 import { getStoreConfig } from '../config/config.mock';
 
 import CheckoutButtonList, { CheckoutButtonListProps } from './CheckoutButtonListV2';
-import CheckoutButton from './CheckoutButtonV2';
 
 const FooButton: ComponentType<CheckoutButtonProps> = () => (
     <button>Foo</button>
 );
 
+const DefaultButton: ComponentType<CheckoutButtonProps> = () => (
+    <button>Default</button>
+);
+
 jest.mock('./resolveCheckoutButton', () => {
     return ({ id }: CheckoutButtonResolveId) => {
         if (id === 'foo') {
-            return id === 'foo' ? FooButton : undefined;
+            return FooButton;
         }
+
+        return DefaultButton;
     };
 });
 
@@ -69,7 +74,7 @@ describe('CheckoutButtonListV2', () => {
 
         const component = mount(<CheckoutButtonListTest { ...defaultProps } />);
 
-        expect(component.find(CheckoutButton).length)
+        expect(component.find(DefaultButton).length)
             .toEqual(1);
         expect(component.find(FooButton).length)
             .toEqual(1);

--- a/packages/core/src/app/customer/CheckoutButtonListV2.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonListV2.spec.tsx
@@ -1,5 +1,5 @@
 import { createCheckoutService, CheckoutService, CheckoutSelectors } from '@bigcommerce/checkout-sdk';
-import { CheckoutButtonProps } from '@bigcommerce/checkout-js/payment-integration';
+import { CheckoutButtonProps, CheckoutButtonResolveId } from '@bigcommerce/checkout-js/payment-integration';
 import { mount } from 'enzyme';
 import { merge, noop } from 'lodash';
 import React, { ComponentType } from 'react';
@@ -10,7 +10,6 @@ import { getStoreConfig } from '../config/config.mock';
 
 import CheckoutButtonList, { CheckoutButtonListProps } from './CheckoutButtonListV2';
 import CheckoutButton from './CheckoutButtonV2';
-import { CheckoutButtonResolveId } from './resolveCheckoutButton';
 
 const FooButton: ComponentType<CheckoutButtonProps> = () => (
     <button>Foo</button>

--- a/packages/core/src/app/customer/CheckoutButtonListV2.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonListV2.tsx
@@ -3,7 +3,6 @@ import React, { Fragment, FunctionComponent } from 'react';
 import { withCheckout, WithCheckoutProps } from '../checkout';
 import { TranslatedString, withLanguage, WithLanguageProps } from '../locale';
 import resolveCheckoutButton from './resolveCheckoutButton';
-import CheckoutButton from './CheckoutButtonV2';
 
 export interface CheckoutButtonListProps {
     onUnhandledError(error: Error): void;
@@ -32,7 +31,11 @@ const CheckoutButtonList: FunctionComponent<
 
             <div className="checkoutRemote">
                 { methodIds.map(methodId => {
-                    const ResolvedCheckoutButton = resolveCheckoutButton({ id: methodId }) ?? CheckoutButton;
+                    const ResolvedCheckoutButton = resolveCheckoutButton({ id: methodId });
+
+                    if (!ResolvedCheckoutButton) {
+                        return null;
+                    }
 
                     return <ResolvedCheckoutButton
                         checkoutService={ checkoutService }

--- a/packages/core/src/app/customer/resolveCheckoutButton.ts
+++ b/packages/core/src/app/customer/resolveCheckoutButton.ts
@@ -1,14 +1,7 @@
-import { CheckoutButtonProps } from '@bigcommerce/checkout-js/payment-integration';
+import { CheckoutButtonProps, CheckoutButtonResolveId } from '@bigcommerce/checkout-js/payment-integration';
 import { ComponentType } from 'react';
 
 import { resolveComponent } from '../common/resolver';
-import { RequireAtLeastOne } from '../common/types';
-
-export type CheckoutButtonResolveId = RequireAtLeastOne<{
-    id?: string;
-    gateway?: string;
-    default?: boolean;
-}>;
 
 export default function resolveCheckoutButton(resolveId: CheckoutButtonResolveId): ComponentType<CheckoutButtonProps> | undefined {
     return resolveComponent<CheckoutButtonResolveId, CheckoutButtonProps>(

--- a/packages/core/src/app/customer/resolveCheckoutButton.ts
+++ b/packages/core/src/app/customer/resolveCheckoutButton.ts
@@ -7,6 +7,7 @@ import { RequireAtLeastOne } from '../common/types';
 export type CheckoutButtonResolveId = RequireAtLeastOne<{
     id?: string;
     gateway?: string;
+    default?: boolean;
 }>;
 
 export default function resolveCheckoutButton(resolveId: CheckoutButtonResolveId): ComponentType<CheckoutButtonProps> | undefined {

--- a/packages/google-pay-integration/.eslintrc.json
+++ b/packages/google-pay-integration/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../.eslintrc.json"
+  ]
+}

--- a/packages/google-pay-integration/README.md
+++ b/packages/google-pay-integration/README.md
@@ -1,0 +1,14 @@
+# google-pay-integration
+
+This library was generated with [Nx](https://nx.dev).
+
+
+## Running unit tests
+
+Run `nx test google-pay-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+
+## Running lint
+
+Run `nx lint google-pay-integration` to execute the lint via [ESLint](https://eslint.org/).
+

--- a/packages/google-pay-integration/jest.config.js
+++ b/packages/google-pay-integration/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: 'google-pay-integration',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        }
+    },
+    setupFilesAfterEnv: ['../../jest-setup.ts'],
+    coverageDirectory: '../../coverage/packages/google-pay-integration'
+};

--- a/packages/google-pay-integration/project.json
+++ b/packages/google-pay-integration/project.json
@@ -1,0 +1,24 @@
+{
+  "root": "packages/google-pay-integration",
+  "sourceRoot": "packages/google-pay-integration/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/google-pay-integration/**/*.{ts,tsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": [
+        "coverage/packages/google-pay-integration"
+      ],
+      "options": {
+        "jestConfig": "packages/google-pay-integration/jest.config.js"
+      }
+    }
+  },
+  "tags": ["scope:integration"]
+}

--- a/packages/google-pay-integration/src/GooglePayButton.spec.tsx
+++ b/packages/google-pay-integration/src/GooglePayButton.spec.tsx
@@ -1,0 +1,47 @@
+import { CheckoutButton } from '@bigcommerce/checkout-js/checkout-button-integration';
+import { CheckoutButtonProps, isEmbedded } from '@bigcommerce/checkout-js/payment-integration';
+import { createCheckoutService, createLanguageService } from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import React from 'react';
+
+import GooglePayButton from './GooglePayButton';
+
+jest.mock('@bigcommerce/checkout-js/payment-integration', () => {
+    return {
+        ...jest.requireActual('@bigcommerce/checkout-js/payment-integration'),
+        isEmbedded: jest.fn(() => false),
+    };
+});
+
+describe('GooglePayButton', () => {
+    let defaultProps: CheckoutButtonProps;
+
+    beforeEach(() => {
+        const checkoutService = createCheckoutService();
+
+        defaultProps = {
+            checkoutService,
+            checkoutState: checkoutService.getState(),
+            containerId: 'button-container',
+            language: createLanguageService(),
+            methodId: 'googlepay',
+            onUnhandledError: jest.fn(),
+        };
+    });
+
+    it('delegates to default checkout button if checkout is not embedded', () => {
+        const component = mount(<GooglePayButton { ...defaultProps } />);
+
+        expect(component.find(CheckoutButton).length)
+            .toEqual(1);
+    });
+
+    it('calls error callback if checkout is embedded', () => {
+        (isEmbedded as jest.Mock).mockReturnValue(true);
+
+        mount(<GooglePayButton { ...defaultProps } />);
+
+        expect(defaultProps.onUnhandledError)
+            .toHaveBeenCalled();
+    });
+});

--- a/packages/google-pay-integration/src/GooglePayButton.tsx
+++ b/packages/google-pay-integration/src/GooglePayButton.tsx
@@ -1,0 +1,28 @@
+import { CheckoutButton } from '@bigcommerce/checkout-js/checkout-button-integration';
+
+import { CheckoutButtonProps, CheckoutButtonResolveId, EmbeddedCheckoutUnsupportedError, isEmbedded, toResolvableComponent } from '@bigcommerce/checkout-js/payment-integration';
+
+import React, { FunctionComponent } from 'react';
+
+const GooglePayButton: FunctionComponent<CheckoutButtonProps> = props => {
+    const { language, onUnhandledError } = props;
+
+    if (isEmbedded()) {
+        onUnhandledError(new EmbeddedCheckoutUnsupportedError(
+            language.translate('embedded_checkout.unsupported_error', {
+                methods: 'googlepay',
+            })
+        ));
+
+        return null;
+    }
+
+    return (
+        <CheckoutButton { ...props } />
+    );
+}
+
+export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(
+    GooglePayButton,
+    [{ id: 'googlepay' }]
+);

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -1,0 +1,1 @@
+export { default as GooglePayButton } from './GooglePayButton';

--- a/packages/google-pay-integration/tsconfig.json
+++ b/packages/google-pay-integration/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/google-pay-integration/tsconfig.lib.json
+++ b/packages/google-pay-integration/tsconfig.lib.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
+}

--- a/packages/google-pay-integration/tsconfig.spec.json
+++ b/packages/google-pay-integration/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/payment-integration/src/CheckoutButtonResolveId.ts
+++ b/packages/payment-integration/src/CheckoutButtonResolveId.ts
@@ -1,0 +1,9 @@
+import RequireAtLeastOne from './RequireAtLeastOne';
+
+type CheckoutButtonResolveId = RequireAtLeastOne<{
+    id?: string;
+    gateway?: string;
+    default?: boolean;
+}>;
+
+export default CheckoutButtonResolveId;

--- a/packages/payment-integration/src/RequireAtLeastOne.ts
+++ b/packages/payment-integration/src/RequireAtLeastOne.ts
@@ -1,0 +1,7 @@
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
+    Pick<T, Exclude<keyof T, Keys>>
+    & {
+        [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+    }[Keys];
+
+export default RequireAtLeastOne;

--- a/packages/payment-integration/src/errors/CustomError.ts
+++ b/packages/payment-integration/src/errors/CustomError.ts
@@ -1,0 +1,33 @@
+export default class CustomError extends Error {
+    static shouldReport: boolean;
+
+    data: any;
+    title: any;
+    type: string;
+
+    constructor({
+        data = {},
+        message = '',
+        title = '',
+        name = '',
+    }: {
+        data?: any;
+        message?: string;
+        title?: string;
+        name?: string;
+    }) {
+        super();
+
+        if (typeof Error.captureStackTrace === 'function') {
+            Error.captureStackTrace(this, CustomError);
+        } else {
+            this.stack = (new Error()).stack;
+        }
+
+        this.data = data;
+        this.message = message;
+        this.name = name;
+        this.title = title;
+        this.type = 'custom';
+    }
+}

--- a/packages/payment-integration/src/errors/EmbeddedCheckoutUnsupportedError.ts
+++ b/packages/payment-integration/src/errors/EmbeddedCheckoutUnsupportedError.ts
@@ -1,0 +1,14 @@
+import setPrototypeOf from '../setPrototypeOf';
+
+import CustomError from './CustomError';
+
+export default class EmbeddedCheckoutUnsupportedError extends CustomError {
+    constructor(message: string) {
+        super({
+            name: 'EMBEDDED_CHECKOUT_UNSUPPORTED_ERROR',
+            message,
+        });
+
+        setPrototypeOf(this, EmbeddedCheckoutUnsupportedError.prototype);
+    }
+}

--- a/packages/payment-integration/src/errors/index.ts
+++ b/packages/payment-integration/src/errors/index.ts
@@ -1,0 +1,2 @@
+export { default as CustomError } from './CustomError';
+export { default as EmbeddedCheckoutUnsupportedError } from './EmbeddedCheckoutUnsupportedError';

--- a/packages/payment-integration/src/index.ts
+++ b/packages/payment-integration/src/index.ts
@@ -1,3 +1,4 @@
+export { EmbeddedCheckoutUnsupportedError } from './errors';
 export { default as CheckoutButtonResolveId } from './CheckoutButtonResolveId';
 export { default as CheckoutButtonProps } from './CheckoutButtonProps';
 export { default as PaymentFormService } from './PaymentFormService';
@@ -5,6 +6,7 @@ export { default as PaymentMethodProps } from './PaymentMethodProps';
 export { default as ResolvableComponent } from './ResolvableComponent';
 export { default as toResolvableComponent } from './toResolvableComponent';
 export { default as isResolvableComponent } from './isResolvableComponent';
+export { default as isEmbedded } from './isEmbedded';
 export {
     default as PaymentFormValues,
     CardInstrumentFieldsetValues,

--- a/packages/payment-integration/src/index.ts
+++ b/packages/payment-integration/src/index.ts
@@ -1,3 +1,4 @@
+export { default as CheckoutButtonResolveId } from './CheckoutButtonResolveId';
 export { default as CheckoutButtonProps } from './CheckoutButtonProps';
 export { default as PaymentFormService } from './PaymentFormService';
 export { default as PaymentMethodProps } from './PaymentMethodProps';

--- a/packages/payment-integration/src/isEmbedded.ts
+++ b/packages/payment-integration/src/isEmbedded.ts
@@ -1,0 +1,7 @@
+export default function isEmbedded(
+    pathname: string = document.location.pathname
+): boolean {
+    const basePath = `/${pathname.split('/')[1]}`;
+
+    return basePath === '/embedded-checkout';
+}

--- a/packages/payment-integration/src/setPrototypeOf.ts
+++ b/packages/payment-integration/src/setPrototypeOf.ts
@@ -1,0 +1,13 @@
+export default function setPrototypeOf<T extends object>(object: T, prototype: object): T {
+    if (Object.setPrototypeOf) {
+        Object.setPrototypeOf(object, prototype);
+    } else if (hasProto(object)) {
+        object.__proto__ = prototype;
+    }
+
+    return object;
+}
+
+function hasProto(object: object): object is object & { __proto__: object } {
+    return '__proto__' in object;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,14 +21,17 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "paths": {
+      "@bigcommerce/checkout-js/apple-pay-integration": [
+        "packages/apple-pay-integration/src/index.ts"
+      ],
       "@bigcommerce/checkout-js/core": [
         "packages/core/src/app/index.ts"
       ],
+      "@bigcommerce/checkout-js/checkout-button-integration": [
+        "packages/checkout-button-integration/src/index.ts"
+      ],
       "@bigcommerce/checkout-js/payment-integration": [
         "packages/payment-integration/src/index.ts"
-      ],
-      "@bigcommerce/checkout-js/apple-pay-integration": [
-        "packages/apple-pay-integration/src/index.ts"
       ],
       "@bigcommerce/checkout-js/workspace-tools": [
         "packages/workspace-tools/src/index.ts"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,9 @@
       "@bigcommerce/checkout-js/checkout-button-integration": [
         "packages/checkout-button-integration/src/index.ts"
       ],
+      "@bigcommerce/checkout-js/google-pay-integration": [
+        "packages/google-pay-integration/src/index.ts"
+      ],
       "@bigcommerce/checkout-js/payment-integration": [
         "packages/payment-integration/src/index.ts"
       ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ function appConfig(options, argv) {
                         "@bigcommerce/checkout-js/payment-integration": join(__dirname, 'packages/payment-integration/src'),
                         "@bigcommerce/checkout-js/apple-pay-integration": join(__dirname, 'packages/apple-pay-integration/src'),
                         "@bigcommerce/checkout-js/checkout-button-integration": join(__dirname, 'packages/checkout-button-integration/src'),
+                        "@bigcommerce/checkout-js/google-pay-integration": join(__dirname, 'packages/google-pay-integration/src'),
                     },
                     extensions: ['.ts', '.tsx', '.js'],
                     // It seems some packages, i.e.: Formik, have incorrect

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,7 @@ function appConfig(options, argv) {
                     alias: {
                         "@bigcommerce/checkout-js/payment-integration": join(__dirname, 'packages/payment-integration/src'),
                         "@bigcommerce/checkout-js/apple-pay-integration": join(__dirname, 'packages/apple-pay-integration/src'),
+                        "@bigcommerce/checkout-js/checkout-button-integration": join(__dirname, 'packages/checkout-button-integration/src'),
                     },
                     extensions: ['.ts', '.tsx', '.js'],
                     // It seems some packages, i.e.: Formik, have incorrect

--- a/workspace.json
+++ b/workspace.json
@@ -1,9 +1,10 @@
 {
   "version": 2,
   "projects": {
-    "core": "packages/core",
-    "payment-integration": "packages/payment-integration",
     "apple-pay-integration": "packages/apple-pay-integration",
+    "core": "packages/core",
+    "checkout-button-integration": "packages/checkout-button-integration",
+    "payment-integration": "packages/payment-integration",
     "workspace-tools": "packages/workspace-tools"
   }
 }

--- a/workspace.json
+++ b/workspace.json
@@ -4,6 +4,7 @@
     "apple-pay-integration": "packages/apple-pay-integration",
     "core": "packages/core",
     "checkout-button-integration": "packages/checkout-button-integration",
+    "google-pay-integration": "packages/google-pay-integration",
     "payment-integration": "packages/payment-integration",
     "workspace-tools": "packages/workspace-tools"
   }


### PR DESCRIPTION
## What?
* Move the default checkout button implementation (`CheckoutButton`) into its own package.
* Create a new package for Google Pay and implement `GooglePayButton` by extending from `CheckoutButton` and layering additional logic to handle embedded checkout.

## Why?
* We can load all the checkout buttons (default, Google Pay, Apple Pay etc...) in a consistent manner.
* Integrators can extend from the default button variant to create new variants.

## Testing / Proof
Unit

@bigcommerce/checkout
