### PR TITLE
feat(payment): PAYPAL-2645 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.390.0",
+        "@bigcommerce/checkout-sdk": "^1.392.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.390.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.390.0.tgz",
-      "integrity": "sha512-64pIcD6cWpGgmr/SV6voxkOvzR2bngl3plWm8cdOreG09U+Wq9OjgDhrYoKldQHPoiyb0+WGFrG+NGPCcdmp6w==",
+      "version": "1.392.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.392.0.tgz",
+      "integrity": "sha512-2vH0G0ZdrdNhhPULnbWoXLIBZOJIOV4AJkrPyH08gmg2gR5eIHeiNc6UWcPPr0DiUJoffCnge0TGE60Ikfe5aQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.390.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.390.0.tgz",
-      "integrity": "sha512-64pIcD6cWpGgmr/SV6voxkOvzR2bngl3plWm8cdOreG09U+Wq9OjgDhrYoKldQHPoiyb0+WGFrG+NGPCcdmp6w==",
+      "version": "1.392.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.392.0.tgz",
+      "integrity": "sha512-2vH0G0ZdrdNhhPULnbWoXLIBZOJIOV4AJkrPyH08gmg2gR5eIHeiNc6UWcPPr0DiUJoffCnge0TGE60Ikfe5aQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.390.0",
+    "@bigcommerce/checkout-sdk": "^1.392.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deliver checkout-sdk-js code 
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2022

## Testing / Proof


@bigcommerce/checkout
