### PR TITLE
fix(payment): STRIPE-0000 bump checkout-sdk-js v1.309.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,20 +1145,20 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.20.0.tgz",
-      "integrity": "sha512-O88thU+FGgUot4IVOgMcSO3PwH7ZgD3m5jtU6Mr6oORmafo2mYezVprgWoPbiNE2FGZngVvxDjzq6X0stn607w==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.20.1.tgz",
+      "integrity": "sha512-LMO6UeJ6Bd+8JF6oxOIe4msO80I9qnYczKLPdpIFy6SgnXm8gpUuaCKdvt/+LnK9V1V88tEenC2aVVWcHxHBJw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
-        "babel-jest": "^27.4.6",
+        "babel-jest": "^27.5.1",
         "deep-assign": "^3.0.0",
         "object-assign": "^4.1.1"
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.309.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.309.1.tgz",
-      "integrity": "sha512-qpYm5ktd0bzQ/3+i9ZkcnZOyDiohwyAwXF/g1D8TZuvdapxVduegO9pw7dT2fvAZsWU0zdvrFGUIurMscp4P4w==",
+      "version": "1.309.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.309.6.tgz",
+      "integrity": "sha512-qA1IiYcM14UWBWTzYn5g4Ls7FRQ97c3kSgqZ5+BTVl5nq/1ytPPHZ8p4VToRNOQAu2DelFLOxzOpuPDRlvyhZA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1215,9 +1215,9 @@
           }
         },
         "@types/lodash": {
-          "version": "4.14.190",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
-          "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw=="
+          "version": "4.14.191",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+          "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
         },
         "core-js": {
           "version": "3.26.1",
@@ -17220,11 +17220,11 @@
       }
     },
     "query-string": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
-      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
       "requires": {
-        "decode-uri-component": "^0.2.0",
+        "decode-uri-component": "^0.2.2",
         "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.309.0",
+    "@bigcommerce/checkout-sdk": "^1.309.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
Fixes for the tickets:
[STRIPE-160](https://bigcommercecloud.atlassian.net/browse/STRIPE-160), PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1690
[STRIPE-167](https://bigcommercecloud.atlassian.net/browse/STRIPE-167), PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1695
[STRIPE-183](https://bigcommercecloud.atlassian.net/browse/STRIPE-183)
[STRIPE-195](https://bigcommercecloud.atlassian.net/browse/STRIPE-195), PR: https://github.com/bigcommerce/checkout-sdk-js/pull/1649

## Testing / Proof


@bigcommerce/checkout @bigcommerce/apex-integrations 
