### PR TITLE
chore(payment): PI-1309 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.519.2",
+        "@bigcommerce/checkout-sdk": "^1.520.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.519.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.2.tgz",
-      "integrity": "sha512-snFxES+90P/O31l7ccEJsalBFFIKQ1Revk2RQcXkmp3uD5/9okgA0VsOFUQ6tkbAEUtG/v9D8D0UBie0pdPb5g==",
+      "version": "1.520.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.520.0.tgz",
+      "integrity": "sha512-UCloSlovQ8pGPBeuF0OraJVsZZTjaByirWTOgg2juab+3zOqxqc0BjPN6ZizCHgaH2Wf0NnHikkzqPG+Ooe2Fw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.519.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.519.2.tgz",
-      "integrity": "sha512-snFxES+90P/O31l7ccEJsalBFFIKQ1Revk2RQcXkmp3uD5/9okgA0VsOFUQ6tkbAEUtG/v9D8D0UBie0pdPb5g==",
+      "version": "1.520.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.520.0.tgz",
+      "integrity": "sha512-UCloSlovQ8pGPBeuF0OraJVsZZTjaByirWTOgg2juab+3zOqxqc0BjPN6ZizCHgaH2Wf0NnHikkzqPG+Ooe2Fw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.519.2",
+    "@bigcommerce/checkout-sdk": "^1.520.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
do deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2331](https://github.com/bigcommerce/checkout-sdk-js/pull/2331)

## Testing / Proof
Unit tests and manually tested

@bigcommerce/team-checkout
