### PR TITLE
chore(payment): INT-6716 Bump checkout-sdk from 1.306.0 to 1.309.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.306.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.306.0.tgz",
-      "integrity": "sha512-i6oyyGpAD7XsvF/m9Jugd2PieMszUSAYOxFy2j682ogFEzA+hhbES0pc/mvkg2/gB9bFxwOn5siANNPkTWc2dQ==",
+      "version": "1.309.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.309.1.tgz",
+      "integrity": "sha512-qpYm5ktd0bzQ/3+i9ZkcnZOyDiohwyAwXF/g1D8TZuvdapxVduegO9pw7dT2fvAZsWU0zdvrFGUIurMscp4P4w==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1215,14 +1215,14 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.188",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
-          "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w=="
+          "version": "4.14.190",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
+          "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw=="
         },
         "core-js": {
-          "version": "3.26.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-          "integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw=="
+          "version": "3.26.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
+          "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.306.0",
+    "@bigcommerce/checkout-sdk": "^1.309.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from 1.306.0 to [1.309.0](https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md#13090-2022-11-28)

## Why?
To release https://github.com/bigcommerce/checkout-sdk-js/pull/1642

## Testing / Proof
CircleCI + testing section on the above PR

@bigcommerce/checkout @bigcommerce/apex-integrations 
