### PR TITLE
fix(payment): BOLT-268 Bolt payment fields with store credits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.313.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.313.2.tgz",
-      "integrity": "sha512-E2eHON2S7XO+OPbjExNtiocufo9qI9EA4wxUuyQzK51WPx6/IA7OcML8hTGfFdvb66K4HS6ImXEpKh5WBb97CQ==",
+      "version": "1.314.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.314.1.tgz",
+      "integrity": "sha512-azWyUOG+Aie8ApkM3ek1q7CEZFwmpeiHnTy4sxQzovtR4rR0Y0KTBqJeSPtxyPOnujYEqMkpoE/bF+8fnP2XxA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.313.2",
+    "@bigcommerce/checkout-sdk": "^1.314.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -113,6 +113,20 @@ describe('HostedWidgetPaymentMethod', () => {
         expect(defaultProps.initializePayment).not.toHaveBeenCalled();
     });
 
+    it('reinitialize payment method after requiring payment data is changing', async () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
+
+        const container = mount(<HostedWidgetPaymentMethodTest {...defaultProps} />);
+        
+        expect(defaultProps.initializePayment).not.toHaveBeenCalled();
+        
+        container.setProps({isPaymentDataRequired: true});
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.initializePayment).toHaveBeenCalled();
+    });
+
     it('renders loading overlay while waiting for method to initialize', () => {
         let component: ReactWrapper;
 

--- a/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -137,6 +137,7 @@ class HostedWidgetPaymentMethod extends Component<
             method,
             onUnhandledError = noop,
             setValidationSchema,
+            isPaymentDataRequired
         } = this.props;
 
         const { selectedInstrumentId } = this.state;
@@ -145,7 +146,8 @@ class HostedWidgetPaymentMethod extends Component<
 
         if (
             selectedInstrumentId !== prevState.selectedInstrumentId ||
-            (prevProps.instruments.length > 0 && instruments.length === 0)
+            (prevProps.instruments.length > 0 && instruments.length === 0) ||
+            prevProps.isPaymentDataRequired !== isPaymentDataRequired
         ) {
             try {
                 await deinitializePayment({

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.spec.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.spec.tsx
@@ -148,6 +148,22 @@ describe('HostedWidgetPaymentMethod', () => {
         expect(defaultProps.initializePayment).not.toHaveBeenCalled();
     });
 
+    it('reinitialize payment method after requiring payment data is changing', async () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
+
+        const container = mount(
+            <HostedWidgetPaymentMethodTest {...defaultProps} isPaymentDataRequired={false} />,
+        );
+
+        expect(defaultProps.initializePayment).not.toHaveBeenCalled();
+
+        container.setProps({ isPaymentDataRequired: true });
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.initializePayment).toHaveBeenCalled();
+    });
+
     it('renders loading overlay while waiting for method to initialize', () => {
         let component: ReactWrapper;
 

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
@@ -146,6 +146,7 @@ class HostedWidgetPaymentComponent extends Component<
             method,
             onUnhandledError = noop,
             setValidationSchema,
+            isPaymentDataRequired,
         } = this.props;
 
         const { selectedInstrumentId } = this.state;
@@ -154,7 +155,8 @@ class HostedWidgetPaymentComponent extends Component<
 
         if (
             selectedInstrumentId !== prevState.selectedInstrumentId ||
-            (prevProps.instruments.length > 0 && instruments.length === 0)
+            (prevProps.instruments.length > 0 && instruments.length === 0) ||
+            prevProps.isPaymentDataRequired !== isPaymentDataRequired
         ) {
             try {
                 // eslint-disable-next-line @typescript-eslint/await-thenable


### PR DESCRIPTION
## What?
Fix issue with empty Bolt payment fields after disabling store credits
Checkout-sdk-js changes: [https://github.com/bigcommerce/checkout-sdk-js/pull/1716](https://github.com/bigcommerce/checkout-sdk-js/pull/1716)

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-268](https://bigcommercecloud.atlassian.net/browse/BOLT-268)

## Testing / Proof
Before:

https://user-images.githubusercontent.com/9430298/205292685-ae7ce077-bce6-4cea-8c16-078c62152da4.mov

After:


https://user-images.githubusercontent.com/9430298/205292732-77c8321a-263a-4ebe-b5bf-331e51191705.mov

Test:
<img width="461" alt="Screenshot 2022-12-02 at 14 28 39" src="https://user-images.githubusercontent.com/9430298/205293098-0d3e2543-1af2-4bc0-89eb-36106d157adf.png">




@bigcommerce/checkout @bigcommerce/payments
