### PR TITLE
chore(payment): PAYPAL-1625 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.287.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.287.1.tgz",
-      "integrity": "sha512-FTG38m1SD36BX7nU+DU1zo02AeTM20MmFubqLVrUfLqgmiCKr2T7WNsXGGBcypLFHxdMYSNE1LKNV1RZMjXtgw==",
+      "version": "1.289.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.289.0.tgz",
+      "integrity": "sha512-IZhNXkIlIgRj8E4XOvOv5EUbp0LcfUj6PQBShUg3MBBlhuecJ5Q6qn3A5vD/KsGbL+2RTRWkMlgAJ2i1SZmENg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.287.1",
+    "@bigcommerce/checkout-sdk": "^1.289.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To make checkout-js be in line with last checkout sdk changes:
https://github.com/bigcommerce/checkout-sdk-js/pull/1588
https://github.com/bigcommerce/checkout-sdk-js/pull/1586
https://github.com/bigcommerce/checkout-sdk-js/pull/1604

## Testing / Proof
Unit tests
Manual tests
CI tests
