### PR TITLE
chore(payment): PI-758 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.461.0",
+        "@bigcommerce/checkout-sdk": "^1.461.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.461.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.461.0.tgz",
-      "integrity": "sha512-skWn4pNRMo+biBDxevGI/HfAzQtudgvGJSp4O34jRuXRdGLOVf9uSfD/u3WZim6P/Ft9XWq8iF9NxoxkLdQ0qQ==",
+      "version": "1.461.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.461.1.tgz",
+      "integrity": "sha512-Y9OFOX4NmDVGonWcCciPQz7OQokOrH6YiktRf35XjoWWqBcHLirO7rmic6LVSFCgIprXAU3Iy0Z19LbEbiLdew==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.461.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.461.0.tgz",
-      "integrity": "sha512-skWn4pNRMo+biBDxevGI/HfAzQtudgvGJSp4O34jRuXRdGLOVf9uSfD/u3WZim6P/Ft9XWq8iF9NxoxkLdQ0qQ==",
+      "version": "1.461.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.461.1.tgz",
+      "integrity": "sha512-Y9OFOX4NmDVGonWcCciPQz7OQokOrH6YiktRf35XjoWWqBcHLirO7rmic6LVSFCgIprXAU3Iy0Z19LbEbiLdew==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.461.0",
+    "@bigcommerce/checkout-sdk": "^1.461.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2201](https://github.com/bigcommerce/checkout-sdk-js/pull/2201)

## Testing / Proof
manually tested and unit tests
<img width="2560" alt="Screenshot 2023-10-05 at 11 42 31" src="https://github.com/bigcommerce/checkout-js/assets/9430298/8d982ccd-aab6-45d7-9ec4-8a3734b37ead">


@bigcommerce/team-checkout
