### PR TITLE
feat(checkout): PI-286 added bigpayToken to the loadPaymentMethod params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.424.0",
+        "@bigcommerce/checkout-sdk": "^1.426.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.424.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.424.0.tgz",
-      "integrity": "sha512-u5sUzKh7muKbx2T0uQhmtiJ0uLwqWmFYZJ0irh722uvLmN0hvCk1esQ+pRpK0ED2IUFyInGVDVptvsnGf/9JpQ==",
+      "version": "1.426.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.426.0.tgz",
+      "integrity": "sha512-JXzJTtMieUC6VYEpFMmMQsLBmvLn8ngZwv2s8v/6NaGYckVviUupWp33aFBZjNohDN0O+EwUGclMaef9to2TyQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.424.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.424.0.tgz",
-      "integrity": "sha512-u5sUzKh7muKbx2T0uQhmtiJ0uLwqWmFYZJ0irh722uvLmN0hvCk1esQ+pRpK0ED2IUFyInGVDVptvsnGf/9JpQ==",
+      "version": "1.426.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.426.0.tgz",
+      "integrity": "sha512-JXzJTtMieUC6VYEpFMmMQsLBmvLn8ngZwv2s8v/6NaGYckVviUupWp33aFBZjNohDN0O+EwUGclMaef9to2TyQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.424.0",
+    "@bigcommerce/checkout-sdk": "^1.426.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -238,6 +238,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     ...options,
                     creditCard: {
                         form: await getHostedFormOptions(selectedInstrument),
+                        bigpayToken: selectedInstrument?.bigpayToken,
                     },
                 });
             },


### PR DESCRIPTION
## What?
Bluesnapdirect 3ds challenge for stored cards without hosted fields
https://github.com/bigcommerce/checkout-sdk-js/pull/2041

## Why?
Because 3ds challenge doesn't appear for stored cards without bluesnap hosted fields. That's why we need to implement manual trigger of 3ds challenge for stored card without card number validation



## Testing / Proof
Tested manually/units
![image](https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/e2cff0e5-fd13-4fde-a2cb-6a824145f28c)


@bigcommerce/team-checkout @bigcommerce/team-payments
