### PR TITLE
fix(checkout): CHECKOUT-5966 Enable multishipping for more than 50 items in cart

### DIFF
--- a/packages/core/src/app/config/config.mock.ts
+++ b/packages/core/src/app/config/config.mock.ts
@@ -20,7 +20,7 @@ export function getStoreConfig(): StoreConfig {
             enableTermsAndConditions: false,
             googleRecaptchaSitekey: 'sitekey',
             googleMapsApiKey: '',
-            hasMultiShippingEnabled: true,
+            hasMultiShippingEnabled: false,
             guestCheckoutEnabled: true,
             isAnalyticsEnabled: true,
             isAccountCreationEnabled: true,

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -349,6 +349,27 @@ describe('Shipping Component', () => {
         expect(checkoutService.deleteConsignment).not.toHaveBeenCalled();
     });
 
+    it('shows multi address shipping link for more than 50 cart items', async () => {
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+            ...getCart(),
+            lineItems: {
+                physicalItems: [
+                    {
+                        ...getPhysicalItem(),
+                        quantity: 51,
+                    },
+                ],
+            },
+        } as Cart);
+        component = mount(<ComponentTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+        component.update();
+
+        expect(component.find('[data-test="shipping-mode-toggle"]').text()).toBe(
+            'Ship to multiple addresses',
+        );
+    });
+
     describe('when multishipping mode is on', () => {
         describe('when shopper is signed', () => {
             beforeEach(async () => {

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -349,140 +349,152 @@ describe('Shipping Component', () => {
         expect(checkoutService.deleteConsignment).not.toHaveBeenCalled();
     });
 
-    it('shows multi address shipping link for more than 50 cart items', async () => {
-        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
-            ...getCart(),
-            lineItems: {
-                physicalItems: [
-                    {
-                        ...getPhysicalItem(),
-                        quantity: 51,
-                    },
-                ],
-            },
-        } as Cart);
-        component = mount(<ComponentTest {...defaultProps} />);
-        await new Promise((resolve) => process.nextTick(resolve));
-        component.update();
-
-        expect(component.find('[data-test="shipping-mode-toggle"]').text()).toBe(
-            'Ship to multiple addresses',
-        );
-    });
-
-    describe('when multishipping mode is on', () => {
-        describe('when shopper is signed', () => {
-            beforeEach(async () => {
-                component = mount(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
-                await new Promise((resolve) => process.nextTick(resolve));
-                component.update();
-            });
-
-            it('calls updateCheckout and navigateNextStep', async () => {
-                component
-                    .find('input[name="orderComment"]')
-                    .simulate('change', { target: { value: 'foo', name: 'orderComment' } });
-
-                component.find('form').simulate('submit');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(checkoutService.updateCheckout).toHaveBeenCalledWith({
-                    customerMessage: 'foo',
-                });
-                expect(defaultProps.navigateNextStep).toHaveBeenCalledWith(false);
-            });
-
-            it('calls onToggleMultiShipping when link is clicked', () => {
-                expect(component.find('[data-test="shipping-mode-toggle"]').text()).toBe(
-                    'Ship to a single address',
-                );
-
-                component.find('[data-test="shipping-mode-toggle"]').simulate('click');
-
-                expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
-            });
-
-            it('renders multishipping header', () => {
-                expect(component.find('[data-test="shipping-address-heading"]').text()).toBe(
-                    'Choose where to ship each item',
-                );
-            });
-
-            it('renders shipping form', () => {
-                expect(component.find(ShippingForm)).toHaveLength(1);
-            });
-
-            it('updates shipping if shopper turns off multishipping mode with multiple consignments', async () => {
-                const consignments = [
-                    { ...getConsignment(), id: 'foo' },
-                    { ...getConsignment(), id: 'bar' },
-                    { ...getConsignment(), id: 'foobar' },
-                ];
-                const multipleConsignmentsProp = {
-                    ...defaultProps,
-                    consignments,
-                };
-
-                component = mount(
-                    <ComponentTest {...multipleConsignmentsProp} isMultiShippingMode={true} />,
-                );
-                await new Promise((resolve) => process.nextTick(resolve));
-                component.update();
-
-                component.find('[data-test="shipping-mode-toggle"]').simulate('click');
-
-                expect(checkoutService.updateShippingAddress).toHaveBeenCalledWith(
-                    consignments[0].shippingAddress,
-                );
-            });
+    describe('when hasMultiShippingEnabled is enabled', () => {
+        beforeEach(async () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                ...getStoreConfig(),
+                checkoutSettings: {
+                    ...getStoreConfig().checkoutSettings,
+                    hasMultiShippingEnabled: true,
+                },
+            })
         });
 
-        describe('when is guest user', () => {
-            beforeEach(async () => {
-                jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
-                    ...getCustomer(),
-                    isGuest: true,
-                });
+        it('shows multi address shipping link for more than 50 cart items', async () => {
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 51,
+                        },
+                    ],
+                },
+            } as Cart);
+            component = mount(<ComponentTest {...defaultProps} />);
+            await new Promise((resolve) => process.nextTick(resolve));
+            component.update();
 
-                component = mount(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
-                await new Promise((resolve) => process.nextTick(resolve));
-                component.update();
-            });
-
-            it('renders multishipping header', () => {
-                expect(component.find('[data-test="shipping-address-heading"]').text()).toBe(
-                    'Please sign in first',
-                );
-            });
-
-            it('doest render shipping form', () => {
-                expect(component.find(ShippingForm)).toHaveLength(1);
-            });
+            expect(component.find('[data-test="shipping-mode-toggle"]').text()).toBe(
+                'Ship to multiple addresses',
+            );
         });
 
-        describe('when there are multiple consignments', () => {
-            beforeEach(async () => {
-                jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([
-                    getConsignment(),
-                    getConsignment(),
-                ]);
-
-                jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
-                    ...getStoreConfig(),
-                    checkoutSettings: {
-                        ...getStoreConfig().checkoutSettings,
-                        hasMultiShippingEnabled: false,
-                    },
+        describe('when multishipping mode is on', () => {
+            describe('when shopper is signed', () => {
+                beforeEach(async () => {
+                    component = mount(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
+                    await new Promise((resolve) => process.nextTick(resolve));
+                    component.update();
                 });
 
-                component = mount(<ComponentTest {...defaultProps} />);
-                await new Promise((resolve) => process.nextTick(resolve));
-                component.update();
+                it('calls updateCheckout and navigateNextStep', async () => {
+                    component
+                        .find('input[name="orderComment"]')
+                        .simulate('change', { target: { value: 'foo', name: 'orderComment' } });
+
+                    component.find('form').simulate('submit');
+
+                    await new Promise((resolve) => process.nextTick(resolve));
+
+                    expect(checkoutService.updateCheckout).toHaveBeenCalledWith({
+                        customerMessage: 'foo',
+                    });
+                    expect(defaultProps.navigateNextStep).toHaveBeenCalledWith(false);
+                });
+
+                it('calls onToggleMultiShipping when link is clicked', () => {
+                    expect(component.find('[data-test="shipping-mode-toggle"]').text()).toBe(
+                        'Ship to a single address',
+                    );
+
+                    component.find('[data-test="shipping-mode-toggle"]').simulate('click');
+
+                    expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
+                });
+
+                it('renders multishipping header', () => {
+                    expect(component.find('[data-test="shipping-address-heading"]').text()).toBe(
+                        'Choose where to ship each item',
+                    );
+                });
+
+                it('renders shipping form', () => {
+                    expect(component.find(ShippingForm)).toHaveLength(1);
+                });
+
+                it('updates shipping if shopper turns off multishipping mode with multiple consignments', async () => {
+                    const consignments = [
+                        { ...getConsignment(), id: 'foo' },
+                        { ...getConsignment(), id: 'bar' },
+                        { ...getConsignment(), id: 'foobar' },
+                    ];
+                    const multipleConsignmentsProp = {
+                        ...defaultProps,
+                        consignments,
+                    };
+
+                    component = mount(
+                        <ComponentTest {...multipleConsignmentsProp} isMultiShippingMode={true} />,
+                    );
+                    await new Promise((resolve) => process.nextTick(resolve));
+                    component.update();
+
+                    component.find('[data-test="shipping-mode-toggle"]').simulate('click');
+
+                    expect(checkoutService.updateShippingAddress).toHaveBeenCalledWith(
+                        consignments[0].shippingAddress,
+                    );
+                });
             });
 
-            it('does not initialize any shipping address', () => {
-                expect(component.find(ShippingForm).prop('address')).toBeFalsy();
+            describe('when is guest user', () => {
+                beforeEach(async () => {
+                    jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+                        ...getCustomer(),
+                        isGuest: true,
+                    });
+
+                    component = mount(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
+                    await new Promise((resolve) => process.nextTick(resolve));
+                    component.update();
+                });
+
+                it('renders multishipping header', () => {
+                    expect(component.find('[data-test="shipping-address-heading"]').text()).toBe(
+                        'Please sign in first',
+                    );
+                });
+
+                it('doest render shipping form', () => {
+                    expect(component.find(ShippingForm)).toHaveLength(1);
+                });
+            });
+
+            describe('when there are multiple consignments', () => {
+                beforeEach(async () => {
+                    jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([
+                        getConsignment(),
+                        getConsignment(),
+                    ]);
+
+                    jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                        ...getStoreConfig(),
+                        checkoutSettings: {
+                            ...getStoreConfig().checkoutSettings,
+                            hasMultiShippingEnabled: false,
+                        },
+                    });
+
+                    component = mount(<ComponentTest {...defaultProps} />);
+                    await new Promise((resolve) => process.nextTick(resolve));
+                    component.update();
+                });
+
+                it('does not initialize any shipping address', () => {
+                    expect(component.find(ShippingForm).prop('address')).toBeFalsy();
+                });
             });
         });
     });

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -383,7 +383,7 @@ export function mapToShippingProps({
         isUpdatingCheckout() ||
         isCreatingCustomerAddress();
     const shouldShowMultiShipping =
-        hasMultiShippingEnabled && !methodId && shippableItemsCount > 1 && shippableItemsCount < 50;
+        hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
     const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ'];
 
     if (features['CHECKOUT-4183.checkout_google_address_autocomplete_uk']) {

--- a/packages/core/src/app/shipping/mapToShippingProps.spec.ts
+++ b/packages/core/src/app/shipping/mapToShippingProps.spec.ts
@@ -58,21 +58,21 @@ describe('mapToShippingProps()', () => {
         });
 
         it('returns true when enabled', () => {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            expect(mapToShippingProps(checkoutContextProps)!.shouldShowMultiShipping).toBe(true);
-        });
-
-        it('returns false when not enabled', () => {
             const { checkoutSettings } = getStoreConfig();
 
             jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
                 ...getStoreConfig(),
                 checkoutSettings: {
                     ...checkoutSettings,
-                    hasMultiShippingEnabled: false,
+                    hasMultiShippingEnabled: true,
                 },
             } as StoreConfig);
 
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            expect(mapToShippingProps(checkoutContextProps)!.shouldShowMultiShipping).toBe(true);
+        });
+
+        it('returns false when not enabled', () => {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             expect(mapToShippingProps(checkoutContextProps)!.shouldShowMultiShipping).toBe(false);
         });


### PR DESCRIPTION
## What?

Remove top limit of 50 cart items to show multi-shipping.

## Why?

Ship to multiple address should be visible if cart items is greater than 1 and no upper limit.

## Testing / Proof

1. Unit test
2. Manual test

**BEFORE**

https://github.com/bigcommerce/checkout-js/assets/141614330/79b5c819-334f-4f75-879c-b8a3d028f861

**AFTER**

https://github.com/bigcommerce/checkout-js/assets/141614330/9da79de4-28a1-48e0-9752-e168aa7fc626
