### PR TITLE
fix(checkout): CHECKOUT-7047 Unable to scroll Cart Summary on Mobile

### DIFF
--- a/packages/core/src/scss/components/foundation/modal/_modal.scss
+++ b/packages/core/src/scss/components/foundation/modal/_modal.scss
@@ -40,6 +40,9 @@
         &.is-active,
         &.modal--afterOpen {
             bottom: 2%;
+            display: flex;
+            flex-direction: column;
+            justify-content: end;
             left: 2%;
             max-width: 96%;
             min-height: 96vh;
@@ -170,34 +173,12 @@
 
 // Specific styles for displaying cart summary on mobile
 body.has-activeModal {
-    overflow: auto;
-
-    #checkout-app,
-    .checkoutHeader.optimizedCheckout-header {
-        display: none;
+    .modal-body {
+        overflow: scroll;
+        padding-bottom: 20%; // This is to fill the space occupied by Safari and Chrome's navigation bar on mobile
 
         @include breakpoint("small") {
-            display: block;
-        }
-    }
-
-    .modalOverlay {
-        margin-top: spacing("base");
-        position: static;
-
-        @include breakpoint("small") {
-            margin-top: 0;
-            position: fixed;
-        }
-
-        .modal {
-            max-height: fit-content;
-            position: absolute;
-
-            @include breakpoint("small") {
-                max-height: 80%;
-                position: fixed;
-            }
+            padding-bottom: 0;
         }
     }
 }

--- a/packages/core/src/scss/components/foundation/modal/_modal.scss
+++ b/packages/core/src/scss/components/foundation/modal/_modal.scss
@@ -40,9 +40,6 @@
         &.is-active,
         &.modal--afterOpen {
             bottom: 2%;
-            display: flex;
-            flex-direction: column;
-            justify-content: end;
             left: 2%;
             max-width: 96%;
             min-height: 96vh;
@@ -169,4 +166,38 @@
 .modal--afterOpen {
     display: block;
     visibility: visible;
+}
+
+// Specific styles for displaying cart summary on mobile
+body.has-activeModal {
+    overflow: auto;
+
+    #checkout-app,
+    .checkoutHeader.optimizedCheckout-header {
+        display: none;
+
+        @include breakpoint("small") {
+            display: block;
+        }
+    }
+
+    .modalOverlay {
+        margin-top: spacing("base");
+        position: static;
+
+        @include breakpoint("small") {
+            margin-top: 0;
+            position: fixed;
+        }
+
+        .modal {
+            max-height: fit-content;
+            position: absolute;
+
+            @include breakpoint("small") {
+                max-height: 80%;
+                position: fixed;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What?
Fix the issue when multiple items are added to checkout, the cart summary modal cannot be exited or scrolled.

## Why?
Previously, the modal had a fixed position, so when its height exceeds the height of the screen, the close button is not visible.

## Testing / Proof
- Manual testing:

https://user-images.githubusercontent.com/88361607/210693686-15c2d7de-2c21-4760-9149-ad253d482435.mov



@bigcommerce/checkout
