### PR TITLE
fix(checkout): CHECKOUT-7656 Rectify vanishing shipping step

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -608,7 +608,7 @@ class Checkout extends Component<
     };
 
     private handleConsignmentsUpdated: (state: CheckoutSelectors) => void = ({ data }) => {
-        const { hasSelectedShippingOptions: prevHasSelectedShippingOptions, activeStepType } =
+        const { hasSelectedShippingOptions: prevHasSelectedShippingOptions, activeStepType, defaultStepType } =
             this.state;
 
         const { steps } = this.props;
@@ -620,8 +620,17 @@ class Checkout extends Component<
         if (
             prevHasSelectedShippingOptions &&
             !newHasSelectedShippingOptions &&
-            findIndex(steps, { type: CheckoutStepType.Shipping }) <
-                findIndex(steps, { type: activeStepType })
+            (
+                findIndex(steps, { type: CheckoutStepType.Shipping }) <
+                findIndex(steps, { type: activeStepType }) ||
+                (
+                    !activeStepType &&
+                    (
+                        defaultStepType === CheckoutStepType.Payment ||
+                        defaultStepType === CheckoutStepType.Billing
+                    )
+                )
+            )
         ) {
             this.navigateToStep(CheckoutStepType.Shipping);
             this.setState({ error: new ShippingOptionExpiredError() });

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -617,20 +617,19 @@ class Checkout extends Component<
             data.getConsignments() || [],
         );
 
+        const isDefaultStepPaymentOrBilling =
+            !activeStepType &&
+            (defaultStepType === CheckoutStepType.Payment ||
+                defaultStepType === CheckoutStepType.Billing);
+
+        const isShippingStepFinished =
+            findIndex(steps, { type: CheckoutStepType.Shipping }) <
+                findIndex(steps, { type: activeStepType }) || isDefaultStepPaymentOrBilling;
+
         if (
             prevHasSelectedShippingOptions &&
             !newHasSelectedShippingOptions &&
-            (
-                findIndex(steps, { type: CheckoutStepType.Shipping }) <
-                findIndex(steps, { type: activeStepType }) ||
-                (
-                    !activeStepType &&
-                    (
-                        defaultStepType === CheckoutStepType.Payment ||
-                        defaultStepType === CheckoutStepType.Billing
-                    )
-                )
-            )
+            isShippingStepFinished
         ) {
             this.navigateToStep(CheckoutStepType.Shipping);
             this.setState({ error: new ShippingOptionExpiredError() });


### PR DESCRIPTION
## What?
Improve the conditions for throwing `ShippingOptionExpiredError`.

## Why?
After a shopper refreshes the checkout page, trying to remove a free shipping coupon doesn't work properly because the checkout fails to trigger the expected `ShippingOptionExpiredError`.

This PR fixes the problem above.

## Testing / Proof
### BEFORE
 
https://github.com/bigcommerce/checkout-js/assets/88361607/45323035-479f-4880-babb-b4f8c642a333

### AFTER

https://github.com/bigcommerce/checkout-js/assets/88361607/374bf8f4-5c73-4945-bb92-511bf558a1f0
