### PR TITLE
chore(payment): PAYPAL-2908 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.441.2",
+        "@bigcommerce/checkout-sdk": "^1.441.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.441.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.2.tgz",
-      "integrity": "sha512-JynZJvi+t5mFJyDBc2X6TamOkAFzQTFh/cRUyfX3iivaTJ4rf1YudNG3aiwUa4UeRryOV67vRD9wQXggBvPgcg==",
+      "version": "1.441.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.3.tgz",
+      "integrity": "sha512-4sV+oeN0DIXLYIzM22tb2M2zmpWjziupiniScH03+JNcWo9ZNelAVlOgxCMwkA/FRIh5mtd/mGlwT/zYIwRpLA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.441.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.2.tgz",
-      "integrity": "sha512-JynZJvi+t5mFJyDBc2X6TamOkAFzQTFh/cRUyfX3iivaTJ4rf1YudNG3aiwUa4UeRryOV67vRD9wQXggBvPgcg==",
+      "version": "1.441.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.441.3.tgz",
+      "integrity": "sha512-4sV+oeN0DIXLYIzM22tb2M2zmpWjziupiniScH03+JNcWo9ZNelAVlOgxCMwkA/FRIh5mtd/mGlwT/zYIwRpLA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.441.2",
+    "@bigcommerce/checkout-sdk": "^1.441.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout sdk version

## Why?
As part of release checkout sdk process:
https://github.com/bigcommerce/checkout-sdk-js/pull/2166

## Testing / Proof
Unit tests
Manual tests

Checkout sdk js loader:
<img width="1512" alt="Screenshot 2023-09-05 at 08 44 35" src="https://github.com/bigcommerce/checkout-js/assets/25133454/f74b0aa6-fd9d-4c62-a298-9eceff833ea3">
