### PR TITLE
chore(payment): INT-5659 Bump checkout-sdk from `1.436.0` to `1.437.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.436.0",
+        "@bigcommerce/checkout-sdk": "^1.437.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.436.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.436.0.tgz",
-      "integrity": "sha512-Z81ISi7UsaK0Ama4jHVyQVtuA8iGZw0K7SvYbAxKOU+sId5lefDDNZWRFKE+s0lDeOLfV/+xb/bfaJU55EXC9w==",
+      "version": "1.437.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.437.0.tgz",
+      "integrity": "sha512-ffP0WNQOY3Q0NsWFuSyErtPdwm5xp2JkiYiQmt/99JlCAMHY+qjOyL3GgjCxOyetxqF6YuaMx0QqJT2CI2jIbw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.436.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.436.0.tgz",
-      "integrity": "sha512-Z81ISi7UsaK0Ama4jHVyQVtuA8iGZw0K7SvYbAxKOU+sId5lefDDNZWRFKE+s0lDeOLfV/+xb/bfaJU55EXC9w==",
+      "version": "1.437.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.437.0.tgz",
+      "integrity": "sha512-ffP0WNQOY3Q0NsWFuSyErtPdwm5xp2JkiYiQmt/99JlCAMHY+qjOyL3GgjCxOyetxqF6YuaMx0QqJT2CI2jIbw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.436.0",
+    "@bigcommerce/checkout-sdk": "^1.437.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from `1.436.0` to `1.437.0`

## Why?
To release all these:
- https://github.com/bigcommerce/checkout-sdk-js/pull/2151
- https://github.com/bigcommerce/checkout-sdk-js/pull/1994

## Testing / Proof
CircleCI + testing section each PR

<img width="688" alt="image" src="https://github.com/bigcommerce/checkout-js/assets/4843328/46b08e33-3a26-49c8-b4a6-335df1df2e88">

@bigcommerce/checkout @bigcommerce/apex-integrations 
