### PR TITLE
chore(payment): INT-7650 Bump @bigcommerce/checkout-sdk to 1.386.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.386.0",
+        "@bigcommerce/checkout-sdk": "^1.386.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.386.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.386.0.tgz",
-      "integrity": "sha512-OIcf7BwE5tv8xVv1t6aJdbnyOoKFpZ8Rb4zYyDjSM8jyFaGKBm/hoaXPlOd3H0wFEAACD8RfbPDRKWI/qVYa8w==",
+      "version": "1.386.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.386.1.tgz",
+      "integrity": "sha512-3dgi3uJdqdrQ+6uLs/W3LBesaSLmOTuXAg3OTQ53Qm2Bzw0sxaLMBChtiJtVqZKiMFW2IKQ1FHxZtEO+PXEpYQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.386.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.386.0.tgz",
-      "integrity": "sha512-OIcf7BwE5tv8xVv1t6aJdbnyOoKFpZ8Rb4zYyDjSM8jyFaGKBm/hoaXPlOd3H0wFEAACD8RfbPDRKWI/qVYa8w==",
+      "version": "1.386.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.386.1.tgz",
+      "integrity": "sha512-3dgi3uJdqdrQ+6uLs/W3LBesaSLmOTuXAg3OTQ53Qm2Bzw0sxaLMBChtiJtVqZKiMFW2IKQ1FHxZtEO+PXEpYQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.386.0",
+    "@bigcommerce/checkout-sdk": "^1.386.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from [v1.386.0 to v1.386.1](https://github.com/bigcommerce/checkout-sdk-js/compare/v1.386.0...v1.386.1)

## Why?
To release https://github.com/bigcommerce/checkout-sdk-js/pull/1992

## Testing / Proof
CircleCI + testing section on the above PR