### PR TITLE
chore(payment): PAYPAL-2873 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.429.0",
+        "@bigcommerce/checkout-sdk": "^1.431.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.429.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.429.0.tgz",
-      "integrity": "sha512-4ws/XkVlXSvYG6zqEbAj3pDBrBkthg/MS6sjWQwdg8sd1K/W553DwA3qFaHoOs2yJoRMPtw/DmAlfRIvXGi6eg==",
+      "version": "1.431.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.431.0.tgz",
+      "integrity": "sha512-+/0fA1XECLSRydPcWXBSpJwHfKEVLY40Hr2ncUlQHFQMFISnun0SN9ZBBTCwvjxF5heDeY8aXMDI4qxS9CJdlA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.429.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.429.0.tgz",
-      "integrity": "sha512-4ws/XkVlXSvYG6zqEbAj3pDBrBkthg/MS6sjWQwdg8sd1K/W553DwA3qFaHoOs2yJoRMPtw/DmAlfRIvXGi6eg==",
+      "version": "1.431.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.431.0.tgz",
+      "integrity": "sha512-+/0fA1XECLSRydPcWXBSpJwHfKEVLY40Hr2ncUlQHFQMFISnun0SN9ZBBTCwvjxF5heDeY8aXMDI4qxS9CJdlA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.429.0",
+    "@bigcommerce/checkout-sdk": "^1.431.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
As part of the release last checkout sdk updates:
https://github.com/bigcommerce/checkout-sdk-js/pull/2135
https://github.com/bigcommerce/checkout-sdk-js/pull/2132
https://github.com/bigcommerce/checkout-sdk-js/pull/2133
https://github.com/bigcommerce/checkout-sdk-js/pull/2134
https://github.com/bigcommerce/checkout-sdk-js/pull/2107

## Testing / Proof
Unit tests
Manual tests

Here is a screenshot of [checkout sdk loader](https://checkout-sdk.bigcommerce.com/v1/loader-v1.431.0.js):
<img width="1320" alt="Screenshot 2023-08-22 at 09 04 06" src="https://github.com/bigcommerce/checkout-js/assets/25133454/4c54eda9-7b13-449c-ac07-024506a5be0f">

