### PR TITLE
chore(payment): STRIPE-281 Bump checkout-SDK 1.316.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.316.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.316.1.tgz",
-      "integrity": "sha512-0O45/3GnyUDnPtuZwTofzsfPXt8EuLhsCZ/m0keI1GfjNlAkTdasT/FADL5K67A7GjHUiQukbldpg97GWv692g==",
+      "version": "1.316.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.316.2.tgz",
+      "integrity": "sha512-RlzpT8RMHhl7lP9bJHU4Nde7w/qjk78V8/5ID2ENRvCrZC4qwVNF+NKC3eyQyFXhXXJFZXTuTzd8QQauhDULbg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",
@@ -1220,9 +1220,9 @@
           "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
         },
         "core-js": {
-          "version": "3.27.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.0.tgz",
-          "integrity": "sha512-wY6cKosevs430KRkHUIsvepDXHGjlXOZO3hYXNyqpD6JvB0X28aXyv0t1Y1vZMwE7SoKmtfa6IASHCPN52FwBQ=="
+          "version": "3.27.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
+          "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.316.1",
+    "@bigcommerce/checkout-sdk": "^1.316.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk `v1.316.2.`

## Why?
Release lastest SDK change(s):

https://github.com/bigcommerce/checkout-sdk-js/pull/1747

## Testing / Proof

CI checks.
