### PR TITLE
chore(payment): STRIPE-52 bump to 1.282.0 SDK version (#1518)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.281.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.281.1.tgz",
-      "integrity": "sha512-KaF/LxB7UQ6LUAmX7pdRpFmaOf4YzSPWjM9wGzfN4YRKc0zVFbgj9b6LRgy+nsfiv+TEsLhHfK9C/ETkjTFe+Q==",
+      "version": "1.282.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.282.0.tgz",
+      "integrity": "sha512-3WoSRiYYqZdEiaE9cyTs2sB1URiRWj1b+iheO4gs14Jq8knqR2aKI8B3ll6GT+vnMCr1x7py5r/64gcaa/3Gcw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.19.0",
@@ -1165,7 +1165,7 @@
         "@types/shallowequal": "^1.1.1",
         "@types/yup": "^0.26.24",
         "card-validator": "^6.2.0",
-        "core-js": "^3.24.0",
+        "core-js": "^3.24.1",
         "current-script-polyfill": "^1.0.0",
         "iframe-resizer": "^3.6.6",
         "local-storage-fallback": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.281.1",
+    "@bigcommerce/checkout-sdk": "^1.282.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What? 
Update SDK version

## Why?
We need to use the latest version of SDK to be able to implement the StripeLink checkout

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/apex-integrations 
