### PR TITLE
chore(payment): PAYPAL-2926 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.456.0",
+        "@bigcommerce/checkout-sdk": "^1.457.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.456.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.456.0.tgz",
-      "integrity": "sha512-rTQ4V7AMrDAVnbi+UNRRL8/D3RB7uUL2I69XcU7W7UIoJeEb1auNx87KrvEV+9jDDfqLPHx87+0+IfDBa7iUmA==",
+      "version": "1.457.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.457.0.tgz",
+      "integrity": "sha512-cUbV8i2jF3pfFfL//RtLrgqygtkavAw/CF6zO1Fkz5EGJwQS5KnTtyGNx4gNkWs1ioMpY8mlxriZcrayECSFGA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.456.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.456.0.tgz",
-      "integrity": "sha512-rTQ4V7AMrDAVnbi+UNRRL8/D3RB7uUL2I69XcU7W7UIoJeEb1auNx87KrvEV+9jDDfqLPHx87+0+IfDBa7iUmA==",
+      "version": "1.457.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.457.0.tgz",
+      "integrity": "sha512-cUbV8i2jF3pfFfL//RtLrgqygtkavAw/CF6zO1Fkz5EGJwQS5KnTtyGNx4gNkWs1ioMpY8mlxriZcrayECSFGA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.456.0",
+    "@bigcommerce/checkout-sdk": "^1.457.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

Releases:
https://github.com/bigcommerce/checkout-sdk-js/pull/2207
https://github.com/bigcommerce/checkout-sdk-js/pull/2203

## Testing / Proof

![Screenshot 2023-09-28 at 12 54 18](https://github.com/bigcommerce/checkout-js/assets/99336044/93442b91-36a2-4068-8e69-94582ceaa52a)

@bigcommerce/team-checkout
