### PR TITLE
fix(payment): BOLT-105 Send 'create_bolt_account: false' for shoppers with registered Bolt account

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BoltEmbeddedPaymentMethod.tsx
@@ -1,14 +1,17 @@
 import React, { FunctionComponent, useCallback, useState } from 'react';
+import { PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
+import { connectFormik, ConnectFormikProps } from '../../common/form';
 
 import BoltCustomForm from './BoltCustomForm';
 import { HostedPaymentMethodProps } from './HostedPaymentMethod';
 import HostedWidgetPaymentMethod from './HostedWidgetPaymentMethod';
 
-const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = ({
+const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps & ConnectFormikProps<PaymentFormValues>> = ({
     isInitializing,
     initializePayment,
     deinitializePayment,
     method,
+    formik: { setFieldValue }
 }) => {
     const [showCreateAccountCheckbox, setShowCreateAccountCheckbox] = useState(false);
 
@@ -23,6 +26,9 @@ const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = (
                     useBigCommerceCheckout: true,
                     onPaymentSelect: (hasBoltAccount: boolean) => {
                         setShowCreateAccountCheckbox(!hasBoltAccount);
+                        if (hasBoltAccount) {
+                            setFieldValue('shouldCreateAccount', false);
+                        }
                     },
                 },
             }),
@@ -52,4 +58,4 @@ const BoltEmbeddedPaymentMethod: FunctionComponent<HostedPaymentMethodProps> = (
     );
 };
 
-export default BoltEmbeddedPaymentMethod;
+export default connectFormik(BoltEmbeddedPaymentMethod);


### PR DESCRIPTION
## What?
Send 'create_bolt_account: false' for shoppers with registered Bolt account

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-105](https://bigcommercecloud.atlassian.net/browse/BOLT-105)

## Testing / Proof
<img width="403" alt="Screenshot 2022-09-23 at 15 49 48" src="https://user-images.githubusercontent.com/9430298/191965451-f8aab37a-243a-44fb-9d81-84b4a66b5008.png">

@bigcommerce/checkout
