### PR TITLE
feat(checkout): CHECKOUT-6837 Disable automatic highlighting

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -45,7 +45,8 @@ class GoogleAutocomplete extends PureComponent<GoogleAutocompleteProps, GoogleAu
 
         return (
             <Autocomplete
-                initialHighlightedIndex={0}
+                defaultHighlightedIndex={-1}
+                initialHighlightedIndex={-1}
                 initialValue={initialValue}
                 inputProps={{
                     ...inputProps,

--- a/packages/core/src/app/ui/autocomplete/Autocomplete.spec.tsx
+++ b/packages/core/src/app/ui/autocomplete/Autocomplete.spec.tsx
@@ -100,6 +100,7 @@ describe('Autocomplete Component', () => {
             tree.find('input')
                 .simulate('change', { target: { value: 'zo' } })
                 .simulate('keyDown', { key: 'ArrowDown', keyCode: 40, which: 40 })
+                .simulate('keyDown', { key: 'ArrowDown', keyCode: 40, which: 40 })
                 .simulate('keyDown', { key: 'Enter', keyCode: 13, which: 13 });
         });
 

--- a/packages/core/src/app/ui/autocomplete/Autocomplete.tsx
+++ b/packages/core/src/app/ui/autocomplete/Autocomplete.tsx
@@ -35,7 +35,7 @@ class Autocomplete extends PureComponent<AutocompleteProps> {
 
         return (
             <Downshift
-                defaultHighlightedIndex={defaultHighlightedIndex || 0}
+                defaultHighlightedIndex={defaultHighlightedIndex}
                 initialHighlightedIndex={initialHighlightedIndex}
                 initialInputValue={initialValue}
                 itemToString={this.itemToString}

--- a/packages/core/src/app/ui/autocomplete/Autocomplete.tsx
+++ b/packages/core/src/app/ui/autocomplete/Autocomplete.tsx
@@ -10,6 +10,7 @@ import AutocompleteItem from './autocomplete-item';
 export interface AutocompleteProps {
     initialValue?: string;
     initialHighlightedIndex?: number;
+    defaultHighlightedIndex?: number;
     children?: ReactNode;
     items: AutocompleteItem[];
     inputProps?: any;
@@ -25,6 +26,7 @@ class Autocomplete extends PureComponent<AutocompleteProps> {
             inputProps,
             initialValue,
             initialHighlightedIndex,
+            defaultHighlightedIndex,
             items,
             children,
             onSelect,
@@ -33,7 +35,7 @@ class Autocomplete extends PureComponent<AutocompleteProps> {
 
         return (
             <Downshift
-                defaultHighlightedIndex={0}
+                defaultHighlightedIndex={defaultHighlightedIndex || 0}
                 initialHighlightedIndex={initialHighlightedIndex}
                 initialInputValue={initialValue}
                 itemToString={this.itemToString}


### PR DESCRIPTION
## What?
Update our Google Autocomplete implementation so that an address in the dropdown list is not highlighted automatically.

## Why?
The shopper believes the highlighted address is selected, but they are unaware that they must click on the item to select it. As a result, several businesses complain that some orders include an incomplete street address.

## Testing / Proof

https://github.com/bigcommerce/checkout-js/assets/88361607/df2f5df9-011f-49bb-8537-66cb1285fafc



@bigcommerce/team-checkout
