### PR TITLE
chore(payment): PI-804 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.446.0",
+        "@bigcommerce/checkout-sdk": "^1.448.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.446.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.446.0.tgz",
-      "integrity": "sha512-n3OW6VBLv0nbvC1C6TUuck9LonJsqaWPhHhSH6rBnBE3PHjkZ9WvOZUJ1qNEDMJTLd8QxVtbmLaJnpXeQtO2Jw==",
+      "version": "1.448.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
+      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.446.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.446.0.tgz",
-      "integrity": "sha512-n3OW6VBLv0nbvC1C6TUuck9LonJsqaWPhHhSH6rBnBE3PHjkZ9WvOZUJ1qNEDMJTLd8QxVtbmLaJnpXeQtO2Jw==",
+      "version": "1.448.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
+      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.446.0",
+    "@bigcommerce/checkout-sdk": "^1.448.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2174

## Why?
...

## Testing / Proof
![Zrzut ekranu 2023-09-13 o 09 35 04](https://github.com/bigcommerce/checkout-js/assets/130039975/914ac257-a279-4ce4-81b2-5ac1b916db6f)
![Zrzut ekranu 2023-09-13 o 09 34 46](https://github.com/bigcommerce/checkout-js/assets/130039975/371e9287-1a7e-4bfb-a49d-e21bdbe7c7c9)


@bigcommerce/team-checkout
