### PR TITLE
feat(payment): PAYPAL-2323 Add component for ACH vaulting | POC

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/BraintreeAchPaymentForm.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BraintreeAchPaymentForm.tsx
@@ -1,17 +1,20 @@
 import {
+    AccountInstrument,
     CardInstrument,
     CheckoutSelectors,
     FormField,
     PaymentInitializeOptions,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
-import React, { FunctionComponent, memo, useEffect } from 'react';
+import { find } from 'lodash';
+import React, { FunctionComponent, memo, useCallback, useEffect, useState } from 'react';
 
 import { AddressKeyMap } from '../../address/address';
 import { ConnectFormikProps } from '../../common/form';
 import { TranslatedString, WithLanguageProps } from '../../locale';
 import { DynamicFormField } from '../../ui/form';
 import { LoadingOverlay } from '../../ui/loading';
+import { AccountInstrumentFieldset } from '../storedInstrument';
 import withAchBraintreeFields from '../withAchBraintreeFields';
 import { WithPaymentProps } from '../withPayment';
 
@@ -63,6 +66,9 @@ export interface BraintreeAchPaymentFormProps {
     mandateText: string;
     isLoadingBillingCountries: boolean;
     initializeBillingAddressFields(): Promise<CheckoutSelectors>;
+    instruments: AccountInstrument[];
+    loadInstruments(): Promise<CheckoutSelectors>;
+    isNewAddress: boolean;
 }
 
 const BraintreeAchPaymentForm: FunctionComponent<
@@ -76,8 +82,14 @@ const BraintreeAchPaymentForm: FunctionComponent<
     isLoadingBillingCountries,
     fieldValues,
     handleChange,
+    instruments,
+    isNewAddress,
     ...props
 }) => {
+    const [currentInstrument, setCurrentInstrument] = useState<AccountInstrument | undefined>(
+        instruments.length ? instruments[0] : undefined
+    );
+
     useEffect(() => {
         const {
             method: {
@@ -85,7 +97,8 @@ const BraintreeAchPaymentForm: FunctionComponent<
                 id: methodId
             },
             initializePayment,
-            initializeBillingAddressFields
+            initializeBillingAddressFields,
+            loadInstruments,
         } = props;
 
         const initialize = async () => {
@@ -95,10 +108,22 @@ const BraintreeAchPaymentForm: FunctionComponent<
                 gatewayId,
                 methodId,
             });
+
+            await loadInstruments();
         }
 
         initialize();
     }, []);
+
+    const handleSelectInstrument = useCallback((id: string) => {
+        setCurrentInstrument(find(instruments, { bigpayToken: id }));
+    }, [instruments, setCurrentInstrument]);
+
+    const handleUseNewInstrument = useCallback(() => {
+        setCurrentInstrument(undefined);
+    }, [setCurrentInstrument]);
+
+    const shouldShowInstrumentFieldset = instruments.length > 0 || isNewAddress;
 
     return (
         <LoadingOverlay
@@ -106,6 +131,14 @@ const BraintreeAchPaymentForm: FunctionComponent<
             isLoading={isLoadingBillingCountries}
         >
             <div className='checkout-ach-form'>
+                {shouldShowInstrumentFieldset && (
+                    <AccountInstrumentFieldset
+                        instruments={instruments}
+                        onSelectInstrument={handleSelectInstrument}
+                        onUseNewInstrument={handleUseNewInstrument}
+                        selectedInstrument={currentInstrument}
+                    />
+                )}
                 <AchFormFields
                     fieldValues={fieldValues}
                     handleChange={handleChange}

--- a/packages/core/src/app/payment/paymentMethod/BraintreeAchPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BraintreeAchPaymentMethod.tsx
@@ -4,7 +4,13 @@ import BraintreeAchPaymentForm, { BraintreeAchPaymentFormProps } from './Braintr
 
 export type BraintreeAchPaymentMethodProps = Omit<
     BraintreeAchPaymentFormProps,
-    'mandateText' | 'isLoadingBillingCountries' | 'usCountry' | 'initializeBillingAddressFields'
+    'mandateText' |
+    'isLoadingBillingCountries' |
+    'usCountry' |
+    'initializeBillingAddressFields' |
+    'instruments' |
+    'isNewAddress' |
+    'loadInstruments'
 >;
 
 const mandateText = 'I authorize Braintree to debit my bank account on behalf of My Online Store.';

--- a/packages/core/src/scss/components/checkout/achForm/_achForm.scss
+++ b/packages/core/src/scss/components/checkout/achForm/_achForm.scss
@@ -4,6 +4,10 @@
     margin: 0 -4px;
     margin-bottom: spacing("half");
 
+    .instrumentFieldset {
+        width: 100%;
+    }
+
     .mandate-text {
         padding: 0 4px;
     }


### PR DESCRIPTION
## What?

Implementing a vaultings component for Braintree ACH Vaulting

## Why?

We need the vaultings component for Braintree ACH to be able to work with stored information

## Testing / Proof

Works with mock data to display the vaulting component

On current step we don't have an ACH instrument to work with this component.
Will back when the instrument is ready to finalize the component.

<img width="706" alt="Screenshot 2023-04-11 at 13 11 12" src="https://user-images.githubusercontent.com/99336044/231143045-ec1681b9-3342-4d78-adbe-f89446c238cc.png">

<img width="723" alt="Screenshot 2023-04-11 at 13 11 28" src="https://user-images.githubusercontent.com/99336044/231143100-25580fe7-46bd-4b5e-bc05-434839a23950.png">
