### PR TITLE
fix(payment): PI-1256 fix icon for diners_club stored card

### DIFF
--- a/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
@@ -9,19 +9,7 @@ import React, { FunctionComponent, PureComponent, ReactNode, useCallback } from 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CreditCardIcon, DropdownTrigger } from '@bigcommerce/checkout/ui';
 
-function mapFromInstrumentCardType(type: string): string {
-    switch (type) {
-        case 'amex':
-        case 'american_express':
-            return 'american-express';
-
-        case 'diners':
-            return 'diners-club';
-
-        default:
-            return type;
-    }
-}
+import { mapFromInstrumentCardType } from '../mapFromInstrumentCardType';
 
 export interface InstrumentSelectProps extends FieldProps<string> {
     instruments: CardInstrument[];


### PR DESCRIPTION
## What?
Fix credit cards brands mapper function

## Why?
To use correct [mapper function](https://github.com/bigcommerce/checkout-js/blob/master/packages/instrument-utils/src/storedInstrument/mapFromInstrumentCardType/mapFromInstrumentCardType.ts) from current package with actual brands list.
Fix icon for Diners Club cards

## Testing / Proof
Before:
<img width="634" alt="Screenshot 2024-01-18 at 17 18 57" src="https://github.com/bigcommerce/checkout-js/assets/9430298/358eccd7-aebe-420b-8efc-c847cf95cc07">
After:
<img width="620" alt="Screenshot 2024-01-18 at 17 19 51" src="https://github.com/bigcommerce/checkout-js/assets/9430298/6ec24c90-49ba-4fe7-b2b3-c9a3aec243c0">


@bigcommerce/team-checkout
