### PR TITLE
refactor(checkout): CHECKOUT-7772 Remove fully rolled out feature account_creation_in_checkout

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -141,7 +141,6 @@ export interface WithCheckoutProps {
     loginUrl: string;
     cartUrl: string;
     createAccountUrl: string;
-    canCreateAccountInCheckout: boolean;
     promotions?: Promotion[];
     steps: CheckoutStepStatus[];
     clearError(error?: Error): void;
@@ -762,12 +761,9 @@ class Checkout extends Component<
     };
 
     private setCustomerViewType: (viewType: CustomerViewType) => void = (customerViewType) => {
-        const { canCreateAccountInCheckout, createAccountUrl } = this.props;
+        const { createAccountUrl } = this.props;
 
-        if (
-            customerViewType === CustomerViewType.CreateAccount &&
-            (!canCreateAccountInCheckout || isEmbedded())
-        ) {
+        if (customerViewType === CustomerViewType.CreateAccount && isEmbedded()) {
             if (window.top) {
                 window.top.location.replace(createAccountUrl);
             }

--- a/packages/core/src/app/checkout/mapToCheckoutProps.ts
+++ b/packages/core/src/app/checkout/mapToCheckoutProps.ts
@@ -60,7 +60,6 @@ export default function mapToCheckoutProps({
         loginUrl,
         cartUrl,
         createAccountUrl,
-        canCreateAccountInCheckout: features['CHECKOUT-4941.account_creation_in_checkout'],
         promotions,
         subscribeToConsignments: subscribeToConsignmentsSelector({
             checkoutService,

--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -179,9 +179,6 @@ describe('Customer', () => {
                 ...getStoreConfig(),
                 checkoutSettings: {
                     ...getStoreConfig().checkoutSettings,
-                    features: {
-                        'CHECKOUT-4941.account_creation_in_checkout': true,
-                    },
                 },
             });
 
@@ -774,9 +771,6 @@ describe('Customer', () => {
                 ...getStoreConfig(),
                 checkoutSettings: {
                     ...getStoreConfig().checkoutSettings,
-                    features: {
-                        'CHECKOUT-4941.account_creation_in_checkout': true,
-                    },
                 },
             });
 


### PR DESCRIPTION
## What?
We utilized CHECKOUT-4941.account_creation_in_checkout feature to determine if a checkout page allows in-page signup or redirects to a signup page.

Removing this old feature flag

## Why?

This feature has been fully rolled out, cleaning up.


## Testing / Proof
Existing tests / CI

@bigcommerce/team-checkout
