### PR TITLE
chore(payment): PAYPAL-1923 bump checkout js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.330.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.330.0.tgz",
-      "integrity": "sha512-7Z1e58e1AHDHO8hxYMyT3YnOW9c4T3zEL/9EfLXJEZcXAbYYiglRj7IRe964nOtB2Im/Xl5SKIKowsgIb2HlKg==",
+      "version": "1.330.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.330.1.tgz",
+      "integrity": "sha512-E5L9m0WXUrVopcAfyUjsr6r4r1GdZcS6CbnQ7tltmVwNx/Rw18h2Vvqex6UbBxOZ3BFesq6I6CiXu1i1gwM+0g==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.330.0",
+    "@bigcommerce/checkout-sdk": "^1.330.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk js version due to next prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1794

## Why?
To keep checkout js up to date

## Testing / Proof
Unit tests
Manual tests
