### PR TITLE
feat(payment): PAYPAL-2946 added loading spinner to ratepay init options

### DIFF
--- a/packages/core/src/scss/components/bigcommerce/loading/_loading.scss
+++ b/packages/core/src/scss/components/bigcommerce/loading/_loading.scss
@@ -64,3 +64,16 @@
         width: 0;
     }
 }
+
+.embedded-checkout-loading-spinner-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    background-color: $loading-spinner-overlay;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    z-index: 999;
+}

--- a/packages/core/src/scss/settings/global/overlay/_overlay.scss
+++ b/packages/core/src/scss/settings/global/overlay/_overlay.scss
@@ -11,3 +11,4 @@
 // -----------------------------------------------------------------------------
 
 $overlay-fill:                  rgba($color-white, 0.9);
+$loading-spinner-overlay:       rgba($color-black, .3);

--- a/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.test.tsx
@@ -71,6 +71,7 @@ describe('PaypalCommerceRatePayPaymentMethod', () => {
             gatewayId: props.method.gateway,
             methodId: props.method.id,
             paypalcommerceratepay: {
+                onPaymentSubmission: expect.any(Function),
                 container: '#checkout-payment-continue',
                 legalTextContainer: 'legal-text-container',
                 getFieldsValues: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
     PaymentMethodProps,
@@ -8,6 +8,7 @@ import {
 import { DynamicFormField, DynamicFormFieldType, FormContext } from '@bigcommerce/checkout/ui';
 import { FormField } from '@bigcommerce/checkout-sdk';
 import getPaypalCommerceRatePayValidationSchema from './validation-schemas/getPaypalCommerceRatePayValidationSchema';
+import { LoadingSpinner } from '@bigcommerce/checkout/ui';
 
 interface RatePayFieldValues {
     ratepayBirthDate: {
@@ -66,6 +67,7 @@ const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
 }) => {
     const fieldsValues = useRef<Partial<RatePayFieldValues>>({});
     const isPaymentDataRequired = checkoutState.data.isPaymentDataRequired();
+    const [isPaymentSubmitting, setIsPaymentSubmitting] = useState(false);
 
     if (!isPaymentDataRequired) {
         return null;
@@ -80,6 +82,7 @@ const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
                     container: '#checkout-payment-continue',
                     legalTextContainer: 'legal-text-container',
                     getFieldsValues: () => fieldsValues.current,
+                    onPaymentSubmission: (isSubmitting: boolean) => setIsPaymentSubmitting(isSubmitting),
                     onError: (error: Error) => {
                         paymentForm.disableSubmit(method, true);
                         onUnhandledError(error);
@@ -140,6 +143,11 @@ const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
 
     return (
         <div style={{marginBottom:'20px'}}>
+            { isPaymentSubmitting &&
+                <div className='embedded-checkout-loading-spinner-overlay'>
+                    <LoadingSpinner isLoading={true}/>
+                </div>
+            }
             <FormContext.Provider value={{ isSubmitted, setSubmitted }}>
                 { formFieldData.map((field) => {
                         return  <DynamicFormField

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -63,6 +63,6 @@ export {
     IconUsdCoin,
     IconAch,
 } from './icon';
-export { LoadingOverlay } from './loading';
+export { LoadingOverlay, LoadingSpinner } from './loading';
 export { Modal, ModalHeader, ModalTrigger, ModalTriggerModalProps } from './modal';
 export { TooltipTrigger } from './tooltip';


### PR DESCRIPTION
## What?
Added loading spinner to ratepay init options

## Why?
To show loading process when polling mechanism is occurs

## Testing / Proof

<img width="1680" alt="272492002-0a24607c-c4a1-425e-8a90-ad77ef0baf43" src="https://github.com/bigcommerce/checkout-js/assets/56301104/6752865b-92d0-4076-8fa6-8c66ce621089">


@bigcommerce/team-checkout @bc-peng @animesh1987 
