### PR TITLE
feat(checkout): CHECKOUT-6438 Refactor `HostedField` component

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.spec.tsx
@@ -9,14 +9,15 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
-import { CheckoutProvider } from '../../checkout';
-import { getStoreConfig } from '../../config/config.mock';
-import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
-import { getPaymentMethod } from '../payment-methods.mock';
+import {
+    HostedFieldPaymentMethodComponent,
+    HostedFieldPaymentMethodComponentProps
+} from '@bigcommerce/checkout/hosted-field-integration';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
+import { getPaymentMethod, getStoreConfig } from '@bigcommerce/checkout/test-utils';
 
-import HostedFieldPaymentMethod, {
-    HostedFieldPaymentMethodProps,
-} from './HostedFieldPaymentMethod';
+import { CheckoutProvider } from '../../checkout';
+
 import { default as PaymentMethodComponent, PaymentMethodProps } from './PaymentMethod';
 import PaymentMethodId from './PaymentMethodId';
 
@@ -58,8 +59,8 @@ describe('when using Square payment', () => {
 
     it('renders as hosted field method', () => {
         const container = mount(<PaymentMethodTest {...defaultProps} method={method} />);
-        const component: ReactWrapper<HostedFieldPaymentMethodProps> =
-            container.find(HostedFieldPaymentMethod);
+        const component: ReactWrapper<HostedFieldPaymentMethodComponentProps> =
+            container.find(HostedFieldPaymentMethodComponent);
 
         expect(component.props()).toEqual(
             expect.objectContaining({
@@ -75,8 +76,8 @@ describe('when using Square payment', () => {
 
     it('initializes method with required config', () => {
         const container = mount(<PaymentMethodTest {...defaultProps} method={method} />);
-        const component: ReactWrapper<HostedFieldPaymentMethodProps> =
-            container.find(HostedFieldPaymentMethod);
+        const component: ReactWrapper<HostedFieldPaymentMethodComponentProps> =
+            container.find(HostedFieldPaymentMethodComponent);
 
         component.prop('initializePayment')({
             methodId: method.id,

--- a/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.tsx
@@ -3,14 +3,15 @@ import { noop } from 'lodash';
 import React, { FunctionComponent, useCallback, useContext } from 'react';
 import { Omit } from 'utility-types';
 
+import {
+    HostedFieldPaymentMethodComponent,
+    HostedFieldPaymentMethodComponentProps
+} from '@bigcommerce/checkout/hosted-field-integration';
+
 import PaymentContext from '../PaymentContext';
 
-import HostedFieldPaymentMethod, {
-    HostedFieldPaymentMethodProps,
-} from './HostedFieldPaymentMethod';
-
 export type SquarePaymentMethodProps = Omit<
-    HostedFieldPaymentMethodProps,
+    HostedFieldPaymentMethodComponentProps,
     'cardCodeId' | 'cardExpiryId' | 'cardNumberId' | 'postalCodeId' | 'walletButtons'
 >;
 
@@ -53,7 +54,7 @@ const SquarePaymentMethod: FunctionComponent<SquarePaymentMethodProps> = ({
     );
 
     return (
-        <HostedFieldPaymentMethod
+        <HostedFieldPaymentMethodComponent
             {...rest}
             cardCodeId="sq-cvv"
             cardExpiryId="sq-expiration-date"

--- a/packages/hosted-field-integration/.eslintrc.json
+++ b/packages/hosted-field-integration/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../.eslintrc.json"
+  ]
+}

--- a/packages/hosted-field-integration/README.md
+++ b/packages/hosted-field-integration/README.md
@@ -1,0 +1,7 @@
+# hosted-field-integration
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test hosted-field-integration` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/hosted-field-integration/jest.config.js
+++ b/packages/hosted-field-integration/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    displayName: 'hosted-field-integration',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        },
+    },
+    transform: {
+        '^.+\\.[tj]sx?$': 'ts-jest',
+    },
+    setupFilesAfterEnv: ['../../jest-setup.ts'],
+    coverageDirectory: '../../coverage/packages/hosted-field-integration',
+};

--- a/packages/hosted-field-integration/project.json
+++ b/packages/hosted-field-integration/project.json
@@ -1,0 +1,22 @@
+{
+  "root": "packages/hosted-field-integration",
+  "sourceRoot": "packages/hosted-field-integration/src",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/hosted-field-integration/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/hosted-field-integration"],
+      "options": {
+        "jestConfig": "packages/hosted-field-integration/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": ["scope:shared"]
+}

--- a/packages/hosted-field-integration/src/index.ts
+++ b/packages/hosted-field-integration/src/index.ts
@@ -1,0 +1,4 @@
+export {
+    HostedFieldPaymentMethodComponent,
+    HostedFieldPaymentMethodComponentProps,
+} from './lib/hosted-field-integration';

--- a/packages/hosted-field-integration/src/lib/hosted-field-integration.spec.tsx
+++ b/packages/hosted-field-integration/src/lib/hosted-field-integration.spec.tsx
@@ -3,18 +3,22 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
-import { getStoreConfig } from '../../config/config.mock';
-import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
-import { LoadingOverlay } from '../../ui/loading';
-import { getPaymentMethod } from '../payment-methods.mock';
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+} from '@bigcommerce/checkout/locale';
+import { getPaymentMethod, getStoreConfig } from '@bigcommerce/checkout/test-utils';
+import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 
-import HostedFieldPaymentMethod, {
-    HostedFieldPaymentMethodProps,
-} from './HostedFieldPaymentMethod';
+import {
+    HostedFieldPaymentMethodComponent,
+    HostedFieldPaymentMethodComponentProps,
+} from './hosted-field-integration';
 
 describe('HostedFieldPaymentMethod', () => {
-    let HostedFieldPaymentMethodTest: FunctionComponent<HostedFieldPaymentMethodProps>;
-    let defaultProps: HostedFieldPaymentMethodProps;
+    let HostedFieldPaymentMethodTest: FunctionComponent<HostedFieldPaymentMethodComponentProps>;
+    let defaultProps: HostedFieldPaymentMethodComponentProps;
     let localeContext: LocaleContextType;
 
     beforeEach(() => {
@@ -31,7 +35,7 @@ describe('HostedFieldPaymentMethod', () => {
         HostedFieldPaymentMethodTest = (props) => (
             <Formik initialValues={{}} onSubmit={noop}>
                 <LocaleContext.Provider value={localeContext}>
-                    <HostedFieldPaymentMethod {...props} />
+                    <HostedFieldPaymentMethodComponent {...props} />
                 </LocaleContext.Provider>
             </Formik>
         );

--- a/packages/hosted-field-integration/src/lib/hosted-field-integration.tsx
+++ b/packages/hosted-field-integration/src/lib/hosted-field-integration.tsx
@@ -7,11 +7,10 @@ import {
 import { noop } from 'lodash';
 import React, { Component, ReactNode } from 'react';
 
-import { TranslatedString } from '../../locale';
-import { FormFieldContainer, Label } from '../../ui/form';
-import { LoadingOverlay } from '../../ui/loading';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { FormFieldContainer, Label, LoadingOverlay } from '@bigcommerce/checkout/ui';
 
-export interface HostedFieldPaymentMethodProps {
+export interface HostedFieldPaymentMethodComponentProps {
     cardCodeId?: string;
     cardExpiryId: string;
     cardNumberId: string;
@@ -25,8 +24,8 @@ export interface HostedFieldPaymentMethodProps {
 }
 
 // TODO: Use HostedCreditCardFieldset
-export default class HostedFieldPaymentMethod extends Component<HostedFieldPaymentMethodProps> {
-    async componentDidMount(): Promise<void> {
+export class HostedFieldPaymentMethodComponent extends Component<HostedFieldPaymentMethodComponentProps> {
+    override async componentDidMount(): Promise<void> {
         const { initializePayment, method, onUnhandledError = noop } = this.props;
 
         try {
@@ -39,7 +38,7 @@ export default class HostedFieldPaymentMethod extends Component<HostedFieldPayme
         }
     }
 
-    async componentWillUnmount(): Promise<void> {
+    override async componentWillUnmount(): Promise<void> {
         const { deinitializePayment, method, onUnhandledError = noop } = this.props;
 
         try {
@@ -52,7 +51,7 @@ export default class HostedFieldPaymentMethod extends Component<HostedFieldPayme
         }
     }
 
-    render(): ReactNode {
+    override render(): ReactNode {
         const {
             cardCodeId,
             cardExpiryId,
@@ -65,7 +64,9 @@ export default class HostedFieldPaymentMethod extends Component<HostedFieldPayme
         return (
             <LoadingOverlay hideContentWhenLoading isLoading={isInitializing}>
                 <div className="form-ccFields">
-                    {walletButtons && <FormFieldContainer>{walletButtons}</FormFieldContainer>}
+                    {Boolean(walletButtons) && (
+                        <FormFieldContainer>{walletButtons}</FormFieldContainer>
+                    )}
 
                     <FormFieldContainer additionalClassName="form-field--ccNumber">
                         <Label>
@@ -83,7 +84,7 @@ export default class HostedFieldPaymentMethod extends Component<HostedFieldPayme
                         <div id={cardExpiryId} />
                     </FormFieldContainer>
 
-                    {cardCodeId && (
+                    {Boolean(cardCodeId) && (
                         <FormFieldContainer additionalClassName="form-field--ccCvv">
                             <Label>
                                 <TranslatedString id="payment.credit_card_cvv_label" />
@@ -93,7 +94,7 @@ export default class HostedFieldPaymentMethod extends Component<HostedFieldPayme
                         </FormFieldContainer>
                     )}
 
-                    {postalCodeId && (
+                    {Boolean(postalCodeId) && (
                         <FormFieldContainer additionalClassName="form-field--postCode">
                             <Label>
                                 <TranslatedString id="payment.postal_code_label" />

--- a/packages/hosted-field-integration/src/lib/hosted-field-integration.tsx
+++ b/packages/hosted-field-integration/src/lib/hosted-field-integration.tsx
@@ -25,7 +25,7 @@ export interface HostedFieldPaymentMethodComponentProps {
 
 // TODO: Use HostedCreditCardFieldset
 export class HostedFieldPaymentMethodComponent extends Component<HostedFieldPaymentMethodComponentProps> {
-    override async componentDidMount(): Promise<void> {
+    async componentDidMount(): Promise<void> {
         const { initializePayment, method, onUnhandledError = noop } = this.props;
 
         try {
@@ -38,7 +38,7 @@ export class HostedFieldPaymentMethodComponent extends Component<HostedFieldPaym
         }
     }
 
-    override async componentWillUnmount(): Promise<void> {
+    async componentWillUnmount(): Promise<void> {
         const { deinitializePayment, method, onUnhandledError = noop } = this.props;
 
         try {
@@ -51,7 +51,7 @@ export class HostedFieldPaymentMethodComponent extends Component<HostedFieldPaym
         }
     }
 
-    override render(): ReactNode {
+    render(): ReactNode {
         const {
             cardCodeId,
             cardExpiryId,
@@ -64,9 +64,7 @@ export class HostedFieldPaymentMethodComponent extends Component<HostedFieldPaym
         return (
             <LoadingOverlay hideContentWhenLoading isLoading={isInitializing}>
                 <div className="form-ccFields">
-                    {Boolean(walletButtons) && (
-                        <FormFieldContainer>{walletButtons}</FormFieldContainer>
-                    )}
+                    {!!walletButtons && <FormFieldContainer>{walletButtons}</FormFieldContainer>}
 
                     <FormFieldContainer additionalClassName="form-field--ccNumber">
                         <Label>
@@ -84,7 +82,7 @@ export class HostedFieldPaymentMethodComponent extends Component<HostedFieldPaym
                         <div id={cardExpiryId} />
                     </FormFieldContainer>
 
-                    {Boolean(cardCodeId) && (
+                    {!!cardCodeId && (
                         <FormFieldContainer additionalClassName="form-field--ccCvv">
                             <Label>
                                 <TranslatedString id="payment.credit_card_cvv_label" />
@@ -94,7 +92,7 @@ export class HostedFieldPaymentMethodComponent extends Component<HostedFieldPaym
                         </FormFieldContainer>
                     )}
 
-                    {Boolean(postalCodeId) && (
+                    {!!postalCodeId && (
                         <FormFieldContainer additionalClassName="form-field--postCode">
                             <Label>
                                 <TranslatedString id="payment.postal_code_label" />

--- a/packages/hosted-field-integration/tsconfig.json
+++ b/packages/hosted-field-integration/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/hosted-field-integration/tsconfig.lib.json
+++ b/packages/hosted-field-integration/tsconfig.lib.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
+}

--- a/packages/hosted-field-integration/tsconfig.spec.json
+++ b/packages/hosted-field-integration/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ]
+}

--- a/packages/test-utils/src/checkout.mock.ts
+++ b/packages/test-utils/src/checkout.mock.ts
@@ -37,6 +37,7 @@ export function getCheckout(): Checkout {
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
         promotions: [],
+        channelId: 123456,
     };
 }
 

--- a/packages/ui/src/form/index.ts
+++ b/packages/ui/src/form/index.ts
@@ -9,3 +9,5 @@ export { TextInput } from './TextInput';
 export { TextInputIframeContainer } from './TextInputIframeContainer';
 export { FormContext, FormContextType } from './contexts';
 export { AddressFormSkeleton, ChecklistSkeleton, CustomerSkeleton } from './LoadingSkeleton';
+export { Label } from './Label';
+export { FormFieldContainer } from './FormFieldContainer';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,7 +10,9 @@ export {
     CustomerSkeleton,
     Fieldset,
     FormContext,
+    FormFieldContainer,
     FormContextType,
+    Label,
     Legend,
     Input,
 } from './form';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -34,6 +34,9 @@
       "@bigcommerce/checkout/hosted-credit-card-integration": [
         "packages/hosted-credit-card-integration/src/index.ts"
       ],
+      "@bigcommerce/checkout/hosted-field-integration": [
+        "packages/hosted-field-integration/src/index.ts"
+      ],
       "@bigcommerce/checkout/locale": ["packages/locale/src/index.ts"],
       "@bigcommerce/checkout/payment-integration-api": [
         "packages/payment-integration-api/src/index.ts"

--- a/workspace.json
+++ b/workspace.json
@@ -8,6 +8,7 @@
     "core": "packages/core",
     "google-pay-integration": "packages/google-pay-integration",
     "hosted-credit-card-integration": "packages/hosted-credit-card-integration",
+    "hosted-field-integration": "packages/hosted-field-integration",
     "hosted-widget-integration": "packages/hosted-widget-integration",
     "locale": "packages/locale",
     "payment-integration-api": "packages/payment-integration-api",


### PR DESCRIPTION
## What?
Refactor the existing `HostedField` component as a shared payment integration package.

## Why?
Support payment method monorepo packages, such as `Square`, that compose with `<HostedFieldPaymentComponent />`.

## Testing / Proof
- CI.
