### PR TITLE
fix(payment): PAYPAL-2575 fixed the issue with PayPalCommerceVenmoPaymentMethod component rendering

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -1,4 +1,4 @@
 export { default as PayPalCommerceAPMsPaymentMethod } from './PayPalCommerceAPMsPaymentMethod';
 export { default as PayPalCommerceCreditPaymentMethod } from './PayPalCommerceCreditPaymentMethod';
 export { default as PayPalCommercePaymentMethod } from './PayPalCommercePaymentMethod';
-export { default as PayPalCommerceVenmoPaymentMethod } from './PayPalCommercePaymentMethod';
+export { default as PayPalCommerceVenmoPaymentMethod } from './PayPalCommerceVenmoPaymentMethod';


### PR DESCRIPTION
## What?
Updated import path for papal commerce venmo payment strategy in paypal commerce integration package index file

## Why?
There was an issue with PayPalCommerceVenmoPaymentMethod component rendering (it could not be defined due to the mistake in import groups)

## Testing / Proof
Unit tests
Manual tests
