### PR TITLE
feat(payment): PAYPAL-3178 added ratepay error for digital item

### DIFF
--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -440,7 +440,8 @@
                     "isRequired": "{fieldName} is required",
                     "isInvalid": "{fieldName} is invalid",
                     "paymentSourceInfoCannotBeVerified": "The combination of your name and address could not be validated. Please correct your data and try again. You can find further information in the <a href='https://www.ratepay.com/en/ratepay-data-privacy-statement/' target='blank'>Ratepay Data Privacy Statement</a> or you can contact Ratepay using this <a href='https://www.ratepay.com/en/contact/' target='blank'>contact form.</a>",
-                    "paymentSourceDeclinedByProcessor": "It is not possible to use the selected payment method. This decision is based on automated data processing. You can find further information in the <a href='https://www.ratepay.com/en/ratepay-data-privacy-statement/' target='blank'>Ratepay Data Privacy Statement</a> or you can contact Ratepay using this <a href='https://www.ratepay.com/en/contact/' target='blank'>contact form.</a>"
+                    "paymentSourceDeclinedByProcessor": "It is not possible to use the selected payment method. This decision is based on automated data processing. You can find further information in the <a href='https://www.ratepay.com/en/ratepay-data-privacy-statement/' target='blank'>Ratepay Data Privacy Statement</a> or you can contact Ratepay using this <a href='https://www.ratepay.com/en/contact/' target='blank'>contact form.</a>",
+                    "itemCategoryNotSupportedByPaymentSource": "Digital items are not supported for given method"
                 }
             }
         },

--- a/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.test.tsx
@@ -17,8 +17,10 @@ import { FormContext } from '@bigcommerce/checkout/ui';
 
 import { getPaypalCommerceRatePayMethodMock } from './mocks/paypalCommerceRatePayMocks';
 import PaypalCommerceRatePayPaymentMethod from './PaypalCommerceRatePayPaymentMethod';
+import {EventEmitter} from "events";
 
 describe('PaypalCommerceRatePayPaymentMethod', () => {
+    let eventEmitter: EventEmitter;
     let PaypalCommerceRatePayPaymentMethodTest: FunctionComponent<PaymentMethodProps>;
     let localeContext: LocaleContextType;
     const checkoutService = createCheckoutService();
@@ -42,6 +44,7 @@ describe('PaypalCommerceRatePayPaymentMethod', () => {
         jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckoutMock());
         jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(true);
         localeContext = createLocaleContext(getStoreConfig());
+        eventEmitter = new EventEmitter();
 
         const submit = jest.fn();
 
@@ -138,5 +141,60 @@ describe('PaypalCommerceRatePayPaymentMethod', () => {
         await new Promise((resolve) => process.nextTick(resolve));
 
         expect(props.onUnhandledError).toHaveBeenCalled();
+    });
+
+    it('calls ratepay digital error', async () => {
+        const onUnhandledErrorMock = jest.fn();
+        const disableSubmitMock = jest.fn();
+        const setSubmittedMock = jest.fn();
+        const setValidationSchema = jest.fn();
+        const digitalErrorMock = {
+            status: 'error',
+            three_ds_result: {
+                acs_url: null,
+                payer_auth_request: null,
+                merchant_data: null,
+                callback_url: null,
+            },
+            errors: [
+                {
+                    code: 'invalid_request_error',
+                    message: 'We are experiencing difficulty processing your transaction'
+                },
+                {
+                    code: 'transaction_declined',
+                    message: 'Your transaction was declined. Please try again',
+                    provider_error: {
+                        code: 'ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE'
+                    }
+                },
+            ],
+        };
+
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('onError', () => {
+                if (options.paypalcommerceratepay?.onError) {
+                    options.paypalcommerceratepay.onError(digitalErrorMock);
+                }
+            });
+
+            return Promise.resolve(checkoutState);
+        });
+        const newProps = {
+            ...props,
+            paymentForm: {
+                disableSubmit: disableSubmitMock,
+                setSubmitted: setSubmittedMock,
+                setValidationSchema: setValidationSchema,
+            } as unknown as PaymentFormService,
+            onUnhandledError: onUnhandledErrorMock,
+        };
+
+        render(<PaypalCommerceRatePayPaymentMethodTest {...newProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        eventEmitter.emit('onError');
+
+        expect(onUnhandledErrorMock).toHaveBeenCalledWith(new Error(props.language.translate('payment.ratepay.errors.itemCategoryNotSupportedByPaymentSource')));
     });
 });

--- a/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
@@ -14,6 +14,7 @@ import { SpecificError } from '@bigcommerce/checkout/payment-integration-api';
 
 const PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED = 'PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED';
 const PAYMENT_SOURCE_DECLINED_BY_PROCESSOR = 'PAYMENT_SOURCE_DECLINED_BY_PROCESSOR';
+const ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE = 'ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE';
 
 interface RatePayFieldValues {
     ratepayBirthDate: {
@@ -101,6 +102,8 @@ const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
                                 case PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED:
                                     translationCode = 'payment.ratepay.errors.paymentSourceInfoCannotBeVerified';
                                     break;
+                                case ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE:
+                                    translationCode = 'payment.ratepay.errors.itemCategoryNotSupportedByPaymentSource';
                                 default:
                                     translationCode = 'common.error_heading';
                             }

--- a/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
@@ -95,7 +95,9 @@ const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
 
                         if (ratepaySpecificError?.length) {
                             let translationCode;
-                            switch (ratepaySpecificError[0].provider_error?.code) {
+                            let ratepayError;
+                            const ratepaySpecificErrorCode = ratepaySpecificError[0].provider_error?.code;
+                            switch (ratepaySpecificErrorCode) {
                                 case PAYMENT_SOURCE_DECLINED_BY_PROCESSOR:
                                     translationCode = 'payment.ratepay.errors.paymentSourceDeclinedByProcessor';
                                     break;
@@ -104,16 +106,21 @@ const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
                                     break;
                                 case ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE:
                                     translationCode = 'payment.ratepay.errors.itemCategoryNotSupportedByPaymentSource';
+                                    break;
                                 default:
                                     translationCode = 'common.error_heading';
                             }
 
-                            const ratepayError = new CustomError({
-                                data: {
-                                    shouldBeTranslatedAsHtml: true,
-                                    translationKey: translationCode,
-                                },
-                            });
+                            if (ratepaySpecificErrorCode !== ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE) {
+                                ratepayError = new CustomError({
+                                    data: {
+                                        shouldBeTranslatedAsHtml: true,
+                                        translationKey: translationCode,
+                                    },
+                                });
+                            } else {
+                                ratepayError = new Error(language.translate(translationCode));
+                            }
 
                             return onUnhandledError(ratepayError);
                         }


### PR DESCRIPTION
## What?
Added ratepay error for digital item

## Why?
To show error that digital item can't be payed by ratepay

## Testing / Proof

<img width="1054" alt="Screenshot 2023-11-08 at 19 42 38" src="https://github.com/bigcommerce/checkout-js/assets/56301104/c596dd09-1fcd-4f42-a171-4972016f1ed3">

@bigcommerce/team-checkout
