### PR TITLE
fix(checkout): CHECKOUT-6840 Fix payment step counter in Safari

### DIFF
--- a/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -19,6 +19,7 @@
 
 .checkout-step {
     border-bottom: container("border");
+    counter-increment: $checkoutStep-counter;
     padding: spacing("single") 0;
 
     &:last-child {
@@ -76,7 +77,6 @@
 
         color: $checkoutStep-counter-color;
         content: counter($checkoutStep-counter);
-        counter-increment: $checkoutStep-counter;
         display: inline-block;
         font-size: fontSize("small");
         line-height: #{$checkoutStep-counter-size}px;


### PR DESCRIPTION
## What?
Fix the problem where Safari always displays 1 as the payment step number instead of 4.

## Why?
Safari's CSS counter function differs from Chrome's.

## Testing / Proof
### Before
<img src="https://user-images.githubusercontent.com/88361607/198919361-6ebeb8ab-c147-4bef-aac4-1d2de9eae0c1.png" width=200 />

### After
iOS Safari
<img src="https://user-images.githubusercontent.com/88361607/198919434-a792ed2d-1869-42b9-a9bf-568112519ac1.PNG" width=200 />

Also tested on iOS Chrome, Android Chrome, and Firefox, all of which behaved as expected.
<img src="https://user-images.githubusercontent.com/88361607/198919444-ee0b5efc-4810-4df2-9f8f-0ba8457854df.PNG" width=200 />
