### PR TITLE
chore(checkout): PAYPAL-2502 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.395.0",
+        "@bigcommerce/checkout-sdk": "^1.395.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.395.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.0.tgz",
-      "integrity": "sha512-4JrLZpduZEK7inILodQ2gW2IQrOfz0nOZ4wmg+R6Ku55Dz0O8/SPU4NwUeKse0Ovu/gBWDfUlJiJwr45wcpVyA==",
+      "version": "1.395.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.4.tgz",
+      "integrity": "sha512-DeVp2q/K+Z3ip+5SV810rGh2aHp/jfV7zPu0MynBRvChDsrKCqo2Vj82if6AwUiJ5ZvANFHoQSaEv7v39RIqYw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.395.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.0.tgz",
-      "integrity": "sha512-4JrLZpduZEK7inILodQ2gW2IQrOfz0nOZ4wmg+R6Ku55Dz0O8/SPU4NwUeKse0Ovu/gBWDfUlJiJwr45wcpVyA==",
+      "version": "1.395.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.4.tgz",
+      "integrity": "sha512-DeVp2q/K+Z3ip+5SV810rGh2aHp/jfV7zPu0MynBRvChDsrKCqo2Vj82if6AwUiJ5ZvANFHoQSaEv7v39RIqYw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.395.0",
+    "@bigcommerce/checkout-sdk": "^1.395.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
to release changes:
[fix(payments): PAYPAL-2634 fixed issue when teardown is called twice](https://github.com/bigcommerce/checkout-sdk-js/pull/2036)

## Testing / Proof
Manually tested and unit test

@bigcommerce/checkout
