### PR TITLE
chore(common): CHECKOUT-6271 Make changes to circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,26 +21,51 @@ orbs:
   node: bigcommerce/internal-node@volatile
 
 jobs:
-  test:
+  test-packages:
     <<: *node_executor
     steps:
       - ci/pre-setup
       - node/npm-install
       - run:
-          name: "Run unit tests"
-          command: npm run test -- --coverage --runInBand
+          name: "Run unit tests for packages"
+          command: npm run test:others
+  test-core:
+    <<: *node_executor
+    parallelism: 2
+    resource_class: small
+    steps:
+      - ci/pre-setup
+      - node/npm-install
+      - run: mkdir ~/junit
+      - run:
+          name: "Run unit tests for core package"
+          command: |
+            TEST=$(circleci tests glob "packages/core/**/*.spec.ts" | circleci tests split --split-by=timings)
+            npx nx run core:generate
+            npm test:core $TEST -- --runInBand
+      - run:
+          command: cp junit.xml ~/junit/
+          when: always
+      - store_test_results:
+          path: ~/junit
       - store_artifacts:
-          path: coverage
-          destination: coverage
+          path: ~/junit
+
+  lint:
+    <<: *node_executor
+    resource_class: medium+
+    steps:
+      - ci/pre-setup
+      - node/npm-install
+      - run:
+          name: "Run lint"
+          command: npm run lint
 
   build:
     <<: *node_executor
     steps:
       - ci/pre-setup
       - node/npm-install
-      - run:
-          name: "Run linter"
-          command: npm run lint
       - run:
           name: "Test build"
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - run:
           name: "Run unit tests for packages"
           command: npm run test:others
+  
   test-core:
     <<: *node_executor
     parallelism: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,10 +152,16 @@ workflows:
 
   pull_request:
     jobs:
-      - test:
+      - test-packages:
+          filters:
+            <<: *pull_request_filter
+      - test-core:
           filters:
             <<: *pull_request_filter
       - build:
+          filters:
+            <<: *pull_request_filter
+      - lint:
           filters:
             <<: *pull_request_filter
       - e2e:
@@ -167,7 +173,13 @@ workflows:
 
   release:
     jobs:
-      - test:
+      - test-core:
+          filters:
+            <<: *release_filter
+      - test-packages:
+          filters:
+            <<: *release_filter
+      - lint:
           filters:
             <<: *release_filter
       - build:
@@ -181,7 +193,9 @@ workflows:
             <<: *release_filter
           type: approval
           requires:
-            - test
+            - test-core
+            - test-packages
+            - lint
             - build
             - e2e
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           command: |
             TEST=$(circleci tests glob "packages/core/**/*.spec.ts" | circleci tests split --split-by=timings)
             npx nx run core:generate
-            npm test:core $TEST -- --runInBand
+            npm run test:core $TEST -- --runInBand
       - run:
           command: cp junit.xml ~/junit/
           when: always

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -12,6 +12,7 @@ module.exports = {
             statements: 80,
         },
     },
+    reporters: ['default', 'jest-junit'],
     transform: {
         '^.+\\.(ts|tsx)?$': 'ts-jest',
         '\\.(gif|png|jpe?g|svg)$': '../../scripts/jest/file-transformer',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13854,6 +13854,32 @@
         }
       }
     },
+    "jest-junit": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-15.0.0.tgz",
+      "integrity": "sha512-Z5sVX0Ag3HZdMUnD5DFlG+1gciIFSy7yIVPhOdGUi8YJaI9iLvvBb530gtQL2CHmv0JJeiwRZenr0VrSR7frvg==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz",
@@ -22424,6 +22450,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w==",
+      "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,15 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:alpha": "npm run lint && npm run test -- --coverage && npm run build -- --env prerelease=prerelease && npm run release:version",
     "release:version": "git add dist && standard-version -a",
+    "test:core": "jest --config packages/core/jest.config.js",
+    "test:others": "npx nx run-many --all --target=test --exclude core --parallel=5 -- --runInBand",
     "generate": "npx nx run core:generate",
     "lint": "npx nx run-many --target=lint --all",
     "test": "npx nx run-many --target=test --all",
     "test:watch": "npx nx run-many --target=test --all --watch"
+  },
+  "jest-junit": {
+    "addFileAttribute": "true"
   },
   "repository": {
     "type": "git",
@@ -131,6 +136,7 @@
     "http-server": "^14.1.1",
     "image-webpack-loader": "^8.1.0",
     "jest": "^25.5.4",
+    "jest-junit": "^15.0.0",
     "mini-css-extract-plugin": "^2.6.0",
     "node-sass": "^4.14.1",
     "nx": "^13.10.3",

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -40,7 +40,8 @@
       "outputs": ["coverage/packages/core"],
       "options": {
         "jestConfig": "packages/core/jest.config.js",
-        "passWithNoTests": false
+        "passWithNoTests": false,
+        "runInBand": true
       },
       "dependsOn": [
         {


### PR DESCRIPTION
## What?
- Move lint to a separate process
- Remove test artifact uploads
- Split test runs into two jobs one for core package and one for the rest of the packages
- Split test runs of core package into two parallel streams

## Why?
At the moment circlet CI runs take around 10 mins approximately, we can optimise this and have a quicker turn around in our CI steps.

## Testing / Proof
- Circle

Updated CI times for PRs

<img width="1257" alt="Screen Shot 2023-02-01 at 5 10 16 pm" src="https://user-images.githubusercontent.com/7134802/215965269-14517147-2838-4b04-b8fb-5d9790eb7b70.png">


@bigcommerce/checkout 
