### PR TITLE
feat(payment): PAYPAL-2617 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.502.0",
+        "@bigcommerce/checkout-sdk": "^1.503.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.502.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.502.0.tgz",
-      "integrity": "sha512-wPkcIJWbvfFwKPUkjgKaaav5xnzxeL3aCaeQj9VG4hSU2gHBC8Wp+FnnsJ6qH6Nf9IInVvDmMqsEwLw7mY2Daw==",
+      "version": "1.503.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.503.0.tgz",
+      "integrity": "sha512-8X0X2Mt9gomjBcmYtx/VgdvciRWtJ4zRQqY8SE25GMpeIiUo+AaB2DptVMGC7Furl+e7PvP5ZfoitQ6WAt8rhw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35565,9 +35565,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.502.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.502.0.tgz",
-      "integrity": "sha512-wPkcIJWbvfFwKPUkjgKaaav5xnzxeL3aCaeQj9VG4hSU2gHBC8Wp+FnnsJ6qH6Nf9IInVvDmMqsEwLw7mY2Daw==",
+      "version": "1.503.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.503.0.tgz",
+      "integrity": "sha512-8X0X2Mt9gomjBcmYtx/VgdvciRWtJ4zRQqY8SE25GMpeIiUo+AaB2DptVMGC7Furl+e7PvP5ZfoitQ6WAt8rhw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.502.0",
+    "@bigcommerce/checkout-sdk": "^1.503.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2289

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
