### PR TITLE
chore(payment): PAYPAL-3190 bump checkout-sdk version to v1.479.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.479.1",
+        "@bigcommerce/checkout-sdk": "^1.479.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.479.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.479.1.tgz",
-      "integrity": "sha512-8wDzKt3bV4bgWLkYkGiUBGkqB/49+y684dmysI4Ym7U1Uix4vSpLIoqEn22lVsfruEbilHmfNhZiUoX8p8+LBQ==",
+      "version": "1.479.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.479.2.tgz",
+      "integrity": "sha512-WUnBNJbkzvs8wlzl4uJDJ3NimM2TEmaZT1GHGZU95aZnRvyrqXb5amwqmkHsxosVBLUdIhX7uTCHAiFndJtS4g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35579,9 +35579,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.479.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.479.1.tgz",
-      "integrity": "sha512-8wDzKt3bV4bgWLkYkGiUBGkqB/49+y684dmysI4Ym7U1Uix4vSpLIoqEn22lVsfruEbilHmfNhZiUoX8p8+LBQ==",
+      "version": "1.479.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.479.2.tgz",
+      "integrity": "sha512-WUnBNJbkzvs8wlzl4uJDJ3NimM2TEmaZT1GHGZU95aZnRvyrqXb5amwqmkHsxosVBLUdIhX7uTCHAiFndJtS4g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.479.1",
+    "@bigcommerce/checkout-sdk": "^1.479.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout-sdk version to v1.479.2

## Why?
As part of release: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2245

## Testing / Proof
Unit tests
Manual tests
QA test
