### PR TITLE
chore(common): CHECKOUT-000 Add script to derive package list and aliases

### DIFF
--- a/scripts/webpack/get-loader-packages.js
+++ b/scripts/webpack/get-loader-packages.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const { projects } = require('../../workspace.json');
+
+const tsLoaderIncludes = [];
+const aliasMap = {};
+
+for (const [packageName, packagePath] of Object.entries(projects)) {
+    const packageSrcPath =  path.join(__dirname, '../../', `${packagePath}/src`);
+
+    tsLoaderIncludes.push(packageSrcPath);
+
+    aliasMap[`@bigcommerce/checkout/${packageName}`] = packageSrcPath;
+}
+
+module.exports = {
+    aliasMap,
+    tsLoaderIncludes
+};

--- a/scripts/webpack/index.js
+++ b/scripts/webpack/index.js
@@ -3,4 +3,5 @@ module.exports = {
     BuildHookPlugin: require('./build-hook-plugin'),
     getNextVersion: require('./get-next-version'),
     transformManifest: require('./transform-manifest'),
+    getLoaderPackages: require('./get-loader-packages'),
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,11 @@ const StyleLintPlugin = require('stylelint-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
-const { AsyncHookPlugin, BuildHookPlugin, getNextVersion, transformManifest } = require('./scripts/webpack');
+const { AsyncHookPlugin,
+    BuildHookPlugin,
+    getLoaderPackages: { aliasMap: alias, tsLoaderIncludes },
+    getNextVersion,
+    transformManifest } = require('./scripts/webpack');
 
 const ENTRY_NAME = 'checkout';
 const LIBRARY_NAME = 'checkout';
@@ -48,12 +52,7 @@ function appConfig(options, argv) {
                 mode,
                 devtool: isProduction ? 'source-map' : 'eval-source-map',
                 resolve: {
-                    alias: {
-                        "@bigcommerce/checkout/payment-integration-api": join(__dirname, 'packages/payment-integration-api/src'),
-                        "@bigcommerce/checkout/apple-pay-integration": join(__dirname, 'packages/apple-pay-integration/src'),
-                        "@bigcommerce/checkout/checkout-button-integration": join(__dirname, 'packages/checkout-button-integration/src'),
-                        "@bigcommerce/checkout/google-pay-integration": join(__dirname, 'packages/google-pay-integration/src'),
-                    },
+                    alias,
                     extensions: ['.ts', '.tsx', '.js'],
                     // It seems some packages, i.e.: Formik, have incorrect
                     // source maps for their ESM bundle. Therefore, until that
@@ -146,11 +145,7 @@ function appConfig(options, argv) {
                         },
                         {
                             test: /\.tsx?$/,
-                            include: [
-                                join(__dirname, 'packages', 'core','src'),
-                                join(__dirname, 'packages', 'payment-integration-api','src'),
-                                join(__dirname, 'packages', 'apple-pay-integration','src'),
-                            ],
+                            include: tsLoaderIncludes,
                             use: [
                                 {
                                     loader: 'ts-loader',


### PR DESCRIPTION
## What?
Add script to derive for webpack configuration, and reduce overhead when creating a new package
- package alias mapping
- ts loader includes

## Why?
At the moment when adding a new package a developer has to update webpack config file, add a script to automate this process. Reducing package creation overhead

## Testing / Proof
- circle

@bigcommerce/checkout
