### PR TITLE
chore(payment): PAYPAL-1630 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.298.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.298.3.tgz",
-      "integrity": "sha512-4QK9vOEAkwzce8jhYWmLGP0bXnsKcw0XzTlYef1F1eUGRtyXDsDLKagkLVuGNp16Vfb9z6fvkDe9ApsFmUmOBA==",
+      "version": "1.299.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.299.0.tgz",
+      "integrity": "sha512-SfQsA1uy9Sfhi2ouQiBzEYar0FaSFnaQCOh+b8tGxHFc/83tXWpkyuc7Td48dw2W/dTLBqSzZBnioy7bwuipHg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1220,9 +1220,9 @@
           "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
         },
         "core-js": {
-          "version": "3.25.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.5.tgz",
-          "integrity": "sha512-nbm6eZSjm+ZuBQxCUPQKQCoUEfFOXjUZ8dTTyikyKaWrTYmAVbykQfwsKE5dBK88u3QCkCrzsx/PPlKfhsvgpw=="
+          "version": "3.26.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
+          "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.298.3",
+    "@bigcommerce/checkout-sdk": "^1.299.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

This version includes several PRs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1629
https://github.com/bigcommerce/checkout-sdk-js/pull/1650
https://github.com/bigcommerce/checkout-sdk-js/pull/1644

## Why?

New checkout sdk version

## Testing / Proof

Unit tests
Manual tests

@bigcommerce/checkout
