### PR TITLE
fix(payment): CHECKOUT-000 Remove default button rendering for V2 components

### DIFF
--- a/packages/checkout-button-integration/src/CheckoutButton.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.tsx
@@ -29,6 +29,7 @@ const CheckoutButton: FunctionComponent<CheckoutButtonProps> = ({
     return <div id={containerId} />;
 };
 
-export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(CheckoutButton, [
-    { default: true },
-]);
+export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(
+    CheckoutButton,
+    [],
+);

--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -39,8 +39,12 @@ exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] 
           id="braintreepaypalCheckoutButton"
         />
         <div
-          id="amazonpayCheckoutButton"
-        />
+          class="AmazonPayContainer"
+        >
+          <div
+            id="amazonpayCheckoutButton"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -96,8 +100,12 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
           id="braintreepaypalCheckoutButton"
         />
         <div
-          id="amazonpayCheckoutButton"
-        />
+          class="AmazonPayContainer"
+        >
+          <div
+            id="amazonpayCheckoutButton"
+          />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What?
Remove default fallback for button resolving.

## Why?
SInce we have moved to using buttons from packages, the default button is always rendered. This can cause an issue for custom buttons such as apple pay.

## Testing / Proof
- CI

@bigcommerce/checkout
