### PR TITLE
chore(payment): PAYPAL-2845 bump chekout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.460.0",
+        "@bigcommerce/checkout-sdk": "^1.461.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.460.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.460.0.tgz",
-      "integrity": "sha512-6/CzDmZM1MBSeGQ7xxFmua97iTsYCc27VTlKC1+NNil130sf24mCOqzxga4+56UVrE4KV496YkG0Ie5obAkBbA==",
+      "version": "1.461.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.461.0.tgz",
+      "integrity": "sha512-skWn4pNRMo+biBDxevGI/HfAzQtudgvGJSp4O34jRuXRdGLOVf9uSfD/u3WZim6P/Ft9XWq8iF9NxoxkLdQ0qQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.460.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.460.0.tgz",
-      "integrity": "sha512-6/CzDmZM1MBSeGQ7xxFmua97iTsYCc27VTlKC1+NNil130sf24mCOqzxga4+56UVrE4KV496YkG0Ie5obAkBbA==",
+      "version": "1.461.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.461.0.tgz",
+      "integrity": "sha512-skWn4pNRMo+biBDxevGI/HfAzQtudgvGJSp4O34jRuXRdGLOVf9uSfD/u3WZim6P/Ft9XWq8iF9NxoxkLdQ0qQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.460.0",
+    "@bigcommerce/checkout-sdk": "^1.461.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump chekout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2196

## Testing / Proof


![Screenshot 2023-10-04 at 12 21 14](https://github.com/bigcommerce/checkout-js/assets/99336044/2315adf1-cd1f-4917-a827-3085f5bfa841)

![Screenshot 2023-10-04 at 12 21 41](https://github.com/bigcommerce/checkout-js/assets/99336044/b29992ad-0ffd-48aa-bb08-9673cae0df74)

@bigcommerce/team-checkout
