### PR TITLE
chore(others): CHECKOUT-000 Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In order to build from the source code, you must have the following set up in yo
 
 * Node >= v16.
 * NPM >= v8.
-* Unix-based operating system.
+* Unix-based operating system. (WSL on Windows)
 
 One of the simplest ways to install Node is using [NVM](https://github.com/nvm-sh/nvm#installation-and-update). You can follow their instructions to set up your environment if it is not already set up.
 


### PR DESCRIPTION
## What?
Update Readme to reflect that UNIX-based operating systems, for a Windows user means Windows Subsystem for Linux.

## Why?
It often comes up in issues, thus it seems we could be more explicit about what that means for Windows users

## Testing / Proof
N/A

@bigcommerce/team-checkout
