### PR TITLE
fix(payment): PAYPAL-3143 fixed the issue with PayPal Connect instrument autoselect after page reload

### DIFF
--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutForm.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutForm.tsx
@@ -28,7 +28,7 @@ const BraintreeAcceleratedCheckoutForm: FunctionComponent<
         if (!isAddingNewInstrument && !selectedInstrument && instruments.length > 0) {
             handleSelectInstrument(instruments[0].bigpayToken);
         }
-    }, []);
+    }, [instruments, selectedInstrument, isAddingNewInstrument]);
 
     return (
         <div className="paymentMethod paymentMethod--creditCard">


### PR DESCRIPTION
## What?
The easiest way to fix that is to add dependencies to useEffect second parameter, so when there is new instrument list passed in component props, then component will trigger handle select method to autofill instrument select with first PayPal Connect instrument.


## Why?
When the customer reloads a page in Payment step of checkout page, the component did not fill up the instrument field with first PayPal Connect instrument (did not auto fill it), so the customer needs to select the instrument by himself. However, if the customer fills up a form for the first time starting from customer step, everything works as expected. There was an issue with component update method: there was no dependency in  useEffect method, so component didn’t update after new instruments list pass to component props.


## Testing
Steps to reproduce:
1. Turn on Braintree Accelerated Checkout feature;
2. Go to Storefront → Select Product → Go to Checkout page;
3. Use test-whitelistallblock-100@test.com email in customer step → fill up OTP fields with 111111 → pass all checkout steps to Payment step;
4. Reload the page;

## Proof

Before:

https://github.com/bigcommerce/checkout-js/assets/25133454/c00fe269-53cc-4360-96bd-726f653dcc35

After:

https://github.com/bigcommerce/checkout-js/assets/25133454/7f526c01-1e1c-483e-9562-24b42208864b

