### PR TITLE
feat(payment): PAYPAL-2728 create shipping strategy for Braintree AXO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.441.3",
+        "@bigcommerce/checkout-sdk": "^1.442.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.441.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.3.tgz",
-      "integrity": "sha512-4sV+oeN0DIXLYIzM22tb2M2zmpWjziupiniScH03+JNcWo9ZNelAVlOgxCMwkA/FRIh5mtd/mGlwT/zYIwRpLA==",
+      "version": "1.442.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.442.0.tgz",
+      "integrity": "sha512-rfHmgkv3uSl/9nCDBZbOgbbroKRMt9StwB/Rx9tngyTsP7JThslSrkq87AgBCHGHeLYk4HYRrq/FWaLy781ZOw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.441.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.3.tgz",
-      "integrity": "sha512-4sV+oeN0DIXLYIzM22tb2M2zmpWjziupiniScH03+JNcWo9ZNelAVlOgxCMwkA/FRIh5mtd/mGlwT/zYIwRpLA==",
+      "version": "1.442.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.442.0.tgz",
+      "integrity": "sha512-rfHmgkv3uSl/9nCDBZbOgbbroKRMt9StwB/Rx9tngyTsP7JThslSrkq87AgBCHGHeLYk4HYRrq/FWaLy781ZOw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.441.3",
+    "@bigcommerce/checkout-sdk": "^1.442.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
+++ b/packages/core/src/app/address/PayPalAxo/usePayPalConnectAddress.ts
@@ -1,6 +1,6 @@
 import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 
-import { PaymentMethodId } from '../../payment/paymentMethod';
+import { isBraintreeConnectPaymentMethod } from '../../payment';
 
 import { isPayPalConnectAddress } from './utils';
 
@@ -8,9 +8,8 @@ const usePayPalConnectAddress = () => {
     const { checkoutState } = useCheckout();
     const { getConfig, getCustomer, getPaymentProviderCustomer } = checkoutState.data;
 
-    const providerWithCustomCheckout = getConfig()?.checkoutSettings?.providerWithCustomCheckout;
-    const isPayPalAxoEnabled = providerWithCustomCheckout === PaymentMethodId.BraintreeAcceleratedCheckout
-        || providerWithCustomCheckout === PaymentMethodId.Braintree;
+    const providerWithCustomCheckout = getConfig()?.checkoutSettings?.providerWithCustomCheckout || '';
+    const isPayPalAxoEnabled = isBraintreeConnectPaymentMethod(providerWithCustomCheckout);
 
     const paypalConnectAddresses = getPaymentProviderCustomer()?.addresses || [];
     const bcAddresses = getCustomer()?.addresses || [];

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -372,7 +372,7 @@ export function mapToShippingProps({
         },
     } = config;
 
-    const methodId = getShippingMethodId(checkout);
+    const methodId = getShippingMethodId(checkout, config);
     const shippableItemsCount = getShippableItemsCount(cart);
     const isLoading =
         isLoadingShippingOptions() ||

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -14,11 +14,12 @@ import {
     ShippingInitializeOptions,
     ShippingRequestOptions,
 } from '@bigcommerce/checkout-sdk';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
 
 import { usePayPalConnectAddress } from '../address/PayPalAxo';
+import { isBraintreeConnectPaymentMethod } from '../payment';
 
 import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm';
 import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
@@ -99,6 +100,12 @@ const ShippingForm = ({
 }: ShippingFormProps & WithLanguageProps) => {
     const { isPayPalAxoEnabled, mergedBcAndPayPalConnectAddresses } = usePayPalConnectAddress();
     const shippingAddresses = isPayPalAxoEnabled ? mergedBcAndPayPalConnectAddresses : addresses;
+
+    useEffect(() => {
+        if (isBraintreeConnectPaymentMethod(methodId) && isPayPalAxoEnabled) {
+            initialize({ methodId });
+        }
+    });
 
     return isMultiShippingMode ? (
         <MultiShippingForm

--- a/packages/core/src/app/shipping/getShippingMethodId.test.tsx
+++ b/packages/core/src/app/shipping/getShippingMethodId.test.tsx
@@ -1,0 +1,63 @@
+import { Checkout, StoreConfig } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout, getCheckoutPayment, getStoreConfig } from '@bigcommerce/checkout/test-utils';
+
+import * as getPreselectedPayment from '../payment/getPreselectedPayment';
+import { PaymentMethodId } from '../payment/paymentMethod';
+
+import getShippingMethodId from './getShippingMethodId';
+
+describe('getShippingMethodId', () => {
+    const checkoutDefault = getCheckout();
+    const configDefault = getStoreConfig();
+
+    const mockOptions = (
+        providerWithCustomCheckout: string | null = null,
+        preselectedPaymentId?: string,
+    ): [Checkout, StoreConfig] => {
+        const config = {
+            ...configDefault,
+            checkoutSettings: {
+                ...configDefault.checkoutSettings,
+                providerWithCustomCheckout,
+            }
+        }
+
+        jest.spyOn(getPreselectedPayment, 'default').mockReturnValue(
+            preselectedPaymentId
+                ? {
+                    ...getCheckoutPayment(),
+                    providerId: preselectedPaymentId,
+                }
+                : undefined,
+
+        );
+
+        return [checkoutDefault, config];
+    }
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns no shipping method ID if no preselected payment method and no provider with custom checkout', () => {
+        const [checkout, config] = mockOptions();
+
+        expect(getShippingMethodId(checkout, config)).toBeUndefined();
+    });
+
+    it('returns shipping method id from provider with custom checkout', () => {
+        const [checkout, config] = mockOptions(PaymentMethodId.BraintreeAcceleratedCheckout);
+
+        expect(getShippingMethodId(checkout, config)).toBe(PaymentMethodId.BraintreeAcceleratedCheckout);
+    });
+
+    it('returns shipping method id from preselected payment method', () => {
+        const [checkout, config] = mockOptions(
+            PaymentMethodId.BraintreeAcceleratedCheckout,
+            PaymentMethodId.AmazonPay,
+        );
+
+        expect(getShippingMethodId(checkout, config)).toBe(PaymentMethodId.AmazonPay);
+    });
+});

--- a/packages/core/src/app/shipping/getShippingMethodId.ts
+++ b/packages/core/src/app/shipping/getShippingMethodId.ts
@@ -1,12 +1,18 @@
-import { Checkout } from '@bigcommerce/checkout-sdk';
+import { Checkout, StoreConfig } from '@bigcommerce/checkout-sdk';
 
 import { getPreselectedPayment } from '../payment';
+import { PaymentMethodId } from '../payment/paymentMethod';
 
-export default function getShippingMethodId(checkout: Checkout): string | undefined {
-    const SHIPPING_METHOD_IDS = ['amazonpay'];
+export default function getShippingMethodId(checkout: Checkout, config: StoreConfig): string | undefined {
+    const SHIPPING_METHOD_IDS: string[] = [PaymentMethodId.AmazonPay, PaymentMethodId.BraintreeAcceleratedCheckout];
+    const providerWithCustomCheckout = config.checkoutSettings?.providerWithCustomCheckout;
     const preselectedPayment = getPreselectedPayment(checkout);
 
-    return preselectedPayment && SHIPPING_METHOD_IDS.indexOf(preselectedPayment.providerId) > -1
-        ? preselectedPayment.providerId
+    if (preselectedPayment && SHIPPING_METHOD_IDS.indexOf(preselectedPayment.providerId) > -1) {
+        return preselectedPayment.providerId;
+    }
+
+    return providerWithCustomCheckout && SHIPPING_METHOD_IDS.indexOf(providerWithCustomCheckout) > -1
+        ? providerWithCustomCheckout
         : undefined;
 }

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptions.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptions.tsx
@@ -89,7 +89,7 @@ export function mapToShippingOptions(
     }
 
     const consignments = sortConsignments(cart, getConsignments() || []);
-    const methodId = getShippingMethodId(checkout);
+    const methodId = getShippingMethodId(checkout, config);
     const { shippingQuoteFailedMessage } = config.checkoutSettings;
 
     return {


### PR DESCRIPTION
## What?
Create shipping strategy for Braintree Accelerated checkout

## Why?
To check logged in user and show OTP modal for PayPal Connect users

## Testing / Proof
Unit test and manually tested

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/dfb0a7d0-8186-4744-bccc-f8a41b765652



@bigcommerce/team-checkout
