### PR TITLE
chore(checkout): CHECKOUT-7202 Bump checkout-sdk v1.316.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.315.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.315.0.tgz",
-      "integrity": "sha512-oA4UKGCOY1DBs07pHdKb13p3yQnawemytK85EUxNl1gpscrh/l4e0098f+w5IEUPnPCL2flsVnDE4y7Yk+o3hA==",
+      "version": "1.316.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.316.1.tgz",
+      "integrity": "sha512-0O45/3GnyUDnPtuZwTofzsfPXt8EuLhsCZ/m0keI1GfjNlAkTdasT/FADL5K67A7GjHUiQukbldpg97GWv692g==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1220,9 +1220,9 @@
           "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
         },
         "core-js": {
-          "version": "3.26.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.1.tgz",
-          "integrity": "sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA=="
+          "version": "3.27.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.0.tgz",
+          "integrity": "sha512-wY6cKosevs430KRkHUIsvepDXHGjlXOZO3hYXNyqpD6JvB0X28aXyv0t1Y1vZMwE7SoKmtfa6IASHCPN52FwBQ=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.315.0",
+    "@bigcommerce/checkout-sdk": "^1.316.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.316.1`.

## Why?
Release lastest SDK change(s):
- https://github.com/bigcommerce/checkout-sdk-js/pull/1749

## Testing / Proof
- CI checks.
