### PR TITLE
chore(checkout): checkout-7538 Bump checkout-sdk v1.401.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.400.0",
+        "@bigcommerce/checkout-sdk": "^1.401.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1745,9 +1745,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
-      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
+      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -1756,11 +1756,11 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.400.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.400.0.tgz",
-      "integrity": "sha512-a8WjitNT3K4IQPDJdhUSceB4Z4qbXLq/ZasWjnyMKCu3Tu8gCO4OmxJgKrDzS+P4QOIkWvN1+G+Voo7PAAaKEg==",
+      "version": "1.401.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.401.0.tgz",
+      "integrity": "sha512-mmokPsStjJVPbinQX9yz700U/csc16yfc/QvG5VFf7603tP4PqaNsZLbq1nKG7uk+e6U7U+AxboMoavFViKhIg==",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.24.2",
+        "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -9927,11 +9927,11 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
-      "integrity": "sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
+      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
       "dependencies": {
-        "@jest/transform": "^29.5.0",
+        "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -9947,32 +9947,32 @@
       }
     },
     "node_modules/babel-jest/node_modules/@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/babel-jest/node_modules/@jest/transform": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.5.0.tgz",
-      "integrity": "sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.5.0",
-        "@jridgewell/trace-mapping": "^0.3.15",
+        "@jest/types": "^29.6.1",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.5.0",
+        "jest-haste-map": "^29.6.1",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.5.0",
+        "jest-util": "^29.6.1",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -9983,11 +9983,11 @@
       }
     },
     "node_modules/babel-jest/node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -9999,9 +9999,9 @@
       }
     },
     "node_modules/babel-jest/node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/babel-jest/node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -10084,19 +10084,19 @@
       }
     },
     "node_modules/babel-jest/node_modules/jest-haste-map": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.5.0.tgz",
-      "integrity": "sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
+      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.1",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.5.0",
-        "jest-worker": "^29.5.0",
+        "jest-util": "^29.6.1",
+        "jest-worker": "^29.6.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -10116,11 +10116,11 @@
       }
     },
     "node_modules/babel-jest/node_modules/jest-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
+      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -10132,12 +10132,12 @@
       }
     },
     "node_modules/babel-jest/node_modules/jest-worker": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
-      "integrity": "sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
+      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.5.0",
+        "jest-util": "^29.6.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -35345,9 +35345,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
-      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
+      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -35356,11 +35356,11 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.400.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.400.0.tgz",
-      "integrity": "sha512-a8WjitNT3K4IQPDJdhUSceB4Z4qbXLq/ZasWjnyMKCu3Tu8gCO4OmxJgKrDzS+P4QOIkWvN1+G+Voo7PAAaKEg==",
+      "version": "1.401.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.401.0.tgz",
+      "integrity": "sha512-mmokPsStjJVPbinQX9yz700U/csc16yfc/QvG5VFf7603tP4PqaNsZLbq1nKG7uk+e6U7U+AxboMoavFViKhIg==",
       "requires": {
-        "@bigcommerce/bigpay-client": "^5.24.2",
+        "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -41716,11 +41716,11 @@
       }
     },
     "babel-jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
-      "integrity": "sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
+      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
       "requires": {
-        "@jest/transform": "^29.5.0",
+        "@jest/transform": "^29.6.1",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -41730,29 +41730,29 @@
       },
       "dependencies": {
         "@jest/schemas": {
-          "version": "29.4.3",
-          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-          "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+          "version": "29.6.0",
+          "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+          "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
           "requires": {
-            "@sinclair/typebox": "^0.25.16"
+            "@sinclair/typebox": "^0.27.8"
           }
         },
         "@jest/transform": {
-          "version": "29.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.5.0.tgz",
-          "integrity": "sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==",
+          "version": "29.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
+          "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
           "requires": {
             "@babel/core": "^7.11.6",
-            "@jest/types": "^29.5.0",
-            "@jridgewell/trace-mapping": "^0.3.15",
+            "@jest/types": "^29.6.1",
+            "@jridgewell/trace-mapping": "^0.3.18",
             "babel-plugin-istanbul": "^6.1.1",
             "chalk": "^4.0.0",
             "convert-source-map": "^2.0.0",
             "fast-json-stable-stringify": "^2.1.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.5.0",
+            "jest-haste-map": "^29.6.1",
             "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.5.0",
+            "jest-util": "^29.6.1",
             "micromatch": "^4.0.4",
             "pirates": "^4.0.4",
             "slash": "^3.0.0",
@@ -41760,11 +41760,11 @@
           }
         },
         "@jest/types": {
-          "version": "29.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-          "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+          "version": "29.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+          "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.0",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
@@ -41773,9 +41773,9 @@
           }
         },
         "@sinclair/typebox": {
-          "version": "0.25.24",
-          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-          "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+          "version": "0.27.8",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+          "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
         },
         "@types/yargs": {
           "version": "17.0.24",
@@ -41831,11 +41831,11 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-haste-map": {
-          "version": "29.5.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.5.0.tgz",
-          "integrity": "sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==",
+          "version": "29.6.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
+          "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
           "requires": {
-            "@jest/types": "^29.5.0",
+            "@jest/types": "^29.6.1",
             "@types/graceful-fs": "^4.1.3",
             "@types/node": "*",
             "anymatch": "^3.0.3",
@@ -41843,8 +41843,8 @@
             "fsevents": "^2.3.2",
             "graceful-fs": "^4.2.9",
             "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.5.0",
-            "jest-worker": "^29.5.0",
+            "jest-util": "^29.6.1",
+            "jest-worker": "^29.6.1",
             "micromatch": "^4.0.4",
             "walker": "^1.0.8"
           }
@@ -41855,11 +41855,11 @@
           "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg=="
         },
         "jest-util": {
-          "version": "29.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-          "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+          "version": "29.6.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
+          "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
           "requires": {
-            "@jest/types": "^29.5.0",
+            "@jest/types": "^29.6.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
@@ -41868,12 +41868,12 @@
           }
         },
         "jest-worker": {
-          "version": "29.5.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
-          "integrity": "sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==",
+          "version": "29.6.1",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
+          "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.5.0",
+            "jest-util": "^29.6.1",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.400.0",
+    "@bigcommerce/checkout-sdk": "^1.401.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.401.0`.

## Why?
Release lastest SDK change(s):
- https://github.com/bigcommerce/checkout-sdk-js/pull/2050
- https://github.com/bigcommerce/checkout-sdk-js/pull/2061

## Testing / Proof
- CI checks.