### PR TITLE
chore(payment): PAYPAL-2910 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.462.0",
+        "@bigcommerce/checkout-sdk": "^1.463.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.462.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.462.0.tgz",
-      "integrity": "sha512-4bBUgnFi3BN1h0YSdO2TAkBjZHrXMMM7QAq8c8jWZ1wbbIyIaQYD9UTECOraN3tlDooyPezkTVdG0/ckc8zepw==",
+      "version": "1.463.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.463.0.tgz",
+      "integrity": "sha512-lDWk6mJh91hWfEoJYRJRJ3KOBurQzn/BcxRxMNm4XmIVfGixVMejRypkhpT12pW0oG27ZZAj8u+GcxGSl0S08A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.462.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.462.0.tgz",
-      "integrity": "sha512-4bBUgnFi3BN1h0YSdO2TAkBjZHrXMMM7QAq8c8jWZ1wbbIyIaQYD9UTECOraN3tlDooyPezkTVdG0/ckc8zepw==",
+      "version": "1.463.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.463.0.tgz",
+      "integrity": "sha512-lDWk6mJh91hWfEoJYRJRJ3KOBurQzn/BcxRxMNm4XmIVfGixVMejRypkhpT12pW0oG27ZZAj8u+GcxGSl0S08A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.462.0",
+    "@bigcommerce/checkout-sdk": "^1.463.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2167

## Testing / Proof

<img width="770" alt="Screenshot 2023-10-09 at 12 59 01" src="https://github.com/bigcommerce/checkout-js/assets/99336044/4e80bbf2-2ff5-4cbb-b7fe-d01c0b249db2">

<img width="797" alt="Screenshot 2023-10-09 at 12 59 16" src="https://github.com/bigcommerce/checkout-js/assets/99336044/8953eafc-947c-47f6-8416-adb913b83cad">

@bigcommerce/team-checkout
