### PR TITLE
chore(other): CHECKOUT-0 Add localization team as codeowner for translations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,3 +62,6 @@
 
 /packages/apple-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 /packages/google-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+
+## Localization team
+/packages/locale/src/translations @bigcommerce/team-checkout @bigcommerce/team-localization


### PR DESCRIPTION
## What?
Add localization team as codeowner for translations

## Why?
So that the localization team can review translation changes made by the translation delivery bot

## Testing / Proof
<img width="777" alt="Screenshot 2023-11-07 at 16 36 54" src="https://github.com/bigcommerce/checkout-js/assets/1606901/6aa151a0-bc5b-4b45-bf64-a0ffa2df6f21">

@bigcommerce/team-checkout