### PR TITLE
feat(payment): PAYPAL-1837 Create paypalcommercecredit customer button strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.344.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.344.0.tgz",
-      "integrity": "sha512-a6TeioCIlAWrliCEfi7dGys5sU212r3KqRUd0xXi967CKVtAiR/vOPft7cv87iLpmvck92r1Y89RJb5he1DXyQ==",
+      "version": "1.345.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.345.0.tgz",
+      "integrity": "sha512-73RSV6atw5BpjBgWUpddrjqb19xegD4hXJv1swoKHWLhZzM7xPCRhPvu446XCk10RSIaZfIBA66MaVXP1CoZAg==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.344.0",
+    "@bigcommerce/checkout-sdk": "^1.345.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -20,6 +20,7 @@ export const SUPPORTED_METHODS: string[] = [
     'masterpass',
     'paypalcommerce',
     'paypalcommercevenmo',
+    'paypalcommercecredit',
     'googlepayadyenv2',
     'googlepayadyenv3',
     'googlepayauthorizenet',
@@ -110,7 +111,7 @@ const CheckoutButtonList: FunctionComponent<CheckoutButtonListProps> = ({
                         );
                     }
 
-                    if (methodId === 'paypalcommerce') {
+                    if (methodId === 'paypalcommerce' || methodId === 'paypalcommercecredit') {
                         return (
                             <PayPalCommerceButton
                                 containerId={`${methodId}CheckoutButton`}

--- a/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.tsx
+++ b/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.tsx
@@ -6,6 +6,7 @@ import { LocaleContext } from '../../locale';
 import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
 
 const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = ({
+    methodId,
     initialize,
     onError,
     ...rest
@@ -15,7 +16,7 @@ const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = ({
         (options: CustomerInitializeOptions) =>
             initialize({
                 ...options,
-                paypalcommerce: {
+                [methodId]: {
                     container: rest.containerId,
                     onError,
                     onComplete: navigateToOrderConfirmation,
@@ -24,7 +25,7 @@ const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = ({
         [initialize, localeContext, onError, rest.containerId],
     );
 
-    return <CheckoutButton initialize={initializeOptions} {...rest} />;
+    return <CheckoutButton initialize={initializeOptions} methodId={methodId} {...rest} />;
 };
 
 export default PayPalCommerceButton;


### PR DESCRIPTION
## What?
Add PayPal Commerce Credit (PayLater) customer strategy which will be used as button on customer step

## Why?
PayPal Commerce Credit (PayLater) button was added to make ability for shoppers to use PayLater payment method on first step and simplify checkout process.
PR for checkout-sdk-js: [https://github.com/bigcommerce/checkout-sdk-js/pull/1829](https://github.com/bigcommerce/checkout-sdk-js/pull/1829)
PR for BCapp: [https://github.com/bigcommerce/bigcommerce/pull/51145](https://github.com/bigcommerce/bigcommerce/pull/51145)

## Testing / Proof
<img width="1161" alt="Screenshot 2023-02-08 at 21 02 41" src="https://user-images.githubusercontent.com/9430298/217628955-c10e4e2a-c11f-4e5b-817c-0c581a32df0c.png">
<img width="412" alt="Screenshot 2023-02-08 at 21 10 41" src="https://user-images.githubusercontent.com/9430298/217630058-6f972280-728c-4352-acfc-1e6b6bf7de25.png">


@bigcommerce/checkout
