### PR TITLE
feat(payment): PAYPAL-1906 Bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.363.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.363.0.tgz",
-      "integrity": "sha512-4C57lh0YHSeNgGZTBDGfZM8TMYltUTWWPcZv2B+I1N+EhWjPraBAACH+8siIdl4T1PT0KitRvXhUWGB2CWUYog==",
+      "version": "1.366.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.366.0.tgz",
+      "integrity": "sha512-by9p/2ELAsvrhENgt13SQpsacJ6ggphgPGzfGt31/izxw9/qUcK/RG6tA5bHbYmCALvtI5KWq3uvczE4hQTI4Q==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.363.0",
+    "@bigcommerce/checkout-sdk": "^1.366.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To keep checkout-sdk-js dependency version up to date.
PR with changes in cherckout-sdk-js:
[https://github.com/bigcommerce/checkout-sdk-js/pull/1808](https://github.com/bigcommerce/checkout-sdk-js/pull/1808)

## Testing / Proof
Unit tests
Manual testing

@bigcommerce/checkout
