### PR TITLE
chore(payment): PAYPAL-1611 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.278.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.278.1.tgz",
-      "integrity": "sha512-Ruk6muMgzFvtpluuZwnPm7DPYUaNcFwNXxibZzlgBMiVWksrl/4/BqQkzzXu8sLW3JEt2n0s6nh6OV4876XPlA==",
+      "version": "1.279.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.279.2.tgz",
+      "integrity": "sha512-RajT4/17lFfUGmrkqHBOtXX0oeqIdsiT2SmGWPK67V+TuDOI+IjYYWMJx/CKFKMbxV4+RluXi4Fe34BQTZ+J0Q==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.19.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.278.1",
+    "@bigcommerce/checkout-sdk": "^1.279.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump up checkout-sdk version

## Why?
To release the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1611

## Testing / Proof
Unit tests
Manual tests
