### PR TITLE
refactor(checkout): CHECKOUT-7421 remove CHECKOUT-3190.enable_buy_now_cart experiment

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -117,7 +117,6 @@ export interface CheckoutState {
     isCartEmpty: boolean;
     isRedirecting: boolean;
     hasSelectedShippingOptions: boolean;
-    isBuyNowCartEnabled: boolean;
     isHidingStepNumbers: boolean;
     isSubscribed: boolean;
 }
@@ -155,7 +154,6 @@ class Checkout extends Component<
         isRedirecting: false,
         isMultiShippingMode: false,
         hasSelectedShippingOptions: false,
-        isBuyNowCartEnabled: false,
         isHidingStepNumbers: true,
         isSubscribed: false,
     };
@@ -230,9 +228,6 @@ class Checkout extends Component<
                 data.getConfig()?.checkoutSettings.hasMultiShippingEnabled;
             const checkoutBillingSameAsShippingEnabled =
                 data.getConfig()?.checkoutSettings.checkoutBillingSameAsShippingEnabled ?? true;
-            const buyNowCartFlag =
-                data.getConfig()?.checkoutSettings.features['CHECKOUT-3190.enable_buy_now_cart'] ??
-                false;
             const removeStepNumbersFlag =
               data.getConfig()?.checkoutSettings.features['CHECKOUT-7255.remove_checkout_step_numbers'] ??
               false;
@@ -247,7 +242,6 @@ class Checkout extends Component<
 
             this.setState({
                 isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled,
-                isBuyNowCartEnabled: buyNowCartFlag,
                 isHidingStepNumbers: removeStepNumbersFlag,
                 isSubscribed: defaultNewsletterSignupOption,
             });
@@ -580,7 +574,6 @@ class Checkout extends Component<
 
     private navigateToOrderConfirmation: (orderId?: number) => void = (orderId) => {
         const { steps, analyticsTracker } = this.props;
-        const { isBuyNowCartEnabled } = this.state;
 
         analyticsTracker.trackStepCompleted(steps[steps.length - 1].type);
 
@@ -589,7 +582,7 @@ class Checkout extends Component<
         }
 
         this.setState({ isRedirecting: true }, () => {
-            navigateToOrderConfirmation(isBuyNowCartEnabled, orderId);
+            navigateToOrderConfirmation(orderId);
         });
     };
 

--- a/packages/core/src/app/checkout/navigateToOrderConfirmation.spec.tsx
+++ b/packages/core/src/app/checkout/navigateToOrderConfirmation.spec.tsx
@@ -13,14 +13,14 @@ describe('navigateToOrderConfirmation', () => {
     });
 
     it('navigates to order confirmation page based on its current path', () => {
-        navigateToOrderConfirmation(true);
+        navigateToOrderConfirmation();
 
         expect(window.location.replace).toHaveBeenCalledWith('/checkout/order-confirmation');
     });
 
     it('navigates to order confirmation page with orderId in the URL when it is a buy now cart checkout', () => {
         window.location.pathname = '/checkout/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
-        navigateToOrderConfirmation(true, 100);
+        navigateToOrderConfirmation(100);
 
         expect(window.location.replace).toHaveBeenCalledWith('/checkout/order-confirmation/100');
     });
@@ -29,7 +29,7 @@ describe('navigateToOrderConfirmation', () => {
         window.location.href = 'https://store.com/embedded-checkout?setCurrencyId=1';
         window.location.pathname = '/embedded-checkout';
 
-        navigateToOrderConfirmation(true);
+        navigateToOrderConfirmation();
 
         expect(window.location.replace).toHaveBeenCalledWith(
             '/embedded-checkout/order-confirmation',

--- a/packages/core/src/app/checkout/navigateToOrderConfirmation.tsx
+++ b/packages/core/src/app/checkout/navigateToOrderConfirmation.tsx
@@ -3,24 +3,16 @@ import { noop } from 'lodash';
 import { isBuyNowCart } from '../common/utility';
 
 export default function navigateToOrderConfirmation(
-    isBuyNowCartEnabled = false,
     orderId?: number,
 ): Promise<never> {
     let url: string;
 
-    if (isBuyNowCartEnabled) {
-        if (orderId && isBuyNowCart()) {
-            url = `/checkout/order-confirmation/${orderId.toString()}`;
-        } else {
-            url = `${window.location.pathname.replace(/\/$/, '')}/order-confirmation`;
-        }
-
-        window.location.replace(url);
-
-        return new Promise(noop);
+    if (orderId && isBuyNowCart()) {
+        url = `/checkout/order-confirmation/${orderId.toString()}`;
+    } else {
+        url = `${window.location.pathname.replace(/\/$/, '')}/order-confirmation`;
     }
 
-    url = `${window.location.pathname.replace(/\/$/, '')}/order-confirmation`;
     window.location.replace(url);
 
     return new Promise(noop);


### PR DESCRIPTION
## What?
Remove `CHECKOUT-3190.enable_buy_now_cart` experiment

## Why?
Since this experiment already ramped out for long time, we decided to remove it. 

## Related PR
BCApp PR related to the experiment removal
https://github.com/bigcommerce/bigcommerce/pull/52032

## Testing / Proof
CI tests

@bigcommerce/checkout
