### PR TITLE
chore(payment): PAYPAL-3360 bump checkout-sdk version to v1.499.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.499.1",
+        "@bigcommerce/checkout-sdk": "^1.499.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.499.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.1.tgz",
-      "integrity": "sha512-h6C1xlr6NlxdKVubRi3uXv99Qwx4Ja3S0v9v9S1oJjts1wym6O9zmP97rFpKQqhbOpLVjptDFkub8r5po4FcOQ==",
+      "version": "1.499.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.2.tgz",
+      "integrity": "sha512-20nzj06Z1thxXw3tYMHT13I5ZtU0HjC8sKsC+7KR07X1VqGx+rAIyX6Qg0yDxH1jEc7M3qlsMVpAKj9H5QYxYQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.499.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.1.tgz",
-      "integrity": "sha512-h6C1xlr6NlxdKVubRi3uXv99Qwx4Ja3S0v9v9S1oJjts1wym6O9zmP97rFpKQqhbOpLVjptDFkub8r5po4FcOQ==",
+      "version": "1.499.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.2.tgz",
+      "integrity": "sha512-20nzj06Z1thxXw3tYMHT13I5ZtU0HjC8sKsC+7KR07X1VqGx+rAIyX6Qg0yDxH1jEc7M3qlsMVpAKj9H5QYxYQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.499.1",
+    "@bigcommerce/checkout-sdk": "^1.499.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to v1.499.2

## Why?
As part of release checkout sdk.

Release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2285
https://github.com/bigcommerce/checkout-sdk-js/pull/2288
https://github.com/bigcommerce/checkout-sdk-js/pull/2286

## Testing / Proof
Unit tests
Manual tests
