### PR TITLE
fix(payment): PI-1656 fixed bluesnap direct ecp validation, fixed package test coverage

### DIFF
--- a/packages/bluesnap-direct-integration/jest.config.js
+++ b/packages/bluesnap-direct-integration/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
     },
     setupFilesAfterEnv: ['../../jest-setup.ts'],
     coverageDirectory: '../../coverage/packages/bluesnap-direct-integration',
+    coveragePathIgnorePatterns: ['./e2e', './src/mocks'],
 };

--- a/packages/bluesnap-direct-integration/src/validation-schemas/getEcpValidationSchema.ts
+++ b/packages/bluesnap-direct-integration/src/validation-schemas/getEcpValidationSchema.ts
@@ -18,7 +18,11 @@ export default memoize(function getEcpValidationSchema(
                           /^\d+$/,
                           language.translate('payment.bluesnap_direct_account_number.only_numbers'),
                       )
-                      .min(8, language.translate('payment.bluesnap_direct_account_number.length')),
+                      .min(4, language.translate('payment.bluesnap_direct_account_number.length'))
+                      .max(
+                          17,
+                          language.translate('payment.bluesnap_direct_account_number.length_max'),
+                      ),
                   routingNumber: string()
                       .required(
                           language.translate('payment.bluesnap_direct_routing_number.is_required'),

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -199,7 +199,8 @@
                 "label": "Account Number",
                 "is_required": "Account Number is required",
                 "only_numbers": "Account Number must contain only numbers",
-                "length": "Account Number must have at least 8 digits"
+                "length": "Account Number must have at least 4 digits",
+                "length_max": "Account Number must have at least 17 digits"
             },
             "bluesnap_direct_iban": {
                 "label": "IBAN",


### PR DESCRIPTION
## What?
Fixed bluesnap direct ecp validation, fixed package test coverage

## Why?
Due to the wrong bluesnap direct validation, [Bluesnap doc ](https://developers.bluesnap.com/v8976-JSON/reference/ecp-transaction#request)

## Testing / Proof
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/31248ae3-c858-431f-b07d-fc0966d14d1b)
Coverage:
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/271d496b-1a93-43ab-a17a-59f46e671eba)

@bigcommerce/team-checkout
