### PR TITLE
fix(payment): PI-617 prevent certificates applying while order submitting

### DIFF
--- a/packages/core/src/app/cart/Redeemable.spec.tsx
+++ b/packages/core/src/app/cart/Redeemable.spec.tsx
@@ -1,17 +1,20 @@
-import { RequestError } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, CheckoutService, createCheckoutService, RequestError } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
 
 import { createLocaleContext, LocaleContext, LocaleContextType, TranslatedString } from '@bigcommerce/checkout/locale';
+import { CheckoutContext } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getStoreConfig } from '../config/config.mock';
 import { Alert } from '../ui/alert';
 
-import Redeemable from './Redeemable';
+import Redeemable, { RedeemableProps } from './Redeemable';
 
 describe('CartSummary Component', () => {
     let localeContext: LocaleContextType;
     let component: ReactWrapper;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
     const applyCoupon = jest.fn();
     const applyGiftCertificate = jest.fn();
     const clearError = jest.fn();
@@ -24,23 +27,33 @@ describe('CartSummary Component', () => {
         errors: [{}],
     } as RequestError;
 
+    const RedeemableTestComponent = (props: RedeemableProps) => (
+        <LocaleContext.Provider value={localeContext}>
+            <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
+                <Redeemable {...props} />
+            </CheckoutContext.Provider>
+        </LocaleContext.Provider>
+    );
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+    });
+
     describe('when coupon code is not collapsed', () => {
         beforeEach(() => {
-            localeContext = createLocaleContext(getStoreConfig());
-
             component = mount(
-                <LocaleContext.Provider value={localeContext}>
-                    <Redeemable
-                        appliedRedeemableError={minPurchaseError}
-                        applyCoupon={applyCoupon}
-                        applyGiftCertificate={applyGiftCertificate}
-                        clearError={clearError}
-                        isApplyingRedeemable={true}
-                        onRemovedCoupon={onRemovedCoupon}
-                        onRemovedGiftCertificate={onRemovedGiftCertificate}
-                        shouldCollapseCouponCode={false}
-                    />
-                </LocaleContext.Provider>,
+                <RedeemableTestComponent
+                    appliedRedeemableError={minPurchaseError}
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    isApplyingRedeemable={true}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={false}
+                />,
             );
         });
 
@@ -75,20 +88,16 @@ describe('CartSummary Component', () => {
 
     describe('when coupon code is collapsed', () => {
         beforeEach(() => {
-            localeContext = createLocaleContext(getStoreConfig());
-
             component = mount(
-                <LocaleContext.Provider value={localeContext}>
-                    <Redeemable
-                        appliedRedeemableError={appliedError}
-                        applyCoupon={applyCoupon}
-                        applyGiftCertificate={applyGiftCertificate}
-                        clearError={clearError}
-                        onRemovedCoupon={onRemovedCoupon}
-                        onRemovedGiftCertificate={onRemovedGiftCertificate}
-                        shouldCollapseCouponCode={true}
-                    />
-                </LocaleContext.Provider>,
+                <RedeemableTestComponent
+                    appliedRedeemableError={appliedError}
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={true}
+                />,
             );
         });
 
@@ -174,6 +183,61 @@ describe('CartSummary Component', () => {
                     expect(applyGiftCertificate).toHaveBeenCalledWith('foo');
                 });
             });
+        });
+    });
+
+    describe('when payment is submitting', () => {
+        let applyGiftCertificate: (code: string) => Promise<CheckoutSelectors>;
+        let applyCoupon: (code: string) => Promise<CheckoutSelectors>;
+        
+        beforeEach(() => {
+            applyGiftCertificate = jest.fn();
+            applyCoupon = jest.fn();
+            
+            checkoutState = checkoutService.getState();
+
+            jest.spyOn(checkoutState.statuses, 'isSubmittingOrder').mockReturnValue(true);
+
+            component = mount(
+                <RedeemableTestComponent
+                    appliedRedeemableError={minPurchaseError}
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    isApplyingRedeemable={false}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={false}
+                />,
+            );
+        });
+
+        it('apply button should be disabled when payment is submitting', () => {
+            const submitButton = component.find('[data-test="redeemableEntry-submit"]');
+
+            expect(submitButton.prop('disabled')).toBe(true);
+            expect(submitButton.hasClass('is-loading')).toBe(false);
+        });
+
+        it('calls applyCoupon when payment is submitting', async () => {
+            const submitButton = component.find('[data-test="redeemableEntry-submit"]');
+
+            submitButton.simulate('click');
+            await new Promise((resolve) => process.nextTick(resolve));
+            component.update();
+
+            expect(applyGiftCertificate).not.toHaveBeenCalled();
+        });
+
+        it('does not call applyCoupon when enter is hit inside input', async () => {
+            component
+                .find('[data-test="redeemableEntry-input"]')
+                .simulate('keyDown', { key: 'Enter', keyCode: 13, which: 13 });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+            component.update();
+
+            expect(applyCoupon).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/payment/storeCredit/StoreCreditField.spec.tsx
+++ b/packages/core/src/app/payment/storeCredit/StoreCreditField.spec.tsx
@@ -1,32 +1,44 @@
-import { CurrencyService } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, CheckoutService, createCheckoutService, CurrencyService } from '@bigcommerce/checkout-sdk';
 import { mount } from 'enzyme';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
 import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
+import { CheckoutContext } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getStoreConfig } from '../../config/config.mock';
 
 import StoreCreditField, { StoreCreditFieldProps } from './StoreCreditField';
 
+interface StoreCreditFieldTestProps extends StoreCreditFieldProps {
+    isSubmittingOrder?: boolean;
+}
+
 describe('StoreCreditField', () => {
     let localeContext: Required<LocaleContextType>;
     let currencyService: CurrencyService;
-    let StoreCreditFieldTest: FunctionComponent<StoreCreditFieldProps>;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
 
-    beforeEach(() => {
+    const StoreCreditFieldTest = ({isSubmittingOrder = false, ...props}: StoreCreditFieldTestProps) => {
         localeContext = createLocaleContext(getStoreConfig());
         currencyService = localeContext.currency;
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
 
-        StoreCreditFieldTest = (props) => (
+        jest.spyOn(checkoutState.statuses, 'isSubmittingOrder').mockReturnValue(isSubmittingOrder);
+
+        return  (
             <LocaleContext.Provider value={localeContext}>
-                <Formik initialValues={{ useStoreCredit: true }} onSubmit={noop}>
-                    <StoreCreditField {...props} />
-                </Formik>
+                <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
+                    <Formik initialValues={{ useStoreCredit: true }} onSubmit={noop}>
+                        <StoreCreditField {...props} />
+                    </Formik>
+                </CheckoutContext.Provider>
             </LocaleContext.Provider>
         );
-    });
+    };
 
     it('renders form field with available store credit as label', () => {
         const component = mount(
@@ -79,5 +91,29 @@ describe('StoreCreditField', () => {
             .simulate('change', { target: { checked: false, name: 'useStoreCredit' } });
 
         expect(handleChange).toHaveBeenCalled();
+    });
+
+    it('checkbox should be disabled while order is submiting', async () => {
+        const handleChange = jest.fn();
+
+        const component = mount(
+            <StoreCreditFieldTest
+                availableStoreCredit={200}
+                isStoreCreditApplied={true}
+                isSubmittingOrder={true}
+                name="useStoreCredit"
+                onChange={handleChange}
+                usableStoreCredit={100}
+            />,
+        );
+
+        const checkboxElement = component.find('input[name="useStoreCredit"]');
+        
+        checkboxElement.simulate('click');
+        await new Promise((resolve) => process.nextTick(resolve));
+        component.update();
+
+        expect(checkboxElement.prop('disabled')).toBe(true);
+        expect(handleChange).not.toHaveBeenCalled();
     });
 });

--- a/packages/core/src/app/payment/storeCredit/StoreCreditField.tsx
+++ b/packages/core/src/app/payment/storeCredit/StoreCreditField.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent, useCallback, useMemo } from 'react';
 
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString, withCurrency, WithCurrencyProps } from '@bigcommerce/checkout/locale';
+import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 
 import { CheckboxInput } from '../../ui/form';
 import { Tooltip, TooltipTrigger } from '../../ui/tooltip';
@@ -23,6 +24,12 @@ const StoreCreditField: FunctionComponent<StoreCreditFieldProps & WithCurrencyPr
     usableStoreCredit,
     isStoreCreditApplied,
 }) => {
+    const {
+        checkoutState: {
+            statuses: { isSubmittingOrder }
+        }
+    } = useCheckout();
+
     const handleChange = useCallback((event) => onChange(event.target.checked), [onChange]);
     const labelContent = useMemo(
         () => (
@@ -54,6 +61,7 @@ const StoreCreditField: FunctionComponent<StoreCreditFieldProps & WithCurrencyPr
     return (
         <CheckboxInput
             checked={isStoreCreditApplied}
+            disabled={isSubmittingOrder()}
             id={name}
             label={labelContent}
             name={name}


### PR DESCRIPTION
## What?
Disable inputs for store credits and gift certificates while order is submitting.

## Why?
To prevent order amount changing while it is submitting, because in such cases we have different amount for payment provider and for Bigcommerce.

## Testing / Proof
Unit test and manually tested

Before:

https://github.com/bigcommerce/checkout-js/assets/9430298/283c9558-48b4-417f-a3b6-c94a5038d3d1



https://github.com/bigcommerce/checkout-js/assets/9430298/78915709-173c-4885-8352-c32147fa47e7



@bigcommerce/team-checkout
