### PR TITLE
chore(others): CHECKOUT-000 Extend codeownership of package json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,9 @@
 /packages/test-framework @bigcommerce/team-checkout
 /packages/workspace-tools @bigcommerce/team-checkout
 
+## Shared
+package.json @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+package-lock.json @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 
 ## Payment integrations team
 


### PR DESCRIPTION
## What?
Extend codeownership of package.json and package-lock.json file

## Why?
In order for payment integration teams to become autonomous it will be nice for teams to own checkout SDK bumps.

## Testing / Proof
- CI

@bigcommerce/team-checkout
