### PR TITLE
feat(payment): PAYPAL-2752 render wallet buttons depends on coupon

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
@@ -22,6 +22,7 @@ describe('CheckoutButtonContainer', () => {
         localeContext = createLocaleContext(getStoreConfig());
 
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getGuestCustomer());
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(true);
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
             merge(getStoreConfig(), {
                 checkoutSettings: {
@@ -36,6 +37,24 @@ describe('CheckoutButtonContainer', () => {
     });
 
     it('displays wallet buttons for guest checkout', () => {
+        const component = render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <CheckoutButtonContainer
+                        checkEmbeddedSupport={jest.fn()}
+                        isPaymentStepActive={false}
+                        onUnhandledError={jest.fn()}
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it('not displays wallet buttons for guest checkout if isPaymentDataRequired = false', () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
+
         const component = render(
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -126,6 +126,7 @@ function mapToCheckoutButtonContainerProps({
         data: {
             getConfig,
             getCustomer,
+            isPaymentDataRequired,
         },
         statuses: {
             isInitializedCustomer,
@@ -137,6 +138,10 @@ function mapToCheckoutButtonContainerProps({
     const config = getConfig();
     const availableMethodIds = getSupportedMethodIds(config?.checkoutSettings.remoteCheckoutProviders ?? []);
     const customer = getCustomer();
+
+    if (!isPaymentDataRequired()) {
+        return null;
+    }
 
     if (!config || availableMethodIds.length === 0 || !customer?.isGuest) {
         return null;

--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -119,4 +119,6 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
 </div>
 `;
 
+exports[`CheckoutButtonContainer not displays wallet buttons for guest checkout if isPaymentDataRequired = false 1`] = `null`;
+
 exports[`CheckoutButtonContainer removes Paypal commerce wallet buttons when payment step is active 1`] = `null`;


### PR DESCRIPTION
## What?
As a shopper who just applied 100% discount coupon during the checkout, we don’t want to see PayPal wallet buttons anymore without having to reload the page manually, so that I can complete the purchase without accidentally clicking on the button that doesn’t work anymore.

## Testing / Proof

https://github.com/bigcommerce/checkout-js/assets/130665807/86c8c1f9-0746-4a4f-a099-2cfd362e6474


@bigcommerce/checkout
