### PR TITLE
fix(checkout): CHECKOUT-7048 Allow user to clear cart changed error

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -373,7 +373,7 @@ class Payment extends Component<
             if (isErrorWithType(error)) {
                 const { body, headers, status } = error;
 
-                if (body.type === 'provider_error' && headers.location) {
+                if (body?.type === 'provider_error' && headers.location) {
                     window.top?.location.assign(headers.location);
                 }
 
@@ -384,8 +384,8 @@ class Payment extends Component<
                 // HTML page instead of JSON response when there is a 429 error.
                 if (
                     status === 429 ||
-                    body.type === 'spam_protection_expired' ||
-                    body.type === 'spam_protection_failed'
+                    body?.type === 'spam_protection_expired' ||
+                    body?.type === 'spam_protection_failed'
                 ) {
                     this.setState({ didExceedSpamLimit: true });
 


### PR DESCRIPTION
## What?
...
Check to see if body is defined within the handleCloseModal method 

## Why?
...
When it it undefined the user cannot clear the error to complete checkout - https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7048 

## Testing / Proof
...
Before:
0:25 error cannot be cleared - TypeError: Cannot read properties of undefined (reading 'type')

https://user-images.githubusercontent.com/5630999/198082107-7c2234dd-e92a-4806-befa-a87882be4fc4.mp4

After:
0:24 error can be cleared to complete checkout

https://user-images.githubusercontent.com/5630999/198083790-1dfa816b-3af5-4bda-b717-0ccf54b5431e.mp4

@bigcommerce/checkout
