### PR TITLE
chore(payment): PAYPAL-3424 bump checkout-sdk version to v1.517.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.517.0",
+    "@bigcommerce/checkout-sdk": "^1.517.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to v1.517.3

## Why?
As part of release checkout-sdk:
https://github.com/bigcommerce/checkout-sdk-js/pull/2326
https://github.com/bigcommerce/checkout-sdk-js/pull/2325
https://github.com/bigcommerce/checkout-sdk-js/pull/2324

## Testing / Proof
Unit tests
CI tests
