### PR TITLE
chore(payment): PAYPAL-3574 bump checkout-sdk version to 1.543.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.541.0",
+        "@bigcommerce/checkout-sdk": "^1.543.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.541.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.541.0.tgz",
-      "integrity": "sha512-QU5MpxnKJJdjeKY2iD/fx/4dIHo8rD+nMHqJBssfwqxXKUVauXbLgNzDFYLZx9x2wIrqRTqRAgc7dqRC3cM4tA==",
+      "version": "1.543.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.543.0.tgz",
+      "integrity": "sha512-h9qR7XrZ5rK864eAPjE4alr6htEs3FUygKHmFT+Q1G0fgLJGg8612ofeL2wQDuUcw+d1eDfWMKYui24mt3wXag==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.541.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.541.0.tgz",
-      "integrity": "sha512-QU5MpxnKJJdjeKY2iD/fx/4dIHo8rD+nMHqJBssfwqxXKUVauXbLgNzDFYLZx9x2wIrqRTqRAgc7dqRC3cM4tA==",
+      "version": "1.543.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.543.0.tgz",
+      "integrity": "sha512-h9qR7XrZ5rK864eAPjE4alr6htEs3FUygKHmFT+Q1G0fgLJGg8612ofeL2wQDuUcw+d1eDfWMKYui24mt3wXag==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.541.0",
+    "@bigcommerce/checkout-sdk": "^1.543.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.543.0

## Why?
As part of checkout sdk release. The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/2364
https://github.com/bigcommerce/checkout-sdk-js/pull/2366
https://github.com/bigcommerce/checkout-sdk-js/pull/2363

## Testing / Proof
Unit tests
Manual tests
CI
