### PR TITLE
feat(common): CHECKOUT-7234 Remove loading for customer guest form

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -26,11 +26,11 @@ import { retry } from '../common/utility';
 import {
     CheckoutButtonContainer,
     CheckoutSuggestion,
+    Customer,
     CustomerInfo,
     CustomerSignOutEvent,
     CustomerViewType,
 } from '../customer';
-import Customer from '../customer/Customer';
 import { EmbeddedCheckoutStylesheet, isEmbedded } from '../embeddedCheckout';
 import { TranslatedString, withLanguage, WithLanguageProps } from '../locale';
 import { PromotionBannerList } from '../promotion';

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -16,7 +16,7 @@ import { find, findIndex } from 'lodash';
 import React, { Component, lazy, ReactNode } from 'react';
 
 import { AnalyticsContextProps } from '@bigcommerce/checkout/analytics';
-import { AddressFormSkeleton, ChecklistSkeleton, CustomerSkeleton } from '@bigcommerce/checkout/ui';
+import { AddressFormSkeleton, ChecklistSkeleton } from '@bigcommerce/checkout/ui';
 
 import { withAnalytics } from '../analytics';
 import { StaticBillingAddress } from '../billing';
@@ -30,6 +30,7 @@ import {
     CustomerSignOutEvent,
     CustomerViewType,
 } from '../customer';
+import Customer from '../customer/Customer';
 import { EmbeddedCheckoutStylesheet, isEmbedded } from '../embeddedCheckout';
 import { TranslatedString, withLanguage, WithLanguageProps } from '../locale';
 import { PromotionBannerList } from '../promotion';
@@ -72,16 +73,6 @@ const CartSummaryDrawer = lazy(() =>
             import(
                 /* webpackChunkName: "cart-summary-drawer" */
                 '../cart/CartSummaryDrawer'
-            ),
-    ),
-);
-
-const Customer = lazy(() =>
-    retry(
-        () =>
-            import(
-                /* webpackChunkName: "customer" */
-                '../customer/Customer'
             ),
     ),
 );
@@ -326,8 +317,8 @@ class Checkout extends Component<
                     <PromotionBannerList promotions={promotions} />
 
                     {isWalletButtonsOnTop && <CheckoutButtonContainer
-                      checkEmbeddedSupport={this.checkEmbeddedSupport}
-                      onUnhandledError={this.handleUnhandledError}
+                        checkEmbeddedSupport={this.checkEmbeddedSupport}
+                        onUnhandledError={this.handleUnhandledError}
                     />}
 
                     <ol className="checkout-steps">
@@ -392,25 +383,23 @@ class Checkout extends Component<
                     />
                 }
             >
-                <LazyContainer loadingSkeleton={<CustomerSkeleton />}>
-                    <Customer
-                        checkEmbeddedSupport={this.checkEmbeddedSupport}
-                        isEmbedded={isEmbedded()}
-                        isSubscribed={isSubscribed}
-                        isWalletButtonsOnTop = {isWalletButtonsOnTop}
-                        onAccountCreated={this.navigateToNextIncompleteStep}
-                        onChangeViewType={this.setCustomerViewType}
-                        onContinueAsGuest={this.navigateToNextIncompleteStep}
-                        onContinueAsGuestError={this.handleError}
-                        onReady={this.handleReady}
-                        onSignIn={this.navigateToNextIncompleteStep}
-                        onSignInError={this.handleError}
-                        onSubscribeToNewsletter={this.handleNewsletterSubscription}
-                        onUnhandledError={this.handleUnhandledError}
-                        step={step}
-                        viewType={customerViewType}
-                    />
-                </LazyContainer>
+                <Customer
+                    checkEmbeddedSupport={this.checkEmbeddedSupport}
+                    isEmbedded={isEmbedded()}
+                    isSubscribed={isSubscribed}
+                    isWalletButtonsOnTop = {isWalletButtonsOnTop}
+                    onAccountCreated={this.navigateToNextIncompleteStep}
+                    onChangeViewType={this.setCustomerViewType}
+                    onContinueAsGuest={this.navigateToNextIncompleteStep}
+                    onContinueAsGuestError={this.handleError}
+                    onReady={this.handleReady}
+                    onSignIn={this.navigateToNextIncompleteStep}
+                    onSignInError={this.handleError}
+                    onSubscribeToNewsletter={this.handleNewsletterSubscription}
+                    onUnhandledError={this.handleUnhandledError}
+                    step={step}
+                    viewType={customerViewType}
+                />
             </CheckoutStep>
         );
     }

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -117,7 +117,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
         this.draftEmail = email;
 
         try {
-            if (providerWithCustomCheckout !== PaymentMethodId.StripeUPE) {
+            if (providerWithCustomCheckout && providerWithCustomCheckout !== PaymentMethodId.StripeUPE) {
                 await initializeCustomer({methodId: providerWithCustomCheckout});
             }
         } catch (error) {
@@ -189,7 +189,11 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             isInitializing={isInitializing}
             methodIds={checkoutButtonIds}
             onError={onUnhandledError}
-          />
+          />;
+
+        const isLoadingGuestForm = isWalletButtonsOnTop ?
+            isContinuingAsGuest :
+            isContinuingAsGuest || isInitializing || isExecutingPaymentMethodCheckout;
 
         return (
             providerWithCustomCheckout === PaymentMethodId.StripeUPE ?
@@ -216,9 +220,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 continueAsGuestButtonLabelId="customer.continue"
                 defaultShouldSubscribe={isSubscribed}
                 email={this.draftEmail || email}
-                isLoading={
-                    isContinuingAsGuest || isInitializing || isExecutingPaymentMethodCheckout
-                }
+                isLoading={isLoadingGuestForm}
                 onChangeEmail={this.handleChangeEmail}
                 onContinueAsGuest={this.handleContinueAsGuest}
                 onShowLogin={this.handleShowLogin}
@@ -465,6 +467,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
     private handleChangeEmail: (email: string) => void = (email) => {
         const { analyticsTracker } = this.props;
+
         this.draftEmail = email;
         analyticsTracker.customerEmailEntry(email);
     };
@@ -495,6 +498,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
     private checkoutPaymentMethodExecuted(payload?: CheckoutPaymentMethodExecutedOptions) {
         const { analyticsTracker } = this.props;
+
         analyticsTracker.customerPaymentMethodExecuted(payload);
     }
 }

--- a/packages/core/src/app/customer/index.ts
+++ b/packages/core/src/app/customer/index.ts
@@ -1,4 +1,4 @@
-export { CustomerProps } from './Customer';
+export { default as Customer, CustomerProps } from './Customer';
 export { default as CustomerViewType } from './CustomerViewType';
 export { default as CustomerInfo, CustomerInfoProps, CustomerSignOutEvent } from './CustomerInfo';
 export { default as CheckoutSuggestion } from './checkoutSuggestion/CheckoutSuggestion';


### PR DESCRIPTION
## What?
As above

## Why?
As we are moving wallet buttons to top of checkout, we can render the form straightaway while the buttons are rendered in their own container. 

Therefore checkout page can have a perception that it loads faster.

## Testing / Proof
- Circle

## Experiment off 
https://user-images.githubusercontent.com/7134802/220211072-3d721c57-16e2-4c62-9ceb-44d4a7e8a118.mov

## Experiment on
https://user-images.githubusercontent.com/7134802/220211130-fdcbdc51-a6aa-4636-805a-03fbef391582.mov

@bigcommerce/checkout
