### PR TITLE
chore(payment): PAYPAL-3156 bump checkout sdk version to v1.478.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.477.0",
+        "@bigcommerce/checkout-sdk": "^1.478.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.477.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.477.0.tgz",
-      "integrity": "sha512-Xv80m6YRbJ5apsxvI2QaSarhi0AGYSeIr1I/XrCtGN8TYIatKWMOK1COh+klkCJ11893XbkbUloV8SG/raP9OQ==",
+      "version": "1.478.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.0.tgz",
+      "integrity": "sha512-O2S8cpaJ0m1b/GU7TyZDd+EeHhdOhG9RTOJSMwKnrbyIYn7i41qT2yYlLyGDrb8YvhQYFJJeY5JwZ9CYjecNLQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35579,9 +35579,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.477.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.477.0.tgz",
-      "integrity": "sha512-Xv80m6YRbJ5apsxvI2QaSarhi0AGYSeIr1I/XrCtGN8TYIatKWMOK1COh+klkCJ11893XbkbUloV8SG/raP9OQ==",
+      "version": "1.478.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.0.tgz",
+      "integrity": "sha512-O2S8cpaJ0m1b/GU7TyZDd+EeHhdOhG9RTOJSMwKnrbyIYn7i41qT2yYlLyGDrb8YvhQYFJJeY5JwZ9CYjecNLQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.477.0",
+    "@bigcommerce/checkout-sdk": "^1.478.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to v1.478.0

## Why?
As part of checkout sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2240

## Testing / Proof
Unit tests
Manual tests