### PR TITLE
fix(checkout): CHECKOUT-5742 shouldSaveAddress is not saved

### DIFF
--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -202,6 +202,28 @@ describe('Shipping Component', () => {
         );
     });
 
+    it('calls updateShippingAddress if shouldSaveAddress changes', async () => {
+        component = mount(<ComponentTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+        component.update();
+
+        const saveAddressField = component.find('input[name="shippingAddress.shouldSaveAddress"]');
+        const currentValue = saveAddressField.get(0).props.value;
+        const changedValue = currentValue === 'true' ? 'false' : 'true';
+
+        saveAddressField.simulate('change', {
+            target: { value: changedValue, name: 'shippingAddress.shouldSaveAddress' },
+        });
+
+        component.find('form').simulate('submit');
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(checkoutService.updateShippingAddress).toHaveBeenCalledWith(
+            expect.objectContaining({ shouldSaveAddress: changedValue }),
+        );
+    });
+
     it('calls updateCheckout if comment changes', async () => {
         component = mount(<ComponentTest {...defaultProps} />);
         await new Promise((resolve) => process.nextTick(resolve));

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -232,7 +232,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const hasRemoteBilling = this.hasRemoteBilling(methodId);
 
-        if (!isEqualAddress(updatedShippingAddress, shippingAddress)) {
+        if (!isEqualAddress(updatedShippingAddress, shippingAddress) || shippingAddress?.shouldSaveAddress !== updatedShippingAddress?.shouldSaveAddress) {
             promises.push(updateShippingAddress(updatedShippingAddress || {}));
         }
 


### PR DESCRIPTION
## What?
Fix the bug that `shouldSaveAddress` was not saved when a shopper made an explicit change to it.

## Why? ([CHECKOUT-5742](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-5742))
Prevously, we only updated `shouldSaveAddress` value on the server if an address change occurred. 

Now, whenever the value of `shouldSaveAddress` is changed, it is sent to the server.

## Testing / Proof
Manual testing:

https://user-images.githubusercontent.com/88361607/199401949-035be053-e0b0-453d-b50c-19b8311c08df.mov

