### PR TITLE
fix(payment): PI-924 Add loader while waiting order confirmation from Stripe

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.spec.tsx
@@ -11,7 +11,7 @@ import React, { FunctionComponent } from 'react';
 import { object } from 'yup';
 
 import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
-import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
+import { CheckoutProvider, MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getStoreConfig } from '../../config/config.mock';
 import {
@@ -138,6 +138,7 @@ describe('when using Stripe payment', () => {
                     methodId: method.id,
                     stripeupe: {
                         containerId: 'stripe-alipay-component-field',
+                        loaderContainerId: MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID,
                         style: expect.objectContaining({
                             fieldText: '#cccccc',
                         }),
@@ -190,6 +191,7 @@ describe('when using Stripe payment', () => {
                     methodId: method.id,
                     stripeupe: {
                         containerId: 'stripe-card-component-field',
+                        loaderContainerId: MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID,
                         style: expect.objectContaining({
                             fieldText: '#cccccc',
                         }),
@@ -242,6 +244,7 @@ describe('when using Stripe payment', () => {
                     methodId: method.id,
                     stripeupe: {
                         containerId: 'stripe-idealBank-component-field',
+                        loaderContainerId: MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID,
                         style: expect.objectContaining({
                             fieldText: '#cccccc',
                         }),
@@ -294,6 +297,7 @@ describe('when using Stripe payment', () => {
                     methodId: method.id,
                     stripeupe: {
                         containerId: 'stripe-iban-component-field',
+                        loaderContainerId: MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID,
                         style: expect.objectContaining({
                             fieldText: '#cccccc',
                         }),

--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -3,7 +3,7 @@ import { noop } from 'lodash';
 import React, { FunctionComponent, useCallback, useContext } from 'react';
 
 import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
-import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
+import { CheckoutContextProps, MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration-api';
 
 import { withCheckout } from '../../checkout';
 import {
@@ -53,6 +53,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
                     ...options,
                     stripeupe: {
                         containerId,
+                        loaderContainerId: MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID,
                         style: {
                             labelText: formLabel.color,
                             fieldText: formInput.color,


### PR DESCRIPTION
## What?
Add polling mechanism to wait while Stripe will confirm order by webhook

## Why?
Polling mechanism is needed in case when payment was successfully confirmed by Stripe.confirmPayment request on FE side, but has some delay to confirm payment on BE side, and BC order status mismatch with Stripe order status.
In this case the second payment request returns an error and we need to add some delay to wait confirmation by webhook on BE side and wait while BC order status will be changed.

PR from checkout-sdk-js: [https://github.com/bigcommerce/checkout-sdk-js/pull/2232](https://github.com/bigcommerce/checkout-sdk-js/pull/2232)

## Testing / Proof
Orders status updates immediately.

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/add170ab-8947-4f92-a291-4352226838d8

Order confirmed by Stripe but has some delay to be updated on BC side

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/030e2b39-c2ea-4e77-bdef-b7a0c270111e

Order was confirmed by Stripe but BC order status wasn't change.

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/d687e414-ce28-4f69-8e53-2b3c8115317e



@bigcommerce/team-checkout @bigcommerce/team-payments
