### PR TITLE
chore(payment): PAYPAL-2843 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.450.0",
+        "@bigcommerce/checkout-sdk": "^1.450.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.450.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.0.tgz",
-      "integrity": "sha512-rPoKfxBsQuJvQForTuVh8a9OpY9gEENNPmOeYwTlzEIbjlmm55YRH0T009DCtez6xFb5IdXDoyNxmXGPXnm3qA==",
+      "version": "1.450.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.1.tgz",
+      "integrity": "sha512-qSCE0NFfb2KchgkyYzCTm4Glpv2P8zF1rxPI29UeJ0PAtrVMi6RV0sH0lGtE7CfrpZPX/ywcRJSQpPSsHWvkCw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.450.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.0.tgz",
-      "integrity": "sha512-rPoKfxBsQuJvQForTuVh8a9OpY9gEENNPmOeYwTlzEIbjlmm55YRH0T009DCtez6xFb5IdXDoyNxmXGPXnm3qA==",
+      "version": "1.450.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.1.tgz",
+      "integrity": "sha512-qSCE0NFfb2KchgkyYzCTm4Glpv2P8zF1rxPI29UeJ0PAtrVMi6RV0sH0lGtE7CfrpZPX/ywcRJSQpPSsHWvkCw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.450.0",
+    "@bigcommerce/checkout-sdk": "^1.450.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2165

## Testing / Proof

All tests passed

![Screenshot 2023-09-19 at 11 37 07](https://github.com/bigcommerce/checkout-js/assets/99336044/84f9d938-5be5-4472-b038-680837c7044b)

@bigcommerce/team-checkout
