### PR TITLE
feat(payment): PI-1148 Hide card holder name from hosted fields form

### DIFF
--- a/packages/core/src/scss/components/bigcommerce/forms-ccFields/_forms-ccFields.scss
+++ b/packages/core/src/scss/components/bigcommerce/forms-ccFields/_forms-ccFields.scss
@@ -15,6 +15,17 @@
     padding: 0 spacing("half");
 }
 
+.form-ccFields--without-card-name:not(.form-ccFields--without-card-code) {
+    .form-field--ccNumber {
+        flex-basis: 100%;
+    }
+
+    .form-field--ccExpiry,
+    .form-ccFields-field--ccCvv {
+        flex-basis: 50%;
+    }
+}
+
 .form-field--ccNumber,
 .form-field--ccName {
     flex-basis: 65%;

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.spec.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.spec.tsx
@@ -418,6 +418,58 @@ describe('HostedCreditCardPaymentMethod', () => {
         });
     });
 
+    it('does not pass card holder name field option when card name is not required', async () => {
+        const { language } = createLocaleContext(getStoreConfig());
+        const config = { ...getPaymentMethod().config, showCardHolderName: false };
+
+        defaultProps = {
+            method: { ...getPaymentMethod(), config },
+            checkoutService,
+            checkoutState,
+            paymentForm,
+            language,
+            onUnhandledError: jest.fn(),
+        };
+
+        mount(<HostedCreditCardPaymentMethodTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(initializePayment).toHaveBeenCalledWith({
+            creditCard: {
+                form: {
+                    fields: {
+                        cardCode: {
+                            accessibilityLabel: 'CVV',
+                            containerId: 'authorizenet-ccCvv',
+                        },
+                        cardExpiry: {
+                            accessibilityLabel: 'Expiration',
+                            containerId: 'authorizenet-ccExpiry',
+                            placeholder: 'MM / YY',
+                        },
+                        cardNumber: {
+                            accessibilityLabel: 'Credit Card Number',
+                            containerId: 'authorizenet-ccNumber',
+                        },
+                    },
+                    styles: {
+                        default: expect.any(Object),
+                        error: expect.any(Object),
+                        focus: expect.any(Object),
+                    },
+                    onBlur: expect.any(Function),
+                    onCardTypeChange: expect.any(Function),
+                    onEnter: expect.any(Function),
+                    onFocus: expect.any(Function),
+                    onValidate: expect.any(Function),
+                },
+            },
+            gatewayId: undefined,
+            methodId: 'authorizenet',
+        });
+    });
+
     it('does not have styleContainerId when instrument is selected', async () => {
         const component = mount(<HostedCreditCardPaymentMethodTest {...defaultProps} />);
 

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -40,7 +40,11 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const isInstrumentCardCodeRequiredProp = isInstrumentCardCodeRequiredSelector(checkoutState);
     const isInstrumentCardNumberRequiredProp =
         isInstrumentCardNumberRequiredSelector(checkoutState);
-    const isCardCodeRequired = method.config.cardCode || method.config.cardCode === null;
+    const {
+        config: { cardCode, showCardHolderName },
+    } = method;
+    const isCardCodeRequired = cardCode || cardCode === null;
+    const isCardHolderNameRequired = showCardHolderName ?? true;
 
     const getHostedFieldId: (name: string) => string = useCallback(
         (name) => {
@@ -108,12 +112,14 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                                   'payment.credit_card_expiration_placeholder_text',
                               ),
                           },
-                          cardName: {
-                              accessibilityLabel: language.translate(
-                                  'payment.credit_card_name_label',
-                              ),
-                              containerId: getHostedFieldId('ccName'),
-                          },
+                          cardName: isCardHolderNameRequired
+                              ? {
+                                    accessibilityLabel: language.translate(
+                                        'payment.credit_card_name_label',
+                                    ),
+                                    containerId: getHostedFieldId('ccName'),
+                                }
+                              : undefined,
                           cardNumber: {
                               accessibilityLabel: language.translate(
                                   'payment.credit_card_number_label',
@@ -168,6 +174,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             focusedFieldType,
             getHostedFieldId,
             isCardCodeRequired,
+            isCardHolderNameRequired,
             isInstrumentCardCodeRequiredProp,
             isInstrumentCardNumberRequiredProp,
             language,
@@ -189,7 +196,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             }
             cardCodeId={isCardCodeRequired ? getHostedFieldId('ccCvv') : undefined}
             cardExpiryId={getHostedFieldId('ccExpiry')}
-            cardNameId={getHostedFieldId('ccName')}
+            cardNameId={isCardHolderNameRequired ? getHostedFieldId('ccName') : undefined}
             cardNumberId={getHostedFieldId('ccNumber')}
             focusedFieldType={focusedFieldType}
         />

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardFieldset/HostedCreditCardFieldset.spec.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardFieldset/HostedCreditCardFieldset.spec.tsx
@@ -38,10 +38,12 @@ describe('HostedCreditCardFieldset', () => {
 
     it('renders required field containers', () => {
         const component = mount(<HostedCreditCardFieldsetTest {...defaultProps} />);
+        const formContainerClasses = component.find('.form-ccFields').prop('className');
 
         expect(component.find(HostedCreditCardNumberField)).toHaveLength(1);
-
         expect(component.find(HostedCreditCardExpiryField)).toHaveLength(1);
+        expect(formContainerClasses).toContain('form-ccFields--without-card-name');
+        expect(formContainerClasses).toContain('form-ccFields--without-card-code');
     });
 
     it('renders optional field containers', () => {
@@ -52,10 +54,12 @@ describe('HostedCreditCardFieldset', () => {
                 cardNameId="cardName"
             />,
         );
+        const formContainerClasses = component.find('.form-ccFields').prop('className');
 
         expect(component.find(HostedCreditCardCodeField)).toHaveLength(1);
-
         expect(component.find(HostedCreditCardNameField)).toHaveLength(1);
+        expect(formContainerClasses).not.toContain('form-ccFields--without-card-name');
+        expect(formContainerClasses).not.toContain('form-ccFields--without-card-code');
     });
 
     it('renders additional fields if provided', () => {

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardFieldset/HostedCreditCardFieldset.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardFieldset/HostedCreditCardFieldset.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, { FunctionComponent, ReactNode } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -34,7 +35,12 @@ const HostedCreditCardFieldset: FunctionComponent<HostedCreditCardFieldsetProps>
             </Legend>
         }
     >
-        <div className="form-ccFields">
+        <div
+            className={classNames('form-ccFields', {
+                'form-ccFields--without-card-name': !cardNameId,
+                'form-ccFields--without-card-code': !cardCodeId,
+            })}
+        >
             <HostedCreditCardNumberField
                 appearFocused={focusedFieldType === 'cardNumber'}
                 id={cardNumberId}


### PR DESCRIPTION
## What?
Add ability to hide card holder name field when payment provider doesn't use it

## Why?
For new TD Bank integration we don't need this field and should not show unused fields

## Testing / Proof
Unit tests and manually tested
<img width="395" alt="Screenshot 2023-12-04 at 11 03 25" src="https://github.com/bigcommerce/checkout-js/assets/9430298/0b4d745b-a587-4ad4-a8e5-75529390b9e1">

### Show all fields 
• When options for specific fields wasn't set
<img width="2560" alt="Screenshot 2023-12-01 at 18 07 17" src="https://github.com/bigcommerce/checkout-js/assets/9430298/cd1c6e09-5e10-4a9a-aeb1-68ef19e4073d">
• When card holder name field was enabled manually
<img width="2560" alt="Screenshot 2023-12-01 at 18 08 06" src="https://github.com/bigcommerce/checkout-js/assets/9430298/4d67d07a-f7dc-4206-9c89-05df21c138cc">
### Hide card holder name
• When only card holder name field was disabled
<img width="2560" alt="Screenshot 2023-12-01 at 18 08 42" src="https://github.com/bigcommerce/checkout-js/assets/9430298/651bba3a-a154-4b5a-9dc1-79ea6e5ca739">
<img width="2560" alt="Screenshot 2023-12-04 at 10 33 35" src="https://github.com/bigcommerce/checkout-js/assets/9430298/7898e18a-be64-47ea-9693-a0eac883cbd5">
<img width="2560" alt="Screenshot 2023-12-04 at 10 36 16" src="https://github.com/bigcommerce/checkout-js/assets/9430298/a5b707d6-dafe-4176-953d-da07ae1042b1">
• When card holder name was disabled and card code field was disabled
<img width="2560" alt="Screenshot 2023-12-01 at 18 09 57" src="https://github.com/bigcommerce/checkout-js/assets/9430298/ab8bd08e-90a2-48a9-b31f-9fdcd4ea79a6">
### Card code field was disabled
card holder name field enabled manually or it's value wasn't set
<img width="2560" alt="Screenshot 2023-12-01 at 18 09 28" src="https://github.com/bigcommerce/checkout-js/assets/9430298/47c83c89-1ca6-4ce2-8cb5-d08e5cc88cc6">


@bigcommerce/team-checkout
