### PR TITLE
fix(payment): PAYPAL-2502 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.394.0",
+        "@bigcommerce/checkout-sdk": "^1.394.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.394.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.394.0.tgz",
-      "integrity": "sha512-dkUA6dBg0RxNDw8c0uQ4z1oqZHrHwTTpAnOEcUupeMceoK9kcQOxiZcj+VPvA/eRt7qRt9q0owNRklhdexYQsA==",
+      "version": "1.394.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.394.1.tgz",
+      "integrity": "sha512-7bl+eQO4Wk4nJTWiOzwSTRGY5yRIrs6weUQD2XusuRt+1LSq6HzCbet2tOASzJ7UWk4U9iXVy25Y3mRkLJFYuQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.394.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.394.0.tgz",
-      "integrity": "sha512-dkUA6dBg0RxNDw8c0uQ4z1oqZHrHwTTpAnOEcUupeMceoK9kcQOxiZcj+VPvA/eRt7qRt9q0owNRklhdexYQsA==",
+      "version": "1.394.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.394.1.tgz",
+      "integrity": "sha512-7bl+eQO4Wk4nJTWiOzwSTRGY5yRIrs6weUQD2XusuRt+1LSq6HzCbet2tOASzJ7UWk4U9iXVy25Y3mRkLJFYuQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.394.0",
+    "@bigcommerce/checkout-sdk": "^1.394.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
checkout-sdk-js PR:https://github.com/bigcommerce/checkout-sdk-js/pull/2031

## Testing / Proof


@bigcommerce/checkout
