### PR TITLE
CHECKOUT-6899: Export PaymentMethodResolveId through payment integration API package

### DIFF
--- a/packages/apple-pay-integration/src/ApplePayPaymentMethod.tsx
+++ b/packages/apple-pay-integration/src/ApplePayPaymentMethod.tsx
@@ -1,4 +1,4 @@
-import { toResolvableComponent, PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
+import { toResolvableComponent, PaymentMethodProps, PaymentMethodResolveId } from '@bigcommerce/checkout/payment-integration-api';
 import React, { FunctionComponent, useEffect } from 'react';
 
 const ApplePaymentMethod: FunctionComponent<PaymentMethodProps> = ({ method, checkoutService, language, onUnhandledError }) => {
@@ -37,7 +37,7 @@ const ApplePaymentMethod: FunctionComponent<PaymentMethodProps> = ({ method, che
     return <></>;
 };
 
-export default toResolvableComponent(
+export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     ApplePaymentMethod,
     [{ id: 'applepay' }]
 );

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
@@ -1,4 +1,4 @@
-import { PaymentMethodProps as ResolvedPaymentMethodProps, PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
+import { PaymentMethodProps as ResolvedPaymentMethodProps, PaymentFormValues, PaymentMethodResolveId } from '@bigcommerce/checkout/payment-integration-api';
 import { PaymentMethod } from '@bigcommerce/checkout-sdk';
 import React, { ComponentType } from 'react';
 
@@ -7,7 +7,7 @@ import { connectFormik, WithFormikProps } from '../../common/form';
 import { withLanguage, WithLanguageProps } from '../../locale';
 import { withForm, WithFormProps } from '../../ui/form';
 import createPaymentFormService from '../createPaymentFormService';
-import resolvePaymentMethod, { PaymentMethodResolveId } from '../resolvePaymentMethod';
+import resolvePaymentMethod from '../resolvePaymentMethod';
 import withPayment, { WithPaymentProps } from '../withPayment';
 
 export interface PaymentMethodProps {

--- a/packages/core/src/app/payment/resolvePaymentMethod.ts
+++ b/packages/core/src/app/payment/resolvePaymentMethod.ts
@@ -1,14 +1,7 @@
-import { PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
+import { PaymentMethodProps, PaymentMethodResolveId } from '@bigcommerce/checkout/payment-integration-api';
 import { ComponentType } from 'react';
 
 import { resolveComponent } from '../common/resolver';
-import { RequireAtLeastOne } from '../common/types';
-
-export type PaymentMethodResolveId = RequireAtLeastOne<{
-    id?: string;
-    gateway?: string;
-    type?: string;
-}>;
 
 export default function resolvePaymentMethod(query: PaymentMethodResolveId): ComponentType<PaymentMethodProps> | undefined {
     return resolveComponent<PaymentMethodResolveId, PaymentMethodProps>(

--- a/packages/payment-integration-api/src/PaymentMethodResolveId.ts
+++ b/packages/payment-integration-api/src/PaymentMethodResolveId.ts
@@ -1,0 +1,9 @@
+import RequireAtLeastOne from './RequireAtLeastOne';
+
+type PaymentMethodResolveId = RequireAtLeastOne<{
+    id?: string;
+    gateway?: string;
+    type?: string;
+}>;
+
+export default PaymentMethodResolveId;

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -3,6 +3,7 @@ export { default as CheckoutButtonResolveId } from './CheckoutButtonResolveId';
 export { default as CheckoutButtonProps } from './CheckoutButtonProps';
 export { default as PaymentFormService } from './PaymentFormService';
 export { default as PaymentMethodProps } from './PaymentMethodProps';
+export { default as PaymentMethodResolveId } from './PaymentMethodResolveId';
 export { default as ResolvableComponent } from './ResolvableComponent';
 export { default as toResolvableComponent } from './toResolvableComponent';
 export { default as isResolvableComponent } from './isResolvableComponent';


### PR DESCRIPTION
## What?
Export `PaymentMethodResolveId` through payment integration API package.

## Why?
So it can be referenced by payment integration packages and core.

## Testing / Proof
CircleCI

@bigcommerce/checkout
