### PR TITLE
fix(checkout): CHECKOUT-5833 fix date issue in different timezones

### DIFF
--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -69,7 +69,7 @@ function getValue(
     }
 
     if (fieldType === DynamicFormFieldType.date && typeof fieldValue === 'string') {
-        if(fieldValue){
+        if (fieldValue) {
             const [year, month, day] = fieldValue.split('-');
             return new Date(Number(year), Number(month)-1, Number(day));
         }

--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -69,7 +69,11 @@ function getValue(
     }
 
     if (fieldType === DynamicFormFieldType.date && typeof fieldValue === 'string') {
-        return fieldValue ? new Date(fieldValue) : undefined;
+        if(fieldValue){
+            const [year, month, day] = fieldValue.split('-');
+            return new Date(Number(year), Number(month)-1, Number(day));
+        }
+        return undefined;
     }
 
     return fieldValue;


### PR DESCRIPTION
## What?
Changed the format of date provided to `new Date(dateString)` function to be separated by year, month and day, i.e. `new Date(year, monthIndex, day)`

## Why?
As the `new Date(dateString)` gives the time in UTC timezone it displays incorrectly (1 day back) in some timezones, so the change is to display correct date in those timezones.

## Testing / Proof
**Manual test**

**BEFORE**

https://github.com/bigcommerce/checkout-js/assets/141614330/17d569d1-c561-44bd-ba3b-0ecb6fff308d

**AFTER**

https://github.com/bigcommerce/checkout-js/assets/141614330/268a1774-a311-4d78-a78b-ec55fec986b3

