### PR TITLE
refactor(checkout): CHECKOUT-7291 Add ApplePay button style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.345.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.345.0.tgz",
-      "integrity": "sha512-73RSV6atw5BpjBgWUpddrjqb19xegD4hXJv1swoKHWLhZzM7xPCRhPvu446XCk10RSIaZfIBA66MaVXP1CoZAg==",
+      "version": "1.345.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.345.1.tgz",
+      "integrity": "sha512-1HL9eJs7Q3CiNnkb0GWybiEQX7JlZPQ2ORJUMUnsMUd5TNsUPtqHABKim2kCaQR9r8cAXkxYlfrZZoJdlgOWOw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",
@@ -1377,9 +1377,9 @@
           }
         },
         "core-js": {
-          "version": "3.27.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
-          "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w=="
+          "version": "3.28.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+          "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.345.0",
+    "@bigcommerce/checkout-sdk": "^1.345.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -16,6 +16,12 @@
         width: remCalc(200px);
     }
 
+    > #applepayCheckoutButton button,
+    > #braintreepaypalcreditCheckoutButton,
+    > #braintreepaypalCheckoutButton {
+        width: 160px;
+    }
+
     > #applepayCheckoutButton button {
         background-color: #000;
         background-image: -webkit-named-image(apple-pay-logo-white);
@@ -24,7 +30,6 @@
         background-size: 100% 60%;
         border-radius: $global-radius;
         height: $wallet-button-height;
-        width: 160px;
     }
 }
 

--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -15,6 +15,17 @@
     > .AmazonPayContainer {
         width: remCalc(200px);
     }
+
+    > #applepayCheckoutButton button {
+        background-color: #000;
+        background-image: -webkit-named-image(apple-pay-logo-white);
+        background-position: 50% 50%;
+        background-repeat: no-repeat;
+        background-size: 100% 60%;
+        border-radius: $global-radius;
+        height: $wallet-button-height;
+        width: 160px;
+    }
 }
 
 .checkoutRemote-button {


### PR DESCRIPTION
## What?
After removing Apple Pay button inline styles from `checkout-sdk`, add those styles to `checkout-js`'s SCSS file.

## Depends on
Will bump SDK version in this PR once the below is merged.
- https://github.com/bigcommerce/checkout-sdk-js/pull/1836

## Why?
`checkout-js` can manage the appearance of an Apple Pay wallet button in the new wallet button container.

## Testing / Proof

<img width="1309" alt="Screenshot 2023-02-13 at 4 22 19 pm" src="https://user-images.githubusercontent.com/88361607/218377980-aecef5bf-5c7c-46bf-ad7a-dfb50061df8e.png">


@bigcommerce/checkout
