### PR TITLE
chore(payment): PAYMENTS-000 bump checkout-sdk version from 1.331.0 to 1.332.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,21 +1156,21 @@
       },
       "dependencies": {
         "@jest/transform": {
-          "version": "29.4.0",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.0.tgz",
-          "integrity": "sha512-hDjw3jz4GnvbyLMgcFpC9/34QcUhVIzJkBqz7o+3AhgfhGRzGuQppuLf5r/q7lDAAyJ6jzL+SFG7JGsScHOcLQ==",
+          "version": "29.4.1",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.1.tgz",
+          "integrity": "sha512-5w6YJrVAtiAgr0phzKjYd83UPbCXsBRTeYI4BXokv9Er9CcrH9hfXL/crCvP2d2nGOcovPUnlYiLPFLZrkG5Hg==",
           "requires": {
             "@babel/core": "^7.11.6",
-            "@jest/types": "^29.4.0",
+            "@jest/types": "^29.4.1",
             "@jridgewell/trace-mapping": "^0.3.15",
             "babel-plugin-istanbul": "^6.1.1",
             "chalk": "^4.0.0",
             "convert-source-map": "^2.0.0",
             "fast-json-stable-stringify": "^2.1.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.4.0",
+            "jest-haste-map": "^29.4.1",
             "jest-regex-util": "^29.2.0",
-            "jest-util": "^29.4.0",
+            "jest-util": "^29.4.1",
             "micromatch": "^4.0.4",
             "pirates": "^4.0.4",
             "slash": "^3.0.0",
@@ -1178,9 +1178,9 @@
           }
         },
         "@jest/types": {
-          "version": "29.4.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.0.tgz",
-          "integrity": "sha512-1S2Dt5uQp7R0bGY/L2BpuwCSji7v12kY3o8zqwlkbYBmOY956SKk+zOWqmfhHSINegiAVqOXydAYuWpzX6TYsQ==",
+          "version": "29.4.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
+          "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
           "requires": {
             "@jest/schemas": "^29.4.0",
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1200,19 +1200,19 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.20",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
-          "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
+          "version": "17.0.21",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.21.tgz",
+          "integrity": "sha512-kQxgIw2qr3/au36DPzK4Kzl5fpB/SehrD7TUBdWQlOLUkgBMhOBQzz1R9Kuukng9ukWxD3lewSMUZWCwNcmRHg==",
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
         "babel-jest": {
-          "version": "29.4.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.0.tgz",
-          "integrity": "sha512-M61cGPg4JBashDvIzKoIV/y95mSF6x3ome7CMEaszUTHD4uo6dtC6Nln+fvRTspYNtwy8lDHl5lmoTBSNY/a+g==",
+          "version": "29.4.1",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.1.tgz",
+          "integrity": "sha512-xBZa/pLSsF/1sNpkgsiT3CmY7zV1kAsZ9OxxtrFqYucnOuRftXAfcJqcDVyOPeN4lttWTwhLdu0T9f8uvoPEUg==",
           "requires": {
-            "@jest/transform": "^29.4.0",
+            "@jest/transform": "^29.4.1",
             "@types/babel__core": "^7.1.14",
             "babel-plugin-istanbul": "^6.1.1",
             "babel-preset-jest": "^29.4.0",
@@ -1252,11 +1252,11 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-haste-map": {
-          "version": "29.4.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.0.tgz",
-          "integrity": "sha512-m/pIEfoK0HoJz4c9bkgS5F9CXN2AM22eaSmUcmqTpadRlNVBOJE2CwkgaUzbrNn5MuAqTV1IPVYwWwjHNnk8eA==",
+          "version": "29.4.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.1.tgz",
+          "integrity": "sha512-imTjcgfVVTvg02khXL11NNLTx9ZaofbAWhilrMg/G8dIkp+HYCswhxf0xxJwBkfhWb3e8dwbjuWburvxmcr58w==",
           "requires": {
-            "@jest/types": "^29.4.0",
+            "@jest/types": "^29.4.1",
             "@types/graceful-fs": "^4.1.3",
             "@types/node": "*",
             "anymatch": "^3.0.3",
@@ -1264,8 +1264,8 @@
             "fsevents": "^2.3.2",
             "graceful-fs": "^4.2.9",
             "jest-regex-util": "^29.2.0",
-            "jest-util": "^29.4.0",
-            "jest-worker": "^29.4.0",
+            "jest-util": "^29.4.1",
+            "jest-worker": "^29.4.1",
             "micromatch": "^4.0.4",
             "walker": "^1.0.8"
           }
@@ -1276,11 +1276,11 @@
           "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA=="
         },
         "jest-util": {
-          "version": "29.4.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.0.tgz",
-          "integrity": "sha512-lCCwlze7UEV8TpR9ArS8w0cTbcMry5tlBkg7QSc5og5kNyV59dnY2aKHu5fY2k5aDJMQpCUGpvL2w6ZU44lveA==",
+          "version": "29.4.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
+          "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
           "requires": {
-            "@jest/types": "^29.4.0",
+            "@jest/types": "^29.4.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
@@ -1289,12 +1289,12 @@
           }
         },
         "jest-worker": {
-          "version": "29.4.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.0.tgz",
-          "integrity": "sha512-dICMQ+Q4W0QVMsaQzWlA1FVQhKNz7QcDCOGtbk1GCAd0Lai+wdkQvfmQwL4MjGumineh1xz+6M5oMj3rfWS02A==",
+          "version": "29.4.1",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.1.tgz",
+          "integrity": "sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==",
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.4.0",
+            "jest-util": "^29.4.1",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           }
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.331.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.331.0.tgz",
-      "integrity": "sha512-/VwtFHvDIkyuh33s2I6GYEHl4vEuWI+zh2cZ8z4Wuvyvsc2Xk+v92qTTEILKeI2O8aOIQBtUa6VOrUoRo7G/eQ==",
+      "version": "1.332.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.332.2.tgz",
+      "integrity": "sha512-gWb/qTNmFLAo9Xo7wUq1i7E+X/6M9u037FEqiZq4vTFGXdD6aG8HvLB6KNigI41kudR3Sl9BDY4Pfk9cQzJr7w==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.331.0",
+    "@bigcommerce/checkout-sdk": "^1.332.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?
To release several checkout-sdk prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1802
https://github.com/bigcommerce/checkout-sdk-js/pull/1800
https://github.com/bigcommerce/checkout-sdk-js/pull/1798
https://github.com/bigcommerce/checkout-sdk-js/pull/1793


## Testing / Proof
Unit tests

@bigcommerce/checkout
