### PR TITLE
chore(checkout): CHECKOUT-7537 Bump checkout-sdk v1.395.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.394.1",
+        "@bigcommerce/checkout-sdk": "^1.395.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.394.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.394.1.tgz",
-      "integrity": "sha512-7bl+eQO4Wk4nJTWiOzwSTRGY5yRIrs6weUQD2XusuRt+1LSq6HzCbet2tOASzJ7UWk4U9iXVy25Y3mRkLJFYuQ==",
+      "version": "1.395.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.0.tgz",
+      "integrity": "sha512-4JrLZpduZEK7inILodQ2gW2IQrOfz0nOZ4wmg+R6Ku55Dz0O8/SPU4NwUeKse0Ovu/gBWDfUlJiJwr45wcpVyA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.394.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.394.1.tgz",
-      "integrity": "sha512-7bl+eQO4Wk4nJTWiOzwSTRGY5yRIrs6weUQD2XusuRt+1LSq6HzCbet2tOASzJ7UWk4U9iXVy25Y3mRkLJFYuQ==",
+      "version": "1.395.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.0.tgz",
+      "integrity": "sha512-4JrLZpduZEK7inILodQ2gW2IQrOfz0nOZ4wmg+R6Ku55Dz0O8/SPU4NwUeKse0Ovu/gBWDfUlJiJwr45wcpVyA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.394.1",
+    "@bigcommerce/checkout-sdk": "^1.395.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.395.0`.

## Why?
Release lastest SDK change(s):
- https://github.com/bigcommerce/checkout-sdk-js/pull/2028

## Testing / Proof
- CI checks.