### PR TITLE
chore(checkout): ADYEN-688 3ds2 redirect for vaulted cards fix release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.324.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.324.0.tgz",
-      "integrity": "sha512-zUe34+vbmsyVi4srXWFWBMp2W1Qb/P3ATspjpOtUJe7rvowD6WRMudtu0h6dVHP7Cp+xElV83kj3vqgZEw7z8w==",
+      "version": "1.324.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.324.1.tgz",
+      "integrity": "sha512-+qLgJWHXmgERyR7pUOEjLvKXKXo0Vb6XHUGsNZNgRFEpt2GrxeOpIDQE/MSLFytu0f5EOUSjdNgLQuHNaEnryA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.21.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.324.0",
+    "@bigcommerce/checkout-sdk": "^1.324.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
3ds2 redirect for vaulted cards fix release

## Why?
Due to the release of https://github.com/bigcommerce/checkout-sdk-js/pull/1771

## Testing / Proof
Tested manually

@bigcommerce/checkout
