### PR TITLE
chore(payment): PAYPAL-1742 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.298.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.298.0.tgz",
-      "integrity": "sha512-qJmd8TFZpMIXT7HCa8+2ksQ1kpxPPIggyVgJIxl9RIlmDd2OZsiirJwW0JPUgZBdflrgZzW8ax7bMWcplHCPTA==",
+      "version": "1.298.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.298.3.tgz",
+      "integrity": "sha512-4QK9vOEAkwzce8jhYWmLGP0bXnsKcw0XzTlYef1F1eUGRtyXDsDLKagkLVuGNp16Vfb9z6fvkDe9ApsFmUmOBA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.298.0",
+    "@bigcommerce/checkout-sdk": "^1.298.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version.

## Why?
To keep checkout sdk version as newest as possible in checkout js.

## Related PRs
Checkout sdk:
https://github.com/bigcommerce/checkout-sdk-js/pull/1611
https://github.com/bigcommerce/checkout-sdk-js/pull/1645
https://github.com/bigcommerce/checkout-sdk-js/pull/1648
https://github.com/bigcommerce/checkout-sdk-js/pull/1653

## Testing / Proof
Unit tests
Manual tests

@bigcommerce/checkout
