### PR TITLE
feat(payment): BOLT-386 Add BODL analytics tracking events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.304.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.304.0.tgz",
-      "integrity": "sha512-WSWk5ZdgQFFTmijh89Had/F7Z0PXxUU7Lib+mmzfWwfH75+lc/j/FT9t3GqZm6wzTQPUik3EdsJHL+b9EKdZCg==",
+      "version": "1.305.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.305.0.tgz",
+      "integrity": "sha512-7mgkIPVzScAbekNsD9se3R7/K5d1cBsV3K5tla65NF5WJWHFY6wYJjobQCLf6ySy+lLPOAq0uVeSHzma5DWXRw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.304.0",
+    "@bigcommerce/checkout-sdk": "^1.305.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/analytics/.eslintrc.json
+++ b/packages/analytics/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.eslintrc.json"]
+}

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,0 +1,14 @@
+# analytics
+
+This library was generated with [Nx](https://nx.dev).
+
+
+## Running unit tests
+
+Run `nx test analytics` to execute the unit tests via [Jest](https://jestjs.io).
+
+
+## Running lint
+
+Run `nx lint analytics` to execute the lint via [ESLint](https://eslint.org/).
+

--- a/packages/analytics/jest.config.js
+++ b/packages/analytics/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    displayName: 'analytics',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        }
+    },
+    transform: {
+        '^.+\\.[tj]sx?$': 'ts-jest'
+    },
+    setupFilesAfterEnv: ['../../jest-setup.ts'],
+    coverageDirectory: '../../coverage/packages/analytics'
+};

--- a/packages/analytics/project.json
+++ b/packages/analytics/project.json
@@ -1,0 +1,30 @@
+{
+  "root": "packages/analytics",
+  "sourceRoot": "packages/analytics/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "packages/analytics/**/*.{ts,tsx}"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": [
+        "coverage/packages/analytics"
+      ],
+      "options": {
+        "jestConfig": "packages/analytics/jest.config.js"
+      }
+    }
+  },
+  "tags": [
+    "scope:shared"
+  ]
+}

--- a/packages/analytics/src/AnalyticsContext.ts
+++ b/packages/analytics/src/AnalyticsContext.ts
@@ -1,0 +1,26 @@
+import { CheckoutPaymentMethodExecutedOptions } from '@bigcommerce/checkout-sdk';
+import { createContext } from 'react';
+
+export interface AnalyticsEvents {
+    checkoutBegin(): void;
+    trackStepCompleted(step: string): void;
+    trackStepViewed(step: string): void;
+    orderPurchased(): void;
+    customerEmailEntry(email: string): void;
+    customerSuggestionExecute(): void;
+    customerPaymentMethodExecuted(payload?: CheckoutPaymentMethodExecutedOptions): void;
+    showShippingMethods(): void;
+    selectedPaymentMethod(methodName?: string): void;
+    clickPayButton(payload?: { [key: string]: unknown }): void;
+    paymentRejected(): void;
+    paymentComplete(): void;
+    exitCheckout(): void;
+}
+
+export interface AnalyticsContextProps {
+    analyticsTracker: AnalyticsEvents;
+}
+
+const AnalyticsContext = createContext<AnalyticsContextProps | undefined>(undefined);
+
+export default AnalyticsContext;

--- a/packages/analytics/src/AnalyticsProvider.mock.tsx
+++ b/packages/analytics/src/AnalyticsProvider.mock.tsx
@@ -1,0 +1,29 @@
+import React, { FunctionComponent } from 'react';
+
+import AnalyticsContext, { AnalyticsEvents } from './AnalyticsContext';
+
+const AnalyticsProviderMock: FunctionComponent = ({ children }) => {
+    const analyticsTracker: AnalyticsEvents = {
+        checkoutBegin: jest.fn(),
+        trackStepCompleted: jest.fn(),
+        trackStepViewed: jest.fn(),
+        orderPurchased: jest.fn(),
+        customerEmailEntry: jest.fn(),
+        customerSuggestionExecute: jest.fn(),
+        customerPaymentMethodExecuted: jest.fn(),
+        showShippingMethods: jest.fn(),
+        selectedPaymentMethod: jest.fn(),
+        clickPayButton: jest.fn(),
+        paymentRejected: jest.fn(),
+        paymentComplete: jest.fn(),
+        exitCheckout: jest.fn(),
+    };
+
+    return (
+        <AnalyticsContext.Provider value={{ analyticsTracker }}>
+            {children}
+        </AnalyticsContext.Provider>
+    );
+};
+
+export default AnalyticsProviderMock;

--- a/packages/analytics/src/AnalyticsProvider.spec.tsx
+++ b/packages/analytics/src/AnalyticsProvider.spec.tsx
@@ -1,0 +1,194 @@
+import * as CheckoutSdk from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import React, { useEffect } from 'react';
+
+import AnalyticsProvider from './AnalyticsProvider';
+import * as createAnalyticsService from './createAnalyticsService';
+import useAnalytics from './useAnalytics';
+
+jest.mock('@bigcommerce/checkout-sdk', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        __esModule: true,
+        ...jest.requireActual('@bigcommerce/checkout-sdk'),
+    };
+});
+
+const AnalyticsProviderChildrenMock = ({
+    eventName,
+    eventPayload,
+}: {
+    eventName: string;
+    eventPayload?: string | CheckoutSdk.BodlEventsPayload;
+}) => {
+    const { analyticsTracker } = useAnalytics();
+
+    useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        analyticsTracker[eventName](eventPayload);
+    }, [analyticsTracker, eventName, eventPayload]);
+
+    return null;
+};
+
+const TestComponent = ({
+    eventName,
+    eventPayload,
+}: {
+    eventName: string;
+    eventPayload?: string | CheckoutSdk.BodlEventsPayload;
+}) => {
+    const checkoutService = CheckoutSdk.createCheckoutService();
+
+    return (
+        <AnalyticsProvider checkoutService={checkoutService}>
+            <AnalyticsProviderChildrenMock eventName={eventName} eventPayload={eventPayload} />
+        </AnalyticsProvider>
+    );
+};
+
+describe('AnalyticsProvider', () => {
+    let stepTrackerMock: CheckoutSdk.StepTracker;
+    let bodlServiceMock: CheckoutSdk.BodlService;
+
+    beforeEach(() => {
+        jest.spyOn(createAnalyticsService, 'default').mockImplementation(
+            (createFn, _args) => createFn,
+        );
+
+        stepTrackerMock = {
+            trackOrderComplete: jest.fn(),
+            trackCheckoutStarted: jest.fn(),
+            trackStepViewed: jest.fn(),
+            trackStepCompleted: jest.fn(),
+        };
+        jest.spyOn(CheckoutSdk, 'createStepTracker').mockImplementation((_args) => stepTrackerMock);
+
+        bodlServiceMock = {
+            checkoutBegin: jest.fn(),
+            orderPurchased: jest.fn(),
+            stepCompleted: jest.fn(),
+            customerEmailEntry: jest.fn(),
+            customerSuggestionExecute: jest.fn(),
+            customerPaymentMethodExecuted: jest.fn(),
+            showShippingMethods: jest.fn(),
+            selectedPaymentMethod: jest.fn(),
+            clickPayButton: jest.fn(),
+            paymentRejected: jest.fn(),
+            paymentComplete: jest.fn(),
+            exitCheckout: jest.fn(),
+        };
+        jest.spyOn(CheckoutSdk, 'createBodlService').mockImplementation(() => bodlServiceMock);
+    });
+
+    it('throws an error when useAnalytics hook used without AnalyticsContext', () => {
+        let errorMessage = '';
+
+        try {
+            mount(<AnalyticsProviderChildrenMock eventName="checkoutBegin" />);
+        } catch (error) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            errorMessage = error.message;
+        }
+
+        expect(errorMessage).toBe('useAnalytics must be used within an <AnalyticsProvider>');
+        expect(stepTrackerMock.trackCheckoutStarted).not.toHaveBeenCalled();
+        expect(bodlServiceMock.checkoutBegin).not.toHaveBeenCalled();
+    });
+
+    it('track checkout begin', () => {
+        mount(<TestComponent eventName="checkoutBegin" />);
+
+        expect(stepTrackerMock.trackCheckoutStarted).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.checkoutBegin).toHaveBeenCalledTimes(1);
+    });
+
+    it('track step completed', () => {
+        mount(<TestComponent eventName="trackStepCompleted" eventPayload="stepName" />);
+
+        expect(stepTrackerMock.trackStepCompleted).toHaveBeenCalledTimes(1);
+        expect(stepTrackerMock.trackStepCompleted).toHaveBeenCalledWith('stepName');
+        expect(bodlServiceMock.stepCompleted).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.stepCompleted).toHaveBeenCalledWith('stepName');
+    });
+
+    it('track step viewed', () => {
+        mount(<TestComponent eventName="trackStepViewed" eventPayload="stepName" />);
+
+        expect(stepTrackerMock.trackStepViewed).toHaveBeenCalledTimes(1);
+        expect(stepTrackerMock.trackStepViewed).toHaveBeenCalledWith('stepName');
+    });
+
+    it('track order purchased', () => {
+        mount(<TestComponent eventName="orderPurchased" />);
+
+        expect(stepTrackerMock.trackOrderComplete).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.orderPurchased).toHaveBeenCalledTimes(1);
+    });
+
+    it('track customer email entry', () => {
+        mount(<TestComponent eventName="customerEmailEntry" eventPayload="email@test.com" />);
+
+        expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledWith('email@test.com');
+    });
+
+    it('track customer suggestion execute', () => {
+        mount(<TestComponent eventName="customerSuggestionExecute" />);
+
+        expect(bodlServiceMock.customerSuggestionExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it('track customer payment method executed', () => {
+        mount(
+            <TestComponent
+                eventName="customerPaymentMethodExecuted"
+                eventPayload={{ data: 'test data' }}
+            />,
+        );
+
+        expect(bodlServiceMock.customerPaymentMethodExecuted).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.customerPaymentMethodExecuted).toHaveBeenCalledWith({
+            data: 'test data',
+        });
+    });
+
+    it('track show shipping methods', () => {
+        mount(<TestComponent eventName="showShippingMethods" />);
+
+        expect(bodlServiceMock.showShippingMethods).toHaveBeenCalledTimes(1);
+    });
+
+    it('track selected payment method', () => {
+        mount(<TestComponent eventName="selectedPaymentMethod" eventPayload="Credit card" />);
+
+        expect(bodlServiceMock.selectedPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.selectedPaymentMethod).toHaveBeenCalledWith('Credit card');
+    });
+
+    it('track click Pay button', () => {
+        mount(<TestComponent eventName="clickPayButton" eventPayload={{ data: 'test data' }} />);
+
+        expect(bodlServiceMock.clickPayButton).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.clickPayButton).toHaveBeenCalledWith({ data: 'test data' });
+    });
+
+    it('track payment rejected', () => {
+        mount(<TestComponent eventName="paymentRejected" />);
+
+        expect(bodlServiceMock.paymentRejected).toHaveBeenCalledTimes(1);
+    });
+
+    it('track payment complete', () => {
+        mount(<TestComponent eventName="paymentComplete" />);
+
+        expect(bodlServiceMock.paymentComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('track exit checkout', () => {
+        mount(<TestComponent eventName="exitCheckout" />);
+
+        expect(bodlServiceMock.exitCheckout).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/analytics/src/AnalyticsProvider.tsx
+++ b/packages/analytics/src/AnalyticsProvider.tsx
@@ -1,0 +1,107 @@
+import {
+    BodlEventsPayload,
+    BodlService,
+    CheckoutService,
+    createBodlService,
+    createStepTracker,
+    StepTracker,
+} from '@bigcommerce/checkout-sdk';
+import React, { ReactNode, useMemo } from 'react';
+
+import AnalyticsContext, { AnalyticsEvents } from './AnalyticsContext';
+import createAnalyticsService from './createAnalyticsService';
+
+interface AnalyticsProviderProps {
+    checkoutService: CheckoutService;
+    children: ReactNode;
+}
+
+const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps) => {
+    const getStepTracker = useMemo(
+        () => createAnalyticsService<StepTracker>(createStepTracker, [checkoutService]),
+        [checkoutService],
+    );
+    const getBodlService = useMemo(
+        () => createAnalyticsService<BodlService>(createBodlService, [checkoutService.subscribe]),
+        [checkoutService],
+    );
+
+    const checkoutBegin = () => {
+        getStepTracker().trackCheckoutStarted();
+        getBodlService().checkoutBegin();
+    };
+
+    const trackStepCompleted = (currentStep: string) => {
+        getStepTracker().trackStepCompleted(currentStep);
+        getBodlService().stepCompleted(currentStep);
+    };
+
+    const trackStepViewed = (step: string) => {
+        getStepTracker().trackStepViewed(step);
+    };
+
+    const orderPurchased = () => {
+        getStepTracker().trackOrderComplete();
+        getBodlService().orderPurchased();
+    };
+
+    const customerEmailEntry = (email: string) => {
+        getBodlService().customerEmailEntry(email);
+    };
+
+    const customerSuggestionExecute = () => {
+        getBodlService().customerSuggestionExecute();
+    };
+
+    const customerPaymentMethodExecuted = (payload: BodlEventsPayload) => {
+        getBodlService().customerPaymentMethodExecuted(payload);
+    };
+
+    const showShippingMethods = () => {
+        getBodlService().showShippingMethods();
+    };
+
+    const selectedPaymentMethod = (methodName?: string) => {
+        getBodlService().selectedPaymentMethod(methodName);
+    };
+
+    const clickPayButton = (payload: BodlEventsPayload) => {
+        getBodlService().clickPayButton(payload);
+    };
+
+    const paymentRejected = () => {
+        getBodlService().paymentRejected();
+    };
+
+    const paymentComplete = () => {
+        getBodlService().paymentComplete();
+    };
+
+    const exitCheckout = () => {
+        getBodlService().exitCheckout();
+    };
+
+    const analyticsTracker: AnalyticsEvents = {
+        checkoutBegin,
+        trackStepCompleted,
+        trackStepViewed,
+        orderPurchased,
+        customerEmailEntry,
+        customerSuggestionExecute,
+        customerPaymentMethodExecuted,
+        showShippingMethods,
+        selectedPaymentMethod,
+        clickPayButton,
+        paymentRejected,
+        paymentComplete,
+        exitCheckout,
+    };
+
+    return (
+        <AnalyticsContext.Provider value={{ analyticsTracker }}>
+            {children}
+        </AnalyticsContext.Provider>
+    );
+};
+
+export default AnalyticsProvider;

--- a/packages/analytics/src/createAnalyticsService.spec.ts
+++ b/packages/analytics/src/createAnalyticsService.spec.ts
@@ -1,0 +1,23 @@
+import createAnalyticsService from './createAnalyticsService';
+
+describe('createAnalyticsService', () => {
+    it('should be created once', () => {
+        const createArguments = ['create', 'arguments'];
+        const createFn = jest.fn().mockImplementation((options: string[]) => options);
+
+        const getService: () => string[] = createAnalyticsService(createFn, [createArguments]);
+
+        expect(getService()[0]).toBe('create');
+        expect(getService()[1]).toBe('arguments');
+        expect(createFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be created without arguments', () => {
+        const createFn = jest.fn().mockImplementation((option: unknown) => option);
+
+        const getService = createAnalyticsService(createFn);
+
+        expect(getService()).toBeUndefined();
+        expect(createFn).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/analytics/src/createAnalyticsService.ts
+++ b/packages/analytics/src/createAnalyticsService.ts
@@ -1,0 +1,16 @@
+export default function createAnalyticsService<T>(
+    createFn: (args?: any) => T,
+    createArguments: unknown[] = [],
+) {
+    let analyticsTracker: T;
+
+    return () => {
+        if (analyticsTracker) {
+            return analyticsTracker;
+        }
+
+        analyticsTracker = createFn(...createArguments);
+
+        return analyticsTracker;
+    };
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,0 +1,8 @@
+export { default as AnalyticsProvider } from './AnalyticsProvider';
+export { default as AnalyticsProviderMock } from './AnalyticsProvider.mock';
+export {
+    default as AnalyticsContext,
+    AnalyticsEvents,
+    AnalyticsContextProps,
+} from './AnalyticsContext';
+export { default as useAnalytics } from './useAnalytics';

--- a/packages/analytics/src/useAnalytics.tsx
+++ b/packages/analytics/src/useAnalytics.tsx
@@ -1,0 +1,20 @@
+import { useContext, useMemo } from 'react';
+
+import AnalyticsContext from './AnalyticsContext';
+
+const useAnalytics = () => {
+    const analyticsContext = useContext(AnalyticsContext);
+
+    if (!analyticsContext) {
+        throw new Error('useAnalytics must be used within an <AnalyticsProvider>');
+    }
+
+    return useMemo(
+        () => ({
+            analyticsTracker: analyticsContext.analyticsTracker,
+        }),
+        [analyticsContext],
+    );
+};
+
+export default useAnalytics;

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/analytics/tsconfig.lib.json
+++ b/packages/analytics/tsconfig.lib.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
+}

--- a/packages/analytics/tsconfig.spec.json
+++ b/packages/analytics/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
+}

--- a/packages/core/src/app/analytics/index.ts
+++ b/packages/core/src/app/analytics/index.ts
@@ -1,0 +1,1 @@
+export { default as withAnalytics } from './withAnalytics';

--- a/packages/core/src/app/analytics/withAnalytics.ts
+++ b/packages/core/src/app/analytics/withAnalytics.ts
@@ -1,0 +1,7 @@
+import { AnalyticsContext } from '@bigcommerce/checkout/analytics';
+
+import { createInjectHoc } from '../common/hoc';
+
+const withAnalytics = createInjectHoc(AnalyticsContext, { displayNamePrefix: 'WithAnalytics' });
+
+export default withAnalytics;

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -1,6 +1,5 @@
 import {
     Address,
-    BodlService,
     Cart,
     CartChangedError,
     CheckoutParams,
@@ -11,14 +10,15 @@ import {
     FlashMessage,
     Promotion,
     RequestOptions,
-    StepTracker,
 } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import { find, findIndex } from 'lodash';
 import React, { Component, lazy, ReactNode } from 'react';
 
-import { AddressFormSkeleton, ChecklistSkeleton, CustomerSkeleton } from '@bigcommerce/checkout/ui'
+import { AnalyticsContextProps } from '@bigcommerce/checkout/analytics';
+import { AddressFormSkeleton, ChecklistSkeleton, CustomerSkeleton } from '@bigcommerce/checkout/ui';
 
+import { withAnalytics } from '../analytics';
 import { StaticBillingAddress } from '../billing';
 import { EmptyCartMessage } from '../cart';
 import { CustomError, ErrorLogger, ErrorModal, isCustomError } from '../common/error';
@@ -112,8 +112,6 @@ export interface CheckoutProps {
     embeddedSupport: CheckoutSupport;
     errorLogger: ErrorLogger;
     createEmbeddedMessenger(options: EmbeddedCheckoutMessengerOptions): EmbeddedCheckoutMessenger;
-    createStepTracker(): StepTracker;
-    createBodlService(): BodlService;
 }
 
 export interface CheckoutState {
@@ -153,12 +151,9 @@ export interface WithCheckoutProps {
 }
 
 class Checkout extends Component<
-    CheckoutProps & WithCheckoutProps & WithLanguageProps,
+    CheckoutProps & WithCheckoutProps & WithLanguageProps & AnalyticsContextProps,
     CheckoutState
 > {
-    stepTracker: StepTracker | undefined;
-    bodlService: BodlService | undefined;
-
     state: CheckoutState = {
         isBillingSameAsShipping: true,
         isCartEmpty: false,
@@ -176,18 +171,20 @@ class Checkout extends Component<
             this.unsubscribeFromConsignments();
             this.unsubscribeFromConsignments = undefined;
         }
+
+        window.removeEventListener('beforeunload', this.handleBeforeExit);
+        this.handleBeforeExit();
     }
 
     async componentDidMount(): Promise<void> {
         const {
             checkoutId,
             containerId,
-            createStepTracker,
-            createBodlService,
             createEmbeddedMessenger,
             embeddedStylesheet,
             loadCheckout,
             subscribeToConsignments,
+            analyticsTracker
         } = this.props;
 
         try {
@@ -227,11 +224,7 @@ class Checkout extends Component<
             messenger.postFrameLoaded({ contentId: containerId });
             messenger.postLoaded();
 
-            this.stepTracker = createStepTracker();
-            this.stepTracker.trackCheckoutStarted();
-
-            this.bodlService = createBodlService();
-            this.bodlService.checkoutBegin();
+            analyticsTracker.checkoutBegin();
 
             const consignments = data.getConsignments();
             const cart = data.getCart();
@@ -259,6 +252,8 @@ class Checkout extends Component<
             } else {
                 this.handleReady();
             }
+
+            window.addEventListener('beforeunload', this.handleBeforeExit);
         } catch (error) {
             if (error instanceof Error) {
                 this.handleUnhandledError(error);
@@ -547,7 +542,7 @@ class Checkout extends Component<
     private navigateToNextIncompleteStep: (options?: { isDefault?: boolean }) => void = (
         options,
     ) => {
-        const { steps } = this.props;
+        const { steps, analyticsTracker } = this.props;
         const activeStepIndex = findIndex(steps, { isActive: true });
         const activeStep = activeStepIndex >= 0 && steps[activeStepIndex];
 
@@ -557,20 +552,18 @@ class Checkout extends Component<
 
         const previousStep = steps[Math.max(activeStepIndex - 1, 0)];
 
-        if (previousStep && this.stepTracker) {
-            this.stepTracker.trackStepCompleted(previousStep.type);
+        if (previousStep) {
+            analyticsTracker.trackStepCompleted(previousStep.type);
         }
 
         this.navigateToStep(activeStep.type, options);
     };
 
     private navigateToOrderConfirmation: (orderId?: number) => void = (orderId) => {
-        const { steps } = this.props;
+        const { steps, analyticsTracker } = this.props;
         const { isBuyNowCartEnabled } = this.state;
 
-        if (this.stepTracker) {
-            this.stepTracker.trackStepCompleted(steps[steps.length - 1].type);
-        }
+        analyticsTracker.trackStepCompleted(steps[steps.length - 1].type);
 
         if (this.embeddedMessenger) {
             this.embeddedMessenger.postComplete();
@@ -619,9 +612,8 @@ class Checkout extends Component<
     };
 
     private handleExpanded: (type: CheckoutStepType) => void = (type) => {
-        if (this.stepTracker) {
-            this.stepTracker.trackStepViewed(type);
-        }
+        const { analyticsTracker } = this.props;
+        analyticsTracker.trackStepViewed(type);
     };
 
     private handleUnhandledError: (error: Error) => void = (error) => {
@@ -717,6 +709,12 @@ class Checkout extends Component<
         this.navigateToStep(CheckoutStepType.Customer);
         this.setState({ customerViewType });
     };
+
+    private handleBeforeExit: () => void = () => {
+        const { analyticsTracker } = this.props;
+
+        analyticsTracker.exitCheckout();
+    }
 }
 
-export default withLanguage(withCheckout(mapToCheckoutProps)(Checkout));
+export default withAnalytics(withLanguage(withCheckout(mapToCheckoutProps)(Checkout)));

--- a/packages/core/src/app/checkout/CheckoutApp.tsx
+++ b/packages/core/src/app/checkout/CheckoutApp.tsx
@@ -1,14 +1,9 @@
-import {
-    BodlService,
-    createBodlService,
-    createCheckoutService,
-    createEmbeddedCheckoutMessenger,
-    createStepTracker,
-    StepTracker,
-} from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, createEmbeddedCheckoutMessenger } from '@bigcommerce/checkout-sdk';
 import { BrowserOptions } from '@sentry/browser';
 import React, { Component } from 'react';
 import ReactModal from 'react-modal';
+
+import { AnalyticsProvider } from '@bigcommerce/checkout/analytics';
 
 import '../../scss/App.scss';
 import { createErrorLogger, ErrorBoundary, ErrorLogger } from '../common/error';
@@ -57,29 +52,21 @@ export default class CheckoutApp extends Component<CheckoutAppProps> {
 
     render() {
         return (
-            <ErrorBoundary logger={this.errorLogger}>
-                <LocaleProvider checkoutService={this.checkoutService}>
-                    <CheckoutProvider checkoutService={this.checkoutService}>
-                        <Checkout
-                            {...this.props}
-                            createBodlService={this.createBodlService}
-                            createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
-                            createStepTracker={this.createStepTracker}
-                            embeddedStylesheet={this.embeddedStylesheet}
-                            embeddedSupport={this.embeddedSupport}
-                            errorLogger={this.errorLogger}
-                        />
+            <ErrorBoundary logger={ this.errorLogger }>
+                <LocaleProvider checkoutService={ this.checkoutService }>
+                    <CheckoutProvider checkoutService={ this.checkoutService }>
+                        <AnalyticsProvider checkoutService={ this.checkoutService }>
+                            <Checkout
+                                {...this.props}
+                                createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
+                                embeddedStylesheet={this.embeddedStylesheet}
+                                embeddedSupport={this.embeddedSupport}
+                                errorLogger={this.errorLogger}
+                            />
+                        </AnalyticsProvider>
                     </CheckoutProvider>
                 </LocaleProvider>
             </ErrorBoundary>
         );
     }
-
-    private createStepTracker: () => StepTracker = () => {
-        return createStepTracker(this.checkoutService);
-    };
-
-    private createBodlService: () => BodlService = () => {
-        return createBodlService(this.checkoutService.subscribe);
-    };
 }

--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -10,6 +10,8 @@ import {
 import { mount, ReactWrapper } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 
+import { AnalyticsProviderMock } from '@bigcommerce/checkout/analytics';
+
 import { getBillingAddress } from '../billing/billingAddresses.mock';
 import { CheckoutProvider } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
@@ -68,7 +70,9 @@ describe('Customer', () => {
         CustomerTest = (props) => (
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
-                    <Customer {...props} />
+                    <AnalyticsProviderMock>
+                        <Customer {...props} />
+                    </AnalyticsProviderMock>
                 </LocaleContext.Provider>
             </CheckoutProvider>
         );

--- a/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.spec.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.spec.tsx
@@ -6,6 +6,8 @@ import {
 import { mount, render } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 
+import { AnalyticsProviderMock } from '@bigcommerce/checkout/analytics';
+
 import { CheckoutProvider } from '../../checkout';
 import { getCheckout } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
@@ -43,7 +45,9 @@ describe('CheckoutSuggestion', () => {
         TestComponent = (props) => (
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleProvider checkoutService={checkoutService}>
-                    <CheckoutSuggestion {...props} />
+                    <AnalyticsProviderMock>
+                        <CheckoutSuggestion {...props} />
+                    </AnalyticsProviderMock>
                 </LocaleProvider>
             </CheckoutProvider>
         );

--- a/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
@@ -6,6 +6,8 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, memo } from 'react';
 
+import { useAnalytics } from '@bigcommerce/checkout/analytics';
+
 import { CheckoutContextProps, withCheckout } from '../../checkout';
 import { PaymentMethodId } from '../../payment/paymentMethod';
 
@@ -27,9 +29,24 @@ export interface WithCheckoutSuggestionsProps {
 
 const CheckoutSuggestion: FunctionComponent<
     WithCheckoutSuggestionsProps & CheckoutSuggestionProps
-> = ({ providerWithCustomCheckout, ...rest }) => {
+> = ({
+    providerWithCustomCheckout,
+    executePaymentMethodCheckout,
+    ...rest
+}) => {
+    const { analyticsTracker } = useAnalytics();
+
+    const handleExecutePaymentMethodCheckout = (options: ExecutePaymentMethodCheckoutOptions) => {
+        analyticsTracker.customerSuggestionExecute();
+        return executePaymentMethodCheckout(options);
+    }
+
     if (providerWithCustomCheckout === PaymentMethodId.Bolt) {
-        return <BoltCheckoutSuggestion methodId={providerWithCustomCheckout} {...rest} />;
+        return <BoltCheckoutSuggestion
+                    executePaymentMethodCheckout={handleExecutePaymentMethodCheckout}
+                    methodId={providerWithCustomCheckout}
+                    {...rest}
+                />;
     }
 
     return null;

--- a/packages/core/src/app/order/OrderConfirmationApp.tsx
+++ b/packages/core/src/app/order/OrderConfirmationApp.tsx
@@ -1,14 +1,9 @@
-import {
-    BodlService,
-    createBodlService,
-    createCheckoutService,
-    createEmbeddedCheckoutMessenger,
-    createStepTracker,
-    StepTracker,
-} from '@bigcommerce/checkout-sdk';
+import { createCheckoutService, createEmbeddedCheckoutMessenger } from '@bigcommerce/checkout-sdk';
 import { BrowserOptions } from '@sentry/browser';
 import React, { Component, ReactNode } from 'react';
 import ReactModal from 'react-modal';
+
+import { AnalyticsProvider } from '@bigcommerce/checkout/analytics';
 
 import '../../scss/App.scss';
 import { CheckoutProvider } from '../checkout';
@@ -58,15 +53,15 @@ class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
             <ErrorBoundary logger={this.errorLogger}>
                 <LocaleProvider checkoutService={this.checkoutService}>
                     <CheckoutProvider checkoutService={this.checkoutService}>
-                        <OrderConfirmation
-                            {...this.props}
-                            createAccount={this.createAccount}
-                            createBodlService={this.createBodlService}
-                            createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
-                            createStepTracker={this.createStepTracker}
-                            embeddedStylesheet={this.embeddedStylesheet}
-                            errorLogger={this.errorLogger}
-                        />
+                        <AnalyticsProvider checkoutService={ this.checkoutService }>
+                            <OrderConfirmation
+                                {...this.props}
+                                createAccount={this.createAccount}
+                                createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
+                                embeddedStylesheet={this.embeddedStylesheet}
+                                errorLogger={this.errorLogger}
+                            />
+                        </AnalyticsProvider>
                     </CheckoutProvider>
                 </LocaleProvider>
             </ErrorBoundary>
@@ -85,14 +80,6 @@ class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
             password,
             confirmPassword,
         });
-    };
-
-    private createStepTracker: () => StepTracker = () => {
-        return createStepTracker(this.checkoutService);
-    };
-
-    private createBodlService: () => BodlService = () => {
-        return createBodlService(this.checkoutService.subscribe);
     };
 }
 

--- a/packages/core/src/app/payment/Payment.spec.tsx
+++ b/packages/core/src/app/payment/Payment.spec.tsx
@@ -11,6 +11,8 @@ import { EventEmitter } from 'events';
 import { find, merge, noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
+import { AnalyticsProviderMock } from '@bigcommerce/checkout/analytics';
+
 import { getCart } from '../cart/carts.mock';
 import { CheckoutProvider } from '../checkout';
 import { getCheckout, getCheckoutPayment } from '../checkout/checkouts.mock';
@@ -95,7 +97,9 @@ describe('Payment', () => {
         PaymentTest = (props) => (
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
-                    <Payment {...props} />
+                    <AnalyticsProviderMock>
+                        <Payment {...props} />
+                    </AnalyticsProviderMock>
                 </LocaleContext.Provider>
             </CheckoutProvider>
         );

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
@@ -4,6 +4,8 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
 
+import { AnalyticsProviderMock } from '@bigcommerce/checkout/analytics';
+
 import { getCart } from '../../cart/carts.mock';
 import { TranslatedString } from '../../locale';
 import { getConsignment } from '../consignment.mock';
@@ -37,11 +39,19 @@ describe('ShippingOptions Component', () => {
         isLoading: jest.fn(() => false),
     };
 
+    const TestWrap: React.FC = ({ children}) => (
+        <AnalyticsProviderMock>
+            <Formik initialValues={{}} onSubmit={noop}>
+                { children }
+            </Formik>
+        </AnalyticsProviderMock>
+    );
+
     it('renders sorted options for all consignments when multi-shipping', () => {
         const component = mount(
-            <Formik initialValues={{}} onSubmit={noop}>
+            <TestWrap>
                 <ShippingOptionsForm {...defaultProps} />
-            </Formik>,
+            </TestWrap>,
         );
 
         expect(component.find(ShippingOptionsList)).toHaveLength(2);
@@ -56,9 +66,9 @@ describe('ShippingOptions Component', () => {
         };
 
         mount(
-            <Formik initialValues={{}} onSubmit={noop}>
+            <TestWrap>
                 <ShippingOptionsForm {...defaultProps} isMultiShippingMode={false} />
-            </Formik>,
+            </TestWrap>,
         );
 
         const selectors = {
@@ -81,14 +91,14 @@ describe('ShippingOptions Component', () => {
 
     it('renders enter shipping address when no consignments', () => {
         const component = mount(
-            <Formik initialValues={{}} onSubmit={noop}>
+            <TestWrap>
                 <ShippingOptionsForm
                     {...defaultProps}
                     consignments={[]}
                     isLoading={() => false}
                     isMultiShippingMode={false}
                 />
-            </Formik>,
+            </TestWrap>,
         );
 
         expect(component.find(TranslatedString).prop('id')).toBe(
@@ -98,14 +108,14 @@ describe('ShippingOptions Component', () => {
 
     it('renders select shipping address when no consignments and amazon shipping', () => {
         const component = mount(
-            <Formik initialValues={{}} onSubmit={noop}>
+            <TestWrap>
                 <ShippingOptionsForm
                     {...defaultProps}
                     consignments={[]}
                     isLoading={() => false}
                     methodId="amazon"
                 />
-            </Formik>,
+            </TestWrap>,
         );
 
         expect(component.find(TranslatedString).prop('id')).toBe(
@@ -115,7 +125,7 @@ describe('ShippingOptions Component', () => {
 
     it('renders invalid shipping when no shipping options available', () => {
         const component = mount(
-            <Formik initialValues={{}} onSubmit={noop}>
+            <TestWrap>
                 <ShippingOptionsForm
                     {...defaultProps}
                     consignments={[
@@ -126,7 +136,7 @@ describe('ShippingOptions Component', () => {
                     ]}
                     isMultiShippingMode={false}
                 />
-            </Formik>,
+            </TestWrap>,
         );
 
         expect(component.find('.shippingOptions-panel-message').text()).toEqual(

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,7 @@
     "paths": {
       "@bigcommerce/checkout/locale": ["packages/locale/src/index.ts"],
       "@bigcommerce/checkout/afterpay-integration": ["packages/afterpay-integration/src/index.ts"],
+      "@bigcommerce/checkout/analytics": ["packages/analytics/src/index.ts"],
       "@bigcommerce/checkout/apple-pay-integration": [
         "packages/apple-pay-integration/src/index.ts"
       ],

--- a/workspace.json
+++ b/workspace.json
@@ -2,6 +2,7 @@
   "version": 2,
   "projects": {
     "afterpay-integration": "packages/afterpay-integration",
+    "analytics": "packages/analytics",
     "apple-pay-integration": "packages/apple-pay-integration",
     "checkout-button-integration": "packages/checkout-button-integration",
     "core": "packages/core",


### PR DESCRIPTION
## What?
Add additional BODL analytics events emitors to checkout.
Checkout-sdk-js PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/1603](https://github.com/bigcommerce/checkout-sdk-js/pull/1603)

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-386](https://bigcommercecloud.atlassian.net/browse/BOLT-386)

## Testing / Proof
Manual tested
<img width="672" alt="Screenshot 2022-11-02 at 22 46 06" src="https://user-images.githubusercontent.com/9430298/199699937-2f0d3478-f73a-4027-bf83-908101f999e3.png">

@bigcommerce/checkout @bigcommerce/payments
