### PR TITLE
fix(shipping): CHECKOUT-7627 Google AddressSelector sometimes autofills the wrong city for Canada addresses

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
@@ -1,6 +1,6 @@
 import AddressSelector from './AddressSelector';
 import AddressSelectorFactory from "./AddressSelectorFactory";
-import { getGoogleAutocompleteNZPlaceMock, getGoogleAutocompletePlaceMock, getGoogleAutocompleteUKPlaceMock } from './googleAutocompleteResult.mock';
+import { getGoogleAutocompleteCAPlaceMockWithLocality, getGoogleAutocompleteCAPlaceMockWithSubLocality, getGoogleAutocompleteNZPlaceMock, getGoogleAutocompletePlaceMock, getGoogleAutocompleteUKPlaceMock } from './googleAutocompleteResult.mock';
 
 describe('AddressSelector', () => {
     let googleAutoCompleteResponseMock: google.maps.places.PlaceResult;
@@ -117,6 +117,20 @@ describe('AddressSelector', () => {
             expect(accessor.getCity()).toBe('Ultimo N');
         });
 
-        it.todo('returns correct value for state for Canada address');
+        it('resturns the correct city for canada when sublocality is present', () => {
+            googleAutoCompleteResponseMock = getGoogleAutocompleteCAPlaceMockWithSubLocality();
+
+            const accessor = AddressSelectorFactory.create(googleAutoCompleteResponseMock);
+
+            expect(accessor.getCity()).toBe('Gloucester');
+        });
+
+        it('resturns the correct city for canada when sublocality is not present', () => {
+            googleAutoCompleteResponseMock = getGoogleAutocompleteCAPlaceMockWithLocality();
+
+            const accessor = AddressSelectorFactory.create(googleAutoCompleteResponseMock);
+
+            expect(accessor.getCity()).toBe('Calgary');
+        });
     });
 });

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelector.spec.ts
@@ -116,5 +116,7 @@ describe('AddressSelector', () => {
 
             expect(accessor.getCity()).toBe('Ultimo N');
         });
+
+        it.todo('returns correct value for state for Canada address');
     });
 });

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorCA.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorCA.ts
@@ -1,0 +1,8 @@
+import AddressSelector from './AddressSelector';
+
+export default class AddressSelectorUK extends AddressSelector {
+    getCity(): string {
+        return this._get('political', 'long_name');
+        ;
+    }
+}

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorCA.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorCA.ts
@@ -2,7 +2,6 @@ import AddressSelector from './AddressSelector';
 
 export default class AddressSelectorUK extends AddressSelector {
     getCity(): string {
-        return this._get('political', 'long_name');
-        ;
+        return this._get('sublocality_level_1', 'long_name') || this._get('locality', 'long_name');
     }
 }

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorCA.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorCA.ts
@@ -1,6 +1,6 @@
 import AddressSelector from './AddressSelector';
 
-export default class AddressSelectorUK extends AddressSelector {
+export default class AddressSelectorCA extends AddressSelector {
     getCity(): string {
         return this._get('sublocality_level_1', 'long_name') || this._get('locality', 'long_name');
     }

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorFactory.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorFactory.ts
@@ -1,15 +1,22 @@
 import AddressSelector from './AddressSelector';
+import AddressSelectorCA from './AddressSelectorCA';
 import AddressSelectorUK from './AddressSelectorUk';
 
 export default class AddressSelectorFactory {
     static create(autocompleteData: google.maps.places.PlaceResult): AddressSelector {
-        const addressSelector = new AddressSelector(autocompleteData);
+        const countryComponent = autocompleteData.address_components?.find(
+            component => component.types.indexOf('country') >= 0);
+        const countryShortName = countryComponent?.short_name || '';
 
-        switch (addressSelector.getCountry()) {
+        switch (countryShortName) {
             case 'GB':
                 return new AddressSelectorUK(autocompleteData);
-        }
 
-        return addressSelector;
+            case 'CA':
+                return new AddressSelectorCA(autocompleteData);
+
+            default:
+                return new AddressSelector(autocompleteData);
+        }
     }
 }

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
@@ -151,3 +151,99 @@ export function getGoogleAutocompleteUKPlaceMock(): google.maps.places.PlaceResu
         ],
     } as google.maps.places.PlaceResult;
 }
+
+export function getGoogleAutocompleteCAPlaceMockWithSubLocality(): google.maps.places.PlaceResult {
+    return {
+        "name" : "1934 Montréal Road",
+        "address_components" : [
+            {
+                "long_name" : '1934',
+                "short_name" : '1934',
+                "types" : ['street_number']
+            },
+            {
+                "long_name" : 'Montréal Road',
+                "short_name" : 'Montréal Rd',
+                "types" : ['route']
+            },
+            {
+                "long_name" : "Gloucester",
+                "short_name" : "Gloucester",
+                "types" : ["sublocality_level_1", "sublocality", "political"]
+            },
+            {
+                "long_name" : "Ottawa",
+                "short_name" : "Ottawa",
+                "types" : [ "locality", "political" ]
+            },
+            {
+                "long_name" : "Ottawa",
+                "short_name" : "Ottawa",
+                "types" : [ "administrative_area_level_3", "political" ]
+            },
+            {
+                "long_name" : "Ottawa",
+                "short_name" : "Ottawa",
+                "types" : [ "administrative_area_level_2", "political" ]
+            },
+            {
+                "long_name" : "Ontario",
+                "short_name" : "ON",
+                "types" : [ "administrative_area_level_1", "political" ]
+            },
+            {
+                "long_name" : "Canada",
+                "short_name" : "CA",
+                "types" : [ "country", "political" ]
+            },
+            {
+                "long_name" : "K1J 8P3",
+                "short_name" : "K1J 8P3",
+                "types" : [ "postal_code" ]
+            }
+        ],
+    } as google.maps.places.PlaceResult;
+}
+
+export function getGoogleAutocompleteCAPlaceMockWithLocality(): google.maps.places.PlaceResult {
+    return {
+        "name" : "7 Avenue Southwest",
+        "address_components" : [
+            {
+                "long_name" : '900',
+                "short_name" : '900',
+                "types" : ['street_number']
+            },
+            {
+                "long_name" : '7 Avenue Southwest',
+                "short_name" : 'Avenue Southwest',
+                "types" : ['route']
+            },
+            {
+                "long_name" : "Downtown",
+                "short_name" : "Downtown",
+                "types" : ["neighborhood", "political"]
+            },
+            {
+                "long_name" : "Calgary",
+                "short_name" : "Calgary",
+                "types" : [ "locality", "political" ]
+            },
+            {
+                "long_name" : "Alberta",
+                "short_name" : "AB",
+                "types" : [ "administrative_area_level_1", "political" ]
+            },
+            {
+                "long_name" : "Canada",
+                "short_name" : "CA",
+                "types" : [ "country", "political" ]
+            },
+            {
+                "long_name" : "K1J 8P3",
+                "short_name" : "K1J 8P3",
+                "types" : [ "postal_code" ]
+            }
+        ],
+    } as google.maps.places.PlaceResult;
+}

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
@@ -51,4 +51,5 @@ export type GoogleAddressFieldType =
     | 'political'
     | 'country'
     | 'subpremise'
-    | 'sublocality';
+    | 'sublocality'
+    | 'sublocality_level_1';


### PR DESCRIPTION
## What?
Fix issue where Google maps API sometimes fills the incorrect value in the city field.

## Why?
This was raised in an issue here https://github.com/bigcommerce/checkout-js/issues/1390.

## Testing / Proof
- circle
- screenshot
<img width="829" alt="Screenshot 2023-08-04 at 10 29 20 am" src="https://github.com/bigcommerce/checkout-js/assets/7134802/6e302963-acb6-4e9e-b6e9-811135f8025b">
<img width="829" alt="Screenshot 2023-08-04 at 10 29 52 am" src="https://github.com/bigcommerce/checkout-js/assets/7134802/7f700691-27de-47e0-8de0-92b3780216e4">

@bigcommerce/checkout
