### PR TITLE
chore(checkout): CHECKOUT-7141 Bump checkout-sdk v1.455

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.454.0",
+        "@bigcommerce/checkout-sdk": "^1.455.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.454.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.454.0.tgz",
-      "integrity": "sha512-POymgtXnY5UrX4SR4j1kw4p5fzjpjpBbmOdOleXwykaJg8OrIHLnfwd7yeTM2KBfMWSxtLRdcelUbXwESUfv4A==",
+      "version": "1.455.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.455.0.tgz",
+      "integrity": "sha512-CQnzY4sZR6YWr9FI02niAkSYarMPBwDsw0kqwoxT0fW1wAQwVOtjZcpRRsGOzKw/wN+ZT5AwA9aI6wGzeuCnlg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.454.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.454.0.tgz",
-      "integrity": "sha512-POymgtXnY5UrX4SR4j1kw4p5fzjpjpBbmOdOleXwykaJg8OrIHLnfwd7yeTM2KBfMWSxtLRdcelUbXwESUfv4A==",
+      "version": "1.455.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.455.0.tgz",
+      "integrity": "sha512-CQnzY4sZR6YWr9FI02niAkSYarMPBwDsw0kqwoxT0fW1wAQwVOtjZcpRRsGOzKw/wN+ZT5AwA9aI6wGzeuCnlg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.454.0",
+    "@bigcommerce/checkout-sdk": "^1.455.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.455.0`.

## Why?
Release lastest SDK change(s):
* https://github.com/bigcommerce/checkout-sdk-js/pull/2180

## Testing / Proof
* CI checks.