### PR TITLE
feat(payment): PAYPAL-2744 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.406.1",
+        "@bigcommerce/checkout-sdk": "^1.407.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.406.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.1.tgz",
-      "integrity": "sha512-wN2rpUsD5bjZWj+Oe6PIqpqtgz4gMKIu3i2lCgis4KbG7djdnU3ruakKpnE8x6mx1hRNBsVdXIeztTQ+UBl6+g==",
+      "version": "1.407.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.407.0.tgz",
+      "integrity": "sha512-p2EEEv/dGgNjBT803wWaEXYGFEqkoYfFfpe6RuOXOgVdSLdRkSXMrmxBxCsFDA0QqL0BULGqEDaTMjaEZfdwYg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.406.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.406.1.tgz",
-      "integrity": "sha512-wN2rpUsD5bjZWj+Oe6PIqpqtgz4gMKIu3i2lCgis4KbG7djdnU3ruakKpnE8x6mx1hRNBsVdXIeztTQ+UBl6+g==",
+      "version": "1.407.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.407.0.tgz",
+      "integrity": "sha512-p2EEEv/dGgNjBT803wWaEXYGFEqkoYfFfpe6RuOXOgVdSLdRkSXMrmxBxCsFDA0QqL0BULGqEDaTMjaEZfdwYg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.406.1",
+    "@bigcommerce/checkout-sdk": "^1.407.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To apply checkout-sdk-js changes
checkout-sdk-js PR : https://github.com/bigcommerce/checkout-sdk-js/pull/2080

## Testing / Proof


@bigcommerce/checkout
