### PR TITLE
feat(payment): PAYPAL-1836 added PayPalCommerce button to customer step

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -5,7 +5,7 @@ import { isApplePayWindow } from '../common/utility';
 import { TranslatedString } from '../locale';
 
 import CheckoutButton from './CheckoutButton';
-import { AmazonPayV2Button, ApplePayButton } from './customWalletButton';
+import { AmazonPayV2Button, ApplePayButton, PayPalCommerceButton } from './customWalletButton';
 
 const APPLE_PAY = 'applepay';
 
@@ -17,6 +17,7 @@ export const SUPPORTED_METHODS: string[] = [
     'braintreevisacheckout',
     'chasepay',
     'masterpass',
+    'paypalcommerce',
     'googlepayadyenv2',
     'googlepayadyenv3',
     'googlepayauthorizenet',
@@ -96,6 +97,18 @@ const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
                     if (methodId === 'amazonpay') {
                         return (
                             <AmazonPayV2Button
+                                containerId={`${methodId}CheckoutButton`}
+                                key={methodId}
+                                methodId={methodId}
+                                onError={onError}
+                                {...rest}
+                            />
+                        );
+                    }
+
+                    if (methodId === 'paypalcommerce') {
+                        return (
+                            <PayPalCommerceButton
                                 containerId={`${methodId}CheckoutButton`}
                                 key={methodId}
                                 methodId={methodId}

--- a/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.spec.tsx
+++ b/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.spec.tsx
@@ -1,0 +1,51 @@
+import { mount } from 'enzyme';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { navigateToOrderConfirmation } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import CheckoutButton from '../CheckoutButton';
+
+import PayPalCommerceButton from './PayPalCommerceButton';
+
+describe('PayPalCommerceButton', () => {
+    let localeContext: LocaleContextType;
+    let ButtonTest: FunctionComponent;
+    const initialize = jest.fn();
+    const error = jest.fn();
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        ButtonTest = () => (
+            <LocaleContext.Provider value={localeContext}>
+                <PayPalCommerceButton
+                    containerId="paypalcommerceId"
+                    deinitialize={noop}
+                    initialize={initialize}
+                    methodId="paypalcommerce"
+                    onError={error}
+                />
+            </LocaleContext.Provider>
+        );
+    });
+
+    it('renders as CheckoutButton', () => {
+        const container = mount(<ButtonTest />);
+
+        expect(container.find(CheckoutButton)).toHaveLength(1);
+    });
+
+    it('initializes the button correctly', () => {
+        mount(<ButtonTest />);
+
+        expect(initialize).toHaveBeenCalledWith({
+            methodId: 'paypalcommerce',
+            paypalcommerce: {
+                container: 'paypalcommerceId',
+                onError: error,
+                onComplete: navigateToOrderConfirmation,
+            },
+        });
+    });
+});

--- a/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.tsx
+++ b/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.tsx
@@ -1,0 +1,30 @@
+import { CustomerInitializeOptions } from '@bigcommerce/checkout-sdk';
+import React, { FunctionComponent, useCallback, useContext } from 'react';
+
+import { navigateToOrderConfirmation } from '../../checkout';
+import { LocaleContext } from '../../locale';
+import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
+
+const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = ({
+    initialize,
+    onError,
+    ...rest
+}) => {
+    const localeContext = useContext(LocaleContext);
+    const initializeOptions = useCallback(
+        (options: CustomerInitializeOptions) =>
+            initialize({
+                ...options,
+                paypalcommerce: {
+                    container: rest.containerId,
+                    onError,
+                    onComplete: navigateToOrderConfirmation,
+                },
+            }),
+        [initialize, localeContext, onError, rest.containerId],
+    );
+
+    return <CheckoutButton initialize={initializeOptions} {...rest} />;
+};
+
+export default PayPalCommerceButton;

--- a/packages/core/src/app/customer/customWalletButton/index.ts
+++ b/packages/core/src/app/customer/customWalletButton/index.ts
@@ -1,2 +1,3 @@
 export { default as ApplePayButton } from './ApplePayButton';
 export { default as AmazonPayV2Button } from './AmazonPayV2Button';
+export { default as PayPalCommerceButton } from './PayPalCommerceButton';


### PR DESCRIPTION
## What?
Added PayPalCommerce button to customer step

## Why?
To give customer an ability to use PayPal to reduce amount of time on filling the data on checkout page

## Testing / Proof
Here is how it looks like:
<img width="1228" alt="Screenshot 2022-12-13 at 14 08 06" src="https://user-images.githubusercontent.com/25133454/207327276-4b1c6099-6156-4c16-bd08-20632b038a69.png">

Here is a video of the result:

https://user-images.githubusercontent.com/25133454/207329128-0a3e051d-a49a-4d0c-adc6-e850b0c23051.mov

## Sibling PRs
bigcommerce: https://github.com/bigcommerce/bigcommerce/pull/50236
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1730