### PR TITLE
chore(payment): PAYPAL-2827 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.423.0",
+        "@bigcommerce/checkout-sdk": "^1.424.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.423.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.423.0.tgz",
-      "integrity": "sha512-T23ZjgY6GXjeY4QAn+OimxalGdAzBP9884SyO3978id15TB37sEWlWQfxU4eOTrb3o0Igva+bhxSiLkXuRtFFQ==",
+      "version": "1.424.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.424.0.tgz",
+      "integrity": "sha512-u5sUzKh7muKbx2T0uQhmtiJ0uLwqWmFYZJ0irh722uvLmN0hvCk1esQ+pRpK0ED2IUFyInGVDVptvsnGf/9JpQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.423.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.423.0.tgz",
-      "integrity": "sha512-T23ZjgY6GXjeY4QAn+OimxalGdAzBP9884SyO3978id15TB37sEWlWQfxU4eOTrb3o0Igva+bhxSiLkXuRtFFQ==",
+      "version": "1.424.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.424.0.tgz",
+      "integrity": "sha512-u5sUzKh7muKbx2T0uQhmtiJ0uLwqWmFYZJ0irh722uvLmN0hvCk1esQ+pRpK0ED2IUFyInGVDVptvsnGf/9JpQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.423.0",
+    "@bigcommerce/checkout-sdk": "^1.424.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

Release contains changes from checkout sdk:
https://github.com/bigcommerce/checkout-sdk-js/pull/2108

## Why?
To keep checkout sdk dependency up to date

## Testing / Proof
Unit tests
Manual tests
QA tests
CI