### PR TITLE
chore(payment): PAYPAL-000 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.348.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.348.4.tgz",
-      "integrity": "sha512-pS8Pm/OOJ2ztxLBcjcPfjx2MGPWTrjaEpgqgWVwn7ZJLI9aJXPS0tjOPfokDWqShMj89ui5RYE9wu2XhUu8jKQ==",
+      "version": "1.348.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.348.6.tgz",
+      "integrity": "sha512-tQY0DR+HtoAQuVMGWtJjoND/aXUCh7w1ZhWNiOj1P/TniYEQYHGlHPwfUw5s4KQQ8bG9G5b/Hcc6ZICQHUjnDQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.348.4",
+    "@bigcommerce/checkout-sdk": "^1.348.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To keep checkout-js project dependency up to date.

Here is a list of checkout-sdk changes:
https://github.com/bigcommerce/checkout-sdk-js/pull/1856
https://github.com/bigcommerce/checkout-sdk-js/pull/1855

## Testing / Proof
Unit tests
