### PR TITLE
fix(payment): PAYPAL-3560 updated paypal commerce connect method mapping

### DIFF
--- a/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.test.ts
+++ b/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.test.ts
@@ -4,7 +4,7 @@ import isPayPalCommerceConnectMethod from './is-paypal-commerce-connect-method';
 
 describe('isPaypalCommerceConnectMethod', () => {
     it('returns true if provided methodId is related to PayPal Connect', () => {
-        expect(isPayPalCommerceConnectMethod(PaymentMethodId.PaypalCommerce)).toBe(true);
+        expect(isPayPalCommerceConnectMethod(PaymentMethodId.PaypalCommerceCreditCards)).toBe(true);
         expect(
             isPayPalCommerceConnectMethod(PaymentMethodId.PayPalCommerceAcceleratedCheckout),
         ).toBe(true);

--- a/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.ts
+++ b/packages/paypal-connect-integration/src/is-paypal-commerce-connect-method.ts
@@ -2,7 +2,7 @@ import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
 
 const isPayPalCommerceConnectMethod = (methodId?: string): boolean => {
     return (
-        methodId === PaymentMethodId.PaypalCommerce || // TODO: remove after A/B testing
+        methodId === PaymentMethodId.PaypalCommerceCreditCards || // TODO: remove after A/B testing
         methodId === PaymentMethodId.PayPalCommerceAcceleratedCheckout
     );
 };


### PR DESCRIPTION
## What?
Updated paypal commerce connect method mapping

## Why?
To be able to show address select with addresses from PP Connect for customer in shipping and billing steps

## Testing / Proof
Unit tests
Manual tests
CI

<img width="845" alt="Screenshot 2024-02-06 at 16 52 25" src="https://github.com/bigcommerce/checkout-js/assets/25133454/2f40d939-ce27-4062-9a3a-1886cebda66a">

