### PR TITLE
fix(cart): CHECKOUT-7403 Remove redundant line items count in updated cart modal

### DIFF
--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -39,7 +39,7 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
             <OrderSummaryHeader>{headerLink}</OrderSummaryHeader>
 
             <OrderSummarySection>
-                <OrderSummaryItems items={nonBundledLineItems} />
+                <OrderSummaryItems displayLineItemsCount items={nonBundledLineItems} />
             </OrderSummarySection>
 
             <OrderSummarySection>

--- a/packages/core/src/app/order/OrderSummaryItems.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.spec.tsx
@@ -20,6 +20,7 @@ describe('OrderSummaryItems', () => {
         beforeEach(() => {
             orderSummaryItems = shallow(
                 <OrderSummaryItems
+                    displayLineItemsCount
                     items={{
                         customItems: [getCustomItem()],
                         physicalItems: [getPhysicalItem()],
@@ -56,6 +57,7 @@ describe('OrderSummaryItems', () => {
             orderSummaryItems = mount(
                 <LocaleContext.Provider value={localeContext}>
                     <OrderSummaryItems
+                        displayLineItemsCount
                         items={{
                             customItems: [getCustomItem()],
                             physicalItems: [
@@ -104,6 +106,24 @@ describe('OrderSummaryItems', () => {
 
                     expect(orderSummaryItems.find('.productList-item')).toHaveLength(4);
                 });
+            });
+        });
+
+        describe('line items count is not rendered if flag is passed as false', () => {
+            it('does not render line items count', () => {
+                const orderSummaryItemsWithoutCount = shallow(
+                    <OrderSummaryItems
+                        displayLineItemsCount={false}
+                        items={{
+                            customItems: [getCustomItem()],
+                            physicalItems: [getPhysicalItem()],
+                            digitalItems: [getDigitalItem()],
+                            giftCertificates: [getGiftCertificateItem()],
+                        }}
+                    />,
+                );
+
+                expect(orderSummaryItemsWithoutCount.find(TranslatedString)).toHaveLength(0);
             });
         });
     });

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -17,6 +17,7 @@ const COLLAPSED_ITEMS_LIMIT = 4;
 const COLLAPSED_ITEMS_LIMIT_SMALL_SCREEN = 3;
 
 export interface OrderSummaryItemsProps {
+    displayLineItemsCount: boolean;
     items: LineItemMap;
 }
 
@@ -36,12 +37,12 @@ class OrderSummaryItems extends React.Component<OrderSummaryItemsProps, OrderSum
     }
 
     render(): ReactNode {
-        const { items } = this.props;
+        const { displayLineItemsCount = true, items } = this.props;
         const { collapsedLimit, isExpanded } = this.state;
 
         return (
             <>
-                <h3
+                {displayLineItemsCount && <h3
                     className="cart-section-heading optimizedCheckout-contentPrimary"
                     data-test="cart-count-total"
                 >
@@ -49,7 +50,7 @@ class OrderSummaryItems extends React.Component<OrderSummaryItemsProps, OrderSum
                         data={{ count: getItemsCount(items) }}
                         id="cart.item_count_text"
                     />
-                </h3>
+                </h3>}
 
                 <ul aria-live="polite" className="productList">
                     {[

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -83,7 +83,7 @@ const OrderSummaryModal: FunctionComponent<
         onRequestClose={onRequestClose}
     >
         <OrderSummarySection>
-            <OrderSummaryItems items={lineItems} />
+            <OrderSummaryItems displayLineItemsCount={!isUpdatedCartSummayModal} items={lineItems} />
         </OrderSummarySection>
         <OrderSummarySection>
             <OrderSummarySubtotals isTaxIncluded={isTaxIncluded} taxes={taxes} {...orderSummarySubtotalsProps} />

--- a/packages/core/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
+++ b/packages/core/src/app/order/__snapshots__/OrderSummary.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`OrderSummary when shopper has same currency as store renders order summ
   </OrderSummaryHeader>
   <OrderSummarySection>
     <OrderSummaryItems
+      displayLineItemsCount={true}
       items={
         Object {
           "customItems": Array [],
@@ -140,6 +141,7 @@ exports[`OrderSummary when taxes are inclusive displays tax as summary section 1
   </OrderSummaryHeader>
   <OrderSummarySection>
     <OrderSummaryItems
+      displayLineItemsCount={true}
       items={
         Object {
           "customItems": Array [],

--- a/packages/core/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
+++ b/packages/core/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
@@ -35,6 +35,7 @@ exports[`OrderSummaryModal renders order summary 1`] = `
 >
   <OrderSummarySection>
     <OrderSummaryItems
+      displayLineItemsCount={true}
       items={
         Object {
           "customItems": Array [],
@@ -191,6 +192,7 @@ exports[`OrderSummaryModal when taxes are inclusive displays tax as summary sect
 >
   <OrderSummarySection>
     <OrderSummaryItems
+      displayLineItemsCount={true}
       items={
         Object {
           "customItems": Array [],

--- a/packages/core/src/scss/components/checkout/cartModal/_cartModal.scss
+++ b/packages/core/src/scss/components/checkout/cartModal/_cartModal.scss
@@ -51,6 +51,10 @@
 }
 
 .with-continue-button {
+    &.cart-modal-header {
+        box-shadow: none;
+    }
+
     .cart-modal-link {
         text-align: left;
     }


### PR DESCRIPTION
## What?
- Remove redundant line items count in cart modal.
- Remove box shadow for cart modal header.

## Why?
We have the item count in modal header hence the item count in modal is redundant.

## Testing / Proof
- Screenshot

<img width="375" alt="Screen Shot 2023-04-28 at 4 49 43 pm" src="https://user-images.githubusercontent.com/7134802/235075953-1e2d21a2-11d8-409f-a52f-ad05c4d095ea.png">

@bigcommerce/checkout
