### PR TITLE
chore(common): CHECKOUT-000 Bump checkout sdk to 1.326.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1200,9 +1200,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.19",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.19.tgz",
-          "integrity": "sha512-cAx3qamwaYX9R0fzOIZAlFpo4A+1uBVCxqpKz9D26uTF4srRXaGTTsikQmaotCtNdbhzyUH7ft6p9ktz9s6UNQ==",
+          "version": "17.0.20",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
+          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.324.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.324.2.tgz",
-      "integrity": "sha512-POguMsGlPyP0TR7xzR6BNBXTscD03g6xpWuy7ZKZvlRl1X0iIwYwbK4qJknvSLZfG/U5WHOiB4DJ8ofHa+88zw==",
+      "version": "1.326.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.326.2.tgz",
+      "integrity": "sha512-Irpnq+xusn4TjsNrJ764DVkm3ltzglcIgBRtslbGbkyH5/EfgyjeVQ9fRyWGd3A82nEQXwZvW/Vu+3UNyAWqEA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.21.0",
@@ -1377,9 +1377,9 @@
           }
         },
         "core-js": {
-          "version": "3.27.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.1.tgz",
-          "integrity": "sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww=="
+          "version": "3.27.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
+          "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.324.2",
+    "@bigcommerce/checkout-sdk": "^1.326.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
As above

## Why?
Release fix for billing address
- https://github.com/bigcommerce/checkout-sdk-js/commit/5cde3c3c557b0a6591992b3443f02ebb8fef0ea2
- https://github.com/bigcommerce/checkout-sdk-js/pull/1700

## Testing / Proof
- circle

@bigcommerce/checkout
