### PR TITLE
chore(payment): PAYPAL-2370 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.379.0",
+        "@bigcommerce/checkout-sdk": "^1.380.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1745,9 +1745,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.380.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.380.0.tgz",
-      "integrity": "sha512-eqzGQnkquNk8H0buxxjHIJzVUSa6YlcnUCiT/nxkMA2jixhA5ek3SWtb7QC05qNpWPO825DUDL1PFfSO96ME5g==",
+      "version": "1.380.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.380.1.tgz",
+      "integrity": "sha512-r60PaW2Ua9Tszuek5TCAPFI8nngHS+3rfT+HjmL+QZmG+L7d3IRVbsu9wzE8LlHg6l0KLIt8JMrgPCw/ukJzRw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -33982,9 +33982,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.380.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.380.0.tgz",
-      "integrity": "sha512-eqzGQnkquNk8H0buxxjHIJzVUSa6YlcnUCiT/nxkMA2jixhA5ek3SWtb7QC05qNpWPO825DUDL1PFfSO96ME5g==",
+      "version": "1.380.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.380.1.tgz",
+      "integrity": "sha512-r60PaW2Ua9Tszuek5TCAPFI8nngHS+3rfT+HjmL+QZmG+L7d3IRVbsu9wzE8LlHg6l0KLIt8JMrgPCw/ukJzRw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.379.0",
+    "@bigcommerce/checkout-sdk": "^1.380.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/braintree-integration/src/BraintreeAchPaymentMethod.spec.tsx
+++ b/packages/braintree-integration/src/BraintreeAchPaymentMethod.spec.tsx
@@ -69,8 +69,7 @@ describe('BraintreeAchPaymentForm', () => {
 
         expect(checkoutService.initializePayment).toHaveBeenCalledWith({
             braintreeach: {
-                mandateText:
-                    'I authorize Braintree to debit my bank account on behalf of My Online Store.',
+                getMandateText: expect.any(Function),
             },
             gatewayId: undefined,
             methodId: 'braintreeach',

--- a/packages/braintree-integration/src/BraintreeAchPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeAchPaymentMethod.tsx
@@ -29,7 +29,7 @@ const BraintreeAchPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     gatewayId,
                     methodId,
                     braintreeach: {
-                        mandateText,
+                        getMandateText: () => mandateText,
                     },
                 });
             } catch (error) {


### PR DESCRIPTION
## What?

1. Bump checkout-sdk-js version
2. Updated ACH initialization options for the `initializePayment` method

## Why?

https://github.com/bigcommerce/checkout-sdk-js/pull/1973

## Testing / Proof
Unit tests
CI tests
Manual tests