### PR TITLE
fix(payment): PAYPAL-3060 fixed the issue with BT AXO payment strategy initializing in the flow with storecredits

### DIFF
--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.test.tsx
@@ -35,10 +35,6 @@ describe('BraintreeAcceleratedCheckoutPaymentMethod', () => {
         onUnhandledError: jest.fn(),
     };
 
-    beforeEach(() => {
-        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockImplementation(() => true);
-    });
-
     it('initializes BraintreeAcceleratedCheckoutPaymentMethod with required props', () => {
         const initializePayment = jest
             .spyOn(checkoutService, 'initializePayment')

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.tsx
@@ -26,7 +26,6 @@ const BraintreeAcceleratedCheckoutPaymentMethod: FunctionComponent<PaymentMethod
     const paypalConnectComponentRef = useRef<PayPalConnectComponentRef>({});
 
     const { isLoadingPaymentMethod, isInitializingPayment } = checkoutState.statuses;
-    const { isPaymentDataRequired } = checkoutState.data;
 
     const initializePaymentOrThrow = async () => {
         try {
@@ -59,20 +58,12 @@ const BraintreeAcceleratedCheckoutPaymentMethod: FunctionComponent<PaymentMethod
     };
 
     useEffect(() => {
-        if (isPaymentDataRequired()) {
-            void initializePaymentOrThrow();
-        }
+        void initializePaymentOrThrow();
 
         return () => {
-            if (isPaymentDataRequired()) {
-                void deinitializePaymentOrThrow();
-            }
+            void deinitializePaymentOrThrow();
         };
     }, []);
-
-    if (!isPaymentDataRequired()) {
-        return null;
-    }
 
     const isLoading = isInitializingPayment() || isLoadingPaymentMethod(method.id);
 


### PR DESCRIPTION
## What?
Fixed the issue with BT AXO payment strategy initializing in the flow with storecredits

## Why?
Because the strategy was not initialized for cases when the storecredit amount is the same or higher than cart amount, so the strategy just skip the initialization process - this is a right behaviour. But, the strategy does not reinitialize when customer uncheck the storecredit checkbox.

## Testing / Proof
Unit tests
Manual tests

Before:

https://github.com/bigcommerce/checkout-js/assets/25133454/de1780b8-b6f0-45d2-bceb-0c24093852ea



After:

https://github.com/bigcommerce/checkout-js/assets/25133454/8174cb19-5e5a-4904-af32-ee718c31c6ec


