### PR TITLE
feat(payment): PAYPAL-1722 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.305.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.305.0.tgz",
-      "integrity": "sha512-7mgkIPVzScAbekNsD9se3R7/K5d1cBsV3K5tla65NF5WJWHFY6wYJjobQCLf6ySy+lLPOAq0uVeSHzma5DWXRw==",
+      "version": "1.306.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.306.0.tgz",
+      "integrity": "sha512-i6oyyGpAD7XsvF/m9Jugd2PieMszUSAYOxFy2j682ogFEzA+hhbES0pc/mvkg2/gB9bFxwOn5siANNPkTWc2dQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.305.0",
+    "@bigcommerce/checkout-sdk": "^1.306.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
According to task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1722
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1667

## Testing / Proof
Tested on dev and int

@bigcommerce/checkout
