### PR TITLE
tech(checkout): PI-000 re-map test id for RTL

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/extend-expect';
+import { configure as configureRTL } from '@testing-library/react';
 import * as Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { configure } from 'enzyme';
 import { noop } from 'lodash';
@@ -7,6 +8,7 @@ import { noop } from 'lodash';
 const adapter = Adapter as any;
 
 configure({ adapter: new adapter.default() });
+configureRTL({ testIdAttribute: 'data-test' });
 
 // https://github.com/facebook/jest/issues/10784
 process.on('unhandledRejection', (reason) => {

--- a/packages/braintree-integration/src/components/BraintreeAchPaymentForm/BraintreeAchPaymentForm.tsx
+++ b/packages/braintree-integration/src/components/BraintreeAchPaymentForm/BraintreeAchPaymentForm.tsx
@@ -184,7 +184,7 @@ const BraintreeAchPaymentForm: FunctionComponent<BraintreeAchPaymentFormProps> =
     return (
         <FormContext.Provider value={{ isSubmitted: isSubmitted(), setSubmitted }}>
             <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                <div className="checkout-ach-form" data-testid="checkout-ach-form">
+                <div className="checkout-ach-form" data-test="checkout-ach-form">
                     <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
                         {shouldShowInstrumentFieldset && !isLoading && (
                             <div className="checkout-ach-form__instrument">

--- a/packages/braintree-integration/src/components/MandateText/MandateText.tsx
+++ b/packages/braintree-integration/src/components/MandateText/MandateText.tsx
@@ -124,7 +124,7 @@ const MandateText: FunctionComponent<MandateTextProps> = ({
     }, [mandateText, updateMandateText]);
 
     return shouldShowMandateText ? (
-        <div className="mandate-text" data-testid="mandate-text">
+        <div className="mandate-text" data-test="mandate-text">
             {mandateText}
         </div>
     ) : null;

--- a/packages/core/src/app/payment/PaymentSubmitButton.tsx
+++ b/packages/core/src/app/payment/PaymentSubmitButton.tsx
@@ -165,7 +165,7 @@ const PaymentSubmitButton: FunctionComponent<
                 ? `payment-submit-button-${methodId}`
                 : undefined
         }
-        data-testid="payment-submit-button"
+        data-test="payment-submit-button"
         disabled={isInitializing || isSubmitting || isDisabled}
         id="checkout-payment-continue"
         isFullWidth

--- a/packages/core/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/CreditCardPaymentMethod.tsx
@@ -208,7 +208,7 @@ class CreditCardPaymentMethod extends Component<
 
         return (
             <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                <div className="paymentMethod paymentMethod--creditCard" data-testid='credit-cart-payment-method'>
+                <div className="paymentMethod paymentMethod--creditCard" data-test='credit-cart-payment-method'>
                     {shouldShowInstrumentFieldset && (
                         <CardInstrumentFieldset
                             instruments={instruments}

--- a/packages/core/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
+++ b/packages/core/src/app/payment/storedInstrument/AccountInstrumentSelect.tsx
@@ -267,7 +267,7 @@ const AccountInstrumentUseNewButton: FunctionComponent<AccountInstrumentUseNewBu
     testId,
     onClick = noop,
 }) => (
-    <button className={className} data-test={testId} data-testid={testId} onClick={onClick} type="button">
+    <button className={className} data-test={testId} onClick={onClick} type="button">
         <div className="instrumentSelect-details instrumentSelect-details--addNew">
             <IconNewAccount additionalClassName="accountIcon-icon" size={IconSize.Medium} />
 

--- a/packages/core/src/app/ui/dropdown/DropdownTrigger.test.tsx
+++ b/packages/core/src/app/ui/dropdown/DropdownTrigger.test.tsx
@@ -34,7 +34,7 @@ describe('DropdownTrigger', () => {
 
     it('hides dropdown when mouse clicks anywhere else in document', () => {
         render(
-            <div data-testid="root-node-id" id={CHECKOUT_ROOT_NODE_ID}>
+            <div data-test="root-node-id" id={CHECKOUT_ROOT_NODE_ID}>
                 <DropdownTrigger dropdown={<div>Hello world</div>}>
                     <button>Foobar</button>
                 </DropdownTrigger>

--- a/packages/core/src/app/ui/icon/IconBolt.tsx
+++ b/packages/core/src/app/ui/icon/IconBolt.tsx
@@ -5,12 +5,12 @@ import withIconContainer from './withIconContainer';
 const IconBolt: FunctionComponent = () => (
     <svg
         aria-labelledby="iconCardBoltTitle"
+        data-test="bolt-icon"
         height="12"
         role="img"
         viewBox="0 0 12 12"
         width="12"
         xmlns="http://www.w3.org/2000/svg"
-        data-testid="bolt-icon"
     >
         <title id="iconCardBoltTitle">Bolt</title>
         <path d="M0 7.502h7.5v4.5L12 4.502H4.5V0z" fill="#FFFFFF" id="mark" />

--- a/packages/instrument-utils/src/storedInstrument/AccountInstrumentFieldset/AccountInstrumentFieldset.tsx
+++ b/packages/instrument-utils/src/storedInstrument/AccountInstrumentFieldset/AccountInstrumentFieldset.tsx
@@ -72,7 +72,7 @@ const AccountInstrumentFieldset: FunctionComponent<AccountInstrumentFieldsetProp
             <BasicFormField name="instrumentId" render={renderInput} />
 
             {instruments.length === 0 && (
-                <div data-testid="instrument-select-note" className="instrumentSelect-note">
+                <div className="instrumentSelect-note" data-test="instrument-select-note">
                     <TranslatedHtml id="payment.account_instrument_new_shipping_address" />
                 </div>
             )}

--- a/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
@@ -31,13 +31,7 @@ const AccountInstrumentUseNewButton: FunctionComponent<AccountInstrumentUseNewBu
     testId,
     onClick = noop,
 }) => (
-    <button
-        className={className}
-        data-test={testId}
-        data-testid={testId}
-        onClick={onClick}
-        type="button"
-    >
+    <button className={className} data-test={testId} onClick={onClick} type="button">
         <div className="instrumentSelect-details instrumentSelect-details--addNew">
             <IconNewAccount additionalClassName="accountIcon-icon" size={IconSize.Medium} />
 
@@ -62,13 +56,7 @@ const AccountInstrumentMenuItem: FunctionComponent<AccountInstrumentMenuItemProp
     onClick,
 }) => {
     return (
-        <button
-            className={className}
-            data-test={testId}
-            data-testid={testId}
-            onClick={onClick}
-            type="button"
-        >
+        <button className={className} data-test={testId} onClick={onClick} type="button">
             <div className="instrumentSelect-details">
                 {
                     // TODO: When we include new account instrument types we can
@@ -76,11 +64,7 @@ const AccountInstrumentMenuItem: FunctionComponent<AccountInstrumentMenuItemProp
                 }
                 <IconPaypal additionalClassName="accountIcon-icon" size={IconSize.Medium} />
 
-                <div
-                    className="instrumentSelect-account"
-                    data-test={`${testId || ''}-externalId`}
-                    data-testid={`${testId || ''}-externalId`}
-                >
+                <div className="instrumentSelect-account" data-test={`${testId || ''}-externalId`}>
                     {externalId}
                 </div>
             </div>
@@ -105,13 +89,7 @@ const AchInstrumentMenuItem: FunctionComponent<AchInstrumentMenuItemProps> = ({
     const accountNumber = `Account number ending in: ${instrument.accountNumber}`;
 
     return (
-        <button
-            className={className}
-            data-test={testId}
-            data-testid={testId}
-            onClick={onClick}
-            type="button"
-        >
+        <button className={className} data-test={testId} onClick={onClick} type="button">
             <div className="instrumentSelect-details">
                 <IconAch size={IconSize.Medium} />
 
@@ -141,13 +119,7 @@ const BankInstrumentMenuItem: FunctionComponent<BankInstrumentMenuItemProps> = (
     const accountNumber = `Account number ending in: ${instrument.accountNumber}`;
 
     return (
-        <button
-            className={className}
-            data-test={testId}
-            data-testid={testId}
-            onClick={onClick}
-            type="button"
-        >
+        <button className={className} data-test={testId} onClick={onClick} type="button">
             <div className="instrumentSelect-details">
                 {
                     // TODO: When we include new account instrument types we can
@@ -216,7 +188,6 @@ const AccountInstrumentMenu: FunctionComponent<AccountInstrumentMenuProps> = ({
         <ul
             className="instrumentSelect-dropdownMenu instrumentSelect-dropdownMenuNext dropdown-menu"
             data-test="instrument-select-menu"
-            data-testid="instrument-select-menu"
         >
             {instruments.map((instrument) => (
                 <li
@@ -339,7 +310,7 @@ class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps
         const { value, ...otherFieldProps } = field;
 
         return (
-            <div className="instrumentSelect" data-testid="account-instrument-select">
+            <div className="instrumentSelect" data-test="account-instrument-select">
                 <DropdownTrigger
                     dropdown={
                         <AccountInstrumentMenu

--- a/packages/instrument-utils/src/storedInstrument/ManageAccountInstrumentsTable/ManageAccountInstrumentsTable.tsx
+++ b/packages/instrument-utils/src/storedInstrument/ManageAccountInstrumentsTable/ManageAccountInstrumentsTable.tsx
@@ -40,7 +40,6 @@ const ManageInstrumentsRow: FunctionComponent<ManageInstrumentsRowProps> = ({
                 <button
                     className="button button--tiny table-actionButton optimizedCheckout-buttonSecondary"
                     data-test="manage-instrument-delete-button"
-                    data-testid="manage-instrument-delete-button"
                     onClick={handleDelete}
                     type="button"
                 >
@@ -72,7 +71,7 @@ const ManageInstrumentsTable: FunctionComponent<ManageAccountInstrumentsTablePro
 
     return (
         <LoadingOverlay isLoading={isDeletingInstrument}>
-            <table className="table" data-testid="manage-instruments-table">
+            <table className="table" data-test="manage-instruments-table">
                 <thead className="table-thead">
                     <tr>
                         <th>

--- a/packages/instrument-utils/src/storedInstrument/ManageAccountInstrumentsTable/__snapshots__/ManageAccountInstrumentsTable.spec.tsx.snap
+++ b/packages/instrument-utils/src/storedInstrument/ManageAccountInstrumentsTable/__snapshots__/ManageAccountInstrumentsTable.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`ManageAccountInstrumentsTable matches snapshot with rendered output 1`]
 >
   <table
     class="table"
-    data-testid="manage-instruments-table"
+    data-test="manage-instruments-table"
   >
     <thead
       class="table-thead"
@@ -58,7 +58,6 @@ exports[`ManageAccountInstrumentsTable matches snapshot with rendered output 1`]
           <button
             class="button button--tiny table-actionButton optimizedCheckout-buttonSecondary"
             data-test="manage-instrument-delete-button"
-            data-testid="manage-instrument-delete-button"
             type="button"
           >
             Delete
@@ -102,7 +101,6 @@ exports[`ManageAccountInstrumentsTable matches snapshot with rendered output 1`]
           <button
             class="button button--tiny table-actionButton optimizedCheckout-buttonSecondary"
             data-test="manage-instrument-delete-button"
-            data-testid="manage-instrument-delete-button"
             type="button"
           >
             Delete

--- a/packages/instrument-utils/src/storedInstrument/ManageAchInstrumentsTable/ManageAchInstrumentsTable.tsx
+++ b/packages/instrument-utils/src/storedInstrument/ManageAchInstrumentsTable/ManageAchInstrumentsTable.tsx
@@ -59,7 +59,7 @@ const ManageAchInstrumentsTable: FunctionComponent<ManageAchInstrumentsTableProp
 
     return (
         <LoadingOverlay isLoading={isDeletingInstrument}>
-            <table className="table" data-testid="manage-ach-instruments-table">
+            <table className="table" data-test="manage-ach-instruments-table">
                 <thead className="table-thead">
                     <tr>
                         <th>

--- a/packages/instrument-utils/src/storedInstrument/ManageAchInstrumentsTable/__snapshots__/ManageAchInstrumentsTable.test.tsx.snap
+++ b/packages/instrument-utils/src/storedInstrument/ManageAchInstrumentsTable/__snapshots__/ManageAchInstrumentsTable.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ManageAchInstrumentsTable matches snapshot with rendered output 1`] = `
 >
   <table
     className="table"
-    data-testid="manage-ach-instruments-table"
+    data-test="manage-ach-instruments-table"
   >
     <thead
       className="table-thead"

--- a/packages/instrument-utils/src/storedInstrument/ManageCardInstrumentsTable/ManageCardInstrumentsTable.tsx
+++ b/packages/instrument-utils/src/storedInstrument/ManageCardInstrumentsTable/ManageCardInstrumentsTable.tsx
@@ -62,7 +62,6 @@ const ManageInstrumentsRow: FunctionComponent<ManageInstrumentsRowProps> = ({
                 <button
                     className="button button--tiny table-actionButton optimizedCheckout-buttonSecondary"
                     data-test="manage-instrument-delete-button"
-                    data-testid="manage-instrument-delete-button"
                     onClick={handleDelete}
                     type="button"
                 >
@@ -94,7 +93,7 @@ const ManageCardInstrumentsTable: FunctionComponent<ManageCardInstrumentsTablePr
 
     return (
         <LoadingOverlay isLoading={isDeletingInstrument}>
-            <table className="table" data-testid="manage-card-instruments-table">
+            <table className="table" data-test="manage-card-instruments-table">
                 <thead className="table-thead">
                     <tr>
                         <th>

--- a/packages/instrument-utils/src/storedInstrument/ManageCardInstrumentsTable/__snapshots__/ManageCardInstrumentsTable.spec.tsx.snap
+++ b/packages/instrument-utils/src/storedInstrument/ManageCardInstrumentsTable/__snapshots__/ManageCardInstrumentsTable.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`ManageCardInstrumentsTable matches snapshot with rendered output 1`] = 
 >
   <table
     class="table"
-    data-testid="manage-card-instruments-table"
+    data-test="manage-card-instruments-table"
   >
     <thead
       class="table-thead"
@@ -55,7 +55,6 @@ exports[`ManageCardInstrumentsTable matches snapshot with rendered output 1`] = 
           <button
             class="button button--tiny table-actionButton optimizedCheckout-buttonSecondary"
             data-test="manage-instrument-delete-button"
-            data-testid="manage-instrument-delete-button"
             type="button"
           >
             Delete
@@ -90,7 +89,6 @@ exports[`ManageCardInstrumentsTable matches snapshot with rendered output 1`] = 
           <button
             class="button button--tiny table-actionButton optimizedCheckout-buttonSecondary"
             data-test="manage-instrument-delete-button"
-            data-testid="manage-instrument-delete-button"
             type="button"
           >
             Delete

--- a/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.tsx
+++ b/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.tsx
@@ -153,20 +153,18 @@ class ManageInstrumentsModal extends Component<
             return (
                 <>
                     <Button
-                        data-test="manage-instrument-cancel-button"
-                        data-testid="manage-instrument-cancel-button"
                         onClick={this.handleCancel}
                         size={ButtonSize.Small}
+                        testId="manage-instrument-cancel-button"
                     >
                         <TranslatedString id="common.cancel_action" />
                     </Button>
 
                     <Button
-                        data-test="manage-instrument-confirm-button"
-                        data-testid="manage-instrument-confirm-button"
                         disabled={isDeletingInstrument() || isLoadingInstruments()}
                         onClick={this.handleConfirmDelete}
                         size={ButtonSize.Small}
+                        testId="manage-instrument-confirm-button"
                         variant={ButtonVariant.Primary}
                     >
                         <TranslatedString id="payment.instrument_manage_modal_confirmation_action" />
@@ -177,9 +175,9 @@ class ManageInstrumentsModal extends Component<
 
         return (
             <Button
-                data-test="manage-instrument-close-button"
                 onClick={onRequestClose}
                 size={ButtonSize.Small}
+                testId="manage-instrument-close-button"
             >
                 <TranslatedString id="common.close_action" />
             </Button>

--- a/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
+++ b/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getPayPalCommerceMethod } from '../mocks/paymentMethods.mock';
+
 import PayPalCommercePaymentMethodComponent from './PayPalCommercePaymentMethodComponent';
 
 describe('PayPalCommercePaymentMethodComponent', () => {
@@ -144,36 +145,34 @@ describe('PayPalCommercePaymentMethodComponent', () => {
 
         const component = (
             <PayPalCommercePaymentMethodComponent {...props}>
-                <div data-testid={testId} />
+                <div data-test={testId} />
             </PayPalCommercePaymentMethodComponent>
         );
 
-        const { getByTestId }= render(component);
+        const { getByTestId } = render(component);
 
         await new Promise((resolve) => process.nextTick(resolve));
 
-        expect(getByTestId(testId)).toBeDefined();
+        expect(getByTestId(testId)).toBeInTheDocument();
     });
 
     it('hides payment submit button by calling onRenderButton callback', async () => {
-        jest.spyOn(checkoutService, 'initializePayment')
-            .mockImplementation((options) => {
-                eventEmitter.on('onRenderButton', () => {
-                    if (options.paypalcommerce?.onRenderButton) {
-                        options.paypalcommerce.onRenderButton();
-                    }
-                });
-
-                return Promise.resolve(checkoutState);
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('onRenderButton', () => {
+                if (options.paypalcommerce?.onRenderButton) {
+                    options.paypalcommerce.onRenderButton();
+                }
             });
 
+            return Promise.resolve(checkoutState);
+        });
 
         const hidePaymentSubmitButtonMock = jest.fn();
         const newProps = {
             ...props,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             paymentForm: {
-                hidePaymentSubmitButton: hidePaymentSubmitButtonMock
+                hidePaymentSubmitButton: hidePaymentSubmitButtonMock,
             } as unknown as PaymentFormService,
         };
 
@@ -187,17 +186,15 @@ describe('PayPalCommercePaymentMethodComponent', () => {
     });
 
     it('submits payment form by calling submitForm callback', async () => {
-        jest.spyOn(checkoutService, 'initializePayment')
-            .mockImplementation((options) => {
-                eventEmitter.on('submitForm', () => {
-                    if (options.paypalcommerce?.submitForm) {
-                        options.paypalcommerce.submitForm();
-                    }
-                });
-
-                return Promise.resolve(checkoutState);
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('submitForm', () => {
+                if (options.paypalcommerce?.submitForm) {
+                    options.paypalcommerce.submitForm();
+                }
             });
 
+            return Promise.resolve(checkoutState);
+        });
 
         const submitFormMock = jest.fn();
         const setSubmittedMock = jest.fn();
@@ -223,17 +220,15 @@ describe('PayPalCommercePaymentMethodComponent', () => {
     it('disables submit button and throws an error by calling onError callback', async () => {
         const errorMock = new Error();
 
-        jest.spyOn(checkoutService, 'initializePayment')
-            .mockImplementation((options) => {
-                eventEmitter.on('onError', () => {
-                    if (options.paypalcommerce?.onError) {
-                        options.paypalcommerce.onError(errorMock);
-                    }
-                });
-
-                return Promise.resolve(checkoutState);
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('onError', () => {
+                if (options.paypalcommerce?.onError) {
+                    options.paypalcommerce.onError(errorMock);
+                }
             });
 
+            return Promise.resolve(checkoutState);
+        });
 
         const disableSubmitMock = jest.fn();
         const onUnhandledErrorMock = jest.fn();
@@ -257,17 +252,15 @@ describe('PayPalCommercePaymentMethodComponent', () => {
     });
 
     it('passed form validation by calling onValidate callback', async () => {
-        jest.spyOn(checkoutService, 'initializePayment')
-            .mockImplementation((options) => {
-                eventEmitter.on('onValidate', async (resolve, reject) => {
-                    if (options.paypalcommerce?.onError) {
-                        await options.paypalcommerce.onValidate(resolve, reject);
-                    }
-                });
-
-                return Promise.resolve(checkoutState);
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('onValidate', async (resolve, reject) => {
+                if (options.paypalcommerce?.onError) {
+                    await options.paypalcommerce.onValidate(resolve, reject);
+                }
             });
 
+            return Promise.resolve(checkoutState);
+        });
 
         const validateFormMock = jest.fn().mockReturnValue({});
         const validationSuccess = jest.fn();
@@ -283,28 +276,22 @@ describe('PayPalCommercePaymentMethodComponent', () => {
 
         await new Promise((resolve) => process.nextTick(resolve));
 
-        eventEmitter.emit(
-            'onValidate',
-            validationSuccess,
-            () => {},
-        );
+        eventEmitter.emit('onValidate', validationSuccess, () => {});
 
         expect(await validateFormMock).toHaveBeenCalled();
         expect(validationSuccess).toHaveBeenCalled();
     });
 
     it('passed form validation by calling onValidate callback', async () => {
-        jest.spyOn(checkoutService, 'initializePayment')
-            .mockImplementation((options) => {
-                eventEmitter.on('onValidate', async (resolve, reject) => {
-                    if (options.paypalcommerce?.onError) {
-                        await options.paypalcommerce.onValidate(resolve, reject);
-                    }
-                });
-
-                return Promise.resolve(checkoutState);
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('onValidate', async (resolve, reject) => {
+                if (options.paypalcommerce?.onError) {
+                    await options.paypalcommerce.onValidate(resolve, reject);
+                }
             });
 
+            return Promise.resolve(checkoutState);
+        });
 
         const validateFormMock = jest.fn().mockReturnValue({
             field1: 'validation error message',
@@ -327,11 +314,7 @@ describe('PayPalCommercePaymentMethodComponent', () => {
 
         await new Promise((resolve) => process.nextTick(resolve));
 
-        eventEmitter.emit(
-            'onValidate',
-            () => {},
-            validationReject,
-        );
+        eventEmitter.emit('onValidate', () => {}, validationReject);
 
         expect(await validateFormMock).toHaveBeenCalled();
         expect(setSubmittedMock).toHaveBeenCalledWith(true);

--- a/packages/ui/src/dropdown/DropdownTrigger.test.tsx
+++ b/packages/ui/src/dropdown/DropdownTrigger.test.tsx
@@ -34,7 +34,7 @@ describe('DropdownTrigger', () => {
 
     it('hides dropdown when mouse clicks anywhere else in document', () => {
         render(
-            <div data-testid="root-node-id" id={CHECKOUT_ROOT_NODE_ID}>
+            <div data-test="root-node-id" id={CHECKOUT_ROOT_NODE_ID}>
                 <DropdownTrigger dropdown={<div>Hello world</div>}>
                     <button>Foobar</button>
                 </DropdownTrigger>

--- a/packages/ui/src/form/Fieldset/Fieldset.tsx
+++ b/packages/ui/src/form/Fieldset/Fieldset.tsx
@@ -16,7 +16,6 @@ const Fieldset = forwardRef(
             {...rest}
             className={className || classNames('form-fieldset', additionalClassName)}
             data-test={testId}
-            data-testid={testId}
             ref={ref}
         >
             {legend}

--- a/packages/ui/src/loading/LoadingOverlay.tsx
+++ b/packages/ui/src/loading/LoadingOverlay.tsx
@@ -37,7 +37,7 @@ const LoadingOverlay: FunctionComponent<LoadingOverlayProps> = ({
             {isLoading && (
                 <div
                     className="loadingOverlay optimizedCheckout-overlay"
-                    data-testid="loading-overlay"
+                    data-test="loading-overlay"
                 />
             )}
         </div>

--- a/packages/ui/src/modal/Modal.tsx
+++ b/packages/ui/src/modal/Modal.tsx
@@ -83,7 +83,6 @@ const Modal: FunctionComponent<ModalProps> = ({
             <div
                 className={classNames('modal-body', additionalBodyClassName)}
                 data-test="modal-body"
-                data-testid="modal-body"
             >
                 {children}
             </div>


### PR DESCRIPTION
## What?
Re-mapping `data-testid` to `data-test` 

## Why?
I think that we using testid in wrong way, because we're duplicating usage of same attribute with different name
To avoid maintaining of two test IDs I've done re-mapping `data-testid` to `data-test` 
before:
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/aa2a8cc4-cfa6-46b5-8a4a-2168879160ca)
after:
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/7d782824-f03a-4757-9689-8d9dbcb151a8)


## Testing / Proof
Units

@bigcommerce/checkout
