### PR TITLE
fix(payment): BOLT-577 Bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.381.0",
+        "@bigcommerce/checkout-sdk": "^1.381.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1745,9 +1745,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.381.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.0.tgz",
-      "integrity": "sha512-y+JZE+ajESaNdyRhr3gatzZDSxZ3elSzlX0RSAhKITrxtzq67Cn0/gJEQ5xXMcavnYEWvwKNUYSlHBxaaQLZdw==",
+      "version": "1.381.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.1.tgz",
+      "integrity": "sha512-fpdqwRHsJ8+fqwqoVsv/LnVzenmfopTYG1T6SJq/kfPfNCSRsCt/kd7cfniHlcHJGtp4kDWBbjqjCi4tVQyDjg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -33982,9 +33982,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.381.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.0.tgz",
-      "integrity": "sha512-y+JZE+ajESaNdyRhr3gatzZDSxZ3elSzlX0RSAhKITrxtzq67Cn0/gJEQ5xXMcavnYEWvwKNUYSlHBxaaQLZdw==",
+      "version": "1.381.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.1.tgz",
+      "integrity": "sha512-fpdqwRHsJ8+fqwqoVsv/LnVzenmfopTYG1T6SJq/kfPfNCSRsCt/kd7cfniHlcHJGtp4kDWBbjqjCi4tVQyDjg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.381.0",
+    "@bigcommerce/checkout-sdk": "^1.381.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump Checkout sdk version

## Why?
To update with PR:
[https://github.com/bigcommerce/checkout-sdk-js/pull/1979](https://github.com/bigcommerce/checkout-sdk-js/pull/1979)

## Testing / Proof
Unit test and manual testing

@bigcommerce/checkout
