### PR TITLE
CHECKOUT-7148: Handle cart inconsistency error and display appropriate message to shopper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.317.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.317.1.tgz",
-      "integrity": "sha512-vbNk0Q42pTOI1AO18vAVrEapiu+nVIHld49eiRe268bzAq2IKkc321BldaErHol7L/hzp1a7eXjhpOnNxrfnmg==",
+      "version": "1.319.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.319.1.tgz",
+      "integrity": "sha512-ChacWUT7sdnGnkKd0kU+szArylaqOZqtcv3CGCF+gqpwdgrdLuN2zVfrZo/WBqI3hqrFp42K0Fw3yYKb5iCZKg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.317.1",
+    "@bigcommerce/checkout-sdk": "^1.319.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/locale/translations/en.json
+++ b/packages/core/src/app/locale/translations/en.json
@@ -75,7 +75,8 @@
             "subtotal_text": "Subtotal",
             "taxes_text": "Taxes",
             "total_text": "Total",
-            "empty_cart_message": "Your cart is empty, you are being redirected. Please <a href=\"{url}\" target=\"_top\">click here</a> if your browser does not redirect you."
+            "empty_cart_message": "Your cart is empty, you are being redirected. Please <a href=\"{url}\" target=\"_top\">click here</a> if your browser does not redirect you.",
+            "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again."
         },
         "common": {
             "cancel_action": "Cancel",

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -378,6 +378,10 @@ class Payment extends Component<
                 window.location.reload();
             }
 
+            if (errorType === 'cart_consistency') {
+                await loadCheckout();
+            }
+
             if (isErrorWithType(error) && error.body) {
                 const { body, headers, status } = error;
 

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -25,6 +25,9 @@ export default function mapSubmitOrderErrorMessage(
         case 'cart_changed':
             return translate('shipping.cart_change_error');
 
+        case 'cart_consistency':
+            return translate('cart.consistency_error');
+
         default:
             if (
                 includes(

--- a/packages/locale/src/en.json
+++ b/packages/locale/src/en.json
@@ -75,7 +75,8 @@
             "subtotal_text": "Subtotal",
             "taxes_text": "Taxes",
             "total_text": "Total",
-            "empty_cart_message": "Your cart is empty, you are being redirected. Please <a href=\"{url}\" target=\"_top\">click here</a> if your browser does not redirect you."
+            "empty_cart_message": "Your cart is empty, you are being redirected. Please <a href=\"{url}\" target=\"_top\">click here</a> if your browser does not redirect you.",
+            "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again."
         },
         "common": {
             "cancel_action": "Cancel",


### PR DESCRIPTION
## What?
Handle `CartConsistencyError` by displaying an error modal when it is thrown and reloading checkout data when the shopper dismisses the modal.

Requires https://github.com/bigcommerce/checkout-sdk-js/pull/1746

## Why?
So shoppers are informed about any changes to their cart (e.g.: price changes) and have a chance to review them before placing their order.

## Testing / Proof
Unit + Manual

https://user-images.githubusercontent.com/667603/209247483-95eb339e-494a-40f4-8ad0-fe04a7d30f5d.mov

@bigcommerce/checkout
