### PR TITLE
feat(payment): PAYPAL-2805 added loading indicator while customer waiting on background processes after clicking on continue button in customer step guest form

### DIFF
--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -193,7 +193,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
           />;
 
         const isLoadingGuestForm = isWalletButtonsOnTop ?
-            isContinuingAsGuest :
+            isContinuingAsGuest || isExecutingPaymentMethodCheckout :
             isContinuingAsGuest || isInitializing || isExecutingPaymentMethodCheckout;
 
         return (


### PR DESCRIPTION
## What?
Added loading indicator while customer waiting on background processes after clicking on continue button in customer step guest form

## Why?
As a customer I after clicking on continue button in the customer step nothing happens for a while (3-5s on integration store), and I don't understand why.

The main reason why the page is freezing after customer clicks on continue button is in process of triggering PP Connect ORP. So to avoid customer's confusion we should show loader while running background process like looking for an email in PP Connect or/and triggering OTP flow.

## Testing / Proof
Manual tests
CI

https://github.com/bigcommerce/checkout-js/assets/25133454/89cef35d-da32-40b2-aa48-a3e9d6c1d33e
