### PR TITLE
feat(payment): PAYPAL-2947 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.451.0",
+        "@bigcommerce/checkout-sdk": "^1.452.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.451.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.451.0.tgz",
-      "integrity": "sha512-1aaO3VRabxDsHFWQgmor5HlS5cHBZm+rz2tX+F/LFOoZQQqoKV9+VpqETqDtg7HgMDWxpLtuxm5ZVjEzMk5EkQ==",
+      "version": "1.452.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.452.0.tgz",
+      "integrity": "sha512-dVkprjpdkROMWmVGZOhw6nm27YawswJZo7UNl/vzaSyDcnvPPjzEehxOnRp6gWnu8OJKA+WuPy6bE5PV7PjBcw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.451.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.451.0.tgz",
-      "integrity": "sha512-1aaO3VRabxDsHFWQgmor5HlS5cHBZm+rz2tX+F/LFOoZQQqoKV9+VpqETqDtg7HgMDWxpLtuxm5ZVjEzMk5EkQ==",
+      "version": "1.452.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.452.0.tgz",
+      "integrity": "sha512-dVkprjpdkROMWmVGZOhw6nm27YawswJZo7UNl/vzaSyDcnvPPjzEehxOnRp6gWnu8OJKA+WuPy6bE5PV7PjBcw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.451.0",
+    "@bigcommerce/checkout-sdk": "^1.452.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To apply changes
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2192

## Testing / Proof
<img width="1680" alt="Screenshot 2023-09-22 at 12 10 39" src="https://github.com/bigcommerce/checkout-js/assets/56301104/0ffc0741-e905-4c07-9fc0-ee93e8b0694e">

@bigcommerce/team-checkout
