### PR TITLE
fix(payment): PAYPAL-3144 fixed the issue with PayPal Connect logo style glitch

### DIFF
--- a/packages/core/src/app/shipping/StaticConsignment.scss
+++ b/packages/core/src/app/shipping/StaticConsignment.scss
@@ -1,5 +1,9 @@
 @import '../ui/Base';
 
+.staticConsignment {
+    width: 100%;
+}
+
 .staticConsignmentContainer {
     ul {
         list-style: none;

--- a/packages/paypal-connect-integration/src/PoweredByPaypalConnectLabel.tsx
+++ b/packages/paypal-connect-integration/src/PoweredByPaypalConnectLabel.tsx
@@ -6,9 +6,11 @@ import { IconPayPalConnect } from '@bigcommerce/checkout/ui';
 import './PoweredByPaypalConnectLabel.scss';
 
 const PoweredByPaypalConnectLabel = () => (
-    <div className="powered-by-paypal-connect-label">
-        <TranslatedString id="remote.powered_by" />
-        <IconPayPalConnect />
+    <div className="powered-by-paypal-connect">
+        <div className="powered-by-paypal-connect-label">
+            <TranslatedString id="remote.powered_by" />
+            <IconPayPalConnect />
+        </div>
     </div>
 );
 


### PR DESCRIPTION
## What?
There was an issue with custom theme that affects PayPal Connect logo styling with display flex

## Why?
PayPal Connect brainding elements looks wrong on merchants checkout page

## Testing / Proof
Unit tests
Manual tests

Before:
<img width="1512" alt="Screenshot 2023-10-24 at 16 54 47" src="https://github.com/bigcommerce/checkout-js/assets/25133454/84a469af-a71a-498c-8787-75a275b8e898">

After:
<img width="1512" alt="Screenshot 2023-10-24 at 16 52 59" src="https://github.com/bigcommerce/checkout-js/assets/25133454/312cc694-c4e9-4a18-91ec-b77ccaf6f947">

Nothing changed for default Cornerstone Checkout page:
<img width="1512" alt="Screenshot 2023-10-24 at 16 52 49" src="https://github.com/bigcommerce/checkout-js/assets/25133454/95962884-1ae7-4999-9ff4-652b2c014dbc">

