### PR TITLE
chore(payment): PAYPAL-000 bump checkout-sdk version to 1.517.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.517.0",
+        "@bigcommerce/checkout-sdk": "^1.517.6",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.517.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.517.0.tgz",
-      "integrity": "sha512-Tzas1k8agYLz7EmyxLnAl+/yquTLGll/JaS+K2/Byw90rC/3OJYY9nnqbG4bMBRyNohzjJqtakAyEBDyoB9DzA==",
+      "version": "1.517.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.517.6.tgz",
+      "integrity": "sha512-onMwuCX5F/PqUlHYrygPIDFHJCQ7ZJqQclxEWE0KIcI9i8+TTQz7+Rw1ECtfygar8lnHiQWIjXGNLm+Jvgm8Vg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.517.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.517.0.tgz",
-      "integrity": "sha512-Tzas1k8agYLz7EmyxLnAl+/yquTLGll/JaS+K2/Byw90rC/3OJYY9nnqbG4bMBRyNohzjJqtakAyEBDyoB9DzA==",
+      "version": "1.517.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.517.6.tgz",
+      "integrity": "sha512-onMwuCX5F/PqUlHYrygPIDFHJCQ7ZJqQclxEWE0KIcI9i8+TTQz7+Rw1ECtfygar8lnHiQWIjXGNLm+Jvgm8Vg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.517.0",
+    "@bigcommerce/checkout-sdk": "^1.517.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.517.6

## Why?
To keep checkout-sdk dependency up to date.

The release contains: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2324 and revert for it https://github.com/bigcommerce/checkout-sdk-js/pull/2332
https://github.com/bigcommerce/checkout-sdk-js/pull/2325
https://github.com/bigcommerce/checkout-sdk-js/pull/2326
https://github.com/bigcommerce/checkout-sdk-js/pull/2323 and revert for it https://github.com/bigcommerce/checkout-sdk-js/pull/2329

## Testing / Proof
Unit tests
Manual tests
CI
