### PR TITLE
feat(payment): STRIPE-183 persisting stripe components when reloads the page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.300.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.300.0.tgz",
-      "integrity": "sha512-E5py9vxtCB+jU6UbHBYZbNwjfDaLW63PnDRjHeWCh/LyczD5Zs+Ytqaj6V7pEt6KQu+GDFuplBMUXajoiQslTw==",
+      "version": "1.304.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.304.0.tgz",
+      "integrity": "sha512-WSWk5ZdgQFFTmijh89Had/F7Z0PXxUU7Lib+mmzfWwfH75+lc/j/FT9t3GqZm6wzTQPUik3EdsJHL+b9EKdZCg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1215,9 +1215,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.186",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-          "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+          "version": "4.14.188",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
+          "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w=="
         },
         "core-js": {
           "version": "3.26.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.300.0",
+    "@bigcommerce/checkout-sdk": "^1.304.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -5,6 +5,7 @@ import { createSelector } from 'reselect';
 import { isValidAddress } from '../address';
 import { EMPTY_ARRAY } from '../common/utility';
 import { SUPPORTED_METHODS } from '../customer';
+import { PaymentMethodId } from '../payment/paymentMethod';
 import {
     hasSelectedShippingOptions,
     hasUnassignedLineItems,
@@ -33,7 +34,7 @@ const getCustomerStepStatus = createSelector(
         const isComplete = hasEmail || isUsingWallet;
         const isEditable = isComplete && !isUsingWallet && isGuest
 
-        if (config?.checkoutSettings.providerWithCustomCheckout === 'stripeupe' && hasEmail && isGuest) {
+        if (config?.checkoutSettings.providerWithCustomCheckout === PaymentMethodId.StripeUPE && hasEmail && isGuest) {
             return {
                 type: CheckoutStepType.Customer,
                 isActive: false,

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -114,7 +114,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
 
         try {
             await loadPaymentMethods();
-            if (providerWithCustomCheckout !== 'stripeupe') {
+            if (providerWithCustomCheckout !== PaymentMethodId.StripeUPE) {
                 await initializeCustomer({methodId: providerWithCustomCheckout});
             }
         } catch (error) {
@@ -473,7 +473,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             providerWithCustomCheckout,
         } = this.props;
 
-        if (providerWithCustomCheckout && providerWithCustomCheckout !== 'stripeupe') {
+        if (providerWithCustomCheckout && providerWithCustomCheckout !== PaymentMethodId.StripeUPE) {
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onContinueAsGuest,

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -114,7 +114,9 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
 
         try {
             await loadPaymentMethods();
-            await initializeCustomer({ methodId: providerWithCustomCheckout });
+            if (providerWithCustomCheckout !== 'stripeupe') {
+                await initializeCustomer({methodId: providerWithCustomCheckout});
+            }
         } catch (error) {
             onUnhandledError(error);
         }
@@ -375,7 +377,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
 
             const customer = data.getCustomer();
 
-            if (customer && customer.shouldEncourageSignIn && customer.isGuest) {
+            if (customer && customer.shouldEncourageSignIn && customer.isGuest && !customer.isStripeLinkAuthenticated) {
                 return onChangeViewType(CustomerViewType.SuggestedLogin);
             }
 
@@ -471,7 +473,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
             providerWithCustomCheckout,
         } = this.props;
 
-        if (providerWithCustomCheckout) {
+        if (providerWithCustomCheckout && providerWithCustomCheckout !== 'stripeupe') {
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onContinueAsGuest,

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -49,6 +49,7 @@ describe('Shipping Component', () => {
                 isRequired: true,
                 type: CheckoutStepType.Shipping },
             isStripeLinkEnabled: true,
+            isShippingMethodLoading: true,
             navigateNextStep: jest.fn(),
             onUnhandledError: jest.fn(),
         };
@@ -122,6 +123,14 @@ describe('Shipping Component', () => {
     it('loads shipping data when component is mounted and stripeupe is enable', () => {
         jest.spyOn(checkoutState.data, 'getCustomer')
             .mockReturnValue({ ...getCustomer(), email: '' ,addresses: [] });
+        jest.spyOn(checkoutState.data, 'getShippingCountries')
+            .mockReturnValue([{
+            code: 'US',
+            name: 'United States',
+            hasPostalCodes: true,
+            subdivisions: [{code: 'bar', name: 'foo' }],
+            requiresState: true,
+        }])
         mount(<ComponentTest { ...defaultProps }/>);
 
         expect(checkoutService.loadShippingAddressFields)

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -139,7 +139,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             isInitializing,
         } = this.state;
 
-        if (isStripeLinkEnabled && !customer.email) {
+        if (isStripeLinkEnabled && !customer.email && this.props.countries.length > 0) {
             return <StripeShipping
                 { ...shippingFormProps }
                 customer={ customer }
@@ -148,6 +148,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                 isBillingSameAsShipping={isBillingSameAsShipping}
                 isGuest={ isGuest }
                 isLoading={ isInitializing }
+                isShippingMethodLoading={ this.props.isLoading }
                 isMultiShippingMode={isMultiShippingMode}
                 onMultiShippingChange={ this.handleMultiShippingModeSwitch }
                 onSubmit={this.handleSingleShippingSubmit}

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
@@ -1,13 +1,4 @@
-import {
-    Address,
-    CheckoutSelectors,
-    Consignment,
-    Country,
-    Customer,
-    FormField,
-    ShippingInitializeOptions,
-    ShippingRequestOptions,
-} from '@bigcommerce/checkout-sdk';
+import { Address, CheckoutSelectors, Consignment, Country, Customer, FormField, ShippingInitializeOptions, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
 import React, { Component, ReactNode } from 'react';
 
 import CheckoutStepStatus from '../../checkout/CheckoutStepStatus';
@@ -28,6 +19,7 @@ export interface StripeShippingProps {
     isGuest: boolean;
     isInitializing: boolean;
     isLoading: boolean;
+    isShippingMethodLoading: boolean;
     isShippingStepPending: boolean;
     methodId?: string;
     shippingAddress?: Address;
@@ -75,6 +67,7 @@ class StripeShipping extends Component<StripeShippingProps, StripeShippingState>
             onSubmit,
             onMultiShippingChange,
             isLoading,
+            isShippingMethodLoading,
             ...shippingFormProps
         } = this.props;
 
@@ -82,7 +75,6 @@ class StripeShipping extends Component<StripeShippingProps, StripeShippingState>
             isStripeLoading,
             isStripeAutoStep,
         } = this.state;
-
 
             return <div className="checkout-form">
                 <div style={ {display: isStripeAutoStep ? 'none' : undefined,} }>
@@ -110,6 +102,7 @@ class StripeShipping extends Component<StripeShippingProps, StripeShippingState>
                                 isMultiShippingMode={isMultiShippingMode}
                                 isStripeAutoStep={this.handleIsAutoStep}
                                 isStripeLoading={this.stripeLoadedCallback}
+                                isShippingMethodLoading={isShippingMethodLoading}
                                 onSubmit={onSubmit}
                                 step={step}
                                 updateAddress={updateAddress}

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
@@ -98,6 +98,7 @@ describe('StripeShippingAddress Component', () => {
                     onChangeShipping: expect.any(Function),
                     availableCountries: 'US',
                     getStyles: expect.any(Function),
+                    getStripeState: expect.any(Function),
                     gatewayId: 'stripeupe',
                     methodId: 'card',
                 },

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -24,6 +24,7 @@ export interface StripeShippingAddressProps {
     countries?: Country[];
     shippingAddress?: Address;
     step: CheckoutStepStatus;
+    isShippingMethodLoading: boolean;
     shouldDisableSubmit: boolean;
     isStripeLoading?(): void;
     isStripeAutoStep?(): void;
@@ -45,6 +46,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
         step,
         isStripeLoading,
         isStripeAutoStep,
+        isShippingMethodLoading,
     } = props;
 
     const [isNewAddress, setIsNewAddress] = useState(true);
@@ -83,17 +85,16 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
     }, [consignments]);
 
     useEffect(() => {
-        if (!isFirstShippingRender && stripeShippingAddress.firstName && !isNewAddress && hasSelectedShippingOptions(consignments)) {
-            setTimeout(() => {
+        if (stripeShippingAddress.firstName && hasSelectedShippingOptions(consignments)) {
+            if (!isFirstShippingRender && !isNewAddress && !isShippingMethodLoading) {
                 if (isStripeLoading && isStripeAutoStep) {
                     isStripeLoading();
                     isStripeAutoStep();
                 }
-
                 onSubmit({billingSameAsShipping: true, shippingAddress: stripeShippingAddress, orderComment: ''});
-            }, 300);
+            }
         }
-    }, [isFirstShippingRender, onSubmit, stripeShippingAddress, shouldDisableSubmit, isNewAddress ,consignments]);
+    }, [isFirstShippingRender, onSubmit, stripeShippingAddress, shouldDisableSubmit, isShippingMethodLoading, isNewAddress ,consignments]);
 
     const availableShippingList = countries?.map(country => ({code: country.code, name: country.name}));
     const allowedCountries = availableShippingList ? availableShippingList.map(country => country.code).join(', ') : '';
@@ -163,9 +164,8 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
         if (parentContainer) {
             return getAppliedStyles(parentContainer, properties);
         }
- 
-            return undefined;
-        
+
+        return undefined;
     };
 
     const getStripeStyles: any = useCallback( () => {
@@ -191,6 +191,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
                 onChangeShipping: handleStripeShippingAddress,
                 availableCountries: allowedCountries,
                 getStyles: getStripeStyles,
+                getStripeState: StripeStateMapper,
                 gatewayId: 'stripeupe',
                 methodId: 'card',
             },

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -85,14 +85,13 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
     }, [consignments]);
 
     useEffect(() => {
-        if (stripeShippingAddress.firstName && hasSelectedShippingOptions(consignments)) {
-            if (!isFirstShippingRender && !isNewAddress && !isShippingMethodLoading) {
-                if (isStripeLoading && isStripeAutoStep) {
-                    isStripeLoading();
-                    isStripeAutoStep();
-                }
-                onSubmit({billingSameAsShipping: true, shippingAddress: stripeShippingAddress, orderComment: ''});
-            }
+        const hasStripeAddressAndHasShippingOptions = stripeShippingAddress.firstName && hasSelectedShippingOptions(consignments);
+        const afterReload = !isFirstShippingRender && !isNewAddress && !isShippingMethodLoading;
+        const isLoadingBeforeAutoStep =  isStripeLoading && isStripeAutoStep;
+        if (hasStripeAddressAndHasShippingOptions && afterReload && isLoadingBeforeAutoStep) {
+            isStripeLoading();
+            isStripeAutoStep();
+            onSubmit({billingSameAsShipping: true, shippingAddress: stripeShippingAddress, orderComment: ''});
         }
     }, [isFirstShippingRender, onSubmit, stripeShippingAddress, shouldDisableSubmit, isShippingMethodLoading, isNewAddress ,consignments]);
 

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.spec.tsx
@@ -36,6 +36,7 @@ describe('SingleShippingForm', () => {
                 isEditable: true,
                 isRequired: true,
                 type: CheckoutStepType.Shipping },
+            isShippingMethodLoading: false,
             customerEmail: 'foo@test.com',
             isShippingStepPending: false,
             onSubmit: jest.fn(),

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
@@ -37,6 +37,7 @@ export interface SingleShippingFormProps {
     countries: Country[];
     customerMessage: string;
     isLoading: boolean;
+    isShippingMethodLoading: boolean;
     isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
@@ -89,6 +90,7 @@ class StripeShippingForm extends PureComponent<
             onSubmit,
             isStripeAutoStep,
             step,
+            isShippingMethodLoading,
         } = this.props;
 
         const { isUpdatingShippingData } = this.state;
@@ -101,6 +103,7 @@ class StripeShippingForm extends PureComponent<
                         countries={countries}
                         deinitialize={deinitialize}
                         initialize={initialize}
+                        isShippingMethodLoading={isShippingMethodLoading}
                         isStripeAutoStep={isStripeAutoStep}
                         isStripeLoading={isStripeLoading}
                         onAddressSelect={this.handleAddressSelect}

--- a/packages/core/src/app/shipping/stripeUPE/StripeStateMapper.spec.ts
+++ b/packages/core/src/app/shipping/stripeUPE/StripeStateMapper.spec.ts
@@ -6,6 +6,11 @@ describe('hasSelectedShippingOptions()', () => {
             .toBe('JAL');
     });
 
+    it('returns correct Stripe state code', () => {
+        expect(StripeStateMapper('MX','JAL'))
+            .toBe('Jal.');
+    });
+
     it('returns same state code with invalid country', () => {
         expect(StripeStateMapper('AU','Foo'))
             .toBe('Foo');

--- a/packages/core/src/app/shipping/stripeUPE/StripeStateMapper.ts
+++ b/packages/core/src/app/shipping/stripeUPE/StripeStateMapper.ts
@@ -1,14 +1,14 @@
-interface stripeCountryMapping {
-    [key: string]: stripeStateMapping;
+interface StripeCountryMapping {
+    [key: string]: StripeStateMapping;
 }
 
-interface stripeStateMapping {
+interface StripeStateMapping {
     [key: string]: string;
 }
 
 export default function StripeStateMapper(country: string, state: string): string {
 
-    const countries: stripeCountryMapping = {
+    const countries: StripeCountryMapping = {
         'MX': {
             'Ags.': 'AGU',
             'B.C.': 'BCN',
@@ -233,12 +233,12 @@ export default function StripeStateMapper(country: string, state: string): strin
     };
 
     if (countries[country]) {
-        return countries[country][state]?? getStripeState(countries[country], state);
+        return countries[country][state] ?? getStripeState(countries[country], state);
     }
 
     return state;
 }
 
-function getStripeState(stateList: stripeStateMapping, state: string) {
+function getStripeState(stateList: StripeStateMapping, state: string) {
     return Object.keys(stateList).find(key => stateList[key] === state) || state;
 }

--- a/packages/core/src/app/shipping/stripeUPE/StripeStateMapper.ts
+++ b/packages/core/src/app/shipping/stripeUPE/StripeStateMapper.ts
@@ -1,6 +1,14 @@
+interface stripeCountryMapping {
+    [key: string]: stripeStateMapping;
+}
+
+interface stripeStateMapping {
+    [key: string]: string;
+}
+
 export default function StripeStateMapper(country: string, state: string): string {
 
-    const bigcommerceStates: any = {
+    const countries: stripeCountryMapping = {
         'MX': {
             'Ags.': 'AGU',
             'B.C.': 'BCN',
@@ -224,9 +232,13 @@ export default function StripeStateMapper(country: string, state: string): strin
         }
     };
 
-    if (bigcommerceStates[country]) {
-        return bigcommerceStates[country][state] || state;
+    if (countries[country]) {
+        return countries[country][state]?? getStripeState(countries[country], state);
     }
 
     return state;
+}
+
+function getStripeState(stateList: stripeStateMapping, state: string) {
+    return Object.keys(stateList).find(key => stateList[key] === state) || state;
 }


### PR DESCRIPTION
## What?  [STRIPE-183](https://bigcommercecloud.atlassian.net/browse/STRIPE-183) & [STRIPE-195](https://bigcommercecloud.atlassian.net/browse/STRIPE-195)

- Persisting data to use when checkout is reloaded, to achieve this we are forcing to load again shipping and customer steps on checkout to refill Stripe components and preserve Stripe behavior, in addition to improving the user experience, we make these steps auto-skip once it finishes loading

- update SDK version 1.304.0

## Why?
For **STRIPE-183**, Link Enrollment Opt-In Disappears If Shopper Navigates Away From Checkout because the information is not persisting & for **STRIPE-195** I want to allow shoppers whose email address is both enrolled in Link and has a merchant registered account to skip the sign-in prompt if they successfully authenticate with Link so that they are not asked to authenticate with two different accounts

## Testing / Proof
[VIDEO STRIPE-183](https://drive.google.com/file/d/1ccuz-hfTxp-3mSgfiJpM2V6CImRdA91P/view?usp=sharing)
[VIDEO STRIPE-195](https://drive.google.com/file/d/1RzP3klUD8DGnnRhc5Y9LUNk6q0iYIu8R/view?usp=sharing)

## Depends on 
https://github.com/bigcommerce/checkout-sdk-js/pull/1649

@bigcommerce/checkout @bigcommerce/apex-integrations 
