### PR TITLE
feat(checkout): CHECKOUT-6835 Address autocomplete for UK

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
@@ -1,5 +1,6 @@
 import AddressSelector from './AddressSelector';
-import { getGoogleAutocompleteNZPlaceMock, getGoogleAutocompletePlaceMock } from './googleAutocompleteResult.mock';
+import AddressSelectorFactory from "./AddressSelectorFactory";
+import { getGoogleAutocompleteNZPlaceMock, getGoogleAutocompletePlaceMock, getGoogleAutocompleteUKPlaceMock } from './googleAutocompleteResult.mock';
 
 describe('AddressSelector', () => {
     let googleAutoCompleteResponseMock: google.maps.places.PlaceResult;
@@ -21,6 +22,13 @@ describe('AddressSelector', () => {
             const accessor = new AddressSelector(googleAutoCompleteResponseMock);
 
             expect(accessor.getState()).toBe('NSW');
+        });
+
+        it('does not return a state for a UK address', () => {
+            googleAutoCompleteResponseMock = getGoogleAutocompleteUKPlaceMock();
+            const accessor = AddressSelectorFactory.create(googleAutoCompleteResponseMock);
+
+            expect(accessor.getState()).toBe('');
         });
     });
 
@@ -61,6 +69,13 @@ describe('AddressSelector', () => {
             const accessor = new AddressSelector(googleAutoCompleteResponseMock);
 
             expect(accessor.getPostCode()).toBe('2007');
+        });
+
+        it('does not return a post code for an UK address', () => {
+            googleAutoCompleteResponseMock = getGoogleAutocompleteUKPlaceMock();
+            const accessor = AddressSelectorFactory.create(googleAutoCompleteResponseMock);
+
+            expect(accessor.getPostCode()).toBe('');
         });
     });
 

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorUk.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorUk.ts
@@ -2,10 +2,14 @@ import AddressSelector from './AddressSelector';
 
 export default class AddressSelectorUK extends AddressSelector {
     getState(): string {
-        return this._get('administrative_area_level_2', 'long_name');
+        return '';
     }
 
     getStreet2(): string {
         return this._get('locality', 'long_name');
+    }
+
+    getPostCode(): string {
+        return '';
     }
 }

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
@@ -56,7 +56,6 @@ export function getGoogleAutocompletePlaceMock(): google.maps.places.PlaceResult
     } as google.maps.places.PlaceResult;
 }
 
-
 export function getGoogleAutocompleteNZPlaceMock(): google.maps.places.PlaceResult {
     return {
         name: '6d/17 Alberton Avenue',
@@ -100,6 +99,54 @@ export function getGoogleAutocompleteNZPlaceMock(): google.maps.places.PlaceResu
                "long_name" : "1025",
                "short_name" : "1025",
                "types" : [ "postal_code" ]
+            }
+        ],
+    } as google.maps.places.PlaceResult;
+}
+
+export function getGoogleAutocompleteUKPlaceMock(): google.maps.places.PlaceResult {
+    return {
+        "name" : "unit 1, 123 Buckingham Palace Rd",
+        "address_components" : [
+            {
+                "long_name" : "unit 1",
+                "short_name" : "unit 1",
+                "types" : [ "subpremise" ]
+            },
+            {
+                "long_name" : "123",
+                "short_name" : "123",
+                "types" : [ "street_number" ]
+            },
+            {
+                "long_name" : "Buckingham Palace Road",
+                "short_name" : "Buckingham Palace Rd",
+                "types" : [ "route" ]
+            },
+            {
+                "long_name" : "London",
+                "short_name" : "London",
+                "types" : [ "postal_town" ]
+            },
+            {
+                "long_name" : "Greater London",
+                "short_name" : "Greater London",
+                "types" : [ "administrative_area_level_2", "political" ]
+            },
+            {
+                "long_name" : "England",
+                "short_name" : "England",
+                "types" : [ "administrative_area_level_1", "political" ]
+            },
+            {
+                "long_name" : "United Kingdom",
+                "short_name" : "GB",
+                "types" : [ "country", "political" ]
+            },
+            {
+                "long_name" : "SW1W 9SR",
+                "short_name" : "SW1W 9SR",
+                "types" : [ "postal_code" ]
             }
         ],
     } as google.maps.places.PlaceResult;


### PR DESCRIPTION
## What?
Allow checkout to not automatically fill in the `postcode` and `state/province` fields for UK shipping addresses.

## Why? ([CHECKOUT-6835](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-6835))
We have discovered that Google does not return UK postcodes reliably.

Furthermore, UK addresses do not have “State/Province”. 

## Testing / Proof
Added two unit tests.