### PR TITLE
fix(shipping): CHECKOUT-7338 Add available options include if custom fields change

### DIFF
--- a/packages/core/src/app/common/hoc/createMappableInjectHoc.tsx
+++ b/packages/core/src/app/common/hoc/createMappableInjectHoc.tsx
@@ -43,7 +43,7 @@ export default function createMappableInjectHoc<TContextProps>(
 
                 const mappedProps = context
                     ? mapToProps(
-                          context ,
+                          context,
                           props as unknown as TOwnProps,
                       )
                     : context;

--- a/packages/core/src/app/shipping/SingleShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.spec.tsx
@@ -131,6 +131,56 @@ describe('SingleShippingForm', () => {
         }, SHIPPING_AUTOSAVE_DELAY * 1.1);
     });
 
+    it('calls updateAddress including shipping options if custom form fields are updated', (done) => {
+        component = mount(
+            <LocaleContext.Provider value={localeContext}>
+                <SingleShippingForm
+                    {...defaultProps}
+                    getFields={() => [
+                        ...addressFormFields,
+                        {
+                            custom: true,
+                            default: '',
+                            fieldType: 'text',
+                            id: 'field_25',
+                            label: 'Custom message',
+                            name: 'field_25',
+                            required: true,
+                            type: 'string',
+                        },
+                    ]}
+                />
+            </LocaleContext.Provider>,
+        );
+
+        component.find('input[name="shippingAddress.customFields.field_25"]').simulate('change', {
+            target: { value: 'foo', name: 'shippingAddress.customFields.field_25' },
+        });
+
+        setTimeout(() => {
+            expect(defaultProps.updateAddress).toHaveBeenCalledWith(
+                {
+                    ...getShippingAddress(),
+                    customFields: [
+                        {
+                            fieldId: 'field_25',
+                            fieldValue: 'foo',
+                        },
+                    ],
+                },
+                {
+                    params: {
+                        include: {
+                            'consignments.availableShippingOptions': true,
+                        },
+                    },
+                },
+            );
+
+            done();
+        }, SHIPPING_AUTOSAVE_DELAY * 1.1);
+    });
+
     it('calls updateAddress without shipping options if modified field does not affect shipping and shipping options have already been requested', (done) => {
         component
             .find('input[name="shippingAddress.address2"]')

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -12,7 +12,7 @@ import {
     ShippingRequestOptions,
 } from '@bigcommerce/checkout-sdk';
 import { FormikProps, withFormik } from 'formik';
-import { debounce, noop } from 'lodash';
+import { debounce, isEqual, noop } from 'lodash';
 import React, { PureComponent, ReactNode } from 'react';
 import { lazy, object } from 'yup';
 
@@ -237,6 +237,13 @@ class SingleShippingForm extends PureComponent<
         } = this.props;
 
         const updatedShippingAddress = addressForm && mapAddressFromFormValues(addressForm);
+
+        if (Array.isArray(shippingAddress?.customFields)) {
+            includeShippingOptions = !isEqual(
+                shippingAddress?.customFields,
+                updatedShippingAddress?.customFields
+            ) || includeShippingOptions;
+        }
 
         if (!updatedShippingAddress || isEqualAddress(updatedShippingAddress, shippingAddress)) {
             return;


### PR DESCRIPTION
## What?
Add available options include to consignment call when custom fields are changed

## Why?
We do refresh shipping rates when custom form fields are changed in the backend, so it does make sense to refresh the rates in the client as well. 

The driver for this is some partner integrations who are using CFF's for adding things like insurance etc.

## Testing / Proof
https://github.com/bigcommerce/checkout-js/assets/7134802/1589c766-f0e8-4d33-b187-f5fe6372b9f1

@bigcommerce/checkout
