### PR TITLE
chore(checkout): PAYPAL-2680 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.393.0",
+        "@bigcommerce/checkout-sdk": "^1.393.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.393.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.393.0.tgz",
-      "integrity": "sha512-Lh/IOUq/Em/ITgacZUGUr9UO6vXo+MvdJGYM3DKfiybc3Bz5EhD/YxyetQf4PlgTc05Xy06OjfFZrAEBxI97Ww==",
+      "version": "1.393.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.393.2.tgz",
+      "integrity": "sha512-IKNwpU4FZ027Z4Qf69zuzVZtk/kJkXy5nPTWw50VaaQQ8A1qT3qiDelmK03rzdqyDnpqR4ZL6sQHYoZ9Wlh1bA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.393.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.393.0.tgz",
-      "integrity": "sha512-Lh/IOUq/Em/ITgacZUGUr9UO6vXo+MvdJGYM3DKfiybc3Bz5EhD/YxyetQf4PlgTc05Xy06OjfFZrAEBxI97Ww==",
+      "version": "1.393.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.393.2.tgz",
+      "integrity": "sha512-IKNwpU4FZ027Z4Qf69zuzVZtk/kJkXy5nPTWw50VaaQQ8A1qT3qiDelmK03rzdqyDnpqR4ZL6sQHYoZ9Wlh1bA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.393.0",
+    "@bigcommerce/checkout-sdk": "^1.393.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
Bump up checkout-sdk to release recent changes:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2025](https://github.com/bigcommerce/checkout-sdk-js/pull/2025)

## Testing / Proof
manual testing and unit test

@bigcommerce/checkout
