### PR TITLE
chore(checkout): checkout-7733 Bump checkout-sdk v1.467.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.466.0",
+        "@bigcommerce/checkout-sdk": "^1.467.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.466.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.466.0.tgz",
-      "integrity": "sha512-52epm9MAXP4xjTh59oEtA8o9lwBG/tN1nH/LWYpKyoyU0f5IltRSVQ75Fqnvf0NaiiIhjQL9NreLiyNCKmnsgQ==",
+      "version": "1.467.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.467.0.tgz",
+      "integrity": "sha512-HLnb1F3clJSGSztJ7HOdwTPJI2cF/PCUG7RpszoFtKZDRFvZN+Vmk9nW9M1T0yRv1kfAFYVcDFuiaDfaSBGrHg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.466.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.466.0.tgz",
-      "integrity": "sha512-52epm9MAXP4xjTh59oEtA8o9lwBG/tN1nH/LWYpKyoyU0f5IltRSVQ75Fqnvf0NaiiIhjQL9NreLiyNCKmnsgQ==",
+      "version": "1.467.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.467.0.tgz",
+      "integrity": "sha512-HLnb1F3clJSGSztJ7HOdwTPJI2cF/PCUG7RpszoFtKZDRFvZN+Vmk9nW9M1T0yRv1kfAFYVcDFuiaDfaSBGrHg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.466.0",
+    "@bigcommerce/checkout-sdk": "^1.467.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk `v1.467.0`.

## Why?
Release lastest SDK change(s):
* https://github.com/bigcommerce/checkout-sdk-js/pull/2187

## Testing / Proof
* CI checks.
