### PR TITLE
fix(payment): INT-7183 SquareV2: Don't hide content when loading

### DIFF
--- a/packages/squarev2-integration/src/SquareV2PaymentMethod.tsx
+++ b/packages/squarev2-integration/src/SquareV2PaymentMethod.tsx
@@ -193,13 +193,12 @@ const SquareV2PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     }, [deinitializePayment, initializePayment]);
 
     return (
-        <LoadingOverlay
-            hideContentWhenLoading
-            isLoading={checkoutState.statuses.isInitializingPayment(method.id)}
-        >
-            {renderPlaceholderFields()}
-            <div id={containerId} />
-        </LoadingOverlay>
+        <div className="loadingSpinner">
+            <LoadingOverlay isLoading={checkoutState.statuses.isInitializingPayment(method.id)}>
+                {renderPlaceholderFields()}
+                <div id={containerId} style={{ minHeight: '100px' }} />
+            </LoadingOverlay>
+        </div>
     );
 };
 


### PR DESCRIPTION
## What? [INT-7183](https://bigcommercecloud.atlassian.net/browse/INT-7183)
Don't hide the Square card component container when loading.

## Why?
Because if it's hidden, the Square card component can't calculate its sizes correctly.

## Testing / Proof
#### _Before_
<img width="621" alt="Screenshot 2023-02-23 at 10 31 04 AM" src="https://user-images.githubusercontent.com/4843328/220970080-d30a4db4-54f2-4242-ba17-122282baefde.png">

#### _Now_
<img width="621" alt="Screenshot 2023-02-23 at 10 30 25 AM" src="https://user-images.githubusercontent.com/4843328/220970073-658272f7-2b8c-40db-a0d0-b59350c7a9fa.png">

@bigcommerce/checkout


[INT-7183]: https://bigcommercecloud.atlassian.net/browse/INT-7183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ