### PR TITLE
chore(payment): PAYPAL-3573 bump checkout sdk version to 1.540.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.539.0",
+        "@bigcommerce/checkout-sdk": "^1.540.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.539.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.539.0.tgz",
-      "integrity": "sha512-HAJwpmgDSQONooa87QcAnTs1Rdq3mZ+Y5O3M8f43vYJxi2cIA8nx+dfdBpJxzrun90i5tnntPQ3VtOoPbT/wQA==",
+      "version": "1.540.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.540.0.tgz",
+      "integrity": "sha512-M9KbkBIemF54bMo4/dCkkgfrrqoSkMV9Wtc2m+aqdgy/TaTtRRweE4fXSHArBsgirJ7vHgA6xmY0fxFyOv/lNg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.539.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.539.0.tgz",
-      "integrity": "sha512-HAJwpmgDSQONooa87QcAnTs1Rdq3mZ+Y5O3M8f43vYJxi2cIA8nx+dfdBpJxzrun90i5tnntPQ3VtOoPbT/wQA==",
+      "version": "1.540.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.540.0.tgz",
+      "integrity": "sha512-M9KbkBIemF54bMo4/dCkkgfrrqoSkMV9Wtc2m+aqdgy/TaTtRRweE4fXSHArBsgirJ7vHgA6xmY0fxFyOv/lNg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.539.0",
+    "@bigcommerce/checkout-sdk": "^1.540.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.540.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2362
https://github.com/bigcommerce/checkout-sdk-js/pull/2361

## Testing / Proof
Unit tests
Manual tests
CI
