### PR TITLE
chore(order): DATA-11056 Bump checkout-sdk v1.396.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.395.4",
+        "@bigcommerce/checkout-sdk": "^1.396.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.395.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.4.tgz",
-      "integrity": "sha512-DeVp2q/K+Z3ip+5SV810rGh2aHp/jfV7zPu0MynBRvChDsrKCqo2Vj82if6AwUiJ5ZvANFHoQSaEv7v39RIqYw==",
+      "version": "1.396.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.396.1.tgz",
+      "integrity": "sha512-Y9JwR3zWr2Bg+PhbnVZf7VPiR2039VVfe34va8Igi3Baw7+cbqBZrsuKKHqkaVMG4u3Q1HaekipouGYe1hdgsA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.395.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.395.4.tgz",
-      "integrity": "sha512-DeVp2q/K+Z3ip+5SV810rGh2aHp/jfV7zPu0MynBRvChDsrKCqo2Vj82if6AwUiJ5ZvANFHoQSaEv7v39RIqYw==",
+      "version": "1.396.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.396.1.tgz",
+      "integrity": "sha512-Y9JwR3zWr2Bg+PhbnVZf7VPiR2039VVfe34va8Igi3Baw7+cbqBZrsuKKHqkaVMG4u3Q1HaekipouGYe1hdgsA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.395.4",
+    "@bigcommerce/checkout-sdk": "^1.396.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/test-framework/src/fixture/pageObject/playwright/PollyObject.ts
+++ b/packages/test-framework/src/fixture/pageObject/playwright/PollyObject.ts
@@ -77,6 +77,10 @@ export class PollyObject {
                 Object.entries(req.headers).filter(([key, _]) => !includes(ignoredHeaders, key)),
             );
 
+            req.url = req.url
+                .replace('%2ClineItems.physicalItems.categories', '')
+                .replace('%2ClineItems.digitalItems.categories', '');
+
             if (req.body && req.body.length > 0) {
                 req.body = JSON.stringify(this.sortPayload(req.jsonBody()));
             }

--- a/packages/test-utils/src/checkout.mock.ts
+++ b/packages/test-utils/src/checkout.mock.ts
@@ -38,6 +38,7 @@ export function getCheckout(): Checkout {
         updatedTime: '2018-03-07T03:44:51+00:00',
         promotions: [],
         channelId: 123456,
+        fees: [],
     };
 }
 


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.396.1`.

## Why?
Release latest SDK change(s):
- https://github.com/bigcommerce/checkout-sdk-js/pull/2042

## Testing / Proof
- CI checks.

@bigcommerce/checkout
