### PR TITLE
chore(payment): PAYPAL-1895 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@bigcommerce/checkout",
-      "version": "1.306.1",
+      "version": "1.308.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.374.2",
+        "@bigcommerce/checkout-sdk": "^1.374.6",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1860,9 +1860,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.374.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.374.2.tgz",
-      "integrity": "sha512-imaKhz98+jN9KhVldxcNj9Dl/LQcJTvewoYjijSaYKU/AYoWAtDteKdIfs6XepDUo2USF46Tj8eYg7OCb7FBXA==",
+      "version": "1.374.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.374.6.tgz",
+      "integrity": "sha512-9mxpVGJbjNt9mNlYPHZ1cagTkfONcrKOSJ39/1No7JlCNqM+vfAIAIgKvU6XIu9TBb/RQOSSNk1Pbcx3Olt7Nw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.22.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -28839,9 +28839,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.374.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.374.2.tgz",
-      "integrity": "sha512-imaKhz98+jN9KhVldxcNj9Dl/LQcJTvewoYjijSaYKU/AYoWAtDteKdIfs6XepDUo2USF46Tj8eYg7OCb7FBXA==",
+      "version": "1.374.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.374.6.tgz",
+      "integrity": "sha512-9mxpVGJbjNt9mNlYPHZ1cagTkfONcrKOSJ39/1No7JlCNqM+vfAIAIgKvU6XIu9TBb/RQOSSNk1Pbcx3Olt7Nw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.22.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.374.2",
+    "@bigcommerce/checkout-sdk": "^1.374.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
Due to the last checkout-sdk changes:
https://github.com/bigcommerce/checkout-sdk-js/pull/1954
https://github.com/bigcommerce/checkout-sdk-js/pull/1953
https://github.com/bigcommerce/checkout-sdk-js/pull/1947
https://github.com/bigcommerce/checkout-sdk-js/pull/1941

## Testing / Proof
Unit tests
CI tests
Manual tests
