### PR TITLE
feat(payment): PAYPAL-3175 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.481.0",
+        "@bigcommerce/checkout-sdk": "^1.482.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.481.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.481.0.tgz",
-      "integrity": "sha512-SN84Oar7kKvT+64/kUvx48uKcVGuAFws55XY6ihTVab6+pT7on/HAW6nCH5k1rmrnXlxPD8cC5c3HniEiUQ3kg==",
+      "version": "1.482.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.482.0.tgz",
+      "integrity": "sha512-UAifdlbOVg3kJFzhOeFlhSC/jCO8nzY6rcBA06lbBmeBE+HVEyuNwhUKsFio/sYuJ7PwW5QlFk13e9zmTNlJeg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.481.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.481.0.tgz",
-      "integrity": "sha512-SN84Oar7kKvT+64/kUvx48uKcVGuAFws55XY6ihTVab6+pT7on/HAW6nCH5k1rmrnXlxPD8cC5c3HniEiUQ3kg==",
+      "version": "1.482.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.482.0.tgz",
+      "integrity": "sha512-UAifdlbOVg3kJFzhOeFlhSC/jCO8nzY6rcBA06lbBmeBE+HVEyuNwhUKsFio/sYuJ7PwW5QlFk13e9zmTNlJeg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.481.0",
+    "@bigcommerce/checkout-sdk": "^1.482.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from `1.481.0` to `1.482.0`

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
