### PR TITLE
feat(payment): PAYPAL-3446 Shipping address form isn't validated when Accelerated Checkout is enabled

### DIFF
--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -28,6 +28,7 @@ import {
     mapAddressToFormValues,
 } from '../address';
 import { getCustomFormFieldsValidationSchema } from '../formFields';
+import { PaymentMethodId } from '../payment/paymentMethod';
 import { Fieldset, Form } from '../ui/form';
 
 import BillingSameAsShippingField from './BillingSameAsShippingField';
@@ -76,6 +77,14 @@ interface SingleShippingFormState {
     isResettingAddress: boolean;
     isUpdatingShippingData: boolean;
     hasRequestedShippingOptions: boolean;
+}
+
+function shouldHaveCustomValidation(methodId?: string): boolean {
+    return !(
+        methodId === PaymentMethodId.BraintreeAcceleratedCheckout ||
+        methodId === PaymentMethodId.PayPalCommerceAcceleratedCheckout ||
+        !methodId
+    );
 }
 
 export const SHIPPING_AUTOSAVE_DELAY = 1700;
@@ -334,7 +343,7 @@ export default withLanguage(
             getFields,
             methodId,
         }: SingleShippingFormProps & WithLanguageProps) =>
-            methodId
+            shouldHaveCustomValidation(methodId)
                 ? object({
                       shippingAddress: lazy<Partial<AddressFormValues>>((formValues) =>
                           getCustomFormFieldsValidationSchema({

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -80,11 +80,12 @@ interface SingleShippingFormState {
 }
 
 function shouldHaveCustomValidation(methodId?: string): boolean {
-    return !(
-        methodId === PaymentMethodId.BraintreeAcceleratedCheckout ||
-        methodId === PaymentMethodId.PayPalCommerceAcceleratedCheckout ||
-        !methodId
-    );
+    const methodIdsWithoutCustomValidation: string[] = [
+        PaymentMethodId.BraintreeAcceleratedCheckout,
+        PaymentMethodId.PayPalCommerceAcceleratedCheckout
+    ];
+
+    return Boolean(methodId && !methodIdsWithoutCustomValidation.includes(methodId));
 }
 
 export const SHIPPING_AUTOSAVE_DELAY = 1700;


### PR DESCRIPTION
## What?

Added `shouldHaveCustomValidation` function to define the validation flow

## Why?

Accelerated Checkout should use the default validation flow

## Testing / Proof

Manual testing

@bigcommerce/team-checkout
