### PR TITLE
test(payment): INT-6517 Increase BluesnapV2 payment method coverage

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.spec.tsx
@@ -113,6 +113,26 @@ describe('when using BlueSnapV2 payment', () => {
         expect(component.find(Modal).prop('isOpen')).toBe(true);
     });
 
+    it('renders modal and appends bluesnap payment page', async () => {
+        const component = mount(<BlueSnapV2PaymentMethodTest />);
+        const initializeOptions = (defaultProps.initializePayment as jest.Mock).mock.calls[0][0];
+        const iframe = document.createElement('iframe');
+
+        act(() => initializeOptions.bluesnapv2.onLoad(iframe, jest.fn()));
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        await act(async () => {
+            component.update();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            component.find(Modal).prop('onAfterOpen')!();
+        });
+
+        expect(component.find(Modal).prop('isOpen')).toBe(true);
+
+        expect(component.find(Modal).render().find('iframe')).toHaveLength(1);
+    });
+
     it('renders modal but does not append bluesnap payment page because is empty', async () => {
         const component = mount(<BlueSnapV2PaymentMethodTest />);
         const initializeOptions = (defaultProps.initializePayment as jest.Mock).mock.calls[0][0];

--- a/packages/core/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BlueSnapV2PaymentMethod.tsx
@@ -62,10 +62,10 @@ const BlueSnapV2PaymentMethod: FunctionComponent<BlueSnapV2PaymentMethodProps> =
 
     const appendPaymentPageContent = useCallback(() => {
         if (ref.current.paymentPageContentRef.current && paymentPageContent) {
-            ref.current.paymentPageContentRef.current.appendChild(paymentPageContent);
             paymentPageContent.addEventListener('load', () => {
                 setisLoadingIframe(false);
             });
+            ref.current.paymentPageContentRef.current.appendChild(paymentPageContent);
         }
     }, [paymentPageContent]);
 


### PR DESCRIPTION
## What? [INT-6517](https://bigcommercecloud.atlassian.net/browse/INT-6517)
Add modal and page content test case for BluesnapV2 payment method.

Also in the payment method, add listener first then append to page.

## Why?
Test missing case and increase the test coverage for the payment method.

If listener is added after appending content, 'load' would have been already fired and method can't be tested properly.

## Testing / Proof
<img width="668" alt="Screen Shot 2022-10-18 at 2 57 59 PM" src="https://user-images.githubusercontent.com/35502707/196532111-e7e8c43a-bd3c-4eeb-ad40-d9715581047d.png">


@bigcommerce/checkout @bigcommerce/apex-integrations 
