### PR TITLE
chore(payment): PAYPAL-2800 bump checkout-sdk to v1.513.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.512.0",
+        "@bigcommerce/checkout-sdk": "^1.513.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.512.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.512.0.tgz",
-      "integrity": "sha512-tUG4KBVf4lbT0wS2UifNj+8AWqrZLQp5aQxMNDsns77ntFPOn9p6OEU1V7W2Zghkn2chl3JTfbipUZCGUh6R/Q==",
+      "version": "1.513.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.513.0.tgz",
+      "integrity": "sha512-ECkUwWCUzxG5GI6KyZGzNf55kWwX74Aziqp785YCt3lkaVv0tdzYnTbzkdQV6ny7hPHpb8XqJ2HdCwWVm/Yozg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.512.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.512.0.tgz",
-      "integrity": "sha512-tUG4KBVf4lbT0wS2UifNj+8AWqrZLQp5aQxMNDsns77ntFPOn9p6OEU1V7W2Zghkn2chl3JTfbipUZCGUh6R/Q==",
+      "version": "1.513.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.513.0.tgz",
+      "integrity": "sha512-ECkUwWCUzxG5GI6KyZGzNf55kWwX74Aziqp785YCt3lkaVv0tdzYnTbzkdQV6ny7hPHpb8XqJ2HdCwWVm/Yozg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.512.0",
+    "@bigcommerce/checkout-sdk": "^1.513.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to v1.513.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2105

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
