### PR TITLE
chore(payment): PAYPAL-3099 bump checkout-sdk to v1.468.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.467.0",
+        "@bigcommerce/checkout-sdk": "^1.468.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.467.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.467.0.tgz",
-      "integrity": "sha512-HLnb1F3clJSGSztJ7HOdwTPJI2cF/PCUG7RpszoFtKZDRFvZN+Vmk9nW9M1T0yRv1kfAFYVcDFuiaDfaSBGrHg==",
+      "version": "1.468.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.468.0.tgz",
+      "integrity": "sha512-PlpD5qoD57Yxjyj50GAnyK/31Zs3mJ8Cs4phR07fo/1aC+cyWgW9Ddfl4jKn8gKc8c4olWLqhLRqTcSstwnQlw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.467.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.467.0.tgz",
-      "integrity": "sha512-HLnb1F3clJSGSztJ7HOdwTPJI2cF/PCUG7RpszoFtKZDRFvZN+Vmk9nW9M1T0yRv1kfAFYVcDFuiaDfaSBGrHg==",
+      "version": "1.468.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.468.0.tgz",
+      "integrity": "sha512-PlpD5qoD57Yxjyj50GAnyK/31Zs3mJ8Cs4phR07fo/1aC+cyWgW9Ddfl4jKn8gKc8c4olWLqhLRqTcSstwnQlw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.467.0",
+    "@bigcommerce/checkout-sdk": "^1.468.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to v1.468.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2219

## Testing / Proof
Unit tests
Manual tests