### PR TITLE
feat(payment): PAYPAL-2632 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.446.0",
+        "@bigcommerce/checkout-sdk": "^1.448.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.446.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.446.0.tgz",
-      "integrity": "sha512-n3OW6VBLv0nbvC1C6TUuck9LonJsqaWPhHhSH6rBnBE3PHjkZ9WvOZUJ1qNEDMJTLd8QxVtbmLaJnpXeQtO2Jw==",
+      "version": "1.448.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
+      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.446.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.446.0.tgz",
-      "integrity": "sha512-n3OW6VBLv0nbvC1C6TUuck9LonJsqaWPhHhSH6rBnBE3PHjkZ9WvOZUJ1qNEDMJTLd8QxVtbmLaJnpXeQtO2Jw==",
+      "version": "1.448.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
+      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.446.0",
+    "@bigcommerce/checkout-sdk": "^1.448.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deliver checkout-sdk-js code changes
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2142

## Testing / Proof
Tested on dev and int

<img width="1680" alt="Screenshot 2023-09-13 at 12 35 39" src="https://github.com/bigcommerce/checkout-js/assets/56301104/ab0db7e9-e268-4790-95fb-4d343f724b20">


@bigcommerce/team-checkout
