### PR TITLE
feat(payment): PI-1142 Add payment strategy for…

### DIFF
--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -277,5 +277,6 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
             id: 'hosted-credit-card',
         },
         { id: 'credit_card', gateway: 'bluesnapdirect' },
+        { id: 'tdonlinemart' },
     ],
 );


### PR DESCRIPTION
… credit card - initialization for CC fields

## What?
Added `id: 'tdonlinemart'`

## Why?
Due to work on TD Online Mart integration

## Testing / Proof
Manually tested
![Zrzut ekranu 2023-12-12 o 13 59 14](https://github.com/bigcommerce/checkout-js/assets/130039975/5e36c35b-3546-475a-87ca-73e7958b9003)


@bigcommerce/team-checkout
