### PR TITLE
chore(payment): PAYPAL-3418 bump checkout sdk version to v1.511.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.510.0",
+        "@bigcommerce/checkout-sdk": "^1.511.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.510.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.510.0.tgz",
-      "integrity": "sha512-joZ99t9bQeW2ckqC8xqp63AuipOnXEPwxvb2cUEC8N2Cd4dcbeFhetX2B7gonbr+7KHmRGe+AecjftcrUPRLQA==",
+      "version": "1.511.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.511.0.tgz",
+      "integrity": "sha512-2DgTK+hgbcXZrHe4pmuLAGHOm+NirdYPCWSziszeQXNnNo2iTFp8VlciIZMLDCr+/isXeK/bdYsjvKuEn+B12A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.510.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.510.0.tgz",
-      "integrity": "sha512-joZ99t9bQeW2ckqC8xqp63AuipOnXEPwxvb2cUEC8N2Cd4dcbeFhetX2B7gonbr+7KHmRGe+AecjftcrUPRLQA==",
+      "version": "1.511.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.511.0.tgz",
+      "integrity": "sha512-2DgTK+hgbcXZrHe4pmuLAGHOm+NirdYPCWSziszeQXNnNo2iTFp8VlciIZMLDCr+/isXeK/bdYsjvKuEn+B12A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.510.0",
+    "@bigcommerce/checkout-sdk": "^1.511.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to v1.511.0

## Why?
As part of release checkout-sdk pr:
https://github.com/bigcommerce/checkout-sdk-js/pull/2308

## Testing / Proof
Unit tests
CI
