### PR TITLE
fix(payment): PAYPAL-2729 added some tests + refactoring and changed the disable button state logic in login form

### DIFF
--- a/packages/core/src/app/customer/CreateAccountForm.spec.tsx
+++ b/packages/core/src/app/customer/CreateAccountForm.spec.tsx
@@ -213,4 +213,42 @@ describe('CreateAccountForm Component', () => {
             }),
         );
     });
+
+    it('disables submit button if the creation account is in progress', async () => {
+        const onSubmit = jest.fn();
+
+        component = mount(
+            <LocaleContext.Provider value={localeContext}>
+                <CreateAccountForm
+                    formFields={formFields}
+                    onSubmit={onSubmit}
+                    requiresMarketingConsent={true}
+                    isCreatingAccount={true}
+                />
+            </LocaleContext.Provider>,
+        );
+
+        const button = component.find('[data-test="customer-continue-create"]');
+
+        expect(button.prop('disabled')).toBeTruthy();
+    });
+
+    it('disables submit button if the execution is in progress', async () => {
+        const onSubmit = jest.fn();
+
+        component = mount(
+            <LocaleContext.Provider value={localeContext}>
+                <CreateAccountForm
+                    formFields={formFields}
+                    onSubmit={onSubmit}
+                    requiresMarketingConsent={true}
+                    isExecutingPaymentMethodCheckout={true}
+                />
+            </LocaleContext.Provider>,
+        );
+
+        const button = component.find('[data-test="customer-continue-create"]');
+
+        expect(button.prop('disabled')).toBeTruthy();
+    });
 });

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -23,6 +23,7 @@ import { withCheckout } from '../checkout';
 import CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 import { isErrorWithType } from '../common/error';
 import { isFloatingLabelEnabled } from '../common/utility';
+import { isBraintreeConnectPaymentMethod } from '../payment';
 import { PaymentMethodId } from '../payment/paymentMethod';
 
 import CheckoutButtonList from './CheckoutButtonList';
@@ -435,7 +436,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
         try {
             await signIn(credentials);
 
-            if (providerWithCustomCheckout === PaymentMethodId.Braintree || providerWithCustomCheckout === PaymentMethodId.BraintreeAcceleratedCheckout) {
+            if (isBraintreeConnectPaymentMethod(providerWithCustomCheckout)) {
                 await executePaymentMethodCheckout({
                     methodId: providerWithCustomCheckout,
                     continueWithCheckoutCallback: onSignIn,
@@ -460,7 +461,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
         await createAccount(mapCreateAccountFromFormValues(values));
 
-        if (providerWithCustomCheckout === PaymentMethodId.Braintree || providerWithCustomCheckout === PaymentMethodId.BraintreeAcceleratedCheckout) {
+        if (isBraintreeConnectPaymentMethod(providerWithCustomCheckout)) {
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onAccountCreated,

--- a/packages/core/src/app/customer/LoginForm.spec.tsx
+++ b/packages/core/src/app/customer/LoginForm.spec.tsx
@@ -228,4 +228,24 @@ describe('LoginForm', () => {
             'Continue as guest',
         );
     });
+
+    it('disables submit button if the sign in process does not complete', async () => {
+        const component = mount(
+            <TestComponent isSigningIn={true} />,
+        );
+
+        const button = component.find('[data-test="customer-continue-button"]');
+
+        expect(button.prop('disabled')).toBeTruthy();
+    });
+
+    it('disables submit button if the execution is in progress', async () => {
+        const component = mount(
+            <TestComponent isExecutingPaymentMethodCheckout={true} />,
+        );
+
+        const button = component.find('[data-test="customer-continue-button"]');
+
+        expect(button.prop('disabled')).toBeTruthy();
+    });
 });

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -167,8 +167,8 @@ const LoginForm: FunctionComponent<
 
                 <div className="form-actions">
                     <Button
-                        disabled={isSigningIn && isExecutingPaymentMethodCheckout}
-                        isLoading={isSigningIn && isExecutingPaymentMethodCheckout}
+                        disabled={isSigningIn || isExecutingPaymentMethodCheckout}
+                        isLoading={isSigningIn || isExecutingPaymentMethodCheckout}
                         id="checkout-customer-continue"
                         testId="customer-continue-button"
                         type="submit"

--- a/packages/core/src/app/payment/index.ts
+++ b/packages/core/src/app/payment/index.ts
@@ -1,2 +1,3 @@
 export { PaymentProps } from './Payment';
+export { default as isBraintreeConnectPaymentMethod } from './isBraintreeConnectPaymentMethod';
 export { default as getPreselectedPayment } from './getPreselectedPayment';

--- a/packages/core/src/app/payment/isBraintreeConnectPaymentMethod.ts
+++ b/packages/core/src/app/payment/isBraintreeConnectPaymentMethod.ts
@@ -1,0 +1,5 @@
+import { PaymentMethodId } from './paymentMethod';
+
+export default function isBraintreeConnectPaymentMethod(methodId?: string): boolean {
+    return methodId === PaymentMethodId.Braintree || methodId === PaymentMethodId.BraintreeAcceleratedCheckout;
+};


### PR DESCRIPTION
## What?
- change submit button disable state logic in login form;
- added some tests for the CreateAccount and Login forms due to the changes with execution method;
- updated Customer.tsx file with isBraintreeConnectPaymentMethod to avoid logic duplication;

## Why?
To keep our code as clean as possible

## Related PRs:
checkout-sdk: https://github.com/bigcommerce/checkout-js/pull/1449

## Testing / Proof
Unit tests
