### PR TITLE
feat(checkout): CHECKOUT-7648 Add automated consent for privacy policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bigcommerce/checkout",
-  "version": "1.367.0",
+  "version": "1.364.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/checkout",
-      "version": "1.367.0",
+      "version": "1.364.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.438.0",
+        "@bigcommerce/checkout-sdk": "^1.439.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.438.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.438.0.tgz",
-      "integrity": "sha512-+McFtjVe0EDeZLeauN33quqFhfwA5Ks9ibArcKLrvzZOZYH+s1Vhw/8xjj7333mSLPlzfRnvLFDs/DtZUJKehA==",
+      "version": "1.439.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.439.0.tgz",
+      "integrity": "sha512-W7g/vsbNms5FyV+3J3nYNhxqzz50kmzzu5B3onbOyjl6g1egQ9MSTsvaPlSNssVMmPuM3pX8p3PfglJ4hqNdfg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.438.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.438.0.tgz",
-      "integrity": "sha512-+McFtjVe0EDeZLeauN33quqFhfwA5Ks9ibArcKLrvzZOZYH+s1Vhw/8xjj7333mSLPlzfRnvLFDs/DtZUJKehA==",
+      "version": "1.439.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.439.0.tgz",
+      "integrity": "sha512-W7g/vsbNms5FyV+3J3nYNhxqzz50kmzzu5B3onbOyjl6g1egQ9MSTsvaPlSNssVMmPuM3pX8p3PfglJ4hqNdfg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bigcommerce/checkout",
-  "version": "1.364.1",
+  "version": "1.367.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bigcommerce/checkout",
-      "version": "1.364.1",
+      "version": "1.367.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/checkout",
-  "version": "1.367.0",
+  "version": "1.364.1",
   "private": true,
   "description": "Browser-based application providing a seamless UI for BigCommerce shoppers to complete their checkout.",
   "license": "MIT",
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.438.0",
+    "@bigcommerce/checkout-sdk": "^1.439.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/checkout",
-  "version": "1.364.1",
+  "version": "1.367.0",
   "private": true,
   "description": "Browser-based application providing a seamless UI for BigCommerce shoppers to complete their checkout.",
   "license": "MIT",

--- a/packages/core/src/app/config/config.mock.ts
+++ b/packages/core/src/app/config/config.mock.ts
@@ -25,6 +25,7 @@ export function getStoreConfig(): StoreConfig {
             isAnalyticsEnabled: true,
             isAccountCreationEnabled: true,
             isCardVaultingEnabled: true,
+            isExpressPrivacyPolicy: false,
             isPaymentRequestEnabled: false,
             isPaymentRequestCanMakePaymentEnabled: false,
             isSpamProtectionEnabled: false,

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -80,6 +80,7 @@ export interface WithCheckoutCustomerProps {
     createAccountError?: Error;
     signInError?: Error;
     isFloatingLabelEnabled?: boolean;
+    isExpressPrivacyPolicy: boolean;
     clearError(error: Error): Promise<CheckoutSelectors>;
     continueAsGuest(credentials: GuestCredentials): Promise<CheckoutSelectors>;
     deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
@@ -181,6 +182,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             onUnhandledError = noop,
             step,
             isFloatingLabelEnabled,
+            isExpressPrivacyPolicy,
         } = this.props;
         const checkoutButtons = isWalletButtonsOnTop
           ? null
@@ -207,6 +209,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                     deinitialize={deinitializeCustomer}
                     email={this.draftEmail || email}
                     initialize={initializeCustomer}
+                    isExpressPrivacyPolicy={isExpressPrivacyPolicy}
                     isLoading={isContinuingAsGuest || isInitializing || isExecutingPaymentMethodCheckout}
                     onChangeEmail={this.handleChangeEmail}
                     onContinueAsGuest={this.handleContinueAsGuest}
@@ -222,6 +225,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 continueAsGuestButtonLabelId="customer.continue"
                 defaultShouldSubscribe={isSubscribed}
                 email={this.draftEmail || email}
+                isExpressPrivacyPolicy={isExpressPrivacyPolicy}
                 isFloatingLabelEnabled={isFloatingLabelEnabled}
                 isLoading={isLoadingGuestForm}
                 onChangeEmail={this.handleChangeEmail}
@@ -612,6 +616,7 @@ export function mapToWithCheckoutCustomerProps({
         signIn: checkoutService.signInCustomer,
         signInError: getSignInError(),
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
+        isExpressPrivacyPolicy: config.checkoutSettings.isExpressPrivacyPolicy,
     };
 }
 

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -579,6 +579,7 @@ export function mapToWithCheckoutCustomerProps({
             requiresMarketingConsent,
             isSignInEmailEnabled,
             isAccountCreationEnabled,
+            isExpressPrivacyPolicy,
         },
     } = config as StoreConfig & { checkoutSettings: { isAccountCreationEnabled: boolean } };
 
@@ -616,7 +617,7 @@ export function mapToWithCheckoutCustomerProps({
         signIn: checkoutService.signInCustomer,
         signInError: getSignInError(),
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
-        isExpressPrivacyPolicy: config.checkoutSettings.isExpressPrivacyPolicy,
+        isExpressPrivacyPolicy,
     };
 }
 

--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -21,6 +21,7 @@ export interface GuestFormProps {
     email?: string;
     isLoading: boolean;
     privacyPolicyUrl?: string;
+    isExpressPrivacyPolicy: boolean;
     isFloatingLabelEnabled?: boolean;
     onChangeEmail(email: string): void;
     onContinueAsGuest(data: GuestFormValues): void;
@@ -43,6 +44,7 @@ const GuestForm: FunctionComponent<
     onShowLogin,
     privacyPolicyUrl,
     requiresMarketingConsent,
+    isExpressPrivacyPolicy,
     isFloatingLabelEnabled,
 }) => {
     const renderField = useCallback(
@@ -72,8 +74,6 @@ const GuestForm: FunctionComponent<
                         {(canSubscribe || requiresMarketingConsent) && (
                             <BasicFormField name="shouldSubscribe" render={renderField} />
                         )}
-
-                        {privacyPolicyUrl && <PrivacyPolicyField url={privacyPolicyUrl} />}
                     </div>
 
                     <div
@@ -93,6 +93,10 @@ const GuestForm: FunctionComponent<
                         </Button>
                     </div>
                 </div>
+
+                {privacyPolicyUrl && (
+                    <PrivacyPolicyField isExpressPrivacyPolicy={isExpressPrivacyPolicy} url={privacyPolicyUrl} />
+                )}
 
                 {!isLoading && (
                     <p>
@@ -127,7 +131,7 @@ export default withLanguage(
         handleSubmit: (values, { props: { onContinueAsGuest } }) => {
             onContinueAsGuest(values);
         },
-        validationSchema: ({ language, privacyPolicyUrl }: GuestFormProps & WithLanguageProps) => {
+        validationSchema: ({ language, privacyPolicyUrl, isExpressPrivacyPolicy }: GuestFormProps & WithLanguageProps) => {
             const email = string()
                 .email(language.translate('customer.email_invalid_error'))
                 .max(256)
@@ -135,7 +139,7 @@ export default withLanguage(
 
             const baseSchema = object({ email });
 
-            if (privacyPolicyUrl) {
+            if (privacyPolicyUrl && !isExpressPrivacyPolicy) {
                 return baseSchema.concat(
                     getPrivacyPolicyValidationSchema({
                         isRequired: !!privacyPolicyUrl,

--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -21,6 +21,7 @@ export interface StripeGuestFormProps {
     continueAsGuestButtonLabelId: string;
     email?: string;
     isLoading: boolean;
+    isExpressPrivacyPolicy: boolean;
     requiresMarketingConsent: boolean;
     defaultShouldSubscribe: boolean;
     privacyPolicyUrl?: string;
@@ -35,6 +36,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
     continueAsGuestButtonLabelId,
     isLoading,
     initialize,
+    isExpressPrivacyPolicy,
     deinitialize,
     onChangeEmail,
     onShowLogin,
@@ -199,10 +201,6 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                                     name="shouldSubscribe"
                                     render={ renderField }
                                 /> }
-
-                                { privacyPolicyUrl && <PrivacyPolicyField
-                                    url={ privacyPolicyUrl }
-                                /> }
                             </div>
 
                             <div className="form-actions customerEmail-action">
@@ -219,6 +217,11 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                                 </Button> }
                             </div>
                         </div>
+
+                        {privacyPolicyUrl && (
+                            <PrivacyPolicyField isExpressPrivacyPolicy={isExpressPrivacyPolicy} url={privacyPolicyUrl} />
+                        )}
+
                         {
                             !isLoading && <p>
                                 <TranslatedString id="customer.login_text"/>
@@ -258,8 +261,8 @@ export default withLanguage(
                     shouldSubscribe: values.shouldSubscribe,
                   });
             },
-            validationSchema: ({ language, privacyPolicyUrl }: StripeGuestFormProps & WithLanguageProps) => {
-                if (privacyPolicyUrl) {
+            validationSchema: ({ language, privacyPolicyUrl, isExpressPrivacyPolicy }: StripeGuestFormProps & WithLanguageProps) => {
+                if (privacyPolicyUrl && !isExpressPrivacyPolicy) {
                     return getPrivacyPolicyValidationSchema({
                             isRequired: !!privacyPolicyUrl,
                             language,

--- a/packages/core/src/app/privacyPolicy/PrivacyPolicyField.spec.tsx
+++ b/packages/core/src/app/privacyPolicy/PrivacyPolicyField.spec.tsx
@@ -3,7 +3,12 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
 
-import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedHtml } from '@bigcommerce/checkout/locale';
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+    TranslatedHtml,
+} from '@bigcommerce/checkout/locale';
 
 import { getStoreConfig } from '../config/config.mock';
 import { CheckboxFormField } from '../ui/form';
@@ -23,7 +28,7 @@ describe('PrivacyPolicyField', () => {
         const component = mount(
             <LocaleContext.Provider value={localeContext}>
                 <Formik initialValues={initialValues} onSubmit={noop}>
-                    <PrivacyPolicyField url="foo" />
+                    <PrivacyPolicyField isExpressPrivacyPolicy={false} url="foo" />
                 </Formik>
             </LocaleContext.Provider>,
         );
@@ -32,6 +37,22 @@ describe('PrivacyPolicyField', () => {
         expect(component.find(TranslatedHtml).props()).toMatchObject({
             data: { url: 'foo' },
             id: 'privacy_policy.label',
+        });
+    });
+
+    it('renders text with external link if isExpressPrivacyPolicy is true', () => {
+        const component = mount(
+            <LocaleContext.Provider value={localeContext}>
+                <Formik initialValues={initialValues} onSubmit={noop}>
+                    <PrivacyPolicyField isExpressPrivacyPolicy={true} url="foo" />
+                </Formik>
+            </LocaleContext.Provider>,
+        );
+
+        expect(component.find(CheckboxFormField)).toHaveLength(0);
+        expect(component.find(TranslatedHtml).props()).toMatchObject({
+            data: { url: 'foo' },
+            id: 'privacy_policy_auto_consent.label',
         });
     });
 });

--- a/packages/core/src/app/privacyPolicy/PrivacyPolicyField.test.tsx
+++ b/packages/core/src/app/privacyPolicy/PrivacyPolicyField.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
@@ -7,11 +7,9 @@ import {
     createLocaleContext,
     LocaleContext,
     LocaleContextType,
-    TranslatedHtml,
 } from '@bigcommerce/checkout/locale';
 
 import { getStoreConfig } from '../config/config.mock';
-import { CheckboxFormField } from '../ui/form';
 
 import PrivacyPolicyField from './PrivacyPolicyField';
 
@@ -25,7 +23,7 @@ describe('PrivacyPolicyField', () => {
     });
 
     it('renders checkbox with external link', () => {
-        const component = mount(
+        render(
             <LocaleContext.Provider value={localeContext}>
                 <Formik initialValues={initialValues} onSubmit={noop}>
                     <PrivacyPolicyField isExpressPrivacyPolicy={false} url="foo" />
@@ -33,15 +31,17 @@ describe('PrivacyPolicyField', () => {
             </LocaleContext.Provider>,
         );
 
-        expect(component.find(CheckboxFormField)).toHaveLength(1);
-        expect(component.find(TranslatedHtml).props()).toMatchObject({
-            data: { url: 'foo' },
-            id: 'privacy_policy.label',
-        });
+        const link = screen.getByText('privacy policy');
+
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', 'foo');
+
+        expect(screen.getByTestId('privacy-policy-checkbox')).toBeInTheDocument();
+        expect(screen.getByLabelText('Yes, I agree with the privacy policy.')).toBeInTheDocument();
     });
 
     it('renders text with external link if isExpressPrivacyPolicy is true', () => {
-        const component = mount(
+        render(
             <LocaleContext.Provider value={localeContext}>
                 <Formik initialValues={initialValues} onSubmit={noop}>
                     <PrivacyPolicyField isExpressPrivacyPolicy={true} url="foo" />
@@ -49,10 +49,11 @@ describe('PrivacyPolicyField', () => {
             </LocaleContext.Provider>,
         );
 
-        expect(component.find(CheckboxFormField)).toHaveLength(0);
-        expect(component.find(TranslatedHtml).props()).toMatchObject({
-            data: { url: 'foo' },
-            id: 'privacy_policy_auto_consent.label',
-        });
+        const link = screen.getByText('privacy policy');
+
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', 'foo');
+
+        expect(screen.getByText('By clicking continue', { exact: false })).toBeInTheDocument();
     });
 });

--- a/packages/core/src/app/privacyPolicy/PrivacyPolicyField.tsx
+++ b/packages/core/src/app/privacyPolicy/PrivacyPolicyField.tsx
@@ -7,7 +7,8 @@ import { CheckboxFormField, Fieldset } from '../ui/form';
 const PrivacyPolicyCheckboxFieldLink: FunctionComponent<{ url: string }> = ({ url }) => (
     <CheckboxFormField
         labelContent={<TranslatedHtml data={{ url }} id="privacy_policy.label" />}
-        name="privacyPolicy" testId='privacy-policy-checkbox'
+        name="privacyPolicy"
+        testId="privacy-policy-checkbox"
     />
 );
 
@@ -17,4 +18,21 @@ const PrivacyPolicyFieldset: FunctionComponent<{ url: string }> = ({ url }) => (
     </Fieldset>
 );
 
-export default memo(PrivacyPolicyFieldset);
+const PrivacyPolicyAutoConsent: FunctionComponent<{ url: string }> = ({ url }) => (
+    <p>
+        <TranslatedHtml data={{ url }} id="privacy_policy_auto_consent.label" />
+    </p>
+);
+
+const PrivacyPolicyField: FunctionComponent<{ url: string; isExpressPrivacyPolicy: boolean }> = ({
+    url,
+    isExpressPrivacyPolicy,
+}) => {
+    if (isExpressPrivacyPolicy) {
+        return <PrivacyPolicyAutoConsent url={url} />;
+    }
+
+    return <PrivacyPolicyFieldset url={url} />;
+};
+
+export default memo(PrivacyPolicyField);

--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -8,7 +8,9 @@
 .customerEmail-container {
     @include grid-row;
 
-    margin-bottom: spacing("single");
+    @include breakpoint("small") {
+        margin-bottom: spacing("single");
+    }
 
     .customerEmail-floating--enabled {
         @include breakpoint("small") {
@@ -25,7 +27,7 @@
 .customerEmail-action {
     @include grid-column($collapse: true, $columns: $total-columns);
 
-    margin-bottom: spacing("single");
+    margin-bottom: spacing("half");
     padding: 0;
 
     @include breakpoint("small") {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -514,6 +514,9 @@
             "label": "Yes, I agree with the <a href=\"{url}\" target=\"_blank\">privacy policy</a>.",
             "heading": "Privacy Policy"
         },
+        "privacy_policy_auto_consent": {
+            "label": "*By clicking continue, you agree to our  <a href=\"{url}\" target=\"_blank\">privacy policy</a>."
+        },
         "tax": {
             "inclusive_label": "Tax Included in Total:"
         },

--- a/packages/test-framework/src/react-testing-library-support/API.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/API.mock.ts
@@ -22,6 +22,7 @@ const checkoutSettings = {
             guestCheckoutEnabled: true,
             isCardVaultingEnabled: true,
             isCouponCodeCollapsed: true,
+            isExpressPrivacyPolicy: false,
             isPaymentRequestEnabled: false,
             isPaymentRequestCanMakePaymentEnabled: false,
             isSignInEmailEnabled: true,

--- a/packages/test-utils/src/config.mock.ts
+++ b/packages/test-utils/src/config.mock.ts
@@ -25,6 +25,7 @@ export function getStoreConfig(): StoreConfig {
             isAnalyticsEnabled: true,
             isAccountCreationEnabled: true,
             isCardVaultingEnabled: true,
+            isExpressPrivacyPolicy: false,
             isPaymentRequestEnabled: false,
             isPaymentRequestCanMakePaymentEnabled: false,
             isSpamProtectionEnabled: false,


### PR DESCRIPTION
## What?
Display automated consent for privacy policy based on the checkout settings.

## Why?
Reduce friction and provides a better UX for stores using an accelerated checkout product such as PayPal Connect.

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/2155

## Testing / Proof
### UI of automated consent for privacy policy

https://github.com/bigcommerce/checkout-js/assets/88361607/79f04576-187e-468d-82c7-de754667ac68

### UI of manual consent for privacy policy

https://github.com/bigcommerce/checkout-js/assets/88361607/515fd346-e398-434c-8439-ec004cdad09f

### A shopper finishes the customer step when automated consent is on

https://github.com/bigcommerce/checkout-js/assets/88361607/881883c7-317d-44f6-8f90-2a18096c1831

### A shopper finishes the customer step when automated consent is off

https://github.com/bigcommerce/checkout-js/assets/88361607/5004b4df-5766-4aa7-9654-ab55aab2ae3a

@bigcommerce/team-checkout
