### PR TITLE
feat(checkout): PI-42 bumped checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.387.0",
+        "@bigcommerce/checkout-sdk": "^1.388.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.387.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.387.0.tgz",
-      "integrity": "sha512-KlxWFLJMzboyQVipOxwPbEleDa0d8AHKxeW6x+NvbHXSVTY51HRtL68PIQEm7+1c4auQH0Hip2Et+obSsZIlhA==",
+      "version": "1.388.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.0.tgz",
+      "integrity": "sha512-TDqaHMPx5y5RxnJmccfTDA3TU6TIoWIbo3N/Ix3uwFsFNnefNa4Aoqrdk0bKmg7uckPnjTS60UwJnRz9zxfuaw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.387.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.387.0.tgz",
-      "integrity": "sha512-KlxWFLJMzboyQVipOxwPbEleDa0d8AHKxeW6x+NvbHXSVTY51HRtL68PIQEm7+1c4auQH0Hip2Et+obSsZIlhA==",
+      "version": "1.388.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.0.tgz",
+      "integrity": "sha512-TDqaHMPx5y5RxnJmccfTDA3TU6TIoWIbo3N/Ix3uwFsFNnefNa4Aoqrdk0bKmg7uckPnjTS60UwJnRz9zxfuaw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.387.0",
+    "@bigcommerce/checkout-sdk": "^1.388.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of stored cards for bluesnap direct

## Why?
Due to the release of https://github.com/bigcommerce/checkout-sdk-js/pull/2002

## Testing / Proof
units/manual

@bigcommerce/checkout
