### PR TITLE
chore(payment): PI-924 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.478.0",
+        "@bigcommerce/checkout-sdk": "^1.478.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.478.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.0.tgz",
-      "integrity": "sha512-O2S8cpaJ0m1b/GU7TyZDd+EeHhdOhG9RTOJSMwKnrbyIYn7i41qT2yYlLyGDrb8YvhQYFJJeY5JwZ9CYjecNLQ==",
+      "version": "1.478.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.1.tgz",
+      "integrity": "sha512-hoglRpVLeKwXU69yqHZc7JRqiLZoN/EyDVe0B9XdpzbLDlvp/VUlrFXuBsVHxRFRWxyDf5awVLUKUiENoPOsbQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35579,9 +35579,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.478.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.0.tgz",
-      "integrity": "sha512-O2S8cpaJ0m1b/GU7TyZDd+EeHhdOhG9RTOJSMwKnrbyIYn7i41qT2yYlLyGDrb8YvhQYFJJeY5JwZ9CYjecNLQ==",
+      "version": "1.478.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.1.tgz",
+      "integrity": "sha512-hoglRpVLeKwXU69yqHZc7JRqiLZoN/EyDVe0B9XdpzbLDlvp/VUlrFXuBsVHxRFRWxyDf5awVLUKUiENoPOsbQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.478.0",
+    "@bigcommerce/checkout-sdk": "^1.478.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
to deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2242](https://github.com/bigcommerce/checkout-sdk-js/pull/2242)

## Testing / Proof
Unit tests and manual testing

@bigcommerce/team-checkout
