### PR TITLE
refactor(payment): PAYPAL-3660 removed unnecessary Braintree tracking event (trackStepViewed)

### DIFF
--- a/packages/analytics/src/AnalyticsProvider.spec.tsx
+++ b/packages/analytics/src/AnalyticsProvider.spec.tsx
@@ -131,8 +131,6 @@ describe('AnalyticsProvider', () => {
 
         expect(stepTrackerMock.trackStepViewed).toHaveBeenCalledTimes(1);
         expect(stepTrackerMock.trackStepViewed).toHaveBeenCalledWith('stepName');
-        expect(braintreeConnectTracker.trackStepViewed).toHaveBeenCalledTimes(1);
-        expect(braintreeConnectTracker.trackStepViewed).toHaveBeenCalledWith('stepName');
     });
 
     it('track order purchased', () => {

--- a/packages/analytics/src/AnalyticsProvider.tsx
+++ b/packages/analytics/src/AnalyticsProvider.tsx
@@ -47,7 +47,6 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
 
     const trackStepViewed = (step: string) => {
         getStepTracker().trackStepViewed(step);
-        getBraintreeConnectTracker().trackStepViewed(step);
     };
 
     const orderPurchased = () => {


### PR DESCRIPTION
## What?
Removed unnecessary Braintree tracking event (trackStepViewed)

## Why?
We don't need to track this event for Braintree Connect anymore

## Testing / Proof
Unit tests
CI
