### PR TITLE
fix(payment): INT-7522 SquareV2: Disable submit only if payment data is required

### DIFF
--- a/packages/squarev2-integration/src/SquareV2PaymentMethod.spec.tsx
+++ b/packages/squarev2-integration/src/SquareV2PaymentMethod.spec.tsx
@@ -42,6 +42,7 @@ describe('SquareV2 payment method', () => {
             .spyOn(checkoutService, 'deinitializePayment')
             .mockResolvedValue(checkoutState);
         checkoutState = checkoutService.getState();
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(true);
         props = {
             method: getSquareV2(),
             checkoutService,

--- a/packages/squarev2-integration/src/SquareV2PaymentMethod.tsx
+++ b/packages/squarev2-integration/src/SquareV2PaymentMethod.tsx
@@ -16,7 +16,11 @@ const SquareV2PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 }) => {
     const [disabled, setDisabled] = useState(true);
 
-    useEffect(() => paymentForm.disableSubmit(method, disabled), [disabled, method, paymentForm]);
+    useEffect(() => {
+        const { isPaymentDataRequired } = checkoutState.data;
+
+        paymentForm.disableSubmit(method, isPaymentDataRequired() && disabled);
+    }, [checkoutState, disabled, method, paymentForm]);
 
     const onValidationChange = useCallback(
         (isValid: boolean) => setDisabled(!isValid),


### PR DESCRIPTION
## What? [INT-7522](https://bigcommercecloud.atlassian.net/browse/INT-7522)
Disable submit only if payment data is required.

## Why?
To allow checkout with $0 orders while SquareV2 is selected.

## Testing / Proof
https://user-images.githubusercontent.com/4843328/220398749-09c05577-4e20-4614-8187-8d456706eebf.mov

---

@bigcommerce/checkout @bigcommerce/apex-integrations

[INT-7522]: https://bigcommercecloud.atlassian.net/browse/INT-7522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ