### PR TITLE
chore(payment): PAYPAL-2908 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.439.0",
+        "@bigcommerce/checkout-sdk": "^1.441.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.439.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.439.0.tgz",
-      "integrity": "sha512-W7g/vsbNms5FyV+3J3nYNhxqzz50kmzzu5B3onbOyjl6g1egQ9MSTsvaPlSNssVMmPuM3pX8p3PfglJ4hqNdfg==",
+      "version": "1.441.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.1.tgz",
+      "integrity": "sha512-WxJALRT3Y2dRuN7CU1wbF149Xb9F/BSmhlt3hdjk4Eu5ntQBRbluVVKxYXAf0/U8lAMOLMgosRpJkw1v5lzUZQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.439.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.439.0.tgz",
-      "integrity": "sha512-W7g/vsbNms5FyV+3J3nYNhxqzz50kmzzu5B3onbOyjl6g1egQ9MSTsvaPlSNssVMmPuM3pX8p3PfglJ4hqNdfg==",
+      "version": "1.441.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.1.tgz",
+      "integrity": "sha512-WxJALRT3Y2dRuN7CU1wbF149Xb9F/BSmhlt3hdjk4Eu5ntQBRbluVVKxYXAf0/U8lAMOLMgosRpJkw1v5lzUZQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.439.0",
+    "@bigcommerce/checkout-sdk": "^1.441.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2163
https://github.com/bigcommerce/checkout-sdk-js/pull/2131
https://github.com/bigcommerce/checkout-sdk-js/pull/2158
https://github.com/bigcommerce/checkout-sdk-js/pull/2161
https://github.com/bigcommerce/checkout-sdk-js/pull/2159
https://github.com/bigcommerce/checkout-sdk-js/pull/2160

## Testing / Proof
Unit tests
Manual tests

Here is a screenshot of working checkout sdk loader cdn:
<img width="1512" alt="Screenshot 2023-09-04 at 12 05 08" src="https://github.com/bigcommerce/checkout-js/assets/25133454/55b52f98-93e7-42cb-b3dc-26f15f9533f0">


