### PR TITLE
fix(order): CHECKOUT-4355 Fix display issue of pick list items

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 ## Testing / Proof
 ...
 
-@bigcommerce/checkout
+@bigcommerce/team-checkout

--- a/packages/core/src/app/order/OrderSummaryModal.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.spec.tsx
@@ -1,12 +1,15 @@
-import { Order } from '@bigcommerce/checkout-sdk';
+import { LineItemMap, Order } from '@bigcommerce/checkout-sdk';
 import { mount, shallow, ShallowWrapper } from 'enzyme';
 import React from 'react';
+
+import { getPhysicalItem } from '@bigcommerce/checkout/test-utils';
 
 import { getStoreConfig } from '../config/config.mock';
 import { SMALL_SCREEN_MAX_WIDTH } from '../ui/responsive';
 
 import mapToOrderSummarySubtotalsProps from './mapToOrderSummarySubtotalsProps';
 import { getOrder } from './orders.mock';
+import OrderSummaryItems from './OrderSummaryItems';
 import OrderSummaryModal from './OrderSummaryModal';
 
 let order: Order;
@@ -32,6 +35,37 @@ describe('OrderSummaryModal', () => {
     it('renders order summary', () => {
         expect(orderSummary).toMatchSnapshot();
     });
+
+    describe('it renders order summary modal for bundled items', () => {
+        it('filters bundled items from line items', () => {
+            const lineItems: LineItemMap = {
+                physicalItems: [],
+                digitalItems: [],
+                giftCertificates: [],
+                customItems: [],
+            };
+
+            lineItems.physicalItems.push(getPhysicalItem(), {...getPhysicalItem(), id: '888', parentId: 'test'})
+
+            const order = { ...getOrder(), lineItems };
+
+            orderSummary = shallow(
+                <OrderSummaryModal
+                    isOpen={true}
+                    {...mapToOrderSummarySubtotalsProps(order)}
+                    additionalLineItems="foo"
+                    lineItems={order.lineItems}
+                    shopperCurrency={getStoreConfig().shopperCurrency}
+                    storeCurrency={getStoreConfig().currency}
+                    total={order.orderAmount}
+                />,
+            );
+
+            const itemsComponent = orderSummary.find(OrderSummaryItems);
+            
+            expect(itemsComponent.props().items.physicalItems).toHaveLength(1);
+        });
+    })
 
     describe('when taxes are inclusive', () => {
         it('displays tax as summary section', () => {

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -3,7 +3,7 @@ import {
     ShopperCurrency as ShopperCurrencyType,
     StoreCurrency,
 } from '@bigcommerce/checkout-sdk';
-import React, { cloneElement, FunctionComponent, isValidElement, ReactNode } from 'react';
+import React, { cloneElement, FunctionComponent, isValidElement, ReactNode, useMemo } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { Button, IconCloseWithBorder } from '@bigcommerce/checkout/ui';
@@ -20,6 +20,7 @@ import OrderSummaryPrice from './OrderSummaryPrice';
 import OrderSummarySection from './OrderSummarySection';
 import OrderSummarySubtotals, { OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
 import OrderSummaryTotal from './OrderSummaryTotal';
+import removeBundledItems from './removeBundledItems';
 
 export interface OrderSummaryDrawerProps {
     additionalLineItems?: ReactNode;
@@ -51,6 +52,7 @@ const OrderSummaryModal: FunctionComponent<
     total,
     ...orderSummarySubtotalsProps
 }) => {
+    const nonBundledLineItems = useMemo(() => removeBundledItems(lineItems), [lineItems]);
     const displayInclusiveTax = isTaxIncluded && taxes && taxes.length > 0;
 
     const subHeaderText = <OrderModalSummarySubheader
@@ -83,7 +85,7 @@ const OrderSummaryModal: FunctionComponent<
         onRequestClose={onRequestClose}
     >
         <OrderSummarySection>
-            <OrderSummaryItems displayLineItemsCount={!isUpdatedCartSummayModal} items={lineItems} />
+            <OrderSummaryItems displayLineItemsCount={!isUpdatedCartSummayModal} items={nonBundledLineItems} />
         </OrderSummarySection>
         <OrderSummarySection>
             <OrderSummarySubtotals isTaxIncluded={isTaxIncluded} taxes={taxes} {...orderSummarySubtotalsProps} />


### PR DESCRIPTION
## What?
Fix display issue of pick list line items in cart mobile summary view.

## Why?
Pick list items are displayed as separate line items in mobile view, which leads to a poor and confusing user experience.

## Testing / Proof
- Screenshot

Before
![before](https://github.com/bigcommerce/checkout-js/assets/7134802/9242e109-74fd-4019-b88d-945885b9ba67)


After
<img width="861" alt="Screenshot 2023-08-17 at 10 55 41 pm" src="https://github.com/bigcommerce/checkout-js/assets/7134802/416d5b6e-56a1-40db-b82f-48b262cf00b1">


@bigcommerce/team-checkout 
