### PR TITLE
chore(checkout): CHECKOUT-7184 bump checkout-sdk v1.313.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.313.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.313.1.tgz",
-      "integrity": "sha512-ERQcc7TUrt6fNt7TTPIdVA8kPRJFlD98/80N3n5+D8VCb60/outpcWVjkhLw48uOe1pNm+art2fHRd0Mq5V0tA==",
+      "version": "1.313.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.313.2.tgz",
+      "integrity": "sha512-E2eHON2S7XO+OPbjExNtiocufo9qI9EA4wxUuyQzK51WPx6/IA7OcML8hTGfFdvb66K4HS6ImXEpKh5WBb97CQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.313.1",
+    "@bigcommerce/checkout-sdk": "^1.313.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to `1.313.2`.

## Why?
Release recent changes, again.

## Testing / Proof
- CI checks.
- Launchbay functional tests:
https://app.circleci.com/pipelines/github/bigcommerce/bigcommerce?branch=pull%2F50362