### PR TITLE
feat(payment): BOLT-483 Bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1319,9 +1319,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.369.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.369.2.tgz",
-      "integrity": "sha512-js8z4M0eWmtqLtPPZeeKX3BByqoURtYbywhxbeKwfzgPg+Czk938WOzpm/sDg/toD0EfKOrW/p1Nn/UsEfokAQ==",
+      "version": "1.370.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.370.0.tgz",
+      "integrity": "sha512-BnffC3IukSkVseh3HhZo8sUUjg8t6Q06GcLC5BSk5lUDSFLApS1KNK+V81cEvTYrVmIo73CVyrYNiliKELWlAw==",
       "requires": {
         "@babel/polyfill": "^7.12.1",
         "@bigcommerce/bigpay-client": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.369.2",
+    "@bigcommerce/checkout-sdk": "^1.370.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To keep checkout-sdk-js dependency version up to date.
PR with changes in cherckout-sdk-js:
[https://github.com/bigcommerce/checkout-sdk-js/pull/1915](https://github.com/bigcommerce/checkout-sdk-js/pull/1915)


## Testing / Proof
unit tests & manual testing

@bigcommerce/checkout
