### PR TITLE
fix(payment): PAYPAL-2451 bump checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.381.4",
+        "@bigcommerce/checkout-sdk": "^1.382.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.381.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.4.tgz",
-      "integrity": "sha512-sffClpz6iN36DybhJSN5UNmw3B7k233Sq16lyzgafsJ0pTiyFRUak7ZY4sRGEMmjLbPeWZoq4b6gEa1T1+6o6w==",
+      "version": "1.382.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.382.0.tgz",
+      "integrity": "sha512-KMz8jHgLc3ribPgTsGJCiNkmgrKWDku7HjyvIsBkXgM8DPlr5V9LgJ2PTJUnubOo4MJmeurS4+UhptmzNIEnig==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.381.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.381.4.tgz",
-      "integrity": "sha512-sffClpz6iN36DybhJSN5UNmw3B7k233Sq16lyzgafsJ0pTiyFRUak7ZY4sRGEMmjLbPeWZoq4b6gEa1T1+6o6w==",
+      "version": "1.382.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.382.0.tgz",
+      "integrity": "sha512-KMz8jHgLc3ribPgTsGJCiNkmgrKWDku7HjyvIsBkXgM8DPlr5V9LgJ2PTJUnubOo4MJmeurS4+UhptmzNIEnig==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.381.4",
+    "@bigcommerce/checkout-sdk": "^1.382.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

Update checkout-js with this PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/1991

## Testing / Proof

All tests passed

@bigcommerce/checkout
