### PR TITLE
fix: DATA-10928 Fire analytics selectedPaymentMethod event when payment methods are loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.390.0",
+        "@bigcommerce/checkout-sdk": "^1.391.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.390.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.390.0.tgz",
-      "integrity": "sha512-64pIcD6cWpGgmr/SV6voxkOvzR2bngl3plWm8cdOreG09U+Wq9OjgDhrYoKldQHPoiyb0+WGFrG+NGPCcdmp6w==",
+      "version": "1.391.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.391.0.tgz",
+      "integrity": "sha512-mFE1I/NHpWL6AU/aFatQzXiClarM0ImbIIDMy0Ew46eCem1u9p2Yegx9f6t2YoqCbLZN2qRP7w4stqCX/DKt4Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.390.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.390.0.tgz",
-      "integrity": "sha512-64pIcD6cWpGgmr/SV6voxkOvzR2bngl3plWm8cdOreG09U+Wq9OjgDhrYoKldQHPoiyb0+WGFrG+NGPCcdmp6w==",
+      "version": "1.391.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.391.0.tgz",
+      "integrity": "sha512-mFE1I/NHpWL6AU/aFatQzXiClarM0ImbIIDMy0Ew46eCem1u9p2Yegx9f6t2YoqCbLZN2qRP7w4stqCX/DKt4Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.390.0",
+    "@bigcommerce/checkout-sdk": "^1.391.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -117,13 +117,9 @@ class Payment extends Component<
             onReady = noop,
             onUnhandledError = noop,
             usableStoreCredit,
-            defaultMethod,
             analyticsTracker
         } = this.props;
 
-        const { selectedMethod } = this.state;
-
-        analyticsTracker.selectedPaymentMethod((selectedMethod || defaultMethod)?.config.displayName);
 
         if (usableStoreCredit) {
             this.handleStoreCreditChange(true);
@@ -131,6 +127,9 @@ class Payment extends Component<
 
         try {
             await loadPaymentMethods();
+
+            const selectedMethod = this.state.selectedMethod || this.props.defaultMethod;
+            analyticsTracker.selectedPaymentMethod(selectedMethod?.config.displayName);
         } catch (error) {
             onUnhandledError(error);
         }


### PR DESCRIPTION
## What? [DATA-10928](https://bigcommercecloud.atlassian.net/browse/DATA-10928)
- Fire analytics selectedPaymentMethod event when payment methods are loaded
- Bump checkout-sdk-js version

## Why?
Previously this event was triggered in the `componentDidMount` right away. However, at this point both `selectedMethod` and `defaultMethod` are `undefined`. This causes issue when the `analyticsTracker.selectedPaymentMethod` does not do anything on page loading. This can be fixed by moving this call after payment methods are actually loaded

## Testing / Proof
Manually on dev store

@bigcommerce/checkout


[DATA-10928]: https://bigcommercecloud.atlassian.net/browse/DATA-10928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ