### PR TITLE
fix(payment): INT-6789 Worldpay Support payment without hosted form

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.spec.tsx
@@ -58,10 +58,12 @@ const injectedProps: WithInjectedHostedCreditCardFieldsetProps = {
     hostedValidationSchema: object(),
 };
 
+const injectedPropsMock = jest.fn().mockReturnValueOnce({}).mockReturnValue(injectedProps)
+
 jest.mock('../hostedCreditCard', () => ({
     ...jest.requireActual('../hostedCreditCard'),
     withHostedCreditCardFieldset: jest.fn((Component) => (props: any) => (
-        <Component {...props} {...injectedProps} />
+        <Component {...props} {...injectedPropsMock()} />
     )) as jest.Mocked<typeof withHostedCreditCardFieldset>,
 }));
 
@@ -145,6 +147,25 @@ describe('WorldpayCreditCardPaymentMethod', () => {
                 </CheckoutProvider>
             );
         };
+    });
+
+    it('initializes payment method when component mounts without hosted form', async () => {
+        jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue(getInstruments());
+
+        mount(<WorldpayCreditCardPaymentMethodTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.initializePayment).toHaveBeenCalledWith({
+            gatewayId: undefined,
+            methodId: 'authorizenet',
+            creditCard: {
+                form: undefined,
+            },
+            worldpay: {
+                onLoad: expect.any(Function),
+            },
+        });
     });
 
     it('initializes payment method when component mounts', async () => {

--- a/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/WorldpayCreditCardPaymentMethod.tsx
@@ -51,12 +51,12 @@ const WorldpayCreditCardPaymentMethod: FunctionComponent<
 
     const initializeWorldpayPayment = useCallback(
         async (options: PaymentInitializeOptions, selectedInstrument) => {
-            const fields = await getHostedFormOptions(selectedInstrument);
 
             return initializePayment({
                 ...options,
                 creditCard: {
-                    form: fields,
+                    form: getHostedFormOptions &&
+                        (await getHostedFormOptions(selectedInstrument)),
                 },
                 worldpay: {
                     onLoad(content: HTMLIFrameElement, cancel: () => void) {


### PR DESCRIPTION
## What? [INT-6789](https://bigcommercecloud.atlassian.net/browse/INT-6789)
**WorldpayCreditCardPaymentMethod.tsx**
- validate if getHostedFormOptions exists before to be called

## Why?
with **Feature_HostedPaymentForm** disabled and we initialize the payment method we was getting a error message 

## Testing / Proof
**Before:** [Video](https://drive.google.com/file/d/1JhcXSNP5DYy-J1utu0pBMLGdy-sbAevN/view?usp=sharing)
**After:** [Video](https://drive.google.com/file/d/1ok71cibs5B1k0hz2WYAigVsol5I0x7CJ/view?usp=sharing)
@bigcommerce/checkout @bigcommerce/apex-integrations 
