### PR TITLE
fix(payment): PAYPAL-0000 warnings fix

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/BraintreePaypalCreditDescription.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BraintreePaypalCreditDescription.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect } from 'react';
 
 import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 
-import { PaymentMethodId } from './index';
+import PaymentMethodId from './PaymentMethodId';
 
 const BraintreePaypalCreditDescription: FunctionComponent<{ onUnhandledError?(error: Error): void }> = ({ onUnhandledError }) => {
     const { checkoutService } = useCheckout();


### PR DESCRIPTION
## What?

Warnings fix

## Why?

To avoid circular dependencies

## Testing / Proof
The following warnings in the screenshot have been fixed:

<img width="1466" alt="Screenshot 2023-08-28 at 15 19 04" src="https://github.com/bigcommerce/checkout-js/assets/99336044/cacf826c-f150-43b5-ab2e-ecaa916e4653">

Final results:

![Screenshot 2023-08-28 at 15 45 39](https://github.com/bigcommerce/checkout-js/assets/99336044/7498bdd1-2a6f-4b50-ab07-ef3bc929b191)

@bigcommerce/team-checkout
