### PR TITLE
chore(payment): CHECKOUT-6904 Update resolver component to return method v1 as fallback

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -9,7 +9,6 @@ import AdyenV3PaymentMethod from './AdyenV3PaymentMethod';
 import AffirmPaymentMethod from './AffirmPaymentMethod';
 import AmazonPaymentMethod from './AmazonPaymentMethod';
 import AmazonPayV2PaymentMethod from './AmazonPayV2PaymentMethod';
-import ApplePayPaymentMethod from './ApplePayPaymentMethod';
 import BarclaycardPaymentMethod from './BarclaycardPaymentMethod';
 import BlueSnapV2PaymentMethod from './BlueSnapV2PaymentMethod';
 import BoltPaymentMethod from './BoltPaymentMethod';
@@ -81,10 +80,6 @@ const PaymentMethodComponent: FunctionComponent<PaymentMethodProps & WithCheckou
 
     if (method.gateway === PaymentMethodId.AdyenV3) {
         return <AdyenV3PaymentMethod { ...props } />;
-    }
-
-    if (method.id === PaymentMethodId.ApplePay) {
-        return <ApplePayPaymentMethod { ...props } />;
     }
 
     if (method.id === PaymentMethodId.SquareV2) {

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -7,8 +7,8 @@ import { isMobile } from '../../common/utility';
 import { Checklist, ChecklistItem } from '../../ui/form';
 
 import getUniquePaymentMethodId, { parseUniquePaymentMethodId } from './getUniquePaymentMethodId';
-import { default as PaymentMethodComponent } from './PaymentMethod';
 import PaymentMethodTitle from './PaymentMethodTitle';
+import PaymentMethodV2 from './PaymentMethodV2';
 
 export interface PaymentMethodListProps {
     isEmbedded?: boolean;
@@ -95,14 +95,14 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     onUnhandledError,
     value,
 }) => {
-    const renderPaymentMethod = useMemo(() => (
-        <PaymentMethodComponent
+    const renderPaymentMethod = useMemo(() => {
+        return <PaymentMethodV2
             isEmbedded={ isEmbedded }
             isUsingMultiShipping={ isUsingMultiShipping }
             method={ method }
-            onUnhandledError={ onUnhandledError }
+            onUnhandledError={ onUnhandledError || noop }
         />
-    ), [
+    }, [
         isEmbedded,
         isUsingMultiShipping,
         method,

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.spec.tsx
@@ -82,4 +82,28 @@ describe('PaymentMethod', () => {
         expect(componentB.find(Bar))
             .toBeDefined();
     });
+
+    it('returns payment method v1 if cannot resolve', () => {
+        const Foo: FunctionComponent<PaymentMethodProps> = ({ method }) => <div>{ method.id }</div>;
+
+        const resolver = (method: PaymentMethod) => {
+            return method.id === 'foo' ? Foo : undefined;
+        };
+
+        const componentFallback = mount(
+            <ContextProvider>
+                <PaymentMethodComponent
+                    method={ {
+                        ...getPaymentMethod(),
+                        id: 'test',
+                    } }
+                    onUnhandledError={ jest.fn() }
+                    resolveComponent={ resolver }
+                />
+            </ContextProvider>
+        );
+
+        expect(componentFallback.find(Foo))
+            .toBeDefined();
+    });
 });

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
@@ -15,7 +15,7 @@ export interface PaymentMethodProps {
     method: PaymentMethod;
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
-    resolveComponent?(query: PaymentMethodResolveId): ComponentType<ResolvedPaymentMethodProps>;
+    resolveComponent?(query: PaymentMethodResolveId): ComponentType<ResolvedPaymentMethodProps> | undefined;
     onUnhandledError(error: Error): void;
 }
 
@@ -62,7 +62,7 @@ const PaymentMethodContainer: ComponentType<
     });
 
     if (!ResolvedPaymentMethod) {
-        console.log('%c method not resolved, using V1 fallback', 'color: red', method.id)
+        console.log('Does this run');
         return <PaymentMethodComponent
             isEmbedded={ isEmbedded }
             isUsingMultiShipping={ isUsingMultiShipping }
@@ -70,8 +70,6 @@ const PaymentMethodContainer: ComponentType<
             onUnhandledError={ onUnhandledError }
         />;
     }
-
-    console.log('%c method resolved successfully', 'color: green', method.id,);
 
     return <ResolvedPaymentMethod
         checkoutService={ checkoutService }

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
@@ -8,7 +8,7 @@ import { withLanguage, WithLanguageProps } from '../../locale';
 import { withForm, WithFormProps } from '../../ui/form';
 import createPaymentFormService from '../createPaymentFormService';
 import resolvePaymentMethod from '../resolvePaymentMethod';
-import { default as PaymentMethodComponent } from './PaymentMethod';
+import { default as PaymentMethodV1 } from './PaymentMethod';
 import withPayment, { WithPaymentProps } from '../withPayment';
 
 export interface PaymentMethodProps {
@@ -62,8 +62,7 @@ const PaymentMethodContainer: ComponentType<
     });
 
     if (!ResolvedPaymentMethod) {
-        console.log('Does this run');
-        return <PaymentMethodComponent
+        return <PaymentMethodV1
             isEmbedded={ isEmbedded }
             isUsingMultiShipping={ isUsingMultiShipping }
             method={ method }

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
@@ -8,10 +8,13 @@ import { withLanguage, WithLanguageProps } from '../../locale';
 import { withForm, WithFormProps } from '../../ui/form';
 import createPaymentFormService from '../createPaymentFormService';
 import resolvePaymentMethod from '../resolvePaymentMethod';
+import { default as PaymentMethodComponent } from './PaymentMethod';
 import withPayment, { WithPaymentProps } from '../withPayment';
 
 export interface PaymentMethodProps {
     method: PaymentMethod;
+    isEmbedded?: boolean;
+    isUsingMultiShipping?: boolean;
     resolveComponent?(query: PaymentMethodResolveId): ComponentType<ResolvedPaymentMethodProps>;
     onUnhandledError(error: Error): void;
 }
@@ -29,7 +32,9 @@ const PaymentMethodContainer: ComponentType<
     checkoutState,
     disableSubmit,
     hidePaymentSubmitButton,
+    isEmbedded,
     isSubmitted,
+    isUsingMultiShipping,
     language,
     method,
     onUnhandledError,
@@ -57,8 +62,16 @@ const PaymentMethodContainer: ComponentType<
     });
 
     if (!ResolvedPaymentMethod) {
-        return null;
+        console.log('%c method not resolved, using V1 fallback', 'color: red', method.id)
+        return <PaymentMethodComponent
+            isEmbedded={ isEmbedded }
+            isUsingMultiShipping={ isUsingMultiShipping }
+            method={ method }
+            onUnhandledError={ onUnhandledError }
+        />;
     }
+
+    console.log('%c method resolved successfully', 'color: green', method.id,);
 
     return <ResolvedPaymentMethod
         checkoutService={ checkoutService }

--- a/packages/core/src/app/payment/resolvePaymentMethod.ts
+++ b/packages/core/src/app/payment/resolvePaymentMethod.ts
@@ -1,11 +1,8 @@
 import { PaymentMethodProps, PaymentMethodResolveId } from '@bigcommerce/checkout/payment-integration-api';
 import { ComponentType } from 'react';
 
-import { resolveComponent } from '../common/resolver';
-
 import * as paymentMethods from '../generated/paymentIntegrations';
-
-console.log('methods are:', paymentMethods);
+import { resolveComponent } from '../common/resolver';
 
 export default function resolvePaymentMethod(query: PaymentMethodResolveId): ComponentType<PaymentMethodProps> | undefined {
     return resolveComponent<PaymentMethodResolveId, PaymentMethodProps>(

--- a/packages/core/src/app/payment/resolvePaymentMethod.ts
+++ b/packages/core/src/app/payment/resolvePaymentMethod.ts
@@ -3,9 +3,13 @@ import { ComponentType } from 'react';
 
 import { resolveComponent } from '../common/resolver';
 
+import * as paymentMethods from '../generated/paymentIntegrations';
+
+console.log('methods are:', paymentMethods);
+
 export default function resolvePaymentMethod(query: PaymentMethodResolveId): ComponentType<PaymentMethodProps> | undefined {
     return resolveComponent<PaymentMethodResolveId, PaymentMethodProps>(
         query,
-        require('../generated/paymentMethods')
+        paymentMethods
     );
 }


### PR DESCRIPTION
## What?
As above

## Why?
Add fallback to v1 payment method component if a component cannot be resolved via the `resolveComponent` method

## Testing / Proof
- tests 
- manual

@bigcommerce/checkout
