### PR TITLE
feat(payment): PAYPAL-3300 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.513.0",
+        "@bigcommerce/checkout-sdk": "^1.514.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.513.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.513.0.tgz",
-      "integrity": "sha512-ECkUwWCUzxG5GI6KyZGzNf55kWwX74Aziqp785YCt3lkaVv0tdzYnTbzkdQV6ny7hPHpb8XqJ2HdCwWVm/Yozg==",
+      "version": "1.514.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.0.tgz",
+      "integrity": "sha512-0Wx74vqFrGSs067nFtPVYMTNcYavN2TR3wqk9WHDFwBKD1/BdsYq9taWnwWb4CPomI0ovfoY+iloZJhFtdVnwQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.513.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.513.0.tgz",
-      "integrity": "sha512-ECkUwWCUzxG5GI6KyZGzNf55kWwX74Aziqp785YCt3lkaVv0tdzYnTbzkdQV6ny7hPHpb8XqJ2HdCwWVm/Yozg==",
+      "version": "1.514.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.0.tgz",
+      "integrity": "sha512-0Wx74vqFrGSs067nFtPVYMTNcYavN2TR3wqk9WHDFwBKD1/BdsYq9taWnwWb4CPomI0ovfoY+iloZJhFtdVnwQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.513.0",
+    "@bigcommerce/checkout-sdk": "^1.514.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2304

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
