### PR TITLE
feat(checkout): CHECKOUT-7763 Remove convertcart filter

### DIFF
--- a/packages/core/src/app/checkout/Checkout.spec.tsx
+++ b/packages/core/src/app/checkout/Checkout.spec.tsx
@@ -20,7 +20,7 @@ import { BillingProps } from '../billing';
 import Billing from '../billing/Billing';
 import { getCart } from '../cart/carts.mock';
 import { getPhysicalItem } from '../cart/lineItem.mock';
-import { CustomError, ErrorModal } from '../common/error';
+import { createErrorLogger, CustomError, ErrorModal } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
 import { CustomerInfo, CustomerInfoProps, CustomerProps, CustomerViewType } from '../customer';
 import Customer from '../customer/Customer';
@@ -42,17 +42,6 @@ import { getCheckout, getCheckoutWithPromotions } from './checkouts.mock';
 import CheckoutStep, { CheckoutStepProps } from './CheckoutStep';
 import CheckoutStepType from './CheckoutStepType';
 import getCheckoutStepStatuses from './getCheckoutStepStatuses';
-
-const errorLoggerMock = {
-    log: jest.fn(),
-};
-
-jest.mock('../common/error', () => {
-    return {
-        ...jest.requireActual('../common/error'),
-        createErrorLogger: jest.fn(() => errorLoggerMock),
-    };
-});
 
 describe('Checkout', () => {
     let CheckoutTest: FunctionComponent<CheckoutProps>;
@@ -82,6 +71,7 @@ describe('Checkout', () => {
             createEmbeddedMessenger: () => embeddedMessengerMock,
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
             embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
+            errorLogger: createErrorLogger(),
             analyticsTracker
         };
 
@@ -110,6 +100,8 @@ describe('Checkout', () => {
 
             return noop;
         });
+
+        jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
 
         jest.spyOn(checkoutState.data, 'getCart').mockReturnValue(getCart());
 
@@ -523,7 +515,7 @@ describe('Checkout', () => {
                 'onUnhandledError',
             )!(error);
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
 
         it('logs error if shopper is unable to sign in', () => {
@@ -534,7 +526,7 @@ describe('Checkout', () => {
                 error,
             );
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
 
         it('logs error if shopper is unable to continue as guest', () => {
@@ -545,7 +537,7 @@ describe('Checkout', () => {
                 'onContinueAsGuestError',
             )!(error);
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
     });
 
@@ -680,7 +672,7 @@ describe('Checkout', () => {
                 'onUnhandledError',
             )(error);
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
     });
 
@@ -731,7 +723,7 @@ describe('Checkout', () => {
                 error,
             );
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
     });
 
@@ -811,7 +803,7 @@ describe('Checkout', () => {
                 error,
             );
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
 
         it('posts message to parent of embedded checkout when there is order submission error', () => {
@@ -835,7 +827,7 @@ describe('Checkout', () => {
                 error,
             );
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
     });
 });

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -27,17 +27,6 @@ import {
 
 import Checkout, { CheckoutProps } from './Checkout';
 
-const errorLoggerMock = {
-    log: jest.fn(),
-};
-
-jest.mock('../common/error', () => {
-    return {
-        ...jest.requireActual('../common/error'),
-        createErrorLogger: jest.fn(() => errorLoggerMock),
-    };
-});
-
 describe('Checkout', () => {
     let checkout: CheckoutPageNodeObject;
     let CheckoutTest: FunctionComponent<CheckoutProps>;
@@ -78,8 +67,11 @@ describe('Checkout', () => {
             createEmbeddedMessenger: () => embeddedMessengerMock,
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
             embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
+            errorLogger: createErrorLogger(),
             analyticsTracker,
         };
+
+        jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
 
         CheckoutTest = (props) => (
             <CheckoutProvider checkoutService={checkoutService}>
@@ -235,7 +227,7 @@ describe('Checkout', () => {
 
             const error = new Error('Apple pay is not supported');
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
     });
 
@@ -268,7 +260,7 @@ describe('Checkout', () => {
 
             await checkout.waitForShippingStep();
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
     });
 
@@ -312,7 +304,7 @@ describe('Checkout', () => {
 
             await checkout.waitForBillingStep();
 
-            expect(errorLoggerMock.log).toHaveBeenCalledWith(error);
+            expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
         });
     });
 
@@ -336,7 +328,7 @@ describe('Checkout', () => {
 
             await checkout.waitForPaymentStep();
 
-            expect(errorLoggerMock.log).toHaveBeenCalled();
+            expect(defaultProps.errorLogger.log).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -261,24 +261,6 @@ class Checkout extends Component<
 
             window.addEventListener('beforeunload', this.handleBeforeExit);
 
-            const isSentryLoggingAll =
-                data.getConfig()?.checkoutSettings.features[
-                    'CHECKOUT-7764.Increase_sentry_logging_to_100_percent'
-                ] ?? false;
-
-            if (isSentryLoggingAll) {
-                const { sentryConfig, publicPath } = this.props;
-
-                this.errorLogger = createErrorLogger(
-                    { sentry: sentryConfig },
-                    {
-                        errorTypes: ['UnrecoverableError'],
-                        publicPath,
-                        sampleRate: 1,
-                    },
-                );
-            }
-
             if (isExtensionEnabled()) {
                 await extensionService.loadExtensions();
             }

--- a/packages/core/src/app/checkout/CheckoutApp.tsx
+++ b/packages/core/src/app/checkout/CheckoutApp.tsx
@@ -5,11 +5,13 @@ import ReactModal from 'react-modal';
 
 import { AnalyticsProvider } from '@bigcommerce/checkout/analytics';
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
+import { ErrorBoundary, ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
 import '../../scss/App.scss';
 
+import { createErrorLogger } from '../common/error';
 import {
     createEmbeddedCheckoutStylesheet,
     createEmbeddedCheckoutSupport,
@@ -22,6 +24,7 @@ export interface CheckoutAppProps {
     containerId: string;
     publicPath?: string;
     sentryConfig?: BrowserOptions;
+    sentrySampleRate?: number;
 }
 
 export default class CheckoutApp extends Component<CheckoutAppProps> {
@@ -31,6 +34,20 @@ export default class CheckoutApp extends Component<CheckoutAppProps> {
     });
     private embeddedStylesheet = createEmbeddedCheckoutStylesheet();
     private embeddedSupport = createEmbeddedCheckoutSupport(getLanguageService());
+    private errorLogger: ErrorLogger;
+
+    constructor(props: Readonly<CheckoutAppProps>) {
+        super(props);
+
+        this.errorLogger = createErrorLogger(
+            { sentry: props.sentryConfig },
+            {
+                errorTypes: ['UnrecoverableError'],
+                publicPath: props.publicPath,
+                sampleRate: props.sentrySampleRate ? props.sentrySampleRate : 0.1,
+            },
+        );
+    }
 
     componentDidMount(): void {
         const { containerId } = this.props;
@@ -40,20 +57,23 @@ export default class CheckoutApp extends Component<CheckoutAppProps> {
 
     render() {
         return (
-            <LocaleProvider checkoutService={this.checkoutService}>
-                <CheckoutProvider checkoutService={this.checkoutService}>
-                    <AnalyticsProvider checkoutService={this.checkoutService}>
-                        <ExtensionProvider checkoutService={this.checkoutService}>
-                            <Checkout
-                                {...this.props}
-                                createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
-                                embeddedStylesheet={this.embeddedStylesheet}
-                                embeddedSupport={this.embeddedSupport}
-                            />
-                        </ExtensionProvider>
-                    </AnalyticsProvider>
-                </CheckoutProvider>
-            </LocaleProvider>
+            <ErrorBoundary logger={this.errorLogger}>
+                <LocaleProvider checkoutService={this.checkoutService}>
+                    <CheckoutProvider checkoutService={this.checkoutService}>
+                        <AnalyticsProvider checkoutService={this.checkoutService}>
+                            <ExtensionProvider checkoutService={this.checkoutService}>
+                                <Checkout
+                                    {...this.props}
+                                    createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
+                                    embeddedStylesheet={this.embeddedStylesheet}
+                                    embeddedSupport={this.embeddedSupport}
+                                    errorLogger={this.errorLogger}
+                                />
+                            </ExtensionProvider>
+                        </AnalyticsProvider>
+                    </CheckoutProvider>
+                </LocaleProvider>
+            </ErrorBoundary>
         );
     }
 }

--- a/packages/core/src/app/checkout/mapToCheckoutProps.ts
+++ b/packages/core/src/app/checkout/mapToCheckoutProps.ts
@@ -18,7 +18,6 @@ export default function mapToCheckoutProps({
     const {
         checkoutSettings: {
             guestCheckoutEnabled: isGuestEnabled = false,
-            features = {},
             checkoutUserExperienceSettings = {
                 walletButtonsOnTop: false,
                 floatingLabelEnabled: false,
@@ -41,9 +40,6 @@ export default function mapToCheckoutProps({
 
     const walletButtonsOnTopFlag = Boolean(checkoutUserExperienceSettings.walletButtonsOnTop);
 
-    const isSentryLoggingAll =
-        features['CHECKOUT-7764.Increase_sentry_logging_to_100_percent'] || false;
-
     return {
         billingAddress: data.getBillingAddress(),
         cart: data.getCart(),
@@ -55,7 +51,6 @@ export default function mapToCheckoutProps({
         isPending: statuses.isPending(),
         isPriceHiddenFromGuests,
         isShowingWalletButtonsOnTop: walletButtonsOnTopFlag,
-        isSentryLoggingAll,
         loadCheckout: checkoutService.loadCheckout,
         loginUrl,
         cartUrl,

--- a/packages/core/src/app/common/error/SentryErrorLogger.spec.ts
+++ b/packages/core/src/app/common/error/SentryErrorLogger.spec.ts
@@ -165,88 +165,12 @@ describe('SentryErrorLogger', () => {
         });
     });
 
-    it('does not log exception event if it relates to convertcart', () => {
-        new SentryErrorLogger(config);
-
-        const clientOptions: BrowserOptions = (init as jest.Mock).mock.calls[0][0];
-         
-        const event = {
-            breadcrumbs: [
-                {
-                    timestamp: 1667952544.208,
-                    category: 'fetch',
-                    data: {
-                        method: 'POST',
-                        url: 'https://dc4.convertcart.com/event/v3/94892041/123.123',
-                        status_code: 200,
-                    },
-                    type: 'http',
-                },
-                {
-                    timestamp: 1667952544.549,
-                    category: 'fetch',
-                    data: {
-                        method: 'GET',
-                        url: '/api/storefront/checkouts/abcdefg',
-                        status_code: 200,
-                    },
-                    type: 'http',
-                },
-                {
-                    timestamp: 1667952544.549,
-                    category: 'fetch',
-                    type: 'http',
-                },
-                {
-                    timestamp: 1667952544.549,
-                    category: 'fetch',
-                    data: {
-                        method: 'GET',
-                        status_code: 200,
-                    },
-                    type: 'http',
-                },
-            ],
-            exception: {
-                values: [
-                    {
-                        type: 'TypeError',
-                        value: "Cannot read properties of null (reading 'setAttribute')",
-                        stacktrace: {
-                            frames: [
-                                {
-                                    filename: 'app:///608-12345.js',
-                                    function: 'u',
-                                    in_app: true,
-                                    lineno: 1,
-                                    colno: 10602,
-                                },
-                            ],
-                        },
-                        mechanism: {
-                            type: 'instrument',
-                            handled: true,
-                            data: {
-                                function: 'setInterval',
-                            },
-                        },
-                    },
-                ],
-            },
-        };
-        /* eslint-enable @typescript-eslint/naming-convention */
-        const hint = { originalException: new Error('Unexpected error') };
-
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        expect(clientOptions.beforeSend!(event, hint)).toBeNull();
-    });
-
     it('configures client to ignore errors from polyfill and Sentry client', () => {
         new SentryErrorLogger(config);
 
         expect(init).toHaveBeenCalledWith(
             expect.objectContaining({
-                denyUrls: ['polyfill~checkout', 'sentry~checkout', 'convertcart'],
+                denyUrls: ['polyfill~checkout', 'sentry~checkout'],
             }),
         );
     });

--- a/packages/core/src/app/common/error/SentryErrorLogger.ts
+++ b/packages/core/src/app/common/error/SentryErrorLogger.ts
@@ -59,7 +59,6 @@ export default class SentryErrorLogger implements ErrorLogger {
                 ...(config.denyUrls || []),
                 'polyfill~checkout',
                 'sentry~checkout',
-                'convertcart',
             ],
             integrations: [
                 new Integrations.GlobalHandlers({
@@ -147,16 +146,6 @@ export default class SentryErrorLogger implements ErrorLogger {
     }
 
     private handleBeforeSend: (event: Event, hint?: EventHint) => Event | null = (event, hint) => {
-        const isConvertcart = Boolean(
-            event.breadcrumbs?.filter((breadcrumb) =>
-                breadcrumb.data?.url?.includes('convertcart'),
-            ).length,
-        );
-
-        if (isConvertcart) {
-            return null;
-        }
-
         if (event.exception) {
             if (
                 !this.shouldReportExceptions(

--- a/packages/core/src/app/order/OrderConfirmation.spec.tsx
+++ b/packages/core/src/app/order/OrderConfirmation.spec.tsx
@@ -12,6 +12,7 @@ import { act } from 'react-dom/test-utils';
 import { AnalyticsContextProps, AnalyticsEvents, AnalyticsProviderMock } from '@bigcommerce/checkout/analytics';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
+import { createErrorLogger } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
 import { createEmbeddedCheckoutStylesheet } from '../embeddedCheckout';
 import { CreatedCustomer, GuestSignUpForm } from '../guestSignup';
@@ -57,6 +58,7 @@ describe('OrderConfirmation', () => {
             createAccount: jest.fn(() => Promise.resolve({} as CreatedCustomer)),
             createEmbeddedMessenger: () => embeddedMessengerMock,
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
+            errorLogger: createErrorLogger(),
             orderId: 105,
             analyticsTracker
         };

--- a/packages/core/src/app/order/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation.tsx
@@ -115,24 +115,6 @@ class OrderConfirmation extends Component<
                 messenger.postFrameLoaded({ contentId: containerId });
 
                 analyticsTracker.orderPurchased();
-
-                const isSentryLoggingAll =
-                    data.getConfig()?.checkoutSettings.features[
-                        'CHECKOUT-7764.Increase_sentry_logging_to_100_percent'
-                    ] ?? false;
-
-                if (isSentryLoggingAll) {
-                    const { sentryConfig, publicPath } = this.props;
-
-                    this.errorLogger = createErrorLogger(
-                        { sentry: sentryConfig },
-                        {
-                            errorTypes: ['UnrecoverableError'],
-                            publicPath,
-                            sampleRate: 1,
-                        },
-                    );
-                }
             })
             .catch(this.handleUnhandledError);
     }

--- a/packages/core/src/app/order/OrderConfirmationApp.tsx
+++ b/packages/core/src/app/order/OrderConfirmationApp.tsx
@@ -5,9 +5,11 @@ import ReactModal from 'react-modal';
 
 import { AnalyticsProvider } from '@bigcommerce/checkout/analytics';
 import '../../scss/App.scss';
+import { ErrorBoundary, ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
+import { createErrorLogger } from '../common/error';
 import { createEmbeddedCheckoutStylesheet } from '../embeddedCheckout';
 import { AccountService, CreatedCustomer, SignUpFormValues } from '../guestSignup';
 
@@ -18,6 +20,7 @@ export interface OrderConfirmationAppProps {
     orderId: number;
     publicPath?: string;
     sentryConfig?: BrowserOptions;
+    sentrySampleRate?: number;
 }
 
 class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
@@ -27,6 +30,20 @@ class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
         shouldWarnMutation: process.env.NODE_ENV === 'development',
     });
     private embeddedStylesheet = createEmbeddedCheckoutStylesheet();
+    private errorLogger: ErrorLogger;
+
+    constructor(props: Readonly<OrderConfirmationAppProps>) {
+        super(props);
+
+        this.errorLogger = createErrorLogger(
+            { sentry: props.sentryConfig },
+            {
+                errorTypes: ['UnrecoverableError'],
+                publicPath: props.publicPath,
+                sampleRate: props.sentrySampleRate ? props.sentrySampleRate : 0.1,
+            },
+        );
+    }
 
     componentDidMount(): void {
         const { containerId } = this.props;
@@ -36,18 +53,21 @@ class OrderConfirmationApp extends Component<OrderConfirmationAppProps> {
 
     render(): ReactNode {
         return (
-            <LocaleProvider checkoutService={this.checkoutService}>
-                <CheckoutProvider checkoutService={this.checkoutService}>
-                    <AnalyticsProvider checkoutService={this.checkoutService}>
-                        <OrderConfirmation
-                            {...this.props}
-                            createAccount={this.createAccount}
-                            createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
-                            embeddedStylesheet={this.embeddedStylesheet}
-                        />
-                    </AnalyticsProvider>
-                </CheckoutProvider>
-            </LocaleProvider>
+            <ErrorBoundary logger={this.errorLogger}>
+                <LocaleProvider checkoutService={this.checkoutService}>
+                    <CheckoutProvider checkoutService={this.checkoutService}>
+                        <AnalyticsProvider checkoutService={ this.checkoutService }>
+                            <OrderConfirmation
+                                {...this.props}
+                                createAccount={this.createAccount}
+                                createEmbeddedMessenger={createEmbeddedCheckoutMessenger}
+                                embeddedStylesheet={this.embeddedStylesheet}
+                                errorLogger={this.errorLogger}
+                            />
+                        </AnalyticsProvider>
+                    </CheckoutProvider>
+                </LocaleProvider>
+            </ErrorBoundary>
         );
     }
 


### PR DESCRIPTION
## What?
- Remove `convertcart` filter for Sentry logging.
- Revert back to the previous structure of `ErrorBoundary`.
- Read sentry sample rate from BCapp template.

## Why?
We are using [Sentry server side filter ](https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#5-applying-workflows)to discard unwanted issues now.
> If you ["Delete & Discard"](https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#delete--discard) an issue, then future error events with the same fingerprint will not count toward your quota.

## Testing / Proof
- CI checks.