### PR TITLE
feat(payment): CHECKOUT-7901 Fetch button config when checkout loads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.483.0",
+        "@bigcommerce/checkout-sdk": "^1.484.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.483.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.483.0.tgz",
-      "integrity": "sha512-oD771I+wh0MLe0o6fez1DIxBK85gmVXGCJQzMsLUxFwmpVapgLOwGinAYXSbjz6IuHFqQ0Pqzaud3fxbxaIYgQ==",
+      "version": "1.484.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.484.0.tgz",
+      "integrity": "sha512-RhAjomZL7KVE8mHhgCW9nlW8Bg7+HqKuTOEFoOixP70PeHMQbIpY8iJCQhdNYRfHNe/v5bV+dY9G6ldqw1t5/Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.483.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.483.0.tgz",
-      "integrity": "sha512-oD771I+wh0MLe0o6fez1DIxBK85gmVXGCJQzMsLUxFwmpVapgLOwGinAYXSbjz6IuHFqQ0Pqzaud3fxbxaIYgQ==",
+      "version": "1.484.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.484.0.tgz",
+      "integrity": "sha512-RhAjomZL7KVE8mHhgCW9nlW8Bg7+HqKuTOEFoOixP70PeHMQbIpY8iJCQhdNYRfHNe/v5bV+dY9G6ldqw1t5/Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.483.0",
+    "@bigcommerce/checkout-sdk": "^1.484.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/apple-pay-integration/e2e/applepay.spec.ts
+++ b/packages/apple-pay-integration/e2e/applepay.spec.ts
@@ -33,7 +33,7 @@ test.describe('ApplePay', () => {
             './packages/test-framework/src/support/orderConfirmation.ejs',
             { orderId: '124' },
         );
-        await page.route('**/api/storefront/payments/applepay?cartId=124', (route) => {
+        await page.route('**/api/storefront/payments/applepay?cartId=*', (route) => {
             void route.fulfill({ ...responseProps, body: applePayCart });
         });
         await page.route('**/api/public/v1/payments/applepay/validate_merchant', (route) => {

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -202,13 +202,13 @@ class Checkout extends Component<
                 },
             }), extensionService.loadExtensions()]);
 
-            const providers = data.getConfig().checkoutSettings.remoteCheckoutProviders;
+            const providers = data.getConfig()?.checkoutSettings?.remoteCheckoutProviders || [];
 
             if (providers.length > 0) {
                 const configs = await loadPaymentMethodByIds(providers);
 
                 this.setState({
-                    buttonConfigs: configs.data.getPaymentMethods(),
+                    buttonConfigs: configs.data.getPaymentMethods() || [],
                 });
             }
 

--- a/packages/core/src/app/checkout/mapToCheckoutProps.ts
+++ b/packages/core/src/app/checkout/mapToCheckoutProps.ts
@@ -52,6 +52,7 @@ export default function mapToCheckoutProps({
         isPriceHiddenFromGuests,
         isShowingWalletButtonsOnTop: walletButtonsOnTopFlag,
         loadCheckout: checkoutService.loadCheckout,
+        loadPaymentMethodByIds: checkoutService.loadPaymentMethodByIds,
         loginUrl,
         cartUrl,
         createAccountUrl,

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -1,6 +1,6 @@
 import { CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, memo } from 'react';
 
 import { TranslatedString, useLocale } from '@bigcommerce/checkout/locale';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
@@ -167,4 +167,4 @@ function mapToCheckoutButtonContainerProps({
     }
 }
 
-export default withCheckout(mapToCheckoutButtonContainerProps)(CheckoutButtonContainer);
+export default memo(withCheckout(mapToCheckoutButtonContainerProps)(CheckoutButtonContainer));


### PR DESCRIPTION
## What?
Fetch button config when checkout loads

## Why?
In order to load button payment configs in parallel, move logic to fetch button configs to checkout component.

## Testing / Proof
- CI
- Manual

@bigcommerce/team-checkout
