### PR TITLE
feat(payment): BOLT-332 fixed issue with initialize Bolt client on mobile

### DIFF
--- a/packages/core/src/app/checkout/CheckoutStep.tsx
+++ b/packages/core/src/app/checkout/CheckoutStep.tsx
@@ -45,14 +45,9 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
 
     componentDidUpdate(prevProps: Readonly<CheckoutStepProps>): void {
         const { isActive } = this.props;
-        const { isClosed } = this.state;
 
         if (isActive && isActive !== prevProps.isActive) {
             this.focusStep();
-        }
-
-        if (!isActive && !isClosed && isMobileView()) {
-            this.setState({ isClosed: true });
         }
     }
 
@@ -113,7 +108,8 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
                         exit={!matched}
                         in={isActive}
                         mountOnEnter
-                        timeout={{}}
+                        onExited={ this.onAnimationEnd }
+                        timeout={ {} }
                         unmountOnExit
                     >
                         <div
@@ -214,16 +210,18 @@ export default class CheckoutStep extends Component<CheckoutStepProps, CheckoutS
     }
 
     private handleTransitionEnd: (node: HTMLElement, done: () => void) => void = (node, done) => {
-        const { isActive } = this.props;
-
         node.addEventListener('transitionend', ({ target }) => {
             if (target === node) {
                 done();
-
-                if (!isActive) {
-                    this.setState({ isClosed: true });
-                }
             }
         });
     };
+
+    private onAnimationEnd = (): void => {
+        const { isActive } = this.props;
+
+        if (!isActive) {
+            this.setState({ isClosed: true });
+        }
+    }
 }


### PR DESCRIPTION
## What?

In the case of mobile devices, after we pressed **EXIT CHECKOUT BOLT**, we do not have a BOLT account because we had a problem initializing `handleTransitionEnd` on mobile device.

This fix resolves the problem

## Why?
According to task [BOLT-332](https://bigcommercecloud.atlassian.net/browse/BOLT-332)

## Testing / Proof

Before

https://user-images.githubusercontent.com/99336044/192528904-38b184b4-c470-4233-9942-2361a416a8b9.mov

After

https://user-images.githubusercontent.com/99336044/191573281-781389fb-317f-4918-9df1-7b244ae95c47.mov

Works on desktop

https://user-images.githubusercontent.com/99336044/193060288-e003050a-fe83-450d-a259-1088ea28b1e2.mov





@bigcommerce/checkout
