### PR TITLE
chore(payment): PI-569 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.455.1",
+        "@bigcommerce/checkout-sdk": "^1.456.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.455.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.455.1.tgz",
-      "integrity": "sha512-dVQJCqSdJgi4gYxPrMG/pw9yBc8CJKWLmrYjZ08nYf+o9BRo8egxRyhn4Hl9Gawq0VI2XfnT0z6nV7VmHynY/A==",
+      "version": "1.456.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.456.0.tgz",
+      "integrity": "sha512-rTQ4V7AMrDAVnbi+UNRRL8/D3RB7uUL2I69XcU7W7UIoJeEb1auNx87KrvEV+9jDDfqLPHx87+0+IfDBa7iUmA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.455.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.455.1.tgz",
-      "integrity": "sha512-dVQJCqSdJgi4gYxPrMG/pw9yBc8CJKWLmrYjZ08nYf+o9BRo8egxRyhn4Hl9Gawq0VI2XfnT0z6nV7VmHynY/A==",
+      "version": "1.456.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.456.0.tgz",
+      "integrity": "sha512-rTQ4V7AMrDAVnbi+UNRRL8/D3RB7uUL2I69XcU7W7UIoJeEb1auNx87KrvEV+9jDDfqLPHx87+0+IfDBa7iUmA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.455.1",
+    "@bigcommerce/checkout-sdk": "^1.456.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2199

## Why?
Klarna started working through redirect again

## Testing / Proof
![Zrzut ekranu 2023-09-28 o 11 47 46](https://github.com/bigcommerce/checkout-js/assets/130039975/0511bda3-8494-4e3b-8cfa-0ca9ed1d6332)
![Zrzut ekranu 2023-09-28 o 11 39 02](https://github.com/bigcommerce/checkout-js/assets/130039975/0e5c1eee-21c8-429e-b072-b1088c0f9e95)

Tested manually

@bigcommerce/team-checkout
