### PR TITLE
chore(payment): PAYPAL-1628 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.294.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.294.0.tgz",
-      "integrity": "sha512-cVWNtmGAnrg1E4eRZNyPXUT6lmN64DkA35f2Kc6kP2pFNhxfbJ0n0UL9SH/QfXQkSum4R5YrQTwcPQqN6l2gPA==",
+      "version": "1.295.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.295.0.tgz",
+      "integrity": "sha512-FqfgXzKO8RFBIiOn+vK9EBJLHWRvc3H1lbC6xMTxglJWavTBFzujTeEyuHJK+ngcc3EwNzOD6OYjkSbXO5w/2w==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.294.0",
+    "@bigcommerce/checkout-sdk": "^1.295.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

The release contains this checkout sdk PRs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1622
https://github.com/bigcommerce/checkout-sdk-js/pull/1624

## Why?
To make checkout js have latest checkout sdk version

## Testing / Proof
Unit tests
Manual tests
