### PR TITLE
chore(payment): PAYPAL-3090 bump checkout-sdk version to v1.470.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.470.0",
+        "@bigcommerce/checkout-sdk": "^1.470.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.470.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.470.0.tgz",
-      "integrity": "sha512-d4GrcgFa4kiLtmJv2TTv21AK51kdD3ItCZic2Sa/FFgeCv4iUHXKErkUDFSFmsRVjProLbpbaExeGUUVbeYKWw==",
+      "version": "1.470.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.470.1.tgz",
+      "integrity": "sha512-ETbJkry12QT2lNgzhDfHl7ziHgNQ8KeKMPevsSNIcOOLi3U7bwkAajHCv432RT3LMvuSZxn+7E2u/Uz/THq4zw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35577,9 +35577,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.470.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.470.0.tgz",
-      "integrity": "sha512-d4GrcgFa4kiLtmJv2TTv21AK51kdD3ItCZic2Sa/FFgeCv4iUHXKErkUDFSFmsRVjProLbpbaExeGUUVbeYKWw==",
+      "version": "1.470.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.470.1.tgz",
+      "integrity": "sha512-ETbJkry12QT2lNgzhDfHl7ziHgNQ8KeKMPevsSNIcOOLi3U7bwkAajHCv432RT3LMvuSZxn+7E2u/Uz/THq4zw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.470.0",
+    "@bigcommerce/checkout-sdk": "^1.470.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to v1.470.1

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2226

## Testing / Proof
Unit tests
Manual tests
QA tests
