### PR TITLE
feat(payment): ADYEN-629 BOLT-408 STRIPE-165 STRIPE-178 CHECKOUT-6401 CHECKOUT-6406 CHECKOUT-6407 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.310.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.310.3.tgz",
-      "integrity": "sha512-VUpWX5KevIyvmhSnQlMliSMDSG5x8Xc3pTNcROpDGew5xRWWLquNalqs2XvRwC/H1xU5FyrKb6qS4BfSZ6FCTg==",
+      "version": "1.313.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.313.0.tgz",
+      "integrity": "sha512-oQKbkWgAB+eWsdC49hGwjKV1jxnyLAedpWLO4W+c7GXXTyacmVcQ9yyNg25SCx9BlsPS7ZQHLi6/4bSgVTj9tQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.310.3",
+    "@bigcommerce/checkout-sdk": "^1.313.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Upgrade checkout-sdk from v1.310.3 to v1.313.0

Includes the following changes:
- https://github.com/bigcommerce/checkout-sdk-js/pull/1641
- https://github.com/bigcommerce/checkout-sdk-js/pull/1662
- https://github.com/bigcommerce/checkout-sdk-js/pull/1711
- https://github.com/bigcommerce/checkout-sdk-js/pull/1723
- https://github.com/bigcommerce/checkout-sdk-js/pull/1727
- https://github.com/bigcommerce/checkout-sdk-js/pull/1735

## Why?
Releasing the above changes

## Testing / Proof
CI + see screenshots and videos on the above PRs

@bigcommerce/checkout