### PR TITLE
fix(payment): ADYEN-540 fixed adyen 3ds2 challenge on googlepay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.284.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.284.1.tgz",
-      "integrity": "sha512-Daxluamyot/FunxucGXALIaahMlGwz3tYgufkey+bNszz6yu+e1yV319CQ3+jTeu+9dd9ezzBEOHFUd3yvowOA==",
+      "version": "1.284.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.284.2.tgz",
+      "integrity": "sha512-XWZBA4WQ+yv8XoFd59WHAAsqwOdZDcI9yPkGp6cuwnTEel6EMuQVxze4j3lTGWDntSRuIpwfpkoMs/OBidt/jw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.284.1",
+    "@bigcommerce/checkout-sdk": "^1.284.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Fixed Adyen 3ds2 challenge on googlepay
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/1596
## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-540

## Testing / Proof
There was a problem with adyen script load on live mode due to the wrong name of mode. Instead of test/live, was used TEST/PRODUCTION

**Now script loads without any errors:** 

<img width="746" alt="image" src="https://user-images.githubusercontent.com/79574476/189838826-1aff3c2b-9822-4088-826c-af0edab82d87.png">


@bigcommerce/checkout @bigcommerce/payments
