### PR TITLE
chore(payment): PAYPAL-1538 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.283.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.283.0.tgz",
-      "integrity": "sha512-75kIzaKtMY+KIatrutUJTdOWdgeFP0bw+E3ardTpPoGwBTUsEeU957VZ4SkwGOfXZaMzRUkzNeLgtg4431cM0w==",
+      "version": "1.284.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.284.1.tgz",
+      "integrity": "sha512-Daxluamyot/FunxucGXALIaahMlGwz3tYgufkey+bNszz6yu+e1yV319CQ3+jTeu+9dd9ezzBEOHFUd3yvowOA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.283.0",
+    "@bigcommerce/checkout-sdk": "^1.284.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js what contains pr below:
https://github.com/bigcommerce/checkout-sdk-js/pull/1589
https://github.com/bigcommerce/checkout-sdk-js/pull/1587
https://github.com/bigcommerce/checkout-sdk-js/pull/1570

## Why?
To have last checkout-sdk-js changes up to date

## Testing / Proof
Unit tests
CI tests
