### PR TITLE
chore(payment): PAYPAL-2932 add PayPal billing addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.448.0",
+        "@bigcommerce/checkout-sdk": "^1.450.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.448.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
-      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
+      "version": "1.450.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.0.tgz",
+      "integrity": "sha512-rPoKfxBsQuJvQForTuVh8a9OpY9gEENNPmOeYwTlzEIbjlmm55YRH0T009DCtez6xFb5IdXDoyNxmXGPXnm3qA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.448.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.448.0.tgz",
-      "integrity": "sha512-tlGSi58ulx2qcMGRKlCVp7rcPAhLFh7h0W6HZnIdPozweeOZZZnBDmfZ7EoPq5bXRcDE5Q1ftj9UpA2WYQj8YA==",
+      "version": "1.450.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.0.tgz",
+      "integrity": "sha512-rPoKfxBsQuJvQForTuVh8a9OpY9gEENNPmOeYwTlzEIbjlmm55YRH0T009DCtez6xFb5IdXDoyNxmXGPXnm3qA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.448.0",
+    "@bigcommerce/checkout-sdk": "^1.450.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version
PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2177](https://github.com/bigcommerce/checkout-sdk-js/pull/2177)

## Why?
Preset billing address fields from PP card info
To setup correct billing address for preset payment instrument

## Testing / Proof
Manually tested and unit test
<img width="2560" alt="Screenshot 2023-09-18 at 12 44 44" src="https://github.com/bigcommerce/checkout-js/assets/9430298/c9bd856c-ee67-477e-9bed-47edfc29f559">


https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/2c14a897-b3e7-412a-bb33-4a5759a6ccf7


@bigcommerce/team-checkout