### PR TITLE
feat(checkout): PI-287 hide cvv validation field for specific providers

### DIFF
--- a/packages/core/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.spec.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.spec.ts
@@ -8,6 +8,7 @@ import { getPaymentMethod } from '../payment-methods.mock';
 import { getCardInstrument } from './instruments.mock';
 import isInstrumentCardCodeRequired, {
     IsInstrumentCardCodeRequiredState,
+    PROVIDERS_WITHOUT_CARD_CODE,
 } from './isInstrumentCardCodeRequired';
 
 describe('isInstrumentCardCodeRequired()', () => {
@@ -30,6 +31,19 @@ describe('isInstrumentCardCodeRequired()', () => {
                 },
             }),
         };
+    });
+
+    it("returns false if payment provider doesn't require CVV", () => {
+        expect(
+            isInstrumentCardCodeRequired(
+                merge({}, state, {
+                    instrument: {
+                        ...state.instrument,
+                        provider: PROVIDERS_WITHOUT_CARD_CODE[0],
+                    },
+                }),
+            ),
+        ).toBe(false);
     });
 
     it('returns true if there is digital item in cart', () => {

--- a/packages/core/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentCardCodeRequired.ts
@@ -2,6 +2,8 @@ import { LineItemMap, PaymentInstrument, PaymentMethod } from '@bigcommerce/chec
 
 import { UntrustedShippingCardVerificationType } from './CardInstrumentFieldset';
 
+export const PROVIDERS_WITHOUT_CARD_CODE = ['bluesnapdirect'];
+
 export interface IsInstrumentCardCodeRequiredState {
     instrument: PaymentInstrument;
     lineItems: LineItemMap;
@@ -13,6 +15,10 @@ export default function isInstrumentCardCodeRequired({
     lineItems,
     paymentMethod,
 }: IsInstrumentCardCodeRequiredState): boolean {
+    if (PROVIDERS_WITHOUT_CARD_CODE.includes(instrument.provider)) {
+        return false;
+    }
+
     // If there's a digital item in the cart, always show CVV field
     if (lineItems.digitalItems.length > 0 || lineItems.giftCertificates.length > 0) {
         return true;

--- a/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/index.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/index.ts
@@ -1,4 +1,5 @@
 export {
     default as isInstrumentCardCodeRequired,
     IsInstrumentCardCodeRequiredState,
+    PROVIDERS_WITHOUT_CARD_CODE,
 } from './isInstrumentCardCodeRequired';

--- a/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.spec.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.spec.ts
@@ -9,7 +9,11 @@ import {
     getPaymentMethod,
 } from '@bigcommerce/checkout/test-utils';
 
-import { isInstrumentCardCodeRequired, IsInstrumentCardCodeRequiredState } from '.';
+import {
+    isInstrumentCardCodeRequired,
+    IsInstrumentCardCodeRequiredState,
+    PROVIDERS_WITHOUT_CARD_CODE,
+} from '.';
 
 describe('isInstrumentCardCodeRequired()', () => {
     let state: IsInstrumentCardCodeRequiredState;
@@ -31,6 +35,19 @@ describe('isInstrumentCardCodeRequired()', () => {
                 },
             }),
         };
+    });
+
+    it("returns false if payment provider doesn't require CVV", () => {
+        expect(
+            isInstrumentCardCodeRequired(
+                merge({}, state, {
+                    instrument: {
+                        ...state.instrument,
+                        provider: PROVIDERS_WITHOUT_CARD_CODE[0],
+                    },
+                }),
+            ),
+        ).toBe(false);
     });
 
     it('returns true if there is digital item in cart', () => {

--- a/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.ts
@@ -1,5 +1,7 @@
 import { LineItemMap, PaymentInstrument, PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+export const PROVIDERS_WITHOUT_CARD_CODE = ['bluesnapdirect'];
+
 export interface IsInstrumentCardCodeRequiredState {
     instrument: PaymentInstrument;
     lineItems: LineItemMap;
@@ -11,6 +13,10 @@ export default function isInstrumentCardCodeRequired({
     lineItems,
     paymentMethod,
 }: IsInstrumentCardCodeRequiredState): boolean {
+    if (PROVIDERS_WITHOUT_CARD_CODE.includes(instrument.provider)) {
+        return false;
+    }
+
     // If there's a digital item in the cart, always show CVV field
     if (lineItems.digitalItems.length > 0 || lineItems.giftCertificates.length > 0) {
         return true;


### PR DESCRIPTION
## What?
Do not show cvv validation field for specific providers

## Why?
Some providers don't require cvv validation for stored cards(like Bluesnap), so that is why I've made these changes

## Testing / Proof
Before:
Previously checkout ask to validate CVV code for digital items
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/4e263a0b-f2d6-4f94-a43f-3b168bda66c8)
After:
After the changes we can skip CVV for some providers
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/36041996-c018-4cac-a169-c7f313e3ab3b)



@bigcommerce/checkout
