### PR TITLE
fix(checkout): CHECKOUT-0000 Revert square to use previous hosted payment component

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedFieldPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedFieldPaymentMethod.spec.tsx
@@ -1,0 +1,106 @@
+import { mount, ReactWrapper } from 'enzyme';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { LoadingOverlay } from '../../ui/loading';
+import { getPaymentMethod } from '../payment-methods.mock';
+
+import HostedFieldPaymentMethod, {
+    HostedFieldPaymentMethodProps,
+} from './HostedFieldPaymentMethod';
+
+describe('HostedFieldPaymentMethod', () => {
+    let HostedFieldPaymentMethodTest: FunctionComponent<HostedFieldPaymentMethodProps>;
+    let defaultProps: HostedFieldPaymentMethodProps;
+    let localeContext: LocaleContextType;
+
+    beforeEach(() => {
+        defaultProps = {
+            cardExpiryId: 'card-expiry',
+            cardNumberId: 'card-number',
+            deinitializePayment: jest.fn(),
+            initializePayment: jest.fn(),
+            method: getPaymentMethod(),
+        };
+
+        localeContext = createLocaleContext(getStoreConfig());
+
+        HostedFieldPaymentMethodTest = (props) => (
+            <Formik initialValues={{}} onSubmit={noop}>
+                <LocaleContext.Provider value={localeContext}>
+                    <HostedFieldPaymentMethod {...props} />
+                </LocaleContext.Provider>
+            </Formik>
+        );
+    });
+
+    it('initializes payment method when component mounts', () => {
+        mount(<HostedFieldPaymentMethodTest {...defaultProps} />);
+
+        expect(defaultProps.initializePayment).toHaveBeenCalled();
+    });
+
+    it('deinitializes payment method when component unmounts', () => {
+        const component = mount(<HostedFieldPaymentMethodTest {...defaultProps} />);
+
+        expect(defaultProps.deinitializePayment).not.toHaveBeenCalled();
+
+        component.unmount();
+
+        expect(defaultProps.deinitializePayment).toHaveBeenCalled();
+    });
+
+    it('renders loading overlay while waiting for method to initialize', () => {
+        let component: ReactWrapper;
+
+        component = mount(<HostedFieldPaymentMethodTest {...defaultProps} isInitializing />);
+
+        expect(component.find(LoadingOverlay).prop('isLoading')).toBe(true);
+
+        component = mount(<HostedFieldPaymentMethodTest {...defaultProps} />);
+
+        expect(component.find(LoadingOverlay).prop('isLoading')).toBe(false);
+    });
+
+    it('renders card number placeholder', () => {
+        const component = mount(<HostedFieldPaymentMethodTest {...defaultProps} />);
+
+        expect(component.exists(`#${defaultProps.cardNumberId}`)).toBe(true);
+    });
+
+    it('renders card expiry placeholder', () => {
+        const component = mount(<HostedFieldPaymentMethodTest {...defaultProps} />);
+
+        expect(component.exists(`#${defaultProps.cardExpiryId}`)).toBe(true);
+    });
+
+    it('renders card cvv placeholder if configured', () => {
+        const component = mount(
+            <HostedFieldPaymentMethodTest {...defaultProps} cardCodeId="card-code" />,
+        );
+
+        expect(component.exists('#card-code')).toBe(true);
+    });
+
+    it('renders postal code placeholder if configured', () => {
+        const component = mount(
+            <HostedFieldPaymentMethodTest {...defaultProps} postalCodeId="postal-code" />,
+        );
+
+        expect(component.exists('#postal-code')).toBe(true);
+    });
+
+    it('renders wallet button placeholder if required', () => {
+        const component = mount(
+            <HostedFieldPaymentMethodTest
+                {...defaultProps}
+                walletButtons={<div id="wallet-button" />}
+            />,
+        );
+
+        expect(component.exists('#wallet-button')).toBe(true);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethod/HostedFieldPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedFieldPaymentMethod.tsx
@@ -1,0 +1,109 @@
+import {
+    CheckoutSelectors,
+    PaymentInitializeOptions,
+    PaymentMethod,
+    PaymentRequestOptions,
+} from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+
+import { TranslatedString } from '../../locale';
+import { FormFieldContainer, Label } from '../../ui/form';
+import { LoadingOverlay } from '../../ui/loading';
+
+export interface HostedFieldPaymentMethodProps {
+    cardCodeId?: string;
+    cardExpiryId: string;
+    cardNumberId: string;
+    isInitializing?: boolean;
+    method: PaymentMethod;
+    postalCodeId?: string;
+    walletButtons?: ReactNode;
+    deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
+    initializePayment(options: PaymentInitializeOptions): Promise<CheckoutSelectors>;
+    onUnhandledError?(error: Error): void;
+}
+
+// TODO: Use HostedCreditCardFieldset
+export default class HostedFieldPaymentMethod extends Component<HostedFieldPaymentMethodProps> {
+    async componentDidMount(): Promise<void> {
+        const { initializePayment, method, onUnhandledError = noop } = this.props;
+
+        try {
+            await initializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    async componentWillUnmount(): Promise<void> {
+        const { deinitializePayment, method, onUnhandledError = noop } = this.props;
+
+        try {
+            await deinitializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    render(): ReactNode {
+        const {
+            cardCodeId,
+            cardExpiryId,
+            cardNumberId,
+            isInitializing = false,
+            postalCodeId,
+            walletButtons,
+        } = this.props;
+
+        return (
+            <LoadingOverlay hideContentWhenLoading isLoading={isInitializing}>
+                <div className="form-ccFields">
+                    {!!walletButtons && <FormFieldContainer>{walletButtons}</FormFieldContainer>}
+
+                    <FormFieldContainer additionalClassName="form-field--ccNumber">
+                        <Label>
+                            <TranslatedString id="payment.credit_card_number_label" />
+                        </Label>
+
+                        <div id={cardNumberId} />
+                    </FormFieldContainer>
+
+                    <FormFieldContainer additionalClassName="form-field--ccExpiry">
+                        <Label>
+                            <TranslatedString id="payment.credit_card_expiration_label" />
+                        </Label>
+
+                        <div id={cardExpiryId} />
+                    </FormFieldContainer>
+
+                    {!!cardCodeId && (
+                        <FormFieldContainer additionalClassName="form-field--ccCvv">
+                            <Label>
+                                <TranslatedString id="payment.credit_card_cvv_label" />
+                            </Label>
+
+                            <div id={cardCodeId} />
+                        </FormFieldContainer>
+                    )}
+
+                    {!!postalCodeId && (
+                        <FormFieldContainer additionalClassName="form-field--postCode">
+                            <Label>
+                                <TranslatedString id="payment.postal_code_label" />
+                            </Label>
+
+                            <div id={postalCodeId} />
+                        </FormFieldContainer>
+                    )}
+                </div>
+            </LoadingOverlay>
+        );
+    }
+}

--- a/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.spec.tsx
@@ -9,15 +9,14 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
-import {
-    HostedFieldPaymentMethodComponent,
-    HostedFieldPaymentMethodComponentProps
-} from '@bigcommerce/checkout/hosted-field-integration';
-import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
-import { getPaymentMethod, getStoreConfig } from '@bigcommerce/checkout/test-utils';
-
 import { CheckoutProvider } from '../../checkout';
+import { getStoreConfig } from '../../config/config.mock';
+import { createLocaleContext, LocaleContext, LocaleContextType } from '../../locale';
+import { getPaymentMethod } from '../payment-methods.mock';
 
+import HostedFieldPaymentMethod, {
+    HostedFieldPaymentMethodProps,
+} from './HostedFieldPaymentMethod';
 import { default as PaymentMethodComponent, PaymentMethodProps } from './PaymentMethod';
 import PaymentMethodId from './PaymentMethodId';
 
@@ -59,8 +58,8 @@ describe('when using Square payment', () => {
 
     it('renders as hosted field method', () => {
         const container = mount(<PaymentMethodTest {...defaultProps} method={method} />);
-        const component: ReactWrapper<HostedFieldPaymentMethodComponentProps> =
-            container.find(HostedFieldPaymentMethodComponent);
+        const component: ReactWrapper<HostedFieldPaymentMethodProps> =
+            container.find(HostedFieldPaymentMethod);
 
         expect(component.props()).toEqual(
             expect.objectContaining({
@@ -76,8 +75,8 @@ describe('when using Square payment', () => {
 
     it('initializes method with required config', () => {
         const container = mount(<PaymentMethodTest {...defaultProps} method={method} />);
-        const component: ReactWrapper<HostedFieldPaymentMethodComponentProps> =
-            container.find(HostedFieldPaymentMethodComponent);
+        const component: ReactWrapper<HostedFieldPaymentMethodProps> =
+            container.find(HostedFieldPaymentMethod);
 
         component.prop('initializePayment')({
             methodId: method.id,

--- a/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/SquarePaymentMethod.tsx
@@ -3,15 +3,16 @@ import { noop } from 'lodash';
 import React, { FunctionComponent, useCallback, useContext } from 'react';
 import { Omit } from 'utility-types';
 
-import {
-    HostedFieldPaymentMethodComponent,
-    HostedFieldPaymentMethodComponentProps
-} from '@bigcommerce/checkout/hosted-field-integration';
 
 import PaymentContext from '../PaymentContext';
 
+import HostedFieldPaymentMethod, {
+    HostedFieldPaymentMethodProps,
+} from './HostedFieldPaymentMethod';
+
+
 export type SquarePaymentMethodProps = Omit<
-    HostedFieldPaymentMethodComponentProps,
+    HostedFieldPaymentMethodProps,
     'cardCodeId' | 'cardExpiryId' | 'cardNumberId' | 'postalCodeId' | 'walletButtons'
 >;
 
@@ -54,19 +55,19 @@ const SquarePaymentMethod: FunctionComponent<SquarePaymentMethodProps> = ({
     );
 
     return (
-        <HostedFieldPaymentMethodComponent
-            {...rest}
-            cardCodeId="sq-cvv"
-            cardExpiryId="sq-expiration-date"
-            cardNumberId="sq-card-number"
-            initializePayment={initializeSquarePayment}
-            method={method}
-            onUnhandledError={(e) => {
-                onUnhandledError(e);
-                paymentContext?.disableSubmit(method, true);
-            }}
-            postalCodeId="sq-postal-code"
-        />
+            <HostedFieldPaymentMethod
+                {...rest}
+                cardCodeId="sq-cvv"
+                cardExpiryId="sq-expiration-date"
+                cardNumberId="sq-card-number"
+                initializePayment={initializeSquarePayment}
+                method={method}
+                onUnhandledError={(e) => {
+                    onUnhandledError(e);
+                    paymentContext?.disableSubmit(method, true);
+                }}
+                postalCodeId="sq-postal-code"
+            />
     );
 };
 


### PR DESCRIPTION
## What?
As above

## Why?
While migrating square payment method to use the `HostedPaymentComponent`  from separate monorepo package. We realised that the translations provider needs to be built correctly, otherwise the component seems to be missing translation context. 

Once we update the locale package with correct translation setup, we can migrate square to use monorepo package component.

## Testing / Proof
- circle

@bigcommerce/checkout
