### PR TITLE
feat(payment): PAYPAL-2975 added ability to show ratepay specific errors

### DIFF
--- a/packages/core/src/app/common/error/ErrorModal.spec.tsx
+++ b/packages/core/src/app/common/error/ErrorModal.spec.tsx
@@ -1,6 +1,7 @@
 import { RequestError } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
+import { screen } from '@testing-library/react';
 
 import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
 
@@ -11,6 +12,7 @@ import { Modal } from '../../ui/modal';
 
 import ErrorCode from './ErrorCode';
 import ErrorModal, { ErrorModalProps } from './ErrorModal';
+import { CustomError } from './index';
 
 describe('ErrorModal', () => {
     let errorModal: ReactWrapper;
@@ -104,6 +106,28 @@ describe('ErrorModal', () => {
 
             it('does not render error code', () => {
                 expect(errorModal.find(ErrorCode)).toHaveLength(0);
+            });
+        });
+
+        describe('when receive custom error where html should be translated', () => {
+            beforeEach(() => {
+                errorModal.setProps({
+                    error: new CustomError({
+                        data: {
+                            shouldBeTranslatedAsHtml: true,
+                            translationKey: 'payment.ratepay.errors.paymentSourceInfoCannotBeVerified',
+                        }
+                    }),
+                    shouldShowErrorCode: false,
+                });
+                errorModal.update();
+            });
+
+            it('display links with correct href',  () => {
+                const link1 = screen.getByRole('link', { name: 'Ratepay Data Privacy Statement' });
+                const link2 = screen.getByRole('link', { name: 'contact form.' });
+                expect(link1).toHaveAttribute('href', 'https://www.ratepay.com/en/ratepay-data-privacy-statement/');
+                expect(link2).toHaveAttribute('href', 'https://www.ratepay.com/en/contact/');
             });
         });
     });

--- a/packages/core/src/app/common/error/ErrorModal.tsx
+++ b/packages/core/src/app/common/error/ErrorModal.tsx
@@ -70,7 +70,7 @@ export default class ErrorModal extends PureComponent<ErrorModalProps> {
 
         return (
             <>
-                {error && isCustomError(error) && isHtmlError(error) &&
+                {error && isHtmlError(error) &&
                     <TranslatedHtml id={error.data.translationKey} />
                 }
                 {message && (

--- a/packages/core/src/app/common/error/ErrorModal.tsx
+++ b/packages/core/src/app/common/error/ErrorModal.tsx
@@ -2,7 +2,7 @@ import { RequestError } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React, { PureComponent, ReactNode, SyntheticEvent } from 'react';
 
-import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { TranslatedHtml, TranslatedString } from '@bigcommerce/checkout/locale';
 
 import { Button, ButtonSize } from '../../ui/button';
 import { IconError, IconSize } from '../../ui/icon';
@@ -12,9 +12,11 @@ import computeErrorCode from './computeErrorCode';
 import ErrorCode from './ErrorCode';
 import isCustomError from './isCustomError';
 import isRequestError from './isRequestError';
+import isHtmlError from './isHtmlError';
+import { CustomError } from './index';
 
 export interface ErrorModalProps {
-    error?: Error | RequestError;
+    error?: Error | RequestError | CustomError;
     message?: ReactNode;
     title?: ReactNode;
     shouldShowErrorCode?: boolean;
@@ -68,6 +70,9 @@ export default class ErrorModal extends PureComponent<ErrorModalProps> {
 
         return (
             <>
+                {error && isCustomError(error) && isHtmlError(error) &&
+                    <TranslatedHtml id={error.data.translationKey} />
+                }
                 {message && (
                     <p aria-live="assertive" id="errorModalMessage" role="alert">
                         {message}

--- a/packages/core/src/app/common/error/isHtmlError.tsx
+++ b/packages/core/src/app/common/error/isHtmlError.tsx
@@ -1,0 +1,11 @@
+import { CustomError } from './index';
+
+export default function isHtmlError(error: CustomError): error is CustomError {
+
+    return (
+        error &&
+        error.data &&
+        typeof error.data.shouldBeTranslatedAsHtml === 'boolean' &&
+        typeof error.data.translationKey === 'string'
+    );
+}

--- a/packages/core/src/app/common/error/isHtmlError.tsx
+++ b/packages/core/src/app/common/error/isHtmlError.tsx
@@ -1,16 +1,12 @@
-import { CustomError } from './index';
+import { CustomError } from "@bigcommerce/checkout/payment-integration-api";
 
 export default function isHtmlError(error: Error): error is CustomError {
-    const customErrorData = getErrorData(error);
 
-    return (
-        customErrorData &&
-        typeof customErrorData.shouldBeTranslatedAsHtml === 'boolean' &&
-        typeof customErrorData.translationKey === 'string'
-    )
+    return 'type' in error &&
+        error.type === 'custom' &&
+        'data' in error &&
+        typeof error.data === 'object' &&
+        error.data !== null &&
+        'shouldBeTranslatedAsHtml' in error.data &&
+        typeof error.data.shouldBeTranslatedAsHtml === 'boolean';
 }
-
-const getErrorData = (error: any) => {
-   return  error?.data !== undefined && error.data;
-}
-

--- a/packages/core/src/app/common/error/isHtmlError.tsx
+++ b/packages/core/src/app/common/error/isHtmlError.tsx
@@ -1,8 +1,8 @@
-import { CustomError } from './index';
+import { CustomError, isCustomError } from './index';
 
-export default function isHtmlError(error: CustomError): error is CustomError {
+export default function isHtmlError(error: Error): error is CustomError {
 
-    return (
+    return isCustomError(error) && (
         error &&
         error.data &&
         typeof error.data.shouldBeTranslatedAsHtml === 'boolean' &&

--- a/packages/core/src/app/common/error/isHtmlError.tsx
+++ b/packages/core/src/app/common/error/isHtmlError.tsx
@@ -2,10 +2,10 @@ import { CustomError, isCustomError } from './index';
 
 export default function isHtmlError(error: Error): error is CustomError {
 
-    return isCustomError(error) && (
+    return isCustomError(error) ? (
         error &&
         error.data &&
         typeof error.data.shouldBeTranslatedAsHtml === 'boolean' &&
         typeof error.data.translationKey === 'string'
-    );
+    ): false;
 }

--- a/packages/core/src/app/common/error/isHtmlError.tsx
+++ b/packages/core/src/app/common/error/isHtmlError.tsx
@@ -1,11 +1,16 @@
-import { CustomError, isCustomError } from './index';
+import { CustomError } from './index';
 
 export default function isHtmlError(error: Error): error is CustomError {
+    const customErrorData = getErrorData(error);
 
-    return isCustomError(error) ? (
-        error &&
-        error.data &&
-        typeof error.data.shouldBeTranslatedAsHtml === 'boolean' &&
-        typeof error.data.translationKey === 'string'
-    ): false;
+    return (
+        customErrorData &&
+        typeof customErrorData.shouldBeTranslatedAsHtml === 'boolean' &&
+        typeof customErrorData.translationKey === 'string'
+    )
 }
+
+const getErrorData = (error: any) => {
+   return  error?.data !== undefined && error.data;
+}
+

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -438,7 +438,9 @@
                 "birth_date": "Date of birth",
                 "errors": {
                     "isRequired": "{fieldName} is required",
-                    "isInvalid": "{fieldName} is invalid"
+                    "isInvalid": "{fieldName} is invalid",
+                    "paymentSourceInfoCannotBeVerified": "The combination of your name and address could not be validated. Please correct your data and try again. You can find further information in the <a href='https://www.ratepay.com/en/ratepay-data-privacy-statement/' target='blank'>Ratepay Data Privacy Statement</a> or you can contact Ratepay using this <a href='https://www.ratepay.com/en/contact/' target='blank'>contact form.</a>",
+                    "paymentSourceDeclinedByProcessor": "It is not possible to use the selected payment method. This decision is based on automated data processing. You can find further information in the <a href='https://www.ratepay.com/en/ratepay-data-privacy-statement/' target='blank'>Ratepay Data Privacy Statement</a> or you can contact Ratepay using this <a href='https://www.ratepay.com/en/contact/' target='blank'>contact form.</a>"
                 }
             }
         },

--- a/packages/payment-integration-api/src/errors/custom-error-types.ts
+++ b/packages/payment-integration-api/src/errors/custom-error-types.ts
@@ -1,4 +1,4 @@
-export interface SpecificError extends Error {
+export default interface SpecificError extends Error {
     errors?: ErrorElement[];
     status?: string;
 }

--- a/packages/payment-integration-api/src/errors/custom-error-types.ts
+++ b/packages/payment-integration-api/src/errors/custom-error-types.ts
@@ -1,0 +1,13 @@
+export interface SpecificError extends Error {
+    errors?: ErrorElement[];
+    status?: string;
+}
+
+interface ErrorElement {
+    code: string;
+    message: string;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    provider_error?: {
+        code: string;
+    };
+}

--- a/packages/payment-integration-api/src/errors/index.ts
+++ b/packages/payment-integration-api/src/errors/index.ts
@@ -1,2 +1,3 @@
 export { default as CustomError } from './CustomError';
 export { default as EmbeddedCheckoutUnsupportedError } from './EmbeddedCheckoutUnsupportedError';
+export { default as SpecificError } from './custom-error-types';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -1,4 +1,4 @@
-export { EmbeddedCheckoutUnsupportedError } from './errors';
+export {  CustomError, EmbeddedCheckoutUnsupportedError } from './errors';
 export { default as getPaymentMethodName } from './getPaymentMethodName';
 export { default as getUniquePaymentMethodId } from './getUniquePaymentMethodId';
 export { default as CardInstrumentFieldsetValues } from './CardInstrumentFieldsetValues';
@@ -28,3 +28,4 @@ export {
     CHECKOUT_ROOT_NODE_ID,
     MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID,
 } from './CheckoutRootWrapperIds';
+export { SpecificError } from './errors';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -1,4 +1,4 @@
-export {  CustomError, EmbeddedCheckoutUnsupportedError } from './errors';
+export { CustomError, EmbeddedCheckoutUnsupportedError } from './errors';
 export { default as getPaymentMethodName } from './getPaymentMethodName';
 export { default as getUniquePaymentMethodId } from './getUniquePaymentMethodId';
 export { default as CardInstrumentFieldsetValues } from './CardInstrumentFieldsetValues';

--- a/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
@@ -9,8 +9,8 @@ import { DynamicFormField, DynamicFormFieldType, FormContext } from '@bigcommerc
 import { FormField } from '@bigcommerce/checkout-sdk';
 import getPaypalCommerceRatePayValidationSchema from './validation-schemas/getPaypalCommerceRatePayValidationSchema';
 import { LoadingSpinner } from '@bigcommerce/checkout/ui';
-import { CustomError } from '../../payment-integration-api/src/errors';
-import { SpecificError } from '../../payment-integration-api/src/errors/custom-error-types';
+import { CustomError } from '@bigcommerce/checkout/payment-integration-api';
+import { SpecificError } from '@bigcommerce/checkout/payment-integration-api';
 
 const PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED = 'PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED';
 const PAYMENT_SOURCE_DECLINED_BY_PROCESSOR = 'PAYMENT_SOURCE_DECLINED_BY_PROCESSOR';


### PR DESCRIPTION
## What?
Added ability to show ratepay specific errors

## Why?
To display specific errors for ratepay

## Testing / Proof

<img width="841" alt="Screenshot 2023-10-16 at 13 22 42" src="https://github.com/bigcommerce/checkout-js/assets/56301104/748748ac-2f7d-4b8d-bb86-958543118431">

@bigcommerce/team-checkout
