### PR TITLE
feat(payment): PI-99 [Sezzle] - Text is overflowing and cropped for the Sezzle Payment gateway on mobile.

### DIFF
--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -44,6 +44,14 @@
     flex-shrink: 1;
 }
 
+@media (max-width: $screen-xsmall) {
+    div[data-test="payment-method-sezzle"] {
+        .paymentProviderHeader-name {
+            visibility: hidden;
+        }
+    }
+}
+
 .paymentMethod--creditCard,
 .paymentMethod--hosted,
 .paymentMethod--walletButton {


### PR DESCRIPTION
## What?
Sezzle payment text was overflowing from the payment modal on checkout page on mobile devices. Now when text can't be fully displayed it is hidden.

## Testing / Proof
Before changes:

https://github.com/bigcommerce/checkout-js/assets/130039975/339643b0-765a-4e26-bcfd-2f3cbf5c0a75

After changes:

https://github.com/bigcommerce/checkout-js/assets/130039975/a42e4761-6b3f-4d04-a62f-0a453b08b940


@bigcommerce/checkout
