### PR TITLE
Revert "feat(payment): PI-429 [Adyen] Improve FE validation for APMs on checkout"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.519.0",
+        "@bigcommerce/checkout-sdk": "^1.519.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.519.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.0.tgz",
-      "integrity": "sha512-08aLQMNyt4zSS5jrJdiaCuXStdOLbDVf0fKpLxgI3jmykEIZ+XnUfIjtSrbbB6BYxC+/rjVonrRvXKjg7Hc4yw==",
+      "version": "1.519.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.1.tgz",
+      "integrity": "sha512-vaArAaPnh0PTL2y3byuEKzPuQjT6uuTJuD3lKVBy4nNCKYAFkMO6XgyccvqeXEPeSCCn3vTFGDs8ZItqpQF72A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.519.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.0.tgz",
-      "integrity": "sha512-08aLQMNyt4zSS5jrJdiaCuXStdOLbDVf0fKpLxgI3jmykEIZ+XnUfIjtSrbbB6BYxC+/rjVonrRvXKjg7Hc4yw==",
+      "version": "1.519.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.1.tgz",
+      "integrity": "sha512-vaArAaPnh0PTL2y3byuEKzPuQjT6uuTJuD3lKVBy4nNCKYAFkMO6XgyccvqeXEPeSCCn3vTFGDs8ZItqpQF72A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.519.0",
+    "@bigcommerce/checkout-sdk": "^1.519.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Revert "feat(payment): PI-429 [Adyen] Improve FE validation for APMs on checkout"

## Why?
Due to the issue with https://github.com/bigcommerce/checkout-sdk-js/pull/2260
Credit card payment was broken for Adyen

## Testing / Proof
Tested manually

@bigcommerce/team-checkout
