### PR TITLE
refactor(checkout): CHECKOUT-7948 Wallet Buttons Auto Layout

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -1,5 +1,4 @@
 import { CheckoutSelectors, CheckoutService } from '@bigcommerce/checkout-sdk';
-import classNames from 'classnames';
 import React, { FunctionComponent, memo } from 'react';
 
 import { TranslatedString, useLocale } from '@bigcommerce/checkout/locale';
@@ -25,7 +24,6 @@ interface WithCheckoutCheckoutButtonContainerProps {
     checkoutState: CheckoutSelectors;
     checkoutService: CheckoutService;
     isLoading: boolean;
-    initializedMethodIds: string[];
 }
 
 const paypalCommerceIds = [
@@ -44,16 +42,13 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
         checkEmbeddedSupport,
         isLoading,
         isPaymentStepActive,
-        initializedMethodIds,
         onUnhandledError,
         onWalletButtonClick,
     }) => {
     const { language } = useLocale();
 
-    const methodIds = isLoading ? availableMethodIds : initializedMethodIds;
-
     try {
-        checkEmbeddedSupport(methodIds);
+        checkEmbeddedSupport(availableMethodIds);
     } catch (error) {
         return null;
     }
@@ -96,15 +91,8 @@ const CheckoutButtonContainer: FunctionComponent<CheckoutButtonContainerProps & 
             <p>
                 <TranslatedString id="remote.start_with_text" />
             </p>
-            <div className={classNames({
-                'checkout-buttons--1': methodIds.length === 1,
-                'checkout-buttons--2': methodIds.length === 2,
-                'checkout-buttons--3': methodIds.length === 3,
-                'checkout-buttons--4': methodIds.length === 4,
-                'checkout-buttons--5': methodIds.length === 5,
-                'checkout-buttons--n': methodIds.length > 5,
-            })}>
-                <WalletButtonsContainerSkeleton buttonsCount={methodIds.length} isLoading={isLoading}>
+            <div className='checkout-buttons-auto-layout'>
+                <WalletButtonsContainerSkeleton buttonsCount={availableMethodIds.length} isLoading={isLoading}>
                     <div className="checkoutRemote">
                         {renderButtons()}
                     </div>
@@ -147,13 +135,11 @@ function mapToCheckoutButtonContainerProps({
     const isLoading = availableMethodIds.filter(
         (methodId) => Boolean(getInitializeCustomerError(methodId)) || isInitializedCustomer(methodId)
     ).length !== availableMethodIds.length;
-    const initializedMethodIds = availableMethodIds.filter((methodId) => isInitializedCustomer(methodId));
 
     return {
         checkoutService,
         checkoutState,
         availableMethodIds,
-        initializedMethodIds,
         isLoading,
     }
 }

--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] 
     Check out faster with:
   </p>
   <div
-    class="checkout-buttons--4"
+    class="checkout-buttons-auto-layout"
   >
     <div
       class="checkoutRemote customer-skeleton"
@@ -89,7 +89,7 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
     Check out faster with:
   </p>
   <div
-    class="checkout-buttons--4"
+    class="checkout-buttons-auto-layout"
   >
     <div
       class="checkoutRemote customer-skeleton"
@@ -164,7 +164,7 @@ exports[`CheckoutButtonContainer removes Paypal commerce wallet buttons when pay
     Check out faster with:
   </p>
   <div
-    class="checkout-buttons--4"
+    class="checkout-buttons-auto-layout"
   >
     <div
       class="checkoutRemote customer-skeleton"

--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -160,42 +160,33 @@ $buttonWidthMap: (
     }
 }
 
-.checkout-buttons--1 {
-    .checkoutRemote {
-        display: block;
-
-        > div {
-            max-width: $wallet-button-max-width;
-        }
+// wallet buttons auto layout based on the number of button divs
+.checkout-buttons-auto-layout {
+    .checkoutRemote > div:first-child:nth-last-child(1) {
+        grid-column: buttonWidth('single');
+        max-width: $wallet-button-max-width;
     }
-}
 
-.checkout-buttons--2 {
-    .checkoutRemote > div {
+    .checkoutRemote > div:first-child:nth-last-child(2),div:first-child:nth-last-child(2) ~ div {
         grid-column: buttonWidth('half');
     }
-}
 
-.checkout-buttons--3 {
-    .checkoutRemote > div:nth-child(1) {
+    .checkoutRemote > div:first-child:nth-last-child(3) {
         grid-column: buttonWidth('single');
 
         @include breakpoint("small") {
             grid-column: buttonWidth('third');
         }
     }
-
-    .checkoutRemote > div:nth-child(n + 2) {
+    .checkoutRemote > div:first-child:nth-last-child(3) ~ div:nth-child(n + 2){
         grid-column: buttonWidth('half');
 
         @include breakpoint("small") {
             grid-column: buttonWidth('third');
         }
     }
-}
 
-.checkout-buttons--4 {
-    .checkoutRemote > div {
+    .checkoutRemote > div:first-child:nth-last-child(4),div:first-child:nth-last-child(4) ~ div {
         grid-column: buttonWidth('half');
 
         @include breakpoint("medium") {
@@ -210,35 +201,25 @@ $buttonWidthMap: (
             grid-column: buttonWidth('quarter');
         }
     }
-}
 
-.checkout-buttons--5 {
-    .checkoutRemote > div:nth-child(1) {
+    .checkoutRemote > div:first-child:nth-last-child(5) {
         grid-column: buttonWidth('single');
 
         @include breakpoint("small") {
             grid-column: buttonWidth('half');
         }
     }
-
-    .checkoutRemote > div:nth-child(2) {
+    .checkoutRemote > div:first-child:nth-last-child(5) ~ div:nth-child(2){
         grid-column: buttonWidth('half');
-
-        @include breakpoint("small") {
-            grid-column: buttonWidth('half');
-        }
     }
-
-    .checkoutRemote > div:nth-child(n + 3) {
+    .checkoutRemote > div:first-child:nth-last-child(5) ~ div:nth-child(n+3){
         grid-column: buttonWidth('half');
 
         @include breakpoint("small") {
             grid-column: buttonWidth('third');
         }
     }
-}
 
-.checkout-buttons--n {
     .checkoutRemote > div {
         grid-column: buttonWidth('half');
 


### PR DESCRIPTION
## What?
- Remove `initializedMethodIds`.
- Autamatically changing wallet buttons layout based on the number of button divs by using a pure CSS method.

## Why?
The checkout UI can present the buttons based on the actual div containers, not internal state.

## Testing / Proof
- Desktop auto layout.

   https://github.com/bigcommerce/checkout-js/assets/88361607/120f9051-e68e-4771-a869-20ea8f0e3f59

- Desktop responsive layout.

   https://github.com/bigcommerce/checkout-js/assets/88361607/9daa4d31-d74f-45f7-9a95-d8ee1eed03ca

- Mobile browser.
   <img src="https://github.com/bigcommerce/checkout-js/assets/88361607/4bad07fc-e0cf-44ff-9173-9b3d7e469404" width=300 />


@bigcommerce/team-checkout
