### PR TITLE
fix(payment): STRIPE-269 exclude wallets from the custom customer step status for stripeLink

### DIFF
--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -32,9 +32,15 @@ const getCustomerStepStatus = createSelector(
                 : false;
         const isGuest = !!(customer && customer.isGuest);
         const isComplete = hasEmail || isUsingWallet;
-        const isEditable = isComplete && !isUsingWallet && isGuest
+        const isEditable = isComplete && !isUsingWallet && isGuest;
 
-        if (config?.checkoutSettings.providerWithCustomCheckout === PaymentMethodId.StripeUPE && hasEmail && isGuest) {
+        // StripeLink is a UX that is only available with StripeUpe and will only be displayed for BC guest users,
+        // it uses its own components in the customer and shipping steps, unfortunately in order to preserve the UX
+        // when reloading the checkout page it's necessary to refill the stripe components with the information saved.
+        // In this step, we require that the customer strategy be reloaded the first time.
+        const isUsingStripeLinkAndCheckoutPageIsReloaded = !isUsingWallet &&
+            config?.checkoutSettings.providerWithCustomCheckout === PaymentMethodId.StripeUPE && hasEmail && isGuest;
+        if (isUsingStripeLinkAndCheckoutPageIsReloaded) {
             return {
                 type: CheckoutStepType.Customer,
                 isActive: false,


### PR DESCRIPTION
## What? [STRIPE-269](https://bigcommercecloud.atlassian.net/browse/STRIPE-269)
Exclude wallet from custom stripeLinkFlow

## Why?
Could affect functionality and UX 

## Testing / Proof
BUG:
https://drive.google.com/file/d/1cw6iNp2HL-StziDoiNc3ZaVAHqZgm7K2/view?usp=share_link

FIX:
https://drive.google.com/file/d/1BuaMZEVnCQKhpOlNlN9TuodBNZf8L1cl/view?usp=share_link

@bigcommerce/checkout @bigcommerce/apex-integrations 
