### PR TITLE
feat(payment): PI-1036 removed Stripe link inititializations for not supported cart amounts

### DIFF
--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.spec.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.spec.ts
@@ -108,6 +108,7 @@ describe('getCheckoutStepStatuses()', () => {
                         ...getStoreConfig().checkoutSettings, providerWithCustomCheckout: PaymentMethodId.StripeUPE,
                     },
                 });
+                jest.spyOn(service.getState().data, 'getCart').mockReturnValue(getCart());
 
                 const steps = getCheckoutStepStatuses(state);
 

--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -1,5 +1,6 @@
 import {
     BillingAddress,
+    Cart,
     Checkout,
     CheckoutService,
     createCheckoutService,
@@ -14,6 +15,7 @@ import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcomme
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getBillingAddress } from '../billing/billingAddresses.mock';
+import { getCart } from '../cart/carts.mock';
 import { getCheckout } from '../checkout/checkouts.mock';
 import CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 import CheckoutStepType from '../checkout/CheckoutStepType';
@@ -33,8 +35,10 @@ describe('Customer', () => {
     let CustomerTest: FunctionComponent<CustomerProps & Partial<WithCheckoutCustomerProps>>;
     let billingAddress: BillingAddress;
     let checkout: Checkout;
+    let cart: Cart;
     let checkoutService: CheckoutService;
     let config: StoreConfig;
+    let configStripeUpe: StoreConfig;
     let customer: CustomerData;
     let localeContext: LocaleContextType;
     const defaultProps = {
@@ -47,8 +51,16 @@ describe('Customer', () => {
     beforeEach(() => {
         billingAddress = getBillingAddress();
         checkout = getCheckout();
+        cart = getCart();
         customer = getGuestCustomer();
         config = getStoreConfig();
+        configStripeUpe = {
+            ...config,
+            checkoutSettings: {
+                ...config.checkoutSettings,
+                providerWithCustomCheckout: PaymentMethodId.StripeUPE,
+            }
+        }
 
         checkoutService = createCheckoutService();
 
@@ -57,6 +69,8 @@ describe('Customer', () => {
         );
 
         jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(checkout);
+
+        jest.spyOn(checkoutService.getState().data, 'getCart').mockReturnValue(cart);
 
         jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(customer);
 
@@ -113,14 +127,41 @@ describe('Customer', () => {
                 isBusy: false,
                 type: CheckoutStepType.Customer };
 
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(configStripeUpe);
+
             const component = mount(
-                <CustomerTest {...defaultProps}  providerWithCustomCheckout={ PaymentMethodId.StripeUPE } step={ steps } viewType={ CustomerViewType.Guest } />
+                <CustomerTest {...defaultProps} step={ steps } viewType={ CustomerViewType.Guest } />
             );
 
             await new Promise(resolve => process.nextTick(resolve));
             component.update();
 
             expect(component.find(StripeGuestForm).exists()).toBe(true);
+        });
+
+        it("doesn't render Stripe guest form if it enabled but cart amount is smaller then Stripe requires", async () => {
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(configStripeUpe);
+            jest.spyOn(checkoutService.getState().data, 'getCart').mockReturnValue({
+                ...cart,
+                cartAmount: 0.4,
+            });
+
+            const steps = { isActive: true,
+                isComplete: true,
+                isEditable: true,
+                isRequired: true,
+                isBusy: false,
+                type: CheckoutStepType.Customer };
+
+            const component = mount(
+                <CustomerTest {...defaultProps}  step={ steps } viewType={ CustomerViewType.Guest } />
+            );
+
+            await new Promise(resolve => process.nextTick(resolve));
+            component.update();
+
+            expect(component.find(StripeGuestForm).exists()).toBe(false);
+            expect(component.find(GuestForm).exists()).toBe(true);
         });
 
         it('calls onUnhandledError if initialize was failed', async () => {

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -17,6 +17,7 @@ import { noop } from 'lodash';
 import React, { Component, ReactNode } from 'react';
 import { createSelector } from 'reselect';
 
+import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
 import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
 
@@ -82,6 +83,7 @@ export interface WithCheckoutShippingProps {
     updateBillingAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
     updateCheckout(payload: CheckoutRequestBody): Promise<CheckoutSelectors>;
     updateShippingAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
+    shouldRenderStripeForm: boolean;
 }
 
 interface ShippingState {
@@ -123,15 +125,13 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             isGuest,
             shouldShowMultiShipping,
             customer,
-            unassignItem,
             updateShippingAddress,
             initializeShippingMethod,
             deinitializeShippingMethod,
             isMultiShippingMode,
-            onToggleMultiShipping,
-            providerWithCustomCheckout,
             step,
             isFloatingLabelEnabled,
+            shouldRenderStripeForm,
             ...shippingFormProps
         } = this.props;
 
@@ -139,7 +139,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             isInitializing,
         } = this.state;
 
-        if (providerWithCustomCheckout === PaymentMethodId.StripeUPE && !customer.email && this.props.countries.length > 0) {
+        if (shouldRenderStripeForm && !customer.email && this.props.countries.length > 0) {
             return <StripeShipping
                 { ...shippingFormProps }
                 customer={ customer }
@@ -430,6 +430,7 @@ export function mapToShippingProps({
         updateCheckout: checkoutService.updateCheckout,
         updateShippingAddress: checkoutService.updateShippingAddress,
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
+        shouldRenderStripeForm: !!(config.checkoutSettings.providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart)),
     };
 }
 

--- a/packages/instrument-utils/src/guards/index.ts
+++ b/packages/instrument-utils/src/guards/index.ts
@@ -11,3 +11,4 @@ export {
 } from './isInstrumentCardNumberRequired';
 export { default as isInstrumentCardCodeRequiredSelector } from './isInstrumentCardCodeRequiredSelector';
 export { default as isInstrumentCardNumberRequiredSelector } from './isInstrumentCardNumberRequiredSelector';
+export { default as shouldUseStripeLinkByMinimumAmount } from './shouldUseStripeLinkByMinimumAmount';

--- a/packages/instrument-utils/src/guards/shouldUseStripeLinkByMinimumAmount.spec.ts
+++ b/packages/instrument-utils/src/guards/shouldUseStripeLinkByMinimumAmount.spec.ts
@@ -1,0 +1,28 @@
+import { getCart } from '@bigcommerce/checkout/test-mocks';
+
+import shouldUseStripeLinkByMinimumAmount from './shouldUseStripeLinkByMinimumAmount';
+
+describe('shouldUseStripeLinkByMinimumAmount()', () => {
+    const cart = getCart();
+    const notSupportedCart = {
+        ...cart,
+        cartAmount: 0.4,
+    };
+
+    it("returns true if cart fulfills Stripe's minimum charge amounts requirement", () => {
+        expect(shouldUseStripeLinkByMinimumAmount(cart)).toBe(true);
+    });
+
+    it("returns false if cart doesn't fulfill Stripe's minimum charge amounts requirement", () => {
+        expect(shouldUseStripeLinkByMinimumAmount(notSupportedCart)).toBe(false);
+    });
+
+    it('returns false if currency is not supported by Stripe', () => {
+        expect(
+            shouldUseStripeLinkByMinimumAmount({
+                ...notSupportedCart,
+                currency: { ...notSupportedCart.currency, code: 'WRONG' },
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/instrument-utils/src/guards/shouldUseStripeLinkByMinimumAmount.ts
+++ b/packages/instrument-utils/src/guards/shouldUseStripeLinkByMinimumAmount.ts
@@ -1,0 +1,51 @@
+import { Cart } from '@bigcommerce/checkout-sdk';
+
+/**
+ * Minimum charge amounts due to the Stripe documentation
+ * https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+ */
+enum stripeLinkMinAmount {
+    'USD' = 0.5,
+    'AED' = 2,
+    'AUD' = 0.5,
+    'BGN' = 1,
+    'BRL' = 0.5,
+    'CAD' = 0.5,
+    'CHF' = 0.5,
+    'CZK' = 15,
+    'DKK' = 2.5,
+    'EUR' = 0.5,
+    'GBP' = 0.3,
+    'HKD' = 4,
+    'HUF' = 175,
+    'INR' = 0.5,
+    'JPY' = 50,
+    'MXN' = 10,
+    'MYR' = 2,
+    'NOK' = 3,
+    'NZD' = 0.5,
+    'PLN' = 2,
+    'RON' = 2,
+    'SEK' = 3,
+    'SGD' = 0.5,
+    'THB' = 10,
+}
+
+const isStripeLinkMinAmount = (code: string): code is keyof typeof stripeLinkMinAmount => {
+    return code in stripeLinkMinAmount;
+};
+
+const shouldUseStripeLinkByMinimumAmount = (cart: Cart) => {
+    const {
+        currency: { code },
+        cartAmount,
+    } = cart;
+
+    if (isStripeLinkMinAmount(code) && cartAmount >= stripeLinkMinAmount[code]) {
+        return true;
+    }
+
+    return false;
+};
+
+export default shouldUseStripeLinkByMinimumAmount;

--- a/packages/instrument-utils/src/index.ts
+++ b/packages/instrument-utils/src/index.ts
@@ -52,4 +52,5 @@ export {
     isInstrumentCardNumberRequiredSelector,
     IsInstrumentCardNumberRequiredState,
     isInstrumentFeatureAvailable,
+    shouldUseStripeLinkByMinimumAmount,
 } from './guards';


### PR DESCRIPTION
## What?
Removed Stripe link inititializations for not supported cart amounts

## Why?
Because with Stripe Link will crash checkout when amount of the card is smaller then Stripe minimum supported value

## Testing / Proof
Before:
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/36d61e85-4cf5-42b8-8838-98349f8a6847)
After:



https://github.com/bigcommerce/checkout-js/assets/79574476/a9f75d5e-7398-4aa8-b60f-5520061c7428




@bigcommerce/team-checkout
