### PR TITLE
fix(checkout): CHECKOUT-0000 Fix shipping component memory leak

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -316,6 +316,7 @@ class Checkout extends Component<
                             .map((step) =>
                                 this.renderStep({
                                     ...step,
+                                    activeStepType,
                                     isActive: activeStepType
                                         ? activeStepType === step.type
                                         : defaultStepType === step.type,

--- a/packages/core/src/app/checkout/CheckoutStepStatus.ts
+++ b/packages/core/src/app/checkout/CheckoutStepStatus.ts
@@ -1,6 +1,7 @@
 import CheckoutStepType from './CheckoutStepType';
 
 export default interface CheckoutStepStatus {
+    activeStepType?: CheckoutStepType;
     isActive: boolean;
     isBusy: boolean;
     isComplete: boolean;

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -43,7 +43,9 @@ describe('Shipping Component', () => {
             onToggleMultiShipping: jest.fn(),
             cartHasChanged: false,
             onSignIn: jest.fn(),
-            step: { isActive: true,
+            step: {
+                activeStepType: CheckoutStepType.Shipping,
+                isActive: true,
                 isComplete: true,
                 isEditable: true,
                 isRequired: true,

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -103,6 +103,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             loadPaymentMethods,
             onReady = noop,
             onUnhandledError = noop,
+            step,
         } = this.props;
 
         try {
@@ -113,7 +114,9 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
         } catch (error) {
             onUnhandledError(error);
         } finally {
-            this.setState({ isInitializing: false });
+            if (step.activeStepType === step.type) {
+                this.setState({ isInitializing: false });
+            }
         }
     }
 


### PR DESCRIPTION
## What?
Fix `<Shipping />` component memory leak.

## Why?
The `finally` block inside `componentDidMount` will always run even after `<Shipping />` is unmounted.

Therefore, before running setState, we need to check the mount status.

## Testing / Proof
Before:
<img width="500" alt="Screen Shot 2022-10-24 at 12 03 07 pm" src="https://user-images.githubusercontent.com/88361607/197431523-be4e81c9-049c-46f7-8c26-bf6ea1678f40.png">

After:
<img width="500" alt="Screen Shot 2022-10-24 at 12 18 28 pm" src="https://user-images.githubusercontent.com/88361607/197431533-3aacde4f-f7c3-47a0-ba3c-50b9b4409ff6.png">


@bigcommerce/checkout
