### PR TITLE
fix(payment): INT-6404 AmazonPayV2: Prevent button flickering

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -4,7 +4,7 @@ import React, { memo, Fragment, FunctionComponent } from 'react';
 import { isApplePayWindow } from '../common/utility';
 import { TranslatedString } from '../locale';
 
-import { ApplePayButton } from './customWalletButton';
+import { ApplePayButton, AmazonPayV2Button } from './customWalletButton';
 import CheckoutButton from './CheckoutButton';
 
 const APPLE_PAY = 'applepay';
@@ -75,23 +75,35 @@ const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
             { !isInitializing && <p><TranslatedString id="remote.continue_with_text" /></p> }
 
             <div className="checkoutRemote">
-                { supportedMethodIds.map(methodId =>
-                    methodId === 'applepay' ?
-                        <ApplePayButton
+                { supportedMethodIds.map(methodId => {
+                    if (methodId === 'applepay') {
+                        return <ApplePayButton
                             containerId={ `${methodId}CheckoutButton` }
                             key={ methodId }
                             methodId={ methodId }
                             onError={ onError }
                             { ...rest }
-                        /> :
-                        <CheckoutButton
+                        />;
+                    }
+
+                    if (methodId === 'amazonpay') {
+                        return <AmazonPayV2Button
                             containerId={ `${methodId}CheckoutButton` }
                             key={ methodId }
                             methodId={ methodId }
                             onError={ onError }
                             { ...rest }
-                        />
-                ) }
+                        />;
+                    }
+
+                    return <CheckoutButton
+                        containerId={ `${methodId}CheckoutButton` }
+                        key={ methodId }
+                        methodId={ methodId }
+                        onError={ onError }
+                        { ...rest }
+                    />
+                }) }
             </div>
         </Fragment>
     );

--- a/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.spec.tsx
+++ b/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.spec.tsx
@@ -1,0 +1,24 @@
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+import React from 'react';
+
+import CheckoutButton from '../CheckoutButton';
+
+import AmazonPayV2Button from './AmazonPayV2Button';
+
+describe('AmazonPayV2Button', () => {
+    it('renders as CheckoutButton', () => {
+        const container = shallow(
+            <AmazonPayV2Button
+                containerId={ 'test' }
+                deinitialize={ noop }
+                initialize={ noop }
+                methodId={ 'amazonpay' }
+                onError={ noop }
+            />
+        );
+
+        expect(container.hasClass('AmazonPayContainer')).toBe(true);
+        expect(container.find(CheckoutButton)).toHaveLength(1);
+    });
+});

--- a/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
+++ b/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
@@ -1,0 +1,11 @@
+import React, { FunctionComponent } from 'react';
+
+import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
+
+const AmazonPayV2Button: FunctionComponent<CheckoutButtonProps> = props => (
+  <div className="AmazonPayContainer">
+    <CheckoutButton { ...props } />
+  </div>
+);
+
+export default AmazonPayV2Button;

--- a/packages/core/src/app/customer/customWalletButton/index.ts
+++ b/packages/core/src/app/customer/customWalletButton/index.ts
@@ -1,1 +1,2 @@
 export { default as ApplePayButton } from './ApplePayButton';
+export { default as AmazonPayV2Button } from './AmazonPayV2Button';

--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -11,6 +11,10 @@
     > div {
         margin-right: spacing("single");
     }
+
+    > .AmazonPayContainer {
+        width: remCalc(200px);
+    }
 }
 
 .checkoutRemote-button {


### PR DESCRIPTION
## What? [INT-6404](https://bigcommercecloud.atlassian.net/browse/INT-6404)
Wrap the Amazon Pay button in a container with a specific size to prevent it from flickering.

## Why?
The size of the button's container is calculated by Amazon's JS every time the window resizes, that's why it flickers. We prevent the script from doing that by providing a parent container with a specific size. Therefore, the button's container inherits this size instead of doing all the math.

## Testing / Proof
#### Before:
https://user-images.githubusercontent.com/4843328/184449774-27043fe6-9bf8-4ffe-a2cd-33c5adf16040.mov
#### After:
https://user-images.githubusercontent.com/4843328/184711992-a61f3880-b2d0-4eaa-8c4b-8eb5ce1b90ec.mov

@bigcommerce/apex-integrations @bigcommerce/checkout
