### PR TITLE
feat(payment): PAYPAL-2732 PayPalAxo Shipping step

### DIFF
--- a/packages/core/src/app/address/AddressSelect.spec.tsx
+++ b/packages/core/src/app/address/AddressSelect.spec.tsx
@@ -30,8 +30,7 @@ describe('AddressSelect Component', () => {
         jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
         jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
             jest.fn().mockImplementation(() => ({
-                isPayPalConnectAddress: () => false,
-                shouldShowPayPalConnectLabel: () => false,
+                shouldShowPayPalConnectLabel: false,
             }))
         );
     });
@@ -142,8 +141,7 @@ describe('AddressSelect Component', () => {
     it('shows Powered By PP Connect label', () => {
         jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
             jest.fn().mockImplementation(() => ({
-                isPayPalConnectAddress: () => false,
-                shouldShowPayPalConnectLabel: () => true,
+                shouldShowPayPalConnectLabel: true,
             }))
         );
 

--- a/packages/core/src/app/address/AddressSelect.spec.tsx
+++ b/packages/core/src/app/address/AddressSelect.spec.tsx
@@ -12,7 +12,10 @@ import { getCustomer } from '../customer/customers.mock';
 
 import { getAddress } from './address.mock';
 import AddressSelect from './AddressSelect';
+import * as usePayPalConnectAddress from './PayPalAxo/usePayPalConnectAddress';
 import StaticAddress from './StaticAddress';
+
+jest.mock('./PayPalAxo/PoweredByPaypalConnectLabel', () => () => (<div data-test="powered-by-pp-connect-label">PoweredByPaypalConnectLabel</div>));
 
 describe('AddressSelect Component', () => {
     let checkoutService: CheckoutService;
@@ -25,6 +28,12 @@ describe('AddressSelect Component', () => {
 
         jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(getCheckout());
         jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
+        jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                isPayPalConnectAddress: () => false,
+                shouldShowPayPalConnectLabel: () => false,
+            }))
+        );
     });
 
     it('renders `Enter Address` when there is no selected address', () => {
@@ -128,5 +137,28 @@ describe('AddressSelect Component', () => {
         component.find('#addressDropdown li:last-child a').simulate('click');
 
         expect(onSelectAddress).not.toHaveBeenCalled();
+    });
+
+    it('shows Powered By PP Connect label', () => {
+        jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                isPayPalConnectAddress: () => false,
+                shouldShowPayPalConnectLabel: () => true,
+            }))
+        );
+
+        component = mount(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <AddressSelect
+                        addresses={getCustomer().addresses}
+                        onSelectAddress={noop}
+                        onUseNewAddress={noop}
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>,
+        );
+
+        expect(component.find('[data-test="powered-by-pp-connect-label"]').text()).toBe('PoweredByPaypalConnectLabel');
     });
 });

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -8,6 +8,7 @@ import { DropdownTrigger } from '../ui/dropdown';
 
 import AddressSelectButton from './AddressSelectButton';
 import isEqualAddress from './isEqualAddress';
+import { PoweredByPaypalConnectLabel, usePayPalConnectAddress } from './PayPalAxo';
 import StaticAddress from './StaticAddress';
 
 import './AddressSelect.scss';
@@ -38,7 +39,7 @@ const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({
         {addresses.map((address) => (
             <li className="dropdown-menu-item dropdown-menu-item--select" key={address.id}>
                 <a href="#" onClick={preventDefault(() => onSelectAddress(address))}>
-                    <StaticAddress address={address} />
+                    <StaticAddress address={address} showProviderIcon />
                 </a>
             </li>
         ))}
@@ -51,6 +52,8 @@ const AddressSelect = ({
     onSelectAddress,
     onUseNewAddress,
 }: AddressSelectProps) => {
+    const { shouldShowPayPalConnectLabel } = usePayPalConnectAddress();
+
     const handleSelectAddress = (newAddress: Address) => {
         if (!isEqualAddress(selectedAddress, newAddress)) {
             onSelectAddress(newAddress);
@@ -80,6 +83,8 @@ const AddressSelect = ({
                     />
                 </DropdownTrigger>
             </div>
+
+            {shouldShowPayPalConnectLabel() && <PoweredByPaypalConnectLabel />}
         </div>
     );
 }

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -39,7 +39,7 @@ const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({
         {addresses.map((address) => (
             <li className="dropdown-menu-item dropdown-menu-item--select" key={address.id}>
                 <a href="#" onClick={preventDefault(() => onSelectAddress(address))}>
-                    <StaticAddress address={address} showProviderIcon />
+                    <StaticAddress address={address} />
                 </a>
             </li>
         ))}
@@ -84,7 +84,7 @@ const AddressSelect = ({
                 </DropdownTrigger>
             </div>
 
-            {shouldShowPayPalConnectLabel() && <PoweredByPaypalConnectLabel />}
+            {shouldShowPayPalConnectLabel && <PoweredByPaypalConnectLabel />}
         </div>
     );
 }

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -27,7 +27,7 @@ const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLang
             onBlur={() => setAriaExpanded(false)}
         >
             {selectedAddress ? (
-                <StaticAddress address={selectedAddress} />
+                <StaticAddress address={selectedAddress} showProviderIcon />
             ) : (
                 <TranslatedString id="address.enter_address_action" />
             )}

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -27,7 +27,7 @@ const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLang
             onBlur={() => setAriaExpanded(false)}
         >
             {selectedAddress ? (
-                <StaticAddress address={selectedAddress} showProviderIcon />
+                <StaticAddress address={selectedAddress} />
             ) : (
                 <TranslatedString id="address.enter_address_action" />
             )}

--- a/packages/core/src/app/address/PayPalAxo/index.ts
+++ b/packages/core/src/app/address/PayPalAxo/index.ts
@@ -1,2 +1,3 @@
 export {default as PoweredByPaypalConnectLabel} from './PoweredByPaypalConnectLabel';
 export {default as usePayPalConnectAddress} from './usePayPalConnectAddress';
+export { isPayPalConnectAddress } from './utils';

--- a/packages/core/src/app/address/PayPalAxo/index.ts
+++ b/packages/core/src/app/address/PayPalAxo/index.ts
@@ -1,0 +1,2 @@
+export {default as PoweredByPaypalConnectLabel} from './PoweredByPaypalConnectLabel';
+export {default as usePayPalConnectAddress} from './usePayPalConnectAddress';

--- a/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.test.tsx
+++ b/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.test.tsx
@@ -1,0 +1,194 @@
+import { Address, CustomerAddress, PaymentProviderCustomer } from '@bigcommerce/checkout-sdk';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import * as PaymentIntegrationApi from '@bigcommerce/checkout/payment-integration-api';
+import { getAddress, getCustomer, getStoreConfig } from '@bigcommerce/checkout/test-utils';
+
+import { getBillingAddress } from '../../billing/billingAddresses.mock';
+import { PaymentMethodId } from '../../payment/paymentMethod';
+
+import usePayPalConnectAddress from './usePayPalConnectAddress';
+
+interface PayPalAxoAddressComponentProps {
+    selectedAddress: Address;
+    addresses: CustomerAddress[];
+}
+
+const PayPalAxoAddressComponent = ({
+    selectedAddress,
+    addresses = [],
+}: PayPalAxoAddressComponentProps) => {
+    const {
+        isPayPalConnectAddress,
+        shouldShowPayPalConnectLabel,
+        mergeWithPayPalAddresses,
+    } = usePayPalConnectAddress();
+    const mergedAddresses = mergeWithPayPalAddresses(addresses);
+
+    return (
+        <>
+            <div data-test="isPayPalConnectAddress">
+                {isPayPalConnectAddress(selectedAddress) ? 'true' : 'false'}
+            </div>
+            <div data-test="shouldShowPayPalConnectLabel">
+                {shouldShowPayPalConnectLabel() ? 'true' : 'false'}
+            </div>
+            <ul>
+                {mergedAddresses.map((address, index) => (
+                    <li key={index}>{address.address1}</li>
+                ))}
+            </ul>
+        </>
+    );
+};
+
+describe('usePayPalConnectAddress', () => {
+    const defaultStoreConfig = getStoreConfig();
+    const defaultBillingAddress = getBillingAddress();
+    const defaultCustomer = getCustomer()
+
+    const useCheckoutMock = (
+        paymentProviderCustomer: PaymentProviderCustomer,
+        billingEmail?: string,
+        customerEmail?: string,
+        providerWithCustomCheckout = PaymentMethodId.BraintreeAcceleratedCheckout,
+    ) => {
+        jest.spyOn(PaymentIntegrationApi, 'useCheckout').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                checkoutState: {
+                    data: {
+                        getPaymentProviderCustomer: () => paymentProviderCustomer,
+                        getBillingAddress: () => ({
+                            ...defaultBillingAddress,
+                            email: billingEmail,
+                        }),
+                        getConfig: () => ({
+                            ...defaultStoreConfig,
+                            checkoutSettings: {
+                                ...defaultStoreConfig.checkoutSettings,
+                                providerWithCustomCheckout
+                            },
+                        }),
+                        getCustomer: () => ({
+                            ...defaultCustomer,
+                            email: customerEmail,
+                        }),
+                    }
+                }
+            }))
+        );
+    };
+
+
+    const defaultAdderss = getAddress();
+    const addressBC1 = {
+        ...defaultAdderss,
+        id: 1,
+        type: 'not-paypal',
+        address1: 'address-BC1',
+    };
+    const addressBC2 = {
+        ...defaultAdderss,
+        id: 2,
+        address1: 'address-BC2-PP1',
+    } as CustomerAddress;
+    const addressPP1 = {
+        ...addressBC2,
+        id: 3,
+    };
+    const addressPP2 = {
+        ...defaultAdderss,
+        id: 4,
+        type: 'paypal-address',
+        address1: 'address-PP2',
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders with BC addresses & no PP Connect addresses, selected BC address', () => {
+        useCheckoutMock({});
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[addressBC1, addressBC2]}
+                selectedAddress={addressBC1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('false');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('false');
+        expect(addressItems).toHaveLength(2);
+        expect(addressItems[0]).toHaveTextContent('address-BC1');
+        expect(addressItems[1]).toHaveTextContent('address-BC2-PP1');
+    });
+
+    it('renders with PP Connect addresses & no BC addresses, selected PP address', () => {
+        useCheckoutMock({
+            addresses: [addressPP1, addressPP2],
+        });
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[]}
+                selectedAddress={addressPP1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('true');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('true');
+        expect(addressItems).toHaveLength(2);
+        expect(addressItems[0]).toHaveTextContent('address-BC2-PP1');
+        expect(addressItems[1]).toHaveTextContent('address-PP2');
+    });
+
+    it('renders with BC addresses & PP Connect address, selected BC address', () => {
+        useCheckoutMock({
+            addresses: [addressPP2],
+        });
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[addressBC1, addressBC2]}
+                selectedAddress={addressBC1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('false');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('true');
+        expect(addressItems).toHaveLength(3);
+        expect(addressItems[0]).toHaveTextContent('address-PP2');
+        expect(addressItems[1]).toHaveTextContent('address-BC1');
+        expect(addressItems[2]).toHaveTextContent('address-BC2-PP1');
+    });
+
+    it('renders with BC addresses & PP Connect address - with address merge, selected PP address', () => {
+        useCheckoutMock({
+            addresses: [addressPP1, addressPP2],
+        });
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[addressBC1, addressBC2]}
+                selectedAddress={addressPP1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('true');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('true');
+        expect(addressItems).toHaveLength(3);
+        expect(addressItems[0]).toHaveTextContent('address-BC2-PP1');
+        expect(addressItems[1]).toHaveTextContent('address-PP2');
+        expect(addressItems[2]).toHaveTextContent('address-BC1');
+    });
+});

--- a/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
+++ b/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
@@ -1,0 +1,78 @@
+import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
+
+import { PaymentMethodId } from '../../payment/paymentMethod';
+import isEqualAddress from '../isEqualAddress';
+
+const PAYPAL_ADDRESS_TYPE = 'paypal-address';
+const PAYPAL_CONNECT_CUSTOMER_KEY = 'paypal-connect.customer';
+
+const usePayPalConnectAddress = () => {
+    const {
+        checkoutState: {
+            data: {
+                getBillingAddress,
+                getConfig,
+                getCustomer,
+                getPaymentProviderCustomer,
+            }
+        }
+    } = useCheckout();
+    const providerWithCustomCheckout = getConfig()?.checkoutSettings?.providerWithCustomCheckout;
+    const isPayPalAxoEnabled = providerWithCustomCheckout === PaymentMethodId.BraintreeAcceleratedCheckout
+        || providerWithCustomCheckout === PaymentMethodId.Braintree;
+
+    const getPaypalConnectAddresses = (): CustomerAddress[] => {
+        if (!isPayPalAxoEnabled) {
+            return [];
+        }
+
+        let addresses = getPaymentProviderCustomer()?.addresses;
+
+        if (!addresses?.length) {
+            const storedPayPalConnectCustomer = localStorage.getItem(PAYPAL_CONNECT_CUSTOMER_KEY);
+
+            if (!storedPayPalConnectCustomer) {
+                return [];
+            }
+
+            const { email: storedEmail, addresses: storedAddresses } = JSON.parse(storedPayPalConnectCustomer) || {};
+            const customerEmail = getCustomer()?.email || getBillingAddress()?.email;
+
+            addresses = customerEmail === storedEmail ? storedAddresses : [];
+        }
+
+        return addresses || [];
+    };
+
+    const isPayPalConnectAddress = (address: CustomerAddress | Address): boolean => {
+        if (!isPayPalAxoEnabled) {
+            return false;
+        }
+
+        if ('type' in address) {
+            return address.type === PAYPAL_ADDRESS_TYPE;
+        }
+
+        return getPaypalConnectAddresses().some(
+            (paypalConnectAddress) => isEqualAddress(address, paypalConnectAddress)
+        );
+    };
+
+    const shouldShowPayPalConnectLabel = (): boolean => isPayPalAxoEnabled && !!getPaypalConnectAddresses().length;
+
+    const mergeWithPayPalAddresses = (customerAddresses: CustomerAddress[]): CustomerAddress[] => [
+        ...getPaypalConnectAddresses(),
+        ...customerAddresses.filter((address) => !isPayPalConnectAddress(address)),
+    ];
+
+    return {
+        isPayPalAxoEnabled,
+        isPayPalConnectAddress,
+        shouldShowPayPalConnectLabel,
+        mergeWithPayPalAddresses,
+    };
+};
+
+export default usePayPalConnectAddress;

--- a/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
+++ b/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
@@ -1,77 +1,34 @@
-import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
-
 import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 
 import { PaymentMethodId } from '../../payment/paymentMethod';
-import isEqualAddress from '../isEqualAddress';
 
-const PAYPAL_ADDRESS_TYPE = 'paypal-address';
-const PAYPAL_CONNECT_CUSTOMER_KEY = 'paypal-connect.customer';
+import { isPayPalConnectAddress } from './utils';
 
 const usePayPalConnectAddress = () => {
-    const {
-        checkoutState: {
-            data: {
-                getBillingAddress,
-                getConfig,
-                getCustomer,
-                getPaymentProviderCustomer,
-            }
-        }
-    } = useCheckout();
+    const { checkoutState } = useCheckout();
+    const { getConfig, getCustomer, getPaymentProviderCustomer } = checkoutState.data;
+
     const providerWithCustomCheckout = getConfig()?.checkoutSettings?.providerWithCustomCheckout;
     const isPayPalAxoEnabled = providerWithCustomCheckout === PaymentMethodId.BraintreeAcceleratedCheckout
         || providerWithCustomCheckout === PaymentMethodId.Braintree;
 
-    const getPaypalConnectAddresses = (): CustomerAddress[] => {
-        if (!isPayPalAxoEnabled) {
-            return [];
-        }
+    const paypalConnectAddresses = getPaymentProviderCustomer()?.addresses || [];
+    const bcAddresses = getCustomer()?.addresses || [];
 
-        let addresses = getPaymentProviderCustomer()?.addresses;
+    const mergedBcAndPayPalConnectAddresses = isPayPalAxoEnabled 
+        ? [
+            ...paypalConnectAddresses,
+            ...bcAddresses.filter((address) => !isPayPalConnectAddress(address, paypalConnectAddresses))
+        ]
+        : bcAddresses;
 
-        if (!addresses?.length) {
-            const storedPayPalConnectCustomer = localStorage.getItem(PAYPAL_CONNECT_CUSTOMER_KEY);
-
-            if (!storedPayPalConnectCustomer) {
-                return [];
-            }
-
-            const { email: storedEmail, addresses: storedAddresses } = JSON.parse(storedPayPalConnectCustomer) || {};
-            const customerEmail = getCustomer()?.email || getBillingAddress()?.email;
-
-            addresses = customerEmail === storedEmail ? storedAddresses : [];
-        }
-
-        return addresses || [];
-    };
-
-    const isPayPalConnectAddress = (address: CustomerAddress | Address): boolean => {
-        if (!isPayPalAxoEnabled) {
-            return false;
-        }
-
-        if ('type' in address) {
-            return address.type === PAYPAL_ADDRESS_TYPE;
-        }
-
-        return getPaypalConnectAddresses().some(
-            (paypalConnectAddress) => isEqualAddress(address, paypalConnectAddress)
-        );
-    };
-
-    const shouldShowPayPalConnectLabel = (): boolean => isPayPalAxoEnabled && !!getPaypalConnectAddresses().length;
-
-    const mergeWithPayPalAddresses = (customerAddresses: CustomerAddress[]): CustomerAddress[] => [
-        ...getPaypalConnectAddresses(),
-        ...customerAddresses.filter((address) => !isPayPalConnectAddress(address)),
-    ];
+    const shouldShowPayPalConnectLabel = !!paypalConnectAddresses.length;
 
     return {
         isPayPalAxoEnabled,
-        isPayPalConnectAddress,
+        paypalConnectAddresses,
         shouldShowPayPalConnectLabel,
-        mergeWithPayPalAddresses,
+        mergedBcAndPayPalConnectAddresses,
     };
 };
 

--- a/packages/core/src/app/address/PayPalAxo/utils.ts
+++ b/packages/core/src/app/address/PayPalAxo/utils.ts
@@ -1,0 +1,15 @@
+import { Address } from '@bigcommerce/checkout-sdk';
+
+import isEqualAddress from '../isEqualAddress';
+
+const PAYPAL_ADDRESS_TYPE = 'paypal-address';
+
+export function isPayPalConnectAddress(address: Address, addresses: Address[]): boolean {
+    if ('type' in address) {
+        return address.type === PAYPAL_ADDRESS_TYPE;
+    }
+
+    return addresses.some(
+        (paypalConnectAddress) => isEqualAddress(address, paypalConnectAddress)
+    );
+}

--- a/packages/core/src/app/address/StaticAddress.scss
+++ b/packages/core/src/app/address/StaticAddress.scss
@@ -1,3 +1,5 @@
+@import "../ui/Base";
+
 .checkout-address--static {
     .address-entry {
         margin: 0;
@@ -5,17 +7,15 @@
 }
 
 .checkout-address--with-provider-icon {
-    $icon-size: 1.85rem;
-
     position: relative;
 
     .address-entry {
-        padding-right: $icon-size;
+        padding-right: $paypal-connect-icon-size;
     }
 
     .icon {
-        width: $icon-size;
-        height: $icon-size;
+        width: $paypal-connect-icon-size;
+        height: $paypal-connect-icon-size;
         position: absolute;
         top: 0;
         right: 0;

--- a/packages/core/src/app/address/StaticAddress.scss
+++ b/packages/core/src/app/address/StaticAddress.scss
@@ -1,5 +1,18 @@
 .checkout-address--static {
+    $icon-size: 1.85rem;
+
+    position: relative;
+
     .address-entry {
         margin: 0;
+        padding-right: $icon-size;
+    }
+
+    .icon {
+        width: $icon-size;
+        height: $icon-size;
+        position: absolute;
+        top: 0;
+        right: 0;
     }
 }

--- a/packages/core/src/app/address/StaticAddress.scss
+++ b/packages/core/src/app/address/StaticAddress.scss
@@ -10,7 +10,7 @@
     position: relative;
 
     .address-entry {
-        padding-right: $paypal-connect-icon-size;
+        padding-right: $paypal-connect-icon-container-size;
     }
 
     .icon {

--- a/packages/core/src/app/address/StaticAddress.scss
+++ b/packages/core/src/app/address/StaticAddress.scss
@@ -1,10 +1,15 @@
 .checkout-address--static {
+    .address-entry {
+        margin: 0;
+    }
+}
+
+.checkout-address--with-provider-icon {
     $icon-size: 1.85rem;
 
     position: relative;
 
     .address-entry {
-        margin: 0;
         padding-right: $icon-size;
     }
 

--- a/packages/core/src/app/address/StaticAddress.spec.tsx
+++ b/packages/core/src/app/address/StaticAddress.spec.tsx
@@ -13,7 +13,13 @@ import { getCountries } from '../geography/countries.mock';
 import { getAddress } from './address.mock';
 import AddressType from './AddressType';
 import { getAddressFormFields } from './formField.mock';
+import * as usePayPalConnectAddress from './PayPalAxo/usePayPalConnectAddress';
 import StaticAddress, { StaticAddressProps } from './StaticAddress';
+
+jest.mock('@bigcommerce/checkout/ui', () => ({
+    ...jest.requireActual('@bigcommerce/checkout/ui'),
+    IconPayPalConnectSmall: () => (<div data-test="pp-connect-icon">IconPayPalConnectSmall</div>)
+}));
 
 describe('StaticAddress Component', () => {
     let StaticAddressTest: FunctionComponent<StaticAddressProps>;
@@ -37,6 +43,12 @@ describe('StaticAddress Component', () => {
 
         jest.spyOn(checkoutState.data, 'getShippingAddressFields').mockReturnValue(
             getAddressFormFields(),
+        );
+
+        jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                isPayPalConnectAddress: () => false,
+            }))
         );
 
         StaticAddressTest = (props) => (
@@ -146,5 +158,63 @@ describe('StaticAddress Component', () => {
         );
 
         expect(container.html()).not.toBe('');
+    });
+
+    describe('provider icon', () => {
+        it('should not show icon', () => {
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={false}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
+        });
+
+        it('should show icon, but address is not from PP Connect', () => {
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={true}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
+        });
+
+        it('should not show icon, but address is from PP Connect', () => {
+            jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+                jest.fn().mockImplementation(() => ({
+                    isPayPalConnectAddress: () => true,
+                }))
+            );
+
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={false}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
+        });
+
+        it('should show icon for PP Connect address', () => {
+            jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+                jest.fn().mockImplementation(() => ({
+                    isPayPalConnectAddress: () => true,
+                }))
+            );
+
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={true}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(1);
+        });
     });
 });

--- a/packages/core/src/app/address/StaticAddress.spec.tsx
+++ b/packages/core/src/app/address/StaticAddress.spec.tsx
@@ -161,39 +161,10 @@ describe('StaticAddress Component', () => {
     });
 
     describe('provider icon', () => {
-        it('should not show icon', () => {
+        it('should not show icon, address is not from PP Connect', () => {
             const container = render(
                 <StaticAddressTest
                     {...defaultProps}
-                    showProviderIcon={false}
-                />
-            );
-
-            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
-        });
-
-        it('should show icon, but address is not from PP Connect', () => {
-            const container = render(
-                <StaticAddressTest
-                    {...defaultProps}
-                    showProviderIcon={true}
-                />
-            );
-
-            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
-        });
-
-        it('should not show icon, but address is from PP Connect', () => {
-            jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
-                jest.fn().mockImplementation(() => ({
-                    isPayPalConnectAddress: () => true,
-                }))
-            );
-
-            const container = render(
-                <StaticAddressTest
-                    {...defaultProps}
-                    showProviderIcon={false}
                 />
             );
 
@@ -203,14 +174,14 @@ describe('StaticAddress Component', () => {
         it('should show icon for PP Connect address', () => {
             jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
                 jest.fn().mockImplementation(() => ({
-                    isPayPalConnectAddress: () => true,
+                    isPayPalAxoEnabled: true,
+                    paypalConnectAddresses: [defaultProps.address]
                 }))
             );
 
             const container = render(
                 <StaticAddressTest
                     {...defaultProps}
-                    showProviderIcon={true}
                 />
             );
 

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -5,6 +5,7 @@ import {
     FormField,
     ShippingInitializeOptions,
 } from '@bigcommerce/checkout-sdk';
+import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import React, { FunctionComponent, memo } from 'react';
 
@@ -48,7 +49,15 @@ const StaticAddress: FunctionComponent<
     const shouldShowProviderIcon = showProviderIcon && isPayPalConnectAddress(addressWithoutLocalization);
 
     return !isValid ? null : (
-        <div className="vcard checkout-address--static">
+        <div
+            className={classNames(
+                'vcard checkout-address--static',
+                {
+                    'checkout-address--with-provider-icon': shouldShowProviderIcon,
+                }
+            )}
+        >
+
 
             {shouldShowProviderIcon && <IconPayPalConnectSmall />}
 

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -9,6 +9,7 @@ import { isEmpty } from 'lodash';
 import React, { FunctionComponent, memo } from 'react';
 
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
+import { IconPayPalConnectSmall } from '@bigcommerce/checkout/ui';
 
 import { withCheckout } from '../checkout';
 
@@ -16,9 +17,11 @@ import AddressType from './AddressType';
 import isValidAddress from './isValidAddress';
 import localizeAddress from './localizeAddress';
 import './StaticAddress.scss';
+import { usePayPalConnectAddress } from './PayPalAxo';
 
 export interface StaticAddressProps {
     address: Address;
+    showProviderIcon?: boolean;
     type?: AddressType;
 }
 
@@ -33,7 +36,8 @@ interface WithCheckoutStaticAddressProps {
 
 const StaticAddress: FunctionComponent<
     StaticAddressEditableProps & WithCheckoutStaticAddressProps
-> = ({ countries, fields, address: addressWithoutLocalization }) => {
+> = ({ countries, fields, address: addressWithoutLocalization, showProviderIcon }) => {
+    const { isPayPalConnectAddress } = usePayPalConnectAddress();
     const address = localizeAddress(addressWithoutLocalization, countries);
     const isValid = !fields
         ? !isEmpty(address)
@@ -41,9 +45,13 @@ const StaticAddress: FunctionComponent<
               address,
               fields.filter((field) => !field.custom),
           );
+    const shouldShowProviderIcon = showProviderIcon && isPayPalConnectAddress(addressWithoutLocalization);
 
     return !isValid ? null : (
         <div className="vcard checkout-address--static">
+
+            {shouldShowProviderIcon && <IconPayPalConnectSmall />}
+
             {(address.firstName || address.lastName) && (
                 <p className="fn address-entry">
                     <span className="first-name">{`${address.firstName} `}</span>

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -17,12 +17,12 @@ import { withCheckout } from '../checkout';
 import AddressType from './AddressType';
 import isValidAddress from './isValidAddress';
 import localizeAddress from './localizeAddress';
+import { isPayPalConnectAddress, usePayPalConnectAddress } from './PayPalAxo';
+
 import './StaticAddress.scss';
-import { usePayPalConnectAddress } from './PayPalAxo';
 
 export interface StaticAddressProps {
     address: Address;
-    showProviderIcon?: boolean;
     type?: AddressType;
 }
 
@@ -37,8 +37,8 @@ interface WithCheckoutStaticAddressProps {
 
 const StaticAddress: FunctionComponent<
     StaticAddressEditableProps & WithCheckoutStaticAddressProps
-> = ({ countries, fields, address: addressWithoutLocalization, showProviderIcon }) => {
-    const { isPayPalConnectAddress } = usePayPalConnectAddress();
+> = ({ countries, fields, address: addressWithoutLocalization }) => {
+    const { isPayPalAxoEnabled, paypalConnectAddresses } = usePayPalConnectAddress();
     const address = localizeAddress(addressWithoutLocalization, countries);
     const isValid = !fields
         ? !isEmpty(address)
@@ -46,7 +46,7 @@ const StaticAddress: FunctionComponent<
               address,
               fields.filter((field) => !field.custom),
           );
-    const shouldShowProviderIcon = showProviderIcon && isPayPalConnectAddress(addressWithoutLocalization);
+    const shouldShowProviderIcon = isPayPalAxoEnabled && isPayPalConnectAddress(addressWithoutLocalization, paypalConnectAddresses);
 
     return !isValid ? null : (
         <div
@@ -57,8 +57,6 @@ const StaticAddress: FunctionComponent<
                 }
             )}
         >
-
-
             {shouldShowProviderIcon && <IconPayPalConnectSmall />}
 
             {(address.firstName || address.lastName) && (

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -17,6 +17,7 @@ enum PaymentMethodId {
     BraintreeVenmo = 'braintreevenmo',
     AuthorizeNetGooglePay = 'googlepayauthorizenet',
     BNZGooglePay = 'googlepaybnz',
+    BraintreeAcceleratedCheckout = 'braintreeacceleratedcheckout',
     BraintreeGooglePay = 'googlepaybraintree',
     BraintreeVisaCheckout = 'braintreevisacheckout',
     BraintreeLocalPaymentMethod = 'braintreelocalmethods',

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -97,8 +97,8 @@ const ShippingForm = ({
     isShippingStepPending,
     isFloatingLabelEnabled,
 }: ShippingFormProps & WithLanguageProps) => {
-    const { isPayPalAxoEnabled, mergeWithPayPalAddresses } = usePayPalConnectAddress();
-    const shippingAddresses = isPayPalAxoEnabled ? mergeWithPayPalAddresses(addresses) : addresses;
+    const { isPayPalAxoEnabled, mergedBcAndPayPalConnectAddresses } = usePayPalConnectAddress();
+    const shippingAddresses = isPayPalAxoEnabled ? mergedBcAndPayPalConnectAddresses : addresses;
 
     return isMultiShippingMode ? (
         <MultiShippingForm

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -18,6 +18,8 @@ import React from 'react';
 
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
 
+import { usePayPalConnectAddress } from '../address/PayPalAxo';
+
 import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm';
 import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
 
@@ -95,9 +97,12 @@ const ShippingForm = ({
     isShippingStepPending,
     isFloatingLabelEnabled,
 }: ShippingFormProps & WithLanguageProps) => {
+    const { isPayPalAxoEnabled, mergeWithPayPalAddresses } = usePayPalConnectAddress();
+    const shippingAddresses = isPayPalAxoEnabled ? mergeWithPayPalAddresses(addresses) : addresses;
+
     return isMultiShippingMode ? (
         <MultiShippingForm
-            addresses={addresses}
+            addresses={shippingAddresses}
             assignItem={assignItem}
             cart={cart}
             cartHasChanged={cartHasChanged}
@@ -122,7 +127,7 @@ const ShippingForm = ({
         />
     ) : (
         <SingleShippingForm
-            addresses={addresses}
+            addresses={shippingAddresses}
             cartHasChanged={cartHasChanged}
             consignments={consignments}
             countries={countries}

--- a/packages/core/src/app/shipping/StaticConsignment.spec.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.spec.tsx
@@ -1,5 +1,8 @@
+import { createCheckoutService } from '@bigcommerce/checkout-sdk';
 import { render } from 'enzyme';
 import React from 'react';
+
+import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getCart } from '../cart/carts.mock';
 
@@ -9,16 +12,23 @@ import StaticConsignment from './StaticConsignment';
 describe('StaticConsignment Component', () => {
     const consignment = getConsignment();
     const cart = getCart();
+    const checkoutService = createCheckoutService();
 
     it('renders static consignment with shipping method', () => {
-        const tree = render(<StaticConsignment cart={cart} consignment={consignment} />);
+        const tree = render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <StaticConsignment cart={cart} consignment={consignment} />
+            </CheckoutProvider>
+        );
 
         expect(tree).toMatchSnapshot();
     });
 
     it('renders compact view of static consignment', () => {
         const tree = render(
-            <StaticConsignment cart={cart} compactView consignment={consignment} />,
+            <CheckoutProvider checkoutService={checkoutService}>
+                <StaticConsignment cart={cart} compactView consignment={consignment} />
+            </CheckoutProvider>
         );
 
         expect(tree).toMatchSnapshot();

--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -2,6 +2,7 @@ import { Cart, Consignment } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, memo } from 'react';
 
 import { AddressType, StaticAddress } from '../address';
+import { PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '../address/PayPalAxo';
 
 import { StaticShippingOption } from './shippingOption';
 import './StaticConsignment.scss';
@@ -18,11 +19,14 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
     cart,
     compactView,
 }) => {
+    const { isPayPalConnectAddress } = usePayPalConnectAddress();
     const { shippingAddress: address, selectedShippingOption } = consignment;
 
     return (
         <div className="staticConsignment">
             <StaticAddress address={address} type={AddressType.Shipping} />
+
+            {isPayPalConnectAddress(address) && <PoweredByPaypalConnectLabel />}
 
             {!compactView && <StaticConsignmentItemList cart={cart} consignment={consignment} />}
 

--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -2,7 +2,7 @@ import { Cart, Consignment } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, memo } from 'react';
 
 import { AddressType, StaticAddress } from '../address';
-import { PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '../address/PayPalAxo';
+import { isPayPalConnectAddress, PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '../address/PayPalAxo';
 
 import { StaticShippingOption } from './shippingOption';
 import './StaticConsignment.scss';
@@ -19,14 +19,16 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
     cart,
     compactView,
 }) => {
-    const { isPayPalConnectAddress } = usePayPalConnectAddress();
+    const { isPayPalAxoEnabled, paypalConnectAddresses } = usePayPalConnectAddress();
     const { shippingAddress: address, selectedShippingOption } = consignment;
+
+    const showPayPalConnectAddressLabel = isPayPalAxoEnabled && isPayPalConnectAddress(address, paypalConnectAddresses);
 
     return (
         <div className="staticConsignment">
             <StaticAddress address={address} type={AddressType.Shipping} />
 
-            {isPayPalConnectAddress(address) && <PoweredByPaypalConnectLabel />}
+            {showPayPalConnectAddressLabel && <PoweredByPaypalConnectLabel />}
 
             {!compactView && <StaticConsignmentItemList cart={cart} consignment={consignment} />}
 

--- a/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
+++ b/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
@@ -4,6 +4,75 @@ exports[`StaticConsignment Component renders compact view of static consignment 
 <div
   class="staticConsignment"
 >
+  <div
+    class="vcard checkout-address--static"
+  >
+    <p
+      class="fn address-entry"
+    >
+      <span
+        class="first-name"
+      >
+        Test 
+      </span>
+      <span
+        class="family-name"
+      >
+        Tester
+      </span>
+    </p>
+    <p
+      class="address-entry"
+    >
+      <span
+        class="company-name"
+      >
+        Bigcommerce 
+      </span>
+      <span
+        class="tel"
+      >
+        555-555-5555
+      </span>
+    </p>
+    <div
+      class="adr"
+    >
+      <p
+        class="street-address address-entry"
+      >
+        <span
+          class="address-line-1"
+        >
+          12345 Testing Way 
+        </span>
+      </p>
+      <p
+        class="address-entry"
+      >
+        <span
+          class="locality"
+        >
+          Some City, 
+        </span>
+        <span
+          class="region"
+        >
+          California, 
+        </span>
+        <span
+          class="postal-code"
+        >
+          95555 / 
+        </span>
+        <span
+          class="country-name"
+        >
+          United States 
+        </span>
+      </p>
+    </div>
+  </div>
   <div>
     <div
       class="shippingOption shippingOption--alt shippingOption--selected"
@@ -29,6 +98,75 @@ exports[`StaticConsignment Component renders static consignment with shipping me
 <div
   class="staticConsignment"
 >
+  <div
+    class="vcard checkout-address--static"
+  >
+    <p
+      class="fn address-entry"
+    >
+      <span
+        class="first-name"
+      >
+        Test 
+      </span>
+      <span
+        class="family-name"
+      >
+        Tester
+      </span>
+    </p>
+    <p
+      class="address-entry"
+    >
+      <span
+        class="company-name"
+      >
+        Bigcommerce 
+      </span>
+      <span
+        class="tel"
+      >
+        555-555-5555
+      </span>
+    </p>
+    <div
+      class="adr"
+    >
+      <p
+        class="street-address address-entry"
+      >
+        <span
+          class="address-line-1"
+        >
+          12345 Testing Way 
+        </span>
+      </p>
+      <p
+        class="address-entry"
+      >
+        <span
+          class="locality"
+        >
+          Some City, 
+        </span>
+        <span
+          class="region"
+        >
+          California, 
+        </span>
+        <span
+          class="postal-code"
+        >
+          95555 / 
+        </span>
+        <span
+          class="country-name"
+        >
+          United States 
+        </span>
+      </p>
+    </div>
+  </div>
   <div
     class="staticConsignment-items"
   >

--- a/packages/core/src/scss/settings/foundation/forms/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/forms/_settings.scss
@@ -165,3 +165,5 @@ $select-outline:                     0;
 $select-paddingRight:                spacing("single");
 $select-focus-borderColor:           $input-focus-border-color;
 $select-focus-boxShadow:             $input-focus-boxShadow;
+
+$paypal-connect-icon-size:           remCalc(30px);

--- a/packages/core/src/scss/settings/foundation/forms/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/forms/_settings.scss
@@ -168,3 +168,4 @@ $select-focus-boxShadow:             $input-focus-boxShadow;
 
 // We use it to display a PayPal Connect icon next to the static shipping address
 $paypal-connect-icon-size:           remCalc(30px);
+$paypal-connect-icon-container-size: calc($paypal-connect-icon-size + remCalc(5px));

--- a/packages/core/src/scss/settings/foundation/forms/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/forms/_settings.scss
@@ -166,4 +166,5 @@ $select-paddingRight:                spacing("single");
 $select-focus-borderColor:           $input-focus-border-color;
 $select-focus-boxShadow:             $input-focus-boxShadow;
 
+// We use it to display a PayPal Connect icon next to the static shipping address
 $paypal-connect-icon-size:           remCalc(30px);


### PR DESCRIPTION
## What?
Add labels for PayPal Connect addresses

## Why?
We need to show for shoppers addresses which we get from PayPal Connect.

## Testing / Proof
BC - guest
PP Connect - guest

https://github.com/bigcommerce/checkout-js/assets/9430298/1027b77f-e1df-4c18-ac96-5bc6bf3c91da

BC - registered
PP Connect - guest

https://github.com/bigcommerce/checkout-js/assets/9430298/6894e174-03ed-4c99-bac2-7a09b3ba5bd5

BC - guest
PP Connect - registered

https://github.com/bigcommerce/checkout-js/assets/9430298/8291b50a-99bb-4f65-9c27-fe50553cdc0d

BC - registered
PP Connect - registered (with address merge)

https://github.com/bigcommerce/checkout-js/assets/9430298/aa14d130-f221-4fbb-805e-c65ee0d44c36




@bigcommerce/checkout
