### PR TITLE
chore(payment): PAYPAL-3466 bump checkout sdk version to 1.519.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.519.1",
+        "@bigcommerce/checkout-sdk": "^1.519.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.519.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.1.tgz",
-      "integrity": "sha512-vaArAaPnh0PTL2y3byuEKzPuQjT6uuTJuD3lKVBy4nNCKYAFkMO6XgyccvqeXEPeSCCn3vTFGDs8ZItqpQF72A==",
+      "version": "1.519.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.2.tgz",
+      "integrity": "sha512-snFxES+90P/O31l7ccEJsalBFFIKQ1Revk2RQcXkmp3uD5/9okgA0VsOFUQ6tkbAEUtG/v9D8D0UBie0pdPb5g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.519.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.1.tgz",
-      "integrity": "sha512-vaArAaPnh0PTL2y3byuEKzPuQjT6uuTJuD3lKVBy4nNCKYAFkMO6XgyccvqeXEPeSCCn3vTFGDs8ZItqpQF72A==",
+      "version": "1.519.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.2.tgz",
+      "integrity": "sha512-snFxES+90P/O31l7ccEJsalBFFIKQ1Revk2RQcXkmp3uD5/9okgA0VsOFUQ6tkbAEUtG/v9D8D0UBie0pdPb5g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.519.1",
+    "@bigcommerce/checkout-sdk": "^1.519.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.519.2

## Why?
To keep checkout-sdk dependency up to date:
https://github.com/bigcommerce/checkout-sdk-js/pull/2330
https://github.com/bigcommerce/checkout-sdk-js/pull/2334

## Testing / Proof
Unit tests
Manual tests
CI
