### PR TITLE
chore(common): CHECKOUT-000 Add applepay to unsupported methods

### DIFF
--- a/packages/core/src/app/embeddedCheckout/createEmbeddedCheckoutSupport.ts
+++ b/packages/core/src/app/embeddedCheckout/createEmbeddedCheckoutSupport.ts
@@ -5,7 +5,7 @@ import { CheckoutSupport, NoopCheckoutSupport } from '../checkout';
 import EmbeddedCheckoutSupport from './EmbeddedCheckoutSupport';
 import isEmbedded from './isEmbedded';
 
-const UNSUPPORTED_METHODS = ['afterpay', 'amazon', 'chasepay', 'googlepay', 'klarna', 'masterpass'];
+const UNSUPPORTED_METHODS = ['afterpay', 'applepay', 'amazon', 'chasepay', 'googlepay', 'klarna', 'masterpass'];
 
 export default function createEmbeddedCheckoutSupport(language: LanguageService): CheckoutSupport {
     return isEmbedded()


### PR DESCRIPTION
## What?
Add applepay to the list of unsupported payment methods in embedded checkout.

## Why?
Applepay is not supported in embedded checkout, updating the list accordingly.

## Testing / Proof
- circle

@bigcommerce/checkout
