### PR TITLE
feat(payment): PAYPAL-3124 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.499.0",
+        "@bigcommerce/checkout-sdk": "^1.499.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.499.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.0.tgz",
-      "integrity": "sha512-mBYbvPJmTQ5VwDR4gGEVYD0xTEm87yn1CS5jZQvfz3nML9zJfn5PfOBYLMeqnnYPrTRUu+z7IIvgJnUC/CzSIQ==",
+      "version": "1.499.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.1.tgz",
+      "integrity": "sha512-h6C1xlr6NlxdKVubRi3uXv99Qwx4Ja3S0v9v9S1oJjts1wym6O9zmP97rFpKQqhbOpLVjptDFkub8r5po4FcOQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.499.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.0.tgz",
-      "integrity": "sha512-mBYbvPJmTQ5VwDR4gGEVYD0xTEm87yn1CS5jZQvfz3nML9zJfn5PfOBYLMeqnnYPrTRUu+z7IIvgJnUC/CzSIQ==",
+      "version": "1.499.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.1.tgz",
+      "integrity": "sha512-h6C1xlr6NlxdKVubRi3uXv99Qwx4Ja3S0v9v9S1oJjts1wym6O9zmP97rFpKQqhbOpLVjptDFkub8r5po4FcOQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.499.0",
+    "@bigcommerce/checkout-sdk": "^1.499.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version.
Related PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/2247

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
