### PR TITLE
fix(checkout): PI-101 3ds2 redirect fix for adyen v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.381.3",
+        "@bigcommerce/checkout-sdk": "^1.381.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.381.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.3.tgz",
-      "integrity": "sha512-QVB2e8aa/W7moCbhdQ2CWH0rwyhgELSCQ6QKb6mvFWnr5uJxZlr/IoZzEuLFXErDx79T6PnjC/TPehmXp4GZYQ==",
+      "version": "1.381.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.4.tgz",
+      "integrity": "sha512-sffClpz6iN36DybhJSN5UNmw3B7k233Sq16lyzgafsJ0pTiyFRUak7ZY4sRGEMmjLbPeWZoq4b6gEa1T1+6o6w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35211,9 +35211,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.381.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.3.tgz",
-      "integrity": "sha512-QVB2e8aa/W7moCbhdQ2CWH0rwyhgELSCQ6QKb6mvFWnr5uJxZlr/IoZzEuLFXErDx79T6PnjC/TPehmXp4GZYQ==",
+      "version": "1.381.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.4.tgz",
+      "integrity": "sha512-sffClpz6iN36DybhJSN5UNmw3B7k233Sq16lyzgafsJ0pTiyFRUak7ZY4sRGEMmjLbPeWZoq4b6gEa1T1+6o6w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.381.3",
+    "@bigcommerce/checkout-sdk": "^1.381.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the  https://github.com/bigcommerce/checkout-sdk-js/pull/1988

## Why?
Due to the absence of the redirect on the adyen v2 3ds2 check

## Testing / Proof
tested manually

@bigcommerce/checkout
