### PR TITLE
fix(checkout): CHECKOUT-000 Add focus to checkout-customer-login

### DIFF
--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -102,8 +102,7 @@ const GuestForm: FunctionComponent<
                     <p>
                         <TranslatedString id="customer.login_text" />{' '}
                         <a
-                            href="#"
-                            tabIndex="0"
+                            tabIndex={0}
                             role="button"
                             data-test="customer-continue-button"
                             id="checkout-customer-login"

--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -102,6 +102,9 @@ const GuestForm: FunctionComponent<
                     <p>
                         <TranslatedString id="customer.login_text" />{' '}
                         <a
+                            href="#"
+                            tabIndex="0"
+                            role="button"
                             data-test="customer-continue-button"
                             id="checkout-customer-login"
                             onClick={onShowLogin}

--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -227,6 +227,9 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                                 <TranslatedString id="customer.login_text"/>
                                 { ' ' }
                                 <a
+                                    href="#"
+                                    tabIndex="0"
+                                    role="button"
                                     data-test="customer-continue-button"
                                     id="checkout-customer-login"
                                     onClick={ onShowLogin }

--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -227,8 +227,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                                 <TranslatedString id="customer.login_text"/>
                                 { ' ' }
                                 <a
-                                    href="#"
-                                    tabIndex="0"
+                                    tabIndex={0}
                                     role="button"
                                     data-test="customer-continue-button"
                                     id="checkout-customer-login"

--- a/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -84,6 +84,9 @@ exports[`Customer when view type is "guest" matches snapshot 1`] = `
           <p>
             Already have an account? 
             <a
+              href="#"
+              tabIndex="0"
+              role="button"
               data-test="customer-continue-button"
               id="checkout-customer-login"
             >

--- a/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -84,10 +84,10 @@ exports[`Customer when view type is "guest" matches snapshot 1`] = `
           <p>
             Already have an account? 
             <a
-              tabIndex="0"
-              role="button"
               data-test="customer-continue-button"
               id="checkout-customer-login"
+              role="button"
+              tabindex="0"
             >
               Sign in now
             </a>

--- a/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -84,8 +84,7 @@ exports[`Customer when view type is "guest" matches snapshot 1`] = `
           <p>
             Already have an account? 
             <a
-              href="#"
-              tabIndex="0"
+              tabIndex={0}
               role="button"
               data-test="customer-continue-button"
               id="checkout-customer-login"

--- a/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/Customer.spec.tsx.snap
@@ -84,7 +84,7 @@ exports[`Customer when view type is "guest" matches snapshot 1`] = `
           <p>
             Already have an account? 
             <a
-              tabIndex={0}
+              tabIndex="0"
               role="button"
               data-test="customer-continue-button"
               id="checkout-customer-login"

--- a/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
@@ -81,8 +81,7 @@ exports[`GuestForm matches snapshot 1`] = `
         <p>
           Already have an account? 
           <a
-            href="#"
-            tabIndex="0"
+            tabIndex={0}
             role="button"
             data-test="customer-continue-button"
             id="checkout-customer-login"

--- a/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
@@ -81,10 +81,10 @@ exports[`GuestForm matches snapshot 1`] = `
         <p>
           Already have an account? 
           <a
-            tabIndex="0"
-            role="button"
             data-test="customer-continue-button"
             id="checkout-customer-login"
+            role="button"
+            tabindex="0"
           >
             Sign in now
           </a>

--- a/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
@@ -81,6 +81,9 @@ exports[`GuestForm matches snapshot 1`] = `
         <p>
           Already have an account? 
           <a
+            href="#"
+            tabIndex="0"
+            role="button"
             data-test="customer-continue-button"
             id="checkout-customer-login"
           >

--- a/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/GuestForm.spec.tsx.snap
@@ -81,7 +81,7 @@ exports[`GuestForm matches snapshot 1`] = `
         <p>
           Already have an account? 
           <a
-            tabIndex={0}
+            tabIndex="0"
             role="button"
             data-test="customer-continue-button"
             id="checkout-customer-login"

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
@@ -105,7 +105,7 @@ Object {
                   Already have an account?
                    
                   <a
-                    tabIndex={0}
+                    tabIndex="0"
                     role="button"
                     data-test="customer-continue-button"
                     id="checkout-customer-login"
@@ -239,7 +239,7 @@ Object {
                 Already have an account?
                  
                 <a
-                  tabIndex={0}
+                  tabIndex="0"
                   role="button"
                   data-test="customer-continue-button"
                   id="checkout-customer-login"

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
@@ -105,10 +105,10 @@ Object {
                   Already have an account?
                    
                   <a
-                    tabIndex="0"
-                    role="button"
                     data-test="customer-continue-button"
                     id="checkout-customer-login"
+                    role="button"
+                    tabindex="0"
                   >
                     Sign in now
                   </a>
@@ -239,10 +239,10 @@ Object {
                 Already have an account?
                  
                 <a
-                  tabIndex="0"
-                  role="button"
                   data-test="customer-continue-button"
                   id="checkout-customer-login"
+                  role="button"
+                  tabindex="0"
                 >
                   Sign in now
                 </a>

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
@@ -105,8 +105,7 @@ Object {
                   Already have an account?
                    
                   <a
-                    href="#"
-                    tabIndex="0"
+                    tabIndex={0}
                     role="button"
                     data-test="customer-continue-button"
                     id="checkout-customer-login"
@@ -240,8 +239,7 @@ Object {
                 Already have an account?
                  
                 <a
-                  href="#"
-                  tabIndex="0"
+                  tabIndex={0}
                   role="button"
                   data-test="customer-continue-button"
                   id="checkout-customer-login"

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
@@ -105,6 +105,9 @@ Object {
                   Already have an account?
                    
                   <a
+                    href="#"
+                    tabIndex="0"
+                    role="button"
                     data-test="customer-continue-button"
                     id="checkout-customer-login"
                   >
@@ -237,6 +240,9 @@ Object {
                 Already have an account?
                  
                 <a
+                  href="#"
+                  tabIndex="0"
+                  role="button"
                   data-test="customer-continue-button"
                   id="checkout-customer-login"
                 >


### PR DESCRIPTION
## What?
Add `tabIndex` and `role="button"` to `#checkout-customer-index`

## Why?
As proposed in #1412 adding these properties will allow screen readers and keyboard users to focus the 'Sign in now` Link

## Testing / Proof
<img width="716" alt="Screenshot 2024-02-14 at 11 34 21" src="https://github.com/bigcommerce/checkout-js/assets/106064302/779b4a49-9045-4ca3-9eed-f360385fdd14">


@bigcommerce/team-checkout
