### PR TITLE
CHECKOUT-6781: Use package name rather than relative path in generated files

### DIFF
--- a/packages/core/auto-export.config.json
+++ b/packages/core/auto-export.config.json
@@ -5,5 +5,6 @@
             "outputPath": "packages/core/src/app/generated/paymentIntegrations/index.ts",
             "memberPattern": ".+PaymentMethod$"
         }
-    ]
+    ],
+    "tsConfigPath": "tsconfig.base.json"
 }

--- a/packages/workspace-tools/src/generators/auto-export/__fixtures__/tsconfig.json
+++ b/packages/workspace-tools/src/generators/auto-export/__fixtures__/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@bigcommerce/function-a": [
+        "packages/workspace-tools/src/generators/auto-export/__fixtures__/function-a/index.ts"
+      ],
+      "@bigcommerce/strategy-a": [
+        "packages/workspace-tools/src/generators/auto-export/__fixtures__/strategy-a/index.ts"
+      ],
+      "@bigcommerce/strategy-b": [
+        "packages/workspace-tools/src/generators/auto-export/__fixtures__/strategy-b/index.ts"
+      ]
+    }
+  }
+}

--- a/packages/workspace-tools/src/generators/auto-export/__snapshots__/auto-export.spec.ts.snap
+++ b/packages/workspace-tools/src/generators/auto-export/__snapshots__/auto-export.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`autoExport() export matching members from files to another file 1`] = `
-"export { StrategyA } from '../__fixtures__/strategy-a';
-export { StrategyB } from '../__fixtures__/strategy-b';
+"export { StrategyA } from '@bigcommerce/strategy-a';
+export { StrategyB } from '@bigcommerce/strategy-b';
 "
 `;
 

--- a/packages/workspace-tools/src/generators/auto-export/auto-export-config.ts
+++ b/packages/workspace-tools/src/generators/auto-export/auto-export-config.ts
@@ -1,5 +1,6 @@
 export default interface AutoExportConfig {
     entries: AutoExportConfigEntry[];
+    tsConfigPath: string;
 }
 
 export interface AutoExportConfigEntry {

--- a/packages/workspace-tools/src/generators/auto-export/auto-export.spec.ts
+++ b/packages/workspace-tools/src/generators/auto-export/auto-export.spec.ts
@@ -1,13 +1,12 @@
-import path from 'path';
-
 import autoExport from './auto-export';
 
 describe('autoExport()', () => {
     it('export matching members from files to another file', async () => {
         const options = {
-            inputPath: path.join(__dirname, '/__fixtures__/**/index.ts'),
-            outputPath: path.join(__dirname, '/__temp__/output.ts'),
+            inputPath: 'packages/workspace-tools/src/generators/auto-export/__fixtures__/**/index.ts',
+            outputPath: 'packages/workspace-tools/src/generators/auto-export/__temp__/output.ts',
             memberPattern: '^Strategy',
+            tsConfigPath: 'packages/workspace-tools/src/generators/auto-export/__fixtures__/tsconfig.json',
         };
 
         expect(await autoExport(options))
@@ -16,9 +15,10 @@ describe('autoExport()', () => {
 
     it('handles scenario where no matching member is found', async () => {
         const options = {
-            inputPath: path.join(__dirname, '/__fixtures__/**/index.ts'),
-            outputPath: path.join(__dirname, '/__temp__/output.ts'),
+            inputPath: 'packages/workspace-tools/src/generators/auto-export/__fixtures__/**/index.ts',
+            outputPath: 'packages/workspace-tools/src/generators/auto-export/__temp__/output.ts',
             memberPattern: '^Test',
+            tsConfigPath: 'packages/workspace-tools/src/generators/auto-export/__fixtures__/tsconfig.json',
         };
 
         expect(await autoExport(options))

--- a/packages/workspace-tools/src/generators/auto-export/generator.ts
+++ b/packages/workspace-tools/src/generators/auto-export/generator.ts
@@ -33,7 +33,10 @@ export default async function autoExportGenerator(
                 join(__dirname, './templates'),
                 parse(entry.outputPath).dir,
                 {
-                    content: await autoExport(entry),
+                    content: await autoExport({
+                        ...entry,
+                        tsConfigPath: config.tsConfigPath,
+                    }),
                     outputName: basename(entry.outputPath),
                 }
             );

--- a/packages/workspace-tools/src/generators/auto-export/is-auto-export-config.ts
+++ b/packages/workspace-tools/src/generators/auto-export/is-auto-export-config.ts
@@ -9,6 +9,10 @@ export default function isAutoExportConfig(config: unknown): config is AutoExpor
         return false;
     }
 
+    if (!hasKey(config, 'tsConfigPath') || typeof config.tsConfigPath !== 'string') {
+        return false;
+    }
+
     return config.entries.every(entry => {
         if (!(entry instanceof Object)) {
             return false;


### PR DESCRIPTION
## What?
Use package name rather than relative path in generated files.

## Why?
To conform with the import rules.

## Testing / Proof
**Before**
```ts
export { ApplePayPaymentMethod } from '../../../../../apple-pay-integration/src';
```

**After**
```ts
export { ApplePayPaymentMethod } from '@bigcommerce/checkout-js/apple-pay-integration';
```

@bigcommerce/checkout
