### PR TITLE
feat(payment): BOLT-409 Bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.361.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.361.0.tgz",
-      "integrity": "sha512-cw7mGvJ6WQ7EkyN+TZaKfG3l2Ldi0gvM70/cewjQSkoHdsGlRCtdTg835rmCCD+dHuiod9ya3JEOaaF+J7cLWQ==",
+      "version": "1.363.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.363.0.tgz",
+      "integrity": "sha512-4C57lh0YHSeNgGZTBDGfZM8TMYltUTWWPcZv2B+I1N+EhWjPraBAACH+8siIdl4T1PT0KitRvXhUWGB2CWUYog==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",
@@ -1377,9 +1377,9 @@
           }
         },
         "core-js": {
-          "version": "3.29.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.0.tgz",
-          "integrity": "sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg=="
+          "version": "3.29.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
+          "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw=="
         },
         "tslib": {
           "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.361.0",
+    "@bigcommerce/checkout-sdk": "^1.363.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To keep checkout-sdk-js dependency version up to date.
PR with changes in cherckout-sdk-js:
[https://github.com/bigcommerce/checkout-sdk-js/pull/1860](https://github.com/bigcommerce/checkout-sdk-js/pull/1860)


## Testing / Proof
Unit tests

@bigcommerce/checkout
