### PR TITLE
fix(checkout): CHECKOUT-6365 Add scrollIntoView to embedded checkout

### DIFF
--- a/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
@@ -20,6 +20,7 @@ describe('OrderSummaryDrawer', () => {
     let localeContext: LocaleContextType;
 
     beforeEach(() => {
+        window.HTMLElement.prototype.scrollIntoView = jest.fn();
         localeContext = createLocaleContext(getStoreConfig());
 
         order = getOrder();
@@ -98,6 +99,9 @@ describe('OrderSummaryDrawer', () => {
                     shopperCurrency: getStoreConfig().shopperCurrency,
                     additionalLineItems: 'foo',
                 });
+
+            expect(document.body.scrollIntoView)
+                .toBeCalled();
         });
     });
 
@@ -122,6 +126,9 @@ describe('OrderSummaryDrawer', () => {
                     shopperCurrency: getStoreConfig().shopperCurrency,
                     additionalLineItems: 'foo',
                 });
+
+            expect(document.body.scrollIntoView)
+                .toBeCalled();
         });
     });
 });

--- a/packages/core/src/app/ui/modal/ModalTrigger.spec.tsx
+++ b/packages/core/src/app/ui/modal/ModalTrigger.spec.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent } from 'react';
 import ModalTrigger, { ModalTriggerModalProps } from './ModalTrigger';
 
 describe('ModalTrigger', () => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
     const Modal: FunctionComponent<ModalTriggerModalProps> = ({ isOpen, onRequestClose }) => (
         isOpen ?
             <div id="modal"><button id="closeButton" onClick={ onRequestClose }>Close</button></div> :
@@ -25,6 +26,9 @@ describe('ModalTrigger', () => {
 
         expect(component.find('#modal'))
             .toHaveLength(1);
+
+        expect(document.body.scrollIntoView)
+            .toBeCalled();
     });
 
     it('closes modal window when "onRequestClose" is called', () => {

--- a/packages/core/src/app/ui/modal/ModalTrigger.tsx
+++ b/packages/core/src/app/ui/modal/ModalTrigger.tsx
@@ -49,6 +49,8 @@ export default class ModalTrigger extends Component<ModalTriggerProps, ModalTrig
     }
 
     private handleOpen: () => void = () => {
+        document.body.scrollIntoView();
+
         if (!this.canHandleEvent) {
             return;
         }


### PR DESCRIPTION
## What?
Add `scrollIntoView` to embedded checkout, so a shopper can always see the content of a modal.

## Why?
A shopper cannot see the content of a modal without scrolling to the top of the iframe when an embedded checkout's iframe is too long.

## Testing / Proof
Before:

https://user-images.githubusercontent.com/88361607/189245953-1258db75-7244-4999-96b5-674ae1b393c3.mov

After:

https://user-images.githubusercontent.com/88361607/189245959-1027d53c-e962-4d27-9872-30de307b1a31.mov