### PR TITLE
feat(payment): PAYPAL-2732 new renderer method for address select component

### DIFF
--- a/packages/core/src/app/shipping/ItemAddressSelect.spec.tsx
+++ b/packages/core/src/app/shipping/ItemAddressSelect.spec.tsx
@@ -18,6 +18,7 @@ describe('ItemAddressSelect Component', () => {
         addresses: getCustomer().addresses,
         onSelectAddress: jest.fn(),
         onUseNewAddress: jest.fn(),
+        renderAddressSelect: (props) => <AddressSelect {...props} />,
     };
 
     it('renders product options', () => {

--- a/packages/core/src/app/shipping/ItemAddressSelect.tsx
+++ b/packages/core/src/app/shipping/ItemAddressSelect.tsx
@@ -1,7 +1,7 @@
 import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
-import React, { FunctionComponent, memo, useCallback } from 'react';
+import React, { FunctionComponent, memo, ReactNode, useCallback } from 'react';
 
-import { AddressSelect } from '../address';
+import { AddressSelectProps } from '../address/AddressSelect';
 
 import ShippableItem from './ShippableItem';
 
@@ -10,6 +10,7 @@ export interface ItemAddressSelectProps {
     addresses: CustomerAddress[];
     onSelectAddress(address: Address, itemId: string, itemKey: string): void;
     onUseNewAddress(address: Address | undefined, itemId: string, itemKey: string): void;
+    renderAddressSelect(props: AddressSelectProps): ReactNode;
 }
 
 const ItemAddressSelect: FunctionComponent<ItemAddressSelectProps> = ({
@@ -17,6 +18,7 @@ const ItemAddressSelect: FunctionComponent<ItemAddressSelectProps> = ({
     addresses,
     onSelectAddress,
     onUseNewAddress,
+    renderAddressSelect,
 }) => {
     const handleUseNewAddress = useCallback(
         (address: Address) => {
@@ -51,12 +53,12 @@ const ItemAddressSelect: FunctionComponent<ItemAddressSelectProps> = ({
                     </ul>
                 ))}
 
-                <AddressSelect
-                    addresses={addresses}
-                    onSelectAddress={handleSelectAddress}
-                    onUseNewAddress={handleUseNewAddress}
-                    selectedAddress={consignment && consignment.shippingAddress}
-                />
+                {renderAddressSelect({
+                    addresses,
+                    onSelectAddress: handleSelectAddress,
+                    onUseNewAddress: handleUseNewAddress,
+                    selectedAddress: consignment && consignment.shippingAddress,
+                })}
             </div>
         </div>
     );

--- a/packages/core/src/app/shipping/MultiShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
 
-import { AddressFormModal } from '../address';
+import { AddressFormModal, AddressSelect } from '../address';
 import { getAddressFormFields } from '../address/formField.mock';
 import { getCart } from '../cart/carts.mock';
 import { getPhysicalItem } from '../cart/lineItem.mock';
@@ -55,6 +55,7 @@ describe('MultiShippingForm Component', () => {
             shouldShowAddAddressInCheckout: true,
             onUnhandledError: jest.fn(),
             onUseNewAddress: jest.fn(),
+            renderAddressSelect: (props) => <AddressSelect {...props} />,
         };
     });
 

--- a/packages/core/src/app/shipping/MultiShippingForm.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.tsx
@@ -21,6 +21,7 @@ import {
     isValidAddress,
     mapAddressFromFormValues,
 } from '../address';
+import { AddressSelectProps } from '../address/AddressSelect';
 import { preventDefault } from '../common/dom';
 import { ErrorModal } from '../common/error';
 import { Form } from '../ui/form';
@@ -58,6 +59,7 @@ export interface MultiShippingFormProps {
     onSubmit(values: MultiShippingFormValues): void;
     onUnhandledError(error: Error): void;
     onUseNewAddress(address: Address, itemId: string): void;
+    renderAddressSelect(props: AddressSelectProps): ReactNode;
 }
 
 interface ShippableItemId {
@@ -105,6 +107,7 @@ class MultiShippingForm extends PureComponent<
             countriesWithAutocomplete,
             googleMapsApiKey,
             isFloatingLabelEnabled,
+            renderAddressSelect,
         } = this.props;
 
         const { items, itemAddingAddress, createCustomerAddressError } = this.state;
@@ -163,6 +166,7 @@ class MultiShippingForm extends PureComponent<
                                     item={item}
                                     onSelectAddress={this.handleSelectAddress}
                                     onUseNewAddress={this.handleUseNewAddress}
+                                    renderAddressSelect={renderAddressSelect}
                                 />
                             </li>
                         ))}

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -20,7 +20,8 @@ import { createSelector } from 'reselect';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
 import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
 
-import { isEqualAddress, mapAddressFromFormValues } from '../address';
+import { AddressSelect, isEqualAddress, mapAddressFromFormValues } from '../address';
+import { AddressSelectProps } from '../address/AddressSelect';
 import { withCheckout } from '../checkout';
 import CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 import { EMPTY_ARRAY, isFloatingLabelEnabled } from '../common/utility';
@@ -177,6 +178,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         onMultiShippingSubmit={this.handleMultiShippingSubmit}
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}
                         onUseNewAddress={this.handleUseNewAddress}
+                        renderAddressSelect={this.renderAddressSelect}
                         shouldShowSaveAddress={!isGuest}
                         updateAddress={updateShippingAddress}
                     />
@@ -184,6 +186,8 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             </AddressFormSkeleton>
         );
     }
+
+    private renderAddressSelect: (props: AddressSelectProps) => ReactNode = (props) => <AddressSelect {...props} />;
 
     private handleMultiShippingModeSwitch: () => void = async () => {
         const {

--- a/packages/core/src/app/shipping/ShippingAddress.spec.tsx
+++ b/packages/core/src/app/shipping/ShippingAddress.spec.tsx
@@ -7,7 +7,7 @@ import React, { FunctionComponent } from 'react';
 import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
-import { StaticAddress } from '../address/';
+import { AddressSelect, StaticAddress } from '../address/';
 import { getFormFields } from '../address/formField.mock';
 import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
@@ -47,6 +47,7 @@ describe('ShippingAddress Component', () => {
             deinitialize: jest.fn(),
             onUnhandledError: jest.fn(),
             onUseNewAddress: jest.fn(),
+            renderAddressSelect: (props) => <AddressSelect {...props} />,
         };
 
         TestComponent = (props) => (

--- a/packages/core/src/app/shipping/ShippingAddress.tsx
+++ b/packages/core/src/app/shipping/ShippingAddress.tsx
@@ -9,9 +9,11 @@ import {
     ShippingRequestOptions,
 } from '@bigcommerce/checkout-sdk';
 import { memoizeOne } from '@bigcommerce/memoize';
-import React, { FunctionComponent, memo, useCallback, useContext } from 'react';
+import React, { FunctionComponent, memo, ReactNode, useCallback, useContext } from 'react';
 
 import { FormContext } from '@bigcommerce/checkout/ui';
+
+import { AddressSelectProps } from '../address/AddressSelect';
 
 import ShippingAddressForm from './ShippingAddressForm';
 import StaticAddressEditable from './StaticAddressEditable';
@@ -36,6 +38,7 @@ export interface ShippingAddressProps {
     onFieldChange(name: string, value: string): void;
     onUnhandledError?(error: Error): void;
     onUseNewAddress(): void;
+    renderAddressSelect(props: AddressSelectProps): ReactNode;
 }
 
 const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
@@ -58,6 +61,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
         shouldShowSaveAddress,
         isShippingStepPending,
         isFloatingLabelEnabled,
+        renderAddressSelect,
     } = props;
 
     const { setSubmitted } = useContext(FormContext);
@@ -122,6 +126,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
             onAddressSelect={onAddressSelect}
             onFieldChange={handleFieldChange}
             onUseNewAddress={onUseNewAddress}
+            renderAddressSelect={renderAddressSelect}
             shouldShowSaveAddress={shouldShowSaveAddress}
         />
     );

--- a/packages/core/src/app/shipping/ShippingAddressForm.spec.tsx
+++ b/packages/core/src/app/shipping/ShippingAddressForm.spec.tsx
@@ -31,6 +31,7 @@ describe('ShippingAddressForm Component', () => {
             onFieldChange: jest.fn(),
             onUseNewAddress: jest.fn(),
             isLoading: false,
+            renderAddressSelect: (props) => <AddressSelect {...props} />,
         };
     });
 

--- a/packages/core/src/app/shipping/ShippingAddressForm.tsx
+++ b/packages/core/src/app/shipping/ShippingAddressForm.tsx
@@ -7,7 +7,8 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import React, { Component, ReactNode } from 'react';
 
-import { AddressForm, AddressSelect, isValidCustomerAddress } from '../address';
+import { AddressForm, isValidCustomerAddress } from '../address';
+import { AddressSelectProps } from '../address/AddressSelect';
 import { connectFormik, ConnectFormikProps } from '../common/form';
 import { Fieldset } from '../ui/form';
 import { LoadingOverlay } from '../ui/loading';
@@ -28,6 +29,7 @@ export interface ShippingAddressFormProps {
     onUseNewAddress(): void;
     onFieldChange(fieldName: string, value: string): void;
     onAddressSelect(address: Address): void;
+    renderAddressSelect(props: AddressSelectProps): ReactNode;
 }
 
 const addressFieldName = 'shippingAddress';
@@ -51,6 +53,7 @@ class ShippingAddressForm extends Component<
             formik: {
                 values: { shippingAddress: formAddress },
             },
+            renderAddressSelect,
         } = this.props;
 
         const hasAddresses = addresses && addresses.length > 0;
@@ -65,14 +68,12 @@ class ShippingAddressForm extends Component<
                 {hasAddresses && (
                     <Fieldset id="shippingAddresses">
                         <LoadingOverlay isLoading={isLoading}>
-                            <AddressSelect
-                                addresses={addresses}
-                                onSelectAddress={onAddressSelect}
-                                onUseNewAddress={onUseNewAddress}
-                                selectedAddress={
-                                    hasValidCustomerAddress ? shippingAddress : undefined
-                                }
-                            />
+                            {renderAddressSelect({
+                                addresses,
+                                onSelectAddress: onAddressSelect,
+                                onUseNewAddress,
+                                selectedAddress: hasValidCustomerAddress ? shippingAddress : undefined,
+                            })}
                         </LoadingOverlay>
                     </Fieldset>
                 )}

--- a/packages/core/src/app/shipping/ShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.spec.tsx
@@ -68,6 +68,7 @@ describe('ShippingForm Component', () => {
             deinitialize: jest.fn(),
             signOut: jest.fn(),
             shouldValidateSafeInput: true,
+            renderAddressSelect: jest.fn(),
         };
 
         checkoutService = createCheckoutService();

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -18,6 +18,8 @@ import React, { Component, ReactNode } from 'react';
 
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
 
+import { AddressSelectProps } from '../address/AddressSelect';
+
 import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm';
 import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
 
@@ -41,6 +43,7 @@ export interface ShippingFormProps {
     shouldShowOrderComments: boolean;
     shouldShowAddAddressInCheckout: boolean;
     isFloatingLabelEnabled?: boolean;
+    renderAddressSelect(props: AddressSelectProps): ReactNode;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -96,6 +99,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
             updateAddress,
             isShippingStepPending,
             isFloatingLabelEnabled,
+            renderAddressSelect,
         } = this.props;
 
         return isMultiShippingMode ? (
@@ -120,6 +124,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
                 onSubmit={onMultiShippingSubmit}
                 onUnhandledError={onUnhandledError}
                 onUseNewAddress={onUseNewAddress}
+                renderAddressSelect={renderAddressSelect}
                 shouldShowAddAddressInCheckout={shouldShowAddAddressInCheckout}
                 shouldShowOrderComments={shouldShowOrderComments}
             />
@@ -144,6 +149,7 @@ class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
                 methodId={methodId}
                 onSubmit={onSingleShippingSubmit}
                 onUnhandledError={onUnhandledError}
+                renderAddressSelect={renderAddressSelect}
                 shippingAddress={shippingAddress}
                 shouldShowOrderComments={shouldShowOrderComments}
                 shouldShowSaveAddress={shouldShowSaveAddress}

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -27,6 +27,7 @@ import {
     mapAddressFromFormValues,
     mapAddressToFormValues,
 } from '../address';
+import { AddressSelectProps } from '../address/AddressSelect';
 import { getCustomFormFieldsValidationSchema } from '../formFields';
 import { Fieldset, Form } from '../ui/form';
 
@@ -64,6 +65,7 @@ export interface SingleShippingFormProps {
         address: Partial<Address>,
         options?: RequestOptions<CheckoutParams>,
     ): Promise<CheckoutSelectors>;
+    renderAddressSelect(props: AddressSelectProps): ReactNode;
 }
 
 export interface SingleShippingFormValues {
@@ -142,6 +144,7 @@ class SingleShippingForm extends PureComponent<
             values: { shippingAddress: addressForm },
             isShippingStepPending,
             isFloatingLabelEnabled,
+            renderAddressSelect,
         } = this.props;
 
         const { isResettingAddress, isUpdatingShippingData, hasRequestedShippingOptions } =
@@ -173,6 +176,7 @@ class SingleShippingForm extends PureComponent<
                         onFieldChange={this.handleFieldChange}
                         onUnhandledError={onUnhandledError}
                         onUseNewAddress={this.onUseNewAddress}
+                        renderAddressSelect={renderAddressSelect}
                         shippingAddress={shippingAddress}
                         shouldShowSaveAddress={shouldShowSaveAddress}
                     />


### PR DESCRIPTION
## What?
Adding new renderer method for AddressSelect component

## Why?
Need this new method to get ability to add custom AddressSelect component for PayPal AXO project
Example in this PR: [https://github.com/bigcommerce/checkout-js/pull/1423](https://github.com/bigcommerce/checkout-js/pull/1423)

## Testing / Proof
Manually tested and unit test

@bigcommerce/checkout
