### PR TITLE
chore(order): Bump checkout-sdk v1.395.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.395.0",
+        "@bigcommerce/checkout-sdk": "^1.395.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.395.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.0.tgz",
-      "integrity": "sha512-4JrLZpduZEK7inILodQ2gW2IQrOfz0nOZ4wmg+R6Ku55Dz0O8/SPU4NwUeKse0Ovu/gBWDfUlJiJwr45wcpVyA==",
+      "version": "1.395.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.2.tgz",
+      "integrity": "sha512-P0vdEwfzsib4XGIol28EEL4AWQn2UVOxO/+1sG9Qe80wpnvLN4zc+Nw9BQo8VEpAfCjYAzimtdEVjRFpzUM3zA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.395.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.0.tgz",
-      "integrity": "sha512-4JrLZpduZEK7inILodQ2gW2IQrOfz0nOZ4wmg+R6Ku55Dz0O8/SPU4NwUeKse0Ovu/gBWDfUlJiJwr45wcpVyA==",
+      "version": "1.395.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.2.tgz",
+      "integrity": "sha512-P0vdEwfzsib4XGIol28EEL4AWQn2UVOxO/+1sG9Qe80wpnvLN4zc+Nw9BQo8VEpAfCjYAzimtdEVjRFpzUM3zA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.395.0",
+    "@bigcommerce/checkout-sdk": "^1.395.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/hosted-credit-card-integration/e2e/__har__/CC-with-BlueSnap-in-Payment-Step_3392749462/recording.har
+++ b/packages/hosted-credit-card-integration/e2e/__har__/CC-with-BlueSnap-in-Payment-Step_3392749462/recording.har
@@ -1055,10 +1055,10 @@
           "queryString": [
             {
               "name": "include",
-              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options"
+              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.physicalItems.categories,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options,lineItems.digitalItems.categories"
             }
           ],
-          "url": "https://4241.project/api/storefront/orders/201?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options"
+          "url": "https://4241.project/api/storefront/orders/201?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.physicalItems.categories%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options%2ClineItems.digitalItems.categories"
         },
         "response": {
           "bodySize": 2880,
@@ -1176,10 +1176,10 @@
           "queryString": [
             {
               "name": "include",
-              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options"
+              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.physicalItems.categories,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options,lineItems.digitalItems.categories"
             }
           ],
-          "url": "https://4241.project/api/storefront/orders/201?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options"
+          "url": "https://4241.project/api/storefront/orders/201?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.physicalItems.categories%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options%2ClineItems.digitalItems.categories"
         },
         "response": {
           "bodySize": 2880,
@@ -1521,10 +1521,10 @@
           "queryString": [
             {
               "name": "include",
-              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options"
+              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.physicalItems.categories,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options,lineItems.digitalItems.categories"
             }
           ],
-          "url": "https://4241.project/api/storefront/orders/201?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options"
+          "url": "https://4241.project/api/storefront/orders/201?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.physicalItems.categories%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options%2ClineItems.digitalItems.categories"
         },
         "response": {
           "bodySize": 2880,

--- a/packages/hosted-credit-card-integration/e2e/__har__/sample-Bigpay-Test-Payment-Provider_3530407662/recording.har
+++ b/packages/hosted-credit-card-integration/e2e/__har__/sample-Bigpay-Test-Payment-Provider_3530407662/recording.har
@@ -1095,10 +1095,10 @@
           "queryString": [
             {
               "name": "include",
-              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options"
+              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.physicalItems.categories,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options,lineItems.digitalItems.categories"
             }
           ],
-          "url": "https://4241.project/api/storefront/orders/102?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options"
+          "url": "https://4241.project/api/storefront/orders/102?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.physicalItems.categories%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options%2ClineItems.digitalItems.categories"
         },
         "response": {
           "bodySize": 2894,
@@ -1349,10 +1349,10 @@
           "queryString": [
             {
               "name": "include",
-              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options"
+              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.physicalItems.categories,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options,lineItems.digitalItems.categories"
             }
           ],
-          "url": "https://4241.project/api/storefront/orders/102?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options"
+          "url": "https://4241.project/api/storefront/orders/102?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.physicalItems.categories%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options%2ClineItems.digitalItems.categories"
         },
         "response": {
           "bodySize": 3076,
@@ -1698,10 +1698,10 @@
           "queryString": [
             {
               "name": "include",
-              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options"
+              "value": "payments,lineItems.physicalItems.socialMedia,lineItems.physicalItems.options,lineItems.physicalItems.categories,lineItems.digitalItems.socialMedia,lineItems.digitalItems.options,lineItems.digitalItems.categories"
             }
           ],
-          "url": "https://4241.project/api/storefront/orders/102?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options"
+          "url": "https://4241.project/api/storefront/orders/102?include=payments%2ClineItems.physicalItems.socialMedia%2ClineItems.physicalItems.options%2ClineItems.physicalItems.categories%2ClineItems.digitalItems.socialMedia%2ClineItems.digitalItems.options%2ClineItems.digitalItems.categories"
         },
         "response": {
           "bodySize": 3076,

--- a/packages/test-framework/src/fixture/pageObject/playwright/PollyObject.ts
+++ b/packages/test-framework/src/fixture/pageObject/playwright/PollyObject.ts
@@ -77,6 +77,10 @@ export class PollyObject {
                 Object.entries(req.headers).filter(([key, _]) => !includes(ignoredHeaders, key)),
             );
 
+            req.url = req.url
+                .replace('%2ClineItems.physicalItems.categories', '')
+                .replace('%2ClineItems.digitalItems.categories', '');
+
             if (req.body && req.body.length > 0) {
                 req.body = JSON.stringify(this.sortPayload(req.jsonBody()));
             }


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.395.1`.

## Why?
Release lastest SDK change(s):
- https://github.com/bigcommerce/checkout-sdk-js/pull/2032

## Testing / Proof
- CI checks.

@bigcommerce/checkout
