### PR TITLE
chore(payment): PAYPAL-2618 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.388.0",
+        "@bigcommerce/checkout-sdk": "^1.388.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.388.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.0.tgz",
-      "integrity": "sha512-TDqaHMPx5y5RxnJmccfTDA3TU6TIoWIbo3N/Ix3uwFsFNnefNa4Aoqrdk0bKmg7uckPnjTS60UwJnRz9zxfuaw==",
+      "version": "1.388.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.1.tgz",
+      "integrity": "sha512-QEMI4BrqePE1iYOZRJpe9NSPQne5j32j+mtx2vsBJ/lDCioO8ev61PJN68z5UZQ3prVwjyblvuQHpa96zGhKyQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.388.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.0.tgz",
-      "integrity": "sha512-TDqaHMPx5y5RxnJmccfTDA3TU6TIoWIbo3N/Ix3uwFsFNnefNa4Aoqrdk0bKmg7uckPnjTS60UwJnRz9zxfuaw==",
+      "version": "1.388.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.1.tgz",
+      "integrity": "sha512-QEMI4BrqePE1iYOZRJpe9NSPQne5j32j+mtx2vsBJ/lDCioO8ev61PJN68z5UZQ3prVwjyblvuQHpa96zGhKyQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.388.0",
+    "@bigcommerce/checkout-sdk": "^1.388.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk js version.

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2013
https://github.com/bigcommerce/checkout-sdk-js/pull/2014
https://github.com/bigcommerce/checkout-sdk-js/pull/1999

## Why?
To keep checkout sdk js dependency up to date.

## Testing / Proof
All tests passed
