### PR TITLE
fix(payment): PAYPAL-2859 fixed the issue with wallet buttons on top rendering process

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
@@ -16,6 +16,13 @@ describe('CheckoutButtonContainer', () => {
     let checkoutService: CheckoutService;
     let checkoutState: CheckoutSelectors;
 
+    const paymentProviders = [
+        'amazonpay',
+        'googlepayauthorizenet',
+        'paypalcommerce',
+        'paypalcommercecredit',
+    ];
+
     beforeEach(() => {
         checkoutService = createCheckoutService();
         checkoutState = checkoutService.getState();
@@ -30,7 +37,7 @@ describe('CheckoutButtonContainer', () => {
                         walletButtonsOnTop: true,
                         floatingLabelEnabled: false,
                     },
-                    remoteCheckoutProviders: ['amazonpay','applepay', 'braintreepaypal'],
+                    remoteCheckoutProviders: paymentProviders,
                 },
             }),
         );
@@ -112,7 +119,7 @@ describe('CheckoutButtonContainer', () => {
                         walletButtonsOnTop: true,
                         floatingLabelEnabled: false,
                     },
-                    remoteCheckoutProviders: ['amazonpay','applepay', 'paypalcommerce'],
+                    remoteCheckoutProviders: paymentProviders,
                 },
             }),
         );

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -46,9 +46,7 @@ const sortMethodIds = (methodIds:string[]): string[] => {
     return methodIds.sort((a, b) => order.indexOf(b) - order.indexOf(a));
 }
 
-const isPayPalCommerce = (methodId: string): boolean => {
-    return paypalCommerceIds.includes(methodId);
-}
+const isPayPalCommerce = (methodId: string): boolean => paypalCommerceIds.includes(methodId);
 
 const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & WithCheckoutCheckoutButtonContainerProps> = (
     {

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -46,6 +46,10 @@ const sortMethodIds = (methodIds:string[]): string[] => {
     return methodIds.sort((a, b) => order.indexOf(b) - order.indexOf(a));
 }
 
+const isPayPalCommerce = (methodId: string): boolean => {
+    return paypalCommerceIds.includes(methodId);
+}
+
 const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & WithCheckoutCheckoutButtonContainerProps> = (
     {
         availableMethodIds,
@@ -68,7 +72,7 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
     }
 
     const renderButtons = () => availableMethodIds.map((methodId) => {
-        if (isPaymentStepActive && paypalCommerceIds.includes(methodId)) {
+        if (isPaymentStepActive && isPayPalCommerce(methodId)) {
             return null;
         }
 

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -24,9 +24,14 @@ interface WithCheckoutCheckoutButtonContainerProps {
     checkoutState: CheckoutSelectors;
     checkoutService: CheckoutService;
     isLoading: boolean;
-    isPaypalCommerce: boolean;
     initializedMethodIds: string[];
 }
+
+const paypalCommerceIds = [
+    'paypalcommerce',
+    'paypalcommercecredit',
+    'paypalcommercevenmo',
+];
 
 const sortMethodIds = (methodIds:string[]): string[] => {
     const order = [
@@ -48,7 +53,6 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         checkoutState,
         checkEmbeddedSupport,
         isLoading,
-        isPaypalCommerce,
         isPaymentStepActive,
         initializedMethodIds,
         onUnhandledError,
@@ -63,11 +67,11 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         return null;
     }
 
-    if (isPaypalCommerce && isPaymentStepActive) {
-        return null;
-    }
-
     const renderButtons = () => availableMethodIds.map((methodId) => {
+        if (isPaymentStepActive && paypalCommerceIds.includes(methodId)) {
+            return null;
+        }
+
         const ResolvedCheckoutButton = resolveCheckoutButton({ id: methodId });
 
         if (!ResolvedCheckoutButton) {
@@ -151,8 +155,6 @@ function mapToCheckoutButtonContainerProps({
         (methodId) => Boolean(getInitializeCustomerError(methodId)) || isInitializedCustomer(methodId)
     ).length !== availableMethodIds.length;
     const initializedMethodIds = availableMethodIds.filter((methodId) => isInitializedCustomer(methodId));
-    const paypalCommerceIds = ['paypalcommerce', 'paypalcommercecredit', 'paypalcommercevenmo'];
-    const isPaypalCommerce = availableMethodIds.some(id => paypalCommerceIds.includes(id));
 
     return {
         checkoutService,
@@ -160,7 +162,6 @@ function mapToCheckoutButtonContainerProps({
         availableMethodIds: sortMethodIds(availableMethodIds),
         initializedMethodIds,
         isLoading,
-        isPaypalCommerce,
     }
 }
 

--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -8,11 +8,25 @@ exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] 
     Check out faster with:
   </p>
   <div
-    class="checkout-buttons--2"
+    class="checkout-buttons--4"
   >
     <div
       class="checkoutRemote customer-skeleton"
     >
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
       <div
         class="skeleton-container"
       >
@@ -36,7 +50,10 @@ exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] 
         class="checkoutRemote"
       >
         <div
-          id="braintreepaypalCheckoutButton"
+          id="paypalcommerceCheckoutButton"
+        />
+        <div
+          id="paypalcommercecreditCheckoutButton"
         />
         <div
           class="AmazonPayContainer"
@@ -45,6 +62,9 @@ exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] 
             id="amazonpayCheckoutButton"
           />
         </div>
+        <div
+          id="googlepayauthorizenetCheckoutButton"
+        />
       </div>
     </div>
   </div>
@@ -69,11 +89,25 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
     Check out faster with:
   </p>
   <div
-    class="checkout-buttons--2"
+    class="checkout-buttons--4"
   >
     <div
       class="checkoutRemote customer-skeleton"
     >
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
       <div
         class="skeleton-container"
       >
@@ -97,15 +131,15 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
         class="checkoutRemote"
       >
         <div
-          id="braintreepaypalCheckoutButton"
-        />
-        <div
           class="AmazonPayContainer"
         >
           <div
             id="amazonpayCheckoutButton"
           />
         </div>
+        <div
+          id="googlepayauthorizenetCheckoutButton"
+        />
       </div>
     </div>
   </div>
@@ -121,4 +155,75 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
 
 exports[`CheckoutButtonContainer not displays wallet buttons for guest checkout if isPaymentDataRequired = false 1`] = `null`;
 
-exports[`CheckoutButtonContainer removes Paypal commerce wallet buttons when payment step is active 1`] = `null`;
+exports[`CheckoutButtonContainer removes Paypal commerce wallet buttons when payment step is active 1`] = `
+<div
+  class="checkout-button-container"
+  style="position:absolute;left:0;top:-100%"
+>
+  <p>
+    Check out faster with:
+  </p>
+  <div
+    class="checkout-buttons--4"
+  >
+    <div
+      class="checkoutRemote customer-skeleton"
+    >
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+      <div
+        class="skeleton-container"
+      >
+        <div
+          class="input-skeleton"
+        />
+      </div>
+    </div>
+    <div
+      class="loading-skeleton"
+      style="position:absolute;left:100%;top:-100%"
+    >
+      <div
+        class="checkoutRemote"
+      >
+        <div
+          class="AmazonPayContainer"
+        >
+          <div
+            id="amazonpayCheckoutButton"
+          />
+        </div>
+        <div
+          id="googlepayauthorizenetCheckoutButton"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="checkout-separator"
+  >
+    <span>
+      OR
+    </span>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## What?
In short: Fixed the issue with wallet buttons on top rendering process.

We had a condition to remove (instead of hiding) all buttons containers to avoid some issues with PayPal Commerce  conflicts between paywall and buttons. This is related for cases when PayPalCommerce enabled on the store. 

So we updated the logic and we remove only PayPal Commerce buttons instead of removing whole container.

## Why?
Some customers get an error like: '**Unable to create sign-in button without valid container ID**'. 

The error occurs in one scenario:
When the store has PayPalCommerce enabled on the store and the customer goes to payment step and refresh the page.

## Testing / Proof
Unit tests
Manual tests

Before:

https://github.com/bigcommerce/checkout-js/assets/25133454/8d257565-e346-4142-96db-f0f540a3486c



After:

https://github.com/bigcommerce/checkout-js/assets/25133454/690fc3aa-486a-445a-8e2a-4abd078a70b8



