### PR TITLE
fix(payment): INT-6720 prevent calls on undefined error body

### DIFF
--- a/packages/core/src/app/payment/Payment.spec.tsx
+++ b/packages/core/src/app/payment/Payment.spec.tsx
@@ -662,6 +662,25 @@ describe('Payment', () => {
         expect(container.find(PaymentForm).prop('didExceedSpamLimit')).toBeTruthy();
     });
 
+    it('clears error when error has no body', async () => {
+        jest.spyOn(checkoutService, 'loadCheckout').mockResolvedValue(checkoutState);
+        jest.spyOn(checkoutService, 'clearError').mockResolvedValue(checkoutState);
+
+        jest.spyOn(checkoutState.errors, 'getSubmitOrderError').mockReturnValue({
+            type: 'request',
+        } as unknown as RequestError);
+
+        const container = mount(<PaymentTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        container.update();
+        container.find('ErrorModal Button').simulate('click');
+
+        expect(checkoutService.loadCheckout).not.toHaveBeenCalled();
+        expect(checkoutService.clearError).toHaveBeenCalled();
+    });
+
     it('calls onUnhandledError if loadPaymentMethods was failed', async () => {
         jest.spyOn(checkoutService, 'loadPaymentMethods').mockRejectedValue(new Error());
 

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -370,7 +370,7 @@ class Payment extends Component<
                 window.location.reload();
             }
 
-            if (isErrorWithType(error)) {
+            if (isErrorWithType(error) && error.body) {
                 const { body, headers, status } = error;
 
                 if (body.type === 'provider_error' && headers.location) {


### PR DESCRIPTION
## What? [INT-6720](https://bigcommercecloud.atlassian.net/browse/INT-6720) [PROJECT-4622](https://bigcommercecloud.atlassian.net/browse/PROJECT-4622)
Prevent calling properties on undefined `error.body` when handling closing modals

## Why?
There are some errors (like `PaymentMethodFailedError` which is thrown by Cardinal) that include a `type` but not a `body`, which breaks the close modal functionality when accessing the property type of undefined.

## Testing / Proof
Without changes:
https://drive.google.com/file/d/1D2XU594smtrOOG6rtp-zVeOP5QM1UEG1/view?usp=sharing

After changes:
https://drive.google.com/file/d/1zgatOvL6gSxGSLLVT11IDLTewdK9N9Tf/view?usp=sharing

@bigcommerce/apex-integrations @bigcommerce/checkout 