### PR TITLE
chore(payment): PAYPAL-2476 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.398.2",
+        "@bigcommerce/checkout-sdk": "^1.399.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.398.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.398.2.tgz",
-      "integrity": "sha512-5hZdKR1g0tCAfrb0Ltlr3CLBiKJ4+OFJXjHby5OG9HMFR/fI/KdwyB+73cG6aYaZ4FHwMunQfJFgyI/Y3v90mA==",
+      "version": "1.399.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.399.0.tgz",
+      "integrity": "sha512-TG/I5wMpGlXf1Fl3esd8dFKTJjOigYuzUgspUN8QEQoUUTU5NVKltfHD2sSivrrGmwvor6qWR8h5H5bGHrfJwA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35356,9 +35356,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.398.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.398.2.tgz",
-      "integrity": "sha512-5hZdKR1g0tCAfrb0Ltlr3CLBiKJ4+OFJXjHby5OG9HMFR/fI/KdwyB+73cG6aYaZ4FHwMunQfJFgyI/Y3v90mA==",
+      "version": "1.399.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.399.0.tgz",
+      "integrity": "sha512-TG/I5wMpGlXf1Fl3esd8dFKTJjOigYuzUgspUN8QEQoUUTU5NVKltfHD2sSivrrGmwvor6qWR8h5H5bGHrfJwA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.398.2",
+    "@bigcommerce/checkout-sdk": "^1.399.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.399.0
The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2033

## Testing / Proof
All tests have been passed