### PR TITLE
fix(checkout): CHECKOUT-6672 Maintain subscription checkbox state

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -128,6 +128,7 @@ export interface CheckoutState {
     isRedirecting: boolean;
     hasSelectedShippingOptions: boolean;
     isBuyNowCartEnabled: boolean;
+    isSubscribed: boolean;
 }
 
 export interface WithCheckoutProps {
@@ -166,6 +167,7 @@ class Checkout extends Component<
         isMultiShippingMode: false,
         hasSelectedShippingOptions: false,
         isBuyNowCartEnabled: false,
+        isSubscribed: false,
     };
 
     private embeddedMessenger?: EmbeddedCheckoutMessenger;
@@ -243,6 +245,9 @@ class Checkout extends Component<
             const buyNowCartFlag =
                 data.getConfig()?.checkoutSettings.features['CHECKOUT-3190.enable_buy_now_cart'] ??
                 false;
+            const defaultNewsletterSignupOption =
+                data.getConfig()?.shopperConfig.defaultNewsletterSignup ??
+                false;
             const isMultiShippingMode =
                 !!cart &&
                 !!consignments &&
@@ -252,6 +257,7 @@ class Checkout extends Component<
             this.setState({
                 isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled,
                 isBuyNowCartEnabled: buyNowCartFlag,
+                isSubscribed: defaultNewsletterSignupOption,
             });
 
             if (isMultiShippingMode) {
@@ -353,6 +359,7 @@ class Checkout extends Component<
         const { isGuestEnabled } = this.props;
         const {
             customerViewType = isGuestEnabled ? CustomerViewType.Guest : CustomerViewType.Login,
+            isSubscribed,
         } = this.state;
 
         return (
@@ -374,6 +381,7 @@ class Checkout extends Component<
                     <Customer
                         checkEmbeddedSupport={this.checkEmbeddedSupport}
                         isEmbedded={isEmbedded()}
+                        isSubscribed={isSubscribed}
                         onAccountCreated={this.navigateToNextIncompleteStep}
                         onChangeViewType={this.setCustomerViewType}
                         onContinueAsGuest={this.navigateToNextIncompleteStep}
@@ -381,6 +389,7 @@ class Checkout extends Component<
                         onReady={this.handleReady}
                         onSignIn={this.navigateToNextIncompleteStep}
                         onSignInError={this.handleError}
+                        onSubscribeToNewsletter={this.handleNewsletterSubscription}
                         onUnhandledError={this.handleUnhandledError}
                         step={step}
                         viewType={customerViewType}
@@ -649,6 +658,10 @@ class Checkout extends Component<
     private handleReady: () => void = () => {
         this.navigateToNextIncompleteStep({ isDefault: true });
     };
+
+    private handleNewsletterSubscription: (subscribed: boolean) => void = (subscribed) => {
+        this.setState({ isSubscribed: subscribed });
+    }
 
     private handleSignOut: (event: CustomerSignOutEvent) => void = ({ isCartEmpty }) => {
         const { loginUrl, cartUrl, isPriceHiddenFromGuests, isGuestEnabled } = this.props;

--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -182,7 +182,7 @@ describe('Customer', () => {
         });
 
         it('passes data to guest form', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const component = mount(<CustomerTest isSubscribed={false} viewType={CustomerViewType.Guest} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -199,7 +199,12 @@ describe('Customer', () => {
                 Promise.resolve(checkoutService.getState()),
             );
 
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const handleNewsletterSubscription=jest.fn();
+            const component = mount(<CustomerTest
+                isSubscribed={true}
+                onSubscribeToNewsletter={handleNewsletterSubscription}
+                viewType={CustomerViewType.Guest}
+            />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -217,12 +222,21 @@ describe('Customer', () => {
         });
 
         it('only subscribes to newsletter if allowed by customer', async () => {
+            jest.spyOn(checkoutService.getState().data, 'getBillingAddress').mockReturnValue({
+                ...billingAddress,
+                id: '',
+            });
             jest.spyOn(checkoutService, 'continueAsGuest').mockReturnValue(
                 Promise.resolve(checkoutService.getState()),
             );
 
             const subscribeToNewsletter = jest.fn();
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const handleNewsletterSubscription = jest.fn();
+            const component = mount(<CustomerTest
+                isSubscribed={false}
+                onSubscribeToNewsletter={handleNewsletterSubscription}
+                viewType={CustomerViewType.Guest}
+            />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -264,9 +278,12 @@ describe('Customer', () => {
             );
 
             const handleContinueAsGuest = jest.fn();
+            const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
+                    isSubscribed={false}
                     onContinueAsGuest={handleContinueAsGuest}
+                    onSubscribeToNewsletter={handleNewsletterSubscription}
                     viewType={CustomerViewType.Guest}
                 />,
             );
@@ -290,9 +307,11 @@ describe('Customer', () => {
             jest.spyOn(checkoutService, 'continueAsGuest').mockRejectedValue(error);
 
             const handleContinueAsGuest = jest.fn();
+            const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
                     onContinueAsGuest={handleContinueAsGuest}
+                    onSubscribeToNewsletter={handleNewsletterSubscription}
                     viewType={CustomerViewType.Guest}
                 />,
             );
@@ -317,9 +336,12 @@ describe('Customer', () => {
             });
 
             const handleChangeViewType = jest.fn();
+            const handleNewsletterSubscription=jest.fn();
             const component = mount(
                 <CustomerTest
+                    isSubscribed={false}
                     onChangeViewType={handleChangeViewType}
+                    onSubscribeToNewsletter={handleNewsletterSubscription}
                     viewType={CustomerViewType.Guest}
                 />,
             );
@@ -352,9 +374,12 @@ describe('Customer', () => {
             );
 
             const handleChangeViewType = jest.fn();
+            const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
+                    isSubscribed={true}
                     onChangeViewType={handleChangeViewType}
+                    onSubscribeToNewsletter={handleNewsletterSubscription}
                     viewType={CustomerViewType.Guest}
                 />,
             );
@@ -383,9 +408,12 @@ describe('Customer', () => {
 
             const handleChangeViewType = jest.fn();
 
+            const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
+                    isSubscribed={true}
                     onChangeViewType={handleChangeViewType}
+                    onSubscribeToNewsletter={handleNewsletterSubscription}
                     viewType={CustomerViewType.Guest}
                 />,
             );

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -60,7 +60,7 @@ export interface WithCheckoutCustomerProps {
     isCreatingAccount: boolean;
     isExecutingPaymentMethodCheckout: boolean;
     isGuestEnabled: boolean;
-    isHavingBillingId: boolean;
+    hasBillingId: boolean;
     isInitializing: boolean;
     isSendingSignInEmail: boolean;
     isSignInEmailEnabled: boolean;
@@ -361,7 +361,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
         const {
             canSubscribe,
             continueAsGuest,
-            isHavingBillingId,
+            hasBillingId,
             defaultShouldSubscribe,
             onChangeViewType = noop,
             onContinueAsGuest = noop,
@@ -371,7 +371,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps, Cust
 
         const email = formValues.email.trim();
         const updateSubscriptionWhenUnchecked =
-            isHavingBillingId || defaultShouldSubscribe ? false : undefined;
+            hasBillingId || defaultShouldSubscribe ? false : undefined;
 
         try {
             const { data } = await continueAsGuest({
@@ -569,7 +569,7 @@ export function mapToWithCheckoutCustomerProps({
         initializeCustomer: checkoutService.initializeCustomer,
         isCreatingAccount: isCreatingCustomerAccount(),
         createAccountError: getCreateCustomerAccountError(),
-        isHavingBillingId: !!billingAddress?.id,
+        hasBillingId: !!billingAddress?.id,
         isContinuingAsGuest: isContinuingAsGuest(),
         isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
         isInitializing: isInitializingCustomer(),


### PR DESCRIPTION
## What?
Fix the bugs:
- A shopper cannot actually opt out marketing newsletter on the checkout page.
- The newsletter option always displays its default state rather than a shopper's actual choice.

The limitation of this bugfix is when a shopper reloads the page, the state will lose.

## Why? [CHECKOUT-6672](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-6672)

The subscription state of a shopper's email address is currently unavailable through our API endpoints. 

There will be a server-side ticket made as a follow-up. (update: [CHECKOUT-7095](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7095))

## Testing / Proof

Manual testing:

https://user-images.githubusercontent.com/88361607/200476203-8c21e6e7-4d47-41dd-95d0-b2cb2232576d.mov



@bigcommerce/checkout
