### PR TITLE
feat(payment): PAYPAL-2733 PayPalAxo Billing step

### DIFF
--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -21,6 +21,7 @@ import {
     isValidCustomerAddress,
     mapAddressToFormValues,
 } from '../address';
+import { usePayPalConnectAddress } from '../address/PayPalAxo';
 import { getCustomFormFieldsValidationSchema } from '../formFields';
 import { OrderComments } from '../orderComments';
 import { Button, ButtonVariant } from '../ui/button';
@@ -66,6 +67,7 @@ const BillingForm = ({
 }: BillingFormProps & WithLanguageProps & FormikProps<BillingFormValues>) => {
     const [isResettingAddress, setIsResettingAddress] = useState(false);
     const addressFormRef: RefObject<HTMLFieldSetElement> = useRef(null);
+    const { isPayPalAxoEnabled, mergedBcAndPayPalConnectAddresses } = usePayPalConnectAddress();
 
     const shouldRenderStaticAddress = methodId === 'amazonpay';
     const allFormFields = getFields(values.countryCode);
@@ -73,12 +75,13 @@ const BillingForm = ({
     const hasCustomFormFields = customFormFields.length > 0;
     const editableFormFields =
         shouldRenderStaticAddress && hasCustomFormFields ? customFormFields : allFormFields;
-    const hasAddresses = addresses?.length > 0;
+    const billingAddresses = isPayPalAxoEnabled ? mergedBcAndPayPalConnectAddresses : addresses;
+    const hasAddresses = billingAddresses?.length > 0;
     const hasValidCustomerAddress =
         billingAddress &&
         isValidCustomerAddress(
             billingAddress,
-            addresses,
+            billingAddresses,
             getFields(billingAddress.countryCode),
         );
 
@@ -113,7 +116,7 @@ const BillingForm = ({
                     <Fieldset id="billingAddresses">
                         <LoadingOverlay isLoading={isResettingAddress}>
                             <AddressSelect
-                                addresses={addresses}
+                                addresses={billingAddresses}
                                 onSelectAddress={handleSelectAddress}
                                 onUseNewAddress={handleUseNewAddress}
                                 selectedAddress={

--- a/packages/core/src/app/billing/StaticBillingAddress.tsx
+++ b/packages/core/src/app/billing/StaticBillingAddress.tsx
@@ -5,6 +5,7 @@ import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
 
 import { AddressType, StaticAddress } from '../address';
+import { isPayPalConnectAddress, PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '../address/PayPalAxo';
 import { withCheckout } from '../checkout';
 import { EMPTY_ARRAY } from '../common/utility';
 
@@ -20,6 +21,9 @@ interface WithCheckoutStaticBillingAddressProps {
 const StaticBillingAddress: FunctionComponent<
     StaticBillingAddressProps & WithCheckoutStaticBillingAddressProps
 > = ({ address, payments = EMPTY_ARRAY }) => {
+    const { isPayPalAxoEnabled, paypalConnectAddresses } = usePayPalConnectAddress();
+    const showPayPalConnectAddressLabel = isPayPalAxoEnabled && isPayPalConnectAddress(address, paypalConnectAddresses);
+
     if (payments.find((payment) => payment.providerId === 'amazonpay')) {
         return (
             <p>
@@ -28,7 +32,13 @@ const StaticBillingAddress: FunctionComponent<
         );
     }
 
-    return <StaticAddress address={address} type={AddressType.Billing} />;
+    return (
+        <>
+            <StaticAddress address={address} type={AddressType.Billing} />
+
+            {showPayPalConnectAddressLabel && <PoweredByPaypalConnectLabel />}
+        </>
+    );
 };
 
 export function mapToStaticBillingAddressProps(


### PR DESCRIPTION
## What?
Add labels for PayPal Connect addresses on Billing step

## Why?
We need to show for shoppers addresses which we get from PayPal Connect.

## Testing / Proof

https://github.com/bigcommerce/checkout-js/assets/9430298/d2487985-c33d-4664-98bf-0d30532a605d

Unit and manually tested

@bigcommerce/checkout
