### PR TITLE
chore(payment): PAYPAL-2036 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@bigcommerce/checkout",
-      "version": "1.310.0",
+      "version": "1.311.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.376.0",
+        "@bigcommerce/checkout-sdk": "^1.376.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1860,9 +1860,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.376.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.376.0.tgz",
-      "integrity": "sha512-MGpu/3zwnOcV6Fz75YyCiSsWzAM2uFS4WJ8UcgpJbZCpdMiu3TyS0OEJxhS+6zE96F91e8vMMuqLhRFwNUaccA==",
+      "version": "1.376.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.376.1.tgz",
+      "integrity": "sha512-mMulhcGy7s3a9SjALGMSF8HNjYkDEDg5nmojHZxaTyGVOOIEKX9BGYkv6m+Z1wuZKkobT6S4hg/C6kh2f9Mpww==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.22.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -28839,9 +28839,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.376.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.376.0.tgz",
-      "integrity": "sha512-MGpu/3zwnOcV6Fz75YyCiSsWzAM2uFS4WJ8UcgpJbZCpdMiu3TyS0OEJxhS+6zE96F91e8vMMuqLhRFwNUaccA==",
+      "version": "1.376.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.376.1.tgz",
+      "integrity": "sha512-mMulhcGy7s3a9SjALGMSF8HNjYkDEDg5nmojHZxaTyGVOOIEKX9BGYkv6m+Z1wuZKkobT6S4hg/C6kh2f9Mpww==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.22.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.376.0",
+    "@bigcommerce/checkout-sdk": "^1.376.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To keep checkout-sdk dependency up to date.

The release contains changes from this pr:
https://github.com/bigcommerce/checkout-sdk-js/pull/1962

## Testing / Proof
Unit tests
Manual tests
CI tests
