### PR TITLE
chore(payment): PAYPAL-3229 bump checkout-sdk version to 1.490.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.483.0",
+        "@bigcommerce/checkout-sdk": "^1.490.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.483.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.483.0.tgz",
-      "integrity": "sha512-oD771I+wh0MLe0o6fez1DIxBK85gmVXGCJQzMsLUxFwmpVapgLOwGinAYXSbjz6IuHFqQ0Pqzaud3fxbxaIYgQ==",
+      "version": "1.490.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.490.0.tgz",
+      "integrity": "sha512-fUyZZAUlhRIRrf+C0D4ugzjlWTrTU+u8CrXvh9PKtQeNmsvD3+kFaB/jKnAc9fuq7nwEbF7t3ik4QaGIiBrpAQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.483.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.483.0.tgz",
-      "integrity": "sha512-oD771I+wh0MLe0o6fez1DIxBK85gmVXGCJQzMsLUxFwmpVapgLOwGinAYXSbjz6IuHFqQ0Pqzaud3fxbxaIYgQ==",
+      "version": "1.490.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.490.0.tgz",
+      "integrity": "sha512-fUyZZAUlhRIRrf+C0D4ugzjlWTrTU+u8CrXvh9PKtQeNmsvD3+kFaB/jKnAc9fuq7nwEbF7t3ik4QaGIiBrpAQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.483.0",
+    "@bigcommerce/checkout-sdk": "^1.490.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.490.0

## Why?
As part of release: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2258
https://github.com/bigcommerce/checkout-sdk-js/pull/2272
https://github.com/bigcommerce/checkout-sdk-js/pull/2270
https://github.com/bigcommerce/checkout-sdk-js/pull/2269
https://github.com/bigcommerce/checkout-sdk-js/pull/2268
https://github.com/bigcommerce/checkout-sdk-js/pull/2271
https://github.com/bigcommerce/checkout-sdk-js/pull/2273

## Testing / Proof
Unit tests
Manual tests 
CI tests
