### PR TITLE
chore(payment): PI-889 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.463.0",
+        "@bigcommerce/checkout-sdk": "^1.464.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.463.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.463.0.tgz",
-      "integrity": "sha512-lDWk6mJh91hWfEoJYRJRJ3KOBurQzn/BcxRxMNm4XmIVfGixVMejRypkhpT12pW0oG27ZZAj8u+GcxGSl0S08A==",
+      "version": "1.464.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.464.0.tgz",
+      "integrity": "sha512-Ham2SMCwRa6zC2vZKPCHw8yDZwI6jljwetZanWjhWjGCdYxy4D+xRzREYtGNyQR/BDlgqSFNCOOI75z4VxPzmQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.463.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.463.0.tgz",
-      "integrity": "sha512-lDWk6mJh91hWfEoJYRJRJ3KOBurQzn/BcxRxMNm4XmIVfGixVMejRypkhpT12pW0oG27ZZAj8u+GcxGSl0S08A==",
+      "version": "1.464.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.464.0.tgz",
+      "integrity": "sha512-Ham2SMCwRa6zC2vZKPCHw8yDZwI6jljwetZanWjhWjGCdYxy4D+xRzREYtGNyQR/BDlgqSFNCOOI75z4VxPzmQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.463.0",
+    "@bigcommerce/checkout-sdk": "^1.464.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To release PR:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2213](https://github.com/bigcommerce/checkout-sdk-js/pull/2213)

## Testing / Proof
<img width="2559" alt="Screenshot 2023-10-10 at 11 07 30" src="https://github.com/bigcommerce/checkout-js/assets/9430298/7dac9e5c-085f-4f91-ab3f-8157ed68f13d">


@bigcommerce/team-checkout
