### PR TITLE
feat(payment): PAYMENTS-8376 Adds ability to enable vaulting for multi-shipping

### DIFF
--- a/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.spec.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.spec.ts
@@ -68,7 +68,7 @@ describe('isInstrumentFeatureAvailable()', () => {
         ).toBe(false);
     });
 
-    it('returns false if shopper is checking out with multiple shipping address', () => {
+    it('returns false if shopper is checking out with multiple shipping address & the feature for vaulting with multiple shipping is not enabled', () => {
         expect(
             isInstrumentFeatureAvailable({
                 ...state,
@@ -78,6 +78,25 @@ describe('isInstrumentFeatureAvailable()', () => {
                 ),
             }),
         ).toBe(false);
+    });
+
+    it('returns true if shopper is checking out with multiple shipping address & the feature for vaulting with multiple shipping is enabled', () => {
+        expect(
+            isInstrumentFeatureAvailable({
+                ...state,
+                config: merge({}, getStoreConfig(), {
+                    checkoutSettings: {
+                        features: {
+                            'PAYMENTS-7667.enable_vaulting_with_multishipping': true,
+                        },
+                    },
+                }),
+                isUsingMultiShipping: isUsingMultiShipping(
+                    [getConsignment(), getConsignment()],
+                    getCart().lineItems,
+                ),
+            }),
+        ).toBe(true);
     });
 
     it('returns true otherwise', () => {

--- a/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.ts
@@ -1,4 +1,4 @@
-import { Customer, PaymentMethod, StoreConfig } from '@bigcommerce/checkout-sdk';
+import { CheckoutSettings, Customer, PaymentMethod, PaymentMethodConfig, StoreConfig } from '@bigcommerce/checkout-sdk';
 
 export interface IsInstrumentFeatureAvailableState {
     config: StoreConfig;
@@ -13,14 +13,27 @@ export default function isInstrumentFeatureAvailable({
     isUsingMultiShipping,
     paymentMethod,
 }: IsInstrumentFeatureAvailableState): boolean {
+    const { checkoutSettings } = config;
+
     if (
-        !config.checkoutSettings.isCardVaultingEnabled ||
-        !paymentMethod.config.isVaultingEnabled ||
+        isVaultingNotEnabled(checkoutSettings, paymentMethod.config) ||
         customer.isGuest ||
-        isUsingMultiShipping
+        isVaultingWithMultiShippingNotEnabled(checkoutSettings, isUsingMultiShipping)
     ) {
         return false;
     }
 
     return true;
+}
+
+function isVaultingNotEnabled(checkoutSettings: CheckoutSettings, paymentMethodConfig: PaymentMethodConfig): boolean {
+    return !checkoutSettings.isCardVaultingEnabled || !paymentMethodConfig.isVaultingEnabled;
+}
+
+function isVaultingWithMultiShippingNotEnabled(checkoutSettings: CheckoutSettings, isUsingMultiShipping: boolean): boolean {
+    if(checkoutSettings.features['PAYMENTS-7667.enable_vaulting_with_multishipping']) {
+        return false;
+    }
+
+    return isUsingMultiShipping;
 }


### PR DESCRIPTION
## What?
Adds an experiment to the condition that determines if a payment instrument can be vaulted if the order has multi-shipping. 

## Why?
Because we want to enable vaulting for multiple shipping addresses. Which would mean that we won't need `isUsingMultiShipping` prop to determine if the payment method should allow vaulting or not. 

Instead of getting rid of the prop right-away, we are using an experiment to control the rollout.

## Testing / Proof
Additional specs

* Without experiment, we don't see the vaulting checkbox for the multi-shipping. This is the current behaviour.
![Screen Shot 2022-12-15 at 2 27 15 pm](https://user-images.githubusercontent.com/107909200/207766945-0f220e36-37f8-4fcb-b51c-4d84c0215a17.png)

* With experiment we see the vaulting checkbox for the multi-shipping. 
 
![Screen Shot 2022-12-15 at 2 21 31 pm](https://user-images.githubusercontent.com/107909200/207766925-47090ea9-c77b-4d97-8d27-06818b38ceed.png)


@bigcommerce/checkout @bigcommerce/payments 
