### PR TITLE
feat(payment): PAYPAL-1607 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.296.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.296.0.tgz",
-      "integrity": "sha512-e27VusRnXpNk3z+ZirZIvwe5dYtTEwpcK0mGRBpjYt0qUSd/AvvAu12Op1yI0mNUvzGt9haTOkw96g7RbWCuOw==",
+      "version": "1.297.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.297.0.tgz",
+      "integrity": "sha512-50tI+pc75Vw4p7O5ssTXenFt95YCBjN+14IhzAv3rHsNUHfOl8wbi/ZM3H+WtukAUhWt39OXTZLXYg01uVqhrg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.296.0",
+    "@bigcommerce/checkout-sdk": "^1.297.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1607

Checkout-sdk-js PRs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1610
https://github.com/bigcommerce/checkout-sdk-js/pull/1607

## Testing / Proof
Tested on dev and Integration

@bigcommerce/checkout
