### PR TITLE
feat(checkout): CHECKOUT-6851 Improve multi-shipping form look

### DIFF
--- a/packages/core/src/app/shipping/StaticConsignment.scss
+++ b/packages/core/src/app/shipping/StaticConsignment.scss
@@ -7,7 +7,6 @@
     }
 
     & + .staticConsignmentContainer {
-        border-top: container("border");
         margin-top: spacing("single");
         padding-top: spacing("single");
     }

--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -2,7 +2,6 @@ import { Cart, Consignment } from '@bigcommerce/checkout-sdk';
 import React, { memo, FunctionComponent } from 'react';
 
 import { AddressType, StaticAddress } from '../address';
-import { TranslatedString } from '../locale';
 
 import { StaticShippingOption } from './shippingOption';
 import './StaticConsignment.scss';
@@ -26,11 +25,6 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
 
     return (
         <div className="staticConsignment">
-            { !compactView &&
-                <strong>
-                    <TranslatedString id="shipping.shipping_address_heading" />
-                </strong> }
-
             <StaticAddress
                 address={ address }
                 type={ AddressType.Shipping }
@@ -44,10 +38,6 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
 
             { selectedShippingOption &&
                 <div>
-                    { !compactView &&
-                        <strong>
-                            <TranslatedString id="shipping.shipping_method_label" />
-                        </strong> }
                     <div className="shippingOption shippingOption--alt shippingOption--selected">
                         <StaticShippingOption
                             displayAdditionalInformation={ false }

--- a/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
+++ b/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
@@ -29,7 +29,6 @@ exports[`StaticConsignment Component renders static consignment with shipping me
 <div
   class="staticConsignment"
 >
-  <strong />
   <div
     class="staticConsignment-items"
   >
@@ -37,7 +36,6 @@ exports[`StaticConsignment Component renders static consignment with shipping me
     <ul />
   </div>
   <div>
-    <strong />
     <div
       class="shippingOption shippingOption--alt shippingOption--selected"
     >


### PR DESCRIPTION
## What?
Improve the multi-shipping details look.

## Why?
We want the checkout flow to be less cluttered.

## Testing / Proof
Before:
<img width="750" src="https://user-images.githubusercontent.com/88361607/186579979-5c53aef6-9c8a-4d66-be53-a996afed7a6b.png">

After:
<img width="750" alt="image" src="https://user-images.githubusercontent.com/88361607/186580006-bf9f47c4-478e-487f-8f4d-07e1dac26e26.png">
