### PR TITLE
chore(payment): PI-585 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.407.0",
+        "@bigcommerce/checkout-sdk": "^1.409.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.407.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.407.0.tgz",
-      "integrity": "sha512-p2EEEv/dGgNjBT803wWaEXYGFEqkoYfFfpe6RuOXOgVdSLdRkSXMrmxBxCsFDA0QqL0BULGqEDaTMjaEZfdwYg==",
+      "version": "1.409.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.409.0.tgz",
+      "integrity": "sha512-ctbMrd3Y+HWt7g9RsPUGUQdp4cyjwgRcak5rJtbcwZeMo812Sdq5f2nkT7/RtHIzeci3q9+/a55mf1bQgkGuWQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.407.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.407.0.tgz",
-      "integrity": "sha512-p2EEEv/dGgNjBT803wWaEXYGFEqkoYfFfpe6RuOXOgVdSLdRkSXMrmxBxCsFDA0QqL0BULGqEDaTMjaEZfdwYg==",
+      "version": "1.409.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.409.0.tgz",
+      "integrity": "sha512-ctbMrd3Y+HWt7g9RsPUGUQdp4cyjwgRcak5rJtbcwZeMo812Sdq5f2nkT7/RtHIzeci3q9+/a55mf1bQgkGuWQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.407.0",
+    "@bigcommerce/checkout-sdk": "^1.409.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2077

## Why?
...

## Testing / Proof
...

@bigcommerce/checkout
