### PR TITLE
chore(payment): PAYPAL-2575 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.382.1",
+        "@bigcommerce/checkout-sdk": "^1.383.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.382.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.382.1.tgz",
-      "integrity": "sha512-afUzjQFYDrFseV6sqb5UhLQxhcx10zOAuYoqIITxZLJV9erq/z+vNvsGZ2X6+IegKUOKWCsDJiTs2iLEHISwHg==",
+      "version": "1.383.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.1.tgz",
+      "integrity": "sha512-B6KCJVqb2+mvXuO4t0DqsnH3Q1Q7hG9aJbir79L1+c/yJ7U/zhjxrgh9CAkREGkvR3RDUFEYDktgvoPu9kojBg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.382.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.382.1.tgz",
-      "integrity": "sha512-afUzjQFYDrFseV6sqb5UhLQxhcx10zOAuYoqIITxZLJV9erq/z+vNvsGZ2X6+IegKUOKWCsDJiTs2iLEHISwHg==",
+      "version": "1.383.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.1.tgz",
+      "integrity": "sha512-B6KCJVqb2+mvXuO4t0DqsnH3Q1Q7hG9aJbir79L1+c/yJ7U/zhjxrgh9CAkREGkvR3RDUFEYDktgvoPu9kojBg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.382.1",
+    "@bigcommerce/checkout-sdk": "^1.383.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To release changes in the prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/2007
https://github.com/bigcommerce/checkout-sdk-js/pull/1993
https://github.com/bigcommerce/checkout-sdk-js/pull/1998

## Testing / Proof
Unit tests
CI tests