### PR TITLE
chore(payment): PAYPAL-1541 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.284.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.284.2.tgz",
-      "integrity": "sha512-XWZBA4WQ+yv8XoFd59WHAAsqwOdZDcI9yPkGp6cuwnTEel6EMuQVxze4j3lTGWDntSRuIpwfpkoMs/OBidt/jw==",
+      "version": "1.285.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.285.2.tgz",
+      "integrity": "sha512-W05DS2JaZxsUoZ2EFBJpzpZumLxp5HTsa/e5x3BvsaVZlMI9qh8Eu2bwzvLIYg0qfL+kwVyRV7BldMZqSlLxRw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.284.2",
+    "@bigcommerce/checkout-sdk": "^1.285.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To deploy last checkout-sdk changes:
https://github.com/bigcommerce/checkout-sdk-js/pull/1584
https://github.com/bigcommerce/checkout-sdk-js/pull/1576
https://github.com/bigcommerce/checkout-sdk-js/pull/1599

## Testing / Proof
Unit tests
CI tests
