### PR TITLE
chore(payment): PAYPAL-2844 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.457.0",
+        "@bigcommerce/checkout-sdk": "^1.458.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.457.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.457.0.tgz",
-      "integrity": "sha512-cUbV8i2jF3pfFfL//RtLrgqygtkavAw/CF6zO1Fkz5EGJwQS5KnTtyGNx4gNkWs1ioMpY8mlxriZcrayECSFGA==",
+      "version": "1.458.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.458.0.tgz",
+      "integrity": "sha512-rCyyoWIiYNJCTXHPorD0DinyPLNdW1vhjIE2zXU/33jjCqvNVkHdUTLFw8P0nwNyRJUybXwblgvFhyPJOnCp8w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.457.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.457.0.tgz",
-      "integrity": "sha512-cUbV8i2jF3pfFfL//RtLrgqygtkavAw/CF6zO1Fkz5EGJwQS5KnTtyGNx4gNkWs1ioMpY8mlxriZcrayECSFGA==",
+      "version": "1.458.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.458.0.tgz",
+      "integrity": "sha512-rCyyoWIiYNJCTXHPorD0DinyPLNdW1vhjIE2zXU/33jjCqvNVkHdUTLFw8P0nwNyRJUybXwblgvFhyPJOnCp8w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.457.0",
+    "@bigcommerce/checkout-sdk": "^1.458.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

bump checkout-sdk version

## Why?

Releases: https://github.com/bigcommerce/checkout-sdk-js/pull/2186

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
