### PR TITLE
chore(payment): PAYPAL-1959 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.336.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.336.0.tgz",
-      "integrity": "sha512-jfqillepPPe8VLVkiyhLt2dd0urmUJ7zv5C7RaTUECtvOtuWCkUMpoipCPzrXGJS/k2/C8Lsstyutue4bjJezg==",
+      "version": "1.337.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.337.0.tgz",
+      "integrity": "sha512-XCy8uAyoLhZF+fs9+26ldkOMBSeLwBSZnYY3t1BN/AMB7xbSFVzJbpurf1uuS5LTmGVTjdeNjLz/ZsbI2eVFlg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.336.0",
+    "@bigcommerce/checkout-sdk": "^1.337.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
To keep project up to date with last checkout-sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/1823
https://github.com/bigcommerce/checkout-sdk-js/pull/1822
https://github.com/bigcommerce/checkout-sdk-js/pull/1821

## Testing / Proof
Unit tests
