### PR TITLE
feat(payment): STRIPE-215 add more validation to avoid Shipping Steps Loads Indefinitely for stripe link

### DIFF
--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
@@ -153,6 +153,54 @@ describe('StripeShippingAddress Component', () => {
             expect(defaultProps.onAddressSelect).toHaveBeenCalled();
         });
 
+        it('renders StripeShippingAddress with initialize props and when page is reloaded', async () => {
+            defaultProps.initialize = jest.fn((options) => {
+                const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
+
+                onChangeShipping({
+                        complete: true,
+                        elementType: 'shipping',
+                        empty: false,
+                        isNewAddress: true,
+                        value: {
+                            address: {
+                                city: 'string',
+                                country: 'US',
+                                line1: 'string',
+                                line2: 'string',
+                                postal_code: 'string',
+                                state: 'string',
+                            },
+                            name: 'cosme fulanito',
+                        },
+                    }
+                );
+                getStyles();
+
+                return Promise.resolve(checkoutService.getState());
+            });
+
+            const stripeProps = {...defaultProps, isStripeLinkEnabled: true, customerEmail: ''};
+            const component = mount(
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <StripeShippingAddress { ...stripeProps } />
+                </Formik>
+            );
+
+            expect(component.find(StripeShippingAddressDisplay).props()).toEqual(
+                expect.objectContaining({
+                    methodId: 'stripeupe',
+                    deinitialize: defaultProps.deinitialize,
+                })
+            );
+
+            expect(defaultProps.initialize).toHaveBeenCalled();
+            expect(defaultProps.onAddressSelect).toHaveBeenCalled();
+        });
+
         it('renders StripeShippingAddress with initialize props without last name', async () => {
             defaultProps.initialize = jest.fn((options) => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -47,6 +47,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
         isStripeLoading,
         isStripeAutoStep,
         isShippingMethodLoading,
+        shippingAddress,
     } = props;
 
     const [isNewAddress, setIsNewAddress] = useState(true);
@@ -103,7 +104,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
             , name = '' } } = shipping;
 
         if(complete) {
-            if (step.isComplete) {
+            if (step.isComplete || (shippingAddress?.firstName && shipping.isNewAddress)) {
                 handleLoading();
             }
 


### PR DESCRIPTION
## What? [STRIPE-215](https://bigcommercecloud.atlassian.net/browse/STRIPE-215)
 Add more validations to avoid infinite spinner in the StripeLink shipping component

## Why?
If a non-Link enrolled guest shopper gets to the payment step but then exits checkout and increases items in her cart, when he/she returns o the checkout, the shipping address loading gif spins indefinitely.

## Testing / Proof
[DEMO](https://drive.google.com/file/d/1Mus_en2JJTyBFjhOlunjAxxTPkCRJIg_/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/apex-integrations 
