### PR TITLE
chore(payment): PI-976 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.474.0",
+        "@bigcommerce/checkout-sdk": "^1.475.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.474.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.474.0.tgz",
-      "integrity": "sha512-nY9Rk6najC4OB8Ou0utd3i89YNnlCRNgbikIZM/d7ZmIPzdYH7FagPKhs64/2LqF/p9Iy64PQSqopQ4pFthL3w==",
+      "version": "1.475.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.475.0.tgz",
+      "integrity": "sha512-lb0c/acmMDTWn2EIyd9bStQJ7LKxSahX3ZqlmgkAcJV+K9I+EKUBj5l0dhufpyuvOyo9H4CosbVY9v0bLvu40A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35579,9 +35579,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.474.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.474.0.tgz",
-      "integrity": "sha512-nY9Rk6najC4OB8Ou0utd3i89YNnlCRNgbikIZM/d7ZmIPzdYH7FagPKhs64/2LqF/p9Iy64PQSqopQ4pFthL3w==",
+      "version": "1.475.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.475.0.tgz",
+      "integrity": "sha512-lb0c/acmMDTWn2EIyd9bStQJ7LKxSahX3ZqlmgkAcJV+K9I+EKUBj5l0dhufpyuvOyo9H4CosbVY9v0bLvu40A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.474.0",
+    "@bigcommerce/checkout-sdk": "^1.475.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
to deploy:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2236](https://github.com/bigcommerce/checkout-sdk-js/pull/2236)

## Testing / Proof
unit tests and manually tested

@bigcommerce/team-checkout
