### PR TITLE
fix(checkout): CHECKOUT-7150 aria-expanded property does not toggle based on the associated drop-down

### DIFF
--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -24,6 +24,7 @@ const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLang
             href="#"
             id="addressToggle"
             onClick={preventDefault(() => setAriaExpanded(!ariaExpanded))}
+            onBlur={() => setAriaExpanded(false)}
         >
             {selectedAddress ? (
                 <StaticAddress address={selectedAddress} />


### PR DESCRIPTION
## What?
Adding an "onBlur" property to the address select button to set the "aria-expanded" property to false when the element loses focus.
## Why?
Currently when a user changes focus to another element, the aria-expanded property does not change back to false. This causes problems for users who navigate checkout using screen reader software.
## Testing / Proof
Before:
<img width="1225" alt="Screenshot 2023-08-02 at 1 41 49 PM" src="https://github.com/bigcommerce/checkout-js/assets/20911717/0e333c9d-4aad-44d2-9c1f-297ff68cbade">

After:
<img width="1279" alt="Screenshot 2023-08-02 at 1 40 44 PM" src="https://github.com/bigcommerce/checkout-js/assets/20911717/fa0a25f6-dc00-4a05-b9fe-0d73d525e9e0">

Additional note:
I am not sure if it would be better to track when the user clicks off the address select element instead of when it loses focus.

@bigcommerce/checkout
