### PR TITLE
feat(cart): CHECKOUT-7403 Fix layout for updated modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+.DS_Store
 junit.xml
 __temp__
 node_modules

--- a/packages/core/src/scss/components/checkout/cartModal/_cartModal.scss
+++ b/packages/core/src/scss/components/checkout/cartModal/_cartModal.scss
@@ -39,11 +39,14 @@
 }
 
 .modal.modal--afterOpen.optimizedCheckout-cart-modal {
-    justify-content: start;
+    display: block;
+    bottom: 0;
+    min-height: 90vh;
 
     .modal-body {
         box-shadow: none;
-        height: 100%;
+        height: 70%;
+        padding-bottom: 0;
     }
 }
 


### PR DESCRIPTION
## What?
As above

## Why?
The continue to checkout button is cut in half in mobile screens. Adjust styles to fix that.

## Testing / Proof
- Screenshot

# Android
![Screen Shot 2023-04-24 at 11 47 50 pm](https://user-images.githubusercontent.com/7134802/234015891-3069d55b-050b-4052-9187-f17b39ef6a53.png)

# IOS Chrome
![Screen Shot 2023-04-24 at 11 48 50 pm](https://user-images.githubusercontent.com/7134802/234016191-196ab27b-8737-4dec-ae5f-092c82b0a3d3.png)

# IOS Safari
![Screen Shot 2023-04-24 at 11 50 07 pm](https://user-images.githubusercontent.com/7134802/234016508-4e2c6758-5486-4464-8606-e5f60a3a04fe.png)

## With more than 3 products
![Screen Shot 2023-04-24 at 11 58 13 pm](https://user-images.githubusercontent.com/7134802/234018774-395866ee-2c3e-4bff-b22e-4324748aafa7.png)



@bigcommerce/checkout
