### PR TITLE
chore(payment): PAYPAL-1898 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,12 +1319,12 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.329.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.329.0.tgz",
-      "integrity": "sha512-uOlKrvtM4FKq+FBLHn6PPKgrumAJcDKhLEBVAFF8qUpV3sQtEXiWcdrUfEg+/161mRrTHmcSzE2ZOKECVUW42Q==",
+      "version": "1.330.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.330.0.tgz",
+      "integrity": "sha512-7Z1e58e1AHDHO8hxYMyT3YnOW9c4T3zEL/9EfLXJEZcXAbYYiglRj7IRe964nOtB2Im/Xl5SKIKowsgIb2HlKg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
-        "@bigcommerce/bigpay-client": "^5.21.0",
+        "@bigcommerce/bigpay-client": "^5.22.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.329.0",
+    "@bigcommerce/checkout-sdk": "^1.330.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk version due to last merged prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1784
https://github.com/bigcommerce/checkout-sdk-js/pull/1791
https://github.com/bigcommerce/checkout-sdk-js/pull/1782

## Why?
To release latest checkout-sdk updates

## Testing / Proof
Unit tests
