### PR TITLE
chore(payment): PAYPAL-1758 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.299.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.299.1.tgz",
-      "integrity": "sha512-5UljArdDU98IQ5yme/w8QWEbvklnm7aYlSAN7fdbNLius9Aj+wrudXYF6Lu1yjmIaVzjBL67GdjyylOO8UhdWw==",
+      "version": "1.300.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.300.0.tgz",
+      "integrity": "sha512-E5py9vxtCB+jU6UbHBYZbNwjfDaLW63PnDRjHeWCh/LyczD5Zs+Ytqaj6V7pEt6KQu+GDFuplBMUXajoiQslTw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.299.1",
+    "@bigcommerce/checkout-sdk": "^1.300.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

This bump contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/1632
https://github.com/bigcommerce/checkout-sdk-js/pull/1664
https://github.com/bigcommerce/checkout-sdk-js/pull/1665

## Why?
To keep checkout js as fresh as possible with latest checkout sdk updates 

## Testing / Proof
Unit tests
Manual tests
