### PR TITLE
chore(payment): PI-1318 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.505.2",
+        "@bigcommerce/checkout-sdk": "^1.506.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.505.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.505.2.tgz",
-      "integrity": "sha512-X0fq7naTPPqPVG3oIDqhqBU8AnksTD5HUrkepIKQQ4ixd6XkF4j+YxrtCeRWPr1DGNtx8N4SZq5FkoNMhAAEkQ==",
+      "version": "1.506.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.506.0.tgz",
+      "integrity": "sha512-rvWWx2+dHyH81d0wuxiup7WoshgceGPYXSrgeg/P9UqGUP6dGj7OlCo2R5abiL0wuIv/meEY7u1vJJbbdBhaGg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.505.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.505.2.tgz",
-      "integrity": "sha512-X0fq7naTPPqPVG3oIDqhqBU8AnksTD5HUrkepIKQQ4ixd6XkF4j+YxrtCeRWPr1DGNtx8N4SZq5FkoNMhAAEkQ==",
+      "version": "1.506.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.506.0.tgz",
+      "integrity": "sha512-rvWWx2+dHyH81d0wuxiup7WoshgceGPYXSrgeg/P9UqGUP6dGj7OlCo2R5abiL0wuIv/meEY7u1vJJbbdBhaGg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.505.2",
+    "@bigcommerce/checkout-sdk": "^1.506.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2296](https://github.com/bigcommerce/checkout-sdk-js/pull/2296)
[https://github.com/bigcommerce/checkout-sdk-js/pull/2302](https://github.com/bigcommerce/checkout-sdk-js/pull/2302)

## Testing / Proof
manually tested and unit test

@bigcommerce/team-checkout
