### PR TITLE
feat(payment): PAYPAL-2732 Addresses components

### DIFF
--- a/packages/core/src/app/address/AddressSelect.spec.tsx
+++ b/packages/core/src/app/address/AddressSelect.spec.tsx
@@ -12,7 +12,10 @@ import { getCustomer } from '../customer/customers.mock';
 
 import { getAddress } from './address.mock';
 import AddressSelect from './AddressSelect';
+import * as usePayPalConnectAddress from './PayPalAxo/usePayPalConnectAddress';
 import StaticAddress from './StaticAddress';
+
+jest.mock('./PayPalAxo/PoweredByPaypalConnectLabel', () => () => (<div data-test="powered-by-pp-connect-label">PoweredByPaypalConnectLabel</div>));
 
 describe('AddressSelect Component', () => {
     let checkoutService: CheckoutService;
@@ -25,6 +28,12 @@ describe('AddressSelect Component', () => {
 
         jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(getCheckout());
         jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
+        jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                isPayPalConnectAddress: () => false,
+                shouldShowPayPalConnectLabel: () => false,
+            }))
+        );
     });
 
     it('renders `Enter Address` when there is no selected address', () => {
@@ -128,5 +137,28 @@ describe('AddressSelect Component', () => {
         component.find('#addressDropdown li:last-child a').simulate('click');
 
         expect(onSelectAddress).not.toHaveBeenCalled();
+    });
+
+    it('shows Powered By PP Connect label', () => {
+        jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                isPayPalConnectAddress: () => false,
+                shouldShowPayPalConnectLabel: () => true,
+            }))
+        );
+
+        component = mount(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <AddressSelect
+                        addresses={getCustomer().addresses}
+                        onSelectAddress={noop}
+                        onUseNewAddress={noop}
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>,
+        );
+
+        expect(component.find('[data-test="powered-by-pp-connect-label"]').text()).toBe('PoweredByPaypalConnectLabel');
     });
 });

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -1,63 +1,23 @@
 import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
-import React, { FunctionComponent, memo, PureComponent, ReactNode } from 'react';
+import React, { FunctionComponent, memo } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
 import { preventDefault } from '../common/dom';
 import { DropdownTrigger } from '../ui/dropdown';
 
-import isEqualAddress from './isEqualAddress';
-import './AddressSelect.scss';
 import AddressSelectButton from './AddressSelectButton';
+import isEqualAddress from './isEqualAddress';
+import { PoweredByPaypalConnectLabel, usePayPalConnectAddress } from './PayPalAxo';
 import StaticAddress from './StaticAddress';
+
+import './AddressSelect.scss';
 
 export interface AddressSelectProps {
     addresses: CustomerAddress[];
     selectedAddress?: Address;
     onSelectAddress(address: Address): void;
     onUseNewAddress(currentAddress?: Address): void;
-}
-
-class AddressSelect extends PureComponent<AddressSelectProps> {
-    render(): ReactNode {
-        const { addresses, selectedAddress } = this.props;
-
-        return (
-            <div className="form-field">
-                <div className="dropdown--select">
-                    <DropdownTrigger
-                        dropdown={
-                            <AddressSelectMenu
-                                addresses={addresses}
-                                onSelectAddress={this.handleSelectAddress}
-                                onUseNewAddress={this.handleUseNewAddress}
-                                selectedAddress={selectedAddress}
-                            />
-                        }
-                    >
-                        <AddressSelectButton
-                            addresses={addresses}
-                            selectedAddress={selectedAddress}
-                        />
-                    </DropdownTrigger>
-                </div>
-            </div>
-        );
-    }
-
-    private handleSelectAddress: (newAddress: Address) => void = (newAddress: Address) => {
-        const { onSelectAddress, selectedAddress } = this.props;
-
-        if (!isEqualAddress(selectedAddress, newAddress)) {
-            onSelectAddress(newAddress);
-        }
-    };
-
-    private handleUseNewAddress: () => void = () => {
-        const { selectedAddress, onUseNewAddress } = this.props;
-
-        onUseNewAddress(selectedAddress);
-    };
 }
 
 const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({
@@ -79,11 +39,54 @@ const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({
         {addresses.map((address) => (
             <li className="dropdown-menu-item dropdown-menu-item--select" key={address.id}>
                 <a href="#" onClick={preventDefault(() => onSelectAddress(address))}>
-                    <StaticAddress address={address} />
+                    <StaticAddress address={address} showProviderIcon />
                 </a>
             </li>
         ))}
     </ul>
 );
+
+const AddressSelect = ({
+    addresses,
+    selectedAddress,
+    onSelectAddress,
+    onUseNewAddress,
+}: AddressSelectProps) => {
+    const { shouldShowPayPalConnectLabel } = usePayPalConnectAddress();
+
+    const handleSelectAddress = (newAddress: Address) => {
+        if (!isEqualAddress(selectedAddress, newAddress)) {
+            onSelectAddress(newAddress);
+        }
+    };
+
+    const handleUseNewAddress = () => {
+        onUseNewAddress(selectedAddress);
+    };
+
+    return (
+        <div className="form-field">
+            <div className="dropdown--select">
+                <DropdownTrigger
+                    dropdown={
+                        <AddressSelectMenu
+                            addresses={addresses}
+                            onSelectAddress={handleSelectAddress}
+                            onUseNewAddress={handleUseNewAddress}
+                            selectedAddress={selectedAddress}
+                        />
+                    }
+                >
+                    <AddressSelectButton
+                        addresses={addresses}
+                        selectedAddress={selectedAddress}
+                    />
+                </DropdownTrigger>
+            </div>
+
+            {shouldShowPayPalConnectLabel() && <PoweredByPaypalConnectLabel />}
+        </div>
+    );
+}
 
 export default memo(AddressSelect);

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -27,7 +27,7 @@ const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLang
             onBlur={() => setAriaExpanded(false)}
         >
             {selectedAddress ? (
-                <StaticAddress address={selectedAddress} />
+                <StaticAddress address={selectedAddress} showProviderIcon />
             ) : (
                 <TranslatedString id="address.enter_address_action" />
             )}

--- a/packages/core/src/app/address/PayPalAxo/index.ts
+++ b/packages/core/src/app/address/PayPalAxo/index.ts
@@ -1,0 +1,2 @@
+export {default as PoweredByPaypalConnectLabel} from './PoweredByPaypalConnectLabel';
+export {default as usePayPalConnectAddress} from './usePayPalConnectAddress';

--- a/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.test.tsx
+++ b/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.test.tsx
@@ -1,0 +1,194 @@
+import { Address, CustomerAddress, PaymentProviderCustomer } from '@bigcommerce/checkout-sdk';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import * as PaymentIntegrationApi from '@bigcommerce/checkout/payment-integration-api';
+import { getAddress, getCustomer, getStoreConfig } from '@bigcommerce/checkout/test-utils';
+
+import { getBillingAddress } from '../../billing/billingAddresses.mock';
+import { PaymentMethodId } from '../../payment/paymentMethod';
+
+import usePayPalConnectAddress from './usePayPalConnectAddress';
+
+interface PayPalAxoAddressComponentProps {
+    selectedAddress: Address;
+    addresses: CustomerAddress[];
+}
+
+const PayPalAxoAddressComponent = ({
+    selectedAddress,
+    addresses = [],
+}: PayPalAxoAddressComponentProps) => {
+    const {
+        isPayPalConnectAddress,
+        shouldShowPayPalConnectLabel,
+        mergeWithPayPalAddresses,
+    } = usePayPalConnectAddress();
+    const mergedAddresses = mergeWithPayPalAddresses(addresses);
+
+    return (
+        <>
+            <div data-test="isPayPalConnectAddress">
+                {isPayPalConnectAddress(selectedAddress) ? 'true' : 'false'}
+            </div>
+            <div data-test="shouldShowPayPalConnectLabel">
+                {shouldShowPayPalConnectLabel() ? 'true' : 'false'}
+            </div>
+            <ul>
+                {mergedAddresses.map((address, index) => (
+                    <li key={index}>{address.address1}</li>
+                ))}
+            </ul>
+        </>
+    );
+};
+
+describe('usePayPalConnectAddress', () => {
+    const defaultStoreConfig = getStoreConfig();
+    const defaultBillingAddress = getBillingAddress();
+    const defaultCustomer = getCustomer()
+
+    const useCheckoutMock = (
+        paymentProviderCustomer: PaymentProviderCustomer,
+        billingEmail?: string,
+        customerEmail?: string,
+        providerWithCustomCheckout = PaymentMethodId.BraintreeAcceleratedCheckout,
+    ) => {
+        jest.spyOn(PaymentIntegrationApi, 'useCheckout').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                checkoutState: {
+                    data: {
+                        getPaymentProviderCustomer: () => paymentProviderCustomer,
+                        getBillingAddress: () => ({
+                            ...defaultBillingAddress,
+                            email: billingEmail,
+                        }),
+                        getConfig: () => ({
+                            ...defaultStoreConfig,
+                            checkoutSettings: {
+                                ...defaultStoreConfig.checkoutSettings,
+                                providerWithCustomCheckout
+                            },
+                        }),
+                        getCustomer: () => ({
+                            ...defaultCustomer,
+                            email: customerEmail,
+                        }),
+                    }
+                }
+            }))
+        );
+    };
+
+
+    const defaultAdderss = getAddress();
+    const addressBC1 = {
+        ...defaultAdderss,
+        id: 1,
+        type: 'not-paypal',
+        address1: 'address-BC1',
+    };
+    const addressBC2 = {
+        ...defaultAdderss,
+        id: 2,
+        address1: 'address-BC2-PP1',
+    } as CustomerAddress;
+    const addressPP1 = {
+        ...addressBC2,
+        id: 3,
+    };
+    const addressPP2 = {
+        ...defaultAdderss,
+        id: 4,
+        type: 'paypal-address',
+        address1: 'address-PP2',
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders with BC addresses & no PP Connect addresses, selected BC address', () => {
+        useCheckoutMock({});
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[addressBC1, addressBC2]}
+                selectedAddress={addressBC1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('false');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('false');
+        expect(addressItems).toHaveLength(2);
+        expect(addressItems[0]).toHaveTextContent('address-BC1');
+        expect(addressItems[1]).toHaveTextContent('address-BC2-PP1');
+    });
+
+    it('renders with PP Connect addresses & no BC addresses, selected PP address', () => {
+        useCheckoutMock({
+            addresses: [addressPP1, addressPP2],
+        });
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[]}
+                selectedAddress={addressPP1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('true');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('true');
+        expect(addressItems).toHaveLength(2);
+        expect(addressItems[0]).toHaveTextContent('address-BC2-PP1');
+        expect(addressItems[1]).toHaveTextContent('address-PP2');
+    });
+
+    it('renders with BC addresses & PP Connect address, selected BC address', () => {
+        useCheckoutMock({
+            addresses: [addressPP2],
+        });
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[addressBC1, addressBC2]}
+                selectedAddress={addressBC1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('false');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('true');
+        expect(addressItems).toHaveLength(3);
+        expect(addressItems[0]).toHaveTextContent('address-PP2');
+        expect(addressItems[1]).toHaveTextContent('address-BC1');
+        expect(addressItems[2]).toHaveTextContent('address-BC2-PP1');
+    });
+
+    it('renders with BC addresses & PP Connect address - with address merge, selected PP address', () => {
+        useCheckoutMock({
+            addresses: [addressPP1, addressPP2],
+        });
+
+        render(
+            <PayPalAxoAddressComponent
+                addresses={[addressBC1, addressBC2]}
+                selectedAddress={addressPP1}
+            />
+        );
+
+        const addressItems = screen.getAllByRole('listitem');
+
+        expect(screen.getByTestId('isPayPalConnectAddress')).toHaveTextContent('true');
+        expect(screen.getByTestId('shouldShowPayPalConnectLabel')).toHaveTextContent('true');
+        expect(addressItems).toHaveLength(3);
+        expect(addressItems[0]).toHaveTextContent('address-BC2-PP1');
+        expect(addressItems[1]).toHaveTextContent('address-PP2');
+        expect(addressItems[2]).toHaveTextContent('address-BC1');
+    });
+});

--- a/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
+++ b/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
@@ -1,0 +1,78 @@
+import { Address, CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
+
+import { PaymentMethodId } from '../../payment/paymentMethod';
+import isEqualAddress from '../isEqualAddress';
+
+const PAYPAL_ADDRESS_TYPE = 'paypal-address';
+const PAYPAL_CONNECT_CUSTOMER_KEY = 'paypal-connect.customer';
+
+const usePayPalConnectAddress = () => {
+    const {
+        checkoutState: {
+            data: {
+                getBillingAddress,
+                getConfig,
+                getCustomer,
+                getPaymentProviderCustomer,
+            }
+        }
+    } = useCheckout();
+    const providerWithCustomCheckout = getConfig()?.checkoutSettings?.providerWithCustomCheckout;
+    const isPayPalAxoEnabled = providerWithCustomCheckout === PaymentMethodId.BraintreeAcceleratedCheckout
+        || providerWithCustomCheckout === PaymentMethodId.Braintree;
+
+    const getPaypalConnectAddresses = (): CustomerAddress[] => {
+        if (!isPayPalAxoEnabled) {
+            return [];
+        }
+
+        let addresses = getPaymentProviderCustomer()?.addresses;
+
+        if (!addresses?.length) {
+            const storedPayPalConnectCustomer = localStorage.getItem(PAYPAL_CONNECT_CUSTOMER_KEY);
+
+            if (!storedPayPalConnectCustomer) {
+                return [];
+            }
+
+            const { email: storedEmail, addresses: storedAddresses } = JSON.parse(storedPayPalConnectCustomer) || {};
+            const customerEmail = getCustomer()?.email || getBillingAddress()?.email;
+
+            addresses = customerEmail === storedEmail ? storedAddresses : [];
+        }
+
+        return addresses || [];
+    };
+
+    const isPayPalConnectAddress = (address: CustomerAddress | Address): boolean => {
+        if (!isPayPalAxoEnabled) {
+            return false;
+        }
+
+        if ('type' in address) {
+            return address.type === PAYPAL_ADDRESS_TYPE;
+        }
+
+        return getPaypalConnectAddresses().some(
+            (paypalConnectAddress) => isEqualAddress(address, paypalConnectAddress)
+        );
+    };
+
+    const shouldShowPayPalConnectLabel = (): boolean => isPayPalAxoEnabled && !!getPaypalConnectAddresses().length;
+
+    const mergeWithPayPalAddresses = (customerAddresses: CustomerAddress[]): CustomerAddress[] => [
+        ...getPaypalConnectAddresses(),
+        ...customerAddresses.filter((address) => !isPayPalConnectAddress(address)),
+    ];
+
+    return {
+        isPayPalAxoEnabled,
+        isPayPalConnectAddress,
+        shouldShowPayPalConnectLabel,
+        mergeWithPayPalAddresses,
+    };
+};
+
+export default usePayPalConnectAddress;

--- a/packages/core/src/app/address/StaticAddress.scss
+++ b/packages/core/src/app/address/StaticAddress.scss
@@ -1,5 +1,18 @@
 .checkout-address--static {
+    $icon-size: 1.85rem;
+
+    position: relative;
+
     .address-entry {
         margin: 0;
+        padding-right: $icon-size;
+    }
+
+    .icon {
+        width: $icon-size;
+        height: $icon-size;
+        position: absolute;
+        top: 0;
+        right: 0;
     }
 }

--- a/packages/core/src/app/address/StaticAddress.spec.tsx
+++ b/packages/core/src/app/address/StaticAddress.spec.tsx
@@ -13,7 +13,13 @@ import { getCountries } from '../geography/countries.mock';
 import { getAddress } from './address.mock';
 import AddressType from './AddressType';
 import { getAddressFormFields } from './formField.mock';
+import * as usePayPalConnectAddress from './PayPalAxo/usePayPalConnectAddress';
 import StaticAddress, { StaticAddressProps } from './StaticAddress';
+
+jest.mock('@bigcommerce/checkout/ui', () => ({
+    ...jest.requireActual('@bigcommerce/checkout/ui'),
+    IconPayPalConnectSmall: () => (<div data-test="pp-connect-icon">IconPayPalConnectSmall</div>)
+}));
 
 describe('StaticAddress Component', () => {
     let StaticAddressTest: FunctionComponent<StaticAddressProps>;
@@ -37,6 +43,12 @@ describe('StaticAddress Component', () => {
 
         jest.spyOn(checkoutState.data, 'getShippingAddressFields').mockReturnValue(
             getAddressFormFields(),
+        );
+
+        jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+            jest.fn().mockImplementation(() => ({
+                isPayPalConnectAddress: () => false,
+            }))
         );
 
         StaticAddressTest = (props) => (
@@ -146,5 +158,63 @@ describe('StaticAddress Component', () => {
         );
 
         expect(container.html()).not.toBe('');
+    });
+
+    describe('provider icon', () => {
+        it('should not show icon', () => {
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={false}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
+        });
+
+        it('should show icon, but address is not from PP Connect', () => {
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={true}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
+        });
+
+        it('should not show icon, but address is from PP Connect', () => {
+            jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+                jest.fn().mockImplementation(() => ({
+                    isPayPalConnectAddress: () => true,
+                }))
+            );
+
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={false}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
+        });
+
+        it('should show icon for PP Connect address', () => {
+            jest.spyOn(usePayPalConnectAddress, 'default').mockImplementation(
+                jest.fn().mockImplementation(() => ({
+                    isPayPalConnectAddress: () => true,
+                }))
+            );
+
+            const container = render(
+                <StaticAddressTest
+                    {...defaultProps}
+                    showProviderIcon={true}
+                />
+            );
+
+            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(1);
+        });
     });
 });

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -9,6 +9,7 @@ import { isEmpty } from 'lodash';
 import React, { FunctionComponent, memo } from 'react';
 
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
+import { IconPayPalConnectSmall } from '@bigcommerce/checkout/ui';
 
 import { withCheckout } from '../checkout';
 
@@ -16,9 +17,11 @@ import AddressType from './AddressType';
 import isValidAddress from './isValidAddress';
 import localizeAddress from './localizeAddress';
 import './StaticAddress.scss';
+import { usePayPalConnectAddress } from './PayPalAxo';
 
 export interface StaticAddressProps {
     address: Address;
+    showProviderIcon?: boolean;
     type?: AddressType;
 }
 
@@ -33,7 +36,8 @@ interface WithCheckoutStaticAddressProps {
 
 const StaticAddress: FunctionComponent<
     StaticAddressEditableProps & WithCheckoutStaticAddressProps
-> = ({ countries, fields, address: addressWithoutLocalization }) => {
+> = ({ countries, fields, address: addressWithoutLocalization, showProviderIcon }) => {
+    const { isPayPalConnectAddress } = usePayPalConnectAddress();
     const address = localizeAddress(addressWithoutLocalization, countries);
     const isValid = !fields
         ? !isEmpty(address)
@@ -41,9 +45,13 @@ const StaticAddress: FunctionComponent<
               address,
               fields.filter((field) => !field.custom),
           );
+    const shouldShowProviderIcon = showProviderIcon && isPayPalConnectAddress(addressWithoutLocalization);
 
     return !isValid ? null : (
         <div className="vcard checkout-address--static">
+
+            {shouldShowProviderIcon && <IconPayPalConnectSmall />}
+
             {(address.firstName || address.lastName) && (
                 <p className="fn address-entry">
                     <span className="first-name">{`${address.firstName} `}</span>

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -17,6 +17,7 @@ enum PaymentMethodId {
     BraintreeVenmo = 'braintreevenmo',
     AuthorizeNetGooglePay = 'googlepayauthorizenet',
     BNZGooglePay = 'googlepaybnz',
+    BraintreeAcceleratedCheckout = 'braintreeacceleratedcheckout',
     BraintreeGooglePay = 'googlepaybraintree',
     BraintreeVisaCheckout = 'braintreevisacheckout',
     BraintreeLocalPaymentMethod = 'braintreelocalmethods',

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -14,9 +14,11 @@ import {
     ShippingInitializeOptions,
     ShippingRequestOptions,
 } from '@bigcommerce/checkout-sdk';
-import React, { Component, ReactNode } from 'react';
+import React from 'react';
 
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
+
+import { usePayPalConnectAddress } from '../address/PayPalAxo';
 
 import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm';
 import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
@@ -60,98 +62,101 @@ export interface ShippingFormProps {
     ): Promise<CheckoutSelectors>;
 }
 
-class ShippingForm extends Component<ShippingFormProps & WithLanguageProps> {
-    render(): ReactNode {
-        const {
-            addresses,
-            assignItem,
-            cart,
-            cartHasChanged,
-            createCustomerAddress,
-            consignments,
-            countries,
-            countriesWithAutocomplete,
-            onCreateAccount,
-            customerMessage,
-            deinitialize,
-            deleteConsignments,
-            getFields,
-            googleMapsApiKey,
-            initialize,
-            isBillingSameAsShipping,
-            isGuest,
-            isLoading,
-            isMultiShippingMode,
-            methodId,
-            onMultiShippingSubmit,
-            onSignIn,
-            onSingleShippingSubmit,
-            onUnhandledError,
-            onUseNewAddress,
-            shippingAddress,
-            shouldShowOrderComments,
-            shouldShowSaveAddress,
-            shouldShowAddAddressInCheckout,
-            signOut,
-            updateAddress,
-            isShippingStepPending,
-            isFloatingLabelEnabled,
-        } = this.props;
+const ShippingForm = ({
+    addresses,
+    assignItem,
+    cart,
+    cartHasChanged,
+    createCustomerAddress,
+    consignments,
+    countries,
+    countriesWithAutocomplete,
+    onCreateAccount,
+    customerMessage,
+    deinitialize,
+    deleteConsignments,
+    getFields,
+    googleMapsApiKey,
+    initialize,
+    isBillingSameAsShipping,
+    isGuest,
+    isLoading,
+    isMultiShippingMode,
+    methodId,
+    onMultiShippingSubmit,
+    onSignIn,
+    onSingleShippingSubmit,
+    onUnhandledError,
+    onUseNewAddress,
+    shippingAddress,
+    shouldShowOrderComments,
+    shouldShowSaveAddress,
+    shouldShowAddAddressInCheckout,
+    signOut,
+    updateAddress,
+    isShippingStepPending,
+    isFloatingLabelEnabled,
+}: ShippingFormProps & WithLanguageProps) => {
+    const { isPayPalAxoEnabled, mergeWithPayPalAddresses } = usePayPalConnectAddress();
+    let addressesToShow = addresses;
 
-        return isMultiShippingMode ? (
-            <MultiShippingForm
-                addresses={addresses}
-                assignItem={assignItem}
-                cart={cart}
-                cartHasChanged={cartHasChanged}
-                consignments={consignments}
-                countries={countries}
-                countriesWithAutocomplete={countriesWithAutocomplete}
-                createCustomerAddress={createCustomerAddress}
-                customerMessage={customerMessage}
-                defaultCountryCode={shippingAddress?.countryCode}
-                getFields={getFields}
-                googleMapsApiKey={googleMapsApiKey}
-                isFloatingLabelEnabled={isFloatingLabelEnabled}
-                isGuest={isGuest}
-                isLoading={isLoading}
-                onCreateAccount={onCreateAccount}
-                onSignIn={onSignIn}
-                onSubmit={onMultiShippingSubmit}
-                onUnhandledError={onUnhandledError}
-                onUseNewAddress={onUseNewAddress}
-                shouldShowAddAddressInCheckout={shouldShowAddAddressInCheckout}
-                shouldShowOrderComments={shouldShowOrderComments}
-            />
-        ) : (
-            <SingleShippingForm
-                addresses={addresses}
-                cartHasChanged={cartHasChanged}
-                consignments={consignments}
-                countries={countries}
-                countriesWithAutocomplete={countriesWithAutocomplete}
-                customerMessage={customerMessage}
-                deinitialize={deinitialize}
-                deleteConsignments={deleteConsignments}
-                getFields={getFields}
-                googleMapsApiKey={googleMapsApiKey}
-                initialize={initialize}
-                isBillingSameAsShipping={isBillingSameAsShipping}
-                isFloatingLabelEnabled={isFloatingLabelEnabled}
-                isLoading={isLoading}
-                isMultiShippingMode={isMultiShippingMode}
-                isShippingStepPending={isShippingStepPending}
-                methodId={methodId}
-                onSubmit={onSingleShippingSubmit}
-                onUnhandledError={onUnhandledError}
-                shippingAddress={shippingAddress}
-                shouldShowOrderComments={shouldShowOrderComments}
-                shouldShowSaveAddress={shouldShowSaveAddress}
-                signOut={signOut}
-                updateAddress={updateAddress}
-            />
-        );
+    if (isPayPalAxoEnabled) {
+        addressesToShow = mergeWithPayPalAddresses(addresses);
     }
-}
+
+    return isMultiShippingMode ? (
+        <MultiShippingForm
+            addresses={addressesToShow}
+            assignItem={assignItem}
+            cart={cart}
+            cartHasChanged={cartHasChanged}
+            consignments={consignments}
+            countries={countries}
+            countriesWithAutocomplete={countriesWithAutocomplete}
+            createCustomerAddress={createCustomerAddress}
+            customerMessage={customerMessage}
+            defaultCountryCode={shippingAddress?.countryCode}
+            getFields={getFields}
+            googleMapsApiKey={googleMapsApiKey}
+            isFloatingLabelEnabled={isFloatingLabelEnabled}
+            isGuest={isGuest}
+            isLoading={isLoading}
+            onCreateAccount={onCreateAccount}
+            onSignIn={onSignIn}
+            onSubmit={onMultiShippingSubmit}
+            onUnhandledError={onUnhandledError}
+            onUseNewAddress={onUseNewAddress}
+            shouldShowAddAddressInCheckout={shouldShowAddAddressInCheckout}
+            shouldShowOrderComments={shouldShowOrderComments}
+        />
+    ) : (
+        <SingleShippingForm
+            addresses={addressesToShow}
+            cartHasChanged={cartHasChanged}
+            consignments={consignments}
+            countries={countries}
+            countriesWithAutocomplete={countriesWithAutocomplete}
+            customerMessage={customerMessage}
+            deinitialize={deinitialize}
+            deleteConsignments={deleteConsignments}
+            getFields={getFields}
+            googleMapsApiKey={googleMapsApiKey}
+            initialize={initialize}
+            isBillingSameAsShipping={isBillingSameAsShipping}
+            isFloatingLabelEnabled={isFloatingLabelEnabled}
+            isLoading={isLoading}
+            isMultiShippingMode={isMultiShippingMode}
+            isShippingStepPending={isShippingStepPending}
+            methodId={methodId}
+            onSubmit={onSingleShippingSubmit}
+            onUnhandledError={onUnhandledError}
+            shippingAddress={shippingAddress}
+            shouldShowOrderComments={shouldShowOrderComments}
+            shouldShowSaveAddress={shouldShowSaveAddress}
+            signOut={signOut}
+            updateAddress={updateAddress}
+        />
+    );
+};
 
 export default withLanguage(ShippingForm);

--- a/packages/core/src/app/shipping/StaticConsignment.spec.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.spec.tsx
@@ -1,5 +1,8 @@
+import { createCheckoutService } from '@bigcommerce/checkout-sdk';
 import { render } from 'enzyme';
 import React from 'react';
+
+import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getCart } from '../cart/carts.mock';
 
@@ -9,16 +12,23 @@ import StaticConsignment from './StaticConsignment';
 describe('StaticConsignment Component', () => {
     const consignment = getConsignment();
     const cart = getCart();
+    const checkoutService = createCheckoutService();
 
     it('renders static consignment with shipping method', () => {
-        const tree = render(<StaticConsignment cart={cart} consignment={consignment} />);
+        const tree = render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <StaticConsignment cart={cart} consignment={consignment} />
+            </CheckoutProvider>
+        );
 
         expect(tree).toMatchSnapshot();
     });
 
     it('renders compact view of static consignment', () => {
         const tree = render(
-            <StaticConsignment cart={cart} compactView consignment={consignment} />,
+            <CheckoutProvider checkoutService={checkoutService}>
+                <StaticConsignment cart={cart} compactView consignment={consignment} />
+            </CheckoutProvider>
         );
 
         expect(tree).toMatchSnapshot();

--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -2,6 +2,7 @@ import { Cart, Consignment } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, memo } from 'react';
 
 import { AddressType, StaticAddress } from '../address';
+import { PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '../address/PayPalAxo';
 
 import { StaticShippingOption } from './shippingOption';
 import './StaticConsignment.scss';
@@ -18,11 +19,14 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
     cart,
     compactView,
 }) => {
+    const { isPayPalConnectAddress } = usePayPalConnectAddress();
     const { shippingAddress: address, selectedShippingOption } = consignment;
 
     return (
         <div className="staticConsignment">
             <StaticAddress address={address} type={AddressType.Shipping} />
+
+            {isPayPalConnectAddress(address) && <PoweredByPaypalConnectLabel />}
 
             {!compactView && <StaticConsignmentItemList cart={cart} consignment={consignment} />}
 

--- a/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
+++ b/packages/core/src/app/shipping/__snapshots__/StaticConsignment.spec.tsx.snap
@@ -4,6 +4,75 @@ exports[`StaticConsignment Component renders compact view of static consignment 
 <div
   class="staticConsignment"
 >
+  <div
+    class="vcard checkout-address--static"
+  >
+    <p
+      class="fn address-entry"
+    >
+      <span
+        class="first-name"
+      >
+        Test 
+      </span>
+      <span
+        class="family-name"
+      >
+        Tester
+      </span>
+    </p>
+    <p
+      class="address-entry"
+    >
+      <span
+        class="company-name"
+      >
+        Bigcommerce 
+      </span>
+      <span
+        class="tel"
+      >
+        555-555-5555
+      </span>
+    </p>
+    <div
+      class="adr"
+    >
+      <p
+        class="street-address address-entry"
+      >
+        <span
+          class="address-line-1"
+        >
+          12345 Testing Way 
+        </span>
+      </p>
+      <p
+        class="address-entry"
+      >
+        <span
+          class="locality"
+        >
+          Some City, 
+        </span>
+        <span
+          class="region"
+        >
+          California, 
+        </span>
+        <span
+          class="postal-code"
+        >
+          95555 / 
+        </span>
+        <span
+          class="country-name"
+        >
+          United States 
+        </span>
+      </p>
+    </div>
+  </div>
   <div>
     <div
       class="shippingOption shippingOption--alt shippingOption--selected"
@@ -29,6 +98,75 @@ exports[`StaticConsignment Component renders static consignment with shipping me
 <div
   class="staticConsignment"
 >
+  <div
+    class="vcard checkout-address--static"
+  >
+    <p
+      class="fn address-entry"
+    >
+      <span
+        class="first-name"
+      >
+        Test 
+      </span>
+      <span
+        class="family-name"
+      >
+        Tester
+      </span>
+    </p>
+    <p
+      class="address-entry"
+    >
+      <span
+        class="company-name"
+      >
+        Bigcommerce 
+      </span>
+      <span
+        class="tel"
+      >
+        555-555-5555
+      </span>
+    </p>
+    <div
+      class="adr"
+    >
+      <p
+        class="street-address address-entry"
+      >
+        <span
+          class="address-line-1"
+        >
+          12345 Testing Way 
+        </span>
+      </p>
+      <p
+        class="address-entry"
+      >
+        <span
+          class="locality"
+        >
+          Some City, 
+        </span>
+        <span
+          class="region"
+        >
+          California, 
+        </span>
+        <span
+          class="postal-code"
+        >
+          95555 / 
+        </span>
+        <span
+          class="country-name"
+        >
+          United States 
+        </span>
+      </p>
+    </div>
+  </div>
   <div
     class="staticConsignment-items"
   >


### PR DESCRIPTION
## What?
Add labels for PayPal Connect addresses

## Why?
We need to show for shoppers addresses which we get from PayPal Connect.

## Testing / Proof
BC - guest
PP Connect - guest

https://github.com/bigcommerce/checkout-js/assets/9430298/1027b77f-e1df-4c18-ac96-5bc6bf3c91da

BC - registered
PP Connect - guest

https://github.com/bigcommerce/checkout-js/assets/9430298/6894e174-03ed-4c99-bac2-7a09b3ba5bd5

BC - guest
PP Connect - registered

https://github.com/bigcommerce/checkout-js/assets/9430298/8291b50a-99bb-4f65-9c27-fe50553cdc0d

BC - registered
PP Connect - registered (with address merge)

https://github.com/bigcommerce/checkout-js/assets/9430298/aa14d130-f221-4fbb-805e-c65ee0d44c36




@bigcommerce/checkout
