### PR TITLE
fix(checkout): PI-294 bump sdk for adyen v3 stored card fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.388.1",
+        "@bigcommerce/checkout-sdk": "^1.388.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.388.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.1.tgz",
-      "integrity": "sha512-QEMI4BrqePE1iYOZRJpe9NSPQne5j32j+mtx2vsBJ/lDCioO8ev61PJN68z5UZQ3prVwjyblvuQHpa96zGhKyQ==",
+      "version": "1.388.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.2.tgz",
+      "integrity": "sha512-aJ+5du3pynQIErgJhU/ddbcp24Kf0aLFHiHTLznVkeCzZUe1X5CqU4r0fmheR8zoQeZ9EjqCfAZ9bcTsExMRtw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.388.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.1.tgz",
-      "integrity": "sha512-QEMI4BrqePE1iYOZRJpe9NSPQne5j32j+mtx2vsBJ/lDCioO8ev61PJN68z5UZQ3prVwjyblvuQHpa96zGhKyQ==",
+      "version": "1.388.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.388.2.tgz",
+      "integrity": "sha512-aJ+5du3pynQIErgJhU/ddbcp24Kf0aLFHiHTLznVkeCzZUe1X5CqU4r0fmheR8zoQeZ9EjqCfAZ9bcTsExMRtw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.388.1",
+    "@bigcommerce/checkout-sdk": "^1.388.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/2016

## Why?
Due to the release of https://github.com/bigcommerce/checkout-sdk-js/pull/2016

## Testing / Proof
Manually

@bigcommerce/checkout
