### PR TITLE
chore(payment): INT-6957 Bump checkout-SDK 1.315.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.314.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.314.2.tgz",
-      "integrity": "sha512-zR1DhDoFK6HamXoeiXfgFnu5yo5uN9pzVi7HLfkBi0JBokl+l4QHyVzjgF4pmV2lfAVg4M3ZstWdblSo3GkfmA==",
+      "version": "1.315.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.315.0.tgz",
+      "integrity": "sha512-oA4UKGCOY1DBs07pHdKb13p3yQnawemytK85EUxNl1gpscrh/l4e0098f+w5IEUPnPCL2flsVnDE4y7Yk+o3hA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.314.2",
+    "@bigcommerce/checkout-sdk": "^1.315.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.315.0`.

## Why?
Release lastest SDK change(s):
- https://github.com/bigcommerce/checkout-sdk-js/pull/1696

## Testing / Proof
- CI checks.