### PR TITLE
chore(payment): PI-1076 bump checkout-sdk version to 1.500.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.499.3",
+        "@bigcommerce/checkout-sdk": "^1.500.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.499.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.3.tgz",
-      "integrity": "sha512-nwhj/qRiKr9FQzcfsclzBKx0DbEYGRFk8TmLIyw2HhemvGXe9buWmqs/C0iow0R9FSXKldLpW7q3F5GmDq4ODA==",
+      "version": "1.500.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.500.0.tgz",
+      "integrity": "sha512-KwGj0lWqVqzGmCHQ0Va5kgSSiiJtHQGjpdg9TxL1DB6+2dwM2qCjTlRj/2PXJTtAEF0mJbw7J+QRx2+Gm8bnew==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.499.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.3.tgz",
-      "integrity": "sha512-nwhj/qRiKr9FQzcfsclzBKx0DbEYGRFk8TmLIyw2HhemvGXe9buWmqs/C0iow0R9FSXKldLpW7q3F5GmDq4ODA==",
+      "version": "1.500.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.500.0.tgz",
+      "integrity": "sha512-KwGj0lWqVqzGmCHQ0Va5kgSSiiJtHQGjpdg9TxL1DB6+2dwM2qCjTlRj/2PXJTtAEF0mJbw7J+QRx2+Gm8bnew==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.499.3",
+    "@bigcommerce/checkout-sdk": "^1.500.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk

## Why?
Part of release: https://github.com/bigcommerce/checkout-sdk-js/pull/2278

## Testing / Proof
Unit/manual tests

@bigcommerce/team-checkout
