### PR TITLE
chore(payment): PAYPAL-2726 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.405.2",
+        "@bigcommerce/checkout-sdk": "^1.406.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1745,9 +1745,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
-      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
+      "version": "5.25.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.25.1.tgz",
+      "integrity": "sha512-5HdF8xdDSP7gUa8xXCYBuM6gmW7WtZds8r/GpdFYHZnZdCfhMGB3MHMk1PnERsSk7fsQXuc914yYigxLfuqI8g==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -1756,11 +1756,11 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.405.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.2.tgz",
-      "integrity": "sha512-cDbeTf6ya1zAqo54wwOFc2Mb/YWMRUnQavIERxbPRtiYn4EIv7wnkqdD8LVTOYyVIGjdGmteodCZ/6K+bocNFA==",
+      "version": "1.406.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.0.tgz",
+      "integrity": "sha512-qBvNTxTjnT8Z6CtVYVQ7RBL+whRr2d3jeYQGJECvfQwj+XsQuYNjqKtmdlEjCGbHISRQfYpDIC9LbLnbg3aNqw==",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.24.4",
+        "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -35345,9 +35345,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
-      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
+      "version": "5.25.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.25.1.tgz",
+      "integrity": "sha512-5HdF8xdDSP7gUa8xXCYBuM6gmW7WtZds8r/GpdFYHZnZdCfhMGB3MHMk1PnERsSk7fsQXuc914yYigxLfuqI8g==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -35356,11 +35356,11 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.405.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.405.2.tgz",
-      "integrity": "sha512-cDbeTf6ya1zAqo54wwOFc2Mb/YWMRUnQavIERxbPRtiYn4EIv7wnkqdD8LVTOYyVIGjdGmteodCZ/6K+bocNFA==",
+      "version": "1.406.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.0.tgz",
+      "integrity": "sha512-qBvNTxTjnT8Z6CtVYVQ7RBL+whRr2d3jeYQGJECvfQwj+XsQuYNjqKtmdlEjCGbHISRQfYpDIC9LbLnbg3aNqw==",
       "requires": {
-        "@bigcommerce/bigpay-client": "^5.24.4",
+        "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.405.2",
+    "@bigcommerce/checkout-sdk": "^1.406.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2068
https://github.com/bigcommerce/checkout-sdk-js/pull/2059
https://github.com/bigcommerce/checkout-sdk-js/pull/2071

## Why?
To keep checkout-sdk up to date

## Testing / Proof
Unit tests
Manual tests
QA tests
CI
