### PR TITLE
chore(payment): INT-7516 Bump checkout-SDK 1.380.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.379.0",
+        "@bigcommerce/checkout-sdk": "^1.380.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.379.0",
+    "@bigcommerce/checkout-sdk": "^1.380.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk `v1.380.0.`

## Why?
Release lastest SDK change(s):

https://github.com/bigcommerce/checkout-sdk-js/pull/1971

## Testing / Proof

CI checks.

@bigcommerce/checkout
