### PR TITLE
feat(payment): BOLT-408 Add BODL event for customer suggestion init

### DIFF
--- a/packages/analytics/src/AnalyticsContext.ts
+++ b/packages/analytics/src/AnalyticsContext.ts
@@ -7,6 +7,7 @@ export interface AnalyticsEvents {
     trackStepViewed(step: string): void;
     orderPurchased(): void;
     customerEmailEntry(email: string): void;
+    customerSuggestionInit(payload?: CheckoutPaymentMethodExecutedOptions): void;
     customerSuggestionExecute(): void;
     customerPaymentMethodExecuted(payload?: CheckoutPaymentMethodExecutedOptions): void;
     showShippingMethods(): void;

--- a/packages/analytics/src/AnalyticsProvider.mock.tsx
+++ b/packages/analytics/src/AnalyticsProvider.mock.tsx
@@ -1,14 +1,20 @@
-import React, { FunctionComponent } from 'react';
+import React, { ReactElement } from 'react';
 
 import AnalyticsContext, { AnalyticsEvents } from './AnalyticsContext';
 
-const AnalyticsProviderMock: FunctionComponent = ({ children }) => {
-    const analyticsTracker: AnalyticsEvents = {
+interface AnalyticsProviderMockProps {
+    children: ReactElement;
+    analyticsTracker?: Partial<AnalyticsEvents>;
+}
+
+const AnalyticsProviderMock = ({ children, analyticsTracker = {} }: AnalyticsProviderMockProps) => {
+    const analyticsTrackerDefault: AnalyticsEvents = {
         checkoutBegin: jest.fn(),
         trackStepCompleted: jest.fn(),
         trackStepViewed: jest.fn(),
         orderPurchased: jest.fn(),
         customerEmailEntry: jest.fn(),
+        customerSuggestionInit: jest.fn(),
         customerSuggestionExecute: jest.fn(),
         customerPaymentMethodExecuted: jest.fn(),
         showShippingMethods: jest.fn(),
@@ -20,7 +26,9 @@ const AnalyticsProviderMock: FunctionComponent = ({ children }) => {
     };
 
     return (
-        <AnalyticsContext.Provider value={{ analyticsTracker }}>
+        <AnalyticsContext.Provider
+            value={{ analyticsTracker: { ...analyticsTrackerDefault, ...analyticsTracker } }}
+        >
             {children}
         </AnalyticsContext.Provider>
     );

--- a/packages/analytics/src/AnalyticsProvider.spec.tsx
+++ b/packages/analytics/src/AnalyticsProvider.spec.tsx
@@ -70,6 +70,7 @@ describe('AnalyticsProvider', () => {
             orderPurchased: jest.fn(),
             stepCompleted: jest.fn(),
             customerEmailEntry: jest.fn(),
+            customerSuggestionInit: jest.fn(),
             customerSuggestionExecute: jest.fn(),
             customerPaymentMethodExecuted: jest.fn(),
             showShippingMethods: jest.fn(),
@@ -132,6 +133,20 @@ describe('AnalyticsProvider', () => {
 
         expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledTimes(1);
         expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledWith('email@test.com');
+    });
+
+    it('track customer suggestion initialization', () => {
+        mount(
+            <TestComponent
+                eventName="customerSuggestionInit"
+                eventPayload={{ data: 'test data' }}
+            />,
+        );
+
+        expect(bodlServiceMock.customerSuggestionInit).toHaveBeenCalledTimes(1);
+        expect(bodlServiceMock.customerSuggestionInit).toHaveBeenCalledWith({
+            data: 'test data',
+        });
     });
 
     it('track customer suggestion execute', () => {

--- a/packages/analytics/src/AnalyticsProvider.tsx
+++ b/packages/analytics/src/AnalyticsProvider.tsx
@@ -49,6 +49,10 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
         getBodlService().customerEmailEntry(email);
     };
 
+    const customerSuggestionInit = (payload: BodlEventsPayload) => {
+        getBodlService().customerSuggestionInit(payload);
+    };
+
     const customerSuggestionExecute = () => {
         getBodlService().customerSuggestionExecute();
     };
@@ -87,6 +91,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
         trackStepViewed,
         orderPurchased,
         customerEmailEntry,
+        customerSuggestionInit,
         customerSuggestionExecute,
         customerPaymentMethodExecuted,
         showShippingMethods,

--- a/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/BoltCheckoutSuggestion.tsx
@@ -7,6 +7,8 @@ import {
 import { noop } from 'lodash';
 import React, { FunctionComponent, memo, useEffect, useState } from 'react';
 
+import { useAnalytics } from '@bigcommerce/checkout/analytics';
+
 import { stopPropagation } from '../../common/dom';
 import { TranslatedString } from '../../locale';
 import { Button } from '../../ui/button';
@@ -32,6 +34,7 @@ const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = (
     onUnhandledError = noop,
 }) => {
     const [showSuggestion, setShowSuggestion] = useState<boolean>(false);
+    const { analyticsTracker } = useAnalytics();
 
     useEffect(() => {
         deinitializeCustomer({ methodId });
@@ -42,6 +45,7 @@ const BoltCheckoutSuggestion: FunctionComponent<BoltCheckoutSuggestionProps> = (
                 bolt: {
                     onInit: (hasBoltAccount) => {
                         setShowSuggestion(hasBoltAccount);
+                        analyticsTracker.customerSuggestionInit({hasBoltAccount});
                     },
                 },
             });


### PR DESCRIPTION
## What?
Add new Bodl analytics event to Bolt customer suggestion initialization

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-408](https://bigcommercecloud.atlassian.net/browse/BOLT-408)

## Testing / Proof
<img width="666" alt="Screenshot 2022-11-29 at 11 49 14" src="https://user-images.githubusercontent.com/9430298/204498882-4a7371e0-2941-42e8-a2d2-5895c29a6c11.png">

@bigcommerce/checkout
