### PR TITLE
feat(payment): PAYPAL-1893 updated initialize payment option from paypalcommerce to paypalcommercecreditcards in PaypalCommerceCreditCardPaymentMethod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.368.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.368.0.tgz",
-      "integrity": "sha512-BsbvFe5ogLrD/SCUvxlJkvpxAYkHXib06MN8Rm+Xu/OQQlmUqqgjl/QYfI5xv3GTEb6Y13uTknlcR4XsutI1ig==",
+      "version": "1.369.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.369.2.tgz",
+      "integrity": "sha512-js8z4M0eWmtqLtPPZeeKX3BByqoURtYbywhxbeKwfzgPg+Czk938WOzpm/sDg/toD0EfKOrW/p1Nn/UsEfokAQ==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.368.0",
+    "@bigcommerce/checkout-sdk": "^1.369.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.spec.tsx
@@ -127,7 +127,7 @@ describe('when using PayPal Commerce Credit Card payment', () => {
             expect.objectContaining({
                 methodId: defaultProps.method.id,
                 gatewayId: defaultProps.method.gateway,
-                paypalcommerce: {
+                paypalcommercecreditcards: {
                     form: hostedFormOptions,
                 },
             }),

--- a/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.tsx
@@ -25,7 +25,7 @@ const PaypalCommerceCreditCardPaymentMethod: FunctionComponent<
             async (options, selectedInstrument) => {
                 return initializePayment({
                     ...options,
-                    paypalcommerce: {
+                    paypalcommercecreditcards: {
                         form:
                             getHostedFormOptions &&
                             (await getHostedFormOptions(selectedInstrument)),


### PR DESCRIPTION
**CI tests can be failed due to the unmerged changes of this PR:**
https://github.com/bigcommerce/checkout-sdk-js/pull/1887

## What?
Updated initialize payment option from paypalcommerce to paypalcommercecreditcards in PaypalCommerceCreditCardPaymentMethod

## Why?
`paypalcommerce` initialization option key is deprecated for `paypalcommercecreditcards` gateway id.
It still works for custom checkouts, but the developers will see a warning message in console about `paypalcommerce` key deprecation.

## Testing / Proof
Unit tests
Manual tests

<img width="689" alt="Screenshot 2023-03-17 at 18 06 11" src="https://user-images.githubusercontent.com/25133454/225964680-669d02c0-19be-4da9-a502-4d82c6ddd0dc.png">
