### PR TITLE
fix(checkout): Re-initialize customer step payment buttons if cart balance has changed

### DIFF
--- a/packages/core/src/app/customer/CheckoutButton.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButton.spec.tsx
@@ -1,16 +1,45 @@
+import {
+    Checkout,
+    CheckoutService,
+    createCheckoutService,
+} from '@bigcommerce/checkout-sdk';
 import { mount } from 'enzyme';
 import { noop } from 'lodash';
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 
-import CheckoutButton from './CheckoutButton';
+
+
+import { CheckoutProvider } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
+
+import CheckoutButton, { CheckoutButtonProps } from './CheckoutButton';
 
 describe('CheckoutButton', () => {
+    
+    let CheckoutButtonTest: FunctionComponent<CheckoutButtonProps>;
+    let checkout: Checkout;
+    let checkoutService: CheckoutService;
+
+    beforeEach(() => {
+        checkout = getCheckout();
+        checkoutService = createCheckoutService();
+
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(checkout);
+
+        CheckoutButtonTest = (props: CheckoutButtonProps) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <CheckoutButton {...props}/>
+            </CheckoutProvider>
+        );
+    });
+
     it('initializes button when component is mounted', () => {
         const initialize = jest.fn();
         const onError = jest.fn();
 
         mount(
-            <CheckoutButton
+            <CheckoutButtonTest
                 containerId="foobarContainer"
                 deinitialize={noop}
                 initialize={initialize}
@@ -28,12 +57,52 @@ describe('CheckoutButton', () => {
         });
     });
 
+    it('re-renders button when cart balance updated', () => {
+        const initialize = jest.fn();
+        const deinitialize = jest.fn();
+
+        const component = mount(
+            <CheckoutButtonTest
+                containerId="foobarContainer"
+                deinitialize={deinitialize}
+                initialize={initialize}
+                methodId="foobar"
+                onError={noop}
+            />,
+        );
+
+        component.setProps({ outstandingBalance: checkout.outstandingBalance - 20 });
+
+        expect(initialize).toHaveBeenCalledTimes(2);
+        expect(deinitialize).toHaveBeenCalledTimes(1);
+    });
+
+    it("doesn't re-render button when cart balance updated with same value", () => {
+        const initialize = jest.fn();
+        const deinitialize = jest.fn();
+
+        const component = mount(
+            <CheckoutButtonTest
+                containerId="foobarContainer"
+                deinitialize={deinitialize}
+                initialize={initialize}
+                methodId="foobar"
+                onError={noop}
+            />,
+        );
+
+        component.setProps({ outstandingBalance: checkout.outstandingBalance });
+
+        expect(initialize).toHaveBeenCalledTimes(1);
+        expect(deinitialize).toHaveBeenCalledTimes(0);
+    });
+
     it('deinitializes button when component unmounts', () => {
         const deinitialize = jest.fn();
         const onError = jest.fn();
 
         const component = mount(
-            <CheckoutButton
+            <CheckoutButtonTest
                 containerId="foobarContainer"
                 deinitialize={deinitialize}
                 initialize={noop}

--- a/packages/core/src/app/customer/CheckoutButton.tsx
+++ b/packages/core/src/app/customer/CheckoutButton.tsx
@@ -1,15 +1,18 @@
 import { CustomerInitializeOptions, CustomerRequestOptions } from '@bigcommerce/checkout-sdk';
 import React, { PureComponent } from 'react';
 
+import { CheckoutContextProps, withCheckout } from '../checkout';
+
 export interface CheckoutButtonProps {
     containerId: string;
     methodId: string;
+    outstandingBalance?: number;
     deinitialize(options: CustomerRequestOptions): void;
     initialize(options: CustomerInitializeOptions): void;
     onError?(error: Error): void;
 }
 
-export default class CheckoutButton extends PureComponent<CheckoutButtonProps> {
+class CheckoutButton extends PureComponent<CheckoutButtonProps> {
     componentDidMount() {
         const { containerId, initialize, methodId, onError } = this.props;
 
@@ -21,6 +24,21 @@ export default class CheckoutButton extends PureComponent<CheckoutButtonProps> {
             },
         });
     }
+
+    componentDidUpdate(prevProps: CheckoutButtonProps) {
+        const { outstandingBalance, containerId, deinitialize, initialize, methodId, onError } = this.props;
+
+        if (prevProps.outstandingBalance !== outstandingBalance) {
+            deinitialize({ methodId });
+            initialize({
+                methodId,
+                [methodId]: {
+                    container: containerId,
+                    onError,
+                },
+            });
+        }
+      }
 
     componentWillUnmount() {
         const { deinitialize, methodId } = this.props;
@@ -34,3 +52,12 @@ export default class CheckoutButton extends PureComponent<CheckoutButtonProps> {
         return <div id={containerId} />;
     }
 }
+
+export default withCheckout(({
+    checkoutState,
+}: CheckoutContextProps) => {
+    const { data: { getCheckout } } = checkoutState;
+    const { outstandingBalance } = getCheckout() || {};
+
+    return { outstandingBalance };
+})(CheckoutButton);


### PR DESCRIPTION
## What?
Re-initialize customer step payment buttons if cart balance has changed.

## Why?
We've found that Google Pay does not include coupon discount at the 'Customer' step of checkout.
I decided to re-initialize customer step payment buttons if the cart balance has changed.


## Testing / Proof
**Before fix:**

https://user-images.githubusercontent.com/79574476/218151786-bacaa63a-82f6-4c4e-b267-d525a6a6be28.mov

**After fix:**

https://user-images.githubusercontent.com/79574476/218151769-9ca95fb7-be10-4c10-96a9-781739f1e677.mov





@bigcommerce/checkout
