### PR TITLE
feat(payment): PAYPAL-3404 updated some conditions to call customer execute method after sign in/up only for Braintree AXO in Customer component

### DIFF
--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -17,7 +17,7 @@ import React, { Component, ReactNode } from 'react';
 import { AnalyticsContextProps } from '@bigcommerce/checkout/analytics';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
-import { isPaypalConnectMethod } from '@bigcommerce/checkout/paypal-connect-integration';
+import { isBraintreeConnectMethod } from '@bigcommerce/checkout/paypal-connect-integration';
 import { CustomerSkeleton } from '@bigcommerce/checkout/ui';
 
 import { withAnalytics } from '../analytics';
@@ -448,7 +448,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
         try {
             await signIn(credentials);
 
-            if (isPaypalConnectMethod(providerWithCustomCheckout)) {
+            if (isBraintreeConnectMethod(providerWithCustomCheckout)) {
                 await executePaymentMethodCheckout({
                     methodId: providerWithCustomCheckout,
                     continueWithCheckoutCallback: onSignIn,
@@ -474,7 +474,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
         await createAccount(mapCreateAccountFromFormValues(values));
 
-        if (isPaypalConnectMethod(providerWithCustomCheckout)) {
+        if (isBraintreeConnectMethod(providerWithCustomCheckout)) {
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onAccountCreated,


### PR DESCRIPTION
## What?
Updated some conditions to call customer execute method after sign in/up only for Braintree AXO in Customer component

## Why?
Execution method should not be called for PPCP AXO (PayPal Commerce Connect / PayPal Commerce Accelerated Checkout) after sign in/up

## Testing / Proof
Manual tests
CI tests