### PR TITLE
feat(checkout): CHECKOUT-7036 Filter out convertcart-related issues

### DIFF
--- a/packages/core/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/packages/core/src/app/common/error/SentryErrorLogger.spec.ts
@@ -164,12 +164,88 @@ describe('SentryErrorLogger', () => {
         });
     });
 
+    it('does not log exception event if it relates to convertcart', () => {
+        new SentryErrorLogger(config);
+
+        const clientOptions: BrowserOptions = (init as jest.Mock).mock.calls[0][0];
+        /* eslint-disable @typescript-eslint/naming-convention */
+        const event = {
+            breadcrumbs: [
+                {
+                    timestamp: 1667952544.208,
+                    category: 'fetch',
+                    data: {
+                        method: 'POST',
+                        url: 'https://dc4.convertcart.com/event/v3/94892041/123.123',
+                        status_code: 200,
+                    },
+                    type: 'http',
+                },
+                {
+                    timestamp: 1667952544.549,
+                    category: 'fetch',
+                    data: {
+                        method: 'GET',
+                        url: '/api/storefront/checkouts/abcdefg',
+                        status_code: 200,
+                    },
+                    type: 'http',
+                },
+                {
+                    timestamp: 1667952544.549,
+                    category: 'fetch',
+                    type: 'http',
+                },
+                {
+                    timestamp: 1667952544.549,
+                    category: 'fetch',
+                    data: {
+                        method: 'GET',
+                        status_code: 200,
+                    },
+                    type: 'http',
+                },
+            ],
+            exception: {
+                values: [
+                    {
+                        type: 'TypeError',
+                        value: "Cannot read properties of null (reading 'setAttribute')",
+                        stacktrace: {
+                            frames: [
+                                {
+                                    filename: 'app:///608-12345.js',
+                                    function: 'u',
+                                    in_app: true,
+                                    lineno: 1,
+                                    colno: 10602,
+                                },
+                            ],
+                        },
+                        mechanism: {
+                            type: 'instrument',
+                            handled: true,
+                            data: {
+                                function: 'setInterval',
+                            },
+                        },
+                    },
+                ],
+            },
+        };
+        /* eslint-enable @typescript-eslint/naming-convention */
+        const hint = { originalException: new Error('Unexpected error') };
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(clientOptions.beforeSend!(event, hint)).toBeNull();
+    });
+
     it('configures client to ignore errors from polyfill and Sentry client', () => {
         new SentryErrorLogger(config);
 
         expect(init).toHaveBeenCalledWith(
             expect.objectContaining({
-                denyUrls: ['polyfill~checkout', 'sentry~checkout'],
+                denyUrls: ['polyfill~checkout', 'sentry~checkout', 'convertcart'],
             }),
         );
     });

--- a/packages/core/src/app/common/error/SentryErrorLogger.ts
+++ b/packages/core/src/app/common/error/SentryErrorLogger.ts
@@ -45,7 +45,7 @@ export default class SentryErrorLogger implements ErrorLogger {
         init({
             sampleRate: SAMPLE_RATE,
             beforeSend: this.handleBeforeSend,
-            denyUrls: [...(config.denyUrls || []), 'polyfill~checkout', 'sentry~checkout'],
+            denyUrls: [...(config.denyUrls || []), 'polyfill~checkout', 'sentry~checkout', 'convertcart'],
             integrations: [
                 new Integrations.GlobalHandlers({
                     onerror: false,
@@ -135,6 +135,12 @@ export default class SentryErrorLogger implements ErrorLogger {
     }
 
     private handleBeforeSend: (event: Event, hint?: EventHint) => Event | null = (event, hint) => {
+        if (
+            event.breadcrumbs?.filter((breadcrumb) => breadcrumb.data?.url?.includes('convertcart'))
+        ) {
+            return null;
+        }
+
         if (event.exception) {
             if (
                 !this.shouldReportExceptions(


### PR DESCRIPTION
## What?
The previous PR did help reduce the number of the convertcart-related issues, it also introduced a new one because it failed to realise that the `url` property is optional.

This PR expands the optional chaining to include `url`.

The updated unit test captures the case where `data` and `url` are optional.

## Why?
Reduce the amount of noisy errors we receive, such as [3505225940](https://sentry.io/organizations/bigcommerce/issues/3505225940/?project=1542560).
## Testing / Proof
- CI.

@bigcommerce/checkout
