### PR TITLE
feat(payment): PAYPAL-3113 bump ckeckout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.523.0",
+        "@bigcommerce/checkout-sdk": "^1.524.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.523.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.523.0.tgz",
-      "integrity": "sha512-zgnRnWe44ZwEl+/xSs+zs1yInazc888goTY4aJWOT2610qsftkDLZPjJMmsr+hrGbRqhYU1wIbhpoeThTercXQ==",
+      "version": "1.524.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.524.0.tgz",
+      "integrity": "sha512-rB36Sy7eGx/boY4GSMiA4H5AMw6/ZfnLkWpFV4w3upfEHWkkAMCoGl/Tum5IoRMcSkzTfi2lknl20oaxd+zO0w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.523.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.523.0.tgz",
-      "integrity": "sha512-zgnRnWe44ZwEl+/xSs+zs1yInazc888goTY4aJWOT2610qsftkDLZPjJMmsr+hrGbRqhYU1wIbhpoeThTercXQ==",
+      "version": "1.524.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.524.0.tgz",
+      "integrity": "sha512-rB36Sy7eGx/boY4GSMiA4H5AMw6/ZfnLkWpFV4w3upfEHWkkAMCoGl/Tum5IoRMcSkzTfi2lknl20oaxd+zO0w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.523.0",
+    "@bigcommerce/checkout-sdk": "^1.524.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump ckeckout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2301

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
