### PR TITLE
feat(payment): PAYPAL-3391 fixed ratepay fields layout

### DIFF
--- a/packages/core/src/scss/components/checkout/ratepayForm/_ratepayForm.scss
+++ b/packages/core/src/scss/components/checkout/ratepayForm/_ratepayForm.scss
@@ -1,14 +1,27 @@
 .dynamic-form-field--ratepayPhoneCountryCode {
   display: inline-flex;
-  width: 20%;
+  width: 26%;
 }
 
 .dynamic-form-field--ratepayPhoneNumber {
   display: inline-flex;
-  width: calc(80% - 0.5em);
+  width: calc(74% - 0.5em);
   margin-left: 0.5em;
 }
 
 .dynamic-form-field--ratepayPhoneNumber > div {
   width:100%;
+}
+
+@media only screen and (max-width: 500px) {
+  .dynamic-form-field--ratepayPhoneNumber {
+    display: block;
+    width: 100%;
+    margin: 0;
+  }
+
+  .dynamic-form-field--ratepayPhoneCountryCode {
+    display: block;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## What?
Fixed ratepay fields layout

## Why?
To render ratepay fields properly on every screen size

## Testing / Proof


https://github.com/bigcommerce/checkout-js/assets/56301104/0281d711-33b8-463b-8d69-8c5b6bd235e3


@bigcommerce/team-checkout
