### PR TITLE
chore(payment): PAYPAL-2803 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.414.0",
+        "@bigcommerce/checkout-sdk": "^1.415.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.414.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.414.0.tgz",
-      "integrity": "sha512-eoBK9olyWix5vCZWmn1vsBmeD249nNV8tskTXyNVEE/u7nTa5Id/sbcQ9Lspf6g5eQX5UmwmqDfUgnCqdEd6IQ==",
+      "version": "1.415.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.415.0.tgz",
+      "integrity": "sha512-4v8AM6X7hDV7NoO6iAxuqVdF6ObkDGH0ScKovORF8DFubHLqsjZSmZYRP+e7OnS8ZRYCFB3hpr1kmOj43SsvCw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.414.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.414.0.tgz",
-      "integrity": "sha512-eoBK9olyWix5vCZWmn1vsBmeD249nNV8tskTXyNVEE/u7nTa5Id/sbcQ9Lspf6g5eQX5UmwmqDfUgnCqdEd6IQ==",
+      "version": "1.415.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.415.0.tgz",
+      "integrity": "sha512-4v8AM6X7hDV7NoO6iAxuqVdF6ObkDGH0ScKovORF8DFubHLqsjZSmZYRP+e7OnS8ZRYCFB3hpr1kmOj43SsvCw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.414.0",
+    "@bigcommerce/checkout-sdk": "^1.415.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2093

## Why?
To keep checkout sdk dependency version up to date

## Testing / Proof
Unit tests
Manual tests
