### PR TITLE
chore(payment): PAYPAL-3098 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.464.0",
+        "@bigcommerce/checkout-sdk": "^1.465.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.464.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.464.0.tgz",
-      "integrity": "sha512-Ham2SMCwRa6zC2vZKPCHw8yDZwI6jljwetZanWjhWjGCdYxy4D+xRzREYtGNyQR/BDlgqSFNCOOI75z4VxPzmQ==",
+      "version": "1.465.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.465.1.tgz",
+      "integrity": "sha512-7ln55WKP+zjBGKfJQJps0wHn4v38t6AZviuwmL9Kc1i/SNdW0qtNBTl5uuofheU5t3b7UWxX0Zh/0mny+d8Pow==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.464.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.464.0.tgz",
-      "integrity": "sha512-Ham2SMCwRa6zC2vZKPCHw8yDZwI6jljwetZanWjhWjGCdYxy4D+xRzREYtGNyQR/BDlgqSFNCOOI75z4VxPzmQ==",
+      "version": "1.465.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.465.1.tgz",
+      "integrity": "sha512-7ln55WKP+zjBGKfJQJps0wHn4v38t6AZviuwmL9Kc1i/SNdW0qtNBTl5uuofheU5t3b7UWxX0Zh/0mny+d8Pow==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.464.0",
+    "@bigcommerce/checkout-sdk": "^1.465.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2217
https://github.com/bigcommerce/checkout-sdk-js/pull/2216

## Testing / Proof
Unit tests
Manual tests
QA tests
