### PR TITLE
fix(customer): #1270 TranslatedString should be TranslatedHtml

### DIFF
--- a/packages/core/src/app/customer/SubscribeField.tsx
+++ b/packages/core/src/app/customer/SubscribeField.tsx
@@ -1,7 +1,7 @@
 import { FieldProps } from 'formik';
 import React, { FunctionComponent, memo } from 'react';
 
-import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { TranslatedHtml } from '@bigcommerce/checkout/locale';
 
 import { Input, Label } from '../ui/form';
 
@@ -23,7 +23,7 @@ const SubscribeField: FunctionComponent<SubscribeFieldProps> = ({
         />
 
         <Label htmlFor={field.name}>
-            <TranslatedString
+            <TranslatedHtml
                 id={
                     requiresMarketingConsent
                         ? 'customer.guest_marketing_consent'


### PR DESCRIPTION
## What?
Changed TranslatedString to TranslatedHtml on the customer subscribe field.

## Why?
As discussed in #1270, this empowers developers to supply HTML strings within the lang files.

## Testing / Proof
...

@bigcommerce/checkout
