### PR TITLE
feat(payment): PI-865 [Amazon Pay] No space between Amazon Pay button…

### DIFF
--- a/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
+++ b/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
@@ -23,9 +23,12 @@ const beautifyAmazonButton = (): void => {
 
     const container = document.querySelector('#amazonpayCheckoutButton > div') as unknown as HTMLElement;
     const amazonButton = container?.shadowRoot?.querySelector('.amazonpay-button-view1') as unknown as HTMLElement;
+    const amazonpayButtonContainer = container?.shadowRoot?.querySelector('.amazonpay-button-container') as unknown as HTMLElement;
 
-    if (container && amazonButton) {
+    if (container && amazonButton && amazonpayButtonContainer) {
         amazonButton.style.height = '36px';
+        amazonpayButtonContainer.style.height = '52px';
+
         return;
     }
 


### PR DESCRIPTION
… and the button caption on the checkout page

## What?
Space between button and microtext in checkout page has been enlarged 

## Why?
Microtext was overlaping an AmazonPay button

## Testing / Proof
1. Before changes
![Before changes](https://github.com/bigcommerce/checkout-js/assets/130039975/19c1dd43-bcd9-4d55-93f4-76e2af8eb4d6)

2. After changes
![After changes](https://github.com/bigcommerce/checkout-js/assets/130039975/8cd7c91c-bc72-425d-8efc-bf04c159b3ff)



@bigcommerce/team-checkout
