### PR TITLE
feat(payment): STRIPE-280 using addressFormSkeleton instead spinner for stripeLink components

### DIFF
--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -8,7 +8,7 @@ import { TranslatedString } from '../locale';
 import { PrivacyPolicyField } from '../privacyPolicy';
 import { Button, ButtonVariant } from '../ui/button';
 import { BasicFormField, Fieldset, Legend } from '../ui/form';
-import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
+import { CustomerSkeleton } from '@bigcommerce/checkout/ui';
 
 import { GuestFormValues } from './GuestForm';
 import SubscribeField from './SubscribeField';
@@ -169,7 +169,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
 
     return (
         <>
-            <AddressFormSkeleton isLoading={isStripeLoading}/>
+            <CustomerSkeleton isLoading={isStripeLoading}/>
             <div className="checkout-form" style={ {display: isStripeLoading ? 'none' : undefined} }>
                     <Fieldset
                         legend={ !authentication &&

--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -8,7 +8,7 @@ import { TranslatedString } from '../locale';
 import { PrivacyPolicyField } from '../privacyPolicy';
 import { Button, ButtonVariant } from '../ui/button';
 import { BasicFormField, Fieldset, Legend } from '../ui/form';
-import { LoadingOverlay } from '../ui/loading';
+import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
 
 import { GuestFormValues } from './GuestForm';
 import SubscribeField from './SubscribeField';
@@ -110,9 +110,9 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
         if (parentContainer) {
             return getAppliedStyles(parentContainer, properties);
         }
- 
+
             return undefined;
-        
+
     };
 
     const containerId = 'stripe-card-component-field';
@@ -169,11 +169,8 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
 
     return (
         <>
-            <div className="checkout-form">
-                <LoadingOverlay
-                    hideContentWhenLoading
-                    isLoading={ isStripeLoading }
-                >
+            <AddressFormSkeleton isLoading={isStripeLoading}/>
+            <div className="checkout-form" style={ {display: isStripeLoading ? 'none' : undefined} }>
                     <Fieldset
                         legend={ !authentication &&
                             <Legend hidden>
@@ -225,7 +222,6 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                         }
                         { !authentication && checkoutButtons }
                     </Fieldset>
-                </LoadingOverlay>
             </div>
             { renderCheckoutThemeStylesForStripeUPE() }
         </>

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.spec.tsx.snap
@@ -3,20 +3,13 @@
 exports[`StripeGuestForm matches snapshot 1`] = `
 Array [
   <div
-    class="checkout-form"
+    class="checkout-form customer-skeleton"
   >
     <div
-      class="form-legend-container"
+      class="customerEmail-container"
     >
       <div
-        class="address-form-heading-skeleton form-legend optimizedCheckout-headingSecondary"
-      />
-    </div>
-    <div
-      class="address-form-skeleton"
-    >
-      <div
-        class="name-fields-skeleton"
+        class="customerEmail-body"
       >
         <div
           class="skeleton-container"
@@ -26,18 +19,14 @@ Array [
           />
         </div>
         <div
-          class="skeleton-container"
-        >
-          <div
-            class="input-skeleton"
-          />
-        </div>
+          class="button-skeleton skeleton-container subscription-skeleton"
+        />
       </div>
       <div
-        class="skeleton-container"
+        class="customerEmail-action customerEmail-floating--enabled"
       >
         <div
-          class="input-skeleton"
+          class="button-skeleton skeleton-container"
         />
       </div>
     </div>

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.spec.tsx.snap
@@ -6,73 +6,102 @@ Array [
     class="checkout-form"
   >
     <div
-      class="loadingSpinner loadingOverlay-container"
-      style="height:100px"
+      class="form-legend-container"
     >
       <div
-        class="loadingOverlay optimizedCheckout-overlay"
+        class="address-form-heading-skeleton form-legend optimizedCheckout-headingSecondary"
       />
     </div>
     <div
-      style="display:none"
+      class="address-form-skeleton"
     >
-      <fieldset
-        class="form-fieldset"
+      <div
+        class="name-fields-skeleton"
       >
-        <legend
-          class="form-legend is-srOnly"
-        />
         <div
-          class="form-body"
+          class="skeleton-container"
         >
           <div
-            class="customerEmail-container"
+            class="input-skeleton"
+          />
+        </div>
+        <div
+          class="skeleton-container"
+        >
+          <div
+            class="input-skeleton"
+          />
+        </div>
+      </div>
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+    </div>
+  </div>,
+  <div
+    class="checkout-form"
+    style="display:none"
+  >
+    <fieldset
+      class="form-fieldset"
+    >
+      <legend
+        class="form-legend is-srOnly"
+      />
+      <div
+        class="form-body"
+      >
+        <div
+          class="customerEmail-container"
+        >
+          <div
+            class="customerEmail-body"
           >
             <div
-              class="customerEmail-body"
-            >
-              <div
-                id="stripeupeLink"
-              />
-              <br />
-              <div
-                class="form-field"
-              >
-                <input
-                  class="form-checkbox"
-                  id="shouldSubscribe"
-                  name="shouldSubscribe"
-                  type="checkbox"
-                  value="false"
-                />
-                <label
-                  class="form-label optimizedCheckout-form-label"
-                  for="shouldSubscribe"
-                />
-              </div>
-            </div>
+              id="stripeupeLink"
+            />
+            <br />
             <div
-              class="form-actions customerEmail-action"
+              class="form-field"
             >
-              <button
-                class="button stripeCustomerEmail-button button--primary optimizedCheckout-buttonPrimary"
-                data-test="stripe-customer-continue-as-guest-button"
-                disabled=""
-                id="stripe-checkout-customer-continue"
-                type="submit"
+              <input
+                class="form-checkbox"
+                id="shouldSubscribe"
+                name="shouldSubscribe"
+                type="checkbox"
+                value="false"
+              />
+              <label
+                class="form-label optimizedCheckout-form-label"
+                for="shouldSubscribe"
               />
             </div>
           </div>
-          <p>
-             
-            <a
-              data-test="customer-continue-button"
-              id="checkout-customer-login"
+          <div
+            class="form-actions customerEmail-action"
+          >
+            <button
+              class="button stripeCustomerEmail-button button--primary optimizedCheckout-buttonPrimary"
+              data-test="stripe-customer-continue-as-guest-button"
+              disabled=""
+              id="stripe-checkout-customer-continue"
+              type="submit"
             />
-          </p>
+          </div>
         </div>
-      </fieldset>
-    </div>
+        <p>
+           
+          <a
+            data-test="customer-continue-button"
+            id="checkout-customer-login"
+          />
+        </p>
+      </div>
+    </fieldset>
   </div>,
   <div
     class="optimizedCheckout-form-input"

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
@@ -2,7 +2,7 @@ import { Address, CheckoutSelectors, Consignment, Country, Customer, FormField, 
 import React, { Component, ReactNode } from 'react';
 
 import CheckoutStepStatus from '../../checkout/CheckoutStepStatus';
-import { LoadingOverlay } from '../../ui/loading';
+import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
 import ShippingHeader from '../ShippingHeader';
 
 import StripeShippingForm, { SingleShippingFormValues } from './StripeShippingForm';
@@ -76,41 +76,31 @@ class StripeShipping extends Component<StripeShippingProps, StripeShippingState>
             isStripeAutoStep,
         } = this.state;
 
-            return <div className="checkout-form">
-                <div style={ {display: isStripeAutoStep ? 'none' : undefined,} }>
-                    <LoadingOverlay
-                        hideContentWhenLoading
-                        isLoading={ isStripeLoading }
-                    >
-                        <ShippingHeader
-                            isGuest={ isGuest }
-                            isMultiShippingMode={ isMultiShippingMode }
-                            onMultiShippingChange={ onMultiShippingChange }
-                            shouldShowMultiShipping={ shouldShowMultiShipping }
-                        />
-
-                        <LoadingOverlay
-                            isLoading={ isLoading }
-                            unmountContentWhenLoading
-                        >
-                            <StripeShippingForm
-                                { ...shippingFormProps }
-                                deinitialize={deinitialize}
-                                initialize={initialize}
-                                isBillingSameAsShipping={isBillingSameAsShipping}
-                                isLoading={ isLoading }
-                                isMultiShippingMode={isMultiShippingMode}
-                                isStripeAutoStep={this.handleIsAutoStep}
-                                isStripeLoading={this.stripeLoadedCallback}
-                                isShippingMethodLoading={isShippingMethodLoading}
-                                onSubmit={onSubmit}
-                                step={step}
-                                updateAddress={updateAddress}
-                            />
-                        </LoadingOverlay>
-                    </LoadingOverlay>
-                </div>
+        return <>
+            <AddressFormSkeleton isLoading={isStripeLoading}/>
+            <div className="checkout-form" style={{display: isStripeAutoStep || isStripeLoading ? 'none' : undefined}}>
+                <ShippingHeader
+                    isGuest={isGuest}
+                    isMultiShippingMode={isMultiShippingMode}
+                    onMultiShippingChange={onMultiShippingChange}
+                    shouldShowMultiShipping={shouldShowMultiShipping}
+                />
+                <StripeShippingForm
+                    {...shippingFormProps}
+                    deinitialize={deinitialize}
+                    initialize={initialize}
+                    isBillingSameAsShipping={isBillingSameAsShipping}
+                    isLoading={isLoading}
+                    isMultiShippingMode={isMultiShippingMode}
+                    isStripeAutoStep={this.handleIsAutoStep}
+                    isStripeLoading={this.stripeLoadedCallback}
+                    isShippingMethodLoading={isShippingMethodLoading}
+                    onSubmit={onSubmit}
+                    step={step}
+                    updateAddress={updateAddress}
+                />
             </div>
+        </>;
     }
 
     private stripeLoadedCallback: () => void = () => {

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
@@ -77,7 +77,7 @@ class StripeShipping extends Component<StripeShippingProps, StripeShippingState>
         } = this.state;
 
         return <>
-            <AddressFormSkeleton isLoading={isStripeLoading}/>
+            <AddressFormSkeleton isLoading={isStripeAutoStep || isStripeLoading}/>
             <div className="checkout-form" style={{display: isStripeAutoStep || isStripeLoading ? 'none' : undefined}}>
                 <ShippingHeader
                     isGuest={isGuest}


### PR DESCRIPTION
## What? [STRIPE-280](https://bigcommercecloud.atlassian.net/browse/STRIPE-280)
 The spinner is to be replaced by addressFormSkeleton in order to get the same UX

## Why?
The Checkout team introduced new CSS loading skeletons to the checkout, replacing the loading spinners so that the checkout feels faster and more responsive.

## Testing / Proof
**Customer**
<img width="713" alt="image" src="https://user-images.githubusercontent.com/42154828/217656993-f302d43c-20e8-41e1-aa23-4f991e324a6c.png">
**Shipping**
<img width="849" alt="image" src="https://user-images.githubusercontent.com/42154828/215225006-f8ac5736-ff32-4d8f-b945-76f0bb0aa8d4.png">
Demo https://drive.google.com/file/d/16S0D8f_iRUExQcSebj3bSViJhN5S56JN/view?usp=sharing
Coverage: [Customer](https://output.circle-artifacts.com/output/job/1a3e45d6-2a4e-4dcd-ac74-d892e6aff652/artifacts/0/coverage/packages/core/app/customer/StripeGuestForm.tsx.html) [Shipping](https://output.circle-artifacts.com/output/job/1a3e45d6-2a4e-4dcd-ac74-d892e6aff652/artifacts/0/coverage/packages/core/app/shipping/stripeUPE/StripeShipping.tsx.html)
@bigcommerce/checkout @bigcommerce/apex-integrations 


[STRIPE-280]: https://bigcommercecloud.atlassian.net/browse/STRIPE-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ