### PR TITLE
chore(payment): PI-1076 bump checkout-sdk to 1.502.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.501.1",
+        "@bigcommerce/checkout-sdk": "^1.502.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.501.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.1.tgz",
-      "integrity": "sha512-Qiky/VGRRyLpuhrUFH7YVp8gzs7TY4AdMSgNQQd6OCJYcEaME0ViaPVb08j+oE/SoArEFVOwasyBiOg7a7pdlg==",
+      "version": "1.502.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.502.0.tgz",
+      "integrity": "sha512-wPkcIJWbvfFwKPUkjgKaaav5xnzxeL3aCaeQj9VG4hSU2gHBC8Wp+FnnsJ6qH6Nf9IInVvDmMqsEwLw7mY2Daw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.501.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.501.1.tgz",
-      "integrity": "sha512-Qiky/VGRRyLpuhrUFH7YVp8gzs7TY4AdMSgNQQd6OCJYcEaME0ViaPVb08j+oE/SoArEFVOwasyBiOg7a7pdlg==",
+      "version": "1.502.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.502.0.tgz",
+      "integrity": "sha512-wPkcIJWbvfFwKPUkjgKaaav5xnzxeL3aCaeQj9VG4hSU2gHBC8Wp+FnnsJ6qH6Nf9IInVvDmMqsEwLw7mY2Daw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.501.1",
+    "@bigcommerce/checkout-sdk": "^1.502.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to v.1.502.0.

## Why?
As part of release https://github.com/bigcommerce/checkout-sdk-js/pull/2295

## Testing / Proof
Unit tests
Manual tests

@bigcommerce/team-checkout
