### PR TITLE
fix(payment): CHECKOUT-5889 Fix issue with element detach modal

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -398,6 +398,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
         const {
             consignments,
             cart,
+            errorLogger,
         } = this.props;
 
         return (
@@ -411,6 +412,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                 <LazyContainer>
                     <Payment
                         checkEmbeddedSupport={ this.checkEmbeddedSupport }
+                        errorLogger= { errorLogger }
                         isEmbedded={ isEmbedded() }
                         isUsingMultiShipping={ cart && consignments ? isUsingMultiShipping(consignments, cart.lineItems) : false }
                         onCartChangedError={ this.handleCartChangedError }

--- a/packages/core/src/app/payment/Payment.spec.tsx
+++ b/packages/core/src/app/payment/Payment.spec.tsx
@@ -7,7 +7,7 @@ import React, { FunctionComponent } from 'react';
 import { getCart } from '../cart/carts.mock';
 import { CheckoutProvider } from '../checkout';
 import { getCheckout, getCheckoutPayment } from '../checkout/checkouts.mock';
-import { ErrorModal } from '../common/error';
+import { createErrorLogger, ErrorModal } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
@@ -85,6 +85,7 @@ describe('Payment', () => {
         localeContext = createLocaleContext(getStoreConfig());
 
         defaultProps = {
+            errorLogger: createErrorLogger(),
             onSubmit: jest.fn(),
             onSubmitError: jest.fn(),
             onUnhandledError: jest.fn(),
@@ -247,6 +248,7 @@ describe('Payment', () => {
         jest.spyOn(checkoutService, 'applyStoreCredit')
             .mockResolvedValue(checkoutState);
         const defaultProps = {
+            errorLogger: createErrorLogger(),
             onSubmit: jest.fn(),
             onSubmitError: jest.fn(),
             onUnhandledError: jest.fn(),

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -6,7 +6,7 @@ import React, { Component, ReactNode } from 'react';
 import { ObjectSchema } from 'yup';
 
 import { withCheckout, CheckoutContextProps } from '../checkout';
-import { isCartChangedError, isRequestError, ErrorModal, ErrorModalOnCloseProps } from '../common/error';
+import { isCartChangedError, isRequestError, ErrorModal, ErrorModalOnCloseProps, ErrorLogger } from '../common/error';
 import { EMPTY_ARRAY } from '../common/utility';
 import { withLanguage, WithLanguageProps } from '../locale';
 import { TermsConditionsType } from '../termsConditions';
@@ -19,6 +19,7 @@ import PaymentContext from './PaymentContext';
 import PaymentForm from './PaymentForm';
 
 export interface PaymentProps {
+    errorLogger: ErrorLogger;
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     checkEmbeddedSupport?(methodIds: string[]): void; // TODO: We're currently doing this check in multiple places, perhaps we should move it up so this check get be done in a single place instead.
@@ -176,6 +177,7 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
                         onMethodSelect={ this.setSelectedMethod }
                         onStoreCreditChange={ this.handleStoreCreditChange }
                         onSubmit={ this.handleSubmit }
+                        onUnhandledError={ this.handleError }
                         selectedMethod={ selectedMethod }
                         shouldDisableSubmit={ uniqueSelectedMethodId && shouldDisableSubmit[uniqueSelectedMethodId] || undefined }
                         shouldHidePaymentSubmitButton={ uniqueSelectedMethodId && shouldHidePaymentSubmitButton[uniqueSelectedMethodId] || undefined }
@@ -376,6 +378,23 @@ class Payment extends Component<PaymentProps & WithCheckoutPaymentProps & WithLa
             onUnhandledError(e);
         }
     };
+
+    private handleError: (error: Error) => void = (error: Error) => {
+        const {
+            onUnhandledError = noop,
+            errorLogger
+        } = this.props;
+
+        const { type } = error as any;
+
+        if (type === 'unexpected_detachment') {
+            errorLogger.log(error);
+
+            return;
+        }
+        
+        return onUnhandledError(error);
+    }
 
     private handleSubmit: (values: PaymentFormValues) => void = async values => {
         const {


### PR DESCRIPTION
## What?
Fix issue with an error modal being displayed if an element is detached

## Why?
At the moment we have an error modal displayed while a user transitions while hosted payment form is being loaded step to another step in checkout. 
Instead of showing the error modal and blocking the UX we can log the error using errorLogger.

## Testing / Proof
- Circle


https://user-images.githubusercontent.com/7134802/184576337-236008ac-62aa-4906-8f43-7e9ef6b94763.mov



@bigcommerce/checkout
