### PR TITLE
fix(payment): PAYPAL-2402 Removed billing address from Braintree ACH Form

### DIFF
--- a/packages/braintree-integration/src/BraintreeAchPaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreeAchPaymentMethod.test.tsx
@@ -37,10 +37,6 @@ describe('BraintreeAchPaymentForm', () => {
 
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
 
-        jest.spyOn(checkoutService, 'loadBillingAddressFields').mockResolvedValue(
-            {} as CheckoutSelectors,
-        );
-
         const { language } = createLocaleContext(getStoreConfig());
 
         defaultProps = {
@@ -63,7 +59,6 @@ describe('BraintreeAchPaymentForm', () => {
         render(<BraintreeAchPaymentMethodTest {...defaultProps} />);
 
         expect(screen.getByTestId('checkout-ach-form')).toBeInTheDocument();
-        expect(checkoutService.loadBillingAddressFields).toHaveBeenCalled();
 
         await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/braintree-integration/src/BraintreeAchPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeAchPaymentMethod.tsx
@@ -63,16 +63,6 @@ const BraintreeAchPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     }, [checkoutService, method.gateway, method.id, onUnhandledError]);
 
     useEffect(() => {
-        const loadBillingAddressFieldsOrThrow = async () => {
-            try {
-                await checkoutService.loadBillingAddressFields();
-            } catch (error) {
-                if (error instanceof Error) {
-                    onUnhandledError(error);
-                }
-            }
-        };
-
         const loadInstrumentsOrThrow = async () => {
             try {
                 if (isInstrumentFeatureAvailable) {
@@ -85,7 +75,6 @@ const BraintreeAchPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             }
         };
 
-        void loadBillingAddressFieldsOrThrow();
         void loadInstrumentsOrThrow();
     }, [checkoutService, onUnhandledError, isInstrumentFeatureAvailable]);
 

--- a/packages/braintree-integration/src/components/AchFormFields/AchFormFields.tsx
+++ b/packages/braintree-integration/src/components/AchFormFields/AchFormFields.tsx
@@ -6,14 +6,8 @@ import { DynamicFormField } from '@bigcommerce/checkout/ui';
 import { AddressKeyMap } from '../BraintreeAchPaymentForm/BraintreeAchPaymentForm';
 
 const LABEL: AddressKeyMap = {
-    address1: 'address.address_line_1_label',
-    address2: 'address.address_line_2_label',
-    city: 'address.city_label',
-    countryCode: 'address.country_label',
     firstName: 'address.first_name_label',
     lastName: 'address.last_name_label',
-    postalCode: 'address.postal_code_label',
-    stateOrProvinceCode: 'address.state_label',
     accountNumber: 'payment.account_number_label',
     routingNumber: 'payment.account_routing_label',
     businessName: 'payment.business_name_label',

--- a/packages/braintree-integration/src/components/BraintreeAchPaymentForm/BraintreeAchPaymentForm.test.tsx
+++ b/packages/braintree-integration/src/components/BraintreeAchPaymentForm/BraintreeAchPaymentForm.test.tsx
@@ -17,7 +17,7 @@ import {
     getStoreConfig,
 } from '@bigcommerce/checkout/test-utils';
 
-import { BraintreeAchBankAccountValues } from '../../validation-schemas';
+import { BraintreeAchFieldType } from '../../validation-schemas';
 
 import BraintreeAchPaymentForm, { BraintreeAchPaymentFormProps } from './BraintreeAchPaymentForm';
 import { OwnershipTypes } from './braintreeAchPaymentFormConfig';
@@ -67,19 +67,6 @@ describe('BraintreeAchPaymentForm', () => {
             customFields: [],
         });
 
-        jest.spyOn(checkoutService.getState().data, 'getBillingCountries').mockReturnValue([
-            {
-                code: 'US',
-                name: 'United States',
-                hasPostalCodes: true,
-                requiresState: true,
-                subdivisions: [
-                    { code: 'CA', name: 'California' },
-                    { code: 'TX', name: 'Texas' },
-                ],
-            },
-        ]);
-
         BraintreeAchPaymentFormTest = (props: BraintreeAchPaymentFormProps) => {
             return (
                 <Formik initialValues={initialValues} onSubmit={noop}>
@@ -103,7 +90,7 @@ describe('BraintreeAchPaymentForm', () => {
         const eventData = {
             target: {
                 value: OwnershipTypes.Personal,
-                name: BraintreeAchBankAccountValues.OwnershipType,
+                name: BraintreeAchFieldType.OwnershipType,
             },
         };
 
@@ -124,7 +111,7 @@ describe('BraintreeAchPaymentForm', () => {
         const eventData = {
             target: {
                 value: OwnershipTypes.Business,
-                name: BraintreeAchBankAccountValues.OwnershipType,
+                name: BraintreeAchFieldType.OwnershipType,
             },
         };
 
@@ -151,7 +138,7 @@ describe('BraintreeAchPaymentForm', () => {
     });
 
     it('renders loading overlay while waiting for method to initialize', () => {
-        jest.spyOn(checkoutState.statuses, 'isLoadingBillingCountries').mockReturnValue(true);
+        jest.spyOn(checkoutState.statuses, 'isLoadingInstruments').mockReturnValue(true);
 
         const { rerender } = render(<BraintreeAchPaymentFormTest {...defaultProps} />);
 
@@ -160,7 +147,7 @@ describe('BraintreeAchPaymentForm', () => {
             'display: none',
         );
 
-        jest.spyOn(checkoutState.statuses, 'isLoadingBillingCountries').mockReturnValue(false);
+        jest.spyOn(checkoutState.statuses, 'isLoadingInstruments').mockReturnValue(false);
 
         rerender(<BraintreeAchPaymentFormTest {...defaultProps} />);
 
@@ -171,7 +158,7 @@ describe('BraintreeAchPaymentForm', () => {
     });
 
     it('hides content while loading', () => {
-        jest.spyOn(checkoutState.statuses, 'isLoadingBillingCountries').mockReturnValue(true);
+        jest.spyOn(checkoutState.statuses, 'isLoadingInstruments').mockReturnValue(true);
 
         render(<BraintreeAchPaymentFormTest {...defaultProps} />);
 

--- a/packages/braintree-integration/src/components/BraintreeAchPaymentForm/braintreeAchPaymentFormConfig.ts
+++ b/packages/braintree-integration/src/components/BraintreeAchPaymentForm/braintreeAchPaymentFormConfig.ts
@@ -2,7 +2,7 @@ import { FormField } from '@bigcommerce/checkout-sdk';
 
 import { DynamicFormFieldType } from '@bigcommerce/checkout/ui';
 
-import { BraintreeAchBankAccountValues } from '../../validation-schemas';
+import { BraintreeAchFieldType } from '../../validation-schemas';
 
 export enum OwnershipTypes {
     Personal = 'Personal',
@@ -38,9 +38,9 @@ export const ownershipTypeOptions = [
 
 export const formFieldData: FormField[] = [
     {
-        name: BraintreeAchBankAccountValues.AccountType,
+        name: BraintreeAchFieldType.AccountType,
         custom: false,
-        id: BraintreeAchBankAccountValues.AccountType,
+        id: BraintreeAchFieldType.AccountType,
         label: 'Account Type',
         required: true,
         fieldType: DynamicFormFieldType.DROPDOWM,
@@ -49,25 +49,25 @@ export const formFieldData: FormField[] = [
         },
     },
     {
-        name: BraintreeAchBankAccountValues.AccountNumber,
+        name: BraintreeAchFieldType.AccountNumber,
         custom: false,
-        id: BraintreeAchBankAccountValues.AccountNumber,
+        id: BraintreeAchFieldType.AccountNumber,
         label: 'Account Number',
         required: true,
         max: 9,
         min: 8,
     },
     {
-        name: BraintreeAchBankAccountValues.RoutingNumber,
+        name: BraintreeAchFieldType.RoutingNumber,
         custom: false,
-        id: BraintreeAchBankAccountValues.RoutingNumber,
+        id: BraintreeAchFieldType.RoutingNumber,
         label: 'Routing Number',
         required: true,
     },
     {
-        name: BraintreeAchBankAccountValues.OwnershipType,
+        name: BraintreeAchFieldType.OwnershipType,
         custom: false,
-        id: BraintreeAchBankAccountValues.OwnershipType,
+        id: BraintreeAchFieldType.OwnershipType,
         label: 'Ownership Type',
         required: true,
         fieldType: DynamicFormFieldType.DROPDOWM,
@@ -76,60 +76,24 @@ export const formFieldData: FormField[] = [
         },
     },
     {
-        name: BraintreeAchBankAccountValues.FirstName,
+        name: BraintreeAchFieldType.FirstName,
         custom: false,
-        id: BraintreeAchBankAccountValues.FirstName,
+        id: BraintreeAchFieldType.FirstName,
         label: 'First Name',
         required: true,
     },
     {
-        name: BraintreeAchBankAccountValues.LastName,
+        name: BraintreeAchFieldType.LastName,
         custom: false,
-        id: BraintreeAchBankAccountValues.LastName,
+        id: BraintreeAchFieldType.LastName,
         label: 'Last Name',
         required: true,
     },
     {
-        name: BraintreeAchBankAccountValues.BusinessName,
+        name: BraintreeAchFieldType.BusinessName,
         custom: false,
-        id: BraintreeAchBankAccountValues.BusinessName,
+        id: BraintreeAchFieldType.BusinessName,
         label: 'Business Name',
-        required: true,
-    },
-    {
-        name: BraintreeAchBankAccountValues.Address1,
-        custom: false,
-        id: BraintreeAchBankAccountValues.Address1,
-        label: 'Address',
-        required: true,
-    },
-    {
-        name: BraintreeAchBankAccountValues.Address2,
-        custom: false,
-        id: BraintreeAchBankAccountValues.Address2,
-        label: 'Apartment/Suite/Building',
-        required: false,
-    },
-    {
-        name: BraintreeAchBankAccountValues.StateOrProvinceCode,
-        custom: false,
-        id: BraintreeAchBankAccountValues.StateOrProvinceCode,
-        label: 'State/Province',
-        required: true,
-        fieldType: DynamicFormFieldType.DROPDOWM,
-    },
-    {
-        name: BraintreeAchBankAccountValues.City,
-        custom: false,
-        id: BraintreeAchBankAccountValues.City,
-        label: 'City',
-        required: true,
-    },
-    {
-        name: BraintreeAchBankAccountValues.PostalCode,
-        custom: false,
-        id: BraintreeAchBankAccountValues.PostalCode,
-        label: 'Postal Code',
         required: true,
     },
 ];

--- a/packages/braintree-integration/src/components/MandateText/MandateText.tsx
+++ b/packages/braintree-integration/src/components/MandateText/MandateText.tsx
@@ -5,7 +5,7 @@ import { ObjectSchema } from 'yup';
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 import { CheckboxFormField } from '@bigcommerce/checkout/ui';
 
-import { BraintreeAchBankAccountValues } from '../../validation-schemas';
+import { BraintreeAchFieldType } from '../../validation-schemas';
 
 export interface MandateTextProps {
     getFieldValue: PaymentFormService['getFieldValue'];
@@ -36,20 +36,12 @@ const MandateText: FunctionComponent<MandateTextProps> = ({
 }) => {
     const [shouldShowMandateText, setShouldShowMandateText] = useState(false);
 
-    const routingNumberValue = String(
-        getFieldValue<string>(BraintreeAchBankAccountValues.RoutingNumber),
-    );
-    const accountNumberValue = String(
-        getFieldValue<string>(BraintreeAchBankAccountValues.AccountNumber),
-    );
-    const firstNameValue = String(getFieldValue<string>(BraintreeAchBankAccountValues.FirstName));
-    const lastNameValue = String(getFieldValue<string>(BraintreeAchBankAccountValues.LastName));
-    const businessNameValue = String(
-        getFieldValue<string>(BraintreeAchBankAccountValues.BusinessName),
-    );
-    const accountTypeValue = String(
-        getFieldValue<string>(BraintreeAchBankAccountValues.AccountType),
-    );
+    const routingNumberValue = String(getFieldValue<string>(BraintreeAchFieldType.RoutingNumber));
+    const accountNumberValue = String(getFieldValue<string>(BraintreeAchFieldType.AccountNumber));
+    const firstNameValue = String(getFieldValue<string>(BraintreeAchFieldType.FirstName));
+    const lastNameValue = String(getFieldValue<string>(BraintreeAchFieldType.LastName));
+    const businessNameValue = String(getFieldValue<string>(BraintreeAchFieldType.BusinessName));
+    const accountTypeValue = String(getFieldValue<string>(BraintreeAchFieldType.AccountType));
 
     useEffect(() => {
         const validate = async () => {

--- a/packages/braintree-integration/src/validation-schemas/getBraintreeAchValidationSchema.ts
+++ b/packages/braintree-integration/src/validation-schemas/getBraintreeAchValidationSchema.ts
@@ -8,25 +8,9 @@ export enum BraintreeAchFieldType {
     AccountNumber = 'accountNumber',
     RoutingNumber = 'routingNumber',
     OwnershipType = 'ownershipType',
-}
-
-export enum BraintreeAchAddressType {
     FirstName = 'firstName',
     LastName = 'lastName',
-    Address1 = 'address1',
-    Address2 = 'address2',
-    PostalCode = 'postalCode',
-    CountryCode = 'countryCode',
-    City = 'city',
-    StateOrProvinceCode = 'stateOrProvinceCode',
 }
-
-export const BraintreeAchBankAccountValues = {
-    ...BraintreeAchFieldType,
-    ...BraintreeAchAddressType,
-};
-
-export type BraintreeAchBankAccount = BraintreeAchFieldType | BraintreeAchAddressType;
 
 export default memoize(function getBraintreeAchValidationSchema({
     formFieldData,
@@ -36,16 +20,11 @@ export default memoize(function getBraintreeAchValidationSchema({
     language: LanguageService;
 }) {
     const requiredFieldErrorTranslationIds: { [fieldName: string]: string } = {
-        [BraintreeAchBankAccountValues.FirstName]: 'address.first_name',
-        [BraintreeAchBankAccountValues.LastName]: 'address.last_name',
-        [BraintreeAchBankAccountValues.Address1]: 'address.address_line_1',
-        [BraintreeAchBankAccountValues.Address2]: 'address.address_line_2',
-        [BraintreeAchBankAccountValues.City]: 'address.city',
-        [BraintreeAchBankAccountValues.StateOrProvinceCode]: 'address.state',
-        [BraintreeAchBankAccountValues.PostalCode]: 'address.postal_code',
-        [BraintreeAchBankAccountValues.AccountNumber]: 'payment.errors.account_number',
-        [BraintreeAchBankAccountValues.RoutingNumber]: 'payment.errors.routing_number',
-        [BraintreeAchBankAccountValues.BusinessName]: 'payment.errors.business_name',
+        [BraintreeAchFieldType.FirstName]: 'address.first_name',
+        [BraintreeAchFieldType.LastName]: 'address.last_name',
+        [BraintreeAchFieldType.AccountNumber]: 'payment.errors.account_number',
+        [BraintreeAchFieldType.RoutingNumber]: 'payment.errors.routing_number',
+        [BraintreeAchFieldType.BusinessName]: 'payment.errors.business_name',
     };
 
     return object(

--- a/packages/braintree-integration/src/validation-schemas/index.tsx
+++ b/packages/braintree-integration/src/validation-schemas/index.tsx
@@ -1,5 +1,4 @@
 export {
     default as getBraintreeAchValidationSchema,
-    BraintreeAchBankAccountValues,
-    BraintreeAchBankAccount,
+    BraintreeAchFieldType,
 } from './getBraintreeAchValidationSchema';

--- a/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.test.tsx
+++ b/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.test.tsx
@@ -157,6 +157,8 @@ describe('AccountInstrumentSelect', () => {
     });
 
     it('cleans the instrumentId when the component unmounts', async () => {
+        jest.useFakeTimers();
+
         const submit = jest.fn();
 
         initialValues.instrumentId = '1234';
@@ -206,10 +208,14 @@ describe('AccountInstrumentSelect', () => {
 
         fireEvent.click(screen.getByTestId('instrument-select-option-use-new'));
 
+        jest.runOnlyPendingTimers();
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         screen.getByRole('form').submit();
 
         await new Promise((resolve) => process.nextTick(resolve));
+
+        jest.useRealTimers();
 
         expect(submit).toHaveBeenCalledWith({ instrumentId: '' }, expect.anything());
     });

--- a/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
@@ -289,6 +289,9 @@ class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps
         const { selectedInstrumentId } = this.props;
 
         if (prevSelectedInstrumentId !== selectedInstrumentId) {
+            // FIXME: Used setTimeout here because setFieldValue call doesnot set value if called before formik is properly mounted.
+            //        This ensures that update Field value is called after formik has mounted.
+            // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
             setTimeout(() => this.updateFieldValue(selectedInstrumentId));
         }
     }

--- a/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
@@ -289,7 +289,7 @@ class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps
         const { selectedInstrumentId } = this.props;
 
         if (prevSelectedInstrumentId !== selectedInstrumentId) {
-            this.updateFieldValue(selectedInstrumentId);
+            setTimeout(() => this.updateFieldValue(selectedInstrumentId));
         }
     }
 


### PR DESCRIPTION
## What?

Removed billing address from Braintree ACH Form

## Why?

Remove billing address fields from the ACH payment component within Payments step of checkout. Shoppers should use our native billing address form on the checkout page. 

Depends:
https://github.com/bigcommerce/checkout-sdk-js/pull/2014 
https://github.com/bigcommerce/checkout-sdk-js/pull/2013

## Testing / Proof

<img width="634" alt="Screenshot 2023-06-09 at 17 43 39" src="https://github.com/bigcommerce/checkout-js/assets/99336044/b96642ca-0909-4ff9-a8ac-198e4427c93e">

<img width="630" alt="Screenshot 2023-06-09 at 17 44 42" src="https://github.com/bigcommerce/checkout-js/assets/99336044/75daeb2e-1a13-45a7-b6c7-8d76f47b4030">
