### PR TITLE
feat(checkout): PI-741 added texts for the adyen boleto ticket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.458.0",
+        "@bigcommerce/checkout-sdk": "^1.459.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.458.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.458.0.tgz",
-      "integrity": "sha512-rCyyoWIiYNJCTXHPorD0DinyPLNdW1vhjIE2zXU/33jjCqvNVkHdUTLFw8P0nwNyRJUybXwblgvFhyPJOnCp8w==",
+      "version": "1.459.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.459.0.tgz",
+      "integrity": "sha512-qyZ2923b6Y07wDRxWlU72WOk7JcBNguWJbMXUBY+2T75gbvW5G4sW+ScZoYZolmuNy5vJRtOpKZA9kcrh39+4w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.458.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.458.0.tgz",
-      "integrity": "sha512-rCyyoWIiYNJCTXHPorD0DinyPLNdW1vhjIE2zXU/33jjCqvNVkHdUTLFw8P0nwNyRJUybXwblgvFhyPJOnCp8w==",
+      "version": "1.459.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.459.0.tgz",
+      "integrity": "sha512-qyZ2923b6Y07wDRxWlU72WOk7JcBNguWJbMXUBY+2T75gbvW5G4sW+ScZoYZolmuNy5vJRtOpKZA9kcrh39+4w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.458.0",
+    "@bigcommerce/checkout-sdk": "^1.459.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -528,6 +528,9 @@
         },
         "order_confirmation": {
             "mandate": {
+                "adyenv3": {
+                    "boletobancario": "Boleto Bancário Ticket"
+                },
                 "checkoutcom": {
                     "boleto": "Boleto Bancário Ticket",
                     "oxxo": "OXXO Ticket",


### PR DESCRIPTION
## What?
Added texts for the adyen boleto ticket
[SDK PR](https://github.com/bigcommerce/checkout-sdk-js/pull/2147)
additionally https://github.com/bigcommerce/checkout-sdk-js/pull/2208

## Why?
Due to the Adyen-Boleto integration

## Testing / Proof
manually
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/98eccb5f-048d-4cd4-80db-0d5207592216)

![image](https://github.com/bigcommerce/checkout-js/assets/79574476/65a355b8-050d-4321-b094-37fa24a51782)


@bigcommerce/team-checkout
