### PR TITLE
feat(payment): PAYPAL-1723 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.306.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.306.0.tgz",
-      "integrity": "sha512-i6oyyGpAD7XsvF/m9Jugd2PieMszUSAYOxFy2j682ogFEzA+hhbES0pc/mvkg2/gB9bFxwOn5siANNPkTWc2dQ==",
+      "version": "1.308.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.308.0.tgz",
+      "integrity": "sha512-sYb73kn6o+dLm3DIPIzLe8DLmu995LBDxApKkCMXpGaKkY0tk33XDSFua9T2SInsht0OOd7D9c0M4K4GJOjbeA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1220,9 +1220,9 @@
           "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w=="
         },
         "core-js": {
-          "version": "3.26.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-          "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
+          "version": "3.26.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+          "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.306.0",
+    "@bigcommerce/checkout-sdk": "^1.308.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1678

## Why?
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1723

## Testing / Proof
Tested on dev and int

@bigcommerce/checkout
