### PR TITLE
chore(payment): PI-1126 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.503.0",
+        "@bigcommerce/checkout-sdk": "^1.504.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.503.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.503.0.tgz",
-      "integrity": "sha512-8X0X2Mt9gomjBcmYtx/VgdvciRWtJ4zRQqY8SE25GMpeIiUo+AaB2DptVMGC7Furl+e7PvP5ZfoitQ6WAt8rhw==",
+      "version": "1.504.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.504.0.tgz",
+      "integrity": "sha512-4SVpPl+bp/MN+p1ZfFPjnvplkAkLJuzYTJnM6L9cuqi9DYPMPnMnu6VhBmnji8hd1TeBAVS5dcG1lpCJn510wA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.503.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.503.0.tgz",
-      "integrity": "sha512-8X0X2Mt9gomjBcmYtx/VgdvciRWtJ4zRQqY8SE25GMpeIiUo+AaB2DptVMGC7Furl+e7PvP5ZfoitQ6WAt8rhw==",
+      "version": "1.504.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.504.0.tgz",
+      "integrity": "sha512-4SVpPl+bp/MN+p1ZfFPjnvplkAkLJuzYTJnM6L9cuqi9DYPMPnMnu6VhBmnji8hd1TeBAVS5dcG1lpCJn510wA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.503.0",
+    "@bigcommerce/checkout-sdk": "^1.504.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2294](https://github.com/bigcommerce/checkout-sdk-js/pull/2294)

## Testing / Proof
unit test and manually tested

@bigcommerce/team-checkout
