### PR TITLE
CHECKOUT-6899: Move mocks out of payment integration API package

### DIFF
--- a/packages/apple-pay-integration/src/ApplePayPaymentMethod.spec.tsx
+++ b/packages/apple-pay-integration/src/ApplePayPaymentMethod.spec.tsx
@@ -1,23 +1,16 @@
-import { getMethod, PaymentFormService } from "@bigcommerce/checkout/payment-integration-api";
+import { PaymentFormService } from "@bigcommerce/checkout/payment-integration-api";
 import { createCheckoutService, LanguageService } from "@bigcommerce/checkout-sdk";
 import { mount } from 'enzyme';
 import React from "react";
 
 import ApplePaymentMethod from './ApplePayPaymentMethod';
+import { getMethod } from './paymentMethods.mock';
 
 describe('ApplePay payment method', () => {
     const checkoutService = createCheckoutService();
     const checkoutState = checkoutService.getState();
     const props = {
-        method: {
-            ...getMethod(),
-            id: 'applepay',
-            initializationData: {
-                merchantCapabilities: [
-                    'supports3DS',
-                ],
-            },
-        },
+        method: getMethod(),
         checkoutService,
         checkoutState,
         paymentForm: jest.fn() as unknown as PaymentFormService,

--- a/packages/apple-pay-integration/src/paymentMethods.mock.ts
+++ b/packages/apple-pay-integration/src/paymentMethods.mock.ts
@@ -2,7 +2,7 @@ import { PaymentMethod } from "@bigcommerce/checkout-sdk";
 
 export function getMethod(): PaymentMethod {
     return {
-        id: 'authorizenet',
+        id: 'applepay',
         gateway: undefined,
         logoUrl: '',
         method: 'credit-card',
@@ -12,7 +12,9 @@ export function getMethod(): PaymentMethod {
             'MC',
         ],
         initializationData: {
-            payPalCreditProductBrandName: {credit: ''},
+            merchantCapabilities: [
+                'supports3DS',
+            ],
         },
         config: {
             displayName: 'Authorizenet',

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -18,4 +18,3 @@ export {
     IdealCustomFormFieldsetValues,
     SepaCustomFormFieldsetValues,
 } from './PaymentFormValues';
-export { getMethod } from './PaymentIntegration.mock';


### PR DESCRIPTION
## What?
Move mocks out of payment integration API package.

## Why?
Mocks used in tests should either belong to method-specific packages or exported from a "test utils" package.

## Testing / Proof
CircleCI

@bigcommerce/checkout
