### PR TITLE
chore(checkout): CHECKOUT-7624 Bump checkout-sdk v1.405.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.405.0",
+        "@bigcommerce/checkout-sdk": "^1.405.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.405.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.0.tgz",
-      "integrity": "sha512-hb/Fr2GUMDdJJzsZ/Y9mkGssC/+NIRP8QTmxGKGfvqG81ACgUb+xetqkx9mHzhFkZq8KUPoKWa8rkWgzR4oi8g==",
+      "version": "1.405.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.2.tgz",
+      "integrity": "sha512-cDbeTf6ya1zAqo54wwOFc2Mb/YWMRUnQavIERxbPRtiYn4EIv7wnkqdD8LVTOYyVIGjdGmteodCZ/6K+bocNFA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35356,9 +35356,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.405.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.0.tgz",
-      "integrity": "sha512-hb/Fr2GUMDdJJzsZ/Y9mkGssC/+NIRP8QTmxGKGfvqG81ACgUb+xetqkx9mHzhFkZq8KUPoKWa8rkWgzR4oi8g==",
+      "version": "1.405.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.2.tgz",
+      "integrity": "sha512-cDbeTf6ya1zAqo54wwOFc2Mb/YWMRUnQavIERxbPRtiYn4EIv7wnkqdD8LVTOYyVIGjdGmteodCZ/6K+bocNFA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.405.0",
+    "@bigcommerce/checkout-sdk": "^1.405.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.405.2`.

## Why?
Release lastest SDK change(s):
- https://github.com/bigcommerce/checkout-sdk-js/pull/2069

## Testing / Proof
- CI checks.