### PR TITLE
fix(checkout): CHECKOUT-6860 Use numeric keypad to type phone number

### DIFF
--- a/packages/core/src/app/ui/form/DynamicFormField.spec.tsx
+++ b/packages/core/src/app/ui/form/DynamicFormField.spec.tsx
@@ -44,6 +44,31 @@ describe('DynamicFormField Component', () => {
             }));
     });
 
+    it('renders telephone field', () => {
+        const telField = {
+            custom: false,
+            fieldType: "text",
+            id: 'field_17',
+            label: 'Phone Number',
+            name: 'phone',
+            required: true,
+            type: "string",
+        };
+        const component = mount(
+            <Formik initialValues={ {} } onSubmit={ jest.fn() }>
+                <DynamicFormField
+                    field={ telField as FormFieldType }
+                />
+            </Formik>
+        );
+
+        expect(component.find(DynamicInput).props())
+            .toEqual(expect.objectContaining({
+                id: 'phone',
+                fieldType: 'tel',
+            }));
+    });
+
     it('renders DynamicInput with expected props', () => {
         const component = mount(
             <Formik initialValues={ {} } onSubmit={ jest.fn() }>

--- a/packages/core/src/app/ui/form/DynamicFormField.tsx
+++ b/packages/core/src/app/ui/form/DynamicFormField.tsx
@@ -1,5 +1,6 @@
 import { FormField as FormFieldType } from '@bigcommerce/checkout-sdk';
 import { FieldProps } from 'formik';
+import { includes } from 'lodash';
 import React, { memo, useCallback, useMemo, FunctionComponent, ReactNode } from 'react';
 
 import { TranslatedString } from '../../locale';
@@ -72,6 +73,10 @@ const DynamicFormField: FunctionComponent<DynamicFormFieldProps>  = ({
         if (fieldType === 'text') {
             if (type === 'integer') {
                 return DynamicFormFieldType.number;
+            }
+
+            if (includes(name,'phone') || includes(name,'tel')) {
+                return DynamicFormFieldType.telephone;
             }
 
             return secret ?


### PR DESCRIPTION
## What?
Using a numeric keypad to enter tel numbers.

## Why?
Speed up the checkout.

## Testing / Proof
<img width="300" src="https://user-images.githubusercontent.com/88361607/189802215-eb8a1c36-4ad9-40d5-8b9d-ade6f61ed3b2.png">


@bigcommerce/checkout
