### PR TITLE
style(checkout): STRIPE-192 Add labels as floating

### DIFF
--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -110,9 +110,9 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
         if (parentContainer) {
             return getAppliedStyles(parentContainer, properties);
         }
- 
+
             return undefined;
-        
+
     };
 
     const containerId = 'stripe-card-component-field';
@@ -181,7 +181,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                             </Legend>
                         }
                     >
-                        <div className="customerEmail-container">
+                        <div className="customerEmail-container" style={{paddingTop: '4px'}}>
                             <div className="customerEmail-body">
                                 <div id="stripeupeLink"/>
                                 <br/>
@@ -195,7 +195,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                                 /> }
                             </div>
 
-                            <div className="form-actions customerEmail-action">
+                            <div className="form-actions customerEmail-action" style={{marginTop: '2px'}}>
                                 { (!authentication || (authentication && !isNewAuth )) && <Button
                                     className="stripeCustomerEmail-button"
                                     disabled={ continueAsAGuestButton }

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.spec.tsx.snap
@@ -14,7 +14,7 @@ Array [
       />
     </div>
     <div
-      style="display:none"
+      style="visibility:hidden"
     >
       <fieldset
         class="form-fieldset"
@@ -27,6 +27,7 @@ Array [
         >
           <div
             class="customerEmail-container"
+            style="padding-top:4px"
           >
             <div
               class="customerEmail-body"
@@ -53,6 +54,7 @@ Array [
             </div>
             <div
               class="form-actions customerEmail-action"
+              style="margin-top:2px"
             >
               <button
                 class="button stripeCustomerEmail-button button--primary optimizedCheckout-buttonPrimary"

--- a/packages/core/src/app/ui/loading/LoadingOverlay.spec.tsx
+++ b/packages/core/src/app/ui/loading/LoadingOverlay.spec.tsx
@@ -24,7 +24,7 @@ describe('LoadingOverlay', () => {
             </LoadingOverlay>,
         );
 
-        expect(component.find('#content').parent().prop('style').display).toBe('none');
+        expect(component.find('#content').parent().prop('style').visibility).toBe('hidden');
 
         expect(component.find(LoadingSpinner).prop('isLoading')).toBe(true);
     });
@@ -36,7 +36,7 @@ describe('LoadingOverlay', () => {
             </LoadingOverlay>,
         );
 
-        expect(component.find('#content').parent().prop('style').display).toBeUndefined();
+        expect(component.find('#content').parent().prop('style').visibility).toBeUndefined();
 
         expect(component.find(LoadingSpinner).prop('isLoading')).toBe(false);
     });

--- a/packages/core/src/app/ui/loading/LoadingOverlay.tsx
+++ b/packages/core/src/app/ui/loading/LoadingOverlay.tsx
@@ -21,7 +21,7 @@ const LoadingOverlay: FunctionComponent<LoadingOverlayProps> = ({
                 {unmountContentWhenLoading && isLoading ? null : (
                     <div
                         style={{
-                            display: hideContentWhenLoading && isLoading ? 'none' : undefined,
+                            visibility: hideContentWhenLoading && isLoading ? 'hidden' : undefined,
                         }}
                     >
                         {children}

--- a/packages/ui/src/loading/LoadingOverlay.spec.tsx
+++ b/packages/ui/src/loading/LoadingOverlay.spec.tsx
@@ -25,7 +25,7 @@ describe('LoadingOverlay', () => {
         );
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        expect(component.find('#content').parent().prop('style').display).toBe('none');
+        expect(component.find('#content').parent().prop('style').visibility).toBe('hidden');
 
         expect(component.find(LoadingSpinner).prop('isLoading')).toBe(true);
     });
@@ -38,7 +38,7 @@ describe('LoadingOverlay', () => {
         );
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        expect(component.find('#content').parent().prop('style').display).toBeUndefined();
+        expect(component.find('#content').parent().prop('style').visibility).toBeUndefined();
 
         expect(component.find(LoadingSpinner).prop('isLoading')).toBe(false);
     });


### PR DESCRIPTION
## What? [STRIPE-192](https://bigcommercecloud.atlassian.net/jira/software/c/projects/STRIPE/boards/622?modal=detail&selectedIssue=STRIPE-192)

Add labels as floating

## Why?
in order to change the style of the label in checkout customer, billing and payment inputs to be inside.

## Ticket Related [Checkout-SDK](https://github.com/bigcommerce/checkout-sdk-js/pull/1682)

## Testing / Proof


https://user-images.githubusercontent.com/67211919/208209385-97c2ae58-df3d-4c23-a7bc-4c61c7f5633c.mov



@bigcommerce/checkout @bigcommerce/payments
