### PR TITLE
fix(shipping): STRIPE-202 Split name input into First and Last name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.351.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.351.0.tgz",
-      "integrity": "sha512-FeBZozQK875DjrbUa2aKzDEDD+HM/iQBgKI69CjPQDx/gFiuUKGp/Krs6rPXjZO/n46LYoJi2gSeSpee6JyspA==",
+      "version": "1.358.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.358.1.tgz",
+      "integrity": "sha512-wXm/LpfolZlkXtG96PnnJTSgDdsQLZNOjAWM2Pmn8VVPVaO8lifz9ao+Zj/o5HBoe7YRinG+gYSAgmn3TPKVzQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",
@@ -1377,9 +1377,9 @@
           }
         },
         "core-js": {
-          "version": "3.28.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
-          "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw=="
+          "version": "3.29.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
+          "integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg=="
         },
         "tslib": {
           "version": "1.14.1",
@@ -4125,9 +4125,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.25.23",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.23.tgz",
-      "integrity": "sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ=="
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
     },
     "@sindresorhus/fnv1a": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.351.0",
+    "@bigcommerce/checkout-sdk": "^1.358.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.spec.tsx
@@ -65,7 +65,7 @@ describe('StripeShippingAddress Component', () => {
                 hasPostalCodes: true,
                 subdivisions: [{code: 'bar', name: 'foo' }],
                 requiresState: true,
-                }],
+            }],
             onAddressSelect: jest.fn(),
             initialize: jest.fn(),
             deinitialize: jest.fn(),
@@ -128,8 +128,8 @@ describe('StripeShippingAddress Component', () => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
 
                 onChangeShipping({
-                    ...stripeEvent,
-                    value: { ...stripeEvent.value, address: { ...stripeEvent.value.address, line2: 'string' } },
+                        ...stripeEvent,
+                        value: { ...stripeEvent.value, address: { ...stripeEvent.value.address, line2: 'string' } },
                     }
                 );
                 getStyles();
@@ -199,8 +199,8 @@ describe('StripeShippingAddress Component', () => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
 
                 onChangeShipping({
-                    ...stripeEvent,
-                    value: { ...stripeEvent.value, name: 'cosme' },
+                        ...stripeEvent,
+                        value: { ...stripeEvent.value, name: 'cosme' },
                     }
                 );
                 getStyles();
@@ -234,9 +234,9 @@ describe('StripeShippingAddress Component', () => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
 
                 onChangeShipping({
-                    ...stripeEvent,
-                    phoneFieldRequired: true,
-                    value: { ...stripeEvent.value, phone: '+523333333333' },
+                        ...stripeEvent,
+                        phoneFieldRequired: true,
+                        value: { ...stripeEvent.value, phone: '+523333333333' },
                     }
                 );
                 getStyles();
@@ -270,7 +270,45 @@ describe('StripeShippingAddress Component', () => {
                 const { getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
 
                 onChangeShipping({
-                    ...stripeEvent,
+                        ...stripeEvent,
+                    }
+                );
+                getStyles();
+
+                return Promise.resolve(checkoutService.getState());
+            });
+
+            const stripeProps = {...defaultProps, isStripeLinkEnabled: true, customerEmail: ''};
+            const component = mount(
+                <Formik
+                    initialValues={ {} }
+                    onSubmit={ noop }
+                >
+                    <StripeShippingAddress { ...stripeProps } />
+                </Formik>
+            );
+
+            expect(component.find(StripeShippingAddressDisplay).props()).toEqual(
+                expect.objectContaining({
+                    methodId: 'stripeupe',
+                    deinitialize: defaultProps.deinitialize,
+                })
+            );
+
+            expect(defaultProps.initialize).toHaveBeenCalled();
+            expect(defaultProps.onAddressSelect).toHaveBeenCalled();
+        });
+
+        it('renders StripeShippingAddress with initialize props with split name', async () => {
+            defaultProps.initialize = jest.fn((options) => {
+                const {getStyles = noop, onChangeShipping = noop} = options.stripeupe || {};
+
+                onChangeShipping({
+                        ...stripeEvent,
+                        value: {...stripeEvent.value, firstName: 'cosme', lastName: 'Fulanito'},
+                        display: {
+                            name: 'split',
+                        },
                     }
                 );
                 getStyles();

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -109,20 +109,21 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
 
     const handleStripeShippingAddress = useCallback(async (shipping: StripeShippingEvent) => {
         const {complete, phoneFieldRequired, value: { address = { country: '', state: '', line1: '', line2: '', city: '', postal_code: '' }
-            , name = '', phone = '' } } = shipping;
+            , name = '', firstName = '', lastName = '', phone = '' } } = shipping;
 
         if (complete) {
             if (shouldShowContent(shipping?.isNewAddress, phoneFieldRequired, phone)) {
                 handleLoading();
             }
 
-            const names = name.split(' ');
+            const names = name?.split(' ');
+
             // @ts-ignore
             const country = availableShippingList?.find(country => country.code === address.country).name;
             const state = StripeStateMapper(address.country, address.state);
             const shippingValue = {
-                firstName: names[0],
-                lastName: names[1] || ' ',
+                firstName: firstName || names[0],
+                lastName: lastName || names[1],
                 company: '',
                 address1: address.line1,
                 address2: address.line2 || '',


### PR DESCRIPTION
## What? [STRIPE-202](https://bigcommercecloud.atlassian.net/browse/STRIPE-202)
Split name input into First and Last name

## Why?
To have a better input field design

## Based documentation
[stripe_doc](https://stripe.com/docs/js/elements_object/create_address_element)

## Refactor
Noticed that there was a missing space in the stripe-upe-payment-strategy.ts so I added it to be more readable

## Testing / Proof
<img width="557" alt="200685408-3923f183-8561-42a8-bd7a-49f864e01dc2" src="https://user-images.githubusercontent.com/106765049/219151546-5892eb24-2ac9-40e7-b5a3-df297c9380f8.png">

<img width="948" alt="Screenshot 2023-02-15 at 14 33 24" src="https://user-images.githubusercontent.com/106765049/219151438-95de921c-500e-429f-ba00-29472af7b0b5.png">

## Depends on
[1675](https://github.com/bigcommerce/checkout-sdk-js/pull/1675)

@bigcommerce/checkout @bigcommerce/apex-integrations 

