### PR TITLE
chore(payment): PAYPAL-2730 bump checkout sdk js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.427.0",
+        "@bigcommerce/checkout-sdk": "^1.428.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.427.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.427.0.tgz",
-      "integrity": "sha512-pkgy4VrcOR1fX1ezq/+qksGoCd0K1WoOEA1Dvn4VV+x1/4YUBAPa8aBOmDo+HEgLBo9T3Vjrq/aNtlenFMZVLg==",
+      "version": "1.428.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.428.0.tgz",
+      "integrity": "sha512-MSPI5srvQ4xA5QzmzlQ30uCAhDjpcVJKp3RboBoohFfVfDmMx21kQhpm0VGYSBRBtq/3XONlfnQoYQnJ6YeHyA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.427.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.427.0.tgz",
-      "integrity": "sha512-pkgy4VrcOR1fX1ezq/+qksGoCd0K1WoOEA1Dvn4VV+x1/4YUBAPa8aBOmDo+HEgLBo9T3Vjrq/aNtlenFMZVLg==",
+      "version": "1.428.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.428.0.tgz",
+      "integrity": "sha512-MSPI5srvQ4xA5QzmzlQ30uCAhDjpcVJKp3RboBoohFfVfDmMx21kQhpm0VGYSBRBtq/3XONlfnQoYQnJ6YeHyA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.427.0",
+    "@bigcommerce/checkout-sdk": "^1.428.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk js version

## Why?
To release this changes:
https://github.com/bigcommerce/checkout-sdk-js/pull/2121
https://github.com/bigcommerce/checkout-sdk-js/pull/2127
https://github.com/bigcommerce/checkout-sdk-js/pull/2116

## Testing / Proof
Unit tests
Manual tests

Here is a screenshot of checkout sdk loader:
<img width="1512" alt="Screenshot 2023-08-18 at 10 28 12" src="https://github.com/bigcommerce/checkout-js/assets/25133454/a1a4df7a-4a44-4f55-af3f-a03bcb095c74">

