### PR TITLE
chore(payment): PI-489 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.433.2",
+        "@bigcommerce/checkout-sdk": "^1.434.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.433.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.433.2.tgz",
-      "integrity": "sha512-I3/MyZRnVCKLmSAFUtsRQQyhkIv6IUbSUAdzmzD2I1OEW61nBSa4bdwpuq/pbzCJgXvkrfZa04ZfV8YxupvfMg==",
+      "version": "1.434.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.434.0.tgz",
+      "integrity": "sha512-TyKux1i+SaAsxbjSc7goe83klRYkuYoSZtw4GMjOTt558m5WveBRrK1TTmGkavl8Gnn9Q83d/uLheEHLGoHnzQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.433.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.433.2.tgz",
-      "integrity": "sha512-I3/MyZRnVCKLmSAFUtsRQQyhkIv6IUbSUAdzmzD2I1OEW61nBSa4bdwpuq/pbzCJgXvkrfZa04ZfV8YxupvfMg==",
+      "version": "1.434.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.434.0.tgz",
+      "integrity": "sha512-TyKux1i+SaAsxbjSc7goe83klRYkuYoSZtw4GMjOTt558m5WveBRrK1TTmGkavl8Gnn9Q83d/uLheEHLGoHnzQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.433.2",
+    "@bigcommerce/checkout-sdk": "^1.434.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
Release bigcommerce/checkout-sdk-js#2126

## Testing / Proof
<img width="1416" alt="Screenshot 2023-08-28 at 12 08 49" src="https://github.com/bigcommerce/checkout-js/assets/138816572/c055d7e0-4ca2-4d2a-a842-02b2ae5ad3be">

@bigcommerce/team-checkout
