### PR TITLE
fix(payment): PAYPAL-3090 updated wallet buttons height to remove differences in styling

### DIFF
--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -18,6 +18,12 @@
     > .AmazonPayContainer {
         width: remCalc(200px);
     }
+
+    .gpay-button {
+        border-radius: $global-radius;
+        height: $wallet-button-height;
+        min-height: $wallet-button-height;
+    }
 }
 
 #applepayCheckoutButton button,
@@ -34,7 +40,6 @@
     background-size: 100% 60%;
     border-radius: $global-radius;
     height: $wallet-button-height;
-    padding: spacing('single');
 }
 
 .checkoutRemote-button {

--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -158,10 +158,6 @@ $buttonWidthMap: (
         min-width: 0;
         width: 100%;
     }
-
-    #applepayCheckoutButton button {
-        padding: 0;
-    }
 }
 
 .checkout-buttons--1 {


### PR DESCRIPTION
## What?
Updated GooglePay and ApplePay button height to be the same as in all other wallet buttons

## Why?
Google Pay and Apple Pay button have more than 36px height, that differ to other buttons on checkout page

## Testing / Proof
Manual tests

<img width="872" alt="Screenshot 2023-10-17 at 15 14 33" src="https://github.com/bigcommerce/checkout-js/assets/25133454/57bdff1a-b087-4740-b3ef-12f9f09d9ea1">

