### PR TITLE
feat(payment): STRIPE-200 add phone number for stripe link

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -44,7 +44,9 @@ const StripeUPEPaymentMethod: FunctionComponent<
                 ]);
                 const formLabel = getStylesFromElement(`${containerId}--label`, ['color']);
                 const formError = getStylesFromElement(`${containerId}--error`, ['color']);
+
                 paymentContext?.hidePaymentSubmitButton(method, true);
+
                 return initializePayment({
                     ...options,
                     stripeupe: {

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
@@ -21,6 +21,24 @@ describe('StripeShippingAddress Component', () => {
     let TestComponent: FunctionComponent<Partial<StripeShippingAddressProps>>;
     let defaultProps: StripeShippingAddressProps;
     const dummyElement = document.createElement('div');
+    const stripeEvent = {
+        complete: true,
+        elementType: 'shipping',
+        empty: false,
+        isNewAddress: false,
+        phoneFieldRequired: false,
+        value: {
+            address: {
+                city: 'string',
+                country: 'US',
+                line1: 'string',
+                postal_code: 'string',
+                state: 'string',
+            },
+            name: 'cosme fulanito',
+            phone: '',
+        },
+    };
 
     beforeAll(() => {
         checkoutService = createCheckoutService();
@@ -110,21 +128,8 @@ describe('StripeShippingAddress Component', () => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
 
                 onChangeShipping({
-                        complete: true,
-                        elementType: 'shipping',
-                        empty: false,
-                        isNewAddress: false,
-                        value: {
-                            address: {
-                                city: 'string',
-                                country: 'US',
-                                line1: 'string',
-                                line2: 'string',
-                                postal_code: 'string',
-                                state: 'string',
-                            },
-                            name: 'cosme fulanito',
-                        },
+                    ...stripeEvent,
+                    value: { ...stripeEvent.value, address: { ...stripeEvent.value.address, line2: 'string' } },
                     }
                 );
                 getStyles();
@@ -158,21 +163,9 @@ describe('StripeShippingAddress Component', () => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
 
                 onChangeShipping({
-                        complete: true,
-                        elementType: 'shipping',
-                        empty: false,
+                        ...stripeEvent,
                         isNewAddress: true,
-                        value: {
-                            address: {
-                                city: 'string',
-                                country: 'US',
-                                line1: 'string',
-                                line2: 'string',
-                                postal_code: 'string',
-                                state: 'string',
-                            },
-                            name: 'cosme fulanito',
-                        },
+                        value: { ...stripeEvent.value, address: { ...stripeEvent.value.address, line2: 'string' } },
                     }
                 );
                 getStyles();
@@ -206,20 +199,78 @@ describe('StripeShippingAddress Component', () => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
 
                 onChangeShipping({
-                        complete: true,
-                        elementType: 'shipping',
-                        empty: false,
-                        isNewAddress: false,
-                        value: {
-                            address: {
-                                city: 'string',
-                                country: 'US',
-                                line1: 'string',
-                                postal_code: 'string',
-                                state: 'string',
-                            },
-                            name: 'cosme fulanito',
-                        },
+                    ...stripeEvent,
+                    value: { ...stripeEvent.value, name: 'cosme' },
+                    }
+                );
+                getStyles();
+
+                return Promise.resolve(checkoutService.getState());
+            });
+
+            const stripeProps = {...defaultProps, isStripeLinkEnabled: true, customerEmail: ''};
+            const component = mount(
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <StripeShippingAddress { ...stripeProps } />
+                </Formik>
+            );
+
+            expect(component.find(StripeShippingAddressDisplay).props()).toEqual(
+                expect.objectContaining({
+                    methodId: 'stripeupe',
+                    deinitialize: defaultProps.deinitialize,
+                })
+            );
+
+            expect(defaultProps.initialize).toHaveBeenCalled();
+            expect(defaultProps.onAddressSelect).toHaveBeenCalled();
+        });
+
+        it('renders StripeShippingAddress with initialize props when phone is required', async () => {
+            defaultProps.initialize = jest.fn((options) => {
+                const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
+
+                onChangeShipping({
+                    ...stripeEvent,
+                    phoneFieldRequired: true,
+                    value: { ...stripeEvent.value, phone: '+523333333333' },
+                    }
+                );
+                getStyles();
+
+                return Promise.resolve(checkoutService.getState());
+            });
+
+            const stripeProps = {...defaultProps, isStripeLinkEnabled: true, customerEmail: ''};
+            const component = mount(
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <StripeShippingAddress { ...stripeProps } />
+                </Formik>
+            );
+
+            expect(component.find(StripeShippingAddressDisplay).props()).toEqual(
+                expect.objectContaining({
+                    methodId: 'stripeupe',
+                    deinitialize: defaultProps.deinitialize,
+                })
+            );
+
+            expect(defaultProps.initialize).toHaveBeenCalled();
+            expect(defaultProps.onAddressSelect).toHaveBeenCalled();
+        });
+
+        it('renders StripeShippingAddress with initialize props when phone is not required', async () => {
+            defaultProps.initialize = jest.fn((options) => {
+                const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
+
+                onChangeShipping({
+                    ...stripeEvent,
                     }
                 );
                 getStyles();

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -99,13 +99,20 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
 
     const availableShippingList = countries?.map(country => ({code: country.code, name: country.name}));
     const allowedCountries = availableShippingList ? availableShippingList.map(country => country.code).join(', ') : '';
+    const shouldShowContent = (isNewAddress = true, phoneFieldRequired: boolean, phone: string) => {
+        const stepCompleted =  step.isComplete;
+        const shippingPopulated = shippingAddress?.firstName && isNewAddress;
+        const PhoneRequiredAndNotFilled = phoneFieldRequired && !phone;
+
+        return stepCompleted || shippingPopulated || PhoneRequiredAndNotFilled;
+    };
 
     const handleStripeShippingAddress = useCallback(async (shipping: StripeShippingEvent) => {
         const {complete, phoneFieldRequired, value: { address = { country: '', state: '', line1: '', line2: '', city: '', postal_code: '' }
             , name = '', phone = '' } } = shipping;
 
-        if(complete) {
-            if (step.isComplete || (shippingAddress?.firstName && shipping.isNewAddress) || (phoneFieldRequired && !phone)) {
+        if (complete) {
+            if (shouldShowContent(shipping?.isNewAddress, phoneFieldRequired, phone)) {
                 handleLoading();
             }
 

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -89,6 +89,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
         const hasStripeAddressAndHasShippingOptions = stripeShippingAddress.firstName && hasSelectedShippingOptions(consignments);
         const afterReload = !isFirstShippingRender && !isNewAddress && !isShippingMethodLoading;
         const isLoadingBeforeAutoStep =  isStripeLoading && isStripeAutoStep;
+
         if (hasStripeAddressAndHasShippingOptions && afterReload && isLoadingBeforeAutoStep) {
             isStripeLoading();
             isStripeAutoStep();

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -100,7 +100,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
     const availableShippingList = countries?.map(country => ({code: country.code, name: country.name}));
     const allowedCountries = availableShippingList ? availableShippingList.map(country => country.code).join(', ') : '';
     const shouldShowContent = (isNewAddress = true, phoneFieldRequired: boolean, phone: string) => {
-        const stepCompleted =  step.isComplete;
+        const stepCompleted = step.isComplete;
         const shippingPopulated = shippingAddress?.firstName && isNewAddress;
         const PhoneRequiredAndNotFilled = phoneFieldRequired && !phone;
 

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -100,11 +100,11 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
     const allowedCountries = availableShippingList ? availableShippingList.map(country => country.code).join(', ') : '';
 
     const handleStripeShippingAddress = useCallback(async (shipping: StripeShippingEvent) => {
-        const {complete, value: { address = { country: '', state: '', line1: '', line2: '', city: '', postal_code: '' }
-            , name = '' } } = shipping;
+        const {complete, phoneFieldRequired, value: { address = { country: '', state: '', line1: '', line2: '', city: '', postal_code: '' }
+            , name = '', phone = '' } } = shipping;
 
         if(complete) {
-            if (step.isComplete || (shippingAddress?.firstName && shipping.isNewAddress)) {
+            if (step.isComplete || (shippingAddress?.firstName && shipping.isNewAddress) || (phoneFieldRequired && !phone)) {
                 handleLoading();
             }
 
@@ -125,7 +125,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
                 country: country || address.country,
                 countryCode: address.country,
                 postalCode: address.postal_code,
-                phone: '',
+                phone: phone || '',
                 customFields: [],
             };
 


### PR DESCRIPTION
## What? [STRIPE-200](https://bigcommercecloud.atlassian.net/browse/STRIPE-200)
Add a Stripe phone field

## Why?
It's required by Stripe to support new fields

## Testing / Proof
<img width="801" alt="image" src="https://user-images.githubusercontent.com/42154828/200919646-21e94c29-96c3-45f5-b79b-e40a39a8c334.png">


## Coverage 
<img width="705" alt="image" src="https://user-images.githubusercontent.com/42154828/217353168-3eb382b7-5fc3-4528-8c4d-3f5677733b3b.png">
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/42154828/217353392-94539153-9389-4a24-9cdc-0bc97ec68ee4.png">

## Dependency of
https://github.com/bigcommerce/checkout-sdk-js/pull/1681


@bigcommerce/checkout @bigcommerce/apex-integrations 
