### PR TITLE
fix(other): PAYPAL-2891 fixed the issue with webpack watch failed on linked checkout sdk watch recompilation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -251,17 +251,23 @@ function loaderConfig(options, argv) {
                 plugins: [
                     new AsyncHookPlugin({
                         onRun({ compiler, done }) {
-                            eventEmitter.on('app:done', () => {
-                                const definePlugin = new DefinePlugin({
-                                    LIBRARY_NAME: JSON.stringify(LIBRARY_NAME),
-                                    MANIFEST_JSON: JSON.stringify(require(
-                                        join(__dirname, isProduction ? 'dist' : 'build', 'manifest.json')
-                                    )),
-                                });
+                            let wasTriggeredBefore = false;
 
-                                definePlugin.apply(compiler);
-                                eventEmitter.emit('loader:done');
-                                done();
+                            eventEmitter.on('app:done', () => {
+                                if (!wasTriggeredBefore) {
+                                    const definePlugin = new DefinePlugin({
+                                        LIBRARY_NAME: JSON.stringify(LIBRARY_NAME),
+                                        MANIFEST_JSON: JSON.stringify(require(
+                                          join(__dirname, isProduction ? 'dist' : 'build', 'manifest.json')
+                                        )),
+                                    });
+
+                                    definePlugin.apply(compiler);
+                                    eventEmitter.emit('loader:done');
+                                    done();
+
+                                    wasTriggeredBefore = true;
+                                }
                             });
 
                             eventEmitter.on('app:error', () => {


### PR DESCRIPTION
## What?
Fixed the issue with webpack watch failed on linked checkout sdk watch recompilation.

## Why?
We have a problem with webpack watcher command run with linked checkout-sdk dependency. The webpack command fails all the time on checkout-sdk recompilation and we didn't have any idea why this happens.

By making more digging into the issue we have found that webpack command fails because of the second recompilation what tries to reset global variables with DefinePlugin on app:done event. This happens due to the change in file dependencies change after checkout-sdk recompilation.

When the checkout sdk is unlinked or there are no changes there, the watcher command works good.

## Testing / Proof
Manual tests

Before:

https://github.com/bigcommerce/checkout-js/assets/25133454/6b9091d0-41ba-4813-8615-9efff2de8b87



After:


https://github.com/bigcommerce/checkout-js/assets/25133454/0cb95780-f9f6-4bfc-abc3-b8747e522f12




