### PR TITLE
chore(payment): PAYPAL-1991 bump checkout-sdk version to 1.357.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.351.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.351.0.tgz",
-      "integrity": "sha512-FeBZozQK875DjrbUa2aKzDEDD+HM/iQBgKI69CjPQDx/gFiuUKGp/Krs6rPXjZO/n46LYoJi2gSeSpee6JyspA==",
+      "version": "1.357.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.357.1.tgz",
+      "integrity": "sha512-ReDHgGJKqgaqQ2D9QuM1KFNoLMBAgWiBGGIYVKUyKUU+25fnsa5bhcOWJpwCQQMQ670Y97ZDjWUOC1K3+QYM0w==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.351.0",
+    "@bigcommerce/checkout-sdk": "^1.357.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump **checkout-sdk** version to **1.357.1**

## Why?

To keep projects up to date

## Testing / Proof

Unit tests

@bigcommerce/checkout
