### PR TITLE
feat(payment): PI-747 load bluesnap script ONLY if it wasn't loaded before

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.437.0",
+        "@bigcommerce/checkout-sdk": "^1.438.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.437.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.437.0.tgz",
-      "integrity": "sha512-ffP0WNQOY3Q0NsWFuSyErtPdwm5xp2JkiYiQmt/99JlCAMHY+qjOyL3GgjCxOyetxqF6YuaMx0QqJT2CI2jIbw==",
+      "version": "1.438.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.438.0.tgz",
+      "integrity": "sha512-+McFtjVe0EDeZLeauN33quqFhfwA5Ks9ibArcKLrvzZOZYH+s1Vhw/8xjj7333mSLPlzfRnvLFDs/DtZUJKehA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.437.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.437.0.tgz",
-      "integrity": "sha512-ffP0WNQOY3Q0NsWFuSyErtPdwm5xp2JkiYiQmt/99JlCAMHY+qjOyL3GgjCxOyetxqF6YuaMx0QqJT2CI2jIbw==",
+      "version": "1.438.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.438.0.tgz",
+      "integrity": "sha512-+McFtjVe0EDeZLeauN33quqFhfwA5Ks9ibArcKLrvzZOZYH+s1Vhw/8xjj7333mSLPlzfRnvLFDs/DtZUJKehA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.437.0",
+    "@bigcommerce/checkout-sdk": "^1.438.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
RELEASE OF https://github.com/bigcommerce/checkout-sdk-js/pull/2153
Fixed not working 3ds challenge for the stored card case when new card form was selected previously

## Why?
Due to the 3ds issue

## Testing / Proof

![image](https://github.com/bigcommerce/checkout-js/assets/79574476/da5ccb8c-c1d3-48e8-9d05-6b4aee5d26fa)


@bigcommerce/team-checkout @bigcommerce/team-payments
