### PR TITLE
chore(checkout): ADYEN-585 bump sdk version due to the Adyen package separation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.300.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.300.0.tgz",
-      "integrity": "sha512-E5py9vxtCB+jU6UbHBYZbNwjfDaLW63PnDRjHeWCh/LyczD5Zs+Ytqaj6V7pEt6KQu+GDFuplBMUXajoiQslTw==",
+      "version": "1.303.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.303.0.tgz",
+      "integrity": "sha512-mSxjQe7YiXu6g07YuFw4ba4VyPUlfY3AfvqNgwVk0Cbp29F0FKSBo68ZMqNLIYeULM9VYsk2WY55kGsYNx9IjQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1215,9 +1215,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.186",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-          "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+          "version": "4.14.188",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
+          "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w=="
         },
         "core-js": {
           "version": "3.26.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.300.0",
+    "@bigcommerce/checkout-sdk": "^1.303.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -191,6 +191,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
                 onChangeShipping: handleStripeShippingAddress,
                 availableCountries: allowedCountries,
                 getStyles: getStripeStyles,
+                getStripeState: () => '',
                 gatewayId: 'stripeupe',
                 methodId: 'card',
             },


### PR DESCRIPTION
## What?
Release of Adyen-585
Setup adyen v2/v3 package and move adyen v2/v3 payment strategy
[SDK PR](https://github.com/bigcommerce/checkout-sdk-js/pull/1626)

## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-585

## Testing / Proof
units/manual testing

@bigcommerce/checkout
