### PR TITLE
chore(checkout): CHECKOUT-0000 bump checkout-sdk v1.313.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.310.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.310.3.tgz",
-      "integrity": "sha512-VUpWX5KevIyvmhSnQlMliSMDSG5x8Xc3pTNcROpDGew5xRWWLquNalqs2XvRwC/H1xU5FyrKb6qS4BfSZ6FCTg==",
+      "version": "1.313.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.313.0.tgz",
+      "integrity": "sha512-oQKbkWgAB+eWsdC49hGwjKV1jxnyLAedpWLO4W+c7GXXTyacmVcQ9yyNg25SCx9BlsPS7ZQHLi6/4bSgVTj9tQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.313.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.313.0.tgz",
-      "integrity": "sha512-oQKbkWgAB+eWsdC49hGwjKV1jxnyLAedpWLO4W+c7GXXTyacmVcQ9yyNg25SCx9BlsPS7ZQHLi6/4bSgVTj9tQ==",
+      "version": "1.313.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.313.1.tgz",
+      "integrity": "sha512-ERQcc7TUrt6fNt7TTPIdVA8kPRJFlD98/80N3n5+D8VCb60/outpcWVjkhLw48uOe1pNm+art2fHRd0Mq5V0tA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.313.0",
+    "@bigcommerce/checkout-sdk": "^1.313.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.310.3",
+    "@bigcommerce/checkout-sdk": "^1.313.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.313.1`.

## Why?
Release lastest changes:
https://github.com/bigcommerce/checkout-sdk-js/commit/1c07aadfd41ae21b265db9ee2fda400cbcb16c06
https://github.com/bigcommerce/checkout-sdk-js/commit/32148c2a4f9596fbf02d72ada2fcad14392fdd95
https://github.com/bigcommerce/checkout-sdk-js/commit/e946565d2b122687411e03b6507519d6fa5d870a
https://github.com/bigcommerce/checkout-sdk-js/commit/85e9cbfa52d90a9a711519daf6cd1e608c8582b8
https://github.com/bigcommerce/checkout-sdk-js/commit/adb845c3d602bfaa277f5eabd1587869723d16ac
https://github.com/bigcommerce/checkout-sdk-js/commit/9465d7d9f532c65d50d15f7e42839be70befebb1
https://github.com/bigcommerce/checkout-sdk-js/commit/6a20e416428595bf79b4d6b64cf68b3f521e28da

## Testing / Proof
- CI checks.