### PR TITLE
chore(payment): PAYPAL-2719 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.401.0",
+        "@bigcommerce/checkout-sdk": "^1.402.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.401.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.401.0.tgz",
-      "integrity": "sha512-mmokPsStjJVPbinQX9yz700U/csc16yfc/QvG5VFf7603tP4PqaNsZLbq1nKG7uk+e6U7U+AxboMoavFViKhIg==",
+      "version": "1.402.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.402.1.tgz",
+      "integrity": "sha512-/BZWtYhUr3UfypDSuPSpO3lAwlGRXUWjrMI45ap54ilYp97enIBaaTVCjZSdRZcK4Xssawejx6k0Tq/K76znuA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35356,9 +35356,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.401.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.401.0.tgz",
-      "integrity": "sha512-mmokPsStjJVPbinQX9yz700U/csc16yfc/QvG5VFf7603tP4PqaNsZLbq1nKG7uk+e6U7U+AxboMoavFViKhIg==",
+      "version": "1.402.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.402.1.tgz",
+      "integrity": "sha512-/BZWtYhUr3UfypDSuPSpO3lAwlGRXUWjrMI45ap54ilYp97enIBaaTVCjZSdRZcK4Xssawejx6k0Tq/K76znuA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.401.0",
+    "@bigcommerce/checkout-sdk": "^1.402.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump **checkout-sdk** version

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2052
https://github.com/bigcommerce/checkout-sdk-js/pull/2058

## Why?

To keep **checkout-sdk** dependency up to date

## Testing / Proof

All test passed

@bigcommerce/checkout
