### PR TITLE
chore(payment): PAYPAL-1474 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,12 +1146,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.281.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.281.1.tgz",
-      "integrity": "sha512-KaF/LxB7UQ6LUAmX7pdRpFmaOf4YzSPWjM9wGzfN4YRKc0zVFbgj9b6LRgy+nsfiv+TEsLhHfK9C/ETkjTFe+Q==",
+      "version": "1.283.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.283.0.tgz",
+      "integrity": "sha512-75kIzaKtMY+KIatrutUJTdOWdgeFP0bw+E3ardTpPoGwBTUsEeU957VZ4SkwGOfXZaMzRUkzNeLgtg4431cM0w==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
-        "@bigcommerce/bigpay-client": "^5.19.0",
+        "@bigcommerce/bigpay-client": "^5.20.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1165,7 +1165,7 @@
         "@types/shallowequal": "^1.1.1",
         "@types/yup": "^0.26.24",
         "card-validator": "^6.2.0",
-        "core-js": "^3.24.0",
+        "core-js": "^3.24.1",
         "current-script-polyfill": "^1.0.0",
         "iframe-resizer": "^3.6.6",
         "local-storage-fallback": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.281.1",
+    "@bigcommerce/checkout-sdk": "^1.283.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
This release contains next checkout-sdk changes:
https://github.com/bigcommerce/checkout-sdk-js/pull/1494
https://github.com/bigcommerce/checkout-sdk-js/pull/1530
https://github.com/bigcommerce/checkout-sdk-js/pull/1518
https://github.com/bigcommerce/checkout-sdk-js/pull/1585

## Testing / Proof
Unit tests
Manual tests

Screenshots of the result:
<img width="1137" alt="Screenshot 2022-09-06 at 12 24 01" src="https://user-images.githubusercontent.com/25133454/189071699-ae718d27-06f6-4035-be0d-e9943c443a61.png">
<img width="303" alt="Screenshot 2022-09-06 at 12 24 13" src="https://user-images.githubusercontent.com/25133454/189071715-47cdb33b-daff-4d85-899c-bfb162bf1c15.png">

