### PR TITLE
feat(payment): PI-833 remove sign out link from hosted widget payment component

### DIFF
--- a/packages/adyen-integration/src/adyenv2/__snapshots__/AdyenV2PaymentMethod.test.tsx.snap
+++ b/packages/adyen-integration/src/adyenv2/__snapshots__/AdyenV2PaymentMethod.test.tsx.snap
@@ -15,19 +15,6 @@ Object {
               id="adyen-scheme-component-field"
               tabindex="-1"
             />
-            <div
-              class="signout-link"
-            >
-              
-               
-              <a
-                href="#"
-              >
-                Sign out of Authorizenet
-              </a>
-               
-              to view other payment methods
-            </div>
           </div>
         </div>
         <div
@@ -50,19 +37,6 @@ Object {
               id="adyen-scheme-component-field"
               tabindex="-1"
             />
-            <div
-              class="signout-link"
-            >
-              
-               
-              <a
-                href="#"
-              >
-                Sign out of Authorizenet
-              </a>
-               
-              to view other payment methods
-            </div>
           </div>
         </div>
         <div
@@ -86,19 +60,6 @@ Object {
             id="adyen-scheme-component-field"
             tabindex="-1"
           />
-          <div
-            class="signout-link"
-          >
-            
-             
-            <a
-              href="#"
-            >
-              Sign out of Authorizenet
-            </a>
-             
-            to view other payment methods
-          </div>
         </div>
       </div>
       <div

--- a/packages/adyen-integration/src/adyenv3/__snapshots__/AdyenV3PaymentMethod.test.tsx.snap
+++ b/packages/adyen-integration/src/adyenv3/__snapshots__/AdyenV3PaymentMethod.test.tsx.snap
@@ -15,19 +15,6 @@ Object {
               id="adyen-scheme-component-field"
               tabindex="-1"
             />
-            <div
-              class="signout-link"
-            >
-              
-               
-              <a
-                href="#"
-              >
-                Sign out of Authorizenet
-              </a>
-               
-              to view other payment methods
-            </div>
           </div>
         </div>
         <div
@@ -50,19 +37,6 @@ Object {
               id="adyen-scheme-component-field"
               tabindex="-1"
             />
-            <div
-              class="signout-link"
-            >
-              
-               
-              <a
-                href="#"
-              >
-                Sign out of Authorizenet
-              </a>
-               
-              to view other payment methods
-            </div>
           </div>
         </div>
         <div
@@ -86,19 +60,6 @@ Object {
             id="adyen-scheme-component-field"
             tabindex="-1"
           />
-          <div
-            class="signout-link"
-          >
-            
-             
-            <a
-              href="#"
-            >
-              Sign out of Authorizenet
-            </a>
-             
-            to view other payment methods
-          </div>
         </div>
       </div>
       <div

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.spec.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.spec.tsx
@@ -16,7 +16,6 @@ import {
     CardInstrumentFieldset,
     getCreditCardValidationSchema,
     SignOutLink,
-    SignOutLinkProps,
 } from '@bigcommerce/checkout/instrument-utils';
 import {
     createLocaleContext,
@@ -296,65 +295,6 @@ describe('HostedWidgetPaymentMethod', () => {
                 ...getCheckout(),
                 payments: [{ ...getCheckoutPayment(), providerId: defaultProps.method.id }],
             });
-        });
-
-        it('renders sign out link if user is signed into their payment method account', () => {
-            const component = mount(
-                <HostedWidgetPaymentMethodTest {...defaultProps} isSignedIn={true} />,
-            );
-
-            expect(component.find(SignOutLink)).toHaveLength(1);
-        });
-
-        it('signs out from payment method account of user when clicking on sign out link', async () => {
-            const handleSignOutError = jest.fn();
-
-            const signOut = jest.fn();
-
-            const component = mount(
-                <HostedWidgetPaymentMethodTest
-                    {...defaultProps}
-                    isSignedIn={true}
-                    onSignOutError={handleSignOutError}
-                    signOut={signOut}
-                />,
-            );
-
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            (component.find(SignOutLink) as ReactWrapper<SignOutLinkProps>).prop('onSignOut')();
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(signOut).toHaveBeenCalledWith({
-                methodId: defaultProps.method.id,
-            });
-
-            expect(handleSignOutError).not.toHaveBeenCalled();
-        });
-
-        it('notifies parent component if unable to sign out', async () => {
-            const handleSignOutError = jest.fn();
-            const signOut = jest.fn().mockRejectedValue(new Error('Unknown error'));
-
-            jest.spyOn(checkoutService, 'signOutCustomer').mockRejectedValue(
-                new Error('Unknown error'),
-            );
-
-            const component = mount(
-                <HostedWidgetPaymentMethodTest
-                    {...defaultProps}
-                    isSignedIn={true}
-                    onSignOutError={handleSignOutError}
-                    signOut={signOut}
-                />,
-            );
-
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            (component.find(SignOutLink) as ReactWrapper<SignOutLinkProps>).prop('onSignOut')();
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(handleSignOutError).toHaveBeenCalledWith(expect.any(Error));
         });
 
         it('renders link for user to edit their selected credit card', () => {

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
@@ -21,7 +21,6 @@ import {
     assertIsCardInstrument,
     CardInstrumentFieldset,
     isBankAccountInstrument,
-    SignOutLink,
     StoreInstrumentFieldset,
 } from '@bigcommerce/checkout/instrument-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -207,8 +206,6 @@ class HostedWidgetPaymentComponent extends Component<
             instruments,
             hideWidget = false,
             isInitializing = false,
-            isSignedIn = false,
-            method,
             isAccountInstrument,
             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
             isLoadingInstruments,
@@ -277,8 +274,6 @@ class HostedWidgetPaymentComponent extends Component<
                     )}
 
                     {this.renderEditButtonIfAvailable()}
-
-                    {isSignedIn && <SignOutLink method={method} onSignOut={this.handleSignOut} />}
                 </div>
             </LoadingOverlay>
         );
@@ -525,18 +520,6 @@ class HostedWidgetPaymentComponent extends Component<
             isAddingNewCard: false,
             selectedInstrumentId: id,
         });
-    };
-
-    private handleSignOut: () => void = async () => {
-        const { method, onSignOut = noop, onSignOutError = noop, signOut } = this.props;
-
-        try {
-            // eslint-disable-next-line @typescript-eslint/await-thenable
-            await signOut({ methodId: method.id });
-            onSignOut();
-        } catch (error) {
-            onSignOutError(error);
-        }
     };
 }
 


### PR DESCRIPTION
## What?
Remove sign out link from hosted widget payment component.

## Why?
[PI-833](https://bigcommercecloud.atlassian.net/browse/PI-833)
Sign out link was showing up for every payment method, but it should only be visible for GooglePay. As GooglePay implementation already contains sign out link, it can be removed from hosted widget payment component.

## Testing / Proof
Before:
<img width="654" alt="Screenshot 2023-09-29 at 17 19 43" src="https://github.com/bigcommerce/checkout-js/assets/138816572/88d83707-11d7-46e8-afff-321d38772a8d">
<img width="623" alt="Screenshot 2023-09-29 at 17 23 57" src="https://github.com/bigcommerce/checkout-js/assets/138816572/a1c84bc0-b65e-4930-902a-6d913fe6d9b1">
<img width="639" alt="Screenshot 2023-09-29 at 17 20 19" src="https://github.com/bigcommerce/checkout-js/assets/138816572/ec5bb94c-8bb5-41d7-8668-814682a0d048">

After:
<img width="652" alt="Screenshot 2023-09-29 at 17 21 22" src="https://github.com/bigcommerce/checkout-js/assets/138816572/fc959b06-d8a7-4809-b0ae-9891a067db0c">
<img width="634" alt="Screenshot 2023-09-29 at 17 24 19" src="https://github.com/bigcommerce/checkout-js/assets/138816572/09e81098-8305-40eb-92a4-021a302c80ff">
<img width="635" alt="Screenshot 2023-09-29 at 17 21 57" src="https://github.com/bigcommerce/checkout-js/assets/138816572/77f499dd-714e-4354-9bff-9d8fc32f9a1e">

@bigcommerce/team-checkout


[PI-833]: https://bigcommercecloud.atlassian.net/browse/PI-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ