### PR TITLE
fix(customer): CHECKOUT-8033 Fix issue with subscription checkbox not selected

### DIFF
--- a/packages/core/src/app/customer/CreateAccountForm.tsx
+++ b/packages/core/src/app/customer/CreateAccountForm.tsx
@@ -23,14 +23,48 @@ export interface CreateAccountFormProps {
     isCreatingAccount?: boolean;
     isExecutingPaymentMethodCheckout?: boolean;
     requiresMarketingConsent: boolean;
+    defaultShouldSubscribe: boolean;
     isFloatingLabelEnabled?: boolean;
     onCancel?(): void;
     onSubmit(values: CreateAccountFormValues): void;
 }
 
+function getacceptsMarketingEmailsDefault(defaultShouldSubscribe: boolean, requiresMarketingConsent: boolean): string[] {
+    if (defaultShouldSubscribe) {
+        return ['1'];
+    }
+
+    return requiresMarketingConsent ? [] : ['0'];
+}
+
+function transformFormFieldsData(formFields: FormField[], defaultShouldSubscribe: boolean): FormField[] {
+    return formFields.map(field => {
+        if (field.name === 'acceptsMarketingEmails') {
+            const { options } = field;
+            const items = options?.items || [];
+            
+            const updatedItems = items.map(item => {
+                return {
+                    value: defaultShouldSubscribe ? '1' : item.value,
+                    label: item.label,
+                }
+            });
+
+            return {
+                ...field,
+                options: {
+                    items: updatedItems,
+                }
+            }
+        }
+
+        return field;
+    });
+}
+
 const CreateAccountForm: FunctionComponent<
     CreateAccountFormProps & WithLanguageProps & FormikProps<CreateAccountFormValues>
-> = ({ formFields, createAccountError, isCreatingAccount, isExecutingPaymentMethodCheckout, onCancel, isFloatingLabelEnabled }) => {
+> = ({ formFields, createAccountError, isCreatingAccount, isExecutingPaymentMethodCheckout, onCancel, isFloatingLabelEnabled, defaultShouldSubscribe }) => {
     const createAccountErrorMessage = useMemo(() => {
         if (!createAccountError) {
             return;
@@ -65,7 +99,7 @@ const CreateAccountForm: FunctionComponent<
                     <Alert type={AlertType.Error}>{createAccountErrorMessage}</Alert>
                 )}
                 <div className="create-account-form">
-                    {formFields.map((field) => (
+                    {transformFormFieldsData(formFields, defaultShouldSubscribe).map((field) => (
                         <DynamicFormField
                             autocomplete={field.name}
                             extraClass={`dynamic-form-field--${field.name}`}
@@ -81,8 +115,8 @@ const CreateAccountForm: FunctionComponent<
             <div className="form-actions">
                 <Button
                     disabled={isCreatingAccount || isExecutingPaymentMethodCheckout}
-                    isLoading={isCreatingAccount || isExecutingPaymentMethodCheckout}
                     id="checkout-customer-create"
+                    isLoading={isCreatingAccount || isExecutingPaymentMethodCheckout}
                     testId="customer-continue-create"
                     type="submit"
                     variant={ButtonVariant.Primary}
@@ -109,13 +143,13 @@ export default withLanguage(
         handleSubmit: (values, { props: { onSubmit = noop } }) => {
             onSubmit(values);
         },
-        mapPropsToValues: ({ requiresMarketingConsent }) => ({
+        mapPropsToValues: ({ defaultShouldSubscribe, requiresMarketingConsent }) => ({
             firstName: '',
             lastName: '',
             email: '',
             password: '',
             customFields: {},
-            acceptsMarketingEmails: requiresMarketingConsent ? [] : ['0'],
+            acceptsMarketingEmails: getacceptsMarketingEmailsDefault(defaultShouldSubscribe, requiresMarketingConsent),
         }),
         validationSchema: ({
             language,

--- a/packages/core/src/app/customer/CreateAccountForm.tsx
+++ b/packages/core/src/app/customer/CreateAccountForm.tsx
@@ -20,6 +20,7 @@ import './CreateAccountForm.scss';
 export interface CreateAccountFormProps {
     formFields: FormField[];
     createAccountError?: Error;
+    fixNewsletterCheckboxExperimentEnabled: boolean;
     isCreatingAccount?: boolean;
     isExecutingPaymentMethodCheckout?: boolean;
     requiresMarketingConsent: boolean;
@@ -29,7 +30,7 @@ export interface CreateAccountFormProps {
     onSubmit(values: CreateAccountFormValues): void;
 }
 
-function getacceptsMarketingEmailsDefault(defaultShouldSubscribe: boolean, requiresMarketingConsent: boolean): string[] {
+function getAcceptsMarketingEmailsDefault(defaultShouldSubscribe: boolean, requiresMarketingConsent: boolean): string[] {
     if (defaultShouldSubscribe) {
         return ['1'];
     }
@@ -64,7 +65,7 @@ function transformFormFieldsData(formFields: FormField[], defaultShouldSubscribe
 
 const CreateAccountForm: FunctionComponent<
     CreateAccountFormProps & WithLanguageProps & FormikProps<CreateAccountFormValues>
-> = ({ formFields, createAccountError, isCreatingAccount, isExecutingPaymentMethodCheckout, onCancel, isFloatingLabelEnabled, defaultShouldSubscribe }) => {
+> = ({ fixNewsletterCheckboxExperimentEnabled, formFields, createAccountError, isCreatingAccount, isExecutingPaymentMethodCheckout, onCancel, isFloatingLabelEnabled, defaultShouldSubscribe }) => {
     const createAccountErrorMessage = useMemo(() => {
         if (!createAccountError) {
             return;
@@ -88,6 +89,9 @@ const CreateAccountForm: FunctionComponent<
         return createAccountError.message;
     }, [createAccountError]);
 
+    const fields = fixNewsletterCheckboxExperimentEnabled ?
+        transformFormFieldsData(formFields, defaultShouldSubscribe): formFields;
+
     return (
         <Form
             className="checkout-form"
@@ -99,7 +103,7 @@ const CreateAccountForm: FunctionComponent<
                     <Alert type={AlertType.Error}>{createAccountErrorMessage}</Alert>
                 )}
                 <div className="create-account-form">
-                    {transformFormFieldsData(formFields, defaultShouldSubscribe).map((field) => (
+                    {fields.map((field) => (
                         <DynamicFormField
                             autocomplete={field.name}
                             extraClass={`dynamic-form-field--${field.name}`}
@@ -149,7 +153,7 @@ export default withLanguage(
             email: '',
             password: '',
             customFields: {},
-            acceptsMarketingEmails: getacceptsMarketingEmailsDefault(defaultShouldSubscribe, requiresMarketingConsent),
+            acceptsMarketingEmails: getAcceptsMarketingEmailsDefault(defaultShouldSubscribe, requiresMarketingConsent),
         }),
         validationSchema: ({
             language,

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -200,8 +200,8 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             initialize={initializeCustomer}
             isInitializing={isInitializing}
             methodIds={checkoutButtonIds}
-            onError={onUnhandledError}
             onClick={onWalletButtonClick}
+            onError={onUnhandledError}
           />;
 
         const isLoadingGuestForm = isWalletButtonsOnTop ?
@@ -282,11 +282,13 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             createAccountError,
             requiresMarketingConsent,
             isFloatingLabelEnabled,
+            defaultShouldSubscribe
         } = this.props;
 
         return (
             <CreateAccountForm
                 createAccountError={createAccountError}
+                defaultShouldSubscribe={defaultShouldSubscribe}
                 formFields={customerAccountFields}
                 isCreatingAccount={isCreatingAccount}
                 isExecutingPaymentMethodCheckout={isExecutingPaymentMethodCheckout}

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -64,6 +64,7 @@ export interface WithCheckoutCustomerProps {
     defaultShouldSubscribe: boolean;
     email?: string;
     firstName?: string;
+    fixNewsletterCheckboxExperimentEnabled: boolean;
     forgotPasswordUrl: string;
     isContinuingAsGuest: boolean;
     isCreatingAccount: boolean;
@@ -282,13 +283,15 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             createAccountError,
             requiresMarketingConsent,
             isFloatingLabelEnabled,
-            defaultShouldSubscribe
+            defaultShouldSubscribe,
+            fixNewsletterCheckboxExperimentEnabled,
         } = this.props;
 
         return (
             <CreateAccountForm
                 createAccountError={createAccountError}
                 defaultShouldSubscribe={defaultShouldSubscribe}
+                fixNewsletterCheckboxExperimentEnabled={fixNewsletterCheckboxExperimentEnabled}
                 formFields={customerAccountFields}
                 isCreatingAccount={isCreatingAccount}
                 isExecutingPaymentMethodCheckout={isExecutingPaymentMethodCheckout}
@@ -598,12 +601,15 @@ export function mapToWithCheckoutCustomerProps({
             isSignInEmailEnabled,
             isAccountCreationEnabled,
             isExpressPrivacyPolicy,
+            features,
         },
     } = config as StoreConfig & { checkoutSettings: { isAccountCreationEnabled: boolean } };
 
     const providerWithCustomCheckout = getProviderWithCustomCheckout(
         config.checkoutSettings.providerWithCustomCheckout,
     );
+
+    const fixNewsletterCheckboxExperimentEnabled = features['CHECKOUT-8033.fix_newletter_checkbox'];
 
     return {
         customerAccountFields: getCustomerAccountFields(),
@@ -618,6 +624,7 @@ export function mapToWithCheckoutCustomerProps({
         executePaymentMethodCheckout: checkoutService.executePaymentMethodCheckout,
         email: billingAddress?.email || customer?.email,
         firstName: customer?.firstName,
+        fixNewsletterCheckboxExperimentEnabled,
         forgotPasswordUrl: config.links.forgotPasswordLink,
         initializeCustomer: checkoutService.initializeCustomer,
         isCreatingAccount: isCreatingCustomerAccount(),


### PR DESCRIPTION
## What?
Fix issue with subscription checkbox not selected.

## Why?
In the account create form the value passed for newsletter checkbox field is not respected. Since we never used to read that value, it's addressed in this PR to set value for form field from the setting

## Testing / Proof
- Screencast

# Experiment on
https://github.com/bigcommerce/checkout-js/assets/7134802/0f703c68-7204-49d4-b23d-a1b2a110e00e

# Experiment off

https://github.com/bigcommerce/checkout-js/assets/7134802/7917cc61-8764-48c1-98a9-23dfb499f3e4


@bigcommerce/team-checkout
