### PR TITLE
refactor(payments): INT-6930 Zip: remove "(Quadpay)" from checkout

### DIFF
--- a/packages/core/src/app/locale/translations/da.json
+++ b/packages/core/src/app/locale/translations/da.json
@@ -294,7 +294,7 @@
             "instrument_trusted_shipping_address_text": "Dette ekstra sikkerhedstrin anvendes på dit kort, når du sender til en adresse for første gang, eller hvis leveringsadressen er blevet redigeret for nylig.",
             "instrument_trusted_shipping_address_title_text": "Indtast dit kortnummer igen for at godkende denne transaktion.",
             "quadpay_continue_action": "Fortsæt med Zip",
-            "quadpay_display_name_text": "Betal i 4 rater (Quadpay)",
+            "quadpay_display_name_text": "Betal i 4 rater",
             "ppsdk_continue_action": "Fortsæt med {methodName}",
             "select_your_bank": "Vælg din bank",
             "sepa_account_number": "Kontonummer (IBAN)",

--- a/packages/core/src/app/locale/translations/de.json
+++ b/packages/core/src/app/locale/translations/de.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Dieser zusätzliche Sicherheitsschritt wird auf Ihre Karte angewendet, wenn der Versand an eine bestimmte Adresse zum ersten Mal erfolgt oder wenn die Versandadresse kürzlich bearbeitet wurde.",
             "instrument_trusted_shipping_address_title_text": "Bitte geben Sie Ihre Kartennummer erneut ein, um diese Transaktion zu autorisieren.",
             "quadpay_continue_action": "Mit Zip fortfahren",
-            "quadpay_display_name_text": "In vier Raten zahlen (Quadpay)",
+            "quadpay_display_name_text": "In vier Raten zahlen",
             "ppsdk_continue_action": "Weiter mit {methodName}",
             "select_your_bank": "Wählen Sie Ihre Bank aus",
             "sepa_account_number": "Kontonummer (IBAN)",

--- a/packages/core/src/app/locale/translations/en.json
+++ b/packages/core/src/app/locale/translations/en.json
@@ -299,7 +299,7 @@
             "instrument_trusted_shipping_address_text": "This additional security step is applied to your card when shipping to an address for the first time or if the shipping address was edited recently.",
             "instrument_trusted_shipping_address_title_text": "Please re-enter your card number to authorize this transaction.",
             "quadpay_continue_action": "Continue with Zip",
-            "quadpay_display_name_text": "Pay in 4 installments (Quadpay)",
+            "quadpay_display_name_text": "Pay in 4 installments",
             "ppsdk_continue_action": "Continue with {methodName}",
             "select_your_bank": "Select your bank",
             "sepa_account_number": "Account Number (IBAN)",

--- a/packages/core/src/app/locale/translations/es-419.json
+++ b/packages/core/src/app/locale/translations/es-419.json
@@ -294,7 +294,7 @@
             "instrument_trusted_shipping_address_text": "Este paso de seguridad adicional se aplica a tu tarjeta cuando realizas el envío a una dirección por primera vez o si la dirección de envío se editó recientemente.",
             "instrument_trusted_shipping_address_title_text": "Vuelve a ingresar tu número de tarjeta para autorizar esta transacción.",
             "quadpay_continue_action": "Continuar con Zip",
-            "quadpay_display_name_text": "Pagar en 4 plazos (Quadpay)",
+            "quadpay_display_name_text": "Pagar en 4 plazos",
             "ppsdk_continue_action": "Continuar con {methodName}",
             "select_your_bank": "Selecciona tu banco",
             "sepa_account_number": "Número de cuenta (IBAN)",

--- a/packages/core/src/app/locale/translations/es-AR.json
+++ b/packages/core/src/app/locale/translations/es-AR.json
@@ -294,7 +294,7 @@
             "instrument_trusted_shipping_address_text": "Este paso de seguridad adicional se aplica a tu tarjeta cuando realizas el envío a una dirección por primera vez o si la dirección de envío se editó recientemente.",
             "instrument_trusted_shipping_address_title_text": "Vuelve a ingresar tu número de tarjeta para autorizar esta transacción.",
             "quadpay_continue_action": "Continuar con Zip",
-            "quadpay_display_name_text": "Pagar en 4 plazos (Quadpay)",
+            "quadpay_display_name_text": "Pagar en 4 plazos",
             "ppsdk_continue_action": "Continuar con {methodName}",
             "select_your_bank": "Selecciona tu banco",
             "sepa_account_number": "Número de cuenta (IBAN)",

--- a/packages/core/src/app/locale/translations/es-CL.json
+++ b/packages/core/src/app/locale/translations/es-CL.json
@@ -294,7 +294,7 @@
             "instrument_trusted_shipping_address_text": "Este paso de seguridad adicional se aplica a tu tarjeta cuando realizas el envío a una dirección por primera vez o si la dirección de envío se editó recientemente.",
             "instrument_trusted_shipping_address_title_text": "Vuelve a ingresar tu número de tarjeta para autorizar esta transacción.",
             "quadpay_continue_action": "Continuar con Zip",
-            "quadpay_display_name_text": "Pagar en 4 plazos (Quadpay)",
+            "quadpay_display_name_text": "Pagar en 4 plazos",
             "ppsdk_continue_action": "Continuar con {methodName}",
             "select_your_bank": "Selecciona tu banco",
             "sepa_account_number": "Número de cuenta (IBAN)",

--- a/packages/core/src/app/locale/translations/es-CO.json
+++ b/packages/core/src/app/locale/translations/es-CO.json
@@ -294,7 +294,7 @@
             "instrument_trusted_shipping_address_text": "Este paso de seguridad adicional se aplica a tu tarjeta cuando realizas el envío a una dirección por primera vez o si la dirección de envío se editó recientemente.",
             "instrument_trusted_shipping_address_title_text": "Vuelve a ingresar tu número de tarjeta para autorizar esta transacción.",
             "quadpay_continue_action": "Continuar con Zip",
-            "quadpay_display_name_text": "Pagar en 4 plazos (Quadpay)",
+            "quadpay_display_name_text": "Pagar en 4 plazos",
             "ppsdk_continue_action": "Continuar con {methodName}",
             "select_your_bank": "Selecciona tu banco",
             "sepa_account_number": "Número de cuenta (IBAN)",

--- a/packages/core/src/app/locale/translations/es-MX.json
+++ b/packages/core/src/app/locale/translations/es-MX.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Este paso de seguridad adicional se aplica a tu tarjeta cuando realizas el envío a una dirección por primera vez o si la dirección de envío se editó recientemente.",
             "instrument_trusted_shipping_address_title_text": "Vuelve a ingresar tu número de tarjeta para autorizar esta transacción.",
             "quadpay_continue_action": "Continuar con Zip",
-            "quadpay_display_name_text": "Pagar en 4 plazos (Quadpay)",
+            "quadpay_display_name_text": "Pagar en 4 plazos",
             "ppsdk_continue_action": "Continuar con {methodName}",
             "select_your_bank": "Selecciona tu banco",
             "sepa_account_number": "Número de cuenta (IBAN)",

--- a/packages/core/src/app/locale/translations/es-PE.json
+++ b/packages/core/src/app/locale/translations/es-PE.json
@@ -294,7 +294,7 @@
             "instrument_trusted_shipping_address_text": "Este paso de seguridad adicional se aplica a tu tarjeta cuando realizas el envío a una dirección por primera vez o si la dirección de envío se editó recientemente.",
             "instrument_trusted_shipping_address_title_text": "Vuelve a ingresar tu número de tarjeta para autorizar esta transacción.",
             "quadpay_continue_action": "Continuar con Zip",
-            "quadpay_display_name_text": "Pagar en 4 plazos (Quadpay)",
+            "quadpay_display_name_text": "Pagar en 4 plazos",
             "ppsdk_continue_action": "Continuar con {methodName}",
             "select_your_bank": "Selecciona tu banco",
             "sepa_account_number": "Número de cuenta (IBAN)",

--- a/packages/core/src/app/locale/translations/es.json
+++ b/packages/core/src/app/locale/translations/es.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Este paso de seguridad adicional se aplica a su tarjeta cuando realice un envío a una dirección por primera vez o si la dirección de envío se ha editado recientemente.",
             "instrument_trusted_shipping_address_title_text": "Vuelva a introducir el número de su tarjeta para autorizar esta transacción.",
             "quadpay_continue_action": "Continuar con Zip",
-            "quadpay_display_name_text": "Pagar en 4 plazos (Quadpay)",
+            "quadpay_display_name_text": "Pagar en 4 plazos",
             "ppsdk_continue_action": "Continuar con {methodName}",
             "select_your_bank": "Seleccione su banco",
             "sepa_account_number": "Número de cuenta (IBAN)",

--- a/packages/core/src/app/locale/translations/fr.json
+++ b/packages/core/src/app/locale/translations/fr.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Cette mesure de sécurité supplémentaire est appliquée à votre carte en cas de livraison vers une nouvelle adresse ou si l'adresse de livraison a été récemment modifiée.",
             "instrument_trusted_shipping_address_title_text": "Veuillez saisir à nouveau votre numéro de carte pour autoriser cette transaction.",
             "quadpay_continue_action": "Continuer avec Zip",
-            "quadpay_display_name_text": "Payer en 4 versements (Quadpay)",
+            "quadpay_display_name_text": "Payer en 4 versements",
             "ppsdk_continue_action": "Continuer avec {methodName}",
             "select_your_bank": "Sélectionnez votre banque",
             "sepa_account_number": "Numéro de compte (IBAN)",

--- a/packages/core/src/app/locale/translations/it.json
+++ b/packages/core/src/app/locale/translations/it.json
@@ -288,7 +288,7 @@
             "instrument_trusted_shipping_address_text": "Questo passaggio di sicurezza aggiuntivo viene applicato se spedisci a un nuovo indirizzo o se l'indirizzo di spedizione è stato modificato di recente.",
             "instrument_trusted_shipping_address_title_text": "Inserisci nuovamente il numero di carta per autorizzare questa transazione.",
             "quadpay_continue_action": "Continua con Zip",
-            "quadpay_display_name_text": "Paga in 4 rate (Quadpay)",
+            "quadpay_display_name_text": "Paga in 4 rate",
             "ppsdk_continue_action": "Continua con {methodName}",
             "select_your_bank": "Seleziona la tua banca",
             "sepa_account_number": "Numero di conto (IBAN)",

--- a/packages/core/src/app/locale/translations/nl.json
+++ b/packages/core/src/app/locale/translations/nl.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Deze extra beveiligingsstap wordt op uw kaart toegepast als u voor het eerst naar een adres verzendt of als het verzendadres onlangs gewijzigd is.",
             "instrument_trusted_shipping_address_title_text": "Voer uw kaartnummer opnieuw in om deze transactie te autoriseren.",
             "quadpay_continue_action": "Doorgaan met Zip",
-            "quadpay_display_name_text": "Betaal in 4 termijnen (Quadpay)",
+            "quadpay_display_name_text": "Betaal in 4 termijnen",
             "ppsdk_continue_action": "Doorgaan met {methodName}",
             "select_your_bank": "Selecteer uw bank",
             "sepa_account_number": "Rekeningnummer (IBAN)",

--- a/packages/core/src/app/locale/translations/no.json
+++ b/packages/core/src/app/locale/translations/no.json
@@ -294,7 +294,7 @@
             "instrument_trusted_shipping_address_text": "Dette ekstra sikkerhetstrinnet brukes på kortet ditt når du sender til en adresse for første gang eller hvis leveringsadressen nylig ble redigert.",
             "instrument_trusted_shipping_address_title_text": "Skriv inn kortnummeret ditt på nytt for å godkjenne denne transaksjonen.",
             "quadpay_continue_action": "Fortsett med Zip",
-            "quadpay_display_name_text": "Betal i 4 avdrag (Quadpay)",
+            "quadpay_display_name_text": "Betal i 4 avdrag",
             "ppsdk_continue_action": "Fortsett med {methodName}",
             "select_your_bank": "Velg din bank",
             "sepa_account_number": "Kontonummer (IBAN)",

--- a/packages/core/src/app/locale/translations/pt-BR.json
+++ b/packages/core/src/app/locale/translations/pt-BR.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Esta etapa de segurança adicional é aplicada ao seu cartão quando você envia para um endereço pela primeira vez ou se o endereço de entrega tiver sido editado recentemente.",
             "instrument_trusted_shipping_address_title_text": "Insira novamente o número do seu cartão para autorizar esta transação.",
             "quadpay_continue_action": "Prosseguir com o Zip",
-            "quadpay_display_name_text": "Pagar em 4 parcelas (Quadpay)",
+            "quadpay_display_name_text": "Pagar em 4 parcelas",
             "ppsdk_continue_action": "Continue com o {methodName}",
             "select_your_bank": "Selecione seu banco",
             "sepa_account_number": "Número da conta (IBAN)",

--- a/packages/core/src/app/locale/translations/pt.json
+++ b/packages/core/src/app/locale/translations/pt.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Esta etapa de segurança adicional é aplicada ao seu cartão quando você envia para um endereço pela primeira vez ou se o endereço de entrega tiver sido editado recentemente.",
             "instrument_trusted_shipping_address_title_text": "Insira novamente o número do seu cartão para autorizar esta transação.",
             "quadpay_continue_action": "Prosseguir com o Zip",
-            "quadpay_display_name_text": "Pagar em 4 parcelas (Quadpay)",
+            "quadpay_display_name_text": "Pagar em 4 parcelas",
             "ppsdk_continue_action": "Continue com o {methodName}",
             "select_your_bank": "Selecione seu banco",
             "sepa_account_number": "Número da conta (IBAN)",

--- a/packages/core/src/app/locale/translations/sv.json
+++ b/packages/core/src/app/locale/translations/sv.json
@@ -289,7 +289,7 @@
             "instrument_trusted_shipping_address_text": "Detta ytterligare säkerhetssteg tillämpas på ditt kort när du skickar till en adress för första gången eller om leveransadressen redigerades nyligen.",
             "instrument_trusted_shipping_address_title_text": "Ange ditt kortnummer igen för att auktorisera transaktionen.",
             "quadpay_continue_action": "Fortsätt med Zip",
-            "quadpay_display_name_text": "Betala i 4 delbetalningar (Quadpay)",
+            "quadpay_display_name_text": "Betala i 4 delbetalningar",
             "ppsdk_continue_action": "Fortsätt med {methodName}",
             "select_your_bank": "Välj din bank",
             "sepa_account_number": "Kontonummer (IBAN)",

--- a/packages/locale/src/en.json
+++ b/packages/locale/src/en.json
@@ -299,7 +299,7 @@
             "instrument_trusted_shipping_address_text": "This additional security step is applied to your card when shipping to an address for the first time or if the shipping address was edited recently.",
             "instrument_trusted_shipping_address_title_text": "Please re-enter your card number to authorize this transaction.",
             "quadpay_continue_action": "Continue with Zip",
-            "quadpay_display_name_text": "Pay in 4 installments (Quadpay)",
+            "quadpay_display_name_text": "Pay in 4 installments",
             "ppsdk_continue_action": "Continue with {methodName}",
             "select_your_bank": "Select your bank",
             "sepa_account_number": "Account Number (IBAN)",


### PR DESCRIPTION
## What? [INT-6930](https://bigcommercecloud.atlassian.net/browse/INT-6930)
Removed the string `(Quadpay)` from all the translation files.

## Why?
A Zip team request.

## Testing / Proof
### Before:
<img width="748" alt="BC_Quadpay 1" src="https://user-images.githubusercontent.com/4843328/201196720-3e47ce8a-eee3-4926-a42e-fa7366c5dee9.png">

### Now:
<img width="637" alt="BC_Quadpay 2" src="https://user-images.githubusercontent.com/4843328/201196712-2032794f-63df-4180-97c7-b62edbbf3058.png">

@bigcommerce/apex-integrations  @bigcommerce/checkout
