### PR TITLE
chore(payment): PI-846 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.478.1",
+        "@bigcommerce/checkout-sdk": "^1.479.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.478.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.1.tgz",
-      "integrity": "sha512-hoglRpVLeKwXU69yqHZc7JRqiLZoN/EyDVe0B9XdpzbLDlvp/VUlrFXuBsVHxRFRWxyDf5awVLUKUiENoPOsbQ==",
+      "version": "1.479.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.479.0.tgz",
+      "integrity": "sha512-Y8CV12rBy039DQzFg1FdGo+XUVb3VxlHDWdJcHqBHPt5wEa9A9axlIdyhyr5CkA5HN4021dFFp3dJ20/xtVTjw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35579,9 +35579,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.478.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.478.1.tgz",
-      "integrity": "sha512-hoglRpVLeKwXU69yqHZc7JRqiLZoN/EyDVe0B9XdpzbLDlvp/VUlrFXuBsVHxRFRWxyDf5awVLUKUiENoPOsbQ==",
+      "version": "1.479.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.479.0.tgz",
+      "integrity": "sha512-Y8CV12rBy039DQzFg1FdGo+XUVb3VxlHDWdJcHqBHPt5wEa9A9axlIdyhyr5CkA5HN4021dFFp3dJ20/xtVTjw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.478.1",
+    "@bigcommerce/checkout-sdk": "^1.479.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
to deploy PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2241

## Testing / Proof
Unit tests and manual testing

@bigcommerce/team-checkout
