### PR TITLE
feat(payment): INT-5953-T Force to use Payment Method V1 when Mollie and ApplePay

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.spec.tsx
@@ -101,4 +101,28 @@ describe('PaymentMethod', () => {
 
         expect(componentFallback.find(Foo)).toBeDefined();
     });
+
+    it('returns payment method v1 if gateway is mollie', () => {
+        const Foo: FunctionComponent<PaymentMethodProps> = ({ method }) => <div>{method.id}</div>;
+
+        const resolver = (method: PaymentMethod) => {
+            return method.id === 'applepay' ? Foo : undefined;
+        };
+
+        const componentFallback = mount(
+            <ContextProvider>
+                <PaymentMethodComponent
+                    method={{
+                        ...getPaymentMethod(),
+                        gateway: 'mollie',
+                        id: 'applepay',
+                    }}
+                    onUnhandledError={jest.fn()}
+                    resolveComponent={resolver}
+                />
+            </ContextProvider>,
+        );
+
+        expect(componentFallback.find(Foo)).toBeDefined();
+    });
 });

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
@@ -16,6 +16,7 @@ import resolvePaymentMethod from '../resolvePaymentMethod';
 import withPayment, { WithPaymentProps } from '../withPayment';
 
 import { default as PaymentMethodV1 } from './PaymentMethod';
+import PaymentMethodId from './PaymentMethodId';
 
 export interface PaymentMethodProps {
     method: PaymentMethod;
@@ -69,7 +70,7 @@ const PaymentMethodContainer: ComponentType<
         type: method.type,
     });
 
-    if (!ResolvedPaymentMethod) {
+    if (!ResolvedPaymentMethod || method.gateway === PaymentMethodId.Mollie) {
         return (
             <PaymentMethodV1
                 isEmbedded={isEmbedded}


### PR DESCRIPTION
## What?
Add a validation to force to use PaymentMethod V1 when the gateway is mollie.
This to use the MolliePaymentStrategy.

## Why?
As a momentarily solution to support Apple Pay on Mollie and using the MolliePaymentMethod, and meanwhile an enhancement to support Mollie as Payment Method V2.

## Testing / Proof
<img width="860" alt="image" src="https://user-images.githubusercontent.com/35146660/199549406-674734ac-3a44-44f6-949b-845c3aa865c2.png">

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1671

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
