### PR TITLE
chore(payment): INT-6092 Bump checkout-sdk from 1.295.0 to 1.296.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.295.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.295.0.tgz",
-      "integrity": "sha512-FqfgXzKO8RFBIiOn+vK9EBJLHWRvc3H1lbC6xMTxglJWavTBFzujTeEyuHJK+ngcc3EwNzOD6OYjkSbXO5w/2w==",
+      "version": "1.296.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.296.0.tgz",
+      "integrity": "sha512-e27VusRnXpNk3z+ZirZIvwe5dYtTEwpcK0mGRBpjYt0qUSd/AvvAu12Op1yI0mNUvzGt9haTOkw96g7RbWCuOw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.295.0",
+    "@bigcommerce/checkout-sdk": "^1.296.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from 1.295.0 to 1.296.0

## Why?
To release https://github.com/bigcommerce/checkout-sdk-js/pull/1605

## Testing / Proof
CircleCI + testing section on the above PR

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 