### PR TITLE
chore(payment): PAYPAL-1673 bump checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1146,9 +1146,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.286.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.286.0.tgz",
-      "integrity": "sha512-2hkYvPfZk/V/k5hbWdaR0BoQqe1kDoBu8NizkcuCp6CZDWS31n8Zhev+Mgl7RswWztjIAMAR6kmOjhIdtY5XvQ==",
+      "version": "1.287.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.287.0.tgz",
+      "integrity": "sha512-/cxDep8JtSlxPUYxBV0tBTzWHa/m6CzULetgU5PEtAjh60XDoKxda7npkjrQ+tAOSK+iRb3Q0oPUKk3An2UFxQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.286.0",
+    "@bigcommerce/checkout-sdk": "^1.287.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
To release related pr:
https://github.com/bigcommerce/checkout-sdk-js/pull/1606

## Testing / Proof
Unit tests
Manual tests
CI tests
