### PR TITLE
chore(other): CHECKOUT-000 Add swc core to dev dependency as it is used for builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "@pollyjs/core": "^6.0.5",
         "@pollyjs/node-server": "^6.0.1",
         "@pollyjs/persister-fs": "^6.0.5",
+        "@swc/core": "^1.3.59",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^14.4.3",
@@ -143,9 +144,6 @@
       "engines": {
         "node": "16",
         "npm": "8"
-      },
-      "optionalDependencies": {
-        "@swc/core-linux-x64-gnu": "^1.2.160"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7766,9 +7764,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.58",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.58.tgz",
-      "integrity": "sha512-tSDcHXMBQIo2ohQ/0ryZnUA+0mBrVhe49+cR+QsFru+XEhCok1BLqdE6cZ2a+sgZ1I+Dmw8aTxYm8Ox64PSKPQ==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.59.tgz",
+      "integrity": "sha512-ZBw31zd2E5SXiodwGvjQdx5ZC90b2uyX/i2LeMMs8LKfXD86pfOfQac+JVrnyEKDhASXj9icgsF9NXBhaMr3Kw==",
       "dev": true,
       "hasInstallScript": true,
       "engines": {
@@ -7779,16 +7777,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.58",
-        "@swc/core-darwin-x64": "1.3.58",
-        "@swc/core-linux-arm-gnueabihf": "1.3.58",
-        "@swc/core-linux-arm64-gnu": "1.3.58",
-        "@swc/core-linux-arm64-musl": "1.3.58",
-        "@swc/core-linux-x64-gnu": "1.3.58",
-        "@swc/core-linux-x64-musl": "1.3.58",
-        "@swc/core-win32-arm64-msvc": "1.3.58",
-        "@swc/core-win32-ia32-msvc": "1.3.58",
-        "@swc/core-win32-x64-msvc": "1.3.58"
+        "@swc/core-darwin-arm64": "1.3.59",
+        "@swc/core-darwin-x64": "1.3.59",
+        "@swc/core-linux-arm-gnueabihf": "1.3.59",
+        "@swc/core-linux-arm64-gnu": "1.3.59",
+        "@swc/core-linux-arm64-musl": "1.3.59",
+        "@swc/core-linux-x64-gnu": "1.3.59",
+        "@swc/core-linux-x64-musl": "1.3.59",
+        "@swc/core-win32-arm64-msvc": "1.3.59",
+        "@swc/core-win32-ia32-msvc": "1.3.59",
+        "@swc/core-win32-x64-msvc": "1.3.59"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -7799,10 +7797,26 @@
         }
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.59.tgz",
+      "integrity": "sha512-AnqWFBgEKHP0jb4iZqx7eVQT9/rX45+DE4Ox7GpwCahUKxxrsDLyXzKhwLwQuAjUvtu5JcSB77szKpPGDM49fQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.58.tgz",
-      "integrity": "sha512-XUdKXRIu8S7N5kmrtd0Nxf3uPIgZhQbgVHPhkvYH+Qwb+uXsdltKPiRwhvLI9M0yF3fvIrKtGJ8qUJdH5ih4zw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.59.tgz",
+      "integrity": "sha512-iqDs+yii9mOsmpJez82SEi4d4prWDRlapHxKnDVJ0x1AqRo41vIq8t3fujrvCHYU5VQgOYGh4ooXQpaP2H3B2A==",
       "cpu": [
         "x64"
       ],
@@ -7815,16 +7829,129 @@
         "node": ">=10"
       }
     },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.58.tgz",
-      "integrity": "sha512-yOI5ucB+8g+gtp4L2AydPBThobZ2I3WR/dU2T+x2DFIE5Qpe/fqt6HPTFb02qmvqvOw36TLT45pRwAe4cY5LAw==",
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.59.tgz",
+      "integrity": "sha512-PB0PP+SgkCSd/kYmltnPiGv42cOSaih1OjXCEjxvNwUFEmWqluW6uGdWaNiR1LoYMxhcHZTc336jL2+O3l6p0Q==",
       "cpu": [
-        "x64"
+        "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.59.tgz",
+      "integrity": "sha512-Ol/JPszWZ+OZ44FOdJe35TfJ1ckG4pYaisZJ4E7PzfwfVe2ygX85C5WWR4e5L0Y1zFvzpcI7gdyC2wzcXk4Cig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.59.tgz",
+      "integrity": "sha512-PtTTtGbj9GiY5gJdoSFL2A0vL6BRaS1haAhp6g3hZvLDkTTg+rJURmzwBMMjaQlnGC62x/lLf6MoszHG/05//Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.59.tgz",
+      "integrity": "sha512-XBW9AGi0YsIN76IfesnDSBn/5sjR69J75KUNte8sH6seYlHJ0/kblqUMbUcfr0CiGoJadbzAZeKZZmfN7EsHpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.59.tgz",
+      "integrity": "sha512-Cy5E939SdWPQ34cg6UABNO0RyEe0FuWqzZ/GLKtK11Ir4fjttVlucZiY59uQNyUVUc8T2qE0VBFCyD/zYGuHtg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.59.tgz",
+      "integrity": "sha512-z5ZJxizRvRoSAaevRIi3YjQh74OFWEIhonSDWNdqDL7RbjEivcatYcG7OikH6s+rtPhOcwNm3PbGV2Prcgh/gg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.59.tgz",
+      "integrity": "sha512-vxpsn+hrKAhi5YusQfB/JXUJJVX40rIRE/L49ilBEqdbH8Khkoego6AD+2vWqTdJcUHo1WiAIAEZ0rTsjyorLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.59.tgz",
+      "integrity": "sha512-Ris/cJbURylcLwqz4RZUUBCEGsuaIHOJsvf69W5pGKHKBryVoOTNhBKpo3Km2hoAi5qFQ/ou0trAT4hBsVPZvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -39920,34 +40047,91 @@
       }
     },
     "@swc/core": {
-      "version": "1.3.58",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.58.tgz",
-      "integrity": "sha512-tSDcHXMBQIo2ohQ/0ryZnUA+0mBrVhe49+cR+QsFru+XEhCok1BLqdE6cZ2a+sgZ1I+Dmw8aTxYm8Ox64PSKPQ==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.59.tgz",
+      "integrity": "sha512-ZBw31zd2E5SXiodwGvjQdx5ZC90b2uyX/i2LeMMs8LKfXD86pfOfQac+JVrnyEKDhASXj9icgsF9NXBhaMr3Kw==",
       "dev": true,
       "requires": {
-        "@swc/core-darwin-arm64": "1.3.58",
-        "@swc/core-darwin-x64": "1.3.58",
-        "@swc/core-linux-arm-gnueabihf": "1.3.58",
-        "@swc/core-linux-arm64-gnu": "1.3.58",
-        "@swc/core-linux-arm64-musl": "1.3.58",
-        "@swc/core-linux-x64-gnu": "1.3.58",
-        "@swc/core-linux-x64-musl": "1.3.58",
-        "@swc/core-win32-arm64-msvc": "1.3.58",
-        "@swc/core-win32-ia32-msvc": "1.3.58",
-        "@swc/core-win32-x64-msvc": "1.3.58"
+        "@swc/core-darwin-arm64": "1.3.59",
+        "@swc/core-darwin-x64": "1.3.59",
+        "@swc/core-linux-arm-gnueabihf": "1.3.59",
+        "@swc/core-linux-arm64-gnu": "1.3.59",
+        "@swc/core-linux-arm64-musl": "1.3.59",
+        "@swc/core-linux-x64-gnu": "1.3.59",
+        "@swc/core-linux-x64-musl": "1.3.59",
+        "@swc/core-win32-arm64-msvc": "1.3.59",
+        "@swc/core-win32-ia32-msvc": "1.3.59",
+        "@swc/core-win32-x64-msvc": "1.3.59"
       }
     },
+    "@swc/core-darwin-arm64": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.59.tgz",
+      "integrity": "sha512-AnqWFBgEKHP0jb4iZqx7eVQT9/rX45+DE4Ox7GpwCahUKxxrsDLyXzKhwLwQuAjUvtu5JcSB77szKpPGDM49fQ==",
+      "dev": true,
+      "optional": true
+    },
     "@swc/core-darwin-x64": {
-      "version": "1.3.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.58.tgz",
-      "integrity": "sha512-XUdKXRIu8S7N5kmrtd0Nxf3uPIgZhQbgVHPhkvYH+Qwb+uXsdltKPiRwhvLI9M0yF3fvIrKtGJ8qUJdH5ih4zw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.59.tgz",
+      "integrity": "sha512-iqDs+yii9mOsmpJez82SEi4d4prWDRlapHxKnDVJ0x1AqRo41vIq8t3fujrvCHYU5VQgOYGh4ooXQpaP2H3B2A==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.59.tgz",
+      "integrity": "sha512-PB0PP+SgkCSd/kYmltnPiGv42cOSaih1OjXCEjxvNwUFEmWqluW6uGdWaNiR1LoYMxhcHZTc336jL2+O3l6p0Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.59.tgz",
+      "integrity": "sha512-Ol/JPszWZ+OZ44FOdJe35TfJ1ckG4pYaisZJ4E7PzfwfVe2ygX85C5WWR4e5L0Y1zFvzpcI7gdyC2wzcXk4Cig==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.59.tgz",
+      "integrity": "sha512-PtTTtGbj9GiY5gJdoSFL2A0vL6BRaS1haAhp6g3hZvLDkTTg+rJURmzwBMMjaQlnGC62x/lLf6MoszHG/05//Q==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.3.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.58.tgz",
-      "integrity": "sha512-yOI5ucB+8g+gtp4L2AydPBThobZ2I3WR/dU2T+x2DFIE5Qpe/fqt6HPTFb02qmvqvOw36TLT45pRwAe4cY5LAw==",
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.59.tgz",
+      "integrity": "sha512-XBW9AGi0YsIN76IfesnDSBn/5sjR69J75KUNte8sH6seYlHJ0/kblqUMbUcfr0CiGoJadbzAZeKZZmfN7EsHpg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.59.tgz",
+      "integrity": "sha512-Cy5E939SdWPQ34cg6UABNO0RyEe0FuWqzZ/GLKtK11Ir4fjttVlucZiY59uQNyUVUc8T2qE0VBFCyD/zYGuHtg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.59.tgz",
+      "integrity": "sha512-z5ZJxizRvRoSAaevRIi3YjQh74OFWEIhonSDWNdqDL7RbjEivcatYcG7OikH6s+rtPhOcwNm3PbGV2Prcgh/gg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.59.tgz",
+      "integrity": "sha512-vxpsn+hrKAhi5YusQfB/JXUJJVX40rIRE/L49ilBEqdbH8Khkoego6AD+2vWqTdJcUHo1WiAIAEZ0rTsjyorLQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.3.59",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.59.tgz",
+      "integrity": "sha512-Ris/cJbURylcLwqz4RZUUBCEGsuaIHOJsvf69W5pGKHKBryVoOTNhBKpo3Km2hoAi5qFQ/ou0trAT4hBsVPZvQ==",
+      "dev": true,
       "optional": true
     },
     "@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/node-server": "^6.0.1",
     "@pollyjs/persister-fs": "^6.0.5",
+    "@swc/core": "^1.3.59",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^14.4.3",
@@ -169,9 +170,6 @@
     "webpack-cli": "^4.9.2",
     "webpack-inject-plugin": "^1.5.3",
     "yargs": "^14.0.0"
-  },
-  "optionalDependencies": {
-    "@swc/core-linux-x64-gnu": "^1.2.160"
   },
   "sideEffects": false,
   "standard-version": {


### PR DESCRIPTION
## What?
Add swc core to dev dependency as it is used for builds

## Why?
Builds fail on different machine types due to swc core not being compatible with operating systems. Need to order this to dev dependencies to get builds working as expected.

## Testing / Proof
- CI

@bigcommerce/checkout
