### PR TITLE
feat(checkout): PI-623 BluesnapDirect APMs via redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.444.0",
+        "@bigcommerce/checkout-sdk": "^1.446.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.444.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.444.0.tgz",
-      "integrity": "sha512-+U1Zzf5G1T3YF3rkEFPRRM7m2U3ClCx/Ig4AKFYzUetOBog+6gB01MNm3EJLwpjRKr6kcbZHEOHBuYtvB+9eDQ==",
+      "version": "1.446.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.446.0.tgz",
+      "integrity": "sha512-n3OW6VBLv0nbvC1C6TUuck9LonJsqaWPhHhSH6rBnBE3PHjkZ9WvOZUJ1qNEDMJTLd8QxVtbmLaJnpXeQtO2Jw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.444.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.444.0.tgz",
-      "integrity": "sha512-+U1Zzf5G1T3YF3rkEFPRRM7m2U3ClCx/Ig4AKFYzUetOBog+6gB01MNm3EJLwpjRKr6kcbZHEOHBuYtvB+9eDQ==",
+      "version": "1.446.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.446.0.tgz",
+      "integrity": "sha512-n3OW6VBLv0nbvC1C6TUuck9LonJsqaWPhHhSH6rBnBE3PHjkZ9WvOZUJ1qNEDMJTLd8QxVtbmLaJnpXeQtO2Jw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.444.0",
+    "@bigcommerce/checkout-sdk": "^1.446.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/bluesnap-direct-integration/src/BlueSnapDirectAlternativePaymentMethod.tsx
+++ b/packages/bluesnap-direct-integration/src/BlueSnapDirectAlternativePaymentMethod.tsx
@@ -1,12 +1,4 @@
-import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import React, {
-    createRef,
-    FunctionComponent,
-    RefObject,
-    useCallback,
-    useRef,
-    useState,
-} from 'react';
+import React, { FunctionComponent } from 'react';
 
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
 import {
@@ -14,83 +6,18 @@ import {
     PaymentMethodResolveId,
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
-import { LoadingOverlay, Modal } from '@bigcommerce/checkout/ui';
-
-interface BlueSnapDirectAlternativePaymentMethodRef {
-    paymentPageContentRef: RefObject<HTMLDivElement>;
-    cancelBlueSnapDirectPayment?(): void;
-}
 
 const BlueSnapDirectAlternativePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     checkoutService,
     ...rest
 }) => {
-    const [isLoadingIframe, setIsLoadingIframe] = useState<boolean>(false);
-    const [paymentPageContent, setPaymentPageContent] = useState<HTMLElement>();
-    const ref = useRef<BlueSnapDirectAlternativePaymentMethodRef>({
-        paymentPageContentRef: createRef(),
-    });
-
-    const cancelBlueSnapDirectModalFlow = useCallback(() => {
-        setPaymentPageContent(undefined);
-
-        if (ref.current.cancelBlueSnapDirectPayment) {
-            ref.current.cancelBlueSnapDirectPayment();
-            ref.current.cancelBlueSnapDirectPayment = undefined;
-        }
-    }, []);
-
-    const initializeBlueSnapDirectPayment = useCallback(
-        (options: PaymentInitializeOptions) => {
-            return checkoutService.initializePayment({
-                gatewayId: options.gatewayId,
-                methodId: options.methodId,
-                bluesnapdirect: {
-                    onLoad(content: HTMLIFrameElement, cancel: () => void) {
-                        setPaymentPageContent(content);
-                        setIsLoadingIframe(true);
-                        ref.current.cancelBlueSnapDirectPayment = cancel;
-                    },
-                    style: {
-                        border: '1px solid lightgray',
-                        height: '60vh',
-                        width: '100%',
-                    },
-                },
-            });
-        },
-        [checkoutService],
-    );
-
-    const appendPaymentPageContent = useCallback(() => {
-        if (ref.current.paymentPageContentRef.current && paymentPageContent) {
-            paymentPageContent.addEventListener('load', () => {
-                setIsLoadingIframe(false);
-            });
-            ref.current.paymentPageContentRef.current.appendChild(paymentPageContent);
-        }
-    }, [paymentPageContent]);
-
     return (
-        <>
-            <HostedPaymentComponent
-                {...rest}
-                checkoutService={checkoutService}
-                deinitializePayment={checkoutService.deinitializePayment}
-                initializePayment={initializeBlueSnapDirectPayment}
-            />
-            <Modal
-                additionalModalClassName="modal--bluesnap"
-                isOpen={!!paymentPageContent}
-                onAfterOpen={appendPaymentPageContent}
-                onRequestClose={cancelBlueSnapDirectModalFlow}
-                shouldShowCloseButton={true}
-            >
-                <LoadingOverlay isLoading={isLoadingIframe}>
-                    <div ref={ref.current.paymentPageContentRef} />
-                </LoadingOverlay>
-            </Modal>
-        </>
+        <HostedPaymentComponent
+            {...rest}
+            checkoutService={checkoutService}
+            deinitializePayment={checkoutService.deinitializePayment}
+            initializePayment={checkoutService.initializePayment}
+        />
     );
 };
 

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -129,6 +129,7 @@ class Payment extends Component<
             await loadPaymentMethods();
 
             const selectedMethod = this.state.selectedMethod || this.props.defaultMethod;
+
             analyticsTracker.selectedPaymentMethod(selectedMethod?.config.displayName);
         } catch (error) {
             onUnhandledError(error);
@@ -324,6 +325,7 @@ class Payment extends Component<
             !selectedMethod ||
             selectedMethod.type === PaymentMethodProviderType.Hosted ||
             selectedMethod.type === PaymentMethodProviderType.PPSDK ||
+            selectedMethod.gateway === PaymentMethodId.BlueSnapDirect ||
             selectedMethod.id === PaymentMethodId.AmazonPay ||
             selectedMethod.id === PaymentMethodId.CBAMPGS ||
             selectedMethod.id === PaymentMethodId.Checkoutcom ||


### PR DESCRIPTION
## What?
BluesnapDirect APMs via redirect
https://github.com/bigcommerce/checkout-sdk-js/pull/2171
Additionaly release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2172

## Why?
Because some of the BluesnapDirect APMs can't work via iframe. so we decided to make APMs payments via redirect

## Testing / Proof


https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/fe701760-e40b-448e-b2ae-ab0247a499c1


@bigcommerce/team-checkout @bigcommerce/team-payments
