### PR TITLE
feat(payment): PAYPAL-1613 removed unnecessary Braintree Venmo logic from PaymentSubmitButton component

### DIFF
--- a/packages/core/src/app/locale/translations/da.json
+++ b/packages/core/src/app/locale/translations/da.json
@@ -255,7 +255,7 @@
             "payment_method_unavailable_error": "Denne betalingsudbyder er midlertidigt utilgængelig. Prøv igen senere.",
             "payment_not_required_text": "Der kræves ikke betaling for denne ordre.",
             "paypal_continue_action": "Fortsæt med PayPal",
-            "braintreevenmo_continue_action": "Fortsæt med Venmo",
+            "paypal_venmo_continue_action": "Fortsæt med Venmo",
             "paypal_credit_continue_action": "Fortsæt med PayPal Credit",
             "paypal_credit_description_text": "Køb nu, betal senere",
             "paypal_description_text": "Betal med din PayPal-konto",

--- a/packages/core/src/app/locale/translations/en.json
+++ b/packages/core/src/app/locale/translations/en.json
@@ -260,7 +260,6 @@
             "paypal_continue_action": "Continue with PayPal",
             "paypal_pay_later_continue_action": "Continue with Pay Later",
             "paypal_venmo_continue_action": "Continue with Venmo",
-            "braintreevenmo_continue_action": "Continue with Venmo",
             "paypal_credit_continue_action": "Continue with PayPal Credit",
             "paypal_credit_description_text": "Buy Now, Pay Over Time",
             "paypal_description_text": "Pay using your PayPal account",

--- a/packages/core/src/app/locale/translations/es-419.json
+++ b/packages/core/src/app/locale/translations/es-419.json
@@ -255,7 +255,7 @@
             "payment_method_unavailable_error": "Este proveedor de pagos no está disponible temporalmente. Vuelve a intentarlo más tarde.",
             "payment_not_required_text": "No se requiere el pago para este pedido.",
             "paypal_continue_action": "Continuar con PayPal",
-            "braintreevenmo_continue_action": "Continuar con Venmo",
+            "paypal_venmo_continue_action": "Continuar con Venmo",
             "paypal_credit_continue_action": "Continuar con PayPal Credit",
             "paypal_credit_description_text": "Compra ahora y paga después",
             "paypal_description_text": "Pagar con tu cuenta de PayPal",

--- a/packages/core/src/app/locale/translations/es-AR.json
+++ b/packages/core/src/app/locale/translations/es-AR.json
@@ -255,7 +255,7 @@
             "payment_method_unavailable_error": "Este proveedor de pagos no está disponible temporalmente. Vuelve a intentarlo más tarde.",
             "payment_not_required_text": "No se requiere el pago para este pedido.",
             "paypal_continue_action": "Continuar con PayPal",
-            "braintreevenmo_continue_action": "Continuar con Venmo",
+            "paypal_venmo_continue_action": "Continuar con Venmo",
             "paypal_credit_continue_action": "Continuar con PayPal Credit",
             "paypal_credit_description_text": "Compra ahora y paga después",
             "paypal_description_text": "Pagar con tu cuenta de PayPal",

--- a/packages/core/src/app/locale/translations/es-CL.json
+++ b/packages/core/src/app/locale/translations/es-CL.json
@@ -255,7 +255,7 @@
             "payment_method_unavailable_error": "Este proveedor de pagos no está disponible temporalmente. Vuelve a intentarlo más tarde.",
             "payment_not_required_text": "No se requiere el pago para este pedido.",
             "paypal_continue_action": "Continuar con PayPal",
-            "braintreevenmo_continue_action": "Continuar con Venmo",
+            "paypal_venmo_continue_action": "Continuar con Venmo",
             "paypal_credit_continue_action": "Continuar con PayPal Credit",
             "paypal_credit_description_text": "Compra ahora y paga después",
             "paypal_description_text": "Pagar con tu cuenta de PayPal",

--- a/packages/core/src/app/locale/translations/es-CO.json
+++ b/packages/core/src/app/locale/translations/es-CO.json
@@ -255,7 +255,7 @@
             "payment_method_unavailable_error": "Este proveedor de pagos no está disponible temporalmente. Vuelve a intentarlo más tarde.",
             "payment_not_required_text": "No se requiere el pago para este pedido.",
             "paypal_continue_action": "Continuar con PayPal",
-            "braintreevenmo_continue_action": "Continuar con Venmo",
+            "paypal_venmo_continue_action": "Continuar con Venmo",
             "paypal_credit_continue_action": "Continuar con PayPal Credit",
             "paypal_credit_description_text": "Compra ahora y paga después",
             "paypal_description_text": "Pagar con tu cuenta de PayPal",

--- a/packages/core/src/app/locale/translations/es-PE.json
+++ b/packages/core/src/app/locale/translations/es-PE.json
@@ -255,7 +255,7 @@
             "payment_method_unavailable_error": "Este proveedor de pagos no está disponible temporalmente. Vuelve a intentarlo más tarde.",
             "payment_not_required_text": "No se requiere el pago para este pedido.",
             "paypal_continue_action": "Continuar con PayPal",
-            "braintreevenmo_continue_action": "Continuar con Venmo",
+            "paypal_venmo_continue_action": "Continuar con Venmo",
             "paypal_credit_continue_action": "Continuar con PayPal Credit",
             "paypal_credit_description_text": "Compra ahora y paga después",
             "paypal_description_text": "Pagar con tu cuenta de PayPal",

--- a/packages/core/src/app/locale/translations/no.json
+++ b/packages/core/src/app/locale/translations/no.json
@@ -255,7 +255,7 @@
             "payment_method_unavailable_error": "Denne betalingsleverandøren er midlertidig utilgjengelig. Prøv igjen senere.",
             "payment_not_required_text": "Betaling kreves ikke for denne bestillingen.",
             "paypal_continue_action": "Fortsett med PayPal",
-            "braintreevenmo_continue_action": "Fortsett med Venmo",
+            "paypal_venmo_continue_action": "Fortsett med Venmo",
             "paypal_credit_continue_action": "Fortsett med PayPal Credit",
             "paypal_credit_description_text": "Kjøp nå, betal over tid",
             "paypal_description_text": "Betal med PayPal-kontoen din",

--- a/packages/core/src/app/payment/PaymentSubmitButton.spec.tsx
+++ b/packages/core/src/app/payment/PaymentSubmitButton.spec.tsx
@@ -8,7 +8,7 @@ import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale
 import { Button } from '../ui/button';
 import { IconBolt } from '../ui/icon';
 
-import { PaymentMethodId } from './paymentMethod';
+import { PaymentMethodId, PaymentMethodType } from './paymentMethod';
 import PaymentSubmitButton, { PaymentSubmitButtonProps } from './PaymentSubmitButton';
 
 describe('PaymentSubmitButton', () => {
@@ -134,13 +134,22 @@ describe('PaymentSubmitButton', () => {
             .toEqual(languageService.translate('payment.paypal_continue_action'));
     });
 
-    it('renders button with special label for BraintreeVenmo', () => {
+    it('renders button with special label for Braintree Venmo', () => {
         const component = mount(
             <PaymentSubmitButtonTest methodId={ PaymentMethodId.BraintreeVenmo } methodType="paypal" />
         );
 
         expect(component.text())
-            .toEqual(languageService.translate('payment.braintreevenmo_continue_action'));
+            .toEqual(languageService.translate('payment.paypal_venmo_continue_action'));
+    });
+
+    it('renders button with special label for PayPal Venmo', () => {
+        const component = mount(
+            <PaymentSubmitButtonTest methodType={ PaymentMethodType.PaypalVenmo } />
+        );
+
+        expect(component.text())
+            .toEqual(languageService.translate('payment.paypal_venmo_continue_action'));
     });
 
     it('renders button with special label for PayPal Credit', () => {

--- a/packages/core/src/app/payment/PaymentSubmitButton.tsx
+++ b/packages/core/src/app/payment/PaymentSubmitButton.tsx
@@ -55,21 +55,16 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
         return <TranslatedString id="payment.chasepay_continue_action" />;
     }
 
-    if (methodType === PaymentMethodType.Paypal) {
-        // TODO: method.id === PaymentMethodId.BraintreeVenmo should be removed after the PAYPAL-1380.checkout_button_strategies_update experiment removal
-        return <TranslatedString id={ methodId === PaymentMethodId.BraintreeVenmo ? 'payment.braintreevenmo_continue_action' : 'payment.paypal_continue_action' } />;
+    if (methodType === PaymentMethodType.PaypalVenmo || methodId === PaymentMethodId.BraintreeVenmo) {
+        return <TranslatedString id="payment.paypal_venmo_continue_action" />;
     }
 
-    if (methodId === PaymentMethodId.BraintreeVenmo) {
-        return <TranslatedString id="payment.braintreevenmo_continue_action" />;
+    if (methodType === PaymentMethodType.Paypal) {
+        return <TranslatedString id="payment.paypal_continue_action" />;
     }
 
     if (methodType === PaymentMethodType.PaypalCredit) {
         return <TranslatedString data={ { brandName } } id={ brandName ? 'payment.continue_with_brand' : 'payment.paypal_pay_later_continue_action' } />;
-    }
-
-    if (methodType === PaymentMethodType.PaypalVenmo) {
-        return <TranslatedString id="payment.paypal_venmo_continue_action" />;
     }
 
     if (methodId === PaymentMethodId.Opy) {


### PR DESCRIPTION
## What?
- Removed unnecessary Braintree Venmo logic from PaymentSubmitButton component;
- added `paypal_venmo_continue_action` translations for other languages;

## Why?
Because we don't need it anymore.

## Testing / Proof
Unit tests
