### PR TITLE
feat(checkout): CHECKOUT-7837 Optimize `loadCheckout` and `loadExtensions` for Parallel Execution

### DIFF
--- a/packages/core/src/app/checkout/Checkout.spec.tsx
+++ b/packages/core/src/app/checkout/Checkout.spec.tsx
@@ -12,7 +12,7 @@ import React, { FunctionComponent } from 'react';
 import { act } from 'react-dom/test-utils';
 
 import { AnalyticsContextProps, AnalyticsEvents, AnalyticsProviderMock } from '@bigcommerce/checkout/analytics';
-import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
+import { ExtensionProvider, ExtensionService } from '@bigcommerce/checkout/checkout-extension';
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
@@ -49,6 +49,7 @@ describe('Checkout', () => {
     let checkoutState: CheckoutSelectors;
     let defaultProps: CheckoutProps & AnalyticsContextProps;
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
+    let extensionService: ExtensionService;
     let subscribeEventEmitter: EventEmitter;
     let analyticsTracker: Partial<AnalyticsEvents>;
 
@@ -58,6 +59,7 @@ describe('Checkout', () => {
         embeddedMessengerMock = createEmbeddedCheckoutMessenger({
             parentOrigin: getStoreConfig().links.siteLink,
         });
+        extensionService = new ExtensionService(checkoutService, jest.fn());
         subscribeEventEmitter = new EventEmitter();
         analyticsTracker = {
             checkoutBegin: jest.fn(),
@@ -72,8 +74,11 @@ describe('Checkout', () => {
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
             embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
             errorLogger: createErrorLogger(),
+            extensionService,
             analyticsTracker
         };
+
+        jest.spyOn(extensionService, 'loadExtensions').mockImplementation(() => jest.fn());
 
         jest.spyOn(checkoutService, 'loadCheckout').mockImplementation(
             () =>

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -189,16 +189,16 @@ class Checkout extends Component<
         } = this.props;
 
         try {
-            await extensionService.loadExtensions();
-            const { data } = await loadCheckout(checkoutId, {
+            const [{ data }] = await Promise.all([loadCheckout(checkoutId, {
                 params: {
                     include: [
                         'cart.lineItems.physicalItems.categoryNames',
                         'cart.lineItems.digitalItems.categoryNames',
                     ] as any, // FIXME: Currently the enum is not exported so it can't be used here.
                 },
-            });
+            }), extensionService.loadExtensions()]);
             extensionService.preloadExtensions();
+
             const { links: { siteLink = '' } = {} } = data.getConfig() || {};
             const errorFlashMessages = data.getFlashMessages('error') || [];
 

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -186,10 +186,10 @@ class Checkout extends Component<
             extensionService,
             loadCheckout,
             subscribeToConsignments,
-            isExtensionEnabled,
         } = this.props;
 
         try {
+            await extensionService.loadExtensions();
             const { data } = await loadCheckout(checkoutId, {
                 params: {
                     include: [
@@ -198,6 +198,7 @@ class Checkout extends Component<
                     ] as any, // FIXME: Currently the enum is not exported so it can't be used here.
                 },
             });
+            extensionService.preloadExtensions();
             const { links: { siteLink = '' } = {} } = data.getConfig() || {};
             const errorFlashMessages = data.getFlashMessages('error') || [];
 
@@ -261,10 +262,6 @@ class Checkout extends Component<
 
             window.addEventListener('beforeunload', this.handleBeforeExit);
 
-            if (isExtensionEnabled()) {
-                await extensionService.loadExtensions();
-                extensionService.preloadExtensions();
-            }
         } catch (error) {
             if (error instanceof Error) {
                 this.handleUnhandledError(error);

--- a/packages/test-framework/src/fixture/pageObject/playwright/PlaywrightHelper.ts
+++ b/packages/test-framework/src/fixture/pageObject/playwright/PlaywrightHelper.ts
@@ -73,6 +73,13 @@ export class PlaywrightHelper {
                 json,
             });
         });
+        await this.page.route('**/api/storefront/checkout-extensions', (route) => {
+            void route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                json: [],
+            });
+        });
     }
 
     async useHAR(har: string, folder: string): Promise<void> {


### PR DESCRIPTION
## What?
Remove `isExtensionEnabled` flag and load extensions in parallel to load checkout.

## Why?
Since the extension is rolled out to 100% now and extensions can be now loaded concurrently to checkout settings.

## Testing / Proof

- CI checks
- Manual testing
