### PR TITLE
feat(payment): PI-921 Amazon Pay Button needs to be changed to one with WITHOUT microtext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.482.0",
+        "@bigcommerce/checkout-sdk": "^1.483.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.482.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.482.0.tgz",
-      "integrity": "sha512-UAifdlbOVg3kJFzhOeFlhSC/jCO8nzY6rcBA06lbBmeBE+HVEyuNwhUKsFio/sYuJ7PwW5QlFk13e9zmTNlJeg==",
+      "version": "1.483.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.483.0.tgz",
+      "integrity": "sha512-oD771I+wh0MLe0o6fez1DIxBK85gmVXGCJQzMsLUxFwmpVapgLOwGinAYXSbjz6IuHFqQ0Pqzaud3fxbxaIYgQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.482.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.482.0.tgz",
-      "integrity": "sha512-UAifdlbOVg3kJFzhOeFlhSC/jCO8nzY6rcBA06lbBmeBE+HVEyuNwhUKsFio/sYuJ7PwW5QlFk13e9zmTNlJeg==",
+      "version": "1.483.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.483.0.tgz",
+      "integrity": "sha512-oD771I+wh0MLe0o6fez1DIxBK85gmVXGCJQzMsLUxFwmpVapgLOwGinAYXSbjz6IuHFqQ0Pqzaud3fxbxaIYgQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.482.0",
+    "@bigcommerce/checkout-sdk": "^1.483.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
+++ b/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
@@ -5,7 +5,7 @@ import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
 const AmazonPayV2Button: FunctionComponent<CheckoutButtonProps> = (props) => {
     useEffect(() => {
         beautifyAmazonButton();
-    }, [props]);
+    }, []);
 
     return (
         <div className="AmazonPayContainer">
@@ -26,10 +26,8 @@ const beautifyAmazonButton = (): void => {
 
     if (container && amazonButton) {
         amazonButton.style.height = '36px';
-        container.style.width = '100%';
-        
         return;
     }
 
-    setTimeout(beautifyAmazonButton, 200);
+    setTimeout(beautifyAmazonButton, 10);
 }

--- a/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
+++ b/packages/core/src/app/customer/customWalletButton/AmazonPayV2Button.tsx
@@ -5,7 +5,7 @@ import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
 const AmazonPayV2Button: FunctionComponent<CheckoutButtonProps> = (props) => {
     useEffect(() => {
         beautifyAmazonButton();
-    }, []);
+    }, [props]);
 
     return (
         <div className="AmazonPayContainer">
@@ -26,8 +26,10 @@ const beautifyAmazonButton = (): void => {
 
     if (container && amazonButton) {
         amazonButton.style.height = '36px';
+        container.style.width = '100%';
+        
         return;
     }
 
-    setTimeout(beautifyAmazonButton, 10);
+    setTimeout(beautifyAmazonButton, 200);
 }

--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -17,6 +17,9 @@
 
     > .AmazonPayContainer {
         width: remCalc(200px);
+        #amazonpayCheckoutButton > div{
+            width: 100% !important;
+        }
     }
 
     .gpay-button {


### PR DESCRIPTION
## What?
AmazonPay button width is adjusted properly.

## Why?
AmazonPay button width in Customer checkout step was not adjusted properly.

## Testing / Proof
1.Before changes 1

<img width="1463" alt="Before changes" src="https://github.com/bigcommerce/checkout-js/assets/130039975/5801ff07-fa18-476a-99a8-187e8fe25281">

2. After changes 1

<img width="1463" alt="After changes" src="https://github.com/bigcommerce/checkout-js/assets/130039975/942068da-6beb-4daa-9c86-0e8fb2fe36aa">

And 

3. Before changes 2
![Before changes 2](https://github.com/bigcommerce/checkout-js/assets/130039975/08a315a8-0528-451c-b917-c1e88d143b4a)

4. After changes  2

<img width="1463" alt="After changes 2" src="https://github.com/bigcommerce/checkout-js/assets/130039975/b01926ac-efaf-4eff-887f-7dfba0ce5af3">

@bigcommerce/team-checkout
