### PR TITLE
chore(payment): PAYPAL-2634 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.406.0",
+        "@bigcommerce/checkout-sdk": "^1.406.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.406.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.0.tgz",
-      "integrity": "sha512-qBvNTxTjnT8Z6CtVYVQ7RBL+whRr2d3jeYQGJECvfQwj+XsQuYNjqKtmdlEjCGbHISRQfYpDIC9LbLnbg3aNqw==",
+      "version": "1.406.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.1.tgz",
+      "integrity": "sha512-wN2rpUsD5bjZWj+Oe6PIqpqtgz4gMKIu3i2lCgis4KbG7djdnU3ruakKpnE8x6mx1hRNBsVdXIeztTQ+UBl6+g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.406.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.0.tgz",
-      "integrity": "sha512-qBvNTxTjnT8Z6CtVYVQ7RBL+whRr2d3jeYQGJECvfQwj+XsQuYNjqKtmdlEjCGbHISRQfYpDIC9LbLnbg3aNqw==",
+      "version": "1.406.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.1.tgz",
+      "integrity": "sha512-wN2rpUsD5bjZWj+Oe6PIqpqtgz4gMKIu3i2lCgis4KbG7djdnU3ruakKpnE8x6mx1hRNBsVdXIeztTQ+UBl6+g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.406.0",
+    "@bigcommerce/checkout-sdk": "^1.406.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump `checkout-sdk-js` version

## Why?

To keep up to date

Includes PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2072

## Testing / Proof

All tests passed

@bigcommerce/checkout
