### PR TITLE
feat(payment): PAYPAL-3229 added BraintreeConnectTracker implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.484.0",
+        "@bigcommerce/checkout-sdk": "^1.492.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.484.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.484.0.tgz",
-      "integrity": "sha512-RhAjomZL7KVE8mHhgCW9nlW8Bg7+HqKuTOEFoOixP70PeHMQbIpY8iJCQhdNYRfHNe/v5bV+dY9G6ldqw1t5/Q==",
+      "version": "1.492.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.492.0.tgz",
+      "integrity": "sha512-+UjH8GXPt+7PI4QjCmuCGmaGtJR1/EgX4zPJRR9h2XjlHy5QQdLgv/ZxN6EskvEAYzgrz+3V10YyWCmYjU32vA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.484.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.484.0.tgz",
-      "integrity": "sha512-RhAjomZL7KVE8mHhgCW9nlW8Bg7+HqKuTOEFoOixP70PeHMQbIpY8iJCQhdNYRfHNe/v5bV+dY9G6ldqw1t5/Q==",
+      "version": "1.492.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.492.0.tgz",
+      "integrity": "sha512-+UjH8GXPt+7PI4QjCmuCGmaGtJR1/EgX4zPJRR9h2XjlHy5QQdLgv/ZxN6EskvEAYzgrz+3V10YyWCmYjU32vA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.484.0",
+    "@bigcommerce/checkout-sdk": "^1.492.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/analytics/src/AnalyticsContext.ts
+++ b/packages/analytics/src/AnalyticsContext.ts
@@ -11,11 +11,12 @@ export interface AnalyticsEvents {
     customerSuggestionExecute(): void;
     customerPaymentMethodExecuted(payload?: CheckoutPaymentMethodExecutedOptions): void;
     showShippingMethods(): void;
-    selectedPaymentMethod(methodName?: string): void;
+    selectedPaymentMethod(methodName: string, methodId: string): void;
     clickPayButton(payload?: { [key: string]: unknown }): void;
     paymentRejected(): void;
     paymentComplete(): void;
     exitCheckout(): void;
+    walletButtonClick(methodId: string): void;
 }
 
 export interface AnalyticsContextProps {

--- a/packages/analytics/src/AnalyticsProvider.mock.tsx
+++ b/packages/analytics/src/AnalyticsProvider.mock.tsx
@@ -23,6 +23,7 @@ const AnalyticsProviderMock = ({ children, analyticsTracker = {} }: AnalyticsPro
         paymentRejected: jest.fn(),
         paymentComplete: jest.fn(),
         exitCheckout: jest.fn(),
+        walletButtonClick: jest.fn(),
     };
 
     return (

--- a/packages/analytics/src/AnalyticsProvider.spec.tsx
+++ b/packages/analytics/src/AnalyticsProvider.spec.tsx
@@ -56,9 +56,7 @@ describe('AnalyticsProvider', () => {
     let braintreeConnectTracker: CheckoutSdk.BraintreeConnectTrackerService;
 
     beforeEach(() => {
-        jest.spyOn(createAnalyticsService, 'default').mockImplementation(
-            (createFn, _args) => createFn,
-        );
+        jest.spyOn(createAnalyticsService, 'default').mockImplementation((createFn) => createFn);
 
         stepTrackerMock = {
             trackOrderComplete: jest.fn(),
@@ -66,7 +64,7 @@ describe('AnalyticsProvider', () => {
             trackStepViewed: jest.fn(),
             trackStepCompleted: jest.fn(),
         };
-        jest.spyOn(CheckoutSdk, 'createStepTracker').mockImplementation((_args) => stepTrackerMock);
+        jest.spyOn(CheckoutSdk, 'createStepTracker').mockImplementation(() => stepTrackerMock);
 
         bodlServiceMock = {
             checkoutBegin: jest.fn(),
@@ -92,7 +90,9 @@ describe('AnalyticsProvider', () => {
             trackStepViewed: jest.fn(),
             walletButtonClick: jest.fn(),
         };
-        jest.spyOn(CheckoutSdk, 'createBraintreeConnectTracker').mockImplementation(() => braintreeConnectTracker);
+        jest.spyOn(CheckoutSdk, 'createBraintreeConnectTracker').mockImplementation(
+            () => braintreeConnectTracker,
+        );
     });
 
     it('throws an error when useAnalytics hook used without AnalyticsContext', () => {
@@ -145,7 +145,6 @@ describe('AnalyticsProvider', () => {
     it('track customer email entry', () => {
         mount(<TestComponent eventName="customerEmailEntry" eventProps={['email@test.com']} />);
 
-
         expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledTimes(1);
         expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledWith('email@test.com');
     });
@@ -197,20 +196,24 @@ describe('AnalyticsProvider', () => {
             <TestComponent
                 eventName="selectedPaymentMethod"
                 eventProps={['Credit card', 'braintreecreditcard']}
-            />
+            />,
         );
 
         expect(bodlServiceMock.selectedPaymentMethod).toHaveBeenCalledTimes(1);
         expect(bodlServiceMock.selectedPaymentMethod).toHaveBeenCalledWith('Credit card');
         expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
-        expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledWith('braintreecreditcard');
+        expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledWith(
+            'braintreecreditcard',
+        );
     });
 
     it('track wallet button click', () => {
         mount(<TestComponent eventName="walletButtonClick" eventProps={['braintreecreditcard']} />);
 
         expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledTimes(1);
-        expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledWith('braintreecreditcard');
+        expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledWith(
+            'braintreecreditcard',
+        );
     });
 
     it('track click Pay button', () => {

--- a/packages/analytics/src/AnalyticsProvider.spec.tsx
+++ b/packages/analytics/src/AnalyticsProvider.spec.tsx
@@ -15,35 +15,37 @@ jest.mock('@bigcommerce/checkout-sdk', () => {
     };
 });
 
+type EventPropsItem = string | CheckoutSdk.BodlEventsPayload;
+
 const AnalyticsProviderChildrenMock = ({
     eventName,
-    eventPayload,
+    eventProps = [],
 }: {
     eventName: string;
-    eventPayload?: string | CheckoutSdk.BodlEventsPayload;
+    eventProps?: EventPropsItem[];
 }) => {
     const { analyticsTracker } = useAnalytics();
 
     useEffect(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        analyticsTracker[eventName](eventPayload);
-    }, [analyticsTracker, eventName, eventPayload]);
+        analyticsTracker[eventName](...eventProps);
+    }, [analyticsTracker, eventName, eventProps]);
 
     return null;
 };
 
 const TestComponent = ({
     eventName,
-    eventPayload,
+    eventProps,
 }: {
     eventName: string;
-    eventPayload?: string | CheckoutSdk.BodlEventsPayload;
+    eventProps?: EventPropsItem[];
 }) => {
     const checkoutService = CheckoutSdk.createCheckoutService();
 
     return (
         <AnalyticsProvider checkoutService={checkoutService}>
-            <AnalyticsProviderChildrenMock eventName={eventName} eventPayload={eventPayload} />
+            <AnalyticsProviderChildrenMock eventName={eventName} eventProps={eventProps} />
         </AnalyticsProvider>
     );
 };
@@ -51,6 +53,7 @@ const TestComponent = ({
 describe('AnalyticsProvider', () => {
     let stepTrackerMock: CheckoutSdk.StepTracker;
     let bodlServiceMock: CheckoutSdk.BodlService;
+    let braintreeConnectTracker: CheckoutSdk.BraintreeConnectTrackerService;
 
     beforeEach(() => {
         jest.spyOn(createAnalyticsService, 'default').mockImplementation(
@@ -81,6 +84,15 @@ describe('AnalyticsProvider', () => {
             exitCheckout: jest.fn(),
         };
         jest.spyOn(CheckoutSdk, 'createBodlService').mockImplementation(() => bodlServiceMock);
+
+        braintreeConnectTracker = {
+            customerPaymentMethodExecuted: jest.fn(),
+            selectedPaymentMethod: jest.fn(),
+            paymentComplete: jest.fn(),
+            trackStepViewed: jest.fn(),
+            walletButtonClick: jest.fn(),
+        };
+        jest.spyOn(CheckoutSdk, 'createBraintreeConnectTracker').mockImplementation(() => braintreeConnectTracker);
     });
 
     it('throws an error when useAnalytics hook used without AnalyticsContext', () => {
@@ -106,7 +118,7 @@ describe('AnalyticsProvider', () => {
     });
 
     it('track step completed', () => {
-        mount(<TestComponent eventName="trackStepCompleted" eventPayload="stepName" />);
+        mount(<TestComponent eventName="trackStepCompleted" eventProps={['stepName']} />);
 
         expect(stepTrackerMock.trackStepCompleted).toHaveBeenCalledTimes(1);
         expect(stepTrackerMock.trackStepCompleted).toHaveBeenCalledWith('stepName');
@@ -115,10 +127,12 @@ describe('AnalyticsProvider', () => {
     });
 
     it('track step viewed', () => {
-        mount(<TestComponent eventName="trackStepViewed" eventPayload="stepName" />);
+        mount(<TestComponent eventName="trackStepViewed" eventProps={['stepName']} />);
 
         expect(stepTrackerMock.trackStepViewed).toHaveBeenCalledTimes(1);
         expect(stepTrackerMock.trackStepViewed).toHaveBeenCalledWith('stepName');
+        expect(braintreeConnectTracker.trackStepViewed).toHaveBeenCalledTimes(1);
+        expect(braintreeConnectTracker.trackStepViewed).toHaveBeenCalledWith('stepName');
     });
 
     it('track order purchased', () => {
@@ -129,7 +143,8 @@ describe('AnalyticsProvider', () => {
     });
 
     it('track customer email entry', () => {
-        mount(<TestComponent eventName="customerEmailEntry" eventPayload="email@test.com" />);
+        mount(<TestComponent eventName="customerEmailEntry" eventProps={['email@test.com']} />);
+
 
         expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledTimes(1);
         expect(bodlServiceMock.customerEmailEntry).toHaveBeenCalledWith('email@test.com');
@@ -139,7 +154,7 @@ describe('AnalyticsProvider', () => {
         mount(
             <TestComponent
                 eventName="customerSuggestionInit"
-                eventPayload={{ data: 'test data' }}
+                eventProps={[{ data: 'test data' }]}
             />,
         );
 
@@ -159,7 +174,7 @@ describe('AnalyticsProvider', () => {
         mount(
             <TestComponent
                 eventName="customerPaymentMethodExecuted"
-                eventPayload={{ data: 'test data' }}
+                eventProps={[{ data: 'test data' }]}
             />,
         );
 
@@ -167,6 +182,8 @@ describe('AnalyticsProvider', () => {
         expect(bodlServiceMock.customerPaymentMethodExecuted).toHaveBeenCalledWith({
             data: 'test data',
         });
+        expect(braintreeConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalledTimes(1);
+        expect(braintreeConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalled();
     });
 
     it('track show shipping methods', () => {
@@ -176,14 +193,28 @@ describe('AnalyticsProvider', () => {
     });
 
     it('track selected payment method', () => {
-        mount(<TestComponent eventName="selectedPaymentMethod" eventPayload="Credit card" />);
+        mount(
+            <TestComponent
+                eventName="selectedPaymentMethod"
+                eventProps={['Credit card', 'braintreecreditcard']}
+            />
+        );
 
         expect(bodlServiceMock.selectedPaymentMethod).toHaveBeenCalledTimes(1);
         expect(bodlServiceMock.selectedPaymentMethod).toHaveBeenCalledWith('Credit card');
+        expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledWith('braintreecreditcard');
+    });
+
+    it('track wallet button click', () => {
+        mount(<TestComponent eventName="walletButtonClick" eventProps={['braintreecreditcard']} />);
+
+        expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledTimes(1);
+        expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledWith('braintreecreditcard');
     });
 
     it('track click Pay button', () => {
-        mount(<TestComponent eventName="clickPayButton" eventPayload={{ data: 'test data' }} />);
+        mount(<TestComponent eventName="clickPayButton" eventProps={[{ data: 'test data' }]} />);
 
         expect(bodlServiceMock.clickPayButton).toHaveBeenCalledTimes(1);
         expect(bodlServiceMock.clickPayButton).toHaveBeenCalledWith({ data: 'test data' });

--- a/packages/analytics/src/AnalyticsProvider.tsx
+++ b/packages/analytics/src/AnalyticsProvider.tsx
@@ -1,8 +1,10 @@
 import {
     BodlEventsPayload,
     BodlService,
+    BraintreeConnectTrackerService,
     CheckoutService,
     createBodlService,
+    createBraintreeConnectTracker,
     createStepTracker,
     StepTracker,
 } from '@bigcommerce/checkout-sdk';
@@ -25,6 +27,13 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
         () => createAnalyticsService<BodlService>(createBodlService, [checkoutService.subscribe]),
         [checkoutService],
     );
+    const getBraintreeConnectTracker = useMemo(
+        () =>
+            createAnalyticsService<BraintreeConnectTrackerService>(createBraintreeConnectTracker, [
+                checkoutService,
+            ]),
+        [checkoutService],
+    );
 
     const checkoutBegin = () => {
         getStepTracker().trackCheckoutStarted();
@@ -38,6 +47,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
 
     const trackStepViewed = (step: string) => {
         getStepTracker().trackStepViewed(step);
+        getBraintreeConnectTracker().trackStepViewed(step);
     };
 
     const orderPurchased = () => {
@@ -59,14 +69,18 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
 
     const customerPaymentMethodExecuted = (payload: BodlEventsPayload) => {
         getBodlService().customerPaymentMethodExecuted(payload);
+        getBraintreeConnectTracker().customerPaymentMethodExecuted();
     };
 
     const showShippingMethods = () => {
         getBodlService().showShippingMethods();
     };
 
-    const selectedPaymentMethod = (methodName?: string) => {
+    const selectedPaymentMethod = (methodName: string, methodId: string) => {
+        console.log(methodName, methodId);
+
         getBodlService().selectedPaymentMethod(methodName);
+        getBraintreeConnectTracker().selectedPaymentMethod(methodId);
     };
 
     const clickPayButton = (payload: BodlEventsPayload) => {
@@ -79,10 +93,15 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
 
     const paymentComplete = () => {
         getBodlService().paymentComplete();
+        getBraintreeConnectTracker().paymentComplete();
     };
 
     const exitCheckout = () => {
         getBodlService().exitCheckout();
+    };
+
+    const walletButtonClick = (methodId: string) => {
+        getBraintreeConnectTracker().walletButtonClick(methodId);
     };
 
     const analyticsTracker: AnalyticsEvents = {
@@ -100,6 +119,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
         paymentRejected,
         paymentComplete,
         exitCheckout,
+        walletButtonClick,
     };
 
     return (

--- a/packages/analytics/src/AnalyticsProvider.tsx
+++ b/packages/analytics/src/AnalyticsProvider.tsx
@@ -77,8 +77,6 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
     };
 
     const selectedPaymentMethod = (methodName: string, methodId: string) => {
-        console.log(methodName, methodId);
-
         getBodlService().selectedPaymentMethod(methodName);
         getBraintreeConnectTracker().selectedPaymentMethod(methodId);
     };

--- a/packages/checkout-button-integration/src/CheckoutButton.spec.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.spec.tsx
@@ -36,6 +36,7 @@ describe('CheckoutButton', () => {
             methodId: 'foobar',
             foobar: {
                 container: 'button-container',
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 onClick: expect.any(Function),
                 onUnhandledError,
             },

--- a/packages/checkout-button-integration/src/CheckoutButton.spec.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.spec.tsx
@@ -19,6 +19,7 @@ describe('CheckoutButton', () => {
             language: createLanguageService(),
             methodId: 'foobar',
             onUnhandledError: jest.fn(),
+            onWalletButtonClick: jest.fn(),
         };
     });
 
@@ -35,6 +36,7 @@ describe('CheckoutButton', () => {
             methodId: 'foobar',
             foobar: {
                 container: 'button-container',
+                onClick: expect.any(Function),
                 onUnhandledError,
             },
         });

--- a/packages/checkout-button-integration/src/CheckoutButton.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.tsx
@@ -11,6 +11,7 @@ const CheckoutButton: FunctionComponent<CheckoutButtonProps> = ({
     containerId,
     methodId,
     onUnhandledError,
+    onWalletButtonClick,
 }) => {
     useEffect(() => {
         initializeCustomer({
@@ -18,6 +19,7 @@ const CheckoutButton: FunctionComponent<CheckoutButtonProps> = ({
             [methodId]: {
                 container: containerId,
                 onUnhandledError,
+                onClick: () => onWalletButtonClick(methodId),
             },
         }).catch(onUnhandledError);
 

--- a/packages/checkout-button-integration/src/CheckoutButton.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.tsx
@@ -26,7 +26,14 @@ const CheckoutButton: FunctionComponent<CheckoutButtonProps> = ({
         return () => {
             deinitializeCustomer({ methodId }).catch(onUnhandledError);
         };
-    }, [containerId, deinitializeCustomer, initializeCustomer, methodId, onUnhandledError]);
+    }, [
+        containerId,
+        deinitializeCustomer,
+        initializeCustomer,
+        methodId,
+        onUnhandledError,
+        onWalletButtonClick,
+    ]);
 
     return <div id={containerId} />;
 };

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -337,6 +337,7 @@ class Checkout extends Component<
                             checkEmbeddedSupport={this.checkEmbeddedSupport}
                             isPaymentStepActive={isPaymentStepActive}
                             onUnhandledError={this.handleUnhandledError}
+                            onWalletButtonClick={this.handleWalletButtonClick}
                         />
                     )}
 
@@ -415,6 +416,7 @@ class Checkout extends Component<
                     onSignInError={this.handleError}
                     onSubscribeToNewsletter={this.handleNewsletterSubscription}
                     onUnhandledError={this.handleUnhandledError}
+                    onWalletButtonClick={this.handleWalletButtonClick}
                     step={step}
                     viewType={customerViewType}
                 />
@@ -760,6 +762,12 @@ class Checkout extends Component<
         const { analyticsTracker } = this.props;
 
         analyticsTracker.exitCheckout();
+    }
+
+    private handleWalletButtonClick: (methodName: string) => void = (methodName) => {
+        const { analyticsTracker } = this.props;
+
+        analyticsTracker.walletButtonClick(methodName);
     }
 }
 

--- a/packages/core/src/app/customer/CheckoutButton.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButton.spec.tsx
@@ -8,6 +8,7 @@ describe('CheckoutButton', () => {
     it('initializes button when component is mounted', () => {
         const initialize = jest.fn();
         const onError = jest.fn();
+        const onClick = jest.fn();
 
         mount(
             <CheckoutButton
@@ -16,6 +17,7 @@ describe('CheckoutButton', () => {
                 initialize={initialize}
                 methodId="foobar"
                 onError={onError}
+                onClick={onClick}
             />,
         );
 
@@ -24,6 +26,7 @@ describe('CheckoutButton', () => {
             foobar: {
                 container: 'foobarContainer',
                 onError,
+                onClick: expect.any(Function),
             },
         });
     });
@@ -31,6 +34,7 @@ describe('CheckoutButton', () => {
     it('deinitializes button when component unmounts', () => {
         const deinitialize = jest.fn();
         const onError = jest.fn();
+        const onClick = jest.fn();
 
         const component = mount(
             <CheckoutButton
@@ -39,6 +43,7 @@ describe('CheckoutButton', () => {
                 initialize={noop}
                 methodId="foobar"
                 onError={onError}
+                onClick={onClick}
             />,
         );
 

--- a/packages/core/src/app/customer/CheckoutButton.tsx
+++ b/packages/core/src/app/customer/CheckoutButton.tsx
@@ -22,7 +22,7 @@ export default class CheckoutButton extends PureComponent<CheckoutButtonProps> {
             isShowingWalletButtonsOnTop,
             methodId,
             onError,
-            onClick  = noop,
+            onClick = noop,
         } = this.props;
 
         const heightOption = isShowingWalletButtonsOnTop && (methodId === 'braintreepaypal' || methodId === 'braintreepaypalcredit' )

--- a/packages/core/src/app/customer/CheckoutButton.tsx
+++ b/packages/core/src/app/customer/CheckoutButton.tsx
@@ -1,4 +1,5 @@
 import { CustomerInitializeOptions, CustomerRequestOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
 import React, { PureComponent } from 'react';
 
 const WALLET_BUTTON_HEIGHT = 36;
@@ -10,11 +11,19 @@ export interface CheckoutButtonProps {
     deinitialize(options: CustomerRequestOptions): void;
     initialize(options: CustomerInitializeOptions): void;
     onError?(error: Error): void;
+    onClick?(methodId: string): void;
 }
 
 export default class CheckoutButton extends PureComponent<CheckoutButtonProps> {
     componentDidMount() {
-        const { containerId, initialize, isShowingWalletButtonsOnTop, methodId, onError } = this.props;
+        const {
+            containerId,
+            initialize,
+            isShowingWalletButtonsOnTop,
+            methodId,
+            onError,
+            onClick  = noop,
+        } = this.props;
 
         const heightOption = isShowingWalletButtonsOnTop && (methodId === 'braintreepaypal' || methodId === 'braintreepaypalcredit' )
             ? { buttonHeight: WALLET_BUTTON_HEIGHT }
@@ -26,6 +35,7 @@ export default class CheckoutButton extends PureComponent<CheckoutButtonProps> {
                 ...heightOption,
                 container: containerId,
                 onError,
+                onClick: () => onClick(methodId),
             },
         });
     }

--- a/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.spec.tsx
@@ -51,6 +51,7 @@ describe('CheckoutButtonContainer', () => {
                         checkEmbeddedSupport={jest.fn()}
                         isPaymentStepActive={false}
                         onUnhandledError={jest.fn()}
+                        onWalletButtonClick={jest.fn()}
                     />
                 </LocaleContext.Provider>
             </CheckoutProvider>
@@ -69,6 +70,7 @@ describe('CheckoutButtonContainer', () => {
                         checkEmbeddedSupport={jest.fn()}
                         isPaymentStepActive={false}
                         onUnhandledError={jest.fn()}
+                        onWalletButtonClick={jest.fn()}
                     />
                 </LocaleContext.Provider>
             </CheckoutProvider>
@@ -87,6 +89,7 @@ describe('CheckoutButtonContainer', () => {
                         checkEmbeddedSupport={jest.fn()}
                         isPaymentStepActive={false}
                         onUnhandledError={jest.fn()}
+                        onWalletButtonClick={jest.fn()}
                     />
                 </LocaleContext.Provider>
             </CheckoutProvider>
@@ -103,6 +106,7 @@ describe('CheckoutButtonContainer', () => {
                         checkEmbeddedSupport={jest.fn()}
                         isPaymentStepActive={true}
                         onUnhandledError={jest.fn()}
+                        onWalletButtonClick={jest.fn()}
                     />
                 </LocaleContext.Provider>
             </CheckoutProvider>
@@ -131,6 +135,7 @@ describe('CheckoutButtonContainer', () => {
                         checkEmbeddedSupport={jest.fn()}
                         isPaymentStepActive={true}
                         onUnhandledError={jest.fn()}
+                        onWalletButtonClick={jest.fn()}
                     />
                 </LocaleContext.Provider>
             </CheckoutProvider>

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -17,6 +17,7 @@ interface CheckoutButtonContainerProps {
     isPaymentStepActive: boolean;
     checkEmbeddedSupport(methodIds: string[]): void;
     onUnhandledError(error: Error): void;
+    onWalletButtonClick(methodId: string): void;
 }
 
 interface WithCheckoutCheckoutButtonContainerProps {
@@ -58,6 +59,7 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         isPaymentStepActive,
         initializedMethodIds,
         onUnhandledError,
+        onWalletButtonClick,
     }) => {
     const { language } = useLocale();
 
@@ -84,6 +86,7 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
                 key={methodId}
                 methodId={methodId}
                 onError={onUnhandledError}
+                onClick={onWalletButtonClick}
             />
         }
 
@@ -95,6 +98,7 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
                     language={language}
                     methodId={methodId}
                     onUnhandledError={onUnhandledError}
+                    onWalletButtonClick={onWalletButtonClick}
                 />;
     });
 

--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -45,6 +45,7 @@ export interface CheckoutButtonListProps {
     deinitialize(options: CustomerRequestOptions): void;
     initialize(options: CustomerInitializeOptions): void;
     onError?(error: Error): void;
+    onClick?(methodId: string): void;
 }
 
 export const filterUnsupportedMethodIds = (methodIds:string[]): string[] => {

--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -697,6 +697,7 @@ describe('Customer', () => {
             expect(checkoutService.executePaymentMethodCheckout).toHaveBeenCalledWith({
                 methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
                 continueWithCheckoutCallback: handleSignedIn,
+                checkoutPaymentMethodExecuted: expect.any(Function),
             });
         });
 
@@ -858,6 +859,7 @@ describe('Customer', () => {
             expect(checkoutService.executePaymentMethodCheckout).toHaveBeenCalledWith({
                 methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
                 continueWithCheckoutCallback: handleCreateAccount,
+                checkoutPaymentMethodExecuted: expect.any(Function),
             });
         });
     });

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -53,6 +53,7 @@ export interface CustomerProps {
     onSignIn?(): void;
     onSignInError?(error: Error): void;
     onUnhandledError?(error: Error): void;
+    onWalletButtonClick?(methodName: string): void;
 }
 
 export interface WithCheckoutCustomerProps {
@@ -182,12 +183,14 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             privacyPolicyUrl,
             requiresMarketingConsent,
             onUnhandledError = noop,
+            onWalletButtonClick = noop,
             step,
             isFloatingLabelEnabled,
             isExpressPrivacyPolicy,
             isPaymentDataRequired,
             shouldRenderStripeForm,
         } = this.props;
+
         const checkoutButtons = isWalletButtonsOnTop || !isPaymentDataRequired
           ? null
           : <CheckoutButtonList
@@ -197,6 +200,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             isInitializing={isInitializing}
             methodIds={checkoutButtonIds}
             onError={onUnhandledError}
+            onClick={onWalletButtonClick}
           />;
 
         const isLoadingGuestForm = isWalletButtonsOnTop ?
@@ -448,6 +452,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 await executePaymentMethodCheckout({
                     methodId: providerWithCustomCheckout,
                     continueWithCheckoutCallback: onSignIn,
+                    checkoutPaymentMethodExecuted: (payload) => this.checkoutPaymentMethodExecuted(payload)
                 });
             } else {
                 onSignIn();
@@ -473,6 +478,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onAccountCreated,
+                checkoutPaymentMethodExecuted: (payload) => this.checkoutPaymentMethodExecuted(payload)
             });
         } else {
             onAccountCreated();

--- a/packages/core/src/app/customer/WalletButtonV1Resolver.spec.tsx
+++ b/packages/core/src/app/customer/WalletButtonV1Resolver.spec.tsx
@@ -11,9 +11,10 @@ describe('CheckoutButtonV1Resolver', () => {
                 initialize={jest.fn()}
                 methodId="applepay"
                 onError={jest.fn()}
+                onClick={jest.fn()}
             />
         );
-        
+
         expect(component).toMatchSnapshot();
     });
 
@@ -25,9 +26,10 @@ describe('CheckoutButtonV1Resolver', () => {
                 isShowingWalletButtonsOnTop={true}
                 methodId="applepay"
                 onError={jest.fn()}
+                onClick={jest.fn()}
             />
         );
-        
+
         expect(component).toMatchSnapshot();
     });
 
@@ -39,9 +41,10 @@ describe('CheckoutButtonV1Resolver', () => {
                 isShowingWalletButtonsOnTop={true}
                 methodId="amazonpay"
                 onError={jest.fn()}
+                onClick={jest.fn()}
             />
         );
-        
+
         expect(component).toMatchSnapshot();
     });
 
@@ -53,9 +56,10 @@ describe('CheckoutButtonV1Resolver', () => {
                 isShowingWalletButtonsOnTop={true}
                 methodId="paypalcommerce"
                 onError={jest.fn()}
+                onClick={jest.fn()}
             />
         );
-        
+
         expect(component).toMatchSnapshot();
     });
 
@@ -67,9 +71,10 @@ describe('CheckoutButtonV1Resolver', () => {
                 isShowingWalletButtonsOnTop={true}
                 methodId="paypalcommercecredit"
                 onError={jest.fn()}
+                onClick={jest.fn()}
             />
         );
-        
+
         expect(component).toMatchSnapshot();
     });
 
@@ -81,9 +86,10 @@ describe('CheckoutButtonV1Resolver', () => {
                 isShowingWalletButtonsOnTop={true}
                 methodId="googlepay"
                 onError={jest.fn()}
+                onClick={jest.fn()}
             />
         );
-        
+
         expect(component).toMatchSnapshot();
     });
 });

--- a/packages/core/src/app/customer/WalletButtonV1Resolver.tsx
+++ b/packages/core/src/app/customer/WalletButtonV1Resolver.tsx
@@ -10,6 +10,7 @@ interface CheckoutButtonV1ResolverProps {
     isShowingWalletButtonsOnTop?: boolean;
     initialize(options: CustomerInitializeOptions): void;
     onError?(error: Error): void;
+    onClick?(methodName: string): void;
 }
 
 const CheckoutButtonV1Resolver: FunctionComponent<CheckoutButtonV1ResolverProps> = ({

--- a/packages/core/src/app/customer/customWalletButton/ApplePayButton.spec.tsx
+++ b/packages/core/src/app/customer/customWalletButton/ApplePayButton.spec.tsx
@@ -26,6 +26,7 @@ describe('ApplePayButton', () => {
                     initialize={initialize}
                     methodId="applepay"
                     onError={error}
+                    onClick={jest.fn()}
                 />
             </LocaleContext.Provider>
         );
@@ -46,6 +47,7 @@ describe('ApplePayButton', () => {
                 container: 'test',
                 shippingLabel: 'Shipping',
                 subtotalLabel: 'Subtotal',
+                onClick: expect.any(Function),
                 onError: error,
                 onPaymentAuthorize: navigateToOrderConfirmation,
             },

--- a/packages/core/src/app/customer/customWalletButton/ApplePayButton.tsx
+++ b/packages/core/src/app/customer/customWalletButton/ApplePayButton.tsx
@@ -1,4 +1,5 @@
 import { CustomerInitializeOptions } from '@bigcommerce/checkout-sdk';
+import { noop } from 'lodash';
 import React, { FunctionComponent, useCallback, useContext } from 'react';
 
 import { LocaleContext } from '@bigcommerce/checkout/locale';
@@ -9,6 +10,7 @@ import CheckoutButton, { CheckoutButtonProps } from '../CheckoutButton';
 const ApplePayButton: FunctionComponent<CheckoutButtonProps> = ({
     initialize,
     onError,
+    onClick = noop,
     ...rest
 }) => {
     const localeContext = useContext(LocaleContext);
@@ -21,6 +23,7 @@ const ApplePayButton: FunctionComponent<CheckoutButtonProps> = ({
                     shippingLabel: localeContext?.language.translate('cart.shipping_text'),
                     subtotalLabel: localeContext?.language.translate('cart.subtotal_text'),
                     onError,
+                    onClick: () => onClick(rest.methodId),
                     onPaymentAuthorize: navigateToOrderConfirmation,
                 },
             }),

--- a/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.spec.tsx
+++ b/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.spec.tsx
@@ -26,6 +26,7 @@ describe('PayPalCommerceButton', () => {
                     initialize={initialize}
                     methodId="paypalcommerce"
                     onError={error}
+                    onClick={jest.fn()}
                 />
             </LocaleContext.Provider>
         );
@@ -44,8 +45,9 @@ describe('PayPalCommerceButton', () => {
             methodId: 'paypalcommerce',
             paypalcommerce: {
                 container: 'paypalcommerceId',
-                onError: error,
                 onComplete: navigateToOrderConfirmation,
+                onClick: expect.any(Function),
+                onError: error,
             },
         });
     });

--- a/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.tsx
+++ b/packages/core/src/app/customer/customWalletButton/PayPalCommerceButton.tsx
@@ -1,5 +1,6 @@
 import { CustomerInitializeOptions } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, useCallback, useContext } from 'react';
+import { noop } from 'lodash';
 
 import { LocaleContext } from '@bigcommerce/checkout/locale';
 
@@ -10,6 +11,7 @@ const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = ({
     methodId,
     initialize,
     onError,
+    onClick = noop,
     ...rest
 }) => {
     const localeContext = useContext(LocaleContext);
@@ -20,6 +22,7 @@ const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = ({
                 [methodId]: {
                     container: rest.containerId,
                     onError,
+                    onClick: () => onClick(methodId),
                     onComplete: navigateToOrderConfirmation,
                 },
             }),

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -117,7 +117,6 @@ class Payment extends Component<
             onReady = noop,
             onUnhandledError = noop,
             usableStoreCredit,
-            analyticsTracker
         } = this.props;
 
 
@@ -130,7 +129,9 @@ class Payment extends Component<
 
             const selectedMethod = this.state.selectedMethod || this.props.defaultMethod;
 
-            analyticsTracker.selectedPaymentMethod(selectedMethod?.config.displayName);
+            if (selectedMethod) {
+                this.trackSelectedPaymentMethod(selectedMethod);
+            }
         } catch (error) {
             onUnhandledError(error);
         }
@@ -480,14 +481,15 @@ class Payment extends Component<
     };
 
     private setSelectedMethod: (method?: PaymentMethod) => void = (method) => {
-        const { analyticsTracker } = this.props;
         const { selectedMethod } = this.state;
 
         if (selectedMethod === method) {
             return;
         }
 
-        analyticsTracker.selectedPaymentMethod(method?.config.displayName);
+        if (method) {
+            this.trackSelectedPaymentMethod(method);
+        }
 
         this.setState({ selectedMethod: method });
     };
@@ -529,6 +531,15 @@ class Payment extends Component<
             },
         });
     };
+
+    private trackSelectedPaymentMethod(method: PaymentMethod) {
+        const { analyticsTracker } = this.props;
+
+        const methodName = method.config.displayName || method.id;
+        const methodId = method.id;
+
+        analyticsTracker.selectedPaymentMethod(methodName, methodId);
+    }
 }
 
 export function mapToPaymentProps({

--- a/packages/payment-integration-api/src/CheckoutButtonProps.tsx
+++ b/packages/payment-integration-api/src/CheckoutButtonProps.tsx
@@ -7,4 +7,5 @@ export default interface CheckoutButtonProps {
     checkoutState: CheckoutSelectors;
     language: LanguageService;
     onUnhandledError(error: Error): void;
+    onWalletButtonClick(methodName: string): void;
 }


### PR DESCRIPTION
P.s.: CI builds fail because related checkout-sdk PR is not in master yet

## What?
- added BraintreeConnectTracker implementation to Analytics Provider
- passed onClick callback to all wallet buttons on checkout page (button on top and in customer step)

## Why?
To be able to track customer events and send some Analytic data to Braintree

## Sibling PR
checkout-sdk: https://github.com/bigcommerce/checkout-sdk-js/pull/2276

## Testing / Proof
Unit tests
Manual tests

Some screenshots:
<img width="442" alt="APM Selected on the paywall" src="https://github.com/bigcommerce/checkout-js/assets/25133454/a410cd51-dc61-4e88-9e2f-94c3d2dd4a62">
<img width="441" alt="Click on Braintree WB" src="https://github.com/bigcommerce/checkout-js/assets/25133454/046dcfc0-4cc4-44b2-806a-81e40eb9dda9">
<img width="412" alt="Email Submitted Guest" src="https://github.com/bigcommerce/checkout-js/assets/25133454/e5d948e6-f4df-44d3-a3d2-e9e090668a95">
<img width="440" alt="Email submitted as a store member" src="https://github.com/bigcommerce/checkout-js/assets/25133454/3aa74ff5-d4c4-48e8-aa7b-4f54db24d841">
<img width="415" alt="Order Placed Event" src="https://github.com/bigcommerce/checkout-js/assets/25133454/1c0cc8ba-e401-447d-884d-754e83468a7d">
<img width="768" alt="Screenshot 2023-11-29 at 15 29 32" src="https://github.com/bigcommerce/checkout-js/assets/25133454/cd9a4aec-31dd-4620-9f48-1cbe7c46712c">
