### PR TITLE
feat(payment): PAYPAL-3423 added PayPalCommerceConnect analytic implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.520.0",
+        "@bigcommerce/checkout-sdk": "^1.521.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.520.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.520.0.tgz",
-      "integrity": "sha512-UCloSlovQ8pGPBeuF0OraJVsZZTjaByirWTOgg2juab+3zOqxqc0BjPN6ZizCHgaH2Wf0NnHikkzqPG+Ooe2Fw==",
+      "version": "1.521.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.521.0.tgz",
+      "integrity": "sha512-KnAmEmypjDCit9016Zoj3VyXKGl9QUoGREfRUWKO2gaU0VQW8QwOz+B5H+3Z9E9BLcBnnVfK0O4gk0/nseNUrg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.520.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.520.0.tgz",
-      "integrity": "sha512-UCloSlovQ8pGPBeuF0OraJVsZZTjaByirWTOgg2juab+3zOqxqc0BjPN6ZizCHgaH2Wf0NnHikkzqPG+Ooe2Fw==",
+      "version": "1.521.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.521.0.tgz",
+      "integrity": "sha512-KnAmEmypjDCit9016Zoj3VyXKGl9QUoGREfRUWKO2gaU0VQW8QwOz+B5H+3Z9E9BLcBnnVfK0O4gk0/nseNUrg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.520.0",
+    "@bigcommerce/checkout-sdk": "^1.521.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/analytics/src/AnalyticsProvider.spec.tsx
+++ b/packages/analytics/src/AnalyticsProvider.spec.tsx
@@ -54,6 +54,7 @@ describe('AnalyticsProvider', () => {
     let stepTrackerMock: CheckoutSdk.StepTracker;
     let bodlServiceMock: CheckoutSdk.BodlService;
     let braintreeConnectTracker: CheckoutSdk.BraintreeConnectTrackerService;
+    let paypalCommerceConnectTracker: CheckoutSdk.PayPalCommerceConnectTrackerService;
 
     beforeEach(() => {
         jest.spyOn(createAnalyticsService, 'default').mockImplementation((createFn) => createFn);
@@ -92,6 +93,16 @@ describe('AnalyticsProvider', () => {
         };
         jest.spyOn(CheckoutSdk, 'createBraintreeConnectTracker').mockImplementation(
             () => braintreeConnectTracker,
+        );
+
+        paypalCommerceConnectTracker = {
+            customerPaymentMethodExecuted: jest.fn(),
+            selectedPaymentMethod: jest.fn(),
+            paymentComplete: jest.fn(),
+            walletButtonClick: jest.fn(),
+        };
+        jest.spyOn(CheckoutSdk, 'createPayPalCommerceConnectTracker').mockImplementation(
+            () => paypalCommerceConnectTracker,
         );
     });
 
@@ -181,6 +192,8 @@ describe('AnalyticsProvider', () => {
         });
         expect(braintreeConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalledTimes(1);
         expect(braintreeConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalled();
+        expect(paypalCommerceConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalledTimes(1);
+        expect(paypalCommerceConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalled();
     });
 
     it('track show shipping methods', () => {
@@ -193,7 +206,7 @@ describe('AnalyticsProvider', () => {
         mount(
             <TestComponent
                 eventName="selectedPaymentMethod"
-                eventProps={['Credit card', 'braintreecreditcard']}
+                eventProps={['Credit card', 'paypalcreditcard']}
             />,
         );
 
@@ -201,16 +214,24 @@ describe('AnalyticsProvider', () => {
         expect(bodlServiceMock.selectedPaymentMethod).toHaveBeenCalledWith('Credit card');
         expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
         expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledWith(
-            'braintreecreditcard',
+            'paypalcreditcard',
+        );
+        expect(paypalCommerceConnectTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(paypalCommerceConnectTracker.selectedPaymentMethod).toHaveBeenCalledWith(
+            'paypalcreditcard',
         );
     });
 
     it('track wallet button click', () => {
-        mount(<TestComponent eventName="walletButtonClick" eventProps={['braintreecreditcard']} />);
+        mount(<TestComponent eventName="walletButtonClick" eventProps={['paypalwalletbutton']} />);
 
         expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledTimes(1);
         expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledWith(
-            'braintreecreditcard',
+            'paypalwalletbutton',
+        );
+        expect(paypalCommerceConnectTracker.walletButtonClick).toHaveBeenCalledTimes(1);
+        expect(paypalCommerceConnectTracker.walletButtonClick).toHaveBeenCalledWith(
+            'paypalwalletbutton',
         );
     });
 

--- a/packages/analytics/src/AnalyticsProvider.tsx
+++ b/packages/analytics/src/AnalyticsProvider.tsx
@@ -5,7 +5,9 @@ import {
     CheckoutService,
     createBodlService,
     createBraintreeConnectTracker,
+    createPayPalCommerceConnectTracker,
     createStepTracker,
+    PayPalCommerceConnectTrackerService,
     StepTracker,
 } from '@bigcommerce/checkout-sdk';
 import React, { ReactNode, useMemo } from 'react';
@@ -32,6 +34,14 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
             createAnalyticsService<BraintreeConnectTrackerService>(createBraintreeConnectTracker, [
                 checkoutService,
             ]),
+        [checkoutService],
+    );
+    const getPayPalCommerceConnectTracker = useMemo(
+        () =>
+            createAnalyticsService<PayPalCommerceConnectTrackerService>(
+                createPayPalCommerceConnectTracker,
+                [checkoutService],
+            ),
         [checkoutService],
     );
 
@@ -69,6 +79,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
     const customerPaymentMethodExecuted = (payload: BodlEventsPayload) => {
         getBodlService().customerPaymentMethodExecuted(payload);
         getBraintreeConnectTracker().customerPaymentMethodExecuted();
+        getPayPalCommerceConnectTracker().customerPaymentMethodExecuted();
     };
 
     const showShippingMethods = () => {
@@ -78,6 +89,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
     const selectedPaymentMethod = (methodName: string, methodId: string) => {
         getBodlService().selectedPaymentMethod(methodName);
         getBraintreeConnectTracker().selectedPaymentMethod(methodId);
+        getPayPalCommerceConnectTracker().selectedPaymentMethod(methodId);
     };
 
     const clickPayButton = (payload: BodlEventsPayload) => {
@@ -91,6 +103,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
     const paymentComplete = () => {
         getBodlService().paymentComplete();
         getBraintreeConnectTracker().paymentComplete();
+        getPayPalCommerceConnectTracker().paymentComplete();
     };
 
     const exitCheckout = () => {
@@ -99,6 +112,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
 
     const walletButtonClick = (methodId: string) => {
         getBraintreeConnectTracker().walletButtonClick(methodId);
+        getPayPalCommerceConnectTracker().walletButtonClick(methodId);
     };
 
     const analyticsTracker: AnalyticsEvents = {


### PR DESCRIPTION
## What?
Added PayPalCommerceConnect analytic implementation

## Why?
To be able to track paypal connect related events on UI side

## Sibling PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/2333

## Testing / Proof
Manual tests
Unit tests
CI

Payment method selected event (on a paywall):
<img width="503" alt="Screenshot 2024-01-19 at 11 09 10" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/332c19fd-0e1c-4dbd-a2a6-478e6ee3a096">

Wallet button selected event:
<img width="519" alt="Screenshot 2024-01-19 at 11 09 59" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/fe2a6574-2517-4f1f-870c-c18b67801533">

Email submitted event:
<img width="526" alt="Screenshot 2024-01-19 at 11 11 00" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/08ec14c6-a3a7-403e-9655-65c162ddc0af">

Order placed event:
<img width="503" alt="Screenshot 2024-01-19 at 11 12 12" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/cd64a051-74fe-49bb-8c81-e92bef3ac211">