### PR TITLE
feat(payment): PAYPAL-2730 added execution method call after sign in customer for BraintreeAcceleratedCheckout payment method

### DIFF
--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -604,6 +604,45 @@ describe('Customer', () => {
             });
         });
 
+        it('triggers execution method if customer is successfully signed in', async () => {
+            jest.spyOn(checkoutService, 'signInCustomer').mockReturnValue(
+                Promise.resolve(checkoutService.getState()),
+            );
+
+            jest.spyOn(checkoutService, 'executePaymentMethodCheckout').mockReturnValue(
+                Promise.resolve(checkoutService.getState()),
+            );
+
+            const handleSignedIn = jest.fn();
+            const component = mount(
+                <CustomerTest
+                    onSignIn={handleSignedIn}
+                    providerWithCustomCheckout={PaymentMethodId.BraintreeAcceleratedCheckout}
+                    viewType={CustomerViewType.Login}
+                />,
+            );
+
+            await new Promise((resolve) => process.nextTick(resolve));
+            component.update();
+
+            (component.find(LoginForm) as ReactWrapper<LoginFormProps>).prop('onSignIn')({
+                email: 'test@bigcommerce.com',
+                password: 'password1',
+            });
+
+            expect(checkoutService.signInCustomer).toHaveBeenCalledWith({
+                email: 'test@bigcommerce.com',
+                password: 'password1',
+            });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.executePaymentMethodCheckout).toHaveBeenCalledWith({
+                methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
+                continueWithCheckoutCallback: handleSignedIn,
+            });
+        });
+
         it('triggers completion callback if customer is successfully signed in', async () => {
             jest.spyOn(checkoutService, 'signInCustomer').mockReturnValue(
                 Promise.resolve(checkoutService.getState()),

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -299,8 +299,6 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             viewType,
         } = this.props;
 
-        const isLoading = isSigningIn || isExecutingPaymentMethodCheckout;
-
         return (
             <LoginForm
                 canCancel={isGuestEnabled}
@@ -314,7 +312,8 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 isFloatingLabelEnabled={isFloatingLabelEnabled}
                 isSendingSignInEmail={isSendingSignInEmail}
                 isSignInEmailEnabled={isSignInEmailEnabled && !isEmbedded}
-                isLoading={isLoading}
+                isSigningIn={isSigningIn}
+                isExecutingPaymentMethodCheckout={isExecutingPaymentMethodCheckout}
                 onCancel={this.handleCancelSignIn}
                 onChangeEmail={this.handleChangeEmail}
                 onContinueAsGuest={this.executePaymentMethodCheckoutOrContinue}

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -29,7 +29,8 @@ export interface LoginFormProps {
     forgotPasswordUrl: string;
     isSignInEmailEnabled?: boolean;
     isSendingSignInEmail?: boolean;
-    isLoading?: boolean;
+    isSigningIn?: boolean;
+    isExecutingPaymentMethodCheckout?: boolean;
     signInError?: Error;
     signInEmailError?: Error;
     viewType?: Omit<CustomerViewType, 'guest'>;
@@ -57,7 +58,8 @@ const LoginForm: FunctionComponent<
     forgotPasswordUrl,
     email,
     isSignInEmailEnabled,
-    isLoading,
+    isSigningIn,
+    isExecutingPaymentMethodCheckout,
     language,
     onCancel = noop,
     onChangeEmail,
@@ -165,8 +167,8 @@ const LoginForm: FunctionComponent<
 
                 <div className="form-actions">
                     <Button
-                        disabled={isLoading}
-                        isLoading={isLoading}
+                        disabled={isSigningIn && isExecutingPaymentMethodCheckout}
+                        isLoading={isSigningIn && isExecutingPaymentMethodCheckout}
                         id="checkout-customer-continue"
                         testId="customer-continue-button"
                         type="submit"

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -29,7 +29,7 @@ export interface LoginFormProps {
     forgotPasswordUrl: string;
     isSignInEmailEnabled?: boolean;
     isSendingSignInEmail?: boolean;
-    isSigningIn?: boolean;
+    isLoading?: boolean;
     signInError?: Error;
     signInEmailError?: Error;
     viewType?: Omit<CustomerViewType, 'guest'>;
@@ -57,7 +57,7 @@ const LoginForm: FunctionComponent<
     forgotPasswordUrl,
     email,
     isSignInEmailEnabled,
-    isSigningIn,
+    isLoading,
     language,
     onCancel = noop,
     onChangeEmail,
@@ -165,7 +165,8 @@ const LoginForm: FunctionComponent<
 
                 <div className="form-actions">
                     <Button
-                        disabled={isSigningIn}
+                        disabled={isLoading}
+                        isLoading={isLoading}
                         id="checkout-customer-continue"
                         testId="customer-continue-button"
                         type="submit"


### PR DESCRIPTION
## What?
Added execution method call right after sign in customer for BraintreeAcceleratedCheckout payment method

## Why?
To be able to trigger PayPal Connect customer authentication

## Testing / Proof
Unit tests
Manual tests



https://github.com/bigcommerce/checkout-js/assets/25133454/9938238c-b159-4a4f-a4b4-22d395413e8f




