### PR TITLE
feat(payment): BOLT-484 Bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.377.0",
+        "@bigcommerce/checkout-sdk": "^1.378.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1860,9 +1860,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.377.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.377.0.tgz",
-      "integrity": "sha512-CLMfYAd4M0zuBkZU+UCAD5od1CWy4VFPcPSmHqPXdvLEigxf6KJUChmCf9gE9aeuJuw0z1kMWT8ym0TU4xrHiw==",
+      "version": "1.378.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.378.0.tgz",
+      "integrity": "sha512-3PfVlmczTCHYxyQD4ZEg1UWpBV0R26aYyvYQtvUwqSpPqA6dfZD87FWcwL0E76tEncbspDbKfB26sKhj9x7cJg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.22.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -28252,9 +28252,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.377.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.377.0.tgz",
-      "integrity": "sha512-CLMfYAd4M0zuBkZU+UCAD5od1CWy4VFPcPSmHqPXdvLEigxf6KJUChmCf9gE9aeuJuw0z1kMWT8ym0TU4xrHiw==",
+      "version": "1.378.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.378.0.tgz",
+      "integrity": "sha512-3PfVlmczTCHYxyQD4ZEg1UWpBV0R26aYyvYQtvUwqSpPqA6dfZD87FWcwL0E76tEncbspDbKfB26sKhj9x7cJg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.22.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.377.0",
+    "@bigcommerce/checkout-sdk": "^1.378.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump  checkout-sdk-js version

## Why?
To keep checkout-sdk dependency up to date.

The release contains changes from this pr:
[https://github.com/bigcommerce/checkout-sdk-js/pull/1968](https://github.com/bigcommerce/checkout-sdk-js/pull/1968)

## Testing / Proof
Unit test and manual testing

@bigcommerce/checkout
