### PR TITLE
fix(payment): CHECKOUT-7761 Remove wallet buttons if no payment is required

### DIFF
--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -15,6 +15,7 @@ import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api'
 
 import { getBillingAddress } from '../billing/billingAddresses.mock';
 import { getCheckout } from '../checkout/checkouts.mock';
+import CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 import CheckoutStepType from '../checkout/CheckoutStepType';
 import { getStoreConfig } from '../config/config.mock';
 import { PaymentMethodId } from '../payment/paymentMethod';
@@ -36,6 +37,12 @@ describe('Customer', () => {
     let config: StoreConfig;
     let customer: CustomerData;
     let localeContext: LocaleContextType;
+    const defaultProps = {
+        isSubscribed: false,
+        isWalletButtonsOnTop: false,
+        onSubscribeToNewsletter: jest.fn(),
+        step:{} as CheckoutStepStatus,
+    };
 
     beforeEach(() => {
         billingAddress = getBillingAddress();
@@ -80,7 +87,8 @@ describe('Customer', () => {
 
     describe('when view type is "guest"', () => {
         it('matches snapshot', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const component = mount(<CustomerTest
+                viewType={CustomerViewType.Guest} {...defaultProps} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -89,7 +97,7 @@ describe('Customer', () => {
         });
 
         it('renders guest form by default', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} {...defaultProps} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -102,10 +110,11 @@ describe('Customer', () => {
                 isComplete: true,
                 isEditable: true,
                 isRequired: true,
+                isBusy: false,
                 type: CheckoutStepType.Customer };
 
             const component = mount(
-                <CustomerTest providerWithCustomCheckout={ PaymentMethodId.StripeUPE } step={ steps } viewType={ CustomerViewType.Guest } />
+                <CustomerTest {...defaultProps}  providerWithCustomCheckout={ PaymentMethodId.StripeUPE } step={ steps } viewType={ CustomerViewType.Guest } />
             );
 
             await new Promise(resolve => process.nextTick(resolve));
@@ -119,7 +128,7 @@ describe('Customer', () => {
 
             const unhandledError = jest.fn();
 
-            mount(<CustomerTest onUnhandledError={ unhandledError } providerWithCustomCheckout='bolt' viewType={ CustomerViewType.Guest } />);
+            mount(<CustomerTest {...defaultProps} onUnhandledError={ unhandledError } providerWithCustomCheckout='bolt' viewType={ CustomerViewType.Guest } />);
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(unhandledError).toHaveBeenCalledWith(expect.any(Error));
@@ -130,7 +139,7 @@ describe('Customer', () => {
 
             const unhandledError = jest.fn();
 
-            const component = mount(<CustomerTest onUnhandledError={ unhandledError } viewType={ CustomerViewType.Guest }/>);
+            const component = mount(<CustomerTest {...defaultProps} onUnhandledError={ unhandledError } viewType={ CustomerViewType.Guest }/>);
 
             await new Promise(resolve => process.nextTick(resolve));
             component.unmount();
@@ -144,7 +153,7 @@ describe('Customer', () => {
                 undefined,
             );
 
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const component = mount(<CustomerTest  {...defaultProps}viewType={CustomerViewType.Guest} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -155,7 +164,7 @@ describe('Customer', () => {
         it('renders guest form if customer is undefined', async () => {
             jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(undefined);
 
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.Guest} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -176,7 +185,7 @@ describe('Customer', () => {
                 },
             });
 
-            const component = mount(<CustomerTest viewType={CustomerViewType.CreateAccount} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.CreateAccount} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -185,7 +194,7 @@ describe('Customer', () => {
         });
 
         it('passes data to guest form', async () => {
-            const component = mount(<CustomerTest isSubscribed={false} viewType={CustomerViewType.Guest} />);
+            const component = mount(<CustomerTest {...defaultProps} isSubscribed={false} viewType={CustomerViewType.Guest} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -204,6 +213,7 @@ describe('Customer', () => {
 
             const handleNewsletterSubscription=jest.fn();
             const component = mount(<CustomerTest
+                {...defaultProps}
                 isSubscribed={true}
                 onSubscribeToNewsletter={handleNewsletterSubscription}
                 viewType={CustomerViewType.Guest}
@@ -236,6 +246,7 @@ describe('Customer', () => {
             const subscribeToNewsletter = jest.fn();
             const handleNewsletterSubscription = jest.fn();
             const component = mount(<CustomerTest
+                {...defaultProps}
                 isSubscribed={false}
                 onSubscribeToNewsletter={handleNewsletterSubscription}
                 viewType={CustomerViewType.Guest}
@@ -262,6 +273,7 @@ describe('Customer', () => {
             const handleChangeViewType = jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     onChangeViewType={handleChangeViewType}
                     viewType={CustomerViewType.Guest}
                 />,
@@ -284,6 +296,7 @@ describe('Customer', () => {
             const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     isSubscribed={false}
                     onContinueAsGuest={handleContinueAsGuest}
                     onSubscribeToNewsletter={handleNewsletterSubscription}
@@ -313,6 +326,7 @@ describe('Customer', () => {
             const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     onContinueAsGuest={handleContinueAsGuest}
                     onSubscribeToNewsletter={handleNewsletterSubscription}
                     viewType={CustomerViewType.Guest}
@@ -342,6 +356,7 @@ describe('Customer', () => {
             const handleNewsletterSubscription=jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     isSubscribed={false}
                     onChangeViewType={handleChangeViewType}
                     onSubscribeToNewsletter={handleNewsletterSubscription}
@@ -380,6 +395,7 @@ describe('Customer', () => {
             const handleChangeViewType = jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     onChangeViewType={handleChangeViewType}
                     viewType={CustomerViewType.Guest}
                 />,
@@ -416,6 +432,7 @@ describe('Customer', () => {
             const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     isSubscribed={true}
                     onChangeViewType={handleChangeViewType}
                     onSubscribeToNewsletter={handleNewsletterSubscription}
@@ -450,6 +467,7 @@ describe('Customer', () => {
             const handleNewsletterSubscription = jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     isSubscribed={true}
                     onChangeViewType={handleChangeViewType}
                     onSubscribeToNewsletter={handleNewsletterSubscription}
@@ -479,6 +497,7 @@ describe('Customer', () => {
             const handleError = jest.fn();
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     onContinueAsGuestError={handleError}
                     viewType={CustomerViewType.Guest}
                 />,
@@ -498,7 +517,7 @@ describe('Customer', () => {
         });
 
         it('retains draft email address when switching to login view', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.Guest} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.Guest} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -519,7 +538,7 @@ describe('Customer', () => {
     describe('when view type is "login"', () => {
         it('matches snapshot', async () => {
             const component = mount(
-                <CustomerTest isAccountCreationEnabled={true} viewType={CustomerViewType.Login} />,
+                <CustomerTest {...defaultProps} isAccountCreationEnabled={true} viewType={CustomerViewType.Login} />,
             );
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -529,7 +548,7 @@ describe('Customer', () => {
         });
 
         it('renders login form', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.Login} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.Login} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -539,7 +558,7 @@ describe('Customer', () => {
 
         it('renders sign-in email when link is clicked', async () => {
             const component = mount(
-                <CustomerTest isSignInEmailEnabled={true} viewType={CustomerViewType.Login} />,
+                <CustomerTest {...defaultProps} isSignInEmailEnabled={true} viewType={CustomerViewType.Login} />,
             );
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -555,7 +574,7 @@ describe('Customer', () => {
 
         it('does not render sign-in email link when is embedded checkout', async () => {
             const component = mount(
-                <CustomerTest
+                <CustomerTest {...defaultProps}
                     isEmbedded={true}
                     isSignInEmailEnabled={true}
                     viewType={CustomerViewType.Login}
@@ -571,7 +590,7 @@ describe('Customer', () => {
         });
 
         it('passes data to login form', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.Login} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.Login} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -588,19 +607,19 @@ describe('Customer', () => {
                 Promise.resolve(checkoutService.getState()),
             );
 
-            const component = mount(<CustomerTest viewType={CustomerViewType.Login} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.Login} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>).prop('onSignIn')({
                 email: 'test@bigcommerce.com',
-                password: 'password1',
+                password: '*******',
             });
 
             expect(checkoutService.signInCustomer).toHaveBeenCalledWith({
                 email: 'test@bigcommerce.com',
-                password: 'password1',
+                password: '*******',
             });
         });
 
@@ -615,7 +634,7 @@ describe('Customer', () => {
 
             const handleSignedIn = jest.fn();
             const component = mount(
-                <CustomerTest
+                <CustomerTest {...defaultProps}
                     onSignIn={handleSignedIn}
                     providerWithCustomCheckout={PaymentMethodId.BraintreeAcceleratedCheckout}
                     viewType={CustomerViewType.Login}
@@ -627,12 +646,12 @@ describe('Customer', () => {
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>).prop('onSignIn')({
                 email: 'test@bigcommerce.com',
-                password: 'password1',
+                password: '*******',
             });
 
             expect(checkoutService.signInCustomer).toHaveBeenCalledWith({
                 email: 'test@bigcommerce.com',
-                password: 'password1',
+                password: '*******',
             });
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -650,7 +669,7 @@ describe('Customer', () => {
 
             const handleSignedIn = jest.fn();
             const component = mount(
-                <CustomerTest onSignIn={handleSignedIn} viewType={CustomerViewType.Login} />,
+                <CustomerTest {...defaultProps} onSignIn={handleSignedIn} viewType={CustomerViewType.Login} />,
             );
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -658,7 +677,7 @@ describe('Customer', () => {
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>).prop('onSignIn')({
                 email: 'test@bigcommerce.com',
-                password: 'password1',
+                password: '*******',
             });
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -673,7 +692,7 @@ describe('Customer', () => {
 
             const handleError = jest.fn();
             const component = mount(
-                <CustomerTest onSignInError={handleError} viewType={CustomerViewType.Login} />,
+                <CustomerTest {...defaultProps} onSignInError={handleError} viewType={CustomerViewType.Login} />,
             );
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -681,7 +700,7 @@ describe('Customer', () => {
 
             (component.find(LoginForm) as ReactWrapper<LoginFormProps>).prop('onSignIn')({
                 email: 'test@bigcommerce.com',
-                password: 'password1',
+                password: '*******',
             });
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -698,7 +717,7 @@ describe('Customer', () => {
                 Promise.resolve(checkoutService.getState()),
             );
 
-            const component = mount(<CustomerTest viewType={CustomerViewType.Login} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.Login} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -712,7 +731,7 @@ describe('Customer', () => {
         it('changes to guest view when "cancel" event is triggered', async () => {
             const handleChangeViewType = jest.fn();
             const component = mount(
-                <CustomerTest
+                <CustomerTest {...defaultProps}
                     onChangeViewType={handleChangeViewType}
                     viewType={CustomerViewType.Login}
                 />,
@@ -728,7 +747,7 @@ describe('Customer', () => {
         });
 
         it('retains draft email address when switching to guest view', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.Login} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.Login} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -771,7 +790,7 @@ describe('Customer', () => {
 
             const handleCreateAccount = jest.fn();
             const component = mount(
-                <CustomerTest
+                <CustomerTest {...defaultProps}
                     onAccountCreated={handleCreateAccount}
                     providerWithCustomCheckout={PaymentMethodId.BraintreeAcceleratedCheckout}
                     viewType={CustomerViewType.CreateAccount}
@@ -782,7 +801,7 @@ describe('Customer', () => {
                 firstName: 'John',
                 lastName: 'Doe',
                 email: 'johndoe@test.com',
-                password: 'mocked_password!',
+                password: '*******!',
             };
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -811,7 +830,7 @@ describe('Customer', () => {
     describe('when view type is "cancellable_enforced_login"', () => {
         it('renders login form', async () => {
             const component = mount(
-                <CustomerTest viewType={CustomerViewType.CancellableEnforcedLogin} />,
+                <CustomerTest {...defaultProps} viewType={CustomerViewType.CancellableEnforcedLogin} />,
             );
 
             await new Promise((resolve) => process.nextTick(resolve));
@@ -825,7 +844,7 @@ describe('Customer', () => {
 
     describe('when view type is "suggested_login"', () => {
         it('renders login form', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.SuggestedLogin} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.SuggestedLogin} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -838,7 +857,7 @@ describe('Customer', () => {
 
     describe('when view type is "enforced_login"', () => {
         it('renders login form', async () => {
-            const component = mount(<CustomerTest viewType={CustomerViewType.EnforcedLogin} />);
+            const component = mount(<CustomerTest {...defaultProps} viewType={CustomerViewType.EnforcedLogin} />);
 
             await new Promise((resolve) => process.nextTick(resolve));
             component.update();
@@ -852,6 +871,7 @@ describe('Customer', () => {
             const sendLoginEmail = jest.fn(() => new Promise<void>((resolve) => resolve()) as any);
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     email="foo@bar.com"
                     isSignInEmailEnabled={true}
                     sendLoginEmail={sendLoginEmail}
@@ -875,6 +895,7 @@ describe('Customer', () => {
             const sendLoginEmail = jest.fn(() => new Promise((_, reject) => reject()) as any);
             const component = mount(
                 <CustomerTest
+                    {...defaultProps}
                     email="foo@bar.com"
                     isSignInEmailEnabled={true}
                     sendLoginEmail={sendLoginEmail}

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -77,6 +77,7 @@ export interface WithCheckoutCustomerProps {
     signInEmail?: SignInEmail;
     signInEmailError?: Error;
     isAccountCreationEnabled: boolean;
+    isPaymentDataRequired: boolean;
     createAccountError?: Error;
     signInError?: Error;
     isFloatingLabelEnabled?: boolean;
@@ -183,8 +184,9 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             step,
             isFloatingLabelEnabled,
             isExpressPrivacyPolicy,
+            isPaymentDataRequired,
         } = this.props;
-        const checkoutButtons = isWalletButtonsOnTop
+        const checkoutButtons = isWalletButtonsOnTop || !isPaymentDataRequired
           ? null
           : <CheckoutButtonList
             checkEmbeddedSupport={checkEmbeddedSupport}
@@ -316,11 +318,11 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 }
                 email={this.draftEmail || email}
                 forgotPasswordUrl={forgotPasswordUrl}
+                isExecutingPaymentMethodCheckout={isExecutingPaymentMethodCheckout}
                 isFloatingLabelEnabled={isFloatingLabelEnabled}
                 isSendingSignInEmail={isSendingSignInEmail}
                 isSignInEmailEnabled={isSignInEmailEnabled && !isEmbedded}
                 isSigningIn={isSigningIn}
-                isExecutingPaymentMethodCheckout={isExecutingPaymentMethodCheckout}
                 onCancel={this.handleCancelSignIn}
                 onChangeEmail={this.handleChangeEmail}
                 onContinueAsGuest={this.executePaymentMethodCheckoutOrContinue}
@@ -551,6 +553,7 @@ export function mapToWithCheckoutCustomerProps({
             getCustomer,
             getSignInEmail,
             getConfig,
+            isPaymentDataRequired,
         },
         errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
         statuses: {
@@ -618,6 +621,7 @@ export function mapToWithCheckoutCustomerProps({
         signInError: getSignInError(),
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
         isExpressPrivacyPolicy,
+        isPaymentDataRequired: isPaymentDataRequired(),
     };
 }
 


### PR DESCRIPTION
## What?
Remove wallet buttons in customer step if payment is not required for an order

## Why?
Presence of wallet buttons in checkout flow if payment is not required for an order causes confusion and causes errors. Hence remove wallet buttons from customer step if payment is not required for an order.

## Testing / Proof
https://github.com/bigcommerce/checkout-js/assets/7134802/6f960cd2-cb0e-42cd-9948-86ae293efb4b


@bigcommerce/team-checkout
