### PR TITLE
Revert "fix(checkout): CHECKOUT-0000 Fix shipping component memory leak"

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -316,7 +316,6 @@ class Checkout extends Component<
                             .map((step) =>
                                 this.renderStep({
                                     ...step,
-                                    activeStepType,
                                     isActive: activeStepType
                                         ? activeStepType === step.type
                                         : defaultStepType === step.type,

--- a/packages/core/src/app/checkout/CheckoutStepStatus.ts
+++ b/packages/core/src/app/checkout/CheckoutStepStatus.ts
@@ -1,7 +1,6 @@
 import CheckoutStepType from './CheckoutStepType';
 
 export default interface CheckoutStepStatus {
-    activeStepType?: CheckoutStepType;
     isActive: boolean;
     isBusy: boolean;
     isComplete: boolean;

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -43,9 +43,7 @@ describe('Shipping Component', () => {
             onToggleMultiShipping: jest.fn(),
             cartHasChanged: false,
             onSignIn: jest.fn(),
-            step: {
-                activeStepType: CheckoutStepType.Shipping,
-                isActive: true,
+            step: { isActive: true,
                 isComplete: true,
                 isEditable: true,
                 isRequired: true,

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -103,7 +103,6 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             loadPaymentMethods,
             onReady = noop,
             onUnhandledError = noop,
-            step,
         } = this.props;
 
         try {
@@ -114,9 +113,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
         } catch (error) {
             onUnhandledError(error);
         } finally {
-            if (step.activeStepType === step.type) {
-                this.setState({ isInitializing: false });
-            }
+            this.setState({ isInitializing: false });
         }
     }
 


### PR DESCRIPTION
### What
Reverts bigcommerce/checkout-js#1073

### Why
When a shopper completes the customer step and reloads the checkout page, or modifies the cart content, `step.activeStepType` can become `undefined`. 

Therefore, the shipping address form will never show up.

// The current BCapp's `checkout-js` version does not contain related changes.