### PR TITLE
chore(release): PI-747 bump sdk version for bluesnap 3ds fix for stored card, billing/shipping state mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.441.1",
+        "@bigcommerce/checkout-sdk": "^1.441.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.441.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.1.tgz",
-      "integrity": "sha512-WxJALRT3Y2dRuN7CU1wbF149Xb9F/BSmhlt3hdjk4Eu5ntQBRbluVVKxYXAf0/U8lAMOLMgosRpJkw1v5lzUZQ==",
+      "version": "1.441.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.2.tgz",
+      "integrity": "sha512-JynZJvi+t5mFJyDBc2X6TamOkAFzQTFh/cRUyfX3iivaTJ4rf1YudNG3aiwUa4UeRryOV67vRD9wQXggBvPgcg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.441.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.1.tgz",
-      "integrity": "sha512-WxJALRT3Y2dRuN7CU1wbF149Xb9F/BSmhlt3hdjk4Eu5ntQBRbluVVKxYXAf0/U8lAMOLMgosRpJkw1v5lzUZQ==",
+      "version": "1.441.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.2.tgz",
+      "integrity": "sha512-JynZJvi+t5mFJyDBc2X6TamOkAFzQTFh/cRUyfX3iivaTJ4rf1YudNG3aiwUa4UeRryOV67vRD9wQXggBvPgcg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.441.1",
+    "@bigcommerce/checkout-sdk": "^1.441.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump sdk version for bluesnap 3ds fix for stored card, billing/shipping state mapping

## Why?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2157

## Testing / Proof
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/651babcf-5808-42e4-981b-dec3cf218ad2)

@bigcommerce/team-checkout
