### PR TITLE
chore(payment): PAYPAL-2852 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.426.0",
+        "@bigcommerce/checkout-sdk": "^1.427.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.426.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.426.0.tgz",
-      "integrity": "sha512-JXzJTtMieUC6VYEpFMmMQsLBmvLn8ngZwv2s8v/6NaGYckVviUupWp33aFBZjNohDN0O+EwUGclMaef9to2TyQ==",
+      "version": "1.427.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.427.0.tgz",
+      "integrity": "sha512-pkgy4VrcOR1fX1ezq/+qksGoCd0K1WoOEA1Dvn4VV+x1/4YUBAPa8aBOmDo+HEgLBo9T3Vjrq/aNtlenFMZVLg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.426.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.426.0.tgz",
-      "integrity": "sha512-JXzJTtMieUC6VYEpFMmMQsLBmvLn8ngZwv2s8v/6NaGYckVviUupWp33aFBZjNohDN0O+EwUGclMaef9to2TyQ==",
+      "version": "1.427.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.427.0.tgz",
+      "integrity": "sha512-pkgy4VrcOR1fX1ezq/+qksGoCd0K1WoOEA1Dvn4VV+x1/4YUBAPa8aBOmDo+HEgLBo9T3Vjrq/aNtlenFMZVLg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.426.0",
+    "@bigcommerce/checkout-sdk": "^1.427.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

Release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2123
https://github.com/bigcommerce/checkout-sdk-js/pull/2119

## Why?
To keep checkout-sdk dependency up to date

## Testing / Proof
Unit tests
Manual tests
