### PR TITLE
feat(payment): PAYMENTS-8493 check untrustedCardVerificationMode befo…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.350.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.350.1.tgz",
-      "integrity": "sha512-SKwhcGa8WAavGOSb5iT2EeTTgu+Fsl5zUJ1LbXf9e2kLi4HAl6Qe3GbzyNtw9DHiuHBAMvHiJk51wixXci5v5Q==",
+      "version": "1.351.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.351.0.tgz",
+      "integrity": "sha512-FeBZozQK875DjrbUa2aKzDEDD+HM/iQBgKI69CjPQDx/gFiuUKGp/Krs6rPXjZO/n46LYoJi2gSeSpee6JyspA==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.350.1",
+    "@bigcommerce/checkout-sdk": "^1.351.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
+++ b/packages/core/src/app/payment/storedInstrument/CardInstrumentFieldset.tsx
@@ -19,6 +19,11 @@ export interface CardInstrumentFieldsetProps {
     onUseNewInstrument(): void;
 }
 
+export enum UntrustedShippingCardVerificationType {
+    CVV = 'cvv',
+    PAN = 'pan'
+}
+
 const CardInstrumentFieldset: FunctionComponent<CardInstrumentFieldsetProps> = ({
     instruments,
     onDeleteInstrument,

--- a/packages/core/src/app/payment/storedInstrument/instruments.mock.ts
+++ b/packages/core/src/app/payment/storedInstrument/instruments.mock.ts
@@ -4,6 +4,7 @@ import {
     CardInstrument,
     PaymentInstrument,
 } from '@bigcommerce/checkout-sdk';
+import { UntrustedShippingCardVerificationType } from './CardInstrumentFieldset';
 
 export function getInstruments(): PaymentInstrument[] {
     return [
@@ -19,6 +20,7 @@ export function getInstruments(): PaymentInstrument[] {
             defaultInstrument: true,
             method: 'card',
             type: 'card',
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
         },
         {
             bigpayToken: '111',
@@ -32,6 +34,7 @@ export function getInstruments(): PaymentInstrument[] {
             defaultInstrument: false,
             method: 'card',
             type: 'card',
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
         },
         {
             bigpayToken: '31415',
@@ -91,6 +94,7 @@ export function getCardInstrument(): CardInstrument {
         defaultInstrument: true,
         method: 'card',
         type: 'card',
+        untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
     };
 }
 

--- a/packages/core/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.ts
@@ -1,5 +1,7 @@
 import { LineItemMap, PaymentInstrument, PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+import { UntrustedShippingCardVerificationType } from './CardInstrumentFieldset';
+
 export interface IsInstrumentCardCodeRequiredState {
     instrument: PaymentInstrument;
     lineItems: LineItemMap;
@@ -19,6 +21,11 @@ export default function isInstrumentCardCodeRequired({
     // If the shipping address is trusted, show CVV field based on the merchant's configuration
     if (instrument.trustedShippingAddress) {
         return !!paymentMethod.config.isVaultingCvvEnabled;
+    }
+
+    // If the shipping address is untrusted, card verficiation mode has set with cvv, card code is required
+    if ('untrustedShippingCardVerificationMode' in instrument && instrument.untrustedShippingCardVerificationMode === UntrustedShippingCardVerificationType.CVV) {
+        return true;
     }
 
     // Otherwise, if the shipping address is untrusted, show CVV field if the

--- a/packages/core/src/app/payment/storedInstrument/isInstrumentCardNumberRequired.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentCardNumberRequired.ts
@@ -1,4 +1,5 @@
 import { Instrument, LineItemMap } from '@bigcommerce/checkout-sdk';
+import { UntrustedShippingCardVerificationType } from './CardInstrumentFieldset';
 
 export interface IsInstrumentCardNumberRequiredState {
     lineItems: LineItemMap;
@@ -13,5 +14,9 @@ export default function isInstrumentCardNumberRequired({
         return false;
     }
 
-    return !instrument.trustedShippingAddress;
+    if (instrument.trustedShippingAddress) {
+        return false;
+    }  
+    
+    return !(instrument.untrustedShippingCardVerificationMode === UntrustedShippingCardVerificationType.CVV);
 }

--- a/packages/test-utils/src/instruments.mock.ts
+++ b/packages/test-utils/src/instruments.mock.ts
@@ -5,6 +5,11 @@ import {
     PaymentInstrument,
 } from '@bigcommerce/checkout-sdk';
 
+export enum UntrustedShippingCardVerificationType {
+    CVV = 'cvv',
+    PAN = 'pan',
+}
+
 export function getInstruments(): PaymentInstrument[] {
     return [
         {
@@ -19,6 +24,7 @@ export function getInstruments(): PaymentInstrument[] {
             defaultInstrument: true,
             method: 'card',
             type: 'card',
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
         },
         {
             bigpayToken: '111',
@@ -32,6 +38,7 @@ export function getInstruments(): PaymentInstrument[] {
             defaultInstrument: false,
             method: 'card',
             type: 'card',
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
         },
         {
             bigpayToken: '31415',
@@ -91,6 +98,7 @@ export function getCardInstrument(): CardInstrument {
         defaultInstrument: true,
         method: 'card',
         type: 'card',
+        untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
     };
 }
 


### PR DESCRIPTION
## What?
This PR can only be merged when https://github.com/bigcommerce/checkout-js/pull/1195 is merged.

## Why?
For detailed reason and context, please refer to parents' PR 
https://github.com/bigcommerce/checkout-js/pull/1195

## Testing / Proof
Local manual testing 
With untrusted shipping address
- with cvv mode: only cvv shows
- with pan mode: pan with cvv shows

With trusted shipping address, works as expected.

Unit tests

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1835

## Dependency of
none

@bigcommerce/checkout
