### PR TITLE
fix(checkout): CHECKOUT-6969 Display cart summary at bottom

### DIFF
--- a/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
@@ -20,7 +20,6 @@ describe('OrderSummaryDrawer', () => {
     let localeContext: LocaleContextType;
 
     beforeEach(() => {
-        window.HTMLElement.prototype.scrollIntoView = jest.fn();
         localeContext = createLocaleContext(getStoreConfig());
 
         order = getOrder();
@@ -96,8 +95,6 @@ describe('OrderSummaryDrawer', () => {
                 shopperCurrency: getStoreConfig().shopperCurrency,
                 additionalLineItems: 'foo',
             });
-
-            expect(document.body.scrollIntoView).toHaveBeenCalled();
         });
     });
 
@@ -119,8 +116,6 @@ describe('OrderSummaryDrawer', () => {
                 shopperCurrency: getStoreConfig().shopperCurrency,
                 additionalLineItems: 'foo',
             });
-
-            expect(document.body.scrollIntoView).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/ui/modal/ModalTrigger.spec.tsx
+++ b/packages/core/src/app/ui/modal/ModalTrigger.spec.tsx
@@ -4,8 +4,6 @@ import React, { FunctionComponent } from 'react';
 import ModalTrigger, { ModalTriggerModalProps } from './ModalTrigger';
 
 describe('ModalTrigger', () => {
-    window.HTMLElement.prototype.scrollIntoView = jest.fn();
-
     const Modal: FunctionComponent<ModalTriggerModalProps> = ({ isOpen, onRequestClose }) =>
         isOpen ? (
             <div id="modal">
@@ -31,8 +29,6 @@ describe('ModalTrigger', () => {
         component.find('#openButton').simulate('click');
 
         expect(component.find('#modal')).toHaveLength(1);
-
-        expect(document.body.scrollIntoView).toHaveBeenCalled();
     });
 
     it('closes modal window when "onRequestClose" is called', () => {

--- a/packages/core/src/app/ui/modal/ModalTrigger.tsx
+++ b/packages/core/src/app/ui/modal/ModalTrigger.tsx
@@ -20,8 +20,6 @@ export interface ModalTriggerState {
     isOpen: boolean;
 }
 
-const wordpressCheckout = parent.document.getElementById('bc-embedded-checkout');
-
 export default class ModalTrigger extends Component<ModalTriggerProps, ModalTriggerState> {
     state = {
         isOpen: false,
@@ -57,13 +55,6 @@ export default class ModalTrigger extends Component<ModalTriggerProps, ModalTrig
     }
 
     private handleOpen: () => void = () => {
-        if (wordpressCheckout) {
-            const top = wordpressCheckout.getBoundingClientRect().top;
-            window.parent.scrollBy(0,top);
-        } else {
-            document.body.scrollIntoView(true);
-        }
-
         if (!this.canHandleEvent) {
             return;
         }

--- a/packages/core/src/scss/components/foundation/modal/_modal.scss
+++ b/packages/core/src/scss/components/foundation/modal/_modal.scss
@@ -40,6 +40,9 @@
         &.is-active,
         &.modal--afterOpen {
             bottom: 2%;
+            display: flex;
+            flex-direction: column;
+            justify-content: end;
             left: 2%;
             max-width: 96%;
             min-height: 96vh;


### PR DESCRIPTION
## What?
Revert previous PR https://github.com/bigcommerce/checkout-js/pull/1036
Not scroll any more, display cart summary at bottom.

## Why?
By default, modern browsers prevent cross-domain iframes from accessing anything in the parent window. 

The previous PR is unable to work in a cross domain scenario, which is the most common use case for the embedded checkout.

As a result, this PR provides a pure CSS solution to the problem that a shopper cannot see the cart summary when clicking on the cart button.

## Testing / Proof

Android - Chrome

https://user-images.githubusercontent.com/88361607/192906250-e95d8b48-2015-4ff8-a6e3-e010e4159a60.MP4

iOS - Safari

https://user-images.githubusercontent.com/88361607/192906254-eb203e66-109b-4ba6-ac61-d6d87c562059.mov

iOS - Chrome

https://user-images.githubusercontent.com/88361607/192906258-a5ea1d78-27a2-4762-8ec5-758841ecf846.mov

mac - Safari

<img src="https://user-images.githubusercontent.com/88361607/192907308-2f18d130-0125-4b21-acea-6025f0e86897.png" width=300 >