### PR TITLE
feat(payment): PAYPAL-3499 authenticate user with PayPal Connect after sing in/up

### DIFF
--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -17,7 +17,7 @@ import React, { Component, ReactNode } from 'react';
 import { AnalyticsContextProps } from '@bigcommerce/checkout/analytics';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
-import { isBraintreeConnectMethod } from '@bigcommerce/checkout/paypal-connect-integration';
+import { isPaypalConnectMethod } from '@bigcommerce/checkout/paypal-connect-integration';
 import { CustomerSkeleton } from '@bigcommerce/checkout/ui';
 
 import { withAnalytics } from '../analytics';
@@ -451,7 +451,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
         try {
             await signIn(credentials);
 
-            if (isBraintreeConnectMethod(providerWithCustomCheckout)) {
+            if (isPaypalConnectMethod(providerWithCustomCheckout)) {
                 await executePaymentMethodCheckout({
                     methodId: providerWithCustomCheckout,
                     continueWithCheckoutCallback: onSignIn,
@@ -477,7 +477,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
         await createAccount(mapCreateAccountFromFormValues(values));
 
-        if (isBraintreeConnectMethod(providerWithCustomCheckout)) {
+        if (isPaypalConnectMethod(providerWithCustomCheckout)) {
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onAccountCreated,


### PR DESCRIPTION
## What?
Added PP Connect user authentication for cases when customer sign in or sign up on checkout page

## Why?
For PP Connect customer's to be able to prefill checkout form with PP Connect data

## Testing / Proof
Unit tests
Manual tests
CI

Here is a screen record for sign in flow:

https://github.com/bigcommerce/checkout-js/assets/25133454/2c8faa00-4b47-4ed9-9a80-e379de4c4d60

Also a screenshot of working sign up flow:
<img width="823" alt="Screenshot 2024-01-31 at 12 17 37" src="https://github.com/bigcommerce/checkout-js/assets/25133454/80c4a988-d1a5-445e-8757-659eb7b85165">



