### PR TITLE
CHECKOUT-000 Change commit validation rule

### DIFF
--- a/commit-validation.json
+++ b/commit-validation.json
@@ -3,7 +3,7 @@
         "billing",
         "cart",
         "checkout",
-        "common",
+        "other",
         "customer",
         "embedded-checkout",
         "order",


### PR DESCRIPTION
## What?
Change commit scopes

## Why?
`other` is a standard scope in most BC Respos. 

## Testing / Proof
N/A

@bigcommerce/checkout
