### PR TITLE
feat(checkout): CHECKOUT-6851 Separate shipping option from address

### DIFF
--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -48,7 +48,7 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
                         <strong>
                             <TranslatedString id="shipping.shipping_method_label" />
                         </strong> }
-                    <div className="shippingOption shippingOption--alt">
+                    <div className="shippingOption shippingOption--alt shippingOption--state-selected">
                         <StaticShippingOption
                             displayAdditionalInformation={ false }
                             method={ selectedShippingOption }

--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -48,7 +48,7 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
                         <strong>
                             <TranslatedString id="shipping.shipping_method_label" />
                         </strong> }
-                    <div className="shippingOption shippingOption--alt shippingOption--state-selected">
+                    <div className="shippingOption shippingOption--alt shippingOption--selected">
                         <StaticShippingOption
                             displayAdditionalInformation={ false }
                             method={ selectedShippingOption }

--- a/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
+++ b/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`StaticConsignment Component renders compact view of static consignment 
 >
   <div>
     <div
-      class="shippingOption shippingOption--alt"
+      class="shippingOption shippingOption--alt shippingOption--state-selected"
     >
       <div
         class="shippingOption shippingOption--alt"
@@ -39,7 +39,7 @@ exports[`StaticConsignment Component renders static consignment with shipping me
   <div>
     <strong />
     <div
-      class="shippingOption shippingOption--alt"
+      class="shippingOption shippingOption--alt shippingOption--state-selected"
     >
       <div
         class="shippingOption shippingOption--alt"

--- a/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
+++ b/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`StaticConsignment Component renders compact view of static consignment 
 >
   <div>
     <div
-      class="shippingOption shippingOption--alt shippingOption--state-selected"
+      class="shippingOption shippingOption--alt shippingOption--selected"
     >
       <div
         class="shippingOption shippingOption--alt"
@@ -39,7 +39,7 @@ exports[`StaticConsignment Component renders static consignment with shipping me
   <div>
     <strong />
     <div
-      class="shippingOption shippingOption--alt shippingOption--state-selected"
+      class="shippingOption shippingOption--alt shippingOption--selected"
     >
       <div
         class="shippingOption shippingOption--alt"

--- a/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -8,7 +8,7 @@
     width: 100%;
 }
 
-.shippingOption--state-selected {
+.shippingOption--selected {
     border-top: container("border");
     margin-top: spacing("half");
     padding-top: spacing("half");

--- a/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -8,6 +8,12 @@
     width: 100%;
 }
 
+.shippingOption--state-selected {
+    border-top: container("border");
+    margin-top: spacing("half");
+    padding-top: spacing("half");
+}
+
 .shippingOption-figure,
 .shippingOption-desc,
 .shippingOption-price {


### PR DESCRIPTION
## What?
Make the shipping address and the shipping method separate.

## Why?
Currently, shipping method is appended at the end of the address. This makes it hard for shoppers to quickly identify it. We want the checkout flow to be less cluttered.

## Testing / Proof
Before:
<img width="750" alt="Before" src="https://user-images.githubusercontent.com/88361607/186346565-5b48619d-9353-41cf-a35b-d7bfbdeda82c.png">
After:
<img width="750" alt="After" src="https://user-images.githubusercontent.com/88361607/186346611-e01d3d9f-6029-4350-886c-f44c5670490a.png">
