### PR TITLE
fix(checkout): CHECKOUT-0000 Change Google Pay button class name

### DIFF
--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -147,7 +147,7 @@ $buttonWidthMap: (
         padding: 0;
     }
 
-    .gpay-button.black.short.new_style {
+    .gpay-button.short {
         background-size: auto;
         border: none;
         border-radius: $global-radius;


### PR DESCRIPTION
## What?
Rename Google Pay button class name.

## Why?
Google Pay ended A/B testing and discontinued using `new_style` in its class name. 

To keep our style overrides working, we also need to remove it.

## Testing / Proof
<img width="500" alt="image" src="https://user-images.githubusercontent.com/88361607/224896247-a4bba540-f264-4d55-8e2c-56a43b976931.png">


@bigcommerce/checkout
