### PR TITLE
chore(payment): PI-516 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.443.0",
+        "@bigcommerce/checkout-sdk": "^1.444.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.443.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.443.0.tgz",
-      "integrity": "sha512-9iIzx8ba62SlwP+bbr+ylC/i+fds3gMihPnmSLaQpaZU9KRKZKFdHugWnDaklgBEo+43PaiMssC4+kNeNsoZ4g==",
+      "version": "1.444.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.444.0.tgz",
+      "integrity": "sha512-+U1Zzf5G1T3YF3rkEFPRRM7m2U3ClCx/Ig4AKFYzUetOBog+6gB01MNm3EJLwpjRKr6kcbZHEOHBuYtvB+9eDQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.443.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.443.0.tgz",
-      "integrity": "sha512-9iIzx8ba62SlwP+bbr+ylC/i+fds3gMihPnmSLaQpaZU9KRKZKFdHugWnDaklgBEo+43PaiMssC4+kNeNsoZ4g==",
+      "version": "1.444.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.444.0.tgz",
+      "integrity": "sha512-+U1Zzf5G1T3YF3rkEFPRRM7m2U3ClCx/Ig4AKFYzUetOBog+6gB01MNm3EJLwpjRKr6kcbZHEOHBuYtvB+9eDQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.443.0",
+    "@bigcommerce/checkout-sdk": "^1.444.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2089

## Why?
For better separation between payment integrations and core Checkout SDK

## Testing / Proof
<img width="1464" alt="Zrzut ekranu 2023-09-11 o 12 27 48" src="https://github.com/bigcommerce/checkout-js/assets/130039975/881d69ab-cb4a-463a-a56a-891c30a914e9">
<img width="1464" alt="Zrzut ekranu 2023-09-11 o 12 30 04" src="https://github.com/bigcommerce/checkout-js/assets/130039975/abc32b0d-1968-426c-ab57-d4d9f854a138">

tested manually

@bigcommerce/team-checkout
