### PR TITLE
fix(checkout): PI-122 fixed credit card display name localization

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodId.ts
@@ -10,6 +10,7 @@ enum PaymentMethodId {
     ApplePay = 'applepay',
     Barclaycard = 'barclaycard',
     BlueSnapV2 = 'bluesnapv2',
+    BlueSnapDirect = 'bluesnapdirect',
     Boleto = 'boleto',
     Bolt = 'bolt',
     Braintree = 'braintree',

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.test.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.test.tsx
@@ -244,6 +244,58 @@ describe('PaymentMethodTitle', () => {
             expect(screen.queryByRole('heading', { name: getPaymentMethodName(localeContext.language)(method) })).not.toBeInTheDocument();
         });
 
+
+        it('renders custom text for Bluesnap Direct credit card', () => {
+            const method = {
+                ...defaultProps.method,
+                gateway: PaymentMethodId.BlueSnapDirect,
+                id: 'credit_card'
+            };
+
+            render(
+                <PaymentMethodTitleTest
+                    {...defaultProps}
+                    method={method}
+                />,
+            );
+
+            expect(screen.getByRole('heading', { name: localeContext.language.translate('payment.credit_card_text') })).toBeInTheDocument();
+        });
+
+        it('renders custom text for Bluesnap Direct ECP', () => {
+            const method = {
+                ...defaultProps.method,
+                gateway: PaymentMethodId.BlueSnapDirect,
+                id: 'ecp'
+            };
+
+            render(
+                <PaymentMethodTitleTest
+                    {...defaultProps}
+                    method={method}
+                />,
+            );
+
+            expect(screen.getByRole('heading', { name: localeContext.language.translate('payment.bluesnap_direct_electronic_check_label') })).toBeInTheDocument();
+        });
+
+        it('renders custom text for Bluesnap Direct Bank Transfer', () => {
+            const method = {
+                ...defaultProps.method,
+                gateway: PaymentMethodId.BlueSnapDirect,
+                id: 'banktransfer'
+            };
+
+            render(
+                <PaymentMethodTitleTest
+                    {...defaultProps}
+                    method={method}
+                />,
+            );
+
+            expect(screen.getByRole('heading', { name: localeContext.language.translate('payment.bluesnap_direct_local_bank_transfer_label') })).toBeInTheDocument();
+        });
+
         it('renders custom text for Bolt hosted payment methods', () => {
             const method = {
                 ...defaultProps.method,
@@ -617,6 +669,8 @@ describe('PaymentMethodTitle', () => {
 
         expect(screen.getByRole('img')).toHaveAttribute('src',  `${config.cdnPath}/img/payment-providers/opy_default.svg`);
     });
+
+
 
     it('renders name for Visa Checkout', () => {
         const method = {

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -215,6 +215,21 @@ function getPaymentMethodTitle(
             },
         };
 
+
+        if (method.gateway === PaymentMethodId.BlueSnapDirect) {
+            if (method.id === 'credit_card') {
+                return { logoUrl: '', titleText: language.translate('payment.credit_card_text') };
+            }
+
+            if (method.id === 'ecp') {
+                return { logoUrl: '', titleText: language.translate('payment.bluesnap_direct_electronic_check_label') };
+            }
+
+            if (method.id === 'banktransfer') {
+                return { logoUrl: '', titleText: language.translate('payment.bluesnap_direct_local_bank_transfer_label') };
+            }
+        }
+
         if (method.id === PaymentMethodId.PaypalCommerceVenmo) {
             return customTitles[PaymentMethodId.PaypalCommerceAlternativeMethod];
         }

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -212,6 +212,7 @@
             },
             "bluesnap_direct_permission": "I authorize this Electronic Check (ACH/ECP) transaction and agree to this debit of my account.",
             "bluesnap_direct_electronic_check_label": "Electronic Check (ACH/ECP)",
+            "bluesnap_direct_local_bank_transfer_label": "Local Bank Transfer",
             "bolt_benefit_1": "Shop hundreds of brands with a passwordless login",
             "bolt_benefit_2": "Check out with saved payment and shipping details",
             "bolt_benefit_3": "Benefit from PCI-compliant account security",


### PR DESCRIPTION
## What?
Fixed credit card display name localization

## Why?
Previously we used non-localized version due to the limitation of getPaymentMethodName method

## Testing / Proof
Manully
@bigcommerce/team-checkout
