### PR TITLE
chore(payment): PAYPAL-2690 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.397.0",
+        "@bigcommerce/checkout-sdk": "^1.398.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.397.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.397.0.tgz",
-      "integrity": "sha512-QZTGMGnkFMo9/HEnbwLkiZCgqKZp862Srmw1G36NtWj2RgB7Udt7QQXCCedDyZB6b8YWtoYwNEu1QkAfhkTO2Q==",
+      "version": "1.398.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.398.0.tgz",
+      "integrity": "sha512-NmR7KizK6TAEZ6R9Plv4W0w42TsijJ9x621Z+hEqCxCwPGCrsTOqgyuyuTQvnjJ/+68vHc/I7g4WR5xD3uHkvQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35338,9 +35338,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.397.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.397.0.tgz",
-      "integrity": "sha512-QZTGMGnkFMo9/HEnbwLkiZCgqKZp862Srmw1G36NtWj2RgB7Udt7QQXCCedDyZB6b8YWtoYwNEu1QkAfhkTO2Q==",
+      "version": "1.398.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.398.0.tgz",
+      "integrity": "sha512-NmR7KizK6TAEZ6R9Plv4W0w42TsijJ9x621Z+hEqCxCwPGCrsTOqgyuyuTQvnjJ/+68vHc/I7g4WR5xD3uHkvQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.397.0",
+    "@bigcommerce/checkout-sdk": "^1.398.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version from 1.397.0 to 1.398.0.

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2044

## Why?
To keep checkout-sdk dependency up to date

## Testing / Proof
Unit tests
Manual tests
