### PR TITLE
chore(other): CHECKOUT-000 Update checkout SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.383.1",
+        "@bigcommerce/checkout-sdk": "^1.383.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.383.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.1.tgz",
-      "integrity": "sha512-B6KCJVqb2+mvXuO4t0DqsnH3Q1Q7hG9aJbir79L1+c/yJ7U/zhjxrgh9CAkREGkvR3RDUFEYDktgvoPu9kojBg==",
+      "version": "1.383.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.2.tgz",
+      "integrity": "sha512-nmSC+QaPc1dZc+3rOdtfNBXkbtNVln2typ6edrNAjFq9MaFf49pUq0JWFkNOw+sJ9TLzd+tLe/0dpdjz0alL3A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.383.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.1.tgz",
-      "integrity": "sha512-B6KCJVqb2+mvXuO4t0DqsnH3Q1Q7hG9aJbir79L1+c/yJ7U/zhjxrgh9CAkREGkvR3RDUFEYDktgvoPu9kojBg==",
+      "version": "1.383.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.2.tgz",
+      "integrity": "sha512-nmSC+QaPc1dZc+3rOdtfNBXkbtNVln2typ6edrNAjFq9MaFf49pUq0JWFkNOw+sJ9TLzd+tLe/0dpdjz0alL3A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.383.1",
+    "@bigcommerce/checkout-sdk": "^1.383.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk to latest version

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/commit/9e849d82259f8322bed0b71311ec4c11572b7dd9

## Testing / Proof
CI 

@bigcommerce/checkout
