### PR TITLE
fix(checkout): PI-78 fixed credit card issuer mapping for stored diners club cards

### DIFF
--- a/packages/core/src/app/payment/storedInstrument/mapFromInstrumentCardType.spec.ts
+++ b/packages/core/src/app/payment/storedInstrument/mapFromInstrumentCardType.spec.ts
@@ -8,6 +8,8 @@ describe('mapFromInstrumentCardType()', () => {
     });
 
     it('maps diners club card type', () => {
+        expect(mapFromInstrumentCardType('diners_club')).toBe('diners-club');
+
         expect(mapFromInstrumentCardType('diners')).toBe('diners-club');
     });
 

--- a/packages/core/src/app/payment/storedInstrument/mapFromInstrumentCardType.ts
+++ b/packages/core/src/app/payment/storedInstrument/mapFromInstrumentCardType.ts
@@ -5,6 +5,7 @@ export default function mapFromInstrumentCardType(type: string): string {
             return 'american-express';
 
         case 'diners':
+        case 'diners_club':
             return 'diners-club';
 
         default:

--- a/packages/instrument-utils/src/storedInstrument/mapFromInstrumentCardType/mapFromInstrumentCardType.spec.ts
+++ b/packages/instrument-utils/src/storedInstrument/mapFromInstrumentCardType/mapFromInstrumentCardType.spec.ts
@@ -8,6 +8,8 @@ describe('mapFromInstrumentCardType()', () => {
     });
 
     it('maps diners club card type', () => {
+        expect(mapFromInstrumentCardType('diners_club')).toBe('diners-club');
+
         expect(mapFromInstrumentCardType('diners')).toBe('diners-club');
     });
 

--- a/packages/instrument-utils/src/storedInstrument/mapFromInstrumentCardType/mapFromInstrumentCardType.ts
+++ b/packages/instrument-utils/src/storedInstrument/mapFromInstrumentCardType/mapFromInstrumentCardType.ts
@@ -5,6 +5,7 @@ export default function mapFromInstrumentCardType(type: string): string {
             return 'american-express';
 
         case 'diners':
+        case 'diners_club':
             return 'diners-club';
 
         default:


### PR DESCRIPTION
## What?
Fix of the Diners club logo in the stored cards selector

## Why?
Due to the absence of the Diners club logo in the stored cards selector

## Testing / Proof
Before fix:
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/e68d5a89-dda4-4bdf-b87e-1b713d45a14e)

After fix:
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/fcd4690d-1bf1-4f21-92aa-0e99a36b7010)


@bigcommerce/team-checkout
