### PR TITLE
chore(common): CHECKOUT-000 Bump checkout-sdk to 1.326.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.326.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.326.2.tgz",
-      "integrity": "sha512-Irpnq+xusn4TjsNrJ764DVkm3ltzglcIgBRtslbGbkyH5/EfgyjeVQ9fRyWGd3A82nEQXwZvW/Vu+3UNyAWqEA==",
+      "version": "1.326.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.326.3.tgz",
+      "integrity": "sha512-0E8up/zkOoVzvuCK1BdHMY1j1m7BgYKbwi/ry3xL7w9P4LYTg7mdxTLCiCIGTJuKOTjiccHU1BEph52qG35GOw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.21.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.326.2",
+    "@bigcommerce/checkout-sdk": "^1.326.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
As above

## Why?
Release fix for order finalisation for barclaycard
- https://github.com/bigcommerce/checkout-sdk-js/pull/1786

## Testing / Proof
- circle

@bigcommerce/checkout
