### PR TITLE
feat(checkout): CHECKOUT-0000 Improve login form spacing

### DIFF
--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -142,10 +142,12 @@ const LoginForm: FunctionComponent<LoginFormProps & WithLanguageProps & FormikPr
                         </a>
                     }
                     { viewType === CustomerViewType.Login && shouldShowCreateAccountLink &&
-                        <TranslatedLink
-                            id="customer.create_account_to_continue_text"
-                            onClick={ onCreateAccount }
-                        />
+                        <span>
+                            <TranslatedLink
+                                id="customer.create_account_to_continue_text"
+                                onClick={ onCreateAccount }
+                            />
+                        </span>
                     }
                 </p>
 

--- a/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -181,11 +181,13 @@ exports[`Customer when view type is "login" matches snapshot 1`] = `
             >
               Forgot password?
             </a>
-            <a
-              href="#"
-            >
-              Create an account
-            </a>
+            <span>
+              <a
+                href="#"
+              >
+                Create an account
+              </a>
+            </span>
           </p>
           <div
             class="form-actions"


### PR DESCRIPTION
## What?
Wrap the "creating account" text as a span to improve login form spacing.

## Why?
Merchants' own wordings make the login form less concise.

## Testing / Proof
Before:
<img width="600" alt="Screen Shot 2022-09-13 at 11 33 42 am" src="https://user-images.githubusercontent.com/88361607/189787957-0fddf2b4-b4df-4c8a-91a7-30727d481d58.png">

After:
<img width="600" alt="Screen Shot 2022-09-13 at 11 34 20 am" src="https://user-images.githubusercontent.com/88361607/189787947-3de6af3b-ab10-4ec3-beee-d6b7f4b35b05.png">
