### PR TITLE
feat(checkout): PI-88 bumped checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.383.2",
+        "@bigcommerce/checkout-sdk": "^1.385.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.383.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.2.tgz",
-      "integrity": "sha512-nmSC+QaPc1dZc+3rOdtfNBXkbtNVln2typ6edrNAjFq9MaFf49pUq0JWFkNOw+sJ9TLzd+tLe/0dpdjz0alL3A==",
+      "version": "1.385.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.385.0.tgz",
+      "integrity": "sha512-YoF14Ps6fz1Ppw8IMFvQ9HgzxkU1SoVvtRpq6WlpRkqmbA9lmFnCyEEC5iNeoqXc7bfXj/K9a+gVWRsFIcQfmw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.383.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.383.2.tgz",
-      "integrity": "sha512-nmSC+QaPc1dZc+3rOdtfNBXkbtNVln2typ6edrNAjFq9MaFf49pUq0JWFkNOw+sJ9TLzd+tLe/0dpdjz0alL3A==",
+      "version": "1.385.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.385.0.tgz",
+      "integrity": "sha512-YoF14Ps6fz1Ppw8IMFvQ9HgzxkU1SoVvtRpq6WlpRkqmbA9lmFnCyEEC5iNeoqXc7bfXj/K9a+gVWRsFIcQfmw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.383.2",
+    "@bigcommerce/checkout-sdk": "^1.385.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/1980

## Why?
Due to the https://github.com/bigcommerce/checkout-sdk-js/pull/1980

## Testing / Proof
Units/manually

@bigcommerce/checkout
