### PR TITLE
chore(payment): PI-626 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.442.0",
+        "@bigcommerce/checkout-sdk": "^1.443.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.442.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.442.0.tgz",
-      "integrity": "sha512-rfHmgkv3uSl/9nCDBZbOgbbroKRMt9StwB/Rx9tngyTsP7JThslSrkq87AgBCHGHeLYk4HYRrq/FWaLy781ZOw==",
+      "version": "1.443.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.443.0.tgz",
+      "integrity": "sha512-9iIzx8ba62SlwP+bbr+ylC/i+fds3gMihPnmSLaQpaZU9KRKZKFdHugWnDaklgBEo+43PaiMssC4+kNeNsoZ4g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.442.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.442.0.tgz",
-      "integrity": "sha512-rfHmgkv3uSl/9nCDBZbOgbbroKRMt9StwB/Rx9tngyTsP7JThslSrkq87AgBCHGHeLYk4HYRrq/FWaLy781ZOw==",
+      "version": "1.443.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.443.0.tgz",
+      "integrity": "sha512-9iIzx8ba62SlwP+bbr+ylC/i+fds3gMihPnmSLaQpaZU9KRKZKFdHugWnDaklgBEo+43PaiMssC4+kNeNsoZ4g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.442.0",
+    "@bigcommerce/checkout-sdk": "^1.443.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
…with Stripe is resulting in error.

## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2148

## Why?
Merchant reported an error in Stripe Dashboard "You cannot confirm this PaymentIntent because it has already succeeded after being previously confirmed". The error occurred as result of try to confirm already confirmed payment.

## Testing / Proof
![Zrzut ekranu 2023-09-6 o 13 34 41](https://github.com/bigcommerce/checkout-js/assets/130039975/7df5ec52-0d1e-4d6e-9e44-aaf5a5576ed4)

tested manually
@bigcommerce/team-checkout
