### PR TITLE
chore(payment): STRIPE-52 bump to 1.292.0 SDK version (#1616)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.289.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.289.0.tgz",
-      "integrity": "sha512-IZhNXkIlIgRj8E4XOvOv5EUbp0LcfUj6PQBShUg3MBBlhuecJ5Q6qn3A5vD/KsGbL+2RTRWkMlgAJ2i1SZmENg==",
+      "version": "1.292.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.292.0.tgz",
+      "integrity": "sha512-9IDhJVhByM6yEv+F1eHjQ7NdCF+LFJy1T6hffn32e62wjGlZ75B37RmjhHu/ckFOOsQdoitUaL3mq8xZTXavkg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1215,9 +1215,9 @@
           }
         },
         "core-js": {
-          "version": "3.25.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.2.tgz",
-          "integrity": "sha512-YB4IAT1bjEfxTJ1XYy11hJAKskO+qmhuDBM8/guIfMz4JvdsAQAqvyb97zXX7JgSrfPLG5mRGFWJwJD39ruq2A=="
+          "version": "3.25.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.3.tgz",
+          "integrity": "sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.289.0",
+    "@bigcommerce/checkout-sdk": "^1.292.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Update SDK version

## Why?
We need to use the latest version of SDK to be able to implement the StripeLink checkout

https://github.com/bigcommerce/checkout-sdk-js/commit/b08223022940cdd0fdf495743719ed82eb8cffdf

## Testing / Proof
- Circle

@bigcommerce/checkout @bigcommerce/apex-integrations 
