### PR TITLE
feat(payment): PAYPAL-3373 created a specific form for PPCP Credit Card strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.521.0",
+        "@bigcommerce/checkout-sdk": "^1.523.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.521.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.521.0.tgz",
-      "integrity": "sha512-KnAmEmypjDCit9016Zoj3VyXKGl9QUoGREfRUWKO2gaU0VQW8QwOz+B5H+3Z9E9BLcBnnVfK0O4gk0/nseNUrg==",
+      "version": "1.523.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.523.0.tgz",
+      "integrity": "sha512-zgnRnWe44ZwEl+/xSs+zs1yInazc888goTY4aJWOT2610qsftkDLZPjJMmsr+hrGbRqhYU1wIbhpoeThTercXQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.521.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.521.0.tgz",
-      "integrity": "sha512-KnAmEmypjDCit9016Zoj3VyXKGl9QUoGREfRUWKO2gaU0VQW8QwOz+B5H+3Z9E9BLcBnnVfK0O4gk0/nseNUrg==",
+      "version": "1.523.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.523.0.tgz",
+      "integrity": "sha512-zgnRnWe44ZwEl+/xSs+zs1yInazc888goTY4aJWOT2610qsftkDLZPjJMmsr+hrGbRqhYU1wIbhpoeThTercXQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.521.0",
+    "@bigcommerce/checkout-sdk": "^1.523.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/hostedCreditCard/HostedCreditCardValidation.spec.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/HostedCreditCardValidation.spec.tsx
@@ -9,6 +9,7 @@ import { getStoreConfig } from '../../config/config.mock';
 
 import HostedCreditCardCodeField from './HostedCreditCardCodeField';
 import HostedCreditCardNumberField from './HostedCreditCardNumberField';
+import HostedCreditCardExpiryField from './HostedCreditCardExpiryField';
 import HostedCreditCardValidation, {
     HostedCreditCardValidationProps,
 } from './HostedCreditCardValidation';
@@ -50,5 +51,17 @@ describe('HostedCreditCardValidation', () => {
         const component = mount(<HostedCreditCardValidationTest cardNumberId="cardNumber" />);
 
         expect(component.find(HostedCreditCardCodeField)).toHaveLength(0);
+    });
+
+    it('shows card expiry field if configured', () => {
+        const component = mount(<HostedCreditCardValidationTest cardExpiryId="cardExpiry" />);
+
+        expect(component.find(HostedCreditCardExpiryField)).toHaveLength(1);
+    });
+
+    it('hides card expiry field if configured', () => {
+        const component = mount(<HostedCreditCardValidationTest cardNumberId="cardCode" />);
+
+        expect(component.find(HostedCreditCardExpiryField)).toHaveLength(0);
     });
 });

--- a/packages/core/src/app/payment/hostedCreditCard/HostedCreditCardValidation.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/HostedCreditCardValidation.tsx
@@ -4,16 +4,19 @@ import { TranslatedString } from '@bigcommerce/checkout/locale';
 
 import HostedCreditCardCodeField from './HostedCreditCardCodeField';
 import HostedCreditCardNumberField from './HostedCreditCardNumberField';
+import HostedCreditCardExpiryField from "./HostedCreditCardExpiryField";
 
 export interface HostedCreditCardValidationProps {
     cardCodeId?: string;
     cardNumberId?: string;
+    cardExpiryId?: string;
     focusedFieldType?: string;
 }
 
 const HostedCreditCardValidation: FunctionComponent<HostedCreditCardValidationProps> = ({
     cardCodeId,
     cardNumberId,
+    cardExpiryId,
     focusedFieldType,
 }) => (
     <>
@@ -43,6 +46,14 @@ const HostedCreditCardValidation: FunctionComponent<HostedCreditCardValidationPr
                     appearFocused={focusedFieldType === 'cardCode'}
                     id={cardCodeId}
                     name="hostedForm.errors.cardCodeVerification"
+                />
+            )}
+
+            {cardExpiryId && (
+                <HostedCreditCardExpiryField
+                    appearFocused={focusedFieldType === 'cardExpiry'}
+                    id={cardExpiryId}
+                    name="hostedForm.errors.cardExpiryVerification"
                 />
             )}
         </div>

--- a/packages/core/src/app/payment/hostedCreditCard/getHostedInstrumentValidationSchema.spec.ts
+++ b/packages/core/src/app/payment/hostedCreditCard/getHostedInstrumentValidationSchema.spec.ts
@@ -70,4 +70,36 @@ describe('getHostedInstrumentValidationSchema', () => {
             'payment.credit_card_number_mismatch_error',
         );
     });
+
+    it('does not throw error if data is valid and cardExpiry is required', () => {
+        schema = getHostedInstrumentValidationSchema({
+            language: language as LanguageService,
+            isCardExpiryRequired: true,
+        });
+
+        expect(() => schema.validateSync(values)).not.toThrow();
+    });
+
+    it('throws error if card expiry field is missing', () => {
+        schema = getHostedInstrumentValidationSchema({
+            language: language as LanguageService,
+            isCardExpiryRequired: true,
+        });
+        values.hostedForm.errors = { cardExpiryVerification: 'required' };
+
+        expect(() => schema.validateSync(values)).toThrow('payment.credit_card_expiration_required_error');
+    });
+
+    it('throws error if card number field is invalid', () => {
+        schema = getHostedInstrumentValidationSchema({
+            language: language as LanguageService,
+            isCardExpiryRequired: true,
+        });
+
+        values.hostedForm.errors = { cardExpiryVerification: 'invalid_card_expiry' };
+
+        expect(() => schema.validateSync(values)).toThrow(
+            'payment.credit_card_expiration_invalid_error',
+        );
+    });
 });

--- a/packages/core/src/app/payment/hostedCreditCard/getHostedInstrumentValidationSchema.ts
+++ b/packages/core/src/app/payment/hostedCreditCard/getHostedInstrumentValidationSchema.ts
@@ -4,6 +4,7 @@ import { object, ObjectSchema, string } from 'yup';
 
 export interface HostedInstrumentValidationSchemaOptions {
     language: LanguageService;
+    isCardExpiryRequired?: boolean;
 }
 
 export interface HostedInstrumentValidationSchemaShape {
@@ -18,6 +19,7 @@ export interface HostedInstrumentValidationSchemaShape {
 
 export default memoize(function getHostedInstrumentValidationSchema({
     language,
+    isCardExpiryRequired,
 }: HostedInstrumentValidationSchemaOptions): ObjectSchema<HostedInstrumentValidationSchemaShape> {
     return object({
         instrumentId: string().required(),
@@ -47,6 +49,20 @@ export default memoize(function getHostedInstrumentValidationSchema({
                         message: language.translate('payment.credit_card_number_mismatch_error'),
                         test: (value) => value !== 'mismatched_card_number',
                     }),
+
+            ...(isCardExpiryRequired ? {
+                cardExpiryVerification: string()
+                    .test({
+                        message: language.translate(
+                            'payment.credit_card_expiration_required_error',
+                        ),
+                        test: (value) => value !== 'required',
+                    })
+                    .test({
+                        message: language.translate('payment.credit_card_expiration_invalid_error'),
+                        test: (value) => value !== 'invalid_card_expiry',
+                    }),
+            } : {})
             }),
         }),
     });

--- a/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.spec.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.spec.tsx
@@ -1,0 +1,391 @@
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+    HostedFieldType,
+} from '@bigcommerce/checkout-sdk';
+import { mount } from 'enzyme';
+import { Formik, FormikProps } from 'formik';
+import { last, merge, noop } from 'lodash';
+import React, { ComponentType, FunctionComponent, ReactNode } from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
+import {
+    CardInstrumentFieldsetValues,
+    CheckoutProvider,
+} from '@bigcommerce/checkout/payment-integration-api';
+import { FormContext, FormContextType } from '@bigcommerce/checkout/ui';
+
+import { getCart } from '../../cart/carts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getCustomer } from '../../customer/customers.mock';
+import { CreditCardInputStylesType, getCreditCardInputStyles } from '../creditCard';
+import { getPaymentMethod } from '../payment-methods.mock';
+import PaymentContext, { PaymentContextProps } from '../PaymentContext';
+import HostedCreditCardFieldsetValues from '../paymentMethod/HostedCreditCardFieldsetValues';
+import { getCardInstrument } from '../storedInstrument/instruments.mock';
+
+import HostedCreditCardFieldset from './HostedCreditCardFieldset';
+import {
+    WithHostedCreditCardFieldsetProps,
+    WithInjectedHostedCreditCardFieldsetProps,
+} from './withHostedCreditCardFieldset';
+import withHostedPayPalCommerceCreditCardFieldset from './withHostedPayPalCommerceCreditCardFieldset';
+
+jest.mock('../creditCard', () => ({
+    ...jest.requireActual('../creditCard'),
+    getCreditCardInputStyles: jest.fn<
+        ReturnType<typeof getCreditCardInputStyles>,
+        Parameters<typeof getCreditCardInputStyles>
+    >((_containerId, _fieldType, type) => {
+        if (type === CreditCardInputStylesType.Error) {
+            return Promise.resolve({ color: 'rgb(255, 0, 0)' });
+        }
+
+        if (type === CreditCardInputStylesType.Focus) {
+            return Promise.resolve({ color: 'rgb(0, 0, 255)' });
+        }
+
+        return Promise.resolve({ color: 'rgb(0, 0, 0)' });
+    }),
+}));
+
+describe('withHostedPayPalCommerceCreditCardFieldset', () => {
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: WithHostedCreditCardFieldsetProps;
+    let formContext: FormContextType;
+    let formikRender: jest.Mock<
+        ReactNode,
+        [FormikProps<HostedCreditCardFieldsetValues & CardInstrumentFieldsetValues>]
+    >;
+    let formikProps: FormikProps<HostedCreditCardFieldsetValues & CardInstrumentFieldsetValues>;
+    let initialValues: HostedCreditCardFieldsetValues & CardInstrumentFieldsetValues;
+    let localeContext: LocaleContextType;
+    let paymentContext: PaymentContextProps;
+    let DecoratedPaymentMethod: ComponentType<WithHostedCreditCardFieldsetProps>;
+    let DecoratedPaymentMethodTest: FunctionComponent<WithHostedCreditCardFieldsetProps>;
+    let InnerPaymentMethod: ComponentType<
+        WithHostedCreditCardFieldsetProps & WithInjectedHostedCreditCardFieldsetProps
+    >;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+
+        defaultProps = {
+            method: merge({}, getPaymentMethod(), {
+                config: {
+                    isHostedFormEnabled: true,
+                },
+            }),
+        };
+
+        initialValues = {
+            hostedForm: {},
+            instrumentId: '',
+        };
+
+        paymentContext = {
+            disableSubmit: jest.fn(),
+            setSubmit: jest.fn(),
+            setValidationSchema: jest.fn(),
+            hidePaymentSubmitButton: jest.fn(),
+        };
+
+        formContext = {
+            isSubmitted: false,
+            setSubmitted: jest.fn(),
+        };
+
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue(getCart());
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
+
+        jest.spyOn(checkoutState.data, 'getPaymentMethod').mockReturnValue(defaultProps.method);
+
+        InnerPaymentMethod = jest.fn(
+            ({ getHostedStoredCardValidationFieldset = noop, hostedFieldset }) => {
+                return (
+                    <>
+                        {hostedFieldset}
+                        {getHostedStoredCardValidationFieldset()}
+                    </>
+                );
+            },
+        );
+
+        DecoratedPaymentMethod = withHostedPayPalCommerceCreditCardFieldset(InnerPaymentMethod);
+
+        DecoratedPaymentMethodTest = (props) => {
+            formikRender = jest.fn((renderProps) => {
+                formikProps = renderProps;
+
+                return <DecoratedPaymentMethod {...props} />;
+            });
+
+            return (
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <PaymentContext.Provider value={paymentContext}>
+                        <LocaleContext.Provider value={localeContext}>
+                            <FormContext.Provider value={formContext}>
+                                <Formik
+                                    initialValues={initialValues}
+                                    onSubmit={noop}
+                                    render={formikRender}
+                                />
+                            </FormContext.Provider>
+                        </LocaleContext.Provider>
+                    </PaymentContext.Provider>
+                </CheckoutProvider>
+            );
+        };
+    });
+
+    it('renders hosted credit card fieldset', () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+
+        expect(container.find(HostedCreditCardFieldset)).toHaveLength(1);
+    });
+
+    it('does not render hosted credit card fieldset if feature is not enabled', () => {
+        const container = mount(
+            <DecoratedPaymentMethodTest
+                {...defaultProps}
+                method={merge({}, getPaymentMethod(), {
+                    config: {
+                        isHostedFormEnabled: false,
+                    },
+                })}
+            />,
+        );
+
+        expect(container.find(HostedCreditCardFieldset)).toHaveLength(0);
+    });
+
+    it('passes hosted form configuration to inner component', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+
+        expect(await getHostedFormOptions()).toEqual({
+            fields: {
+                cardCode: { accessibilityLabel: 'CVV', containerId: 'authorizenet-ccCvv' },
+                cardExpiry: {
+                    accessibilityLabel: 'Expiration',
+                    containerId: 'authorizenet-ccExpiry',
+                    placeholder: 'MM / YY',
+                },
+                cardName: {
+                    accessibilityLabel: 'Name on Card',
+                    containerId: 'authorizenet-ccName',
+                },
+                cardNumber: {
+                    accessibilityLabel: 'Credit Card Number',
+                    containerId: 'authorizenet-ccNumber',
+                },
+            },
+            styles: {
+                default: expect.any(Object),
+                error: expect.any(Object),
+                focus: expect.any(Object),
+            },
+            onBlur: expect.any(Function),
+            onCardTypeChange: expect.any(Function),
+            onEnter: expect.any(Function),
+            onFocus: expect.any(Function),
+            onValidate: expect.any(Function),
+        });
+    });
+
+    it('passes hosted verification form options to inner component when there is selected instrument', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+
+        expect(
+            await getHostedFormOptions({
+                ...getCardInstrument(),
+                trustedShippingAddress: false,
+            }),
+        ).toEqual({
+            fields: {
+                cardCodeVerification: {
+                    accessibilityLabel: 'CVV',
+                    containerId: 'authorizenet-ccCvv',
+                    instrumentId: getCardInstrument().bigpayToken,
+                },
+                cardNumberVerification: {
+                    accessibilityLabel: 'Credit Card Number',
+                    containerId: 'authorizenet-ccNumber',
+                    instrumentId: getCardInstrument().bigpayToken,
+                },
+                cardExpiryVerification: {
+                    accessibilityLabel: 'optimized_checkout.payment.credit_card_expiry_label',
+                    containerId: 'authorizenet-ccExpiry',
+                    instrumentId: '123'
+                }
+            },
+            styles: {
+                default: expect.any(Object),
+                error: expect.any(Object),
+                focus: expect.any(Object),
+            },
+            onBlur: expect.any(Function),
+            onCardTypeChange: expect.any(Function),
+            onEnter: expect.any(Function),
+            onFocus: expect.any(Function),
+            onValidate: expect.any(Function),
+        });
+    });
+
+    it('passes styling properties to hosted form', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+
+        expect(await getHostedFormOptions()).toEqual(
+            expect.objectContaining({
+                styles: {
+                    default: { color: 'rgb(0, 0, 0)' },
+                    error: { color: 'rgb(255, 0, 0)' },
+                    focus: { color: 'rgb(0, 0, 255)' },
+                },
+            }),
+        );
+
+        expect(getCreditCardInputStyles).toHaveBeenCalledWith('authorizenet-ccNumber', [
+            'color',
+            'fontFamily',
+            'fontSize',
+            'fontWeight',
+        ]);
+        expect(getCreditCardInputStyles).toHaveBeenCalledWith(
+            'authorizenet-ccNumber',
+            ['color', 'fontFamily', 'fontSize', 'fontWeight'],
+            CreditCardInputStylesType.Error,
+        );
+        expect(getCreditCardInputStyles).toHaveBeenCalledWith(
+            'authorizenet-ccNumber',
+            ['color', 'fontFamily', 'fontSize', 'fontWeight'],
+            CreditCardInputStylesType.Focus,
+        );
+    });
+
+    it('passes error messages from hosted form to Formik form', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+        const { onValidate } = await getHostedFormOptions();
+
+        onValidate({
+            isValid: false,
+            errors: {
+                cardCode: [],
+                cardExpiry: [],
+                cardName: [],
+                cardNumber: [
+                    {
+                        fieldType: 'cardNumber',
+                        type: 'required',
+                        message: 'Card number is required',
+                    },
+                ],
+            },
+        });
+
+        container.update();
+
+        expect(
+            (last(formikRender.mock.calls)![0].values as HostedCreditCardFieldsetValues).hostedForm
+                .errors,
+        ).toEqual(
+            expect.objectContaining({
+                cardNumber: 'required',
+            }),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(last(formikRender.mock.calls)![0].touched).toEqual(
+            expect.objectContaining({
+                hostedForm: {
+                    errors: {
+                        cardNumber: true,
+                    },
+                },
+            }),
+        );
+    });
+
+    it('passes card type from hosted form to Formik form', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+        const { onCardTypeChange } = await getHostedFormOptions();
+
+        onCardTypeChange({ cardType: 'mastercard' });
+
+        container.update();
+
+        expect(
+            (last(formikRender.mock.calls)![0].values as HostedCreditCardFieldsetValues).hostedForm
+                .cardType,
+        ).toBe('mastercard');
+    });
+
+    it('highlights hosted field in focus', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+        const { onFocus } = await getHostedFormOptions();
+
+        act(() => {
+            onFocus({ fieldType: 'cardNumber' as HostedFieldType });
+        });
+
+        container.update();
+
+        expect(container.find(HostedCreditCardFieldset).prop('focusedFieldType')).toBe(
+            'cardNumber',
+        );
+    });
+
+    it('clears highlight if hosted field in no longer in focus', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+        const { onBlur } = await getHostedFormOptions();
+
+        onBlur({ fieldType: 'cardNumber' as HostedFieldType });
+
+        container.update();
+
+        expect(container.find(HostedCreditCardFieldset).prop('focusedFieldType')).toBeUndefined();
+    });
+
+    it('submits form when enter key is pressed', async () => {
+        const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+        const { onEnter } = await getHostedFormOptions();
+
+        onEnter({ fieldType: 'cardNumber' as HostedFieldType });
+
+        container.update();
+
+        expect(formikProps.submitCount).toBe(1);
+        expect(formContext.setSubmitted).toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.tsx
@@ -1,0 +1,345 @@
+import {
+    CardInstrument,
+    HostedFormOptions,
+    Instrument,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk';
+import { compact, forIn } from 'lodash';
+import React, { ComponentType, FunctionComponent, ReactNode, useCallback, useState } from 'react';
+import { ObjectSchema } from 'yup';
+
+import { MapToPropsFactory } from '@bigcommerce/checkout/legacy-hoc';
+import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
+import { CheckoutContextProps, PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
+
+import { withCheckout } from '../../checkout';
+import { connectFormik, ConnectFormikProps } from '../../common/form';
+import { withForm, WithFormProps } from '../../ui/form';
+import {
+    CreditCardCustomerCodeField,
+    CreditCardInputStylesType,
+    getCreditCardInputStyles,
+} from '../creditCard';
+import {
+    isInstrumentCardCodeRequiredSelector,
+    isInstrumentCardNumberRequiredSelector,
+    isInstrumentFeatureAvailable,
+} from '../storedInstrument';
+
+import getHostedCreditCardValidationSchema, {
+    HostedCreditCardValidationSchemaShape,
+} from './getHostedCreditCardValidationSchema';
+import getHostedInstrumentValidationSchema, {
+    HostedInstrumentValidationSchemaShape,
+} from './getHostedInstrumentValidationSchema';
+import HostedCreditCardFieldset from './HostedCreditCardFieldset';
+import HostedCreditCardValidation from './HostedCreditCardValidation';
+
+export interface WithHostedCreditCardFieldsetProps {
+    isUsingMultiShipping?: boolean;
+    method: PaymentMethod;
+}
+
+export interface WithInjectedHostedCreditCardFieldsetProps {
+    hostedFieldset: ReactNode;
+    hostedStoredCardValidationSchema: ObjectSchema<HostedInstrumentValidationSchemaShape>;
+    hostedValidationSchema: ObjectSchema<HostedCreditCardValidationSchemaShape>;
+    getHostedFormOptions(selectedInstrument?: CardInstrument): Promise<HostedFormOptions>;
+    getHostedStoredCardValidationFieldset(selectedInstrument?: CardInstrument): ReactNode;
+}
+
+export interface WithCheckoutContextProps {
+    isCardCodeRequired: boolean;
+    isInstrumentFeatureAvailable: boolean;
+    isInstrumentCardCodeRequired(instrument: Instrument, method: PaymentMethod): boolean;
+    isInstrumentCardNumberRequired(instrument: Instrument): boolean;
+}
+
+export default function withHostedPayPalCommerceCreditCardFieldset<
+    TProps extends WithHostedCreditCardFieldsetProps,
+>(
+    OriginalComponent: ComponentType<TProps & Partial<WithInjectedHostedCreditCardFieldsetProps>>,
+): ComponentType<Omit<TProps, keyof WithInjectedHostedCreditCardFieldsetProps>> {
+    const Component: FunctionComponent<
+        WithHostedCreditCardFieldsetProps &
+        WithCheckoutContextProps &
+        WithLanguageProps &
+        WithFormProps &
+        ConnectFormikProps<PaymentFormValues>
+    > = ({
+             formik: { setFieldValue, setFieldTouched, submitForm },
+             isCardCodeRequired,
+             isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
+             isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
+             isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
+             isSubmitted,
+             language,
+             method,
+             setSubmitted,
+             ...rest
+         }) => {
+        const [focusedFieldType, setFocusedFieldType] = useState<string>();
+
+        const getHostedFieldId: (name: string) => string = useCallback(
+            (name) => {
+                return `${compact([method.gateway, method.id]).join('-')}-${name}`;
+            },
+            [method],
+        );
+
+        const getHostedFormOptions: (
+            selectedInstrument?: CardInstrument,
+        ) => Promise<HostedFormOptions> = useCallback(
+            async (selectedInstrument) => {
+                const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
+
+                const isInstrumentCardNumberRequired = selectedInstrument
+                    ? isInstrumentCardNumberRequiredProp(selectedInstrument)
+                    : false;
+                const isInstrumentCardCodeRequired = selectedInstrument
+                    ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
+                    : false;
+                const isInstrumentCardExpiryRequired = selectedInstrument
+                    ? !selectedInstrument.trustedShippingAddress
+                    : false;
+
+                const styleContainerId = selectedInstrument
+                    ? isInstrumentCardCodeRequired
+                        ? getHostedFieldId('ccCvv')
+                        : undefined
+                    : getHostedFieldId('ccNumber');
+
+                return {
+                    fields: selectedInstrument
+                        ? {
+                            cardCodeVerification:
+                                isInstrumentCardCodeRequired && selectedInstrument
+                                    ? {
+                                        accessibilityLabel: language.translate(
+                                            'payment.credit_card_cvv_label',
+                                        ),
+                                        containerId: getHostedFieldId('ccCvv'),
+                                        instrumentId: selectedInstrument.bigpayToken,
+                                    }
+                                    : undefined,
+                            cardNumberVerification:
+                                isInstrumentCardNumberRequired && selectedInstrument
+                                    ? {
+                                        accessibilityLabel: language.translate(
+                                            'payment.credit_card_number_label',
+                                        ),
+                                        containerId: getHostedFieldId('ccNumber'),
+                                        instrumentId: selectedInstrument.bigpayToken,
+                                    }
+                                    : undefined,
+                            cardExpiryVerification:
+                                isInstrumentCardExpiryRequired && selectedInstrument
+                                    ? {
+                                          accessibilityLabel: language.translate(
+                                              'payment.credit_card_expiry_label',
+                                          ),
+                                          containerId: getHostedFieldId('ccExpiry'),
+                                          instrumentId: selectedInstrument.bigpayToken,
+                                      }
+                                    : undefined,
+                        }
+                        : {
+                            cardCode: isCardCodeRequired
+                                ? {
+                                    accessibilityLabel: language.translate(
+                                        'payment.credit_card_cvv_label',
+                                    ),
+                                    containerId: getHostedFieldId('ccCvv'),
+                                }
+                                : undefined,
+                            cardExpiry: {
+                                accessibilityLabel: language.translate(
+                                    'payment.credit_card_expiration_label',
+                                ),
+                                containerId: getHostedFieldId('ccExpiry'),
+                                placeholder: language.translate(
+                                    'payment.credit_card_expiration_placeholder_text',
+                                ),
+                            },
+                            cardName: {
+                                accessibilityLabel: language.translate(
+                                    'payment.credit_card_name_label',
+                                ),
+                                containerId: getHostedFieldId('ccName'),
+                            },
+                            cardNumber: {
+                                accessibilityLabel: language.translate(
+                                    'payment.credit_card_number_label',
+                                ),
+                                containerId: getHostedFieldId('ccNumber'),
+                            },
+                        },
+                    styles: styleContainerId
+                        ? {
+                            default: await getCreditCardInputStyles(styleContainerId, styleProps),
+                            error: await getCreditCardInputStyles(
+                                styleContainerId,
+                                styleProps,
+                                CreditCardInputStylesType.Error,
+                            ),
+                            focus: await getCreditCardInputStyles(
+                                styleContainerId,
+                                styleProps,
+                                CreditCardInputStylesType.Focus,
+                            ),
+                        }
+                        : {},
+                    onBlur: ({ fieldType }) => {
+                        if (focusedFieldType === fieldType) {
+                            setFocusedFieldType(undefined);
+                        }
+                    },
+                    onCardTypeChange: ({ cardType }) => {
+                        setFieldValue('hostedForm.cardType', cardType);
+                    },
+                    onEnter: () => {
+                        setSubmitted(true);
+                        submitForm();
+                    },
+                    onFocus: ({ fieldType }) => {
+                        setFocusedFieldType(fieldType);
+                    },
+                    onValidate: ({ errors = {} }) => {
+                        forIn(errors, (fieldErrors = [], fieldType) => {
+                            const errorKey = `hostedForm.errors.${fieldType}`;
+
+                            setFieldValue(errorKey, fieldErrors[0]?.type ?? '');
+
+                            if (fieldErrors[0]) {
+                                setFieldTouched(errorKey);
+                            }
+                        });
+                    },
+                };
+            },
+            [
+                focusedFieldType,
+                getHostedFieldId,
+                isCardCodeRequired,
+                isInstrumentCardCodeRequiredProp,
+                isInstrumentCardNumberRequiredProp,
+                language,
+                method,
+                setFieldValue,
+                setFieldTouched,
+                setFocusedFieldType,
+                setSubmitted,
+                submitForm,
+            ],
+        );
+
+        const getHostedStoredCardValidationFieldset: (
+            selectedInstrument: CardInstrument,
+        ) => ReactNode = useCallback(
+            (selectedInstrument) => {
+                const isInstrumentCardNumberRequired = selectedInstrument
+                    ? isInstrumentCardNumberRequiredProp(selectedInstrument)
+                    : false;
+                const isInstrumentCardCodeRequired = selectedInstrument
+                    ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
+                    : false;
+                const isInstrumentCardExpiryRequired = selectedInstrument
+                    ? !selectedInstrument.trustedShippingAddress
+                    : false;
+
+                return (
+                    <HostedCreditCardValidation
+                        cardCodeId={
+                            isInstrumentCardCodeRequired ? getHostedFieldId('ccCvv') : undefined
+                        }
+                        cardNumberId={
+                            isInstrumentCardNumberRequired
+                                ? getHostedFieldId('ccNumber')
+                                : undefined
+                        }
+                        cardExpiryId={
+                            isInstrumentCardExpiryRequired
+                                ? getHostedFieldId('ccExpiry')
+                                : undefined
+                        }
+                        focusedFieldType={focusedFieldType}
+                    />
+                );
+            },
+            [
+                focusedFieldType,
+                getHostedFieldId,
+                isInstrumentCardCodeRequiredProp,
+                isInstrumentCardNumberRequiredProp,
+                method,
+            ],
+        );
+
+        if (!method.config.isHostedFormEnabled) {
+            return <OriginalComponent {...(rest as TProps)} method={method} />;
+        }
+
+        return (
+            <OriginalComponent
+                {...(rest as TProps)}
+                getHostedFormOptions={getHostedFormOptions}
+                getHostedStoredCardValidationFieldset={getHostedStoredCardValidationFieldset}
+                hostedFieldset={
+                    <HostedCreditCardFieldset
+                        additionalFields={
+                            method.config.requireCustomerCode && (
+                                <CreditCardCustomerCodeField name="ccCustomerCode" />
+                            )
+                        }
+                        cardCodeId={isCardCodeRequired ? getHostedFieldId('ccCvv') : undefined}
+                        cardExpiryId={getHostedFieldId('ccExpiry')}
+                        cardNameId={getHostedFieldId('ccName')}
+                        cardNumberId={getHostedFieldId('ccNumber')}
+                        focusedFieldType={focusedFieldType}
+                    />
+                }
+                hostedStoredCardValidationSchema={getHostedInstrumentValidationSchema({ language, isCardExpiryRequired: true })}
+                hostedValidationSchema={getHostedCreditCardValidationSchema({ language })}
+                method={method}
+            />
+        );
+    };
+
+    return connectFormik(
+        withForm(withLanguage(withCheckout(mapFromCheckoutProps)(Component))),
+    ) as ComponentType<Omit<TProps, keyof WithInjectedHostedCreditCardFieldsetProps>>;
+}
+
+const mapFromCheckoutProps: MapToPropsFactory<
+    CheckoutContextProps,
+    WithCheckoutContextProps,
+    WithHostedCreditCardFieldsetProps & ConnectFormikProps<PaymentFormValues>
+> = () => {
+    return ({ checkoutState }, { isUsingMultiShipping = false, method }) => {
+        const {
+            data: { getConfig, getCustomer },
+        } = checkoutState;
+
+        const config = getConfig();
+        const customer = getCustomer();
+
+        if (!config || !customer) {
+            return null;
+        }
+
+        const isInstrumentFeatureAvailableProp = isInstrumentFeatureAvailable({
+            config,
+            customer,
+            isUsingMultiShipping,
+            paymentMethod: method,
+        });
+
+        return {
+            method,
+            isCardCodeRequired: method.config.cardCode || method.config.cardCode === null,
+            isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredSelector(checkoutState),
+            isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredSelector(checkoutState),
+            isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
+        };
+    };
+};

--- a/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.spec.tsx
@@ -14,10 +14,8 @@ import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api'
 import { getCart } from '../../cart/carts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getCustomer } from '../../customer/customers.mock';
-import {
-    withHostedCreditCardFieldset,
-    WithInjectedHostedCreditCardFieldsetProps,
-} from '../hostedCreditCard';
+import { WithInjectedHostedCreditCardFieldsetProps } from '../hostedCreditCard';
+import withHostedPayPalCommerceCreditCardFieldset from '../hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset';
 import { getPaymentMethod } from '../payment-methods.mock';
 
 import CreditCardPaymentMethod from './CreditCardPaymentMethod';
@@ -43,11 +41,11 @@ const injectedProps: WithInjectedHostedCreditCardFieldsetProps = {
     hostedValidationSchema: object(),
 };
 
-jest.mock('../hostedCreditCard', () => ({
-    ...jest.requireActual('../hostedCreditCard'),
-    withHostedCreditCardFieldset: jest.fn((Component) => (props: any) => (
+jest.mock('../hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset', () => ({
+    __esModule: true,
+    default: jest.fn((Component) => (props: any) => (
         <Component {...props} {...injectedProps} />
-    )) as jest.Mocked<typeof withHostedCreditCardFieldset>,
+    )) as jest.Mocked<typeof withHostedPayPalCommerceCreditCardFieldset>,
 }));
 
 jest.mock(

--- a/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaypalCommerceCreditCardPaymentMethod.tsx
@@ -1,11 +1,9 @@
 import React, { FunctionComponent, useCallback } from 'react';
 
-import {
-    withHostedCreditCardFieldset,
-    WithInjectedHostedCreditCardFieldsetProps,
-} from '../hostedCreditCard';
+import { WithInjectedHostedCreditCardFieldsetProps } from '../hostedCreditCard';
 
 import CreditCardPaymentMethod, { CreditCardPaymentMethodProps } from './CreditCardPaymentMethod';
+import withHostedPayPalCommerceCreditCardFieldset from '../hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset';
 
 export type PaypalCommerceCreditCardPaymentMethodProps = CreditCardPaymentMethodProps;
 
@@ -47,4 +45,4 @@ const PaypalCommerceCreditCardPaymentMethod: FunctionComponent<
     );
 };
 
-export default withHostedCreditCardFieldset(PaypalCommerceCreditCardPaymentMethod);
+export default withHostedPayPalCommerceCreditCardFieldset(PaypalCommerceCreditCardPaymentMethod);


### PR DESCRIPTION
## What?
A specific form for PPCP Credit Card  with untrusted shipping address. Added an additional `expiry` field.

## Why?
Because there are three required fields (number, cvv, expiry) needed for PPCP Card Fields API. 

## Testing / Proof
<img width="891" alt="Screenshot 2024-01-10 at 17 38 26" src="https://github.com/bigcommerce/checkout-js/assets/130665807/af62e4f9-a585-4eef-a811-d31f98fa02aa">


@bigcommerce/team-checkout
