### PR TITLE
feat(payment): INT-7573 Add config of Access Worldpay GooglePay

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -32,6 +32,7 @@ export const SUPPORTED_METHODS: string[] = [
     'googlepayorbital',
     'googlepaystripe',
     'googlepaystripeupe',
+    'googlepayworldpayaccess',
 ];
 
 export interface CheckoutButtonListProps {

--- a/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
@@ -89,6 +89,7 @@ describe('when using Google Pay payment', () => {
         [PaymentMethodId.OrbitalGooglePay],
         [PaymentMethodId.StripeGooglePay],
         [PaymentMethodId.StripeUPEGooglePay],
+        [PaymentMethodId.WorldpayAccessGooglePay],
     ]).it('initializes %s with required config', (id) => {
         method.id = id;
 

--- a/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
@@ -90,6 +90,11 @@ const GooglePayPaymentMethod: FunctionComponent<GooglePayPaymentMethodProps> = (
             onError: onUnhandledError,
             onPaymentSelect: () => reinitializePayment(mergedOptions),
           },
+          googlepayworldpayaccess: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
         };
 
             return initializePayment(mergedOptions);

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -166,7 +166,8 @@ const PaymentMethodComponent: FunctionComponent<
         method.id === PaymentMethodId.CybersourceV2GooglePay ||
         method.id === PaymentMethodId.OrbitalGooglePay ||
         method.id === PaymentMethodId.StripeGooglePay ||
-        method.id === PaymentMethodId.StripeUPEGooglePay
+        method.id === PaymentMethodId.StripeUPEGooglePay ||
+        method.id === PaymentMethodId.WorldpayAccessGooglePay
     ) {
         return <GooglePayPaymentMethod {...props} />;
     }

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -57,6 +57,7 @@ enum PaymentMethodId {
     StripeV3 = 'stripev3',
     StripeUPE = 'stripeupe',
     WorldpayAccess = 'worldpayaccess',
+    WorldpayAccessGooglePay = 'googlepayworldpayaccess',
     Zip = 'zip',
 }
 


### PR DESCRIPTION
## What? [INT-7573](https://bigcommercecloud.atlassian.net/browse/INT-7573)
Created and modified files necessary for google pay initialization.

## Why?
As a Merchant I want to enable Google Pay with Worldpay Access so that I can offer shoppers Google Pay as a payment method to my shoppers.

## Testing / Proof

## Dependency on
https://github.com/bigcommerce/checkout-sdk-js/pull/1966

@bigcommerce/checkout @bigcommerce/payments 

[INT-7573]: https://bigcommercecloud.atlassian.net/browse/INT-7573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ