### PR TITLE
feat(payment): STRIPE-178 Loading Submit button after card loads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,9 +1156,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.316.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.316.2.tgz",
-      "integrity": "sha512-RlzpT8RMHhl7lP9bJHU4Nde7w/qjk78V8/5ID2ENRvCrZC4qwVNF+NKC3eyQyFXhXXJFZXTuTzd8QQauhDULbg==",
+      "version": "1.316.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.316.3.tgz",
+      "integrity": "sha512-7nlyyCui+UWtCppYbwWaP4x+0/58yhamYaAeKcTxNimCuSi2iHHwBN8+julfzbw2TsWJRuaHvcnl9atu5SEVBQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.316.2",
+    "@bigcommerce/checkout-sdk": "^1.316.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
@@ -141,6 +141,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );
@@ -192,6 +193,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );
@@ -243,6 +245,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );
@@ -294,6 +297,7 @@ describe('when using Stripe payment', () => {
                             fieldText: '#cccccc',
                         }),
                         onError: expect.any(Function),
+                        render: expect.any(Function),
                     },
                 }),
             );

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -1,6 +1,6 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
-import React, { FunctionComponent, useCallback } from 'react';
+import React, { FunctionComponent, useCallback, useContext } from 'react';
 
 import { CheckoutContextProps, withCheckout } from '../../checkout';
 import { getAppliedStyles } from '../../common/dom';
@@ -8,6 +8,7 @@ import {
     withHostedCreditCardFieldset,
     WithInjectedHostedCreditCardFieldsetProps,
 } from '../hostedCreditCard';
+import PaymentContext from '../PaymentContext';
 
 import HostedWidgetPaymentMethod, {
     HostedWidgetPaymentMethodProps,
@@ -26,6 +27,12 @@ const StripeUPEPaymentMethod: FunctionComponent<
 > = ({ initializePayment, method, storeUrl, onUnhandledError = noop, ...rest }) => {
     const containerId = `stripe-${method.id}-component-field`;
 
+    const paymentContext = useContext(PaymentContext);
+
+    const renderSubmitButton = () => {
+        paymentContext?.hidePaymentSubmitButton(method, false);
+    }
+
     const initializeStripePayment: HostedWidgetPaymentMethodProps['initializePayment'] =
         useCallback(
             async (options: PaymentInitializeOptions) => {
@@ -37,7 +44,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
                 ]);
                 const formLabel = getStylesFromElement(`${containerId}--label`, ['color']);
                 const formError = getStylesFromElement(`${containerId}--error`, ['color']);
-
+                paymentContext?.hidePaymentSubmitButton(method, true);
                 return initializePayment({
                     ...options,
                     stripeupe: {
@@ -52,6 +59,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
                             fieldBorder: formInput['border-color'],
                         },
                         onError: onUnhandledError,
+                        render: renderSubmitButton,
                     },
                 });
             },


### PR DESCRIPTION
## What?
To help in the release of the PR, https://github.com/bigcommerce/checkout-js/pull/1080, I created this PR to include the related SDK change, https://github.com/bigcommerce/checkout-sdk-js/pull/1662.

## Why?
Due to permission restrictions, I was unable to rebase the related JS PR, https://github.com/bigcommerce/checkout-js/pull/1080.

As a result, I copied the content and made this one.

## Testing / Proof
- CI checks.
