### PR TITLE
fix(billing): CHECKOUT-7803 Load billing address countries when shipping form loads

### DIFF
--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -65,6 +65,10 @@ describe('Shipping Component', () => {
             {} as CheckoutSelectors,
         );
 
+        jest.spyOn(checkoutService, 'loadBillingAddressFields').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
         jest.spyOn(checkoutService, 'deleteConsignment').mockResolvedValue({} as CheckoutSelectors);
 
         jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
@@ -121,6 +125,7 @@ describe('Shipping Component', () => {
         mount(<ComponentTest {...defaultProps} />);
 
         expect(checkoutService.loadShippingAddressFields).toHaveBeenCalled();
+        expect(checkoutService.loadBillingAddressFields).toHaveBeenCalled();
 
         expect(checkoutService.loadShippingOptions).toHaveBeenCalled();
     });

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -73,6 +73,7 @@ export interface WithCheckoutShippingProps {
     deleteConsignments(): Promise<Address | undefined>;
     getFields(countryCode?: string): FormField[];
     initializeShippingMethod(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
+    loadBillingAddressFields(): Promise<CheckoutSelectors>;
     loadShippingAddressFields(): Promise<CheckoutSelectors>;
     loadShippingOptions(): Promise<CheckoutSelectors>;
     signOut(options?: CustomerRequestOptions): void;
@@ -99,13 +100,14 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
     async componentDidMount(): Promise<void> {
         const {
             loadShippingAddressFields,
+            loadBillingAddressFields,
             loadShippingOptions,
             onReady = noop,
             onUnhandledError = noop,
         } = this.props;
 
         try {
-            await Promise.all([loadShippingAddressFields(), loadShippingOptions()]);
+            await Promise.all([loadShippingAddressFields(), loadShippingOptions(), loadBillingAddressFields()]);
 
             onReady();
         } catch (error) {
@@ -386,6 +388,9 @@ export function mapToShippingProps({
         hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
     const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ'];
 
+    console.log('get billing address');
+    // checkoutService.loadBillingAddressFields();
+
     if (features['CHECKOUT-4183.checkout_google_address_autocomplete_uk']) {
         countriesWithAutocomplete.push('GB');
     }
@@ -412,6 +417,7 @@ export function mapToShippingProps({
         isInitializing: isLoadingShippingCountries() || isLoadingShippingOptions(),
         isLoading,
         isShippingStepPending: isShippingStepPending(),
+        loadBillingAddressFields: checkoutService.loadBillingAddressFields,
         loadShippingAddressFields: checkoutService.loadShippingAddressFields,
         loadShippingOptions: checkoutService.loadShippingOptions,
         methodId,


### PR DESCRIPTION
## What?
Load billing address countries as part of loading shipping form.

## Why?
We have a bug at this moment due to which billing form is displayed even if the setting `My billing address is the same as my shipping address.` is checked `true`, but postal code is not required for a country. 

This happens due to https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/core/src/form/form-selector.ts#L130 line resolving to and `[]` since we have not loaded billing countries yet. Which results in postal code being marked as required on the form and hence the form being incomplete which results in user loading the form.

Hence if we fetch billing countries earlier in the process and update the state we can get accurate form field validations as per the countries data.


## Testing / Proof
- CI

@bigcommerce/team-checkout
