### PR TITLE
feat(payment): PAYPAL-3469 enable submit button after error

### DIFF
--- a/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PaypalCommerceRatePayPaymentMethod.tsx
@@ -58,7 +58,6 @@ const formFieldData: FormField[] = [
 const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
     method,
     checkoutService,
-    paymentForm,
     onUnhandledError,
     paymentForm: {
         isSubmitted,
@@ -92,7 +91,6 @@ const PaypalCommerceRatePayPaymentMethod: FunctionComponent<any> = ({
                     loadingContainerId: 'checkout-page-container',
                     getFieldsValues: () => fieldsValues.current,
                     onError: (error: SpecificError) => {
-                        paymentForm.disableSubmit(method, true);
                         const ratepaySpecificError = error?.errors?.filter(e => e.provider_error);
 
                         if (ratepaySpecificError?.length) {


### PR DESCRIPTION
## What?
Enabled submit button after error

## Why?
To enable submit button for another try

## Testing / Proof

**Before**

https://github.com/bigcommerce/checkout-js/assets/56301104/f8cf6a34-aa14-44aa-a1cd-59e0627c569e



**After**

https://github.com/bigcommerce/checkout-js/assets/56301104/2fddce09-563f-46ae-8150-d1d2104cea6e




@bigcommerce/team-checkout
