### PR TITLE
fix(payment): INT-6478 SquareV2 - Fail Gracefully when payment provider unavailable

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.tsx
@@ -1,10 +1,12 @@
+import { noop } from 'lodash';
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { FunctionComponent, useCallback, useContext } from 'react';
 import { Omit } from 'utility-types';
 
 import HostedFieldPaymentMethod, {
     HostedFieldPaymentMethodProps,
 } from './HostedFieldPaymentMethod';
+import PaymentContext from '../PaymentContext';
 
 export type SquarePaymentMethodProps = Omit<
     HostedFieldPaymentMethodProps,
@@ -14,8 +16,10 @@ export type SquarePaymentMethodProps = Omit<
 const SquarePaymentMethod: FunctionComponent<SquarePaymentMethodProps> = ({
     initializePayment,
     method,
+    onUnhandledError = noop,
     ...rest
 }) => {
+    const paymentContext = useContext(PaymentContext);
     const initializeSquarePayment = useCallback(
         (options: PaymentInitializeOptions) =>
             initializePayment({
@@ -56,6 +60,10 @@ const SquarePaymentMethod: FunctionComponent<SquarePaymentMethodProps> = ({
             initializePayment={initializeSquarePayment}
             method={method}
             postalCodeId="sq-postal-code"
+            onUnhandledError={(e) => {
+                onUnhandledError(e);
+                paymentContext?.disableSubmit(method, true);
+            }}
         />
     );
 };


### PR DESCRIPTION
## JIRA: [INT-6478](https://bigcommercecloud.atlassian.net/browse/INT-6478)

## What?
Refactoring to catch a bug and disable the place order button when provider scripts fail.

## Why?
If you decide to make the purchase with square even though it did not show the capture fields (Checkout section). Throws a modal with an error you can't get out of.

## Testing / Proof
https://drive.google.com/file/d/1Yu3xmSnwiiCQBGlzN7yaV-VV6mEu-Iq2/view?usp=sharing

## Linked to this [PR](https://github.com/bigcommerce/checkout-sdk-js/pull/1618) of Checkout SDK

@bigcommerce/checkout
