### PR TITLE
feat(payment): PAYPAL-2449 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.386.1",
+        "@bigcommerce/checkout-sdk": "^1.387.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1745,9 +1745,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.23.0.tgz",
-      "integrity": "sha512-KBhxoHCFVnAjMvXIqOPlaW+JDJVY8oK4YvpVE2ALsljbJuXYiBGhIwYWeWeGKn63DxiFWhPiimXmdVDjMQZLOw==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
+      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -1756,11 +1756,11 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.386.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.386.1.tgz",
-      "integrity": "sha512-3dgi3uJdqdrQ+6uLs/W3LBesaSLmOTuXAg3OTQ53Qm2Bzw0sxaLMBChtiJtVqZKiMFW2IKQ1FHxZtEO+PXEpYQ==",
+      "version": "1.387.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.387.0.tgz",
+      "integrity": "sha512-KlxWFLJMzboyQVipOxwPbEleDa0d8AHKxeW6x+NvbHXSVTY51HRtL68PIQEm7+1c4auQH0Hip2Et+obSsZIlhA==",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.23.0",
+        "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -35327,9 +35327,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.23.0.tgz",
-      "integrity": "sha512-KBhxoHCFVnAjMvXIqOPlaW+JDJVY8oK4YvpVE2ALsljbJuXYiBGhIwYWeWeGKn63DxiFWhPiimXmdVDjMQZLOw==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
+      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -35338,11 +35338,11 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.386.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.386.1.tgz",
-      "integrity": "sha512-3dgi3uJdqdrQ+6uLs/W3LBesaSLmOTuXAg3OTQ53Qm2Bzw0sxaLMBChtiJtVqZKiMFW2IKQ1FHxZtEO+PXEpYQ==",
+      "version": "1.387.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.387.0.tgz",
+      "integrity": "sha512-KlxWFLJMzboyQVipOxwPbEleDa0d8AHKxeW6x+NvbHXSVTY51HRtL68PIQEm7+1c4auQH0Hip2Et+obSsZIlhA==",
       "requires": {
-        "@bigcommerce/bigpay-client": "^5.23.0",
+        "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.386.1",
+    "@bigcommerce/checkout-sdk": "^1.387.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deliver checkout-sdk-js changes 
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2015

## Testing / Proof


@bigcommerce/checkout
