### PR TITLE
fix(checkout): PI-657 fixed validation for stored bluesnap direct card verification fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.433.0",
+        "@bigcommerce/checkout-sdk": "^1.433.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.433.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.433.0.tgz",
-      "integrity": "sha512-gae8qWVLge6fjpvxj35P9jSqAfpQqvBnCyjnZlxlZbDlU/wRBHOnGt7FxDXOwYrH4eQNXA+F9Q81YxNBYGNGjg==",
+      "version": "1.433.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.433.1.tgz",
+      "integrity": "sha512-rE1K3W96JuPQ+OPoWBwSK2FxBhxcE7L+N/+xyUVA41m9IcOzOTPzoharH2Nb+m6QuFPl+s7tWsaRvDSLcckpWw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.433.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.433.0.tgz",
-      "integrity": "sha512-gae8qWVLge6fjpvxj35P9jSqAfpQqvBnCyjnZlxlZbDlU/wRBHOnGt7FxDXOwYrH4eQNXA+F9Q81YxNBYGNGjg==",
+      "version": "1.433.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.433.1.tgz",
+      "integrity": "sha512-rE1K3W96JuPQ+OPoWBwSK2FxBhxcE7L+N/+xyUVA41m9IcOzOTPzoharH2Nb+m6QuFPl+s7tWsaRvDSLcckpWw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.433.0",
+    "@bigcommerce/checkout-sdk": "^1.433.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of validation fix for stored bluesnap direct card verification fields
https://github.com/bigcommerce/checkout-sdk-js/pull/2139

## Why?
Due to the absence UI notifications in validation error cases

## Testing / Proof
units/manually
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/7eeb30e6-cf14-4115-bcc4-c2176d43b3b0)



@bigcommerce/team-checkout
