### PR TITLE
feat(checkout): CHECKOUT-3430 Display inclusive tax below subtotal

### DIFF
--- a/packages/core/src/app/cart/mapToOrderSummarySubtotalsProps.ts
+++ b/packages/core/src/app/cart/mapToOrderSummarySubtotalsProps.ts
@@ -5,7 +5,7 @@ import { hasSelectedShippingOptions } from '../shipping';
 
 export default function mapToOrderSummarySubtotalsProps({
     subtotal,
-    cart: { discountAmount },
+    cart: { discountAmount, isTaxIncluded },
     giftCertificates,
     consignments,
     handlingCostTotal,
@@ -25,5 +25,6 @@ export default function mapToOrderSummarySubtotalsProps({
         handlingAmount: handlingCostTotal,
         coupons,
         taxes,
+        isTaxIncluded,
     };
 }

--- a/packages/core/src/app/locale/translations/en.json
+++ b/packages/core/src/app/locale/translations/en.json
@@ -461,6 +461,9 @@
             "label": "Yes, I agree with the <a href=\"{url}\" target=\"_blank\">privacy policy</a>.",
             "heading": "Privacy Policy"
         },
+        "tax": {
+            "inclusive_label": "Tax Included in Total:"
+        },
         "terms_and_conditions": {
             "agreement_required_error": "Please agree to the terms and conditions",
             "agreement_text": "Yes, I agree with the above terms and conditions.",

--- a/packages/core/src/app/order/OrderSummary.spec.tsx
+++ b/packages/core/src/app/order/OrderSummary.spec.tsx
@@ -37,4 +37,28 @@ describe('OrderSummary', () => {
             expect(orderSummary.find('.cart-note')).toHaveLength(0);
         });
     });
+
+    describe('when taxes are inclusive', () => {
+        it('displays tax as summary section', () => {
+            const taxIncludedOrder = {
+                ...getOrder(),
+                isTaxIncluded: true,
+            };
+
+            orderSummary = shallow(
+                <OrderSummary
+                    {...mapToOrderSummarySubtotalsProps(taxIncludedOrder)}
+                    headerLink={<PrintLink />}
+                    lineItems={taxIncludedOrder.lineItems}
+                    shopperCurrency={getStoreConfig().shopperCurrency}
+                    storeCurrency={getStoreConfig().currency}
+                    total={taxIncludedOrder.orderAmount}
+                />,
+            );
+
+            expect(orderSummary).toMatchSnapshot();
+
+            expect(orderSummary.find('.cart-taxItem')).toHaveLength(1);
+        });
+    });
 });

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -42,7 +42,7 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
             </OrderSummarySection>
 
             <OrderSummarySection>
-                <OrderSummarySubtotals isTaxIncluded taxes={taxes} {...orderSummarySubtotalsProps} />
+                <OrderSummarySubtotals isTaxIncluded={isTaxIncluded} taxes={taxes} {...orderSummarySubtotalsProps} />
                 {additionalLineItems}
             </OrderSummarySection>
 
@@ -54,16 +54,16 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
                 />
             </OrderSummarySection>
 
-            <OrderSummarySection>
+            {isTaxIncluded && <OrderSummarySection>
                 <h5
-                    className="cart-section-heading optimizedCheckout-contentPrimary"
+                    className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary"
                     data-test="tax-text"
                 >
                     <TranslatedString
                         id="tax.inclusive_label"
                     />
                 </h5>
-                {isTaxIncluded && (taxes || []).map((tax, index) => (
+                {(taxes || []).map((tax, index) => (
                     <OrderSummaryPrice
                         amount={tax.amount}
                         key={index}
@@ -71,7 +71,7 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
                         testId="cart-taxes"
                     />
                 ))}
-            </OrderSummarySection>
+            </OrderSummarySection>}
         </article>
     );
 };

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -1,8 +1,11 @@
 import { LineItemMap, ShopperCurrency, StoreCurrency } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, ReactNode, useMemo } from 'react';
 
+import { TranslatedString } from '../locale';
+
 import OrderSummaryHeader from './OrderSummaryHeader';
 import OrderSummaryItems from './OrderSummaryItems';
+import OrderSummaryPrice from './OrderSummaryPrice';
 import OrderSummarySection from './OrderSummarySection';
 import OrderSummarySubtotals, { OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
 import OrderSummaryTotal from './OrderSummaryTotal';
@@ -18,6 +21,8 @@ export interface OrderSummaryProps {
 }
 
 const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsProps> = ({
+    isTaxIncluded,
+    taxes,
     storeCurrency,
     shopperCurrency,
     headerLink,
@@ -37,7 +42,7 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
             </OrderSummarySection>
 
             <OrderSummarySection>
-                <OrderSummarySubtotals {...orderSummarySubtotalsProps} />
+                <OrderSummarySubtotals isTaxIncluded taxes={taxes} {...orderSummarySubtotalsProps} />
                 {additionalLineItems}
             </OrderSummarySection>
 
@@ -47,6 +52,25 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
                     shopperCurrencyCode={shopperCurrency.code}
                     storeCurrencyCode={storeCurrency.code}
                 />
+            </OrderSummarySection>
+
+            <OrderSummarySection>
+                <h5
+                    className="cart-section-heading optimizedCheckout-contentPrimary"
+                    data-test="tax-text"
+                >
+                    <TranslatedString
+                        id="tax.inclusive_label"
+                    />
+                </h5>
+                {isTaxIncluded && (taxes || []).map((tax, index) => (
+                    <OrderSummaryPrice
+                        amount={tax.amount}
+                        key={index}
+                        label={tax.name}
+                        testId="cart-taxes"
+                    />
+                ))}
             </OrderSummarySection>
         </article>
     );

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -32,6 +32,7 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
     ...orderSummarySubtotalsProps
 }) => {
     const nonBundledLineItems = useMemo(() => removeBundledItems(lineItems), [lineItems]);
+    const displayInclusiveTax = isTaxIncluded && taxes && taxes.length > 0;
 
     return (
         <article className="cart optimizedCheckout-orderSummary" data-test="cart">
@@ -54,7 +55,7 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
                 />
             </OrderSummarySection>
 
-            {isTaxIncluded && <OrderSummarySection>
+            {displayInclusiveTax && <OrderSummarySection>
                 <h5
                     className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary"
                     data-test="tax-text"

--- a/packages/core/src/app/order/OrderSummaryDrawer.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.tsx
@@ -34,6 +34,7 @@ const OrderSummaryDrawer: FunctionComponent<
     giftCertificates,
     handlingAmount,
     headerLink,
+    isTaxIncluded,
     lineItems,
     onRemovedCoupon,
     onRemovedGiftCertificate,
@@ -57,6 +58,7 @@ const OrderSummaryDrawer: FunctionComponent<
                 giftWrappingAmount={giftWrappingAmount}
                 handlingAmount={handlingAmount}
                 headerLink={headerLink}
+                isTaxIncluded={isTaxIncluded}
                 lineItems={lineItems}
                 onRemovedCoupon={onRemovedCoupon}
                 onRemovedGiftCertificate={onRemovedGiftCertificate}
@@ -76,6 +78,7 @@ const OrderSummaryDrawer: FunctionComponent<
             giftCertificates,
             handlingAmount,
             headerLink,
+            isTaxIncluded,
             lineItems,
             onRemovedCoupon,
             onRemovedGiftCertificate,

--- a/packages/core/src/app/order/OrderSummaryModal.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.spec.tsx
@@ -31,4 +31,28 @@ describe('OrderSummaryModal', () => {
     it('renders order summary', () => {
         expect(orderSummary).toMatchSnapshot();
     });
+
+    describe('when taxes are inclusive', () => {
+        it('displays tax as summary section', () => {
+            const taxIncludedOrder = {
+                ...getOrder(),
+                isTaxIncluded: true,
+            };
+
+            orderSummary = shallow(
+                <OrderSummaryModal
+                    {...mapToOrderSummarySubtotalsProps(taxIncludedOrder)}
+                    isOpen={true}
+                    lineItems={taxIncludedOrder.lineItems}
+                    shopperCurrency={getStoreConfig().shopperCurrency}
+                    storeCurrency={getStoreConfig().currency}
+                    total={taxIncludedOrder.orderAmount}
+                />,
+            );
+
+            expect(orderSummary).toMatchSnapshot();
+
+            expect(orderSummary.find('.cart-taxItem')).toHaveLength(1);
+        });
+    });
 });

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -44,8 +44,10 @@ const OrderSummaryModal: FunctionComponent<
     lineItems,
     total,
     ...orderSummarySubtotalsProps
-}) => (
-    <Modal
+}) => {
+    const displayInclusiveTax = isTaxIncluded && taxes && taxes.length > 0;
+
+    return <Modal
         additionalBodyClassName="cart-modal-body optimizedCheckout-orderSummary"
         additionalHeaderClassName="cart-modal-header optimizedCheckout-orderSummary"
         header={renderHeader({ headerLink, onRequestClose })}
@@ -67,7 +69,7 @@ const OrderSummaryModal: FunctionComponent<
                 storeCurrencyCode={storeCurrency.code}
             />
         </OrderSummarySection>
-        {isTaxIncluded && <OrderSummarySection>
+        {displayInclusiveTax && <OrderSummarySection>
                 <h5
                     className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary"
                     data-test="tax-text"
@@ -86,7 +88,7 @@ const OrderSummaryModal: FunctionComponent<
                 ))}
             </OrderSummarySection>}
     </Modal>
-);
+};
 
 const renderHeader: FunctionComponent<{
     headerLink: ReactNode;

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -11,6 +11,7 @@ import { IconClose } from '../ui/icon';
 import { Modal, ModalHeader } from '../ui/modal';
 
 import OrderSummaryItems from './OrderSummaryItems';
+import OrderSummaryPrice from './OrderSummaryPrice';
 import OrderSummarySection from './OrderSummarySection';
 import OrderSummarySubtotals, { OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
 import OrderSummaryTotal from './OrderSummaryTotal';
@@ -32,6 +33,8 @@ const OrderSummaryModal: FunctionComponent<
 > = ({
     additionalLineItems,
     children,
+    isTaxIncluded,
+    taxes,
     onRequestClose,
     onAfterOpen,
     storeCurrency,
@@ -54,7 +57,7 @@ const OrderSummaryModal: FunctionComponent<
             <OrderSummaryItems items={lineItems} />
         </OrderSummarySection>
         <OrderSummarySection>
-            <OrderSummarySubtotals {...orderSummarySubtotalsProps} />
+            <OrderSummarySubtotals isTaxIncluded={isTaxIncluded} taxes={taxes} {...orderSummarySubtotalsProps} />
             {additionalLineItems}
         </OrderSummarySection>
         <OrderSummarySection>
@@ -64,6 +67,24 @@ const OrderSummaryModal: FunctionComponent<
                 storeCurrencyCode={storeCurrency.code}
             />
         </OrderSummarySection>
+        {isTaxIncluded && <OrderSummarySection>
+                <h5
+                    className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary"
+                    data-test="tax-text"
+                >
+                    <TranslatedString
+                        id="tax.inclusive_label"
+                    />
+                </h5>
+                {(taxes || []).map((tax, index) => (
+                    <OrderSummaryPrice
+                        amount={tax.amount}
+                        key={index}
+                        label={tax.name}
+                        testId="cart-taxes"
+                    />
+                ))}
+            </OrderSummarySection>}
     </Modal>
 );
 

--- a/packages/core/src/app/order/OrderSummarySubtotals.spec.tsx
+++ b/packages/core/src/app/order/OrderSummarySubtotals.spec.tsx
@@ -28,4 +28,25 @@ describe('OrderSummarySubtotals', () => {
     it('renders component', () => {
         expect(orderSummarySubtotals).toMatchSnapshot();
     });
+
+
+    describe('Tax summary is not rendered if tax is inclusive', () => {
+        it('Renders component without tax summary', () => {
+            const order = { ...getOrder(), isTaxIncluded: true };
+
+            orderSummarySubtotals = shallow(
+                <OrderSummarySubtotals
+                    coupons={order.coupons}
+                    discountAmount={order.discountAmount}
+                    giftCertificates={order.payments && mapFromPayments(order.payments)}
+                    handlingAmount={order.handlingCostTotal}
+                    shippingAmount={order.shippingCostTotal}
+                    subtotalAmount={order.orderAmount}
+                    taxes={order.taxes}
+                />,
+            );
+
+            expect(orderSummarySubtotals).toMatchSnapshot();
+        });
+    })
 });

--- a/packages/core/src/app/order/OrderSummarySubtotals.tsx
+++ b/packages/core/src/app/order/OrderSummarySubtotals.tsx
@@ -10,7 +10,7 @@ export interface OrderSummarySubtotalsProps {
     coupons: Coupon[];
     giftCertificates?: GiftCertificate[];
     discountAmount?: number;
-    isTaxIncluded: boolean;
+    isTaxIncluded?: boolean;
     taxes?: Tax[];
     giftWrappingAmount?: number;
     shippingAmount?: number;

--- a/packages/core/src/app/order/OrderSummarySubtotals.tsx
+++ b/packages/core/src/app/order/OrderSummarySubtotals.tsx
@@ -10,6 +10,7 @@ export interface OrderSummarySubtotalsProps {
     coupons: Coupon[];
     giftCertificates?: GiftCertificate[];
     discountAmount?: number;
+    isTaxIncluded: boolean;
     taxes?: Tax[];
     giftWrappingAmount?: number;
     shippingAmount?: number;
@@ -22,6 +23,7 @@ export interface OrderSummarySubtotalsProps {
 
 const OrderSummarySubtotals: FunctionComponent<OrderSummarySubtotalsProps> = ({
     discountAmount,
+    isTaxIncluded,
     giftCertificates,
     taxes,
     giftWrappingAmount,
@@ -96,7 +98,7 @@ const OrderSummarySubtotals: FunctionComponent<OrderSummarySubtotalsProps> = ({
                 />
             )}
 
-            {(taxes || []).map((tax, index) => (
+            {!isTaxIncluded && (taxes || []).map((tax, index) => (
                 <OrderSummaryPrice
                     amount={tax.amount}
                     key={index}

--- a/packages/core/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
+++ b/packages/core/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
@@ -106,6 +106,7 @@ exports[`OrderSummary when shopper has same currency as store renders order summ
       }
       giftWrappingAmount={0}
       handlingAmount={8}
+      isTaxIncluded={false}
       shippingAmount={20}
       storeCreditAmount={0}
       subtotalAmount={200}
@@ -124,6 +125,152 @@ exports[`OrderSummary when shopper has same currency as store renders order summ
       orderAmount={190}
       shopperCurrencyCode="USD"
       storeCurrencyCode="USD"
+    />
+  </OrderSummarySection>
+</article>
+`;
+
+exports[`OrderSummary when taxes are inclusive displays tax as summary section 1`] = `
+<article
+  className="cart optimizedCheckout-orderSummary"
+  data-test="cart"
+>
+  <OrderSummaryHeader>
+    <Memo(PrintLink) />
+  </OrderSummaryHeader>
+  <OrderSummarySection>
+    <OrderSummaryItems
+      items={
+        Object {
+          "customItems": Array [],
+          "digitalItems": Array [],
+          "giftCertificates": Array [
+            Object {
+              "amount": 100,
+              "id": "bd391ead-8c58-4105-b00e-d75d233b429a",
+              "message": "message",
+              "name": "$100 Gift Certificate",
+              "recipient": Object {
+                "email": "lu@is.com",
+                "name": "luis",
+              },
+              "sender": Object {
+                "email": "pa@blo.com",
+                "name": "pablo",
+              },
+              "taxable": false,
+              "theme": "General",
+            },
+          ],
+          "physicalItems": Array [
+            Object {
+              "addedByPromotion": false,
+              "brand": "OFS",
+              "categoryNames": Array [
+                "Cat 1",
+              ],
+              "comparisonPrice": 200,
+              "couponAmount": 0,
+              "discountAmount": 0,
+              "discounts": Array [],
+              "extendedComparisonPrice": 250,
+              "extendedListPrice": 200,
+              "extendedSalePrice": 200,
+              "id": "666",
+              "imageUrl": "/images/canvas-laundry-cart.jpg",
+              "isShippingRequired": true,
+              "isTaxable": true,
+              "listPrice": 200,
+              "name": "Canvas Laundry Cart",
+              "options": Array [
+                Object {
+                  "name": "n",
+                  "nameId": 1,
+                  "value": "v",
+                  "valueId": 3,
+                },
+              ],
+              "productId": 103,
+              "quantity": 1,
+              "salePrice": 200,
+              "sku": "CLC",
+              "url": "/canvas-laundry-cart/",
+              "variantId": 71,
+            },
+          ],
+        }
+      }
+    />
+  </OrderSummarySection>
+  <OrderSummarySection>
+    <Memo(OrderSummarySubtotals)
+      coupons={
+        Array [
+          Object {
+            "code": "savebig2015",
+            "couponType": "percentage_discount",
+            "discountedAmount": 5,
+            "displayName": "20% off each item",
+            "id": "1",
+          },
+          Object {
+            "code": "279F507D817E3E7",
+            "couponType": "shipping_discount",
+            "discountedAmount": 5,
+            "displayName": "$5.00 off the shipping total",
+            "id": "4",
+          },
+        ]
+      }
+      discountAmount={10}
+      giftCertificates={
+        Array [
+          Object {
+            "balance": 10,
+            "code": "gc",
+            "purchaseDate": "",
+            "remaining": 3,
+            "used": 7,
+          },
+        ]
+      }
+      giftWrappingAmount={0}
+      handlingAmount={8}
+      isTaxIncluded={true}
+      shippingAmount={20}
+      storeCreditAmount={0}
+      subtotalAmount={200}
+      taxes={
+        Array [
+          Object {
+            "amount": 3,
+            "name": "Tax",
+          },
+        ]
+      }
+    />
+  </OrderSummarySection>
+  <OrderSummarySection>
+    <WithCurrency(OrderSummaryTotal)
+      orderAmount={190}
+      shopperCurrencyCode="USD"
+      storeCurrencyCode="USD"
+    />
+  </OrderSummarySection>
+  <OrderSummarySection>
+    <h5
+      className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary"
+      data-test="tax-text"
+    >
+      <WithLanguage(TranslatedString)
+        id="tax.inclusive_label"
+      />
+    </h5>
+    <OrderSummaryPrice
+      amount={3}
+      key="0"
+      label="Tax"
+      testId="cart-taxes"
     />
   </OrderSummarySection>
 </article>

--- a/packages/core/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
+++ b/packages/core/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
@@ -129,6 +129,7 @@ exports[`OrderSummaryModal renders order summary 1`] = `
       }
       giftWrappingAmount={0}
       handlingAmount={8}
+      isTaxIncluded={false}
       shippingAmount={20}
       storeCreditAmount={0}
       subtotalAmount={200}
@@ -148,6 +149,175 @@ exports[`OrderSummaryModal renders order summary 1`] = `
       orderAmount={190}
       shopperCurrencyCode="USD"
       storeCurrencyCode="USD"
+    />
+  </OrderSummarySection>
+</Modal>
+`;
+
+exports[`OrderSummaryModal when taxes are inclusive displays tax as summary section 1`] = `
+<Modal
+  additionalBodyClassName="cart-modal-body optimizedCheckout-orderSummary"
+  additionalHeaderClassName="cart-modal-header optimizedCheckout-orderSummary"
+  header={
+    <React.Fragment>
+      <a
+        className="cart-modal-close"
+        href="#"
+        onClick={[Function]}
+      >
+        <span
+          className="is-srOnly"
+        >
+          <WithLanguage(TranslatedString)
+            id="common.close_action"
+          />
+        </span>
+        <Memo />
+      </a>
+      <ModalHeader
+        additionalClassName="cart-modal-title"
+      >
+        <WithLanguage(TranslatedString)
+          id="cart.cart_heading"
+        />
+      </ModalHeader>
+    </React.Fragment>
+  }
+  isOpen={true}
+>
+  <OrderSummarySection>
+    <OrderSummaryItems
+      items={
+        Object {
+          "customItems": Array [],
+          "digitalItems": Array [],
+          "giftCertificates": Array [
+            Object {
+              "amount": 100,
+              "id": "bd391ead-8c58-4105-b00e-d75d233b429a",
+              "message": "message",
+              "name": "$100 Gift Certificate",
+              "recipient": Object {
+                "email": "lu@is.com",
+                "name": "luis",
+              },
+              "sender": Object {
+                "email": "pa@blo.com",
+                "name": "pablo",
+              },
+              "taxable": false,
+              "theme": "General",
+            },
+          ],
+          "physicalItems": Array [
+            Object {
+              "addedByPromotion": false,
+              "brand": "OFS",
+              "categoryNames": Array [
+                "Cat 1",
+              ],
+              "comparisonPrice": 200,
+              "couponAmount": 0,
+              "discountAmount": 0,
+              "discounts": Array [],
+              "extendedComparisonPrice": 250,
+              "extendedListPrice": 200,
+              "extendedSalePrice": 200,
+              "id": "666",
+              "imageUrl": "/images/canvas-laundry-cart.jpg",
+              "isShippingRequired": true,
+              "isTaxable": true,
+              "listPrice": 200,
+              "name": "Canvas Laundry Cart",
+              "options": Array [
+                Object {
+                  "name": "n",
+                  "nameId": 1,
+                  "value": "v",
+                  "valueId": 3,
+                },
+              ],
+              "productId": 103,
+              "quantity": 1,
+              "salePrice": 200,
+              "sku": "CLC",
+              "url": "/canvas-laundry-cart/",
+              "variantId": 71,
+            },
+          ],
+        }
+      }
+    />
+  </OrderSummarySection>
+  <OrderSummarySection>
+    <Memo(OrderSummarySubtotals)
+      coupons={
+        Array [
+          Object {
+            "code": "savebig2015",
+            "couponType": "percentage_discount",
+            "discountedAmount": 5,
+            "displayName": "20% off each item",
+            "id": "1",
+          },
+          Object {
+            "code": "279F507D817E3E7",
+            "couponType": "shipping_discount",
+            "discountedAmount": 5,
+            "displayName": "$5.00 off the shipping total",
+            "id": "4",
+          },
+        ]
+      }
+      discountAmount={10}
+      giftCertificates={
+        Array [
+          Object {
+            "balance": 10,
+            "code": "gc",
+            "purchaseDate": "",
+            "remaining": 3,
+            "used": 7,
+          },
+        ]
+      }
+      giftWrappingAmount={0}
+      handlingAmount={8}
+      isTaxIncluded={true}
+      shippingAmount={20}
+      storeCreditAmount={0}
+      subtotalAmount={200}
+      taxes={
+        Array [
+          Object {
+            "amount": 3,
+            "name": "Tax",
+          },
+        ]
+      }
+    />
+  </OrderSummarySection>
+  <OrderSummarySection>
+    <WithCurrency(OrderSummaryTotal)
+      orderAmount={190}
+      shopperCurrencyCode="USD"
+      storeCurrencyCode="USD"
+    />
+  </OrderSummarySection>
+  <OrderSummarySection>
+    <h5
+      className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary"
+      data-test="tax-text"
+    >
+      <WithLanguage(TranslatedString)
+        id="tax.inclusive_label"
+      />
+    </h5>
+    <OrderSummaryPrice
+      amount={3}
+      key="0"
+      label="Tax"
+      testId="cart-taxes"
     />
   </OrderSummarySection>
 </Modal>

--- a/packages/core/src/app/order/__snapshots__/OrderSummarySubtotals.spec.tsx.snap
+++ b/packages/core/src/app/order/__snapshots__/OrderSummarySubtotals.spec.tsx.snap
@@ -1,5 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OrderSummarySubtotals Tax summary is not rendered if tax is inclusive Renders component without tax summary 1`] = `
+<Fragment>
+  <OrderSummaryPrice
+    amount={190}
+    className="cart-priceItem--subtotal"
+    label={
+      <WithLanguage(TranslatedString)
+        id="cart.subtotal_text"
+      />
+    }
+    testId="cart-subtotal"
+  />
+  <Memo(OrderSummaryDiscount)
+    amount={5}
+    code="savebig2015"
+    key="0"
+    label="20% off each item"
+    testId="cart-coupon"
+  />
+  <Memo(OrderSummaryDiscount)
+    amount={5}
+    code="279F507D817E3E7"
+    key="1"
+    label="$5.00 off the shipping total"
+    testId="cart-coupon"
+  />
+  <Memo(OrderSummaryDiscount)
+    amount={10}
+    label={
+      <WithLanguage(TranslatedString)
+        id="cart.discount_text"
+      />
+    }
+    testId="cart-discount"
+  />
+  <Memo(OrderSummaryDiscount)
+    amount={7}
+    code="gc"
+    key="0"
+    label={
+      <WithLanguage(TranslatedString)
+        id="cart.gift_certificate_text"
+      />
+    }
+    remaining={3}
+    testId="cart-gift-certificate"
+  />
+  <OrderSummaryPrice
+    amount={15}
+    label={
+      <WithLanguage(TranslatedString)
+        id="cart.shipping_text"
+      />
+    }
+    testId="cart-shipping"
+    zeroLabel={
+      <WithLanguage(TranslatedString)
+        id="cart.free_text"
+      />
+    }
+  />
+  <OrderSummaryPrice
+    amount={8}
+    label={
+      <WithLanguage(TranslatedString)
+        id="cart.handling_text"
+      />
+    }
+    testId="cart-handling"
+  />
+  <OrderSummaryPrice
+    amount={3}
+    key="0"
+    label="Tax"
+    testId="cart-taxes"
+  />
+</Fragment>
+`;
+
 exports[`OrderSummarySubtotals renders component 1`] = `
 <Fragment>
   <OrderSummaryPrice

--- a/packages/core/src/app/order/mapToOrderSummarySubtotalsProps.ts
+++ b/packages/core/src/app/order/mapToOrderSummarySubtotalsProps.ts
@@ -8,6 +8,7 @@ import { OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
 export default function mapToOrderSummarySubtotalsProps({
     baseAmount,
     discountAmount,
+    isTaxIncluded,
     shippingCostBeforeDiscount,
     payments,
     handlingCostTotal,
@@ -25,5 +26,6 @@ export default function mapToOrderSummarySubtotalsProps({
         coupons,
         giftCertificates: payments && mapFromPayments(payments),
         taxes,
+        isTaxIncluded,
     };
 }

--- a/packages/core/src/app/order/orders.mock.ts
+++ b/packages/core/src/app/order/orders.mock.ts
@@ -15,6 +15,10 @@ export function getOrder(): Order {
         baseAmount: 200,
         billingAddress: getBillingAddress(),
         cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+        channelId: 1,
+        consignments: {
+            shipping: [],
+        },
         coupons: [getCoupon(), getShippingCoupon()],
         currency: getCurrency(),
         customerMessage: '',

--- a/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
+++ b/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
@@ -141,7 +141,6 @@
     margin-top: spacing("half");
 }
 
-
 // Cart Tax Item
 // -----------------------------------------------------------------------------
 //
@@ -158,4 +157,3 @@
 .cart-taxItem--subtotal {
     font-weight: 600;
 }
-

--- a/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
+++ b/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
@@ -155,5 +155,5 @@
 }
 
 .cart-taxItem--subtotal {
-    font-weight: 600;
+    font-weight: fontWeight("semibold");
 }

--- a/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
+++ b/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
@@ -140,3 +140,22 @@
     margin-bottom: 0;
     margin-top: spacing("half");
 }
+
+
+// Cart Tax Item
+// -----------------------------------------------------------------------------
+//
+// Purpose: Styling of the tax section if tax is exclusive
+//
+// -----------------------------------------------------------------------------
+
+.cart-taxItem {
+    display: table;
+    margin-bottom: spacing("half");
+    width: 100%;
+}
+
+.cart-taxItem--subtotal {
+    font-weight: 600;
+}
+

--- a/packages/locale/src/en.json
+++ b/packages/locale/src/en.json
@@ -462,6 +462,9 @@
             "agreement_with_link_text": "Yes, I agree with the <a href=\"{url}\" target=\"_blank\">terms and conditions</a>.",
             "terms_and_conditions_heading": "Terms and Conditions"
         },
+        "tax": {
+            "inclusive_label": "Tax Included in Total"
+        },
         "order_confirmation": {
             "mandate": {
                 "checkoutcom": {

--- a/packages/locale/src/en.json
+++ b/packages/locale/src/en.json
@@ -463,7 +463,7 @@
             "terms_and_conditions_heading": "Terms and Conditions"
         },
         "tax": {
-            "inclusive_label": "Tax Included in Total"
+            "inclusive_label": "Tax included in Total"
         },
         "order_confirmation": {
             "mandate": {


### PR DESCRIPTION
## What?
If tax is set as inclusive, display tax total under total cart price.

## Why?
Order Summary shows the Total price of the order as (Subtotal + Shipping). Although it might be clear to the merchant about inclusive tax, however for the customer it's not apparent. The customer can evaluate the price of the cart as (Subtotal + Shipping + tax) which is not true.

## Testing / Proof
- Circle

## Total Inclusive of tax
![Screen Shot 2023-03-14 at 5 39 35 pm](https://user-images.githubusercontent.com/7134802/224916623-dcf9da85-ca96-4250-b1b5-3aa72b1c3a20.png)

![Screen Shot 2023-03-14 at 5 39 49 pm](https://user-images.githubusercontent.com/7134802/224916662-1de2293c-0ca1-4263-b5b1-6c518f2fe476.png)

## Total exclusive of tax
![Screen Shot 2023-03-14 at 5 40 46 pm](https://user-images.githubusercontent.com/7134802/224916859-3977b8d1-e84f-46fa-8a68-1699c7c9cb81.png)

![Screen Shot 2023-03-14 at 5 41 02 pm](https://user-images.githubusercontent.com/7134802/224916898-057efa49-14d6-44a6-9296-98ee83ae8363.png)


@bigcommerce/checkout @theromulans 
