### PR TITLE
fix(payment): PAYPAL-3519 fixed the issue with analytic tracking of selected payment method on payment step load

### DIFF
--- a/packages/core/src/app/payment/Payment.spec.tsx
+++ b/packages/core/src/app/payment/Payment.spec.tsx
@@ -1,6 +1,5 @@
 import {
     CartConsistencyError,
-    Checkout,
     CheckoutSelectors,
     CheckoutService,
     createCheckoutService,
@@ -46,29 +45,29 @@ describe('Payment', () => {
     ) => {
         const subscribeEventEmitter = new EventEmitter();
         let previousFilterValue: any;
-    
+
         jest.spyOn(checkoutService, 'subscribe').mockImplementation(
             (subscriber, filter = noop) => {
                 subscribeEventEmitter.on('change', () => {
                     const filterValue = filter(checkoutService.getState());
-                    
+
                     if (!filterValue || previousFilterValue === filterValue) {
                         return noop;
                     } else if (!previousFilterValue) {
                         previousFilterValue = filterValue;
-                        
+
                         return noop;
                     }
 
                     previousFilterValue = filterValue;
-                    
+
                     return subscriber(checkoutService.getState());
                 });
                 subscribeEventEmitter.emit('change');
-    
+
                 return noop;
             });
-    
+
         return subscribeEventEmitter;
     }
 

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -547,14 +547,14 @@ class Payment extends Component<
 
     private async loadPaymentMethodsOrThrow(): Promise<void> {
         const {
-            defaultMethod,
             loadPaymentMethods,
             onUnhandledError = noop,
         } = this.props;
-        const { selectedMethod = defaultMethod } = this.state;
 
         try {
             await loadPaymentMethods();
+
+            const selectedMethod = this.state.selectedMethod || this.props.defaultMethod;
 
             if (selectedMethod) {
                 this.trackSelectedPaymentMethod(selectedMethod);


### PR DESCRIPTION
## What?
Fixed the issue with analytic tracking of selected payment method on payment step load

## Why?
When the form is loaded we have different payment method selected by default, but it is not the same that provided to analytics tracking method on payment step first load. This issue occurs because prev default payment method provided to tracking method instead of actual one.

## Testing / Proof
Manual tests
CI

Before:
<img width="1512" alt="Screenshot 2024-02-01 at 12 49 02" src="https://github.com/bigcommerce/checkout-js/assets/25133454/59ec7c33-6db6-4371-ae08-5f63f6da136e">

After:
<img width="1512" alt="Screenshot 2024-02-01 at 12 44 34" src="https://github.com/bigcommerce/checkout-js/assets/25133454/6286e912-8461-48ff-964d-5b12c46ea68f">


