### PR TITLE
chore(payment): PAYPAL-3419 bump checkout sdk version to 1.530.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.529.0",
+        "@bigcommerce/checkout-sdk": "^1.530.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.529.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.529.0.tgz",
-      "integrity": "sha512-TBjWYzmKB+S/CYtuNpM3G1cq1ASGMN3JFpKhG7Vc6jlysCU/dr6MbZCv/3exeQRDLzdMMtVKSM8STL3q32UULQ==",
+      "version": "1.530.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.530.0.tgz",
+      "integrity": "sha512-Y4WULcsOZbh2VSnzmi+ms8LaAjfgCvphM6n/Xr8qUkqaY0ty3grCWYi4Koh6P46mK1lqRopwcYLpWZvEs4yAkA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.529.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.529.0.tgz",
-      "integrity": "sha512-TBjWYzmKB+S/CYtuNpM3G1cq1ASGMN3JFpKhG7Vc6jlysCU/dr6MbZCv/3exeQRDLzdMMtVKSM8STL3q32UULQ==",
+      "version": "1.530.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.530.0.tgz",
+      "integrity": "sha512-Y4WULcsOZbh2VSnzmi+ms8LaAjfgCvphM6n/Xr8qUkqaY0ty3grCWYi4Koh6P46mK1lqRopwcYLpWZvEs4yAkA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.529.0",
+    "@bigcommerce/checkout-sdk": "^1.530.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout sdk version to 1.530.0

## Why?
As part of checkout-sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2339

## Testing / Proof
Unit tests
Manual tests
CI
