### PR TITLE
chore(payment): PI-734 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.448.0",
+        "@bigcommerce/checkout-sdk": "^1.449.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.448.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
-      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
+      "version": "1.449.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.449.0.tgz",
+      "integrity": "sha512-yf/dQNl8LGroi3d8PRQhw1zvJO7EZmRDLDWJvNwG6XA4U7ocjsCTInogdxahte/dCTSnAzpzPVSPkpzZNcNXuQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.448.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
-      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
+      "version": "1.449.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.449.0.tgz",
+      "integrity": "sha512-yf/dQNl8LGroi3d8PRQhw1zvJO7EZmRDLDWJvNwG6XA4U7ocjsCTInogdxahte/dCTSnAzpzPVSPkpzZNcNXuQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.448.0",
+    "@bigcommerce/checkout-sdk": "^1.449.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version.

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/2169

## Testing / Proof
<img width="1512" alt="Screenshot 2023-09-13 at 11 50 52" src="https://github.com/bigcommerce/checkout-js/assets/138816572/a77f3016-b8f4-4896-bb5d-c93270e5f5d9">

@bigcommerce/team-checkout
