### PR TITLE
feat(payment): STRIPE-178 Loading Submit button after stripe card loads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,20 +1145,20 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.20.0.tgz",
-      "integrity": "sha512-O88thU+FGgUot4IVOgMcSO3PwH7ZgD3m5jtU6Mr6oORmafo2mYezVprgWoPbiNE2FGZngVvxDjzq6X0stn607w==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.20.1.tgz",
+      "integrity": "sha512-LMO6UeJ6Bd+8JF6oxOIe4msO80I9qnYczKLPdpIFy6SgnXm8gpUuaCKdvt/+LnK9V1V88tEenC2aVVWcHxHBJw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
-        "babel-jest": "^27.4.6",
+        "babel-jest": "^27.5.1",
         "deep-assign": "^3.0.0",
         "object-assign": "^4.1.1"
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.299.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.299.0.tgz",
-      "integrity": "sha512-SfQsA1uy9Sfhi2ouQiBzEYar0FaSFnaQCOh+b8tGxHFc/83tXWpkyuc7Td48dw2W/dTLBqSzZBnioy7bwuipHg==",
+      "version": "1.316.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.316.3.tgz",
+      "integrity": "sha512-7nlyyCui+UWtCppYbwWaP4x+0/58yhamYaAeKcTxNimCuSi2iHHwBN8+julfzbw2TsWJRuaHvcnl9atu5SEVBQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1215,14 +1215,14 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.186",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-          "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+          "version": "4.14.191",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+          "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
         },
         "core-js": {
-          "version": "3.26.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-          "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
+          "version": "3.27.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+          "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww=="
         },
         "tslib": {
           "version": "1.14.1",
@@ -17220,16 +17220,21 @@
       }
     },
     "query-string": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
-      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
       "requires": {
-        "decode-uri-component": "^0.2.0",
+        "decode-uri-component": "^0.2.2",
         "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       },
       "dependencies": {
+        "decode-uri-component": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+          "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
+        },
         "strict-uri-encode": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.299.0",
+    "@bigcommerce/checkout-sdk": "^1.316.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
@@ -141,6 +141,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );
@@ -192,6 +193,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );
@@ -243,6 +245,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );
@@ -294,6 +297,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -1,6 +1,6 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { FunctionComponent, useCallback, useContext } from 'react';
 
 import { CheckoutContextProps, withCheckout } from '../../checkout';
 import { getAppliedStyles } from '../../common/dom';
@@ -8,6 +8,7 @@ import {
     withHostedCreditCardFieldset,
     WithInjectedHostedCreditCardFieldsetProps,
 } from '../hostedCreditCard';
+import PaymentContext from '../PaymentContext';
 
 import HostedWidgetPaymentMethod, {
     HostedWidgetPaymentMethodProps,
@@ -26,6 +27,12 @@ const StripeUPEPaymentMethod: FunctionComponent<
 > = ({ initializePayment, method, storeUrl, onUnhandledError = noop, ...rest }) => {
     const containerId = `stripe-${method.id}-component-field`;
 
+    const paymentContext = useContext(PaymentContext);
+
+    const renderSubmitButton = () => {
+        paymentContext?.hidePaymentSubmitButton(method, false);
+    }
+
     const initializeStripePayment: HostedWidgetPaymentMethodProps['initializePayment'] =
         useCallback(
             async (options: PaymentInitializeOptions) => {
@@ -37,7 +44,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
                 ]);
                 const formLabel = getStylesFromElement(`${containerId}--label`, ['color']);
                 const formError = getStylesFromElement(`${containerId}--error`, ['color']);
-
+                paymentContext?.hidePaymentSubmitButton(method, true);
                 return initializePayment({
                     ...options,
                     stripeupe: {
@@ -52,6 +59,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
                             fieldBorder: formInput['border-color'],
                         },
                         onError: onUnhandledError,
+                        render: renderSubmitButton,
                     },
                 });
             },


### PR DESCRIPTION
## What? [STRIPE-178](https://bigcommercecloud.atlassian.net/browse/STRIPE-178)
Render Submit Button after the payment form and input elements have fully loaded.

## Why?
So that shoppers know that they have additional information to fill in prior to trying to submit payment.

## Testing / Proof
On loading
<img width="681" alt="Screen Shot 2022-10-26 at 17 08 40" src="https://user-images.githubusercontent.com/106765049/198148008-c70a3101-23fb-4a14-81d3-1e0d4733df72.png">

Loaded
<img width="732" alt="Screen Shot 2022-10-26 at 17 08 48" src="https://user-images.githubusercontent.com/106765049/198147949-0822a8e8-2375-4cb8-a017-f422248f6761.png">

## Depends on
[#1662](https://github.com/bigcommerce/checkout-sdk-js/pull/1662)

@bigcommerce/checkout @bigcommerce/apex-integrations 
