### PR TITLE
fix(checkout): PI-147 remove "Pay over time" text from the Clearpay

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.spec.tsx
@@ -173,7 +173,6 @@ describe('PaymentMethodTitle', () => {
         const methodIds = [
             PaymentMethodId.Affirm,
             PaymentMethodId.Afterpay,
-            PaymentMethodId.Clearpay,
             PaymentMethodId.Klarna,
             PaymentMethodId.Quadpay,
             PaymentMethodId.Sezzle,
@@ -221,6 +220,7 @@ describe('PaymentMethodTitle', () => {
         const methodIds = [
             PaymentMethodId.AmazonPay,
             PaymentMethodId.ChasePay,
+            PaymentMethodId.Clearpay,
             PaymentMethodId.Humm,
             PaymentMethodId.Opy,
             PaymentMethodId.PaypalCommerce,

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -99,7 +99,7 @@ function getPaymentMethodTitle(
             },
             [PaymentMethodId.Clearpay]: {
                 logoUrl: cdnPath('/img/payment-providers/clearpay-header.png'),
-                titleText: methodName,
+                titleText: '',
             },
             [PaymentMethodType.GooglePay]: {
                 logoUrl: cdnPath('/img/payment-providers/google-pay.png'),


### PR DESCRIPTION
## What?
Text "Pay over time" removed from the Clearpay

## Why?
In the BigCommerce payment integration we currently use the copy “Pay over time” next to the Clearpay logo (see image below). This is no longer approved language for Clearpay UK merchants and needs to be removed before the FCA June 1st deadline. No need to replace the language with something else

## Testing / Proof
<img width="777" alt="image" src="https://github.com/bigcommerce/checkout-js/assets/79574476/306f1445-315e-4319-968c-965f03fc3186">

![image](https://github.com/bigcommerce/checkout-js/assets/79574476/8104b2f9-2fac-4664-b481-c816d5c95033)



@bigcommerce/checkout
