### PR TITLE
feat(payment): PAYPAL-1838 Create paypalcommercevenmo customer button strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.343.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.343.0.tgz",
-      "integrity": "sha512-zT6/71C0xY2aCiTmwzYnd2T5POjnoS+tHtUzaFqHOpR7v3MRz6IAA4SO3fzGGdP1r9j8O4b4VZ//TeLSQa/TcQ==",
+      "version": "1.344.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.344.0.tgz",
+      "integrity": "sha512-a6TeioCIlAWrliCEfi7dGys5sU212r3KqRUd0xXi967CKVtAiR/vOPft7cv87iLpmvck92r1Y89RJb5he1DXyQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.343.0",
+    "@bigcommerce/checkout-sdk": "^1.344.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -19,6 +19,7 @@ export const SUPPORTED_METHODS: string[] = [
     'chasepay',
     'masterpass',
     'paypalcommerce',
+    'paypalcommercevenmo',
     'googlepayadyenv2',
     'googlepayadyenv3',
     'googlepayauthorizenet',


### PR DESCRIPTION
## What?
Add PayPal Commerce Venmo customer strategy which will be used as button on customer step

## Why?
PayPal Commerce Venmo button was added to make ability for shoppers to use venmo payment method on first step and simplify checkout process.
PR for checkout-sdk-js: [https://github.com/bigcommerce/checkout-sdk-js/pull/1824](https://github.com/bigcommerce/checkout-sdk-js/pull/1824)

## Testing / Proof

https://user-images.githubusercontent.com/9430298/217316025-da535674-8ab6-4330-a387-244731bf6e11.mov

<img width="359" alt="Screenshot 2023-02-07 at 19 00 49" src="https://user-images.githubusercontent.com/9430298/217316079-484381d7-ac8f-4b5a-9ae1-425c6d166d78.png">


@bigcommerce/checkout
