### PR TITLE
feat(payment): INT-7516 SquareV2: Unsubscribe from Square form validation

### DIFF
--- a/packages/squarev2-integration/src/SquareV2PaymentMethod.spec.tsx
+++ b/packages/squarev2-integration/src/SquareV2PaymentMethod.spec.tsx
@@ -8,7 +8,6 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import { mount } from 'enzyme';
 import React, { FunctionComponent } from 'react';
-import { act } from 'react-dom/test-utils';
 
 import {
     PaymentFormService,
@@ -120,7 +119,6 @@ describe('SquareV2 payment method', () => {
                         '.message-text.is-error': { color: 'rgb(5, 5, 5)' },
                         '.message-icon.is-error': { color: 'rgb(5, 5, 5)' },
                     },
-                    onValidationChange: expect.any(Function),
                 },
             }),
         );
@@ -137,31 +135,9 @@ describe('SquareV2 payment method', () => {
                 squarev2: {
                     containerId: 'squarev2_payment_element_container',
                     style: undefined,
-                    onValidationChange: expect.any(Function),
                 },
             }),
         );
-    });
-
-    it('should enable submit button', () => {
-        const {
-            paymentForm: { disableSubmit },
-            method,
-        } = props;
-
-        mount(<SquareV2PaymentMethodTest />);
-
-        const onValidationChange = initializePayment.mock.calls[0][0].squarev2?.onValidationChange;
-
-        act(() => {
-            if (onValidationChange) {
-                onValidationChange(true);
-            }
-        });
-
-        expect(disableSubmit).toHaveBeenCalledTimes(2);
-        expect(disableSubmit).toHaveBeenNthCalledWith(1, method, true);
-        expect(disableSubmit).toHaveBeenNthCalledWith(2, method, false);
     });
 
     it('should be deinitialized with the required config', () => {

--- a/packages/squarev2-integration/src/SquareV2PaymentMethod.tsx
+++ b/packages/squarev2-integration/src/SquareV2PaymentMethod.tsx
@@ -1,5 +1,5 @@
 import { difference } from 'lodash';
-import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import React, { FunctionComponent, useCallback, useEffect } from 'react';
 
 import {
     PaymentMethodProps,
@@ -12,21 +12,7 @@ const SquareV2PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     method,
     checkoutService,
     checkoutState,
-    paymentForm,
 }) => {
-    const [disabled, setDisabled] = useState(true);
-
-    useEffect(() => {
-        const { isPaymentDataRequired } = checkoutState.data;
-
-        paymentForm.disableSubmit(method, isPaymentDataRequired() && disabled);
-    }, [checkoutState, disabled, method, paymentForm]);
-
-    const onValidationChange = useCallback(
-        (isValid: boolean) => setDisabled(!isValid),
-        [setDisabled],
-    );
-
     const renderPlaceholderFields = () => {
         return (
             <div data-test="squarev2_placeholder_form" style={{ display: 'none' }}>
@@ -165,7 +151,6 @@ const SquareV2PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             squarev2: {
                 containerId,
                 style,
-                onValidationChange,
             },
         });
     }, [
@@ -174,7 +159,6 @@ const SquareV2PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         mapToSquareStyles,
         method.gateway,
         method.id,
-        onValidationChange,
     ]);
 
     const deinitializePayment = useCallback(async () => {


### PR DESCRIPTION
## What? [INT-7516](https://bigcommercecloud.atlassian.net/browse/INT-7516)
Unsubscribe from Square form validation to keep the "Place Order" button always enabled.

## Why?
`onValidationChange` is having some troubles at the moment with auto-fill mechanisms and does not enable the "Place Order" button. Therefore, we want to remove this validation and instead show the tokenization errors that may occur product of the user submitting empty or invalid data.

## Testing / Proof
https://user-images.githubusercontent.com/4843328/236931834-4e573e93-0b9b-42ff-b9cf-fde122042f29.mov

## Depends on
👉 https://github.com/bigcommerce/checkout-sdk-js/pull/1971 to show a more user-friendly message.

@bigcommerce/checkout


[INT-7516]: https://bigcommercecloud.atlassian.net/browse/INT-7516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ