### PR TITLE
chore(payment): PI-1328 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.514.0",
+        "@bigcommerce/checkout-sdk": "^1.514.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.514.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.0.tgz",
-      "integrity": "sha512-0Wx74vqFrGSs067nFtPVYMTNcYavN2TR3wqk9WHDFwBKD1/BdsYq9taWnwWb4CPomI0ovfoY+iloZJhFtdVnwQ==",
+      "version": "1.514.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.2.tgz",
+      "integrity": "sha512-buM9a1zwfGmwaZNfx7x/oeMjUucTpJKE6bekE4wDz94J7q6DUtZ2/xU8JlMT/q4qDrrGgohvbmt9mQF11Fb76g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.514.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.0.tgz",
-      "integrity": "sha512-0Wx74vqFrGSs067nFtPVYMTNcYavN2TR3wqk9WHDFwBKD1/BdsYq9taWnwWb4CPomI0ovfoY+iloZJhFtdVnwQ==",
+      "version": "1.514.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.2.tgz",
+      "integrity": "sha512-buM9a1zwfGmwaZNfx7x/oeMjUucTpJKE6bekE4wDz94J7q6DUtZ2/xU8JlMT/q4qDrrGgohvbmt9mQF11Fb76g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.514.0",
+    "@bigcommerce/checkout-sdk": "^1.514.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/2315

## Why?
For better separation between payment integrations and core Checkout SDK

## Testing / Proof
Unit tests
Manual tests

@bigcommerce/team-checkout
