### PR TITLE
chore(payment): PAYPAL-000 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.335.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.335.0.tgz",
-      "integrity": "sha512-DfJ1+yB3VLTd7xYP4MYj6h+nRnwP1eRkn8XyrJU9DXKw9Z4e5TPy2e3lNgi57uuc080sx0DujVUbtKECKZQDIg==",
+      "version": "1.336.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.336.0.tgz",
+      "integrity": "sha512-jfqillepPPe8VLVkiyhLt2dd0urmUJ7zv5C7RaTUECtvOtuWCkUMpoipCPzrXGJS/k2/C8Lsstyutue4bjJezg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.335.0",
+    "@bigcommerce/checkout-sdk": "^1.336.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk dependency version

## Why?
To keep project up to date.

Here is a list of updates related to new checkout sdk version:
https://github.com/bigcommerce/checkout-sdk-js/pull/1817
https://github.com/bigcommerce/checkout-sdk-js/pull/1813
https://github.com/bigcommerce/checkout-sdk-js/pull/1815
https://github.com/bigcommerce/checkout-sdk-js/pull/1801
https://github.com/bigcommerce/checkout-sdk-js/pull/1820
https://github.com/bigcommerce/checkout-sdk-js/pull/1816
https://github.com/bigcommerce/checkout-sdk-js/pull/1779

## Testing / Proof
Unit tests
