### PR TITLE
chore(payment): PAYPAL-2737 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.417.0",
+        "@bigcommerce/checkout-sdk": "^1.420.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1745,9 +1745,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.25.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.25.1.tgz",
-      "integrity": "sha512-5HdF8xdDSP7gUa8xXCYBuM6gmW7WtZds8r/GpdFYHZnZdCfhMGB3MHMk1PnERsSk7fsQXuc914yYigxLfuqI8g==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.0.tgz",
+      "integrity": "sha512-fODAOJqa0fAnBG58BX4KkkI6nTCgv7vZ3TX5943Ce7+VzYcQbuAJf7CXx0TFagr/Myp2UAnlTfUQqdHxPvA2iw==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -1756,11 +1756,11 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.417.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.417.0.tgz",
-      "integrity": "sha512-Htzsb9FE7i1lLGvYXsqjmc4DiEiTDAQFKEtJ3CnUBFKnceEc3eVjMC+8RgeOV2j6dtBHLAsRpkRUVAf9xUImXA==",
+      "version": "1.420.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.420.0.tgz",
+      "integrity": "sha512-Bv8+OLkyXgXRvRjwZV8h6CzxKJNUVeeV1lx1CUrEaisVfDhCbAwIAsTitu5OkOAvqRFgOiQuuI+cCbSjxRDASA==",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.25.1",
+        "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -9945,11 +9945,11 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
-      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.2.tgz",
+      "integrity": "sha512-BYCzImLos6J3BH/+HvUCHG1dTf2MzmAB4jaVxHV+29RZLjR29XuYTmsf2sdDwkrb+FczkGo3kOhE7ga6sI0P4A==",
       "dependencies": {
-        "@jest/transform": "^29.6.1",
+        "@jest/transform": "^29.6.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -9976,9 +9976,9 @@
       }
     },
     "node_modules/babel-jest/node_modules/@jest/transform": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
-      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.2.tgz",
+      "integrity": "sha512-ZqCqEISr58Ce3U+buNFJYUktLJZOggfyvR+bZMaiV1e8B1SIvJbwZMrYz3gx/KAPn9EXmOmN+uB08yLCjWkQQg==",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.1",
@@ -9988,9 +9988,9 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -10102,9 +10102,9 @@
       }
     },
     "node_modules/babel-jest/node_modules/jest-haste-map": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
-      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.2.tgz",
+      "integrity": "sha512-+51XleTDAAysvU8rT6AnS1ZJ+WHVNqhj1k6nTvN2PYP+HjU3kqlaKQ1Lnw3NYW3bm2r8vq82X0Z1nDDHZMzHVA==",
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@types/graceful-fs": "^4.1.3",
@@ -10113,8 +10113,8 @@
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.1",
-        "jest-worker": "^29.6.1",
+        "jest-util": "^29.6.2",
+        "jest-worker": "^29.6.2",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -10134,9 +10134,9 @@
       }
     },
     "node_modules/babel-jest/node_modules/jest-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.2.tgz",
+      "integrity": "sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==",
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@types/node": "*",
@@ -10150,12 +10150,12 @@
       }
     },
     "node_modules/babel-jest/node_modules/jest-worker": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
-      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.2.tgz",
+      "integrity": "sha512-l3ccBOabTdkng8I/ORCkADz4eSMKejTYv1vB/Z83UiubqhC1oQ5Li6dWCyqOIvSifGjUBxuvxvlm6KGK2DtuAQ==",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -35566,9 +35566,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.25.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.25.1.tgz",
-      "integrity": "sha512-5HdF8xdDSP7gUa8xXCYBuM6gmW7WtZds8r/GpdFYHZnZdCfhMGB3MHMk1PnERsSk7fsQXuc914yYigxLfuqI8g==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.0.tgz",
+      "integrity": "sha512-fODAOJqa0fAnBG58BX4KkkI6nTCgv7vZ3TX5943Ce7+VzYcQbuAJf7CXx0TFagr/Myp2UAnlTfUQqdHxPvA2iw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -35577,11 +35577,11 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.417.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.417.0.tgz",
-      "integrity": "sha512-Htzsb9FE7i1lLGvYXsqjmc4DiEiTDAQFKEtJ3CnUBFKnceEc3eVjMC+8RgeOV2j6dtBHLAsRpkRUVAf9xUImXA==",
+      "version": "1.420.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.420.0.tgz",
+      "integrity": "sha512-Bv8+OLkyXgXRvRjwZV8h6CzxKJNUVeeV1lx1CUrEaisVfDhCbAwIAsTitu5OkOAvqRFgOiQuuI+cCbSjxRDASA==",
       "requires": {
-        "@bigcommerce/bigpay-client": "^5.25.1",
+        "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -41937,11 +41937,11 @@
       }
     },
     "babel-jest": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
-      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.2.tgz",
+      "integrity": "sha512-BYCzImLos6J3BH/+HvUCHG1dTf2MzmAB4jaVxHV+29RZLjR29XuYTmsf2sdDwkrb+FczkGo3kOhE7ga6sI0P4A==",
       "requires": {
-        "@jest/transform": "^29.6.1",
+        "@jest/transform": "^29.6.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -41959,9 +41959,9 @@
           }
         },
         "@jest/transform": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
-          "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
+          "version": "29.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.2.tgz",
+          "integrity": "sha512-ZqCqEISr58Ce3U+buNFJYUktLJZOggfyvR+bZMaiV1e8B1SIvJbwZMrYz3gx/KAPn9EXmOmN+uB08yLCjWkQQg==",
           "requires": {
             "@babel/core": "^7.11.6",
             "@jest/types": "^29.6.1",
@@ -41971,9 +41971,9 @@
             "convert-source-map": "^2.0.0",
             "fast-json-stable-stringify": "^2.1.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.6.1",
+            "jest-haste-map": "^29.6.2",
             "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.6.1",
+            "jest-util": "^29.6.2",
             "micromatch": "^4.0.4",
             "pirates": "^4.0.4",
             "slash": "^3.0.0",
@@ -42052,9 +42052,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-haste-map": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
-          "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
+          "version": "29.6.2",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.2.tgz",
+          "integrity": "sha512-+51XleTDAAysvU8rT6AnS1ZJ+WHVNqhj1k6nTvN2PYP+HjU3kqlaKQ1Lnw3NYW3bm2r8vq82X0Z1nDDHZMzHVA==",
           "requires": {
             "@jest/types": "^29.6.1",
             "@types/graceful-fs": "^4.1.3",
@@ -42064,8 +42064,8 @@
             "fsevents": "^2.3.2",
             "graceful-fs": "^4.2.9",
             "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.6.1",
-            "jest-worker": "^29.6.1",
+            "jest-util": "^29.6.2",
+            "jest-worker": "^29.6.2",
             "micromatch": "^4.0.4",
             "walker": "^1.0.8"
           }
@@ -42076,9 +42076,9 @@
           "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg=="
         },
         "jest-util": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-          "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+          "version": "29.6.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.2.tgz",
+          "integrity": "sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==",
           "requires": {
             "@jest/types": "^29.6.1",
             "@types/node": "*",
@@ -42089,12 +42089,12 @@
           }
         },
         "jest-worker": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
-          "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
+          "version": "29.6.2",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.2.tgz",
+          "integrity": "sha512-l3ccBOabTdkng8I/ORCkADz4eSMKejTYv1vB/Z83UiubqhC1oQ5Li6dWCyqOIvSifGjUBxuvxvlm6KGK2DtuAQ==",
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.6.1",
+            "jest-util": "^29.6.2",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.417.0",
+    "@bigcommerce/checkout-sdk": "^1.420.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.test.tsx
@@ -1,5 +1,5 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
@@ -37,32 +37,9 @@ describe('BraintreeAcceleratedCheckoutPaymentMethod', () => {
         onUnhandledError: jest.fn(),
     };
 
-    it('initializes BraintreeAcceleratedCheckoutPaymentMethod with required props', () => {
-        const initializePayment = jest
-            .spyOn(checkoutService, 'initializePayment')
-            .mockResolvedValue(checkoutState);
-
+    it('main braintree axo container to be in the doc', () => {
         render(<BraintreeAcceleratedCheckoutPaymentMethod {...props} />);
 
-        expect(initializePayment).toHaveBeenCalledWith({
-            methodId: props.method.id,
-            braintreeacceleratedcheckout: {
-                container: '#braintree-axo-cc-form-container',
-            },
-        });
-    });
-
-    it('deinitializes BraintreeLocalMethod with required props', () => {
-        const deinitializePayment = jest
-            .spyOn(checkoutService, 'deinitializePayment')
-            .mockResolvedValue(checkoutState);
-
-        const view = render(<BraintreeAcceleratedCheckoutPaymentMethod {...props} />);
-
-        view.unmount();
-
-        expect(deinitializePayment).toHaveBeenCalledWith({
-            methodId: props.method.id,
-        });
+        expect(screen.getByTestId('braintree-axo-cc-form-container')).toBeInTheDocument();
     });
 });

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent } from 'react';
 
 import {
     PaymentMethodProps,
@@ -6,49 +6,10 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
-const BraintreeAcceleratedCheckoutPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
-    method,
-    checkoutService,
-    onUnhandledError,
-}) => {
-    const initializePayment = async () => {
-        try {
-            await checkoutService.initializePayment({
-                methodId: method.id,
-                braintreeacceleratedcheckout: {
-                    container: '#braintree-axo-cc-form-container',
-                },
-            });
-        } catch (error) {
-            if (error instanceof Error) {
-                onUnhandledError(error);
-            }
-        }
-    };
-
-    const deinitializePayment = async () => {
-        try {
-            await checkoutService.deinitializePayment({
-                methodId: method.id,
-            });
-        } catch (error) {
-            if (error instanceof Error) {
-                onUnhandledError(error);
-            }
-        }
-    };
-
-    useEffect(() => {
-        void initializePayment();
-
-        return () => {
-            void deinitializePayment();
-        };
-    }, []);
-
+const BraintreeAcceleratedCheckoutPaymentMethod: FunctionComponent<PaymentMethodProps> = () => {
     return (
         <div>
-            <div id="braintree-axo-cc-form-container" />
+            <div id="braintree-axo-cc-form-container" data-test="braintree-axo-cc-form-container" />
         </div>
     );
 };


### PR DESCRIPTION
## What?
Bump checkout-sdk version

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2095
https://github.com/bigcommerce/checkout-sdk-js/pull/2098
https://github.com/bigcommerce/checkout-sdk-js/pull/2099
https://github.com/bigcommerce/checkout-sdk-js/pull/2096
https://github.com/bigcommerce/checkout-sdk-js/pull/2088

## Why?
To keep checkout-sdk dependency up to date

## Testing / Proof
Manual tests
CI