### PR TITLE
chore(others): CHECKOUT-000 Update checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.421.0",
+        "@bigcommerce/checkout-sdk": "^1.421.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.421.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.421.0.tgz",
-      "integrity": "sha512-Q1w5EVvQc3/ZdrFSNpJeQhiECWwOyFC3eURfOwnoZDjVF5OH2eqV0hGAS+zsrjBgymPKW2XIAer3ybZ5HTKtRw==",
+      "version": "1.421.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.421.1.tgz",
+      "integrity": "sha512-KNdohSNtm6NZswBbTNJglyimsVLvebnlnfDnNghFUOAxbK0+5f2ciXeFaQvGCHI6DhRHyjm2s83FrfY+wgIBSQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -1786,8 +1786,8 @@
         "yup": "^1.2.0"
       },
       "engines": {
-        "node": "16",
-        "npm": "8"
+        "node": "18",
+        "npm": "9"
       }
     },
     "node_modules/@bigcommerce/checkout-sdk/node_modules/@bigcommerce/request-sender": {
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.421.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.421.0.tgz",
-      "integrity": "sha512-Q1w5EVvQc3/ZdrFSNpJeQhiECWwOyFC3eURfOwnoZDjVF5OH2eqV0hGAS+zsrjBgymPKW2XIAer3ybZ5HTKtRw==",
+      "version": "1.421.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.421.1.tgz",
+      "integrity": "sha512-KNdohSNtm6NZswBbTNJglyimsVLvebnlnfDnNghFUOAxbK0+5f2ciXeFaQvGCHI6DhRHyjm2s83FrfY+wgIBSQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.421.0",
+    "@bigcommerce/checkout-sdk": "^1.421.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
As above

## Why?
Update checkout sdk version to latest that bumps sdk dependencies to use node 18.

## Testing / Proof
CI

@bigcommerce/checkout
