### PR TITLE
fix(payment): STRIPE-175 remove extra payment call and extra code on core

### DIFF
--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -18,6 +18,7 @@ import { getCheckout } from '../checkout/checkouts.mock';
 import CheckoutStepType from '../checkout/CheckoutStepType';
 import { getStoreConfig } from '../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+import { PaymentMethodId } from '../payment/paymentMethod';
 
 import CreateAccountForm from './CreateAccountForm';
 import Customer, { CustomerProps, WithCheckoutCustomerProps } from './Customer';
@@ -105,7 +106,7 @@ describe('Customer', () => {
                 type: CheckoutStepType.Customer };
 
             const component = mount(
-                <CustomerTest isStripeLinkEnabled={ true } step={ steps } viewType={ CustomerViewType.Guest } />
+                <CustomerTest providerWithCustomCheckout={ PaymentMethodId.StripeUPE } step={ steps } viewType={ CustomerViewType.Guest } />
             );
 
             await new Promise(resolve => process.nextTick(resolve));

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -17,6 +17,7 @@ import CheckoutStepType from '../checkout/CheckoutStepType';
 import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '../locale';
+import { PaymentMethodId } from '../payment/paymentMethod';
 
 import { getConsignment } from './consignment.mock';
 import Shipping, { ShippingProps, WithCheckoutShippingProps } from './Shipping';
@@ -48,7 +49,7 @@ describe('Shipping Component', () => {
                 isEditable: true,
                 isRequired: true,
                 type: CheckoutStepType.Shipping },
-            isStripeLinkEnabled: true,
+            providerWithCustomCheckout: PaymentMethodId.StripeUPE,
             isShippingMethodLoading: true,
             navigateNextStep: jest.fn(),
             onUnhandledError: jest.fn(),


### PR DESCRIPTION
## What? [STRIPE-175](https://bigcommercecloud.atlassian.net/browse/STRIPE-175)
Remove functionality to loadPaymentMethods in the customer and shipping step added for stripeLink flow

## Why?
We are using a flag called providerWithCustomCheckout to determine if StripeLink is available instead of pre-reload payment providers in the checkout

## Testing / Proof

https://user-images.githubusercontent.com/42154828/207467614-d36e323a-116e-4adb-b08d-5ce6670d702b.mp4



@bigcommerce/checkout @bigcommerce/apex-integrations 
