### PR TITLE
fix(payment): PI-1329 update payment methods after total amount change

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -1,6 +1,7 @@
 import {
     CartChangedError,
     CheckoutSelectors,
+    CheckoutService,
     CheckoutSettings,
     OrderRequestBody,
     PaymentMethod,
@@ -74,6 +75,7 @@ interface WithCheckoutPaymentProps {
     loadCheckout(): Promise<CheckoutSelectors>;
     loadPaymentMethods(): Promise<CheckoutSelectors>;
     submitOrder(values: OrderRequestBody): Promise<CheckoutSelectors>;
+    checkoutServiceSubscribe: CheckoutService['subscribe'];
 }
 
 interface PaymentState {
@@ -99,6 +101,8 @@ class Payment extends Component<
         submitFunctions: {},
     };
 
+    private grandTotalChangeUnsubscribe?: () => void;
+
     private getContextValue = memoizeOne(() => {
         return {
             disableSubmit: this.disableSubmit,
@@ -111,12 +115,11 @@ class Payment extends Component<
     async componentDidMount(): Promise<void> {
         const {
             finalizeOrderIfNeeded,
-            loadPaymentMethods,
             onFinalize = noop,
             onFinalizeError = noop,
             onReady = noop,
-            onUnhandledError = noop,
             usableStoreCredit,
+            checkoutServiceSubscribe,
         } = this.props;
 
 
@@ -124,17 +127,7 @@ class Payment extends Component<
             this.handleStoreCreditChange(true);
         }
 
-        try {
-            await loadPaymentMethods();
-
-            const selectedMethod = this.state.selectedMethod || this.props.defaultMethod;
-
-            if (selectedMethod) {
-                this.trackSelectedPaymentMethod(selectedMethod);
-            }
-        } catch (error) {
-            onUnhandledError(error);
-        }
+        await this.loadPaymentMethodsOrThrow();
 
         try {
             const state = await finalizeOrderIfNeeded();
@@ -146,6 +139,12 @@ class Payment extends Component<
                 onFinalizeError(error);
             }
         }
+
+        this.grandTotalChangeUnsubscribe = checkoutServiceSubscribe(
+            () => this.handleCartTotalChange(),
+            ({ data }) => data.getCheckout()?.grandTotal,
+            ({ data }) => data.getCheckout()?.outstandingBalance,
+        );
 
         window.addEventListener('beforeunload', this.handleBeforeUnload);
         this.setState({ isReady: true });
@@ -159,6 +158,11 @@ class Payment extends Component<
     }
 
     componentWillUnmount(): void {
+        if (this.grandTotalChangeUnsubscribe) {
+            this.grandTotalChangeUnsubscribe();
+            this.grandTotalChangeUnsubscribe = undefined;
+        }
+
         window.removeEventListener('beforeunload', this.handleBeforeUnload);
     }
 
@@ -540,6 +544,39 @@ class Payment extends Component<
 
         analyticsTracker.selectedPaymentMethod(methodName, methodId);
     }
+
+    private async loadPaymentMethodsOrThrow(): Promise<void> {
+        const {
+            defaultMethod,
+            loadPaymentMethods,
+            onUnhandledError = noop,
+        } = this.props;
+        const { selectedMethod = defaultMethod } = this.state;
+
+        try {
+            await loadPaymentMethods();
+
+            if (selectedMethod) {
+                this.trackSelectedPaymentMethod(selectedMethod);
+            }
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    private async handleCartTotalChange(): Promise<void> {
+        const { isReady } = this.state;
+
+        if (!isReady) {
+            return;
+        }
+
+        this.setState({ isReady: false });
+
+        await this.loadPaymentMethodsOrThrow();
+
+        this.setState({ isReady: true });
+    }
 }
 
 export function mapToPaymentProps({
@@ -654,6 +691,7 @@ export function mapToPaymentProps({
             features['PAYMENTS-6799.localise_checkout_payment_error_messages'],
         submitOrder: checkoutService.submitOrder,
         submitOrderError: getSubmitOrderError(),
+        checkoutServiceSubscribe: checkoutService.subscribe,
         termsConditionsText:
             isTermsConditionsRequired && termsConditionsType === TermsConditionsType.TextArea
                 ? termsCondtitionsText


### PR DESCRIPTION
## What?
Refetch available payment methods list after total amount change

## Why?
Some providers have available payment methods based on total amount of the cart
For example:
For Mollie we get list of available payment methods from Mollie API (on BigPay side)
and for different amount we can get different payment methods list
• amount [0.01...10000] we will receive [card, APM1, APM2, ...]
• amount 0 -> [card]
• amount more then 10000$ will return [APM1, APM2 ...]

thats why we need to refresh available payment providers  list each time when total amount changes

## Testing / Proof

https://github.com/bigcommerce/checkout-js/assets/9430298/78097dff-b3b8-4ad1-8c10-734f331b298c



@bigcommerce/team-checkout
