### PR TITLE
feat(payment): PAYPAL-3468 added providerWithCustomCheckout mapper

### DIFF
--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -25,6 +25,7 @@ import { withCheckout } from '../checkout';
 import CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 import { isErrorWithType } from '../common/error';
 import { isFloatingLabelEnabled } from '../common/utility';
+import getProviderWithCustomCheckout from '../payment/getProviderWithCustomCheckout';
 import { PaymentMethodId } from '../payment/paymentMethod';
 
 import CheckoutButtonList from './CheckoutButtonList';
@@ -596,6 +597,10 @@ export function mapToWithCheckoutCustomerProps({
         },
     } = config as StoreConfig & { checkoutSettings: { isAccountCreationEnabled: boolean } };
 
+    const providerWithCustomCheckout = getProviderWithCustomCheckout(
+        config.checkoutSettings.providerWithCustomCheckout,
+    );
+
     return {
         customerAccountFields: getCustomerAccountFields(),
         canSubscribe: config.shopperConfig.showNewsletterSignup,
@@ -625,14 +630,14 @@ export function mapToWithCheckoutCustomerProps({
         signInEmail,
         signInEmailError: getSignInEmailError(),
         privacyPolicyUrl,
-        providerWithCustomCheckout: config.checkoutSettings.providerWithCustomCheckout || undefined,
+        providerWithCustomCheckout,
         requiresMarketingConsent,
         signIn: checkoutService.signInCustomer,
         signInError: getSignInError(),
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
         isExpressPrivacyPolicy,
         isPaymentDataRequired: isPaymentDataRequired(),
-        shouldRenderStripeForm: !!(config.checkoutSettings.providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart)),
+        shouldRenderStripeForm: providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart),
     };
 }
 

--- a/packages/core/src/app/payment/getProviderWithCustomCheckout.test.ts
+++ b/packages/core/src/app/payment/getProviderWithCustomCheckout.test.ts
@@ -1,0 +1,21 @@
+import getProviderWithCustomCheckout from './getProviderWithCustomCheckout';
+import { PaymentMethodId } from './paymentMethod';
+
+describe('getProviderWithCustomCheckout', () => {
+    it('returns provided method id', () => {
+        const providerWithCustomCheckout = getProviderWithCustomCheckout(PaymentMethodId.StripeUPE);
+
+        expect(providerWithCustomCheckout).toEqual(PaymentMethodId.StripeUPE);
+    });
+
+    it('returns undefined if method id is null or it is not provided', () => {
+        expect(getProviderWithCustomCheckout(null)).toBeUndefined();
+        expect(getProviderWithCustomCheckout()).toBeUndefined();
+    });
+
+    it('returns mapped method id', () => {
+        const providerWithCustomCheckout = getProviderWithCustomCheckout(PaymentMethodId.PaypalCommerce);
+
+        expect(providerWithCustomCheckout).toEqual(PaymentMethodId.PayPalCommerceAcceleratedCheckout);
+    });
+});

--- a/packages/core/src/app/payment/getProviderWithCustomCheckout.ts
+++ b/packages/core/src/app/payment/getProviderWithCustomCheckout.ts
@@ -1,0 +1,13 @@
+import { PaymentMethodId } from './paymentMethod';
+
+export default function getProviderWithCustomCheckout(methodId?: string | null): string | undefined {
+    if (!methodId) {
+        return undefined;
+    }
+
+    if (methodId === PaymentMethodId.PaypalCommerce) {
+        return PaymentMethodId.PayPalCommerceAcceleratedCheckout;
+    }
+
+    return methodId;
+}

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -25,6 +25,7 @@ import { isEqualAddress, mapAddressFromFormValues } from '../address';
 import { withCheckout } from '../checkout';
 import CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 import { EMPTY_ARRAY, isFloatingLabelEnabled } from '../common/utility';
+import getProviderWithCustomCheckout from '../payment/getProviderWithCustomCheckout';
 import { PaymentMethodId } from '../payment/paymentMethod';
 
 import { UnassignItemError } from './errors';
@@ -395,6 +396,10 @@ export function mapToShippingProps({
     const shippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();
 
+    const providerWithCustomCheckout = getProviderWithCustomCheckout(
+        config.checkoutSettings.providerWithCustomCheckout,
+    );
+
     return {
         assignItem: checkoutService.assignItemsToAddress,
         billingAddress: getBillingAddress(),
@@ -418,7 +423,7 @@ export function mapToShippingProps({
         loadBillingAddressFields: checkoutService.loadBillingAddressFields,
         loadShippingOptions: checkoutService.loadShippingOptions,
         methodId,
-        providerWithCustomCheckout: config.checkoutSettings.providerWithCustomCheckout || undefined,
+        providerWithCustomCheckout,
         shippingAddress,
         shouldShowMultiShipping,
         shouldShowAddAddressInCheckout:
@@ -430,7 +435,7 @@ export function mapToShippingProps({
         updateCheckout: checkoutService.updateCheckout,
         updateShippingAddress: checkoutService.updateShippingAddress,
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
-        shouldRenderStripeForm: !!(config.checkoutSettings.providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart)),
+        shouldRenderStripeForm: providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart),
     };
 }
 

--- a/packages/core/src/app/shipping/getShippingMethodId.ts
+++ b/packages/core/src/app/shipping/getShippingMethodId.ts
@@ -1,11 +1,14 @@
 import { Checkout, StoreConfig } from '@bigcommerce/checkout-sdk';
 
 import { getPreselectedPayment } from '../payment';
+import getProviderWithCustomCheckout from '../payment/getProviderWithCustomCheckout';
 import { PaymentMethodId } from '../payment/paymentMethod';
 
 export default function getShippingMethodId(checkout: Checkout, config: StoreConfig): string | undefined {
     const SHIPPING_METHOD_IDS: string[] = [PaymentMethodId.AmazonPay, PaymentMethodId.BraintreeAcceleratedCheckout];
-    const providerWithCustomCheckout = config.checkoutSettings?.providerWithCustomCheckout;
+    const providerWithCustomCheckout = getProviderWithCustomCheckout(
+        config.checkoutSettings?.providerWithCustomCheckout,
+    );
     const preselectedPayment = getPreselectedPayment(checkout);
 
     if (preselectedPayment && SHIPPING_METHOD_IDS.indexOf(preselectedPayment.providerId) > -1) {


### PR DESCRIPTION
## What?
Added getProviderWithCustomCheckout method to be able to change `paypalcommerce` method id to `paypalcommerceacceleratedcheckout`. This change fixes an issue with initialising PPCP AXO customer strategy for a control group that makes PPCP Connect initialisation.

## Why?
For PPCP AXO A/B testing we manipulating with `providerWithCustomCheckout` checkout config and switch ppcp payment methods based on PPCP AXO BE module state (on/off). So in both cases we should initialise PPCP AXO customer strategy using `paypalcommerceacceleratedcheckout`, because `paypalcommerce` is responsible for rendering wallet button in customer step.

## Testing / Proof
Unit tests
CI tests