### PR TITLE
feat(checkout): CHECKOUT-6875 Improve accessibility part II

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -255,6 +255,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
                             .map(step => this.renderStep({
                                 ...step,
                                 isActive: activeStepType ? activeStepType === step.type : defaultStepType === step.type,
+                                isBusy: isPending,
                             })) }
                     </ol>
                 </div>

--- a/packages/core/src/app/checkout/CheckoutStep.tsx
+++ b/packages/core/src/app/checkout/CheckoutStep.tsx
@@ -108,7 +108,7 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
     }
 
     private renderContent(): ReactNode {
-        const { children, isActive } = this.props;
+        const { children, isActive, isBusy } = this.props;
 
         return <>
             <MobileView>
@@ -124,6 +124,7 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
                         unmountOnExit
                     >
                         <div
+                            aria-busy={ isBusy }
                             className="checkout-view-content"
                             ref={ this.contentRef }
                         >

--- a/packages/core/src/app/checkout/CheckoutStep.tsx
+++ b/packages/core/src/app/checkout/CheckoutStep.tsx
@@ -11,6 +11,7 @@ import CheckoutStepType from './CheckoutStepType';
 export interface CheckoutStepProps {
     heading?: ReactNode;
     isActive?: boolean;
+    isBusy: boolean;
     isComplete?: boolean;
     isEditable?: boolean;
     suggestion?: ReactNode;

--- a/packages/core/src/app/checkout/CheckoutStepStatus.ts
+++ b/packages/core/src/app/checkout/CheckoutStepStatus.ts
@@ -2,6 +2,7 @@ import CheckoutStepType from './CheckoutStepType';
 
 export default interface CheckoutStepStatus {
     isActive: boolean;
+    isBusy: boolean;
     isComplete: boolean;
     isEditable: boolean;
     isRequired: boolean;

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -133,6 +133,7 @@ const getCheckoutStepStatuses = createSelector(
             return {
                 ...step,
                 isActive: defaultActiveStep.type === step.type,
+                isBusy: false,
                 // A step is only editable if its previous step is complete or not required
                 isEditable: isPrevStepComplete && step.isEditable,
             };

--- a/packages/core/src/app/ui/loading/LoadingNotification.tsx
+++ b/packages/core/src/app/ui/loading/LoadingNotification.tsx
@@ -18,7 +18,7 @@ const LoadingNotification: FunctionComponent<LoadingNotificationProps> = ({
             <div className="loadingNotification-label optimizedCheckout-loadingToaster">
                 <div className="spinner" />
 
-                <span className="label">
+                <span aria-live="assertive" className="label" role="alert">
                     <TranslatedString id="common.loading_text" />
                 </span>
             </div>

--- a/packages/core/src/app/ui/loading/__snapshots__/LoadingNotification.spec.tsx.snap
+++ b/packages/core/src/app/ui/loading/__snapshots__/LoadingNotification.spec.tsx.snap
@@ -11,7 +11,9 @@ exports[`LoadingNotification renders markup that matches snapshot 1`] = `
       className="spinner"
     />
     <span
+      aria-live="assertive"
       className="label"
+      role="alert"
     >
       <WithLanguage(TranslatedString)
         id="common.loading_text"


### PR DESCRIPTION
## What?
We want to use `aria-busy="true"` to prevent a screen reader from using the modified content when there is an ongoing API request. Additionally, the loading state should be immediately announced by the screen reader.

## Related PR
Part I: https://github.com/bigcommerce/checkout-js/pull/996

## Why?
BC merchants can benefit from the ADA-compliant native checkout and order confirmation pages.

## Testing / Proof
Please notice the `aria-busy` changes on the right side of the video.

https://user-images.githubusercontent.com/88361607/187326520-18697916-3cba-4a7e-9c94-fc2b23e50216.mov


