### PR TITLE
chore(common): CHECKOUT-6855 INT-6023 INT-6115 INT-6128 STRF-9829 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.274.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.274.0.tgz",
-      "integrity": "sha512-Be54gUBeEDGbprvFsQPPXwkiHzu5fzl/8SH6rq0MIv1ze84rqhIYy1lIY0uv1SHuuoKvq7L7yOxMsNathdSO5g==",
+      "version": "1.278.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.278.1.tgz",
+      "integrity": "sha512-Ruk6muMgzFvtpluuZwnPm7DPYUaNcFwNXxibZzlgBMiVWksrl/4/BqQkzzXu8sLW3JEt2n0s6nh6OV4876XPlA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.274.0",
+    "@bigcommerce/checkout-sdk": "^1.278.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from [version 1.274.0](https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md#12740-2022-08-08) to [version 1.278.0](https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md#12780-2022-08-12).

## Why?
To release:
- https://github.com/bigcommerce/checkout-sdk-js/pull/1489
- https://github.com/bigcommerce/checkout-sdk-js/pull/1491
- https://github.com/bigcommerce/checkout-sdk-js/pull/1502
- https://github.com/bigcommerce/checkout-sdk-js/pull/1521
- https://github.com/bigcommerce/checkout-sdk-js/pull/1540
- https://github.com/bigcommerce/checkout-sdk-js/pull/1541
- https://github.com/bigcommerce/checkout-sdk-js/pull/1552
- https://github.com/bigcommerce/checkout-sdk-js/pull/1556

## Testing / Proof
CircleCI + testing section on the above PRs

@bigcommerce/checkout