### PR TITLE
fix(payment): INT-6928 [Mollie] No Ability To Use A Different Card To Pay

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -1,5 +1,6 @@
 import {
     BankInstrument,
+    CardInstrument,
     CheckoutSelectors,
     CheckoutService,
     createCheckoutService,
@@ -382,6 +383,41 @@ describe('HostedWidgetPaymentMethod', () => {
             expect(container.text()).not.toMatch(/account/i);
 
             expect(container.find('input[name="shouldSaveInstrument"]').exists()).toBe(true);
+        });
+
+        it('shows fields on the Widget when you click Use another payment form on the vaulted card instruments dropdown', () => {
+            const mockCardInstrument: CardInstrument[] = [
+                {
+                    bigpayToken: '123',
+                    provider: 'braintree',
+                    iin: '11111111',
+                    last4: '4321',
+                    expiryMonth: '02',
+                    expiryYear: '2025',
+                    brand: 'visa',
+                    trustedShippingAddress: true,
+                    defaultInstrument: true,
+                    method: 'card',
+                    type: 'card',
+                }
+            ];
+
+            jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue(mockCardInstrument);
+
+            const component = mount(<HostedWidgetPaymentMethodTest {...defaultProps} />);
+
+            component.find(CardInstrumentFieldset).prop('onUseNewInstrument')();
+            component.update();
+
+            const hostedWidgetComponent = component.find('#widget-container');
+
+            expect(hostedWidgetComponent).toHaveLength(1);
+
+            expect(component.text()).toMatch(/save/i);
+            expect(component.text()).toMatch(/card/i);
+            expect(component.text()).not.toMatch(/account/i);
+
+            expect(component.find('input[name="shouldSaveInstrument"]').exists()).toBe(true);
         });
 
         it('shows save account checkbox when has isAccountInstrument prop', () => {

--- a/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -429,7 +429,9 @@ class HostedWidgetPaymentMethod extends Component<
             signInCustomer = noop,
         } = this.props;
 
-        const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
+        const { selectedInstrumentId = this.getDefaultInstrumentId(), isAddingNewCard } = this.state;
+
+        let selectedInstrument;
 
         if (!isPaymentDataRequired) {
             setSubmit(method, null);
@@ -447,9 +449,11 @@ class HostedWidgetPaymentMethod extends Component<
 
         setSubmit(method, null);
 
-        const selectedInstrument =
-            instruments.find((instrument) => instrument.bigpayToken === selectedInstrumentId) ||
-            instruments[0];
+        if (!isAddingNewCard) {
+            selectedInstrument =
+                instruments.find((instrument) => instrument.bigpayToken === selectedInstrumentId) ||
+                instruments[0];
+        }
 
         return initializePayment(
             {

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.spec.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.spec.tsx
@@ -1,5 +1,6 @@
 import {
     BankInstrument,
+    CardInstrument,
     CheckoutSelectors,
     CheckoutService,
     createCheckoutService,
@@ -425,6 +426,47 @@ describe('HostedWidgetPaymentMethod', () => {
             );
 
             expect(component.find(CardInstrumentFieldset)).toHaveLength(1);
+        });
+
+        it('shows fields on the Widget when you click Use another payment form on the vaulted card instruments dropdown', () => {
+            const mockCardInstrument: CardInstrument[] = [
+                {
+                    bigpayToken: '123',
+                    provider: 'braintree',
+                    iin: '11111111',
+                    last4: '4321',
+                    expiryMonth: '02',
+                    expiryYear: '2025',
+                    brand: 'visa',
+                    trustedShippingAddress: true,
+                    defaultInstrument: true,
+                    method: 'card',
+                    type: 'card',
+                },
+            ];
+
+            jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue(mockCardInstrument);
+
+            const component = mount(
+                <HostedWidgetPaymentMethodTest
+                    {...defaultProps}
+                    instruments={mockCardInstrument}
+                    isInstrumentFeatureAvailable={true}
+                />,
+            );
+
+            component.find(CardInstrumentFieldset).prop('onUseNewInstrument')();
+            component.update();
+
+            const hostedWidgetComponent = component.find('#widget-container');
+
+            expect(hostedWidgetComponent).toHaveLength(1);
+
+            expect(component.text()).toMatch(/save/i);
+            expect(component.text()).not.toMatch(/account/i);
+            expect(component.text()).toMatch(/card/i);
+
+            expect(component.find('input[name="shouldSaveInstrument"]').exists()).toBe(true);
         });
 
         it('shows hosted widget and save credit card form when there are no stored instruments', () => {

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
@@ -444,7 +444,10 @@ class HostedWidgetPaymentComponent extends Component<
             signInCustomer = noop,
         } = this.props;
 
-        const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
+        const { selectedInstrumentId = this.getDefaultInstrumentId(), isAddingNewCard } =
+            this.state;
+
+        let selectedInstrument;
 
         if (!isPaymentDataRequired) {
             setSubmit(method, null);
@@ -462,9 +465,11 @@ class HostedWidgetPaymentComponent extends Component<
 
         setSubmit(method, null);
 
-        const selectedInstrument =
-            instruments.find((instrument) => instrument.bigpayToken === selectedInstrumentId) ||
-            instruments[0];
+        if (!isAddingNewCard) {
+            selectedInstrument =
+                instruments.find((instrument) => instrument.bigpayToken === selectedInstrumentId) ||
+                instruments[0];
+        }
 
         return initializePayment(
             {

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
@@ -293,16 +293,18 @@ class HostedWidgetPaymentComponent extends Component<
             bigpayToken: selectedInstrumentId,
         });
 
-        assertIsCardInstrument(selectedInstrument);
+        if (selectedInstrument) {
+            assertIsCardInstrument(selectedInstrument);
 
-        const shouldShowNumberField = isInstrumentCardNumberRequiredProp(selectedInstrument);
+            const shouldShowNumberField = isInstrumentCardNumberRequiredProp(selectedInstrument);
 
-        if (hideVerificationFields) {
-            return;
-        }
+            if (hideVerificationFields) {
+                return;
+            }
 
-        if (validateInstrument) {
-            return validateInstrument(shouldShowNumberField, selectedInstrument);
+            if (validateInstrument) {
+                return validateInstrument(shouldShowNumberField, selectedInstrument);
+            }
         }
     }
 


### PR DESCRIPTION
## What? [INT-6928](https://bigcommercecloud.atlassian.net/browse/INT-6928)
Logged in shoppers who saved their card previously are not able to select the option of using a different card and entering their new credit card details.

## Why?
When the shopper selects “use a different card” they should see the credit card fields 

## Testing / Proof

### After

https://user-images.githubusercontent.com/104527753/203615753-1b3be81e-4fe2-4cfb-8de1-edf9049227a7.mov

### Before

https://user-images.githubusercontent.com/104527753/203615803-0205ef7e-3f38-41a6-bf89-76d34ff4de47.mov

## Depends of 

- https://github.com/bigcommerce/checkout-sdk-js/pull/1702

@bigcommerce/checkout @bigcommerce/apex-integrations 
