### PR TITLE
fix(customer): CHECKOUT-000 Replace translated string with html

### DIFF
--- a/packages/core/src/app/customer/SubscribeField.tsx
+++ b/packages/core/src/app/customer/SubscribeField.tsx
@@ -1,7 +1,7 @@
 import { FieldProps } from 'formik';
 import React, { FunctionComponent, memo } from 'react';
 
-import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { TranslatedHtml } from '@bigcommerce/checkout/locale';
 
 import { Input, Label } from '../ui/form';
 
@@ -19,12 +19,12 @@ const SubscribeField: FunctionComponent<SubscribeFieldProps> = ({
             checked={field.value}
             className="form-checkbox"
             id={field.name}
-            type="checkbox"
             testId="should-subscribe-checkbox"
+            type="checkbox"
         />
 
         <Label htmlFor={field.name}>
-            <TranslatedString
+            <TranslatedHtml
                 id={
                     requiresMarketingConsent
                         ? 'customer.guest_marketing_consent'

--- a/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -62,7 +62,9 @@ exports[`Customer when view type is "guest" matches snapshot 1`] = `
                   class="form-label optimizedCheckout-form-label"
                   for="shouldSubscribe"
                 >
-                  Subscribe to our newsletter.
+                  <span>
+                    Subscribe to our newsletter.
+                  </span>
                 </label>
               </div>
             </div>

--- a/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
@@ -59,7 +59,9 @@ exports[`GuestForm matches snapshot 1`] = `
                 class="form-label optimizedCheckout-form-label"
                 for="shouldSubscribe"
               >
-                Subscribe to our newsletter.
+                <span>
+                  Subscribe to our newsletter.
+                </span>
               </label>
             </div>
           </div>

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
@@ -81,7 +81,9 @@ Object {
                         class="form-label optimizedCheckout-form-label"
                         for="shouldSubscribe"
                       >
-                        Subscribe to our newsletter.
+                        <span>
+                          Subscribe to our newsletter.
+                        </span>
                       </label>
                     </div>
                   </div>
@@ -211,7 +213,9 @@ Object {
                       class="form-label optimizedCheckout-form-label"
                       for="shouldSubscribe"
                     >
-                      Subscribe to our newsletter.
+                      <span>
+                        Subscribe to our newsletter.
+                      </span>
                     </label>
                   </div>
                 </div>


### PR DESCRIPTION
## What?
Changed TranslatedString to TranslatedHtml on the customer subscribe field.
- Taken from https://github.com/bigcommerce/checkout-js/pull/1271

## Why?
Raised here https://github.com/bigcommerce/checkout-js/issues/1270

## Testing / Proof
- CI

@bigcommerce/checkout
