### PR TITLE
feat(payment): PI-875 [Stripe] Error while try to save Stripe Link stored card as BC vaulted instrument

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.spec.tsx
@@ -498,5 +498,17 @@ describe('HostedWidgetPaymentMethod', () => {
                 Object.keys(expectedSchema.describe().fields),
             );
         });
+
+        it('does not shows "Save this card for future transactions" checkbox when shouldSavingCardsBeEnabled prop is false', () => {
+            defaultProps.shouldSavingCardsBeEnabled = false;
+
+            jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+
+            const container = mount(<HostedWidgetPaymentMethodTest {...defaultProps} />);
+            const hostedWidgetComponent = container.find('#widget-container');
+
+            expect(hostedWidgetComponent).toHaveLength(1);
+            expect(container.find('input[name="shouldSaveInstrument"]').exists()).toBe(false);
+        });
     });
 });

--- a/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedWidgetPaymentMethod.tsx
@@ -120,7 +120,13 @@ class HostedWidgetPaymentMethod extends Component<
         setValidationSchema(method, this.getValidationSchema());
 
         try {
-            if (this.isInstrumentFeatureAvailable()) {
+            if (isInstrumentFeatureAvailable({
+                config: this.props.config,
+                customer: this.props.customer,
+                isUsingMultiShipping: this.props.isUsingMultiShipping,
+                paymentMethod: this.props.paymentMethod, 
+                shouldSavingCardsBeEnabled: this.props.shouldSavingCardsBeEnabled,
+        })) {
                 await loadInstruments();
             }
 
@@ -206,8 +212,13 @@ class HostedWidgetPaymentMethod extends Component<
             shouldShow = true,
         } = this.props;
 
-        const isInstrumentFeatureAvailable = this.isInstrumentFeatureAvailable()
-
+        const isInstrumentFeature = isInstrumentFeatureAvailable({
+            config: this.props.config,
+            customer: this.props.customer,
+            isUsingMultiShipping: this.props.isUsingMultiShipping,
+            paymentMethod: this.props.paymentMethod, 
+            shouldSavingCardsBeEnabled: this.props.shouldSavingCardsBeEnabled,
+        })
         const { isAddingNewCard, selectedInstrumentId = this.getDefaultInstrumentId() } =
             this.state;
 
@@ -220,7 +231,7 @@ class HostedWidgetPaymentMethod extends Component<
             instruments[0];
 
         const shouldShowInstrumentFieldset =
-            isInstrumentFeatureAvailable && instruments.length > 0;
+            isInstrumentFeature && instruments.length > 0;
         const shouldShowCreditCardFieldset = !shouldShowInstrumentFieldset || isAddingNewCard;
         const isLoading = (isInitializing || isLoadingInstruments) && !hideWidget;
 
@@ -259,7 +270,7 @@ class HostedWidgetPaymentMethod extends Component<
 
                     {this.renderContainer(shouldShowCreditCardFieldset)}
 
-                    {isInstrumentFeatureAvailable && (
+                    {isInstrumentFeature && (
                         <StoreInstrumentFieldset
                             instrumentId={selectedInstrumentId}
                             isAccountInstrument={isAccountInstrument || shouldShowAccountInstrument}
@@ -338,28 +349,6 @@ class HostedWidgetPaymentMethod extends Component<
         );
     }
 
-
-    private isInstrumentFeatureAvailable() {
-        const { 
-            config,
-            customer,
-            isUsingMultiShipping,
-            paymentMethod, 
-            shouldSavingCardsBeEnabled,
-        } = this.props;
-
-        const instrumentFeatureAvailable = isInstrumentFeatureAvailable({
-            config,
-            customer,
-            isUsingMultiShipping,
-            paymentMethod,
-            shouldSavingCardsBeEnabled,
-        })
-
-        return instrumentFeatureAvailable;
-
-    }
-
     private getValidationSchema(): ObjectSchema | null {
         const {
             isPaymentDataRequired,
@@ -372,7 +361,13 @@ class HostedWidgetPaymentMethod extends Component<
 
         const selectedInstrument = this.getSelectedInstrument();
 
-        if (this.isInstrumentFeatureAvailable() && selectedInstrument) {
+        if (isInstrumentFeatureAvailable({
+                config: this.props.config,
+                customer: this.props.customer,
+                isUsingMultiShipping: this.props.isUsingMultiShipping,
+                paymentMethod: this.props.paymentMethod, 
+                shouldSavingCardsBeEnabled: this.props.shouldSavingCardsBeEnabled,
+        }) && selectedInstrument) {
             return storedCardValidationSchema || null;
         }
 

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
@@ -14,6 +14,7 @@ import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcomme
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getStoreConfig } from '../../config/config.mock';
+import { getCustomer } from '../../customer/customers.mock';
 import {
     withHostedCreditCardFieldset,
     WithInjectedHostedCreditCardFieldsetProps,
@@ -79,6 +80,8 @@ describe('when using Stripe payment', () => {
         localeContext = createLocaleContext(getStoreConfig());
 
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
 
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
 

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -20,13 +20,15 @@ export type StripePaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'con
 
 interface WithCheckoutStripePaymentMethodProps {
     storeUrl: string;
+    isGuest: boolean;
+    isLinkEnabled: boolean;
 }
 
 const StripeUPEPaymentMethod: FunctionComponent<
     StripePaymentMethodProps &
         WithInjectedHostedCreditCardFieldsetProps &
         WithCheckoutStripePaymentMethodProps
-> = ({ initializePayment, method, storeUrl, onUnhandledError = noop, ...rest }) => {
+> = ({ initializePayment, method, storeUrl, isGuest, isLinkEnabled, onUnhandledError = noop, ...rest }) => {
     const containerId = `stripe-${method.id}-component-field`;
 
     const paymentContext = useContext(PaymentContext);
@@ -97,6 +99,14 @@ const StripeUPEPaymentMethod: FunctionComponent<
         );
     };
 
+    const shouldSavingCardsBeEnabled = (): boolean => {
+        if (!isGuest && isLinkEnabled) {
+            return false;
+        } 
+
+        return true;
+    }
+
     return (
         <>
             <HostedWidgetPaymentMethod
@@ -105,13 +115,14 @@ const StripeUPEPaymentMethod: FunctionComponent<
                 hideContentWhenSignedOut
                 initializePayment={initializeStripePayment}
                 method={method}
+                shouldSavingCardsBeEnabled={shouldSavingCardsBeEnabled()}
             />
             {renderCheckoutThemeStylesForStripeUPE()}
         </>
     );
 };
 
-function mapFromCheckoutProps({ checkoutState }: CheckoutContextProps) {
+function mapFromCheckoutProps({ checkoutState }: CheckoutContextProps, props:any) {
     const {
         data: { getConfig },
     } = checkoutState;
@@ -123,6 +134,8 @@ function mapFromCheckoutProps({ checkoutState }: CheckoutContextProps) {
 
     return {
         storeUrl: config.links.siteLink,
+        isGuest: checkoutState.data.getCustomer()?.isGuest,
+        isLinkEnabled: props.method.initializationData.enableLink,
     };
 }
 

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -21,14 +21,13 @@ export type StripePaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'con
 interface WithCheckoutStripePaymentMethodProps {
     storeUrl: string;
     isGuest: boolean;
-    isLinkEnabled: boolean;
 }
 
 const StripeUPEPaymentMethod: FunctionComponent<
     StripePaymentMethodProps &
         WithInjectedHostedCreditCardFieldsetProps &
         WithCheckoutStripePaymentMethodProps
-> = ({ initializePayment, method, storeUrl, isGuest, isLinkEnabled, onUnhandledError = noop, ...rest }) => {
+> = ({ initializePayment, method, storeUrl, isGuest, onUnhandledError = noop, ...rest }) => {
     const containerId = `stripe-${method.id}-component-field`;
 
     const paymentContext = useContext(PaymentContext);
@@ -100,7 +99,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
     };
 
     const shouldSavingCardsBeEnabled = (): boolean => {
-        if (!isGuest && isLinkEnabled) {
+        if (!isGuest && method.initializationData.enableLink) {
             return false;
         } 
 
@@ -122,20 +121,20 @@ const StripeUPEPaymentMethod: FunctionComponent<
     );
 };
 
-function mapFromCheckoutProps({ checkoutState }: CheckoutContextProps, props:any) {
+function mapFromCheckoutProps({ checkoutState }: CheckoutContextProps ) {
     const {
-        data: { getConfig },
+        data: { getConfig, getCustomer },
     } = checkoutState;
     const config = getConfig();
+    const customer = getCustomer();
 
-    if (!config) {
+    if (!config || !customer) {
         return null;
     }
 
     return {
         storeUrl: config.links.siteLink,
-        isGuest: checkoutState.data.getCustomer()?.isGuest,
-        isLinkEnabled: props.method.initializationData.enableLink,
+        isGuest: customer.isGuest,
     };
 }
 

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -21,13 +21,14 @@ export type StripePaymentMethodProps = Omit<HostedWidgetPaymentMethodProps, 'con
 interface WithCheckoutStripePaymentMethodProps {
     storeUrl: string;
     isGuest: boolean;
+    isStripeLinkAuthenticated: boolean | undefined;
 }
 
 const StripeUPEPaymentMethod: FunctionComponent<
     StripePaymentMethodProps &
         WithInjectedHostedCreditCardFieldsetProps &
         WithCheckoutStripePaymentMethodProps
-> = ({ initializePayment, method, storeUrl, isGuest, onUnhandledError = noop, ...rest }) => {
+> = ({ initializePayment, method, storeUrl, isGuest, isStripeLinkAuthenticated,  onUnhandledError = noop, ...rest }) => {
     const containerId = `stripe-${method.id}-component-field`;
 
     const paymentContext = useContext(PaymentContext);
@@ -99,7 +100,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
     };
 
     const shouldSavingCardsBeEnabled = (): boolean => {
-        if (!isGuest && method.initializationData.enableLink) {
+        if (!isGuest && isStripeLinkAuthenticated) {
             return false;
         } 
 
@@ -135,6 +136,7 @@ function mapFromCheckoutProps({ checkoutState }: CheckoutContextProps ) {
     return {
         storeUrl: config.links.siteLink,
         isGuest: customer.isGuest,
+        isStripeLinkAuthenticated: customer.isStripeLinkAuthenticated,
     };
 }
 

--- a/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.spec.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.spec.ts
@@ -28,6 +28,7 @@ describe('isInstrumentFeatureAvailable()', () => {
                     isVaultingEnabled: true,
                 },
             }),
+            shouldSavingCardsBeEnabled: true,
         };
     });
 
@@ -97,6 +98,15 @@ describe('isInstrumentFeatureAvailable()', () => {
                 ),
             }),
         ).toBe(true);
+    });
+
+    it('returns false if shouldSavingCardsBeEnabled argument is false', () => {
+        expect(
+            isInstrumentFeatureAvailable({
+                ...state,
+                shouldSavingCardsBeEnabled: false,
+            }),
+        ).toBe(false);
     });
 
     it('returns true otherwise', () => {

--- a/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.ts
@@ -18,7 +18,8 @@ export default function isInstrumentFeatureAvailable({
     if (
         isVaultingNotEnabled(checkoutSettings, paymentMethod.config) ||
         customer.isGuest ||
-        isVaultingWithMultiShippingNotEnabled(checkoutSettings, isUsingMultiShipping)
+        isVaultingWithMultiShippingNotEnabled(checkoutSettings, isUsingMultiShipping) ||
+        paymentMethod.initializationData.enableLink
     ) {
         return false;
     }

--- a/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.ts
+++ b/packages/core/src/app/payment/storedInstrument/isInstrumentFeatureAvailable.ts
@@ -5,6 +5,7 @@ export interface IsInstrumentFeatureAvailableState {
     customer: Customer;
     isUsingMultiShipping: boolean;
     paymentMethod: PaymentMethod;
+    shouldSavingCardsBeEnabled?: boolean;
 }
 
 export default function isInstrumentFeatureAvailable({
@@ -12,6 +13,7 @@ export default function isInstrumentFeatureAvailable({
     customer,
     isUsingMultiShipping,
     paymentMethod,
+    shouldSavingCardsBeEnabled = true,
 }: IsInstrumentFeatureAvailableState): boolean {
     const { checkoutSettings } = config;
 
@@ -19,7 +21,7 @@ export default function isInstrumentFeatureAvailable({
         isVaultingNotEnabled(checkoutSettings, paymentMethod.config) ||
         customer.isGuest ||
         isVaultingWithMultiShippingNotEnabled(checkoutSettings, isUsingMultiShipping) ||
-        paymentMethod.initializationData.enableLink
+        !shouldSavingCardsBeEnabled
     ) {
         return false;
     }


### PR DESCRIPTION
## What?
Now for StripeLink when customer is logged in BC account, the "save this card for future transaction" is not displayed.

## Why?
Shopper should not have ability to save Stripe Link instruments to BC. Remove checkbox.

## Testing / Proof
Before changes
![image](https://github.com/bigcommerce/checkout-js/assets/130039975/cda64039-0cfc-439b-8041-f5b79ceffd22)

After changes
![Zrzut ekranu 2023-10-27 o 08 58 25](https://github.com/bigcommerce/checkout-js/assets/130039975/febb129d-c7c4-4e4c-99ca-c0e225714092)



@bigcommerce/team-checkout
