### PR TITLE
feat(payment): PAYPAL-2616 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.495.0",
+        "@bigcommerce/checkout-sdk": "^1.496.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.495.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.495.0.tgz",
-      "integrity": "sha512-pmZrSWfJAjr6GZwfR7zxQmECHovVcTP0pwHWjY+jXF51Dc/iNRnAJd14ZeoToPFDGmhWcAPPPCT02XYDpErxGg==",
+      "version": "1.496.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.496.0.tgz",
+      "integrity": "sha512-Oq3Pbv7oEcjpzCwvHrA0UVtkHsMkfCKokC6WA5gDhzm1OhsA4BbSwjSedyajuNPNZ+xE+r58FmlnSdJvJ+SWTA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.495.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.495.0.tgz",
-      "integrity": "sha512-pmZrSWfJAjr6GZwfR7zxQmECHovVcTP0pwHWjY+jXF51Dc/iNRnAJd14ZeoToPFDGmhWcAPPPCT02XYDpErxGg==",
+      "version": "1.496.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.496.0.tgz",
+      "integrity": "sha512-Oq3Pbv7oEcjpzCwvHrA0UVtkHsMkfCKokC6WA5gDhzm1OhsA4BbSwjSedyajuNPNZ+xE+r58FmlnSdJvJ+SWTA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.495.0",
+    "@bigcommerce/checkout-sdk": "^1.496.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2257