### PR TITLE
fix(checkout): CHECKOUT-6365 Scroll to modal in WordPress

### DIFF
--- a/packages/core/src/app/ui/modal/ModalTrigger.tsx
+++ b/packages/core/src/app/ui/modal/ModalTrigger.tsx
@@ -14,6 +14,8 @@ export interface ModalTriggerState {
     isOpen: boolean;
 }
 
+const wordpressCheckout = parent.document.getElementById('bc-embedded-checkout');
+
 export default class ModalTrigger extends Component<ModalTriggerProps, ModalTriggerState> {
     state = {
         isOpen: false,
@@ -49,7 +51,6 @@ export default class ModalTrigger extends Component<ModalTriggerProps, ModalTrig
     }
 
     private handleOpen: () => void = () => {
-        const wordpressCheckout = parent.document.getElementById('bc-embedded-checkout');
         if (wordpressCheckout) {
             const top = wordpressCheckout.getBoundingClientRect().top;
             window.parent.scrollBy(0,top);

--- a/packages/core/src/app/ui/modal/ModalTrigger.tsx
+++ b/packages/core/src/app/ui/modal/ModalTrigger.tsx
@@ -49,7 +49,13 @@ export default class ModalTrigger extends Component<ModalTriggerProps, ModalTrig
     }
 
     private handleOpen: () => void = () => {
-        document.body.scrollIntoView();
+        const wordpressCheckout = parent.document.getElementById('bc-embedded-checkout');
+        if (wordpressCheckout) {
+            const top = wordpressCheckout.getBoundingClientRect().top;
+            window.parent.scrollBy(0,top);
+        } else {
+            document.body.scrollIntoView(true);
+        }
 
         if (!this.canHandleEvent) {
             return;


### PR DESCRIPTION
## What?
For iOS, when a user clicks on "show details" button, the parent page will scroll to the top of the checkout iframe.

## Why?
`ScrollIntoView` does not work in iOS due to CSS conflicts with the Bigcommerce WordPress plug-in. Therefore, adding a method specific to the Bigcommerce WordPress plug-in.

## Testing / Proof
iOS Safari:

https://user-images.githubusercontent.com/88361607/192404635-4e7d93d5-9eec-43b9-bb7e-38b422c2ae47.mov

iOS Chrome:

https://user-images.githubusercontent.com/88361607/192404642-8fb877ec-b795-4d44-8aad-7f7c106ed538.mov

