### PR TITLE
feat(payment): PAYPAL-2576 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.452.0",
+        "@bigcommerce/checkout-sdk": "^1.453.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.452.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.452.0.tgz",
-      "integrity": "sha512-dVkprjpdkROMWmVGZOhw6nm27YawswJZo7UNl/vzaSyDcnvPPjzEehxOnRp6gWnu8OJKA+WuPy6bE5PV7PjBcw==",
+      "version": "1.453.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.453.0.tgz",
+      "integrity": "sha512-AYUR0QkykGmpiFGAski4vVphsX2Ria9J4M9hKtmSTCtP8QzKkRWtyuXvHwUYeajL8yKnAMLCZleYQly84TkVHA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.452.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.452.0.tgz",
-      "integrity": "sha512-dVkprjpdkROMWmVGZOhw6nm27YawswJZo7UNl/vzaSyDcnvPPjzEehxOnRp6gWnu8OJKA+WuPy6bE5PV7PjBcw==",
+      "version": "1.453.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.453.0.tgz",
+      "integrity": "sha512-AYUR0QkykGmpiFGAski4vVphsX2Ria9J4M9hKtmSTCtP8QzKkRWtyuXvHwUYeajL8yKnAMLCZleYQly84TkVHA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.452.0",
+    "@bigcommerce/checkout-sdk": "^1.453.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version from `1.452.0` to `1.453.0`

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
