### PR TITLE
chore(common): CHECKOUT-000 Remove small resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
   test-core:
     <<: *node_executor
     parallelism: 2
-    resource_class: small
     steps:
       - ci/pre-setup
       - node/npm-install


### PR DESCRIPTION
## What?
- Remove small as a resource for test core jobs

## Why?
Need to remove small as resource since fresh node install fails most of the time, causing flakiness to the pipeline.

## Testing / Proof
- circle

@bigcommerce/checkout
