### PR TITLE
fix(payment) INT-6328 Bluesnap open a new tab insted of using iframe to complete order

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.tsx
@@ -1,6 +1,7 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { createRef, useCallback, useRef, useState, FunctionComponent, RefObject } from 'react';
 
+import { LoadingOverlay } from "../../ui/loading";
 import { Modal } from '../../ui/modal';
 
 import HostedPaymentMethod, { HostedPaymentMethodProps } from './HostedPaymentMethod';
@@ -16,6 +17,7 @@ const BlueSnapV2PaymentMethod: FunctionComponent<BlueSnapV2PaymentMethodProps> =
     initializePayment,
     ...rest
 }) => {
+    const [isLoadingIframe, setisLoadingIframe] = useState<boolean>(false);
     const [paymentPageContent, setPaymentPageContent] = useState<HTMLElement>();
     const ref = useRef<BlueSnapV2PaymentMethodRef>({
         paymentPageContentRef: createRef(),
@@ -36,6 +38,7 @@ const BlueSnapV2PaymentMethod: FunctionComponent<BlueSnapV2PaymentMethodProps> =
             bluesnapv2: {
                 onLoad(content: HTMLIFrameElement, cancel: () => void) {
                     setPaymentPageContent(content);
+                    setisLoadingIframe(true);
                     ref.current.cancelBlueSnapV2Payment = cancel;
                 },
                 style: {
@@ -50,6 +53,11 @@ const BlueSnapV2PaymentMethod: FunctionComponent<BlueSnapV2PaymentMethodProps> =
     const appendPaymentPageContent = useCallback(() => {
         if (ref.current.paymentPageContentRef.current && paymentPageContent) {
             ref.current.paymentPageContentRef.current.appendChild(paymentPageContent);
+            paymentPageContent.addEventListener('load',
+                () => {
+                    setisLoadingIframe(false);
+                }
+            );
         }
     }, [paymentPageContent]);
 
@@ -66,7 +74,9 @@ const BlueSnapV2PaymentMethod: FunctionComponent<BlueSnapV2PaymentMethodProps> =
                 onRequestClose={ cancelBlueSnapV2ModalFlow }
                 shouldShowCloseButton={ true }
             >
-                <div ref={ ref.current.paymentPageContentRef } />
+                <LoadingOverlay isLoading={ isLoadingIframe }  >
+                    <div ref={ ref.current.paymentPageContentRef } />
+                </LoadingOverlay>
             </Modal>
         </>
     );


### PR DESCRIPTION
## What?[INT-6328](https://bigcommercecloud.atlassian.net/browse/INT-6328)
Added a LoadingOverlay inside the modal

## Why?
Related to [PR 1578](https://github.com/bigcommerce/checkout-sdk-js/pull/1578)
The loading of the bluesnap checkout inside the modal may take some time.


## Testing / Proof
Before
<img width="1344" alt="Screen Shot 2022-08-23 at 9 28 42" src="https://user-images.githubusercontent.com/107939414/186187660-a3baaf70-1cff-4609-9178-e2fb808ecdf2.png">

After
<img width="1344" alt="Screen Shot 2022-08-23 at 12 05 42" src="https://user-images.githubusercontent.com/107939414/186220544-3de3e6ad-7933-4ae0-a05d-b5068f0ccb15.png">



Ping
@bigcommerce/apex-integrations  @bigcommerce/payments 