### PR TITLE
chore(checkout): ADYEN-588 bump checkout-sdk version due to the google pay balance fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,21 +1156,21 @@
       },
       "dependencies": {
         "@jest/transform": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.2.tgz",
-          "integrity": "sha512-kf1v5iTJHn7p9RbOsBuc/lcwyPtJaZJt5885C98omWz79NIeD3PfoiiaPSu7JyCyFzNOIzKhmMhQLUhlTL9BvQ==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.3.tgz",
+          "integrity": "sha512-8u0+fBGWolDshsFgPQJESkDa72da/EVwvL+II0trN2DR66wMwiQ9/CihaGfHdlLGFzbBZwMykFtxuwFdZqlKwg==",
           "requires": {
             "@babel/core": "^7.11.6",
-            "@jest/types": "^29.4.2",
+            "@jest/types": "^29.4.3",
             "@jridgewell/trace-mapping": "^0.3.15",
             "babel-plugin-istanbul": "^6.1.1",
             "chalk": "^4.0.0",
             "convert-source-map": "^2.0.0",
             "fast-json-stable-stringify": "^2.1.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.4.2",
-            "jest-regex-util": "^29.4.2",
-            "jest-util": "^29.4.2",
+            "jest-haste-map": "^29.4.3",
+            "jest-regex-util": "^29.4.3",
+            "jest-util": "^29.4.3",
             "micromatch": "^4.0.4",
             "pirates": "^4.0.4",
             "slash": "^3.0.0",
@@ -1178,11 +1178,11 @@
           }
         },
         "@jest/types": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.2.tgz",
-          "integrity": "sha512-CKlngyGP0fwlgC1BRUtPZSiWLBhyS9dKwKmyGxk8Z6M82LBEGB2aLQSg+U1MyLsU+M7UjnlLllBM2BLWKVm/Uw==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+          "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
           "requires": {
-            "@jest/schemas": "^29.4.2",
+            "@jest/schemas": "^29.4.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
@@ -1208,23 +1208,23 @@
           }
         },
         "babel-jest": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.2.tgz",
-          "integrity": "sha512-vcghSqhtowXPG84posYkkkzcZsdayFkubUgbE3/1tuGbX7AQtwCkkNA/wIbB0BMjuCPoqTkiDyKN7Ty7d3uwNQ==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.3.tgz",
+          "integrity": "sha512-o45Wyn32svZE+LnMVWv/Z4x0SwtLbh4FyGcYtR20kIWd+rdrDZ9Fzq8Ml3MYLD+mZvEdzCjZsCnYZ2jpJyQ+Nw==",
           "requires": {
-            "@jest/transform": "^29.4.2",
+            "@jest/transform": "^29.4.3",
             "@types/babel__core": "^7.1.14",
             "babel-plugin-istanbul": "^6.1.1",
-            "babel-preset-jest": "^29.4.2",
+            "babel-preset-jest": "^29.4.3",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.9",
             "slash": "^3.0.0"
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.4.2.tgz",
-          "integrity": "sha512-5HZRCfMeWypFEonRbEkwWXtNS1sQK159LhRVyRuLzyfVBxDy/34Tr/rg4YVi0SScSJ4fqeaR/OIeceJ/LaQ0pQ==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.4.3.tgz",
+          "integrity": "sha512-mB6q2q3oahKphy5V7CpnNqZOCkxxZ9aokf1eh82Dy3jQmg4xvM1tGrh5y6BQUJh4a3Pj9+eLfwvAZ7VNKg7H8Q==",
           "requires": {
             "@babel/template": "^7.3.3",
             "@babel/types": "^7.3.3",
@@ -1233,11 +1233,11 @@
           }
         },
         "babel-preset-jest": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.4.2.tgz",
-          "integrity": "sha512-ecWdaLY/8JyfUDr0oELBMpj3R5I1L6ZqG+kRJmwqfHtLWuPrJStR0LUkvUhfykJWTsXXMnohsayN/twltBbDrQ==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.4.3.tgz",
+          "integrity": "sha512-gWx6COtSuma6n9bw+8/F+2PCXrIgxV/D1TJFnp6OyBK2cxPWg0K9p/sriNYeifKjpUkMViWQ09DSWtzJQRETsw==",
           "requires": {
-            "babel-plugin-jest-hoist": "^29.4.2",
+            "babel-plugin-jest-hoist": "^29.4.3",
             "babel-preset-current-node-syntax": "^1.0.0"
           }
         },
@@ -1252,35 +1252,35 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-haste-map": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.2.tgz",
-          "integrity": "sha512-WkUgo26LN5UHPknkezrBzr7lUtV1OpGsp+NfXbBwHztsFruS3gz+AMTTBcEklvi8uPzpISzYjdKXYZQJXBnfvw==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.3.tgz",
+          "integrity": "sha512-eZIgAS8tvm5IZMtKlR8Y+feEOMfo2pSQkmNbufdbMzMSn9nitgGxF1waM/+LbryO3OkMcKS98SUb+j/cQxp/vQ==",
           "requires": {
-            "@jest/types": "^29.4.2",
+            "@jest/types": "^29.4.3",
             "@types/graceful-fs": "^4.1.3",
             "@types/node": "*",
             "anymatch": "^3.0.3",
             "fb-watchman": "^2.0.0",
             "fsevents": "^2.3.2",
             "graceful-fs": "^4.2.9",
-            "jest-regex-util": "^29.4.2",
-            "jest-util": "^29.4.2",
-            "jest-worker": "^29.4.2",
+            "jest-regex-util": "^29.4.3",
+            "jest-util": "^29.4.3",
+            "jest-worker": "^29.4.3",
             "micromatch": "^4.0.4",
             "walker": "^1.0.8"
           }
         },
         "jest-regex-util": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.2.tgz",
-          "integrity": "sha512-XYZXOqUl1y31H6VLMrrUL1ZhXuiymLKPz0BO1kEeR5xER9Tv86RZrjTm74g5l9bPJQXA/hyLdaVPN/sdqfteig=="
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
+          "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg=="
         },
         "jest-util": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.2.tgz",
-          "integrity": "sha512-wKnm6XpJgzMUSRFB7YF48CuwdzuDIHenVuoIb1PLuJ6F+uErZsuDkU+EiExkChf6473XcawBrSfDSnXl+/YG4g==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.3.tgz",
+          "integrity": "sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==",
           "requires": {
-            "@jest/types": "^29.4.2",
+            "@jest/types": "^29.4.3",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
@@ -1289,12 +1289,12 @@
           }
         },
         "jest-worker": {
-          "version": "29.4.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.2.tgz",
-          "integrity": "sha512-VIuZA2hZmFyRbchsUCHEehoSf2HEl0YVF8SDJqtPnKorAaBuh42V8QsLnde0XP5F6TyCynGPEGgBOn3Fc+wZGw==",
+          "version": "29.4.3",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.3.tgz",
+          "integrity": "sha512-GLHN/GTAAMEy5BFdvpUfzr9Dr80zQqBrh0fz1mtRMe05hqP45+HfQltu7oTBfduD0UeZs09d+maFtFYAXFWvAA==",
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.4.2",
+            "jest-util": "^29.4.3",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           }
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.348.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.348.0.tgz",
-      "integrity": "sha512-4+uCeauaiLLzLOgCQrR50kWbyrXjq0vOrazMTnfwp4JqMQmb87vm6FrTEBG66nBn73YJ7lasCQNCZ7ef5lFx8g==",
+      "version": "1.348.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.348.4.tgz",
+      "integrity": "sha512-pS8Pm/OOJ2ztxLBcjcPfjx2MGPWTrjaEpgqgWVwn7ZJLI9aJXPS0tjOPfokDWqShMj89ui5RYE9wu2XhUu8jKQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",
@@ -2938,9 +2938,9 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.2.tgz",
-      "integrity": "sha512-ZrGzGfh31NtdVH8tn0mgJw4khQuNHiKqdzJAFbCaERbyCP9tHlxWuL/mnMu8P7e/+k4puWjI1NOzi/sFsjce/g==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
       "requires": {
         "@sinclair/typebox": "^0.25.16"
       }
@@ -4125,9 +4125,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
+      "version": "0.25.23",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.23.tgz",
+      "integrity": "sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ=="
     },
     "@sindresorhus/fnv1a": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.348.0",
+    "@bigcommerce/checkout-sdk": "^1.348.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
 Bump checkout-sdk version due to the google pay balance fix

## Why?
Due to the release of https://github.com/bigcommerce/checkout-sdk-js/pull/1839

## Testing / Proof
Units/manually

@bigcommerce/checkout
