### PR TITLE
chore(payment): bump sdk for PI-120 Autofilling of holderName to be configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.389.0",
+        "@bigcommerce/checkout-sdk": "^1.390.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.389.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.389.0.tgz",
-      "integrity": "sha512-TsAY1GvB9SZYJcQlYKi6ahIPlU1aqNBuGv55rpD7nuid/C0K8wSmQYsAH1Ua4mnnS+VzqDkCCR88ql6+fmOGqw==",
+      "version": "1.390.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.390.0.tgz",
+      "integrity": "sha512-64pIcD6cWpGgmr/SV6voxkOvzR2bngl3plWm8cdOreG09U+Wq9OjgDhrYoKldQHPoiyb0+WGFrG+NGPCcdmp6w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.389.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.389.0.tgz",
-      "integrity": "sha512-TsAY1GvB9SZYJcQlYKi6ahIPlU1aqNBuGv55rpD7nuid/C0K8wSmQYsAH1Ua4mnnS+VzqDkCCR88ql6+fmOGqw==",
+      "version": "1.390.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.390.0.tgz",
+      "integrity": "sha512-64pIcD6cWpGgmr/SV6voxkOvzR2bngl3plWm8cdOreG09U+Wq9OjgDhrYoKldQHPoiyb0+WGFrG+NGPCcdmp6w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.389.0",
+    "@bigcommerce/checkout-sdk": "^1.390.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of [bigcommerce/checkout-sdk#2008](https://github.com/bigcommerce/checkout-sdk-js/pull/2008)

## Why?
To release the above change

## Testing / Proof
See the testing section on the above PR

@bigcommerce/checkout
