### PR TITLE
feat(checkout): CHECKOUT-0000 Hide wallet buttons during payment step

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -305,7 +305,7 @@ class Checkout extends Component<
 
         const isPaymentStepActive = activeStepType
             ? activeStepType === CheckoutStepType.Payment
-            : defaultStepType === CheckoutStepType.Payment || (!activeStepType && !defaultStepType);
+            : defaultStepType === CheckoutStepType.Payment;
 
         return (
             <LoadingOverlay hideContentWhenLoading isLoading={isRedirecting}>
@@ -314,10 +314,13 @@ class Checkout extends Component<
 
                     <PromotionBannerList promotions={promotions} />
 
-                    {isShowingWalletButtonsOnTop && !isPaymentStepActive && <CheckoutButtonContainer
-                      checkEmbeddedSupport={this.checkEmbeddedSupport}
-                      onUnhandledError={this.handleUnhandledError}
-                    />}
+                    {isShowingWalletButtonsOnTop && (
+                        <CheckoutButtonContainer
+                            checkEmbeddedSupport={this.checkEmbeddedSupport}
+                            isPaymentStepActive={isPaymentStepActive}
+                            onUnhandledError={this.handleUnhandledError}
+                        />
+                    )}
 
                     <ol className="checkout-steps">
                         {steps

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -303,6 +303,10 @@ class Checkout extends Component<
             return <EmptyCartMessage loginUrl={loginUrl} waitInterval={3000} />;
         }
 
+        const isPaymentStepActive = activeStepType
+            ? activeStepType === CheckoutStepType.Payment
+            : defaultStepType === CheckoutStepType.Payment || (!activeStepType && !defaultStepType);
+
         return (
             <LoadingOverlay hideContentWhenLoading isLoading={isRedirecting}>
                 <div className="layout-main">
@@ -310,7 +314,7 @@ class Checkout extends Component<
 
                     <PromotionBannerList promotions={promotions} />
 
-                    {isShowingWalletButtonsOnTop && <CheckoutButtonContainer
+                    {isShowingWalletButtonsOnTop && !isPaymentStepActive && <CheckoutButtonContainer
                       checkEmbeddedSupport={this.checkEmbeddedSupport}
                       onUnhandledError={this.handleUnhandledError}
                     />}

--- a/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
@@ -8,7 +8,7 @@ import { getStoreConfig } from '../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType, } from '../locale';
 
 import CheckoutButtonContainer from './CheckoutButtonContainer';
-import { getGuestCustomer } from './customers.mock';
+import { getCustomer, getGuestCustomer } from './customers.mock';
 
 describe('CheckoutButtonContainer', () => {
     let localeContext: LocaleContextType;
@@ -28,19 +28,81 @@ describe('CheckoutButtonContainer', () => {
                         walletButtonsOnTop: true,
                         floatingLabelEnabled: false,
                     },
-                    remoteCheckoutProviders: ['amazonpay','applepay', 'paypalcommerce', 'paypalcommercecredit'],
+                    remoteCheckoutProviders: ['amazonpay','applepay', 'braintreepaypal'],
                 },
             }),
         );
     });
 
-    it('matches snapshot', () => {
+    it('displays wallet buttons for guest checkout', () => {
         const component = render(
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
                     <CheckoutButtonContainer
                         checkEmbeddedSupport={jest.fn()}
                         isPaymentStepActive={false}
+                        onUnhandledError={jest.fn()}
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it('hides wallet buttons for signed-in shoppers', () => {
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
+
+        const component = render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <CheckoutButtonContainer
+                        checkEmbeddedSupport={jest.fn()}
+                        isPaymentStepActive={false}
+                        onUnhandledError={jest.fn()}
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it('hides wallet buttons with CSS when payment step is active', () => {
+        const component = render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <CheckoutButtonContainer
+                        checkEmbeddedSupport={jest.fn()}
+                        isPaymentStepActive={true}
+                        onUnhandledError={jest.fn()}
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it('removes Paypal commerce wallet buttons when payment step is active', () => {
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+            merge(getStoreConfig(), {
+                checkoutSettings: {
+                    checkoutUserExperienceSettings: {
+                        walletButtonsOnTop: true,
+                        floatingLabelEnabled: false,
+                    },
+                    remoteCheckoutProviders: ['amazonpay','applepay', 'paypalcommerce'],
+                },
+            }),
+        );
+
+        const component = render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <CheckoutButtonContainer
+                        checkEmbeddedSupport={jest.fn()}
+                        isPaymentStepActive={true}
                         onUnhandledError={jest.fn()}
                     />
                 </LocaleContext.Provider>

--- a/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
@@ -8,6 +8,7 @@ import { getStoreConfig } from '../config/config.mock';
 import { createLocaleContext, LocaleContext, LocaleContextType, } from '../locale';
 
 import CheckoutButtonContainer from './CheckoutButtonContainer';
+import { getGuestCustomer } from './customers.mock';
 
 describe('CheckoutButtonContainer', () => {
     let localeContext: LocaleContextType;
@@ -19,6 +20,7 @@ describe('CheckoutButtonContainer', () => {
         checkoutState = checkoutService.getState();
         localeContext = createLocaleContext(getStoreConfig());
 
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getGuestCustomer());
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
             merge(getStoreConfig(), {
                 checkoutSettings: {
@@ -38,6 +40,7 @@ describe('CheckoutButtonContainer', () => {
                 <LocaleContext.Provider value={localeContext}>
                     <CheckoutButtonContainer
                         checkEmbeddedSupport={jest.fn()}
+                        isPaymentStepActive={false}
                         onUnhandledError={jest.fn()}
                     />
                 </LocaleContext.Provider>

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -18,6 +18,7 @@ interface CheckoutButtonContainerProps {
 interface WithCheckoutCheckoutButtonContainerProps{
     availableMethodIds: string[];
     isLoading: boolean;
+    isPaypalCommerce: boolean;
     initializedMethodIds: string[];
     deinitialize(options: CustomerRequestOptions): void;
     initialize(options: CustomerInitializeOptions): void;
@@ -42,6 +43,7 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         checkEmbeddedSupport,
         deinitialize,
         isLoading,
+        isPaypalCommerce,
         isPaymentStepActive,
         initialize,
         initializedMethodIds,
@@ -55,9 +57,6 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
     } catch (error) {
         return null;
     }
-
-    const paypalCommerceIds = ['paypalcommerce', 'paypalcommercecredit', 'paypalcommercevenmo'];
-    const isPaypalCommerce = methodIds.some(id => paypalCommerceIds.includes(id));
 
     if (isPaypalCommerce && isPaymentStepActive) {
         return null;
@@ -123,6 +122,8 @@ function mapToCheckoutButtonContainerProps({
         (methodId) => Boolean(getInitializeCustomerError(methodId)) || isInitializedCustomer(methodId)
     ).length !== availableMethodIds.length;
     const initializedMethodIds = availableMethodIds.filter((methodId) => isInitializedCustomer(methodId));
+    const paypalCommerceIds = ['paypalcommerce', 'paypalcommercecredit', 'paypalcommercevenmo'];
+    const isPaypalCommerce = availableMethodIds.some(id => paypalCommerceIds.includes(id));
 
     return {
         availableMethodIds,
@@ -130,6 +131,7 @@ function mapToCheckoutButtonContainerProps({
         initialize: checkoutService.initializeCustomer,
         initializedMethodIds,
         isLoading,
+        isPaypalCommerce,
     }
 }
 

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -99,6 +99,7 @@ function mapToCheckoutButtonContainerProps({
     checkoutState: {
        data: {
            getConfig,
+           getCustomer,
        },
        statuses: {
            isInitializedCustomer,
@@ -111,8 +112,9 @@ function mapToCheckoutButtonContainerProps({
 }: CheckoutContextProps): WithCheckoutCheckoutButtonContainerProps | null {
     const config = getConfig();
     const availableMethodIds = filterUnsupportedMethodIds(config?.checkoutSettings.remoteCheckoutProviders ?? []);
+    const customer = getCustomer();
 
-    if (!config || availableMethodIds.length === 0) {
+    if (!config || availableMethodIds.length === 0 || !customer?.isGuest) {
         return null;
     }
 

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -64,7 +64,7 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
 
     return (
         <div className='checkout-button-container'
-             style={ isPaymentStepActive ? { position: 'absolute', left: '100%', top: '-100%' } : undefined }
+             style={ isPaymentStepActive ? { position: 'absolute', left: '0', top: '-100%' } : undefined }
         >
             <p>
                 <TranslatedString id="remote.start_with_text" />

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -56,7 +56,8 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         return null;
     }
 
-    const isPaypalCommerce = methodIds.includes('paypalcommerce');
+    const paypalCommerceIds = ['paypalcommerce', 'paypalcommercecredit', 'paypalcommercevenmo'];
+    const isPaypalCommerce = methodIds.some(id => paypalCommerceIds.includes(id));
 
     if (isPaypalCommerce && isPaymentStepActive) {
         return null;

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -10,6 +10,7 @@ import { TranslatedString } from '../locale';
 import CheckoutButtonListV1, { filterUnsupportedMethodIds } from './CheckoutButtonList';
 
 interface CheckoutButtonContainerProps {
+    isPaymentStepActive: boolean;
     checkEmbeddedSupport(methodIds: string[]): void;
     onUnhandledError(error: Error): void;
 }
@@ -41,6 +42,7 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         checkEmbeddedSupport,
         deinitialize,
         isLoading,
+        isPaymentStepActive,
         initialize,
         initializedMethodIds,
         onUnhandledError,
@@ -54,8 +56,16 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         return null;
     }
 
+    const isPaypalCommerce = methodIds.includes('paypalcommerce');
+
+    if (isPaypalCommerce && isPaymentStepActive) {
+        return null;
+    }
+
     return (
-        <div className='checkout-button-container'>
+        <div className='checkout-button-container'
+             style={ isPaymentStepActive ? { position: 'absolute', left: '100%', top: '-100%' } : undefined }
+        >
             <p>
                 <TranslatedString id="remote.start_with_text" />
             </p>

--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CheckoutButtonContainer matches snapshot 1`] = `
+exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] = `
 <div
   class="checkout-button-container"
 >
@@ -8,18 +8,11 @@ exports[`CheckoutButtonContainer matches snapshot 1`] = `
     Check out faster with:
   </p>
   <div
-    class="checkout-buttons--3"
+    class="checkout-buttons--2"
   >
     <div
       class="checkoutRemote customer-skeleton"
     >
-      <div
-        class="skeleton-container"
-      >
-        <div
-          class="input-skeleton"
-        />
-      </div>
       <div
         class="skeleton-container"
       >
@@ -43,10 +36,7 @@ exports[`CheckoutButtonContainer matches snapshot 1`] = `
         class="checkoutRemote"
       >
         <div
-          id="paypalcommerceCheckoutButton"
-        />
-        <div
-          id="paypalcommercecreditCheckoutButton"
+          id="braintreepaypalCheckoutButton"
         />
         <div
           class="AmazonPayContainer"
@@ -67,3 +57,66 @@ exports[`CheckoutButtonContainer matches snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`CheckoutButtonContainer hides wallet buttons for signed-in shoppers 1`] = `null`;
+
+exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step is active 1`] = `
+<div
+  class="checkout-button-container"
+  style="position:absolute;left:100%;top:-100%"
+>
+  <p>
+    Check out faster with:
+  </p>
+  <div
+    class="checkout-buttons--2"
+  >
+    <div
+      class="checkoutRemote customer-skeleton"
+    >
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+    </div>
+    <div
+      class="loading-skeleton"
+      style="position:absolute;left:100%;top:-100%"
+    >
+      <div
+        class="checkoutRemote"
+      >
+        <div
+          id="braintreepaypalCheckoutButton"
+        />
+        <div
+          class="AmazonPayContainer"
+        >
+          <div
+            id="amazonpayCheckoutButton"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="checkout-separator"
+  >
+    <span>
+      OR
+    </span>
+  </div>
+</div>
+`;
+
+exports[`CheckoutButtonContainer removes Paypal commerce wallet buttons when payment step is active 1`] = `null`;

--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -63,7 +63,7 @@ exports[`CheckoutButtonContainer hides wallet buttons for signed-in shoppers 1`]
 exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step is active 1`] = `
 <div
   class="checkout-button-container"
-  style="position:absolute;left:100%;top:-100%"
+  style="position:absolute;left:0;top:-100%"
 >
   <p>
     Check out faster with:


### PR DESCRIPTION
## What?
Hide wallet buttons when a shopper enters the payment step.

## Why?
`paypalcommerce` does not support simultaneously display wallet buttons and payment methods.

## Testing / Proof
- CI.

@bigcommerce/checkout
