### PR TITLE
chore(payment): STRIPE-0 checkout-sdk bump version 1.355.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1200,9 +1200,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.21",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.21.tgz",
-          "integrity": "sha512-kQxgIw2qr3/au36DPzK4Kzl5fpB/SehrD7TUBdWQlOLUkgBMhOBQzz1R9Kuukng9ukWxD3lewSMUZWCwNcmRHg==",
+          "version": "17.0.22",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
+          "integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.332.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.332.2.tgz",
-      "integrity": "sha512-gWb/qTNmFLAo9Xo7wUq1i7E+X/6M9u037FEqiZq4vTFGXdD6aG8HvLB6KNigI41kudR3Sl9BDY4Pfk9cQzJr7w==",
+      "version": "1.335.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.335.0.tgz",
+      "integrity": "sha512-DfJ1+yB3VLTd7xYP4MYj6h+nRnwP1eRkn8XyrJU9DXKw9Z4e5TPy2e3lNgi57uuc080sx0DujVUbtKECKZQDIg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.332.2",
+    "@bigcommerce/checkout-sdk": "^1.335.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump for checkout-sdk version 1.355.0

## Why?
To create a bump


@bigcommerce/checkout
