### PR TITLE
chore(payment): PAYPAL-1919 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.345.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.345.1.tgz",
-      "integrity": "sha512-1HL9eJs7Q3CiNnkb0GWybiEQX7JlZPQ2ORJUMUnsMUd5TNsUPtqHABKim2kCaQR9r8cAXkxYlfrZZoJdlgOWOw==",
+      "version": "1.348.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.348.0.tgz",
+      "integrity": "sha512-4+uCeauaiLLzLOgCQrR50kWbyrXjq0vOrazMTnfwp4JqMQmb87vm6FrTEBG66nBn73YJ7lasCQNCZ7ef5lFx8g==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.345.1",
+    "@bigcommerce/checkout-sdk": "^1.348.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To keep checkout-sdk-js in checkout-js project up to date

Here are checkout-sdk prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/1840
https://github.com/bigcommerce/checkout-sdk-js/pull/1842
https://github.com/bigcommerce/checkout-sdk-js/pull/1838
https://github.com/bigcommerce/checkout-sdk-js/pull/1681

## Testing / Proof
Unit tests
