### PR TITLE
chore(checkout): CHECKOUT-0000 Bump SDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.309.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.309.6.tgz",
-      "integrity": "sha512-qA1IiYcM14UWBWTzYn5g4Ls7FRQ97c3kSgqZ5+BTVl5nq/1ytPPHZ8p4VToRNOQAu2DelFLOxzOpuPDRlvyhZA==",
+      "version": "1.310.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.310.3.tgz",
+      "integrity": "sha512-VUpWX5KevIyvmhSnQlMliSMDSG5x8Xc3pTNcROpDGew5xRWWLquNalqs2XvRwC/H1xU5FyrKb6qS4BfSZ6FCTg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.309.6",
+    "@bigcommerce/checkout-sdk": "^1.310.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump `checkout-sdk` version.

## Why?
Release lastest SDK changes.

- https://github.com/bigcommerce/checkout-sdk-js/commit/18fa2176b800e648b1ba26ed424b4ced8d964a52
- https://github.com/bigcommerce/checkout-sdk-js/commit/7eb83cd6db9bcd2280c92f6609902e0aa95e9e18
- https://github.com/bigcommerce/checkout-sdk-js/commit/971378b159bbd764ddcabd0bd2c6b72b5c4500a7
- https://github.com/bigcommerce/checkout-sdk-js/commit/555556811a82c728f691c90a303342a388cb0858
- https://github.com/bigcommerce/checkout-sdk-js/commit/7a039ba34671492f1633ca6fc9ebed12ab142ceb

## Testing / Proof
- CircleCI