### PR TITLE
chore(payment): PAYPAL-1978 bump checkout sdk js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.348.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.348.6.tgz",
-      "integrity": "sha512-tQY0DR+HtoAQuVMGWtJjoND/aXUCh7w1ZhWNiOj1P/TniYEQYHGlHPwfUw5s4KQQ8bG9G5b/Hcc6ZICQHUjnDQ==",
+      "version": "1.350.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.350.1.tgz",
+      "integrity": "sha512-SKwhcGa8WAavGOSb5iT2EeTTgu+Fsl5zUJ1LbXf9e2kLi4HAl6Qe3GbzyNtw9DHiuHBAMvHiJk51wixXci5v5Q==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.348.6",
+    "@bigcommerce/checkout-sdk": "^1.350.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk js version

## Why?
To keep checkout-sdk-js dependency version up to date.

Here is a list of updates:
https://github.com/bigcommerce/checkout-sdk-js/pull/1852
https://github.com/bigcommerce/checkout-sdk-js/pull/1853
https://github.com/bigcommerce/checkout-sdk-js/pull/1858
https://github.com/bigcommerce/checkout-sdk-js/pull/1859

## Testing / Proof
Unit tests
