### PR TITLE
fix(checkout): Add missing Order Comments input id

### DIFF
--- a/packages/core/src/app/orderComments/OrderComments.tsx
+++ b/packages/core/src/app/orderComments/OrderComments.tsx
@@ -31,7 +31,7 @@ const OrderComments: FunctionComponent = () => {
 
     return (
         <Fieldset legend={legend} testId="checkout-shipping-comments">
-            <FormField input={renderInput} label={renderLabel} name="orderComment" />
+            <FormField input={renderInput} label={renderLabel} name="orderComment" id="orderComment" />
         </Fieldset>
     );
 };


### PR DESCRIPTION
## What?
Added the missing ID attribute to the Order Comment input

## Why?
To match the label and fix accessibility issues

## Testing / Proof


@bigcommerce/team-checkout
