### PR TITLE
fix(payment): PAYPAL-2595 PayPal button shows on store credit

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -207,6 +207,7 @@ class Payment extends Component<
                             }
                             shouldHidePaymentSubmitButton={
                                 (uniqueSelectedMethodId &&
+                                    rest.isPaymentDataRequired() &&
                                     shouldHidePaymentSubmitButton[uniqueSelectedMethodId]) ||
                                 undefined
                             }

--- a/packages/paypal-commerce-integration/src/PayPalCommerceAPMsPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceAPMsPaymentMethod.test.tsx
@@ -1,5 +1,6 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom'
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
@@ -29,5 +30,23 @@ describe('PayPalCommerceAPMsPaymentMethod', () => {
         const { container } = render(<PayPalCommerceAPMsPaymentMethod {...props} />);
 
         expect(container).toMatchSnapshot();
+    });
+
+    it('renders nothing if Payment Data is not Required', () => {
+        const mockChild = <div>test child</div>;
+        const localProps = {
+            ...props,
+            checkoutState: {
+                ...checkoutState,
+                data: {
+                    ...checkoutState.data,
+                    isPaymentDataRequired: jest.fn().mockReturnValue(false)
+                }
+            },
+            children: mockChild
+        }
+        const { container } = render(<PayPalCommerceAPMsPaymentMethod {...localProps} />);
+
+        expect(container).toBeEmptyDOMElement();
     });
 });

--- a/packages/paypal-commerce-integration/src/PayPalCommerceAPMsPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceAPMsPaymentMethod.tsx
@@ -11,6 +11,12 @@ import PayPalCommercePaymentMethodComponent from './components/PayPalCommercePay
 
 const PayPalCommerceAPMsPaymentMethod: FunctionComponent<PaymentMethodProps> = props => {
     const { method } = props;
+    const isPaymentDataRequired = props.checkoutState.data.isPaymentDataRequired();
+
+    if (!isPaymentDataRequired) {
+        return null;
+    }
+
 
     const widgetContainerId = getUniquePaymentMethodId(method.id, method.gateway);
     const extraOptions = {

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCreditPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCreditPaymentMethod.test.tsx
@@ -1,5 +1,6 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom'
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
@@ -26,5 +27,23 @@ describe('PayPalCommerceCreditPaymentMethod', () => {
         const { container } = render(<PayPalCommerceCreditPaymentMethod {...props} />);
 
         expect(container).toMatchSnapshot();
+    });
+
+    it('renders nothing if Payment Data is not Required', () => {
+        const mockChild = <div>test child</div>;
+        const localProps = {
+            ...props,
+            checkoutState: {
+                ...checkoutState,
+                data: {
+                    ...checkoutState.data,
+                    isPaymentDataRequired: jest.fn().mockReturnValue(false)
+                }
+            },
+            children: mockChild
+        }
+        const { container } = render(<PayPalCommerceCreditPaymentMethod {...localProps} />);
+
+        expect(container).toBeEmptyDOMElement();
     });
 });

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCreditPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCreditPaymentMethod.tsx
@@ -9,6 +9,12 @@ import {
 import PayPalCommercePaymentMethodComponent from './components/PayPalCommercePaymentMethodComponent';
 
 const PayPalCommerceCreditPaymentMethod: FunctionComponent<PaymentMethodProps> = props => {
+    const isPaymentDataRequired = props.checkoutState.data.isPaymentDataRequired();
+
+    if (!isPaymentDataRequired) {
+        return null;
+    }
+
     return <PayPalCommercePaymentMethodComponent
         providerOptionsKey="paypalcommercecredit"
         {...props}

--- a/packages/paypal-commerce-integration/src/PayPalCommercePaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommercePaymentMethod.test.tsx
@@ -1,5 +1,6 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom'
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
@@ -26,5 +27,23 @@ describe('PayPalCommercePaymentMethod', () => {
         const { container } = render(<PayPalCommercePaymentMethod {...props} />);
 
         expect(container).toMatchSnapshot();
+    });
+
+    it('renders nothing if Payment Data is not Required', () => {
+        const mockChild = <div>test child</div>;
+        const localProps = {
+            ...props,
+            checkoutState: {
+                ...checkoutState,
+                data: {
+                    ...checkoutState.data,
+                    isPaymentDataRequired: jest.fn().mockReturnValue(false)
+                }
+            },
+            children: mockChild
+        }
+        const { container } = render(<PayPalCommercePaymentMethod {...localProps} />);
+
+        expect(container).toBeEmptyDOMElement();
     });
 });

--- a/packages/paypal-commerce-integration/src/PayPalCommercePaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommercePaymentMethod.tsx
@@ -9,6 +9,12 @@ import {
 import PayPalCommercePaymentMethodComponent from './components/PayPalCommercePaymentMethodComponent';
 
 const PayPalCommercePaymentMethod: FunctionComponent<PaymentMethodProps> = props => {
+    const isPaymentDataRequired = props.checkoutState.data.isPaymentDataRequired();
+
+    if (!isPaymentDataRequired) {
+        return null;
+    }
+
     return <PayPalCommercePaymentMethodComponent
         providerOptionsKey="paypalcommerce"
         {...props}

--- a/packages/paypal-commerce-integration/src/PayPalCommerceVenmoPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceVenmoPaymentMethod.test.tsx
@@ -1,5 +1,6 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom'
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
@@ -25,5 +26,23 @@ describe('PayPalCommerceVenmoPaymentMethod', () => {
         const { container } = render(<PayPalCommerceVenmoPaymentMethod {...props} />);
 
         expect(container).toMatchSnapshot();
+    });
+
+    it('renders nothing if Payment Data is not Required', () => {
+        const mockChild = <div>test child</div>;
+        const localProps = {
+            ...props,
+            checkoutState: {
+                ...checkoutState,
+                data: {
+                    ...checkoutState.data,
+                    isPaymentDataRequired: jest.fn().mockReturnValue(false)
+                }
+            },
+            children: mockChild
+        }
+        const { container } = render(<PayPalCommerceVenmoPaymentMethod {...localProps} />);
+
+        expect(container).toBeEmptyDOMElement();
     });
 });

--- a/packages/paypal-commerce-integration/src/PayPalCommerceVenmoPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceVenmoPaymentMethod.tsx
@@ -9,6 +9,12 @@ import {
 import PayPalCommercePaymentMethodComponent from './components/PayPalCommercePaymentMethodComponent';
 
 const PayPalCommerceVenmoPaymentMethod: FunctionComponent<PaymentMethodProps> = props => {
+    const isPaymentDataRequired = props.checkoutState.data.isPaymentDataRequired();
+
+    if (!isPaymentDataRequired) {
+        return null;
+    }
+
     return <PayPalCommercePaymentMethodComponent
         providerOptionsKey="paypalcommercevenmo"
         {...props}

--- a/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
+++ b/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
@@ -32,18 +32,6 @@ describe('PayPalCommercePaymentMethodComponent', () => {
         eventEmitter = new EventEmitter();
     });
 
-    it('does not do anything if payment data is not required', () => {
-        const initializePayment = jest
-            .spyOn(checkoutService, 'initializePayment')
-            .mockResolvedValue(checkoutState);
-
-        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
-
-        render(<PayPalCommercePaymentMethodComponent {...props} />);
-
-        expect(initializePayment).not.toHaveBeenCalled();
-    });
-
     it('initializes PayPalCommerce with required props', () => {
         const initializePayment = jest
             .spyOn(checkoutService, 'initializePayment')

--- a/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.tsx
+++ b/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.tsx
@@ -20,7 +20,6 @@ interface PayPalCommercePaymentMethodComponentProps {
 
 const PayPalCommercePaymentMethodComponent: FunctionComponent<PaymentMethodProps & PayPalCommercePaymentMethodComponentProps> = ({
     method,
-    checkoutState,
     checkoutService,
     paymentForm,
     onUnhandledError,
@@ -28,10 +27,6 @@ const PayPalCommercePaymentMethodComponent: FunctionComponent<PaymentMethodProps
     providerOptionsData,
     children,
 }) => {
-    if (!checkoutState.data.isPaymentDataRequired()) {
-        return null;
-    }
-
     const initializePayment = async () => {
         try {
             await checkoutService.initializePayment({


### PR DESCRIPTION
## What?
Fixed the issue with PayPal button shows up when the customer tries to buy free product

## Why?
The issue was about PayPalCommercePaymentMethodComponent re-rendering when user clicks on the Store Credit checkbox, so I added a render logic in a wrapper of this component.

## Testing / Proof
<img width="853" alt="Screenshot 2023-06-29 at 12 28 31" src="https://github.com/bigcommerce/checkout-js/assets/130665807/2018f46c-98fe-4112-acd9-1ddff21e0b4d">
<img width="850" alt="Screenshot 2023-06-29 at 12 28 22" src="https://github.com/bigcommerce/checkout-js/assets/130665807/417372fb-7f59-49fc-a843-a260c03775a5">
