### PR TITLE
feat(payment): INT-6637 Sezzle change displayed text

### DIFF
--- a/packages/core/src/app/locale/translations/en.json
+++ b/packages/core/src/app/locale/translations/en.json
@@ -307,7 +307,7 @@
             "sepa_bic": "BIC",
             "sepa_bic_length": "BIC must be 8 or 11 characters",
             "sepa_mandate_required": "You must accept the mandate form",
-            "sezzle_display_name_text": "Pay Later. 0% Interest.",
+            "sezzle_display_name_text": "Buy Now Pay Later with Sezzle.",
             "stripe_sepa_display_name_text": "Sepa Direct Debit.",
             "stripe_sepa_mandate_disclaimer": "By providing your IBAN and confirming this payment, you authorise (A) {storeUrl} and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. You are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within eight weeks starting from the date on which your account was debited.",
             "tax_provider_unavailable": "Sales tax could not be calculated. Please try again. If unsuccessful, please reach out to our support team to complete checkout.",


### PR DESCRIPTION
## What?  [INT-6637](https://bigcommercecloud.atlassian.net/browse/INT-6637)
Change the displayed text to **Buy Now Pay Later with Sezzle**

## Why?
Sezzle prefer the another text

## Testing / Proof
### Before
![image](https://user-images.githubusercontent.com/4907027/196549343-675626b2-1fbc-470c-8259-c46dc44f4a46.png)

### After
![image](https://user-images.githubusercontent.com/4907027/196549459-ca3bd0c1-7e37-401f-8938-08dec3881d50.png)

@bigcommerce/checkout. @bigcommerce/apex-integrations 
