### PR TITLE
fix(checkout): CHECKOUT-0000 Avoid linting e2e test report

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "preinstall": "npx check-node-version --package",
-    "prebuild": "rm -rf dist",
+    "prebuild": "rm -rf dist && rm -rf packages/test-framework/report",
     "build": "nx run core:build",
     "build:server": "http-server dist",
     "dev": "nx run core:dev",


### PR DESCRIPTION
## What?
Delete e2e test report folder before running `build` command.

## Why?
`webpack` lints the e2e test report file by default, resulting in building failure. 
Therefore, any existing e2e test report should be removed.

## Testing / Proof
Before:
<img width="500" alt="Screenshot 2023-12-07 at 4 48 35 pm" src="https://github.com/bigcommerce/checkout-js/assets/88361607/ffe3dfbd-eee3-4212-b164-96554a9fa4f7">

After:
<img width="500" alt="Screenshot 2023-12-07 at 4 51 17 pm" src="https://github.com/bigcommerce/checkout-js/assets/88361607/d4f31368-41f7-4e98-bdaa-f63f1659f6d2">

@bigcommerce/team-checkout
