### PR TITLE
chore(payment): PAYPAL-2984 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.459.0",
+        "@bigcommerce/checkout-sdk": "^1.460.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.459.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.459.0.tgz",
-      "integrity": "sha512-qyZ2923b6Y07wDRxWlU72WOk7JcBNguWJbMXUBY+2T75gbvW5G4sW+ScZoYZolmuNy5vJRtOpKZA9kcrh39+4w==",
+      "version": "1.460.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.460.0.tgz",
+      "integrity": "sha512-6/CzDmZM1MBSeGQ7xxFmua97iTsYCc27VTlKC1+NNil130sf24mCOqzxga4+56UVrE4KV496YkG0Ie5obAkBbA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.459.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.459.0.tgz",
-      "integrity": "sha512-qyZ2923b6Y07wDRxWlU72WOk7JcBNguWJbMXUBY+2T75gbvW5G4sW+ScZoYZolmuNy5vJRtOpKZA9kcrh39+4w==",
+      "version": "1.460.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.460.0.tgz",
+      "integrity": "sha512-6/CzDmZM1MBSeGQ7xxFmua97iTsYCc27VTlKC1+NNil130sf24mCOqzxga4+56UVrE4KV496YkG0Ie5obAkBbA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.459.0",
+    "@bigcommerce/checkout-sdk": "^1.460.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
As part of release process: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2206

## Testing / Proof
Unit tests
Manual tests
