### PR TITLE
chore(payment): PAYPAL-2868 bump checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.428.0",
+        "@bigcommerce/checkout-sdk": "^1.429.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.428.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.428.0.tgz",
-      "integrity": "sha512-MSPI5srvQ4xA5QzmzlQ30uCAhDjpcVJKp3RboBoohFfVfDmMx21kQhpm0VGYSBRBtq/3XONlfnQoYQnJ6YeHyA==",
+      "version": "1.429.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.429.0.tgz",
+      "integrity": "sha512-4ws/XkVlXSvYG6zqEbAj3pDBrBkthg/MS6sjWQwdg8sd1K/W553DwA3qFaHoOs2yJoRMPtw/DmAlfRIvXGi6eg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.428.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.428.0.tgz",
-      "integrity": "sha512-MSPI5srvQ4xA5QzmzlQ30uCAhDjpcVJKp3RboBoohFfVfDmMx21kQhpm0VGYSBRBtq/3XONlfnQoYQnJ6YeHyA==",
+      "version": "1.429.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.429.0.tgz",
+      "integrity": "sha512-4ws/XkVlXSvYG6zqEbAj3pDBrBkthg/MS6sjWQwdg8sd1K/W553DwA3qFaHoOs2yJoRMPtw/DmAlfRIvXGi6eg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.428.0",
+    "@bigcommerce/checkout-sdk": "^1.429.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk

## Why?
To deliver a list of PRs:
https://github.com/bigcommerce/checkout-sdk-js/pull/2120
https://github.com/bigcommerce/checkout-sdk-js/pull/2130

## Testing / Proof
Unit tests
Manual tests

Checkout sdk loader with 1.149 version is available on cdn:
<img width="1250" alt="Screenshot 2023-08-21 at 07 11 29" src="https://github.com/bigcommerce/checkout-js/assets/25133454/69bd9ab0-2dd9-40a7-aac4-6ae85350e49d">

