### PR TITLE
feat(payment): PAYPAL-2451 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.381.1",
+        "@bigcommerce/checkout-sdk": "^1.381.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1745,9 +1745,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.381.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.1.tgz",
-      "integrity": "sha512-fpdqwRHsJ8+fqwqoVsv/LnVzenmfopTYG1T6SJq/kfPfNCSRsCt/kd7cfniHlcHJGtp4kDWBbjqjCi4tVQyDjg==",
+      "version": "1.381.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.3.tgz",
+      "integrity": "sha512-QVB2e8aa/W7moCbhdQ2CWH0rwyhgELSCQ6QKb6mvFWnr5uJxZlr/IoZzEuLFXErDx79T6PnjC/TPehmXp4GZYQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -33982,9 +33982,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.381.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.1.tgz",
-      "integrity": "sha512-fpdqwRHsJ8+fqwqoVsv/LnVzenmfopTYG1T6SJq/kfPfNCSRsCt/kd7cfniHlcHJGtp4kDWBbjqjCi4tVQyDjg==",
+      "version": "1.381.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.3.tgz",
+      "integrity": "sha512-QVB2e8aa/W7moCbhdQ2CWH0rwyhgELSCQ6QKb6mvFWnr5uJxZlr/IoZzEuLFXErDx79T6PnjC/TPehmXp4GZYQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.381.1",
+    "@bigcommerce/checkout-sdk": "^1.381.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

Update checkout-js with this PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/1989

## Testing / Proof

All tests passed

@bigcommerce/checkout
