### PR TITLE
chore(payment): PAYPAL-2979 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.450.1",
+        "@bigcommerce/checkout-sdk": "^1.451.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.450.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.1.tgz",
-      "integrity": "sha512-qSCE0NFfb2KchgkyYzCTm4Glpv2P8zF1rxPI29UeJ0PAtrVMi6RV0sH0lGtE7CfrpZPX/ywcRJSQpPSsHWvkCw==",
+      "version": "1.451.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.451.0.tgz",
+      "integrity": "sha512-1aaO3VRabxDsHFWQgmor5HlS5cHBZm+rz2tX+F/LFOoZQQqoKV9+VpqETqDtg7HgMDWxpLtuxm5ZVjEzMk5EkQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.450.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.450.1.tgz",
-      "integrity": "sha512-qSCE0NFfb2KchgkyYzCTm4Glpv2P8zF1rxPI29UeJ0PAtrVMi6RV0sH0lGtE7CfrpZPX/ywcRJSQpPSsHWvkCw==",
+      "version": "1.451.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.451.0.tgz",
+      "integrity": "sha512-1aaO3VRabxDsHFWQgmor5HlS5cHBZm+rz2tX+F/LFOoZQQqoKV9+VpqETqDtg7HgMDWxpLtuxm5ZVjEzMk5EkQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.450.1",
+    "@bigcommerce/checkout-sdk": "^1.451.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
As part of release checkout-sdk:
https://github.com/bigcommerce/checkout-sdk-js/pull/2188
https://github.com/bigcommerce/checkout-sdk-js/pull/2185
https://github.com/bigcommerce/checkout-sdk-js/pull/2184
https://github.com/bigcommerce/checkout-sdk-js/pull/2182
https://github.com/bigcommerce/checkout-sdk-js/pull/2183

## Testing / Proof
Unit tests
Manual tests
CI

Here is a screenshot of checkout-sdk loader:
<img width="1512" alt="Screenshot 2023-09-21 at 06 34 21" src="https://github.com/bigcommerce/checkout-js/assets/25133454/1dbb3906-8dc9-4c6b-9864-234eb22d32b4">

Also checked that checkout sdk loader was deployed to all envs.
