### PR TITLE
feat(payment): PAYPAL-3419 added PPCP AXO method id to shipping strategy method id mapper

### DIFF
--- a/packages/core/src/app/shipping/getShippingMethodId.test.tsx
+++ b/packages/core/src/app/shipping/getShippingMethodId.test.tsx
@@ -52,6 +52,12 @@ describe('getShippingMethodId', () => {
         expect(getShippingMethodId(checkout, config)).toBe(PaymentMethodId.BraintreeAcceleratedCheckout);
     });
 
+    it('returns shipping method id from provider with custom checkout (PayPal Commerce Accelerated Checkout check)', () => {
+        const [checkout, config] = mockOptions(PaymentMethodId.PayPalCommerceAcceleratedCheckout);
+
+        expect(getShippingMethodId(checkout, config)).toBe(PaymentMethodId.PayPalCommerceAcceleratedCheckout);
+    });
+
     it('returns shipping method id from preselected payment method', () => {
         const [checkout, config] = mockOptions(
             PaymentMethodId.BraintreeAcceleratedCheckout,

--- a/packages/core/src/app/shipping/getShippingMethodId.ts
+++ b/packages/core/src/app/shipping/getShippingMethodId.ts
@@ -5,7 +5,11 @@ import getProviderWithCustomCheckout from '../payment/getProviderWithCustomCheck
 import { PaymentMethodId } from '../payment/paymentMethod';
 
 export default function getShippingMethodId(checkout: Checkout, config: StoreConfig): string | undefined {
-    const SHIPPING_METHOD_IDS: string[] = [PaymentMethodId.AmazonPay, PaymentMethodId.BraintreeAcceleratedCheckout];
+    const SHIPPING_METHOD_IDS: string[] = [
+        PaymentMethodId.AmazonPay,
+        PaymentMethodId.BraintreeAcceleratedCheckout,
+        PaymentMethodId.PayPalCommerceAcceleratedCheckout,
+    ];
     const providerWithCustomCheckout = getProviderWithCustomCheckout(
         config.checkoutSettings?.providerWithCustomCheckout,
     );


### PR DESCRIPTION
## What?
Added PayPalCommerceAcceleratedCheckout method id to shipping strategy method id mapper

## Why?
To be able to initialise PayPalCommerceAcceleratedCheckout shipping strategy when providerWithCustomCheckout is `paypalcommerceacceleratedcheckout`

## Testing / Proof
Unit tests
Manual tests
