### PR TITLE
feat(payment): PAYPAL-1545 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.412.0",
+        "@bigcommerce/checkout-sdk": "^1.414.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.412.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.412.0.tgz",
-      "integrity": "sha512-LQeK+ETDGb2WXf06RK7glV5xCYpvSMaP2iyAfjn8ReqVxIQtn+MHBZA9xN6OsgaDkSQm7QfFJc5ndXWCXmfkrA==",
+      "version": "1.414.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.414.0.tgz",
+      "integrity": "sha512-eoBK9olyWix5vCZWmn1vsBmeD249nNV8tskTXyNVEE/u7nTa5Id/sbcQ9Lspf6g5eQX5UmwmqDfUgnCqdEd6IQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.412.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.412.0.tgz",
-      "integrity": "sha512-LQeK+ETDGb2WXf06RK7glV5xCYpvSMaP2iyAfjn8ReqVxIQtn+MHBZA9xN6OsgaDkSQm7QfFJc5ndXWCXmfkrA==",
+      "version": "1.414.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.414.0.tgz",
+      "integrity": "sha512-eoBK9olyWix5vCZWmn1vsBmeD249nNV8tskTXyNVEE/u7nTa5Id/sbcQ9Lspf6g5eQX5UmwmqDfUgnCqdEd6IQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.412.0",
+    "@bigcommerce/checkout-sdk": "^1.414.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To apply changes from checkout-sdk-js
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2040

## Testing / Proof


@bigcommerce/checkout
