### PR TITLE
feat(common): INT-7169 BlueSnapDirect: Add a new select component

### DIFF
--- a/packages/ui/src/form/Select/Select.spec.tsx
+++ b/packages/ui/src/form/Select/Select.spec.tsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Select from './Select';
+
+describe('Select', () => {
+    const options = [
+        { item: 'Foo', value: 'foo' },
+        { item: 'Bar', value: 'bar' },
+        { item: 'Baz', value: 'baz' },
+    ];
+
+    it('matches snapshot', () => {
+        expect(shallow(<Select name="foobar" options={options} />)).toMatchSnapshot();
+    });
+
+    it('renders component with test ID', () => {
+        expect(
+            shallow(<Select name="foobar" options={options} testId="test" />).prop('data-test'),
+        ).toBe('test');
+    });
+
+    it('listens to DOM events', () => {
+        const handleChange = jest.fn();
+        const component = shallow(
+            <Select name="foobar" onChange={handleChange} options={options} />,
+        );
+
+        component.simulate('change');
+
+        expect(handleChange).toHaveBeenCalled();
+    });
+});

--- a/packages/ui/src/form/Select/Select.tsx
+++ b/packages/ui/src/form/Select/Select.tsx
@@ -1,0 +1,23 @@
+import React, { forwardRef, Ref, SelectHTMLAttributes } from 'react';
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+    options: Array<{
+        item: string;
+        value: string;
+    }>;
+    testId?: string;
+}
+
+const Input = forwardRef(
+    ({ options, testId, ...rest }: SelectProps, ref: Ref<HTMLSelectElement>) => (
+        <select {...rest} data-test={testId} ref={ref}>
+            {options.map(({ item, value }, index) => (
+                <option key={index} value={value}>
+                    {item}
+                </option>
+            ))}
+        </select>
+    ),
+);
+
+export default Input;

--- a/packages/ui/src/form/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/ui/src/form/Select/__snapshots__/Select.spec.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select matches snapshot 1`] = `
+<select
+  name="foobar"
+>
+  <option
+    key="0"
+    value="foo"
+  >
+    Foo
+  </option>
+  <option
+    key="1"
+    value="bar"
+  >
+    Bar
+  </option>
+  <option
+    key="2"
+    value="baz"
+  >
+    Baz
+  </option>
+</select>
+`;

--- a/packages/ui/src/form/Select/index.ts
+++ b/packages/ui/src/form/Select/index.ts
@@ -1,0 +1,1 @@
+export { default as Select, SelectProps } from './Select';

--- a/packages/ui/src/form/SelectInput/SelectInput.spec.tsx
+++ b/packages/ui/src/form/SelectInput/SelectInput.spec.tsx
@@ -1,0 +1,50 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { Select } from '../Select';
+
+import SelectInput from './SelectInput';
+
+describe('SelectInput', () => {
+    const options = [
+        { item: 'Foo', value: 'foo' },
+        { item: 'Bar', value: 'bar' },
+        { item: 'Baz', value: 'baz' },
+    ];
+
+    it('renders Select element', () => {
+        const component = shallow(<SelectInput name="foobar" options={options} />);
+
+        expect(component.find(Select)).toHaveLength(1);
+    });
+
+    it('renders with class names', () => {
+        const component = shallow(
+            <SelectInput additionalClassName="foobar" name="foobar" options={options} />,
+        );
+
+        expect(component.find(Select).hasClass('form-select')).toBe(true);
+
+        expect(component.find(Select).hasClass('optimizedCheckout-form-select')).toBe(true);
+
+        expect(component.find(Select).hasClass('foobar')).toBe(true);
+    });
+
+    it('appears focused if configured', () => {
+        const component = shallow(<SelectInput appearFocused name="foobar" options={options} />);
+
+        expect(component.find(Select).hasClass('form-select--focus')).toBe(true);
+
+        expect(component.find(Select).hasClass('optimizedCheckout-form-select--focus')).toBe(true);
+    });
+
+    it('does not appear focused unless configured', () => {
+        const component = shallow(
+            <SelectInput appearFocused={false} name="foobar" options={options} />,
+        );
+
+        expect(component.find(Select).hasClass('form-select--focus')).toBe(false);
+
+        expect(component.find(Select).hasClass('optimizedCheckout-form-select--focus')).toBe(false);
+    });
+});

--- a/packages/ui/src/form/SelectInput/SelectInput.tsx
+++ b/packages/ui/src/form/SelectInput/SelectInput.tsx
@@ -1,0 +1,30 @@
+import classNames from 'classnames';
+import React, { forwardRef, Ref } from 'react';
+
+import { Select, SelectProps } from '../Select';
+
+export interface SelectInputProps extends SelectProps {
+    additionalClassName?: string;
+    appearFocused?: boolean;
+}
+
+const SelectInput = forwardRef(
+    (
+        { additionalClassName, appearFocused, ...rest }: SelectInputProps,
+        ref: Ref<HTMLSelectElement>,
+    ) => (
+        <Select
+            {...rest}
+            className={classNames(
+                'form-select',
+                'optimizedCheckout-form-select',
+                { 'form-select--focus': appearFocused },
+                { 'optimizedCheckout-form-select--focus': appearFocused },
+                additionalClassName,
+            )}
+            ref={ref}
+        />
+    ),
+);
+
+export default SelectInput;

--- a/packages/ui/src/form/SelectInput/index.ts
+++ b/packages/ui/src/form/SelectInput/index.ts
@@ -1,0 +1,1 @@
+export { default as SelectInput } from './SelectInput';

--- a/packages/ui/src/form/index.ts
+++ b/packages/ui/src/form/index.ts
@@ -5,6 +5,8 @@ export { Fieldset } from './Fieldset';
 export { FormField } from './FormField';
 export { Input } from './Input';
 export { Legend } from './Legend';
+export { Select } from './Select';
+export { SelectInput } from './SelectInput';
 export { TextArea } from './TextArea';
 export { TextInput } from './TextInput';
 export { TextInputIframeContainer } from './TextInputIframeContainer';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,8 @@ export {
     Label,
     Legend,
     Input,
+    Select,
+    SelectInput,
     TextInput,
     TextInputIframeContainer,
 } from './form';


### PR DESCRIPTION
## What? [INT-7169](https://bigcommercecloud.atlassian.net/browse/INT-7169)
Add a new `Select` component.

## Why?
We need this new component to allow the shopper to choose the account type for ACH/ECP through BlueSnap direct.

## Testing / Proof
https://user-images.githubusercontent.com/4843328/220785231-361f2ff5-49ce-4b9d-bad6-4c5513857544.mov

@bigcommerce/checkout


[INT-7169]: https://bigcommercecloud.atlassian.net/browse/INT-7169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ