### PR TITLE
chore(payment): PAYPAL-000 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.420.0",
+        "@bigcommerce/checkout-sdk": "^1.421.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.420.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.420.0.tgz",
-      "integrity": "sha512-Bv8+OLkyXgXRvRjwZV8h6CzxKJNUVeeV1lx1CUrEaisVfDhCbAwIAsTitu5OkOAvqRFgOiQuuI+cCbSjxRDASA==",
+      "version": "1.421.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.421.0.tgz",
+      "integrity": "sha512-Q1w5EVvQc3/ZdrFSNpJeQhiECWwOyFC3eURfOwnoZDjVF5OH2eqV0hGAS+zsrjBgymPKW2XIAer3ybZ5HTKtRw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.420.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.420.0.tgz",
-      "integrity": "sha512-Bv8+OLkyXgXRvRjwZV8h6CzxKJNUVeeV1lx1CUrEaisVfDhCbAwIAsTitu5OkOAvqRFgOiQuuI+cCbSjxRDASA==",
+      "version": "1.421.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.421.0.tgz",
+      "integrity": "sha512-Q1w5EVvQc3/ZdrFSNpJeQhiECWwOyFC3eURfOwnoZDjVF5OH2eqV0hGAS+zsrjBgymPKW2XIAer3ybZ5HTKtRw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.420.0",
+    "@bigcommerce/checkout-sdk": "^1.421.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2101

## Why?
To keep checkout sdk dependency version up to date

## Testing / Proof
Unit tests
Manual tests
CI
