### PR TITLE
feat(checkout): STRF-9858 Integrate Bodl Service with Checkout Begin and Order Purchased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,9 +1205,9 @@
           }
         },
         "core-js": {
-          "version": "3.25.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.0.tgz",
-          "integrity": "sha512-CVU1xvJEfJGhyCpBrzzzU1kjCfgsGUxhEvwUV2e/cOedYWHdmluamx+knDnmhqALddMG16fZvIqvs9aijsHHaA=="
+          "version": "3.25.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
+          "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ=="
         },
         "yup": {
           "version": "0.27.0",

--- a/packages/core/src/app/checkout/Checkout.spec.tsx
+++ b/packages/core/src/app/checkout/Checkout.spec.tsx
@@ -1,4 +1,4 @@
-import { createCheckoutService, createEmbeddedCheckoutMessenger, CheckoutSelectors, CheckoutService, EmbeddedCheckoutMessenger, StepTracker } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, createEmbeddedCheckoutMessenger, CheckoutSelectors, CheckoutService, EmbeddedCheckoutMessenger, StepTracker, BodlService } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import { EventEmitter } from 'events';
 import { noop, omit } from 'lodash';
@@ -38,6 +38,7 @@ describe('Checkout', () => {
     let defaultProps: CheckoutProps;
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
     let stepTracker: StepTracker;
+    let bodlService: BodlService;
     let subscribeEventEmitter: EventEmitter;
 
     beforeEach(() => {
@@ -49,6 +50,9 @@ describe('Checkout', () => {
             trackStepViewed: jest.fn(),
             trackStepCompleted: jest.fn(),
         } as unknown as StepTracker;
+        bodlService = {
+            checkoutBegin: jest.fn(),
+        } as unknown as StepTracker;
         subscribeEventEmitter = new EventEmitter();
 
         defaultProps = {
@@ -59,6 +63,7 @@ describe('Checkout', () => {
             embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
             errorLogger: createErrorLogger(),
             createStepTracker: () => stepTracker,
+            createBodlService: () => bodlService,
         };
 
         jest.spyOn(checkoutService, 'loadCheckout')
@@ -133,6 +138,16 @@ describe('Checkout', () => {
         await new Promise(resolve => process.nextTick(resolve));
 
         expect(stepTracker.trackCheckoutStarted)
+            .toHaveBeenCalled();
+    });
+
+    it('tracks BODL checkout begin', async () => {
+        const container = mount(<CheckoutTest { ...defaultProps } />);
+        container.update();
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(bodlService.checkoutBegin)
             .toHaveBeenCalled();
     });
 

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -1,4 +1,4 @@
-import { Address, Cart, CartChangedError, CheckoutParams, CheckoutSelectors, Consignment, EmbeddedCheckoutMessenger, EmbeddedCheckoutMessengerOptions, FlashMessage, Promotion, RequestOptions, StepTracker } from '@bigcommerce/checkout-sdk';
+import { Address, Cart, CartChangedError, CheckoutParams, CheckoutSelectors, Consignment, EmbeddedCheckoutMessenger, EmbeddedCheckoutMessengerOptions, FlashMessage, Promotion, RequestOptions, StepTracker, BodlService } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import { find, findIndex } from 'lodash';
 import React, { lazy, Component, ReactNode } from 'react';
@@ -62,6 +62,7 @@ export interface CheckoutProps {
     errorLogger: ErrorLogger;
     createEmbeddedMessenger(options: EmbeddedCheckoutMessengerOptions): EmbeddedCheckoutMessenger;
     createStepTracker(): StepTracker;
+    createBodlService(): BodlService;
 }
 
 export interface CheckoutState {
@@ -102,6 +103,7 @@ export interface WithCheckoutProps {
 
 class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguageProps, CheckoutState> {
     stepTracker: StepTracker | undefined;
+    bodlService: BodlService | undefined;
 
     state: CheckoutState = {
         isBillingSameAsShipping: true,
@@ -127,6 +129,7 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
             checkoutId,
             containerId,
             createStepTracker,
+            createBodlService,
             createEmbeddedMessenger,
             embeddedStylesheet,
             loadCheckout,
@@ -168,6 +171,9 @@ class Checkout extends Component<CheckoutProps & WithCheckoutProps & WithLanguag
 
             this.stepTracker = createStepTracker();
             this.stepTracker.trackCheckoutStarted();
+
+            this.bodlService = createBodlService();
+            this.bodlService.checkoutBegin();
 
             const consignments = data.getConsignments();
             const cart = data.getCart();

--- a/packages/core/src/app/checkout/CheckoutApp.tsx
+++ b/packages/core/src/app/checkout/CheckoutApp.tsx
@@ -1,4 +1,4 @@
-import { createCheckoutService, createEmbeddedCheckoutMessenger, createStepTracker, StepTracker } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, createEmbeddedCheckoutMessenger, createStepTracker, StepTracker, createBodlService, BodlService } from '@bigcommerce/checkout-sdk';
 import { BrowserOptions } from '@sentry/browser';
 import React, { Component } from 'react';
 import ReactModal from 'react-modal';
@@ -52,6 +52,7 @@ export default class CheckoutApp extends Component<CheckoutAppProps> {
                     <CheckoutProvider checkoutService={ this.checkoutService }>
                         <Checkout
                             { ...this.props }
+                            createBodlService={ this.createBodlService }
                             createEmbeddedMessenger={ createEmbeddedCheckoutMessenger }
                             createStepTracker={ this.createStepTracker }
                             embeddedStylesheet={ this.embeddedStylesheet }
@@ -66,5 +67,9 @@ export default class CheckoutApp extends Component<CheckoutAppProps> {
 
     private createStepTracker: () => StepTracker = () => {
         return createStepTracker(this.checkoutService);
+    };
+
+    private createBodlService: () => BodlService = () => {
+        return createBodlService(this.checkoutService.subscribe);
     };
 }

--- a/packages/core/src/app/order/OrderConfirmation.spec.tsx
+++ b/packages/core/src/app/order/OrderConfirmation.spec.tsx
@@ -1,4 +1,4 @@
-import { createCheckoutService, createEmbeddedCheckoutMessenger, CheckoutSelectors, CheckoutService, EmbeddedCheckoutMessenger, StepTracker } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, createEmbeddedCheckoutMessenger, CheckoutSelectors, CheckoutService, EmbeddedCheckoutMessenger, StepTracker, BodlService } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 import { act } from 'react-dom/test-utils';
@@ -21,6 +21,7 @@ describe('OrderConfirmation', () => {
     let checkoutState: CheckoutSelectors;
     let defaultProps: OrderConfirmationProps;
     let stepTracker: StepTracker;
+    let bodlService: BodlService;
     let ComponentTest: FunctionComponent<OrderConfirmationProps>;
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
     let orderConfirmation: ReactWrapper;
@@ -31,6 +32,9 @@ describe('OrderConfirmation', () => {
         stepTracker = {
             trackOrderComplete: jest.fn(),
         } as unknown as StepTracker;
+        bodlService = {
+            orderPurchased: jest.fn(),
+        } as unknown as BodlService;
         embeddedMessengerMock = createEmbeddedCheckoutMessenger({ parentOrigin: getStoreConfig().links.siteLink });
 
         jest.spyOn(checkoutService, 'loadOrder')
@@ -50,6 +54,7 @@ describe('OrderConfirmation', () => {
             createAccount: jest.fn(() => Promise.resolve({} as CreatedCustomer)),
             createEmbeddedMessenger: () => embeddedMessengerMock,
             createStepTracker: () => stepTracker,
+            createBodlService: () => bodlService,
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
             errorLogger: createErrorLogger(),
             orderId: 105,
@@ -74,6 +79,19 @@ describe('OrderConfirmation', () => {
         await new Promise(resolve => process.nextTick(resolve));
 
         expect(stepTracker.trackOrderComplete)
+            .toHaveBeenCalled();
+    });
+
+    it('calls bodl event order complete triggered', async () => {
+        jest.spyOn(checkoutState.data, 'getConfig')
+            .mockReturnValue(undefined);
+
+        const component = mount(<ComponentTest { ...defaultProps } />);
+        component.update();
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(bodlService.orderPurchased)
             .toHaveBeenCalled();
     });
 

--- a/packages/core/src/app/order/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation.tsx
@@ -1,4 +1,4 @@
-import { CheckoutSelectors, EmbeddedCheckoutMessenger, EmbeddedCheckoutMessengerOptions, Order, ShopperConfig, StepTracker, StoreConfig } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, EmbeddedCheckoutMessenger, EmbeddedCheckoutMessengerOptions, Order, ShopperConfig, StepTracker, BodlService, StoreConfig } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
 import React, { lazy, Component, Fragment, ReactNode } from 'react';
@@ -46,6 +46,7 @@ export interface OrderConfirmationProps {
     createAccount(values: SignUpFormValues): Promise<CreatedCustomer>;
     createEmbeddedMessenger(options: EmbeddedCheckoutMessengerOptions): EmbeddedCheckoutMessenger;
     createStepTracker(): StepTracker;
+    createBodlService(): BodlService;
 }
 
 interface WithCheckoutOrderConfirmationProps {
@@ -68,6 +69,7 @@ class OrderConfirmation extends Component<
             containerId,
             createEmbeddedMessenger,
             createStepTracker,
+            createBodlService,
             embeddedStylesheet,
             loadOrder,
             orderId,
@@ -84,6 +86,7 @@ class OrderConfirmation extends Component<
                 messenger.postFrameLoaded({ contentId: containerId });
 
                 createStepTracker().trackOrderComplete();
+                createBodlService().orderPurchased();
             })
             .catch(this.handleUnhandledError);
     }

--- a/packages/core/src/app/order/OrderConfirmationApp.tsx
+++ b/packages/core/src/app/order/OrderConfirmationApp.tsx
@@ -1,4 +1,4 @@
-import { createCheckoutService, createEmbeddedCheckoutMessenger, createStepTracker, StepTracker } from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, createEmbeddedCheckoutMessenger, createStepTracker, StepTracker, createBodlService, BodlService } from '@bigcommerce/checkout-sdk';
 import { BrowserOptions } from '@sentry/browser';
 import React, { Component, ReactNode } from 'react';
 import ReactModal from 'react-modal';
@@ -54,6 +54,7 @@ class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
                         <OrderConfirmation
                             { ...this.props }
                             createAccount={ this.createAccount }
+                            createBodlService={ this.createBodlService }
                             createEmbeddedMessenger={ createEmbeddedCheckoutMessenger }
                             createStepTracker={ this.createStepTracker }
                             embeddedStylesheet={ this.embeddedStylesheet }
@@ -81,6 +82,10 @@ class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
 
     private createStepTracker: () => StepTracker = () => {
         return createStepTracker(this.checkoutService);
+    };
+
+    private createBodlService: () => BodlService = () => {
+        return createBodlService(this.checkoutService.subscribe);
     };
 }
 


### PR DESCRIPTION
## What?

- Called checkout begin event for BODL on checkout page load
- Called order purchsed event for BODL on order confirmation page load 

## Why?

It's required for BODL phase 1 

## Testing / Proof
<img width="932" alt="Screenshot 2022-09-12 at 10 00 56" src="https://user-images.githubusercontent.com/68893868/189603183-e9048288-3b30-4de4-8361-9fbce9b51c29.png">
<img width="918" alt="Screenshot 2022-09-12 at 10 07 29" src="https://user-images.githubusercontent.com/68893868/189603877-de316805-7af3-48e1-955a-d3b590c90c54.png">



@bigcommerce/checkout
