### PR TITLE
chore(payment): PI-1487 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.533.0",
+        "@bigcommerce/checkout-sdk": "^1.534.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.533.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.533.0.tgz",
-      "integrity": "sha512-sRc7gj6JDNkqAXzd7JagfoJ6P+Z42RLb3P7fIuq+p0scj32kSfLZRv22mz684IhVVRLqf/6S2ZNmTMGRIgHyrg==",
+      "version": "1.534.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.534.0.tgz",
+      "integrity": "sha512-beDWf1zNlwteZjG2XAQ4FFC6cQGulCfrrYLB4zIEe9OifX2L3iPBAzXJGKQwTQEsGhFNokLTrFBShMewsLHePQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.533.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.533.0.tgz",
-      "integrity": "sha512-sRc7gj6JDNkqAXzd7JagfoJ6P+Z42RLb3P7fIuq+p0scj32kSfLZRv22mz684IhVVRLqf/6S2ZNmTMGRIgHyrg==",
+      "version": "1.534.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.534.0.tgz",
+      "integrity": "sha512-beDWf1zNlwteZjG2XAQ4FFC6cQGulCfrrYLB4zIEe9OifX2L3iPBAzXJGKQwTQEsGhFNokLTrFBShMewsLHePQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.533.0",
+    "@bigcommerce/checkout-sdk": "^1.534.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2350](https://github.com/bigcommerce/checkout-sdk-js/pull/2350)

## Testing / Proof
manually tested and unit tetst

@bigcommerce/team-checkout
