### PR TITLE
chore(payment): PAYPAL-3660 bump checkout-sdk version to 1.499.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.499.2",
+        "@bigcommerce/checkout-sdk": "^1.499.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.499.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.2.tgz",
-      "integrity": "sha512-20nzj06Z1thxXw3tYMHT13I5ZtU0HjC8sKsC+7KR07X1VqGx+rAIyX6Qg0yDxH1jEc7M3qlsMVpAKj9H5QYxYQ==",
+      "version": "1.499.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.3.tgz",
+      "integrity": "sha512-nwhj/qRiKr9FQzcfsclzBKx0DbEYGRFk8TmLIyw2HhemvGXe9buWmqs/C0iow0R9FSXKldLpW7q3F5GmDq4ODA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.499.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.2.tgz",
-      "integrity": "sha512-20nzj06Z1thxXw3tYMHT13I5ZtU0HjC8sKsC+7KR07X1VqGx+rAIyX6Qg0yDxH1jEc7M3qlsMVpAKj9H5QYxYQ==",
+      "version": "1.499.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.3.tgz",
+      "integrity": "sha512-nwhj/qRiKr9FQzcfsclzBKx0DbEYGRFk8TmLIyw2HhemvGXe9buWmqs/C0iow0R9FSXKldLpW7q3F5GmDq4ODA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.499.2",
+    "@bigcommerce/checkout-sdk": "^1.499.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.499.3

## Why?
As part of release: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2291

## Testing / Proof
Unit tests 
Manual tests