### PR TITLE
fix(payment): PAYPAL-2984 updated BT AXO CC component styling

### DIFF
--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutCreditCardForm.scss
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutCreditCardForm.scss
@@ -1,3 +1,4 @@
 .braintree-axo-cc-form-container {
-    margin: 0 -1.25rem;
+    font-weight: initial;
+    padding-bottom: 1rem;
 }


### PR DESCRIPTION
## What?
Updated BT AXO CC component styling

## Why?
PayPal updated default styles for their component, so it looks a bit odd on BC checkout.

## Testing / Proof
Unit tests
Manual tests

<img width="819" alt="Screenshot 2023-10-03 at 11 41 43" src="https://github.com/bigcommerce/checkout-js/assets/25133454/24038de1-8a0d-4bd4-b21b-d35a8d439059">

<img width="493" alt="Screenshot 2023-09-29 at 16 08 43" src="https://github.com/bigcommerce/checkout-js/assets/25133454/8fa79ae7-dc70-4230-b3aa-8e6f27ce25ce">

