### PR TITLE
feat(payment): PAYPAL-1828 fixed cvv tooltip

### DIFF
--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -216,13 +216,19 @@
 
     .loading-skeleton {
         animation: grows 150ms ease-out;
-        overflow: hidden;
         will-change: max-height;
     }
 
     @keyframes grows {
-        0% { max-height: $floating-label-input-height * 4; }
-        100% { max-height: 2000px; }
+        0% {
+            max-height: $floating-label-input-height * 4;
+            overflow: hidden;
+        }
+
+        100% {
+            max-height: 2000px;
+            overflow: visible;
+        }
     }
 
     .address-form-heading-skeleton {


### PR DESCRIPTION
## What?
Fixed cvv tooltip being cut off on braintree credit card

## Why?
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1828

## Testing / Proof
<img width="1236" alt="Screenshot 2022-12-16 at 13 47 01" src="https://user-images.githubusercontent.com/56301104/208091708-5d465839-06d9-4f50-b273-b2ee71e617a5.png">


@bigcommerce/checkout
