### PR TITLE
chore(payment): PAYPAL-1904 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.321.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.321.0.tgz",
-      "integrity": "sha512-623prjGr9htr7VDlikV3sxt6v7r5fbOwMNtwaIeQJla7t95aGVKvwCwgrTs7H5sVJfnsFYXk0jaaNnsrzRywoA==",
+      "version": "1.323.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.323.1.tgz",
+      "integrity": "sha512-uWX/L+F1KyRv2coXPQuXcf+CydYtmcux0dLtoGLzqk1WkRWIBkiNXuf2G4XfLIzcJxZiReocIeIh2cXqVGUJTQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.21.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.321.0",
+    "@bigcommerce/checkout-sdk": "^1.323.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To release several updates on checkout-sdk:
https://github.com/bigcommerce/checkout-sdk-js/pull/1767
https://github.com/bigcommerce/checkout-sdk-js/pull/1694
https://github.com/bigcommerce/checkout-sdk-js/pull/1751

## Testing / Proof
Unit tests
