### PR TITLE
fix(shipping): CHECKOUT-5034 Update autocomplete address set for NZ address

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
@@ -1,5 +1,5 @@
 import AddressSelector from './AddressSelector';
-import { getGoogleAutocompletePlaceMock } from './googleAutocompleteResult.mock';
+import { getGoogleAutocompleteNZPlaceMock, getGoogleAutocompletePlaceMock } from './googleAutocompleteResult.mock';
 
 describe('AddressSelector', () => {
     let googleAutoCompleteResponseMock: google.maps.places.PlaceResult;
@@ -37,6 +37,14 @@ describe('AddressSelector', () => {
             const accessor = new AddressSelector(googleAutoCompleteResponseMock);
 
             expect(accessor.getStreet2()).toBe('unit 6');
+        });
+
+        it('returns the correct street2 value for NZ', () => {
+            const googleAutoCompleteResponseMock = getGoogleAutocompleteNZPlaceMock();
+            const accessor = new AddressSelector(googleAutoCompleteResponseMock);
+
+            expect(accessor.getStreet()).toBe('6d/17 Alberton Avenue');
+            expect(accessor.getStreet2()).toBe('Mount Albert');
         });
     });
 

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelector.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelector.ts
@@ -20,6 +20,10 @@ export default class AddressSelector {
     }
 
     getStreet2(): string {
+        if (this.getCountry() === 'NZ') {
+            return this._get('sublocality', 'short_name');
+        }
+
         return this._get('subpremise', 'short_name');
     }
 

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
@@ -55,3 +55,52 @@ export function getGoogleAutocompletePlaceMock(): google.maps.places.PlaceResult
         ],
     } as google.maps.places.PlaceResult;
 }
+
+
+export function getGoogleAutocompleteNZPlaceMock(): google.maps.places.PlaceResult {
+    return {
+        name: '6d/17 Alberton Avenue',
+        address_components: [
+            {
+               "long_name" : "6d",
+               "short_name" : "6d",
+               "types" : [ "subpremise" ]
+            },
+            {
+               "long_name" : "17",
+               "short_name" : "17",
+               "types" : [ "street_number" ]
+            },
+            {
+               "long_name" : "Alberton Avenue",
+               "short_name" : "Alberton Ave",
+               "types" : [ "route" ]
+            },
+            {
+               "long_name" : "Mount Albert",
+               "short_name" : "Mount Albert",
+               "types" : [ "sublocality_level_1", "sublocality", "political" ]
+            },
+            {
+               "long_name" : "Auckland",
+               "short_name" : "Auckland",
+               "types" : [ "locality", "political" ]
+            },
+            {
+               "long_name" : "Auckland",
+               "short_name" : "Auckland",
+               "types" : [ "administrative_area_level_1", "political" ]
+            },
+            {
+               "long_name" : "New Zealand",
+               "short_name" : "NZ",
+               "types" : [ "country", "political" ]
+            },
+            {
+               "long_name" : "1025",
+               "short_name" : "1025",
+               "types" : [ "postal_code" ]
+            }
+        ],
+    } as google.maps.places.PlaceResult;
+}

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
@@ -50,4 +50,5 @@ export type GoogleAddressFieldType =
     | 'route'
     | 'political'
     | 'country'
-    | 'subpremise';
+    | 'subpremise'
+    | 'sublocality';


### PR DESCRIPTION
## What?
Set `sublocality` as street 2 for NZ based addresses. 

## Why?
Set `sublocality` as street 2 for NZ based addresses, since NZ has a concept of a sublocality which is not captured in our shipping form as part of google autocomplete.

## Testing / Proof
- Tests
- Screenshot

<img width="1018" alt="Screen Shot 2022-10-12 at 5 29 17 pm" src="https://user-images.githubusercontent.com/7134802/195266719-a0a9bf60-d316-46b6-8a68-d1b3881b0ed5.png">


@bigcommerce/checkout
