### PR TITLE
feat(checkout): CHECKOUT-7255 Remove checkout step numbers

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -292,7 +292,7 @@ class Checkout extends Component<
         }
 
         return (
-            <div className={classNames({ 'is-embedded': isEmbedded(), 'remove_checkout_step_numbers': isHidingStepNumbers })}>
+            <div className={classNames({ 'is-embedded': isEmbedded(), 'remove-checkout-step-numbers': isHidingStepNumbers })}>
                 <div className="layout optimizedCheckout-contentPrimary">
                     {this.renderContent()}
                 </div>

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -126,6 +126,7 @@ export interface CheckoutState {
     isRedirecting: boolean;
     hasSelectedShippingOptions: boolean;
     isBuyNowCartEnabled: boolean;
+    isHidingStepNumbers: boolean;
     isSubscribed: boolean;
 }
 
@@ -162,6 +163,7 @@ class Checkout extends Component<
         isMultiShippingMode: false,
         hasSelectedShippingOptions: false,
         isBuyNowCartEnabled: false,
+        isHidingStepNumbers: true,
         isSubscribed: false,
     };
 
@@ -238,6 +240,9 @@ class Checkout extends Component<
             const buyNowCartFlag =
                 data.getConfig()?.checkoutSettings.features['CHECKOUT-3190.enable_buy_now_cart'] ??
                 false;
+            const removeStepNumbersFlag =
+              data.getConfig()?.checkoutSettings.features['CHECKOUT-7255.remove_checkout_step_numbers'] ??
+              false;
             const defaultNewsletterSignupOption =
                 data.getConfig()?.shopperConfig.defaultNewsletterSignup ??
                 false;
@@ -250,6 +255,7 @@ class Checkout extends Component<
             this.setState({
                 isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled,
                 isBuyNowCartEnabled: buyNowCartFlag,
+                isHidingStepNumbers: removeStepNumbersFlag,
                 isSubscribed: defaultNewsletterSignupOption,
             });
 
@@ -268,7 +274,7 @@ class Checkout extends Component<
     }
 
     render(): ReactNode {
-        const { error } = this.state;
+        const { error, isHidingStepNumbers } = this.state;
         let errorModal = null;
 
         if (error) {
@@ -286,7 +292,7 @@ class Checkout extends Component<
         }
 
         return (
-            <div className={classNames({ 'is-embedded': isEmbedded() })}>
+            <div className={classNames({ 'is-embedded': isEmbedded(), 'remove_checkout_step_numbers': isHidingStepNumbers })}>
                 <div className="layout optimizedCheckout-contentPrimary">
                     {this.renderContent()}
                 </div>

--- a/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -138,6 +138,23 @@
     min-width: 9rem;
 }
 
+.remove_checkout_step_numbers {
+    li.checkout-step {
+        div.stepHeader-counter.icon {
+            display: none;
+        }
+
+        h2.stepHeader-title {
+            margin-left: 0;
+        }
+
+        .checkout-form,
+        div.checklist-skeleton {
+            margin-left: 0;
+        }
+    }
+}
+
 .stepHeader-body {
     @include textTruncateMultiline;
 

--- a/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -144,12 +144,10 @@
             display: none;
         }
 
-        h2.stepHeader-title {
-            margin-left: 0;
-        }
-
         .checkout-form,
-        div.checklist-skeleton {
+        div.stepHeader-body,
+        div.checklist-skeleton,
+        h2.stepHeader-title {
             margin-left: 0;
         }
     }

--- a/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -138,7 +138,7 @@
     min-width: 9rem;
 }
 
-.remove_checkout_step_numbers {
+.remove-checkout-step-numbers {
     li.checkout-step {
         div.stepHeader-counter.icon {
             display: none;


### PR DESCRIPTION
## What?
Removing all checkout step numbers.
- Remove the step counter of each unfinished checkout step.
- Remove the circle, check mark of each finished checkout step.
- Change the step header’s left padding to zero.
- Putting all changes behind an experiment so that we can roll out changes incrementally.

## Why?
Once we introduce wallet buttons on the top of the checkout page, the step numbers are no longer accurate progress indicators.

## Testing / Proof

<img width="500" alt="customer" src="https://user-images.githubusercontent.com/88361607/216851478-4a2a6977-94e6-4844-abcc-1dbe30c905a4.png">

<img width="500" alt="shipping" src="https://user-images.githubusercontent.com/88361607/216851487-c195c09b-db1f-45dd-9925-b65bdb68d2b5.png">

<img width="500" alt="payment" src="https://user-images.githubusercontent.com/88361607/216851497-7a3039ec-183a-49b6-87a6-5a1219a24cfa.png">

https://user-images.githubusercontent.com/88361607/216851440-9d7db6c9-6f80-4427-8cd9-02e18ff33442.mov




@bigcommerce/checkout
