### PR TITLE
chore(payment): PAYPAL-3405 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.514.2",
+        "@bigcommerce/checkout-sdk": "^1.516.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1746,9 +1746,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.26.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.2.tgz",
-      "integrity": "sha512-Gdzahix8fTpXVlyRVAviX/IV2DlmAqj5e7JDICAJ6uZXWCGHIbq3V8xZHk1+pVv6p7oZnb/b0pULupoUDvriUw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.27.0.tgz",
+      "integrity": "sha512-yBMEzTavay+wHTgIfu6gt9efD/z7Bqxe0iYCQeM561PwwF/5v+vAaLS2Y8kasD9m9IszMy98rBBFMzhGBiMhNA==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -1757,11 +1757,11 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.514.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.2.tgz",
-      "integrity": "sha512-buM9a1zwfGmwaZNfx7x/oeMjUucTpJKE6bekE4wDz94J7q6DUtZ2/xU8JlMT/q4qDrrGgohvbmt9mQF11Fb76g==",
+      "version": "1.516.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.516.0.tgz",
+      "integrity": "sha512-5L+q34eKC+vp5eHi+/iF9VfSQVeaa6fY66HhJFOmTwQvM/CvlqilcxlNtL1Ofeull5BsR91grx9sdq5ZLDp0aQ==",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.26.2",
+        "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -35588,9 +35588,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.26.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.2.tgz",
-      "integrity": "sha512-Gdzahix8fTpXVlyRVAviX/IV2DlmAqj5e7JDICAJ6uZXWCGHIbq3V8xZHk1+pVv6p7oZnb/b0pULupoUDvriUw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.27.0.tgz",
+      "integrity": "sha512-yBMEzTavay+wHTgIfu6gt9efD/z7Bqxe0iYCQeM561PwwF/5v+vAaLS2Y8kasD9m9IszMy98rBBFMzhGBiMhNA==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -35599,11 +35599,11 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.514.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.514.2.tgz",
-      "integrity": "sha512-buM9a1zwfGmwaZNfx7x/oeMjUucTpJKE6bekE4wDz94J7q6DUtZ2/xU8JlMT/q4qDrrGgohvbmt9mQF11Fb76g==",
+      "version": "1.516.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.516.0.tgz",
+      "integrity": "sha512-5L+q34eKC+vp5eHi+/iF9VfSQVeaa6fY66HhJFOmTwQvM/CvlqilcxlNtL1Ofeull5BsR91grx9sdq5ZLDp0aQ==",
       "requires": {
-        "@bigcommerce/bigpay-client": "^5.26.2",
+        "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.514.2",
+    "@bigcommerce/checkout-sdk": "^1.516.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
As part of checkout sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2312
https://github.com/bigcommerce/checkout-sdk-js/pull/2317
https://github.com/bigcommerce/checkout-sdk-js/pull/2316

## Testing / Proof
Unit tests
Manual tests
CI
