### PR TITLE
chore(payment): PAYPAL-2888 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.434.0",
+        "@bigcommerce/checkout-sdk": "^1.436.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.434.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.434.0.tgz",
-      "integrity": "sha512-TyKux1i+SaAsxbjSc7goe83klRYkuYoSZtw4GMjOTt558m5WveBRrK1TTmGkavl8Gnn9Q83d/uLheEHLGoHnzQ==",
+      "version": "1.436.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.436.0.tgz",
+      "integrity": "sha512-Z81ISi7UsaK0Ama4jHVyQVtuA8iGZw0K7SvYbAxKOU+sId5lefDDNZWRFKE+s0lDeOLfV/+xb/bfaJU55EXC9w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.434.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.434.0.tgz",
-      "integrity": "sha512-TyKux1i+SaAsxbjSc7goe83klRYkuYoSZtw4GMjOTt558m5WveBRrK1TTmGkavl8Gnn9Q83d/uLheEHLGoHnzQ==",
+      "version": "1.436.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.436.0.tgz",
+      "integrity": "sha512-Z81ISi7UsaK0Ama4jHVyQVtuA8iGZw0K7SvYbAxKOU+sId5lefDDNZWRFKE+s0lDeOLfV/+xb/bfaJU55EXC9w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.434.0",
+    "@bigcommerce/checkout-sdk": "^1.436.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
To release this checkout sdk prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/2149
https://github.com/bigcommerce/checkout-sdk-js/pull/2144
https://github.com/bigcommerce/checkout-sdk-js/pull/2113

## Testing / Proof
Unit tests
CI tests

Checkout sdk loader is working as expected:
<img width="1512" alt="Screenshot 2023-08-29 at 10 03 36" src="https://github.com/bigcommerce/checkout-js/assets/25133454/cd990e5f-1910-4953-a9bd-f0db6f5fa532">

The actual checkout sdk version was deployed for every env

