### PR TITLE
chore(common): INT-6478 STRIPE-99 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.297.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.297.0.tgz",
-      "integrity": "sha512-50tI+pc75Vw4p7O5ssTXenFt95YCBjN+14IhzAv3rHsNUHfOl8wbi/ZM3H+WtukAUhWt39OXTZLXYg01uVqhrg==",
+      "version": "1.298.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.298.0.tgz",
+      "integrity": "sha512-qJmd8TFZpMIXT7HCa8+2ksQ1kpxPPIggyVgJIxl9RIlmDd2OZsiirJwW0JPUgZBdflrgZzW8ax7bMWcplHCPTA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1170,12 +1170,12 @@
         "@braintree/browser-detection": "^1.14.0",
         "@types/card-validator": "^4.1.0",
         "@types/iframe-resizer": "^3.5.9",
-        "@types/lodash": "^4.14.182",
+        "@types/lodash": "^4.14.184",
         "@types/reselect": "^2.2.0",
         "@types/shallowequal": "^1.1.1",
         "@types/yup": "^0.26.24",
         "card-validator": "^6.2.0",
-        "core-js": "^3.24.1",
+        "core-js": "^3.25.0",
         "current-script-polyfill": "^1.0.0",
         "iframe-resizer": "^3.6.6",
         "local-storage-fallback": "^4.1.2",
@@ -1213,6 +1213,11 @@
               }
             }
           }
+        },
+        "@types/lodash": {
+          "version": "4.14.186",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
+          "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
         },
         "core-js": {
           "version": "3.25.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.297.0",
+    "@bigcommerce/checkout-sdk": "^1.298.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from [version 1.297.0](https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md#12970-2022-10-17) to [version 1.298.0](https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md#12980-2022-10-18).

## Why?
To release:
- https://github.com/bigcommerce/checkout-sdk-js/pull/1591
- https://github.com/bigcommerce/checkout-sdk-js/pull/1618

## Testing / Proof
CircleCI + testing section on the above PRs

@bigcommerce/checkout