### PR TITLE
chore(checkout): CHECKOUT-6860 Bump checkout-sdk v1.286.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.285.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.285.2.tgz",
-      "integrity": "sha512-W05DS2JaZxsUoZ2EFBJpzpZumLxp5HTsa/e5x3BvsaVZlMI9qh8Eu2bwzvLIYg0qfL+kwVyRV7BldMZqSlLxRw==",
+      "version": "1.286.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.286.0.tgz",
+      "integrity": "sha512-2hkYvPfZk/V/k5hbWdaR0BoQqe1kDoBu8NizkcuCp6CZDWS31n8Zhev+Mgl7RswWztjIAMAR6kmOjhIdtY5XvQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1205,9 +1205,9 @@
           }
         },
         "core-js": {
-          "version": "3.25.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.1.tgz",
-          "integrity": "sha512-sr0FY4lnO1hkQ4gLDr24K0DGnweGO1QwSj5BpfQjpSJPdqWalja4cTps29Y/PJVG/P7FYlPDkH3hO+Tr0CvDgQ=="
+          "version": "3.25.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.2.tgz",
+          "integrity": "sha512-YB4IAT1bjEfxTJ1XYy11hJAKskO+qmhuDBM8/guIfMz4JvdsAQAqvyb97zXX7JgSrfPLG5mRGFWJwJD39ruq2A=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.285.2",
+    "@bigcommerce/checkout-sdk": "^1.286.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk v1.286.0`.

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/1595.

## Testing / Proof
CI.