### PR TITLE
fix(payment): INT-6115 Payment with hosted credit card

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.spec.tsx
@@ -76,7 +76,7 @@ describe('when using Worldpay payment', () => {
             isInitializing: false,
             method: {
                 ...getPaymentMethod(),
-                id: PaymentMethodId.Worldpay,
+                id: PaymentMethodId.WorldpayAccess,
             },
             onUnhandledError: jest.fn(),
         };
@@ -140,10 +140,35 @@ describe('when using Worldpay payment', () => {
 
         await new Promise(resolve => process.nextTick(resolve));
 
+        const creditCard = {
+            form: {
+                fields: {
+                    cardCode: {
+                        containerId: "cardCode",
+                        placeholder: "Card code"
+                    },
+                    cardExpiry: {
+                        containerId: "cardExpiry",
+                        placeholder: "Card expiry"
+                    },
+                    cardName: {
+                        containerId: "cardName",
+                        "placeholder": "Card name"
+                    },
+                    cardNumber: {
+                        containerId: "cardNumber",
+                        placeholder: "Card number"
+                    }
+                }
+            }
+        }
+
         expect(defaultProps.initializePayment)
             .toHaveBeenCalledWith(expect.objectContaining({
                 methodId: defaultProps.method.id,
                 gatewayId: defaultProps.method.gateway,
+                worldpay: {onLoad: expect.any(Function)},
+                creditCard: creditCard
             }));
     });
 


### PR DESCRIPTION
## What?  [INT-6115](https://bigcommercecloud.atlassian.net/browse/INT-6115)
Allow to pay with hosted payment 

## Why?
the payment was failing when Feature_HostedPaymentForm was enabled

## Testing / Proof
[Video](https://drive.google.com/file/d/1hv8EayUMZ80jKXQBJjnuz8n4tqL_yqRQ/view?usp=sharing)

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1583

@bigcommerce/checkout
