### PR TITLE
chore(payment): INT-7103 Bump checkout-sdk from 1.324.1 to 1.324.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.324.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.324.1.tgz",
-      "integrity": "sha512-+qLgJWHXmgERyR7pUOEjLvKXKXo0Vb6XHUGsNZNgRFEpt2GrxeOpIDQE/MSLFytu0f5EOUSjdNgLQuHNaEnryA==",
+      "version": "1.324.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.324.2.tgz",
+      "integrity": "sha512-POguMsGlPyP0TR7xzR6BNBXTscD03g6xpWuy7ZKZvlRl1X0iIwYwbK4qJknvSLZfG/U5WHOiB4DJ8ofHa+88zw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.21.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.324.1",
+    "@bigcommerce/checkout-sdk": "^1.324.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from `1.324.1` to [`1.324.2`](https://github.com/bigcommerce/checkout-sdk-js/blob/master/CHANGELOG.md#13242-2023-01-17)

## Why?
To release https://github.com/bigcommerce/checkout-sdk-js/pull/1765

## Testing / Proof
CircleCI + testing section on the above PR

@bigcommerce/checkout @bigcommerce/apex-integrations 
