### PR TITLE
feat(payment): PAYPAL-3404 added isPayPalCommerceConnect method to paypal-connect-integration package

### DIFF
--- a/packages/paypal-connect-integration/src/index.ts
+++ b/packages/paypal-connect-integration/src/index.ts
@@ -1,4 +1,6 @@
 export { default as isPayPalConnectAddress } from './is-paypal-connect-address';
 export { default as isPaypalConnectMethod } from './is-paypal-connect-method';
+export { default as isBraintreeConnectMethod } from './is-braintree-connect-method';
+export { default as isPayPalCommerceConnectMethod } from './is-paypal-connect-method';
 export { default as PoweredByPaypalConnectLabel } from './PoweredByPaypalConnectLabel';
 export { default as usePayPalConnectAddress } from './usePayPalConnectAddress';

--- a/packages/paypal-connect-integration/src/is-braintree-connect-method.test.ts
+++ b/packages/paypal-connect-integration/src/is-braintree-connect-method.test.ts
@@ -1,0 +1,16 @@
+import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
+
+import isBraintreeConnectMethod from './is-braintree-connect-method';
+
+describe('isBraintreeConnectMethod', () => {
+    it('returns true if provided methodId is related to PayPal Connect', () => {
+        expect(isBraintreeConnectMethod(PaymentMethodId.Braintree)).toBe(true);
+        expect(isBraintreeConnectMethod(PaymentMethodId.BraintreeAcceleratedCheckout)).toBe(true);
+    });
+
+    it('returns false if provided methodId is not related to PayPal Connect', () => {
+        expect(isBraintreeConnectMethod(PaymentMethodId.PayPalCommerceAcceleratedCheckout)).toBe(
+            false,
+        );
+    });
+});

--- a/packages/paypal-connect-integration/src/is-braintree-connect-method.ts
+++ b/packages/paypal-connect-integration/src/is-braintree-connect-method.ts
@@ -1,0 +1,10 @@
+import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
+
+const isBraintreeConnectMethod = (methodId?: string): boolean => {
+    return (
+        methodId === PaymentMethodId.Braintree || // TODO: remove after A/B testing
+        methodId === PaymentMethodId.BraintreeAcceleratedCheckout
+    );
+};
+
+export default isBraintreeConnectMethod;

--- a/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.test.ts
+++ b/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.test.ts
@@ -1,0 +1,16 @@
+import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
+
+import isPayPalCommerceConnectMethod from './is-paypal-commerce-connect-method';
+
+describe('isPaypalCommerceConnectMethod', () => {
+    it('returns true if provided methodId is related to PayPal Connect', () => {
+        expect(isPayPalCommerceConnectMethod(PaymentMethodId.PaypalCommerce)).toBe(true);
+        expect(
+            isPayPalCommerceConnectMethod(PaymentMethodId.PayPalCommerceAcceleratedCheckout),
+        ).toBe(true);
+    });
+
+    it('returns false if provided methodId is not related to PayPal Connect', () => {
+        expect(isPayPalCommerceConnectMethod(PaymentMethodId.Braintree)).toBe(false);
+    });
+});

--- a/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.ts
+++ b/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.ts
@@ -1,0 +1,10 @@
+import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
+
+const isPayPalCommerceConnectMethod = (methodId?: string): boolean => {
+    return (
+        methodId === PaymentMethodId.PaypalCommerce || // TODO: remove after A/B testing
+        methodId === PaymentMethodId.PayPalCommerceAcceleratedCheckout
+    );
+};
+
+export default isPayPalCommerceConnectMethod;

--- a/packages/paypal-connect-integration/src/is-paypal-connect-method.test.ts
+++ b/packages/paypal-connect-integration/src/is-paypal-connect-method.test.ts
@@ -5,6 +5,7 @@ import isPaypalConnectMethod from './is-paypal-connect-method';
 describe('isPaypalConnectMethod', () => {
     it('returns true if provided methodId is related to PayPal Connect', () => {
         expect(isPaypalConnectMethod(PaymentMethodId.BraintreeAcceleratedCheckout)).toBe(true);
+        expect(isPaypalConnectMethod(PaymentMethodId.PayPalCommerceAcceleratedCheckout)).toBe(true);
     });
 
     it('returns false if provided methodId is not related to PayPal Connect', () => {

--- a/packages/paypal-connect-integration/src/is-paypal-connect-method.ts
+++ b/packages/paypal-connect-integration/src/is-paypal-connect-method.ts
@@ -1,10 +1,8 @@
-import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
+import isBraintreeConnectMethod from './is-braintree-connect-method';
+import isPayPalCommerceConnectMethod from './is-paypal-commerce-connect-method';
 
 const isPaypalConnectMethod = (methodId?: string): boolean => {
-    return (
-        methodId === PaymentMethodId.Braintree ||
-        methodId === PaymentMethodId.BraintreeAcceleratedCheckout
-    );
+    return isBraintreeConnectMethod(methodId) || isPayPalCommerceConnectMethod(methodId);
 };
 
 export default isPaypalConnectMethod;


### PR DESCRIPTION
## What?
Added isPayPalCommerceConnect method to paypal-connect-integration package

## Why?
To be able to run some functionality only for paypal commerce accelerated checkout provider

## Testing / Proof
Unit tests
CI tests
Manual tests

<img width="873" alt="Screenshot 2023-12-27 at 09 05 58" src="https://github.com/bigcommerce/checkout-js/assets/25133454/e0957cd6-e5b3-4ab9-9f6c-4f2a5e0799b4">
<img width="801" alt="Screenshot 2023-12-27 at 09 06 12" src="https://github.com/bigcommerce/checkout-js/assets/25133454/2aea12f2-7715-4af7-8082-f674b669d937">

