### PR TITLE
feat(checkout): CHECKOUT-7838 preload extension with link tag

### DIFF
--- a/packages/checkout-extension/src/ExtensionService.ts
+++ b/packages/checkout-extension/src/ExtensionService.ts
@@ -22,6 +22,35 @@ export class ExtensionService {
         await this.checkoutService.loadExtensions();
     }
 
+    preloadExtensions(): void {
+        const state = this.checkoutService.getState();
+        const extensions = state.data.getExtensions();
+        const cartId = state.data.getCart()?.id;
+        const parentOrigin = state.data.getConfig()?.links.siteLink;
+
+        if (!cartId || !parentOrigin) return;
+        extensions?.forEach((extension) => {
+            const url = new URL(extension.url);
+
+            url.searchParams.set('extensionId', extension.id);
+            url.searchParams.set('cartId', cartId);
+            url.searchParams.set('parentOrigin', parentOrigin);
+
+            const link = document.createElement('link');
+
+            // Set the attributes for the link element
+            link.rel = 'preload';
+            link.as = 'document';
+            link.href = url.toString();
+
+            // Get the head element of the document
+            const head = document.head;
+
+            // Append the link element to the head
+            head.appendChild(link);
+        });
+    }
+
     async renderExtension(container: string, region: ExtensionRegion): Promise<void> {
         const extension = this.checkoutService.getState().data.getExtensionByRegion(region);
 

--- a/packages/checkout-extension/src/ExtensionService.ts
+++ b/packages/checkout-extension/src/ExtensionService.ts
@@ -28,7 +28,10 @@ export class ExtensionService {
         const cartId = state.data.getCart()?.id;
         const parentOrigin = state.data.getConfig()?.links.siteLink;
 
-        if (!cartId || !parentOrigin) return;
+        if (!cartId || !parentOrigin) {
+            return;
+        }
+
         extensions?.forEach((extension) => {
             const url = new URL(extension.url);
 
@@ -38,15 +41,12 @@ export class ExtensionService {
 
             const link = document.createElement('link');
 
-            // Set the attributes for the link element
             link.rel = 'preload';
             link.as = 'document';
             link.href = url.toString();
 
-            // Get the head element of the document
             const head = document.head;
 
-            // Append the link element to the head
             head.appendChild(link);
         });
     }

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -263,6 +263,7 @@ class Checkout extends Component<
 
             if (isExtensionEnabled()) {
                 await extensionService.loadExtensions();
+                extensionService.preloadExtensions();
             }
         } catch (error) {
             if (error instanceof Error) {


### PR DESCRIPTION
## What?
Optimize Extension Loading with Preloading via `<link>` tag

## Why?
In the extension project context, we can add all extension URLs to `<head>` within `<link>` tag as soon as we finish loading extensions so that we can shorten the time it takes to display an extension.

## Testing / Proof

- Manual testing

https://github.com/bigcommerce/checkout-js/assets/141614330/16f7df69-112d-43d9-8510-305bb74ba492


