### PR TITLE
feat(payment): PAYPAL-2729 trigger customer execution method after creation account in create account form for BT AXO

### DIFF
--- a/packages/core/src/app/customer/CreateAccountForm.tsx
+++ b/packages/core/src/app/customer/CreateAccountForm.tsx
@@ -21,15 +21,16 @@ export interface CreateAccountFormProps {
     formFields: FormField[];
     createAccountError?: Error;
     isCreatingAccount?: boolean;
+    isExecutingPaymentMethodCheckout?: boolean;
     requiresMarketingConsent: boolean;
     isFloatingLabelEnabled?: boolean;
     onCancel?(): void;
-    onSubmit?(values: CreateAccountFormValues): void;
+    onSubmit(values: CreateAccountFormValues): void;
 }
 
 const CreateAccountForm: FunctionComponent<
     CreateAccountFormProps & WithLanguageProps & FormikProps<CreateAccountFormValues>
-> = ({ formFields, createAccountError, isCreatingAccount, onCancel, isFloatingLabelEnabled }) => {
+> = ({ formFields, createAccountError, isCreatingAccount, isExecutingPaymentMethodCheckout, onCancel, isFloatingLabelEnabled }) => {
     const createAccountErrorMessage = useMemo(() => {
         if (!createAccountError) {
             return;
@@ -79,7 +80,8 @@ const CreateAccountForm: FunctionComponent<
 
             <div className="form-actions">
                 <Button
-                    disabled={isCreatingAccount}
+                    disabled={isCreatingAccount || isExecutingPaymentMethodCheckout}
+                    isLoading={isCreatingAccount || isExecutingPaymentMethodCheckout}
                     id="checkout-customer-create"
                     testId="customer-continue-create"
                     type="submit"

--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -19,7 +19,7 @@ import CheckoutStepType from '../checkout/CheckoutStepType';
 import { getStoreConfig } from '../config/config.mock';
 import { PaymentMethodId } from '../payment/paymentMethod';
 
-import CreateAccountForm from './CreateAccountForm';
+import CreateAccountForm, { CreateAccountFormProps } from './CreateAccountForm';
 import Customer, { CustomerProps, WithCheckoutCustomerProps } from './Customer';
 import { getCustomer, getGuestCustomer } from './customers.mock';
 import CustomerViewType from './CustomerViewType';
@@ -27,6 +27,7 @@ import EmailLoginForm from './EmailLoginForm';
 import GuestForm, { GuestFormProps } from './GuestForm';
 import LoginForm, { LoginFormProps } from './LoginForm';
 import StripeGuestForm from './StripeGuestForm';
+import { string } from 'yup';
 
 describe('Customer', () => {
     let CustomerTest: FunctionComponent<CustomerProps & Partial<WithCheckoutCustomerProps>>;
@@ -705,6 +706,68 @@ describe('Customer', () => {
             expect((component.find(GuestForm) as ReactWrapper<GuestFormProps>).prop('email')).toBe(
                 'test@bigcommerce.com',
             );
+        });
+    });
+
+    describe('when view type is "create_account"', () => {
+        it('triggers execution method if customer is successfully signed in', async () => {
+            jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(undefined);
+
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                ...getStoreConfig(),
+                checkoutSettings: {
+                    ...getStoreConfig().checkoutSettings,
+                    features: {
+                        'CHECKOUT-4941.account_creation_in_checkout': true,
+                    },
+                },
+            });
+
+            jest.spyOn(checkoutService, 'createCustomerAccount').mockReturnValue(
+                Promise.resolve(checkoutService.getState()),
+            );
+
+            jest.spyOn(checkoutService, 'executePaymentMethodCheckout').mockReturnValue(
+                Promise.resolve(checkoutService.getState()),
+            );
+
+            const handleCreateAccount = jest.fn();
+            const component = mount(
+                <CustomerTest
+                    onAccountCreated={handleCreateAccount}
+                    providerWithCustomCheckout={PaymentMethodId.BraintreeAcceleratedCheckout}
+                    viewType={CustomerViewType.CreateAccount}
+                />,
+            );
+
+            const customerFormData = {
+                firstName: 'John',
+                lastName: 'Doe',
+                email: 'johndoe@test.com',
+                password: 'mocked_password!',
+            };
+
+            await new Promise((resolve) => process.nextTick(resolve));
+            component.update();
+
+            (component.find(CreateAccountForm) as ReactWrapper<CreateAccountFormProps>).prop('onSubmit')({
+                ...customerFormData,
+                customFields: {},
+            });
+
+            expect(checkoutService.createCustomerAccount).toHaveBeenCalledWith({
+                ...customerFormData,
+                acceptsMarketingEmails: undefined,
+                customFields: [],
+            });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.executePaymentMethodCheckout).toHaveBeenCalledWith({
+                email: customerFormData.email,
+                methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
+                continueWithCheckoutCallback: handleCreateAccount,
+            });
         });
     });
 

--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -27,7 +27,6 @@ import EmailLoginForm from './EmailLoginForm';
 import GuestForm, { GuestFormProps } from './GuestForm';
 import LoginForm, { LoginFormProps } from './LoginForm';
 import StripeGuestForm from './StripeGuestForm';
-import { string } from 'yup';
 
 describe('Customer', () => {
     let CustomerTest: FunctionComponent<CustomerProps & Partial<WithCheckoutCustomerProps>>;
@@ -764,7 +763,6 @@ describe('Customer', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(checkoutService.executePaymentMethodCheckout).toHaveBeenCalledWith({
-                email: customerFormData.email,
                 methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
                 continueWithCheckoutCallback: handleCreateAccount,
             });

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -448,7 +448,6 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onAccountCreated,
-                email: values.email,
             });
         } else {
             onAccountCreated();


### PR DESCRIPTION
## What?
Trigger customer execution method after creation account in create account form for BT AXO

## Why?
To be able to trigger PayPal Connect authentication flow right after customer creates an account

## Testing / Proof
Unit tests
Manual tests


https://github.com/bigcommerce/checkout-js/assets/25133454/5113eb42-8b07-44ec-8106-e2bdce079a6f




