### PR TITLE
feat(payment): PAYPAL-2856 updated braintree paypal connect form margins to place the form in right place

### DIFF
--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutCreditCardForm.scss
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutCreditCardForm.scss
@@ -1,0 +1,3 @@
+.braintree-axo-cc-form-container {
+    margin: 0 -1.25rem;
+}

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutCreditCardForm.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutCreditCardForm.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent, useEffect } from 'react';
 
 import { PayPalConnectComponentRef } from '../BraintreeAcceleratedCheckoutPaymentMethod';
 
+import './BraintreeAcceleratedCheckoutCreditCardForm.scss';
+
 interface BraintreeAcceleratedCheckoutCreditCardFormProps {
     renderPayPalConnectComponent?: PayPalConnectComponentRef['render'];
 }
@@ -15,7 +17,13 @@ const BraintreeAcceleratedCheckoutCreditCardForm: FunctionComponent<
         }
     }, [renderPayPalConnectComponent]);
 
-    return <div data-test="braintree-axo-cc-form-container" id="braintree-axo-cc-form-container" />;
+    return (
+        <div
+            data-test="braintree-axo-cc-form-container"
+            id="braintree-axo-cc-form-container"
+            className="braintree-axo-cc-form-container"
+        />
+    );
 };
 
 export default BraintreeAcceleratedCheckoutCreditCardForm;


### PR DESCRIPTION
## What?
Updated braintree paypal connect form margins to place the form in right place

## Why?
PayPal Connect Credit Card component has white background and inner padding. The component has some differences between other CC forms that we have in out themes, so we need to make it almost the same as in Cornerstone (remove inner padding + make background color transparent)

## Testing / Proof
Unit tests
Manual tests

<img width="841" alt="Screenshot 2023-08-17 at 11 16 09" src="https://github.com/bigcommerce/checkout-js/assets/25133454/28c85443-a159-4d34-bfa0-351018f352ec">
<img width="686" alt="Screenshot 2023-08-17 at 11 27 08" src="https://github.com/bigcommerce/checkout-js/assets/25133454/16b076d8-173d-4eec-bbd0-5a12e5221492">

