### PR TITLE
chore(payment): INT-6772 Bump checkout-sdk to 1.299.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.299.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.299.0.tgz",
-      "integrity": "sha512-SfQsA1uy9Sfhi2ouQiBzEYar0FaSFnaQCOh+b8tGxHFc/83tXWpkyuc7Td48dw2W/dTLBqSzZBnioy7bwuipHg==",
+      "version": "1.299.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.299.1.tgz",
+      "integrity": "sha512-5UljArdDU98IQ5yme/w8QWEbvklnm7aYlSAN7fdbNLius9Aj+wrudXYF6Lu1yjmIaVzjBL67GdjyylOO8UhdWw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.299.0",
+    "@bigcommerce/checkout-sdk": "^1.299.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What? [INT-6772](https://github.com/bigcommerce/checkout-sdk-js/pull/1647)
Update a new version in the package checkout-sdk to  1.299.1 

## Why?
To update the new changes with https://github.com/bigcommerce/checkout-sdk-js/pull/1647



@bigcommerce/checkout @bigcommerce/apex-integrations 
