### PR TITLE
fix(checkout): INT-6968 fix for the misaligned text when it has spaces in between on APMs name

### DIFF
--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -19,6 +19,7 @@
 
     + .paymentProviderHeader-name {
         margin-left: spacing("half");
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
## What? [INT-6968](https://bigcommercecloud.atlassian.net/browse/INT-6968)
The CSS class name that gives style to the APMs' checkout section now includes "white-space: nowrap;."

## Why?
On the payment step of checkout, the Apple Pay logo is misaligned and the text is broken into separate lines on the radio button payment method selection.
![ApplePay](https://user-images.githubusercontent.com/90646906/202512469-c728408d-ff2c-4c50-bc6a-1b7c43832584.png)

![Screen Shot 2022-11-17 at 1 54 18 p m](https://user-images.githubusercontent.com/90646906/202546196-52ac22f1-368f-4412-aa15-2c5d132870a7.png)


## Testing / Proof
![Screen Shot 2022-11-17 at 12 52 48 p m](https://user-images.githubusercontent.com/90646906/202533361-4937e8eb-9d6e-4e7a-aede-5def7c07bc7d.png)

![Screen Shot 2022-11-17 at 1 52 07 p m](https://user-images.githubusercontent.com/90646906/202545439-47859a17-173f-40ff-9d74-da8892810f8d.png)

## How can this change be undone in case of failure?

Revert PR

@bigcommerce/checkout @bigcommerce/apex-integrations
