### PR TITLE
chore(payment): PAYPAL-2725 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.403.0",
+        "@bigcommerce/checkout-sdk": "^1.405.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.403.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.403.0.tgz",
-      "integrity": "sha512-O9NsxCIAgbiS4P6A02fdM0JnyqseJ+JIB+0Lna+IpbyIB+19eIrTE4RqCnGPg+p1susWGzxxpN5kHwryH9UHQA==",
+      "version": "1.405.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.0.tgz",
+      "integrity": "sha512-hb/Fr2GUMDdJJzsZ/Y9mkGssC/+NIRP8QTmxGKGfvqG81ACgUb+xetqkx9mHzhFkZq8KUPoKWa8rkWgzR4oi8g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35356,9 +35356,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.403.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.403.0.tgz",
-      "integrity": "sha512-O9NsxCIAgbiS4P6A02fdM0JnyqseJ+JIB+0Lna+IpbyIB+19eIrTE4RqCnGPg+p1susWGzxxpN5kHwryH9UHQA==",
+      "version": "1.405.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.0.tgz",
+      "integrity": "sha512-hb/Fr2GUMDdJJzsZ/Y9mkGssC/+NIRP8QTmxGKGfvqG81ACgUb+xetqkx9mHzhFkZq8KUPoKWa8rkWgzR4oi8g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.403.0",
+    "@bigcommerce/checkout-sdk": "^1.405.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version.

## Why?
To keep checkout-sdk dependency up to date.

The release contains: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2065
https://github.com/bigcommerce/checkout-sdk-js/pull/2063
https://github.com/bigcommerce/checkout-sdk-js/pull/2056

## Testing / Proof
Unit tests
CI tests
Manual tests

@bigcommerce/checkout
