### PR TITLE
chore(payment): PAYPAL-3560 bump checkout sdk version to 1.533.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.532.0",
+        "@bigcommerce/checkout-sdk": "^1.533.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.532.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.532.0.tgz",
-      "integrity": "sha512-rUF90Ta9DfRamBP2GyxRawyZwXMOYAb+GP2VZwxFxLUq/lHgVU88YhC9gkiBB5YQyRkvUH8MFKt2Z4JRai5QyA==",
+      "version": "1.533.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.533.0.tgz",
+      "integrity": "sha512-sRc7gj6JDNkqAXzd7JagfoJ6P+Z42RLb3P7fIuq+p0scj32kSfLZRv22mz684IhVVRLqf/6S2ZNmTMGRIgHyrg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.532.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.532.0.tgz",
-      "integrity": "sha512-rUF90Ta9DfRamBP2GyxRawyZwXMOYAb+GP2VZwxFxLUq/lHgVU88YhC9gkiBB5YQyRkvUH8MFKt2Z4JRai5QyA==",
+      "version": "1.533.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.533.0.tgz",
+      "integrity": "sha512-sRc7gj6JDNkqAXzd7JagfoJ6P+Z42RLb3P7fIuq+p0scj32kSfLZRv22mz684IhVVRLqf/6S2ZNmTMGRIgHyrg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.532.0",
+    "@bigcommerce/checkout-sdk": "^1.533.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.533.0

## Why?
As part of checkout sdk release:

## Testing / Proof
Unit tests
Manual tests
CI
