### PR TITLE
chore(payment): PAYPAL-3382 bump checkout sdk version to 1.501.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.499.3",
+        "@bigcommerce/checkout-sdk": "^1.501.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.499.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.3.tgz",
-      "integrity": "sha512-nwhj/qRiKr9FQzcfsclzBKx0DbEYGRFk8TmLIyw2HhemvGXe9buWmqs/C0iow0R9FSXKldLpW7q3F5GmDq4ODA==",
+      "version": "1.501.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.0.tgz",
+      "integrity": "sha512-12CTGwOLIEycTxFbR3HpefNJr3CRr1hs+6KNHCfZ4NJmfBMHK6jlvC4qsbfvRz9XXg8DZa5Hkz9U8HWWHGyC5Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.499.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.499.3.tgz",
-      "integrity": "sha512-nwhj/qRiKr9FQzcfsclzBKx0DbEYGRFk8TmLIyw2HhemvGXe9buWmqs/C0iow0R9FSXKldLpW7q3F5GmDq4ODA==",
+      "version": "1.501.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.0.tgz",
+      "integrity": "sha512-12CTGwOLIEycTxFbR3HpefNJr3CRr1hs+6KNHCfZ4NJmfBMHK6jlvC4qsbfvRz9XXg8DZa5Hkz9U8HWWHGyC5Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.501.0",
+        "@bigcommerce/checkout-sdk": "^1.501.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.501.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.0.tgz",
-      "integrity": "sha512-12CTGwOLIEycTxFbR3HpefNJr3CRr1hs+6KNHCfZ4NJmfBMHK6jlvC4qsbfvRz9XXg8DZa5Hkz9U8HWWHGyC5Q==",
+      "version": "1.501.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.1.tgz",
+      "integrity": "sha512-Qiky/VGRRyLpuhrUFH7YVp8gzs7TY4AdMSgNQQd6OCJYcEaME0ViaPVb08j+oE/SoArEFVOwasyBiOg7a7pdlg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.501.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.0.tgz",
-      "integrity": "sha512-12CTGwOLIEycTxFbR3HpefNJr3CRr1hs+6KNHCfZ4NJmfBMHK6jlvC4qsbfvRz9XXg8DZa5Hkz9U8HWWHGyC5Q==",
+      "version": "1.501.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.1.tgz",
+      "integrity": "sha512-Qiky/VGRRyLpuhrUFH7YVp8gzs7TY4AdMSgNQQd6OCJYcEaME0ViaPVb08j+oE/SoArEFVOwasyBiOg7a7pdlg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.501.0",
+    "@bigcommerce/checkout-sdk": "^1.501.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.499.3",
+    "@bigcommerce/checkout-sdk": "^1.501.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.501.1

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2292

## Testing / Proof
Unit tests
Manual tests
