### PR TITLE
Revert "feat(checkout): CHECKOUT-7036 Filter out convertcart-related issues on Sentry."

### DIFF
--- a/packages/core/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/packages/core/src/app/common/error/SentryErrorLogger.spec.ts
@@ -65,68 +65,6 @@ describe('SentryErrorLogger', () => {
         expect(clientOptions.sampleRate).toBe(0.123);
     });
 
-    it('does not log exception event if it relates to convertcart', () => {
-        new SentryErrorLogger(config);
-
-        const clientOptions: BrowserOptions = (init as jest.Mock).mock.calls[0][0];
-        /* eslint-disable @typescript-eslint/naming-convention */
-        const event = {
-            breadcrumbs: [
-                {
-                    timestamp: 1667952544.208,
-                    category: 'fetch',
-                    data: {
-                        method: 'POST',
-                        url: 'https://dc4.convertcart.com/event/v3/94892041/123.123',
-                        status_code: 200,
-                    },
-                    type: 'http',
-                },
-                {
-                    timestamp: 1667952544.549,
-                    category: 'fetch',
-                    data: {
-                        method: 'GET',
-                        url: '/api/storefront/checkouts/abcdefg',
-                        status_code: 200,
-                    },
-                    type: 'http',
-                },
-            ],
-            exception: {
-                values: [
-                    {
-                        type: 'TypeError',
-                        value: "Cannot read properties of null (reading 'setAttribute')",
-                        stacktrace: {
-                            frames: [
-                                {
-                                    filename: 'app:///608-12345.js',
-                                    function: 'u',
-                                    in_app: true,
-                                    lineno: 1,
-                                    colno: 10602,
-                                },
-                            ],
-                        },
-                        mechanism: {
-                            type: 'instrument',
-                            handled: true,
-                            data: {
-                                function: 'setInterval',
-                            },
-                        },
-                    },
-                ],
-            },
-        };
-        /* eslint-enable @typescript-eslint/naming-convention */
-        const hint = { originalException: new Error('Unexpected error') };
-
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        expect(clientOptions.beforeSend!(event, hint)).toBeNull();
-    });
-
     it('does not log exception event if it does not contain stacktrace', () => {
         new SentryErrorLogger(config);
 
@@ -231,7 +169,7 @@ describe('SentryErrorLogger', () => {
 
         expect(init).toHaveBeenCalledWith(
             expect.objectContaining({
-                denyUrls: ['polyfill~checkout', 'sentry~checkout', 'convertcart'],
+                denyUrls: ['polyfill~checkout', 'sentry~checkout'],
             }),
         );
     });

--- a/packages/core/src/app/common/error/SentryErrorLogger.ts
+++ b/packages/core/src/app/common/error/SentryErrorLogger.ts
@@ -45,7 +45,7 @@ export default class SentryErrorLogger implements ErrorLogger {
         init({
             sampleRate: SAMPLE_RATE,
             beforeSend: this.handleBeforeSend,
-            denyUrls: [...(config.denyUrls || []), 'polyfill~checkout', 'sentry~checkout', 'convertcart'],
+            denyUrls: [...(config.denyUrls || []), 'polyfill~checkout', 'sentry~checkout'],
             integrations: [
                 new Integrations.GlobalHandlers({
                     onerror: false,
@@ -135,12 +135,6 @@ export default class SentryErrorLogger implements ErrorLogger {
     }
 
     private handleBeforeSend: (event: Event, hint?: EventHint) => Event | null = (event, hint) => {
-        if (
-            event.breadcrumbs?.filter((breadcrumb) => breadcrumb.data?.url.includes('convertcart'))
-        ) {
-            return null;
-        }
-
         if (event.exception) {
             if (
                 !this.shouldReportExceptions(


### PR DESCRIPTION
Reverts bigcommerce/checkout-js#1092

This seems to be causing:

```
TypeError: undefined is not an object (evaluating 't.url.includes')
  at ? (./packages/core/src/app/common/error/SentryErrorLogger.ts:139:72)
  at filter([native code])
  at ? (./packages/core/src/app/common/error/SentryErrorLogger.ts:139:32)
```

ping @bigcommerce/checkout