### PR TITLE
chore(checkout): PI-520 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.434.0",
+        "@bigcommerce/checkout-sdk": "^1.435.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.434.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.434.0.tgz",
-      "integrity": "sha512-TyKux1i+SaAsxbjSc7goe83klRYkuYoSZtw4GMjOTt558m5WveBRrK1TTmGkavl8Gnn9Q83d/uLheEHLGoHnzQ==",
+      "version": "1.435.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.435.0.tgz",
+      "integrity": "sha512-TYYXhsrRM6AGBjGtnCF1+B3TXxVx2RP9kxWvG5WjRwnbKWzZ2CrMrgR9GHsaw0S04Jl3nwjexe6YiPUhhJqEIA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.434.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.434.0.tgz",
-      "integrity": "sha512-TyKux1i+SaAsxbjSc7goe83klRYkuYoSZtw4GMjOTt558m5WveBRrK1TTmGkavl8Gnn9Q83d/uLheEHLGoHnzQ==",
+      "version": "1.435.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.435.0.tgz",
+      "integrity": "sha512-TYYXhsrRM6AGBjGtnCF1+B3TXxVx2RP9kxWvG5WjRwnbKWzZ2CrMrgR9GHsaw0S04Jl3nwjexe6YiPUhhJqEIA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.434.0",
+    "@bigcommerce/checkout-sdk": "^1.435.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
to release https://github.com/bigcommerce/checkout-sdk-js/pull/2113

## Testing / Proof
<img width="1509" alt="Screenshot 2023-08-28 at 14 10 58" src="https://github.com/bigcommerce/checkout-js/assets/130754705/04633df0-2def-4678-9823-364e50a29d52">

@bigcommerce/team-checkout
