### PR TITLE
chore(payment): STRIPE-0 Bump checkout-SDK 1.335.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.335.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.335.0.tgz",
-      "integrity": "sha512-DfJ1+yB3VLTd7xYP4MYj6h+nRnwP1eRkn8XyrJU9DXKw9Z4e5TPy2e3lNgi57uuc080sx0DujVUbtKECKZQDIg==",
+      "version": "1.335.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.335.2.tgz",
+      "integrity": "sha512-Jt7KdhcVqvkmUa9Mt7bf/GAVfvg0GPZy2DalNQ581r2oDnByph4a/OZY4TIXPLYlNlOkNO8FpFWEUYhREsndFg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.335.0",
+    "@bigcommerce/checkout-sdk": "^1.335.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk `v1.335.2.`

## Why?
Release lastest SDK change(s):

https://github.com/bigcommerce/checkout-sdk-js/pull/1779

## Testing / Proof

CI checks.
