### PR TITLE
fix(customer): CHECKOUT-8073 Remove email address from message on sign in link

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,4 +70,4 @@ package-lock.json @bigcommerce/team-checkout @bigcommerce/team-integrations @big
 /packages/google-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 
 ## Localization team
-/packages/locale/src/translations @bigcommerce/team-checkout @bigcommerce/team-localization
+/packages/locale/src/translations @bigcommerce/team-checkout

--- a/packages/core/src/app/customer/EmailLoginForm.spec.tsx
+++ b/packages/core/src/app/customer/EmailLoginForm.spec.tsx
@@ -170,7 +170,6 @@ describe('EmailLoginForm', () => {
         expect(component.find('p').find(TranslatedHtml).props()).toEqual({
             id: 'login_email.sent_text',
             data: {
-                email: 'foo@bar.com',
                 minutes: 15,
             },
         });

--- a/packages/core/src/app/customer/EmailLoginForm.tsx
+++ b/packages/core/src/app/customer/EmailLoginForm.tsx
@@ -159,7 +159,6 @@ const EmailLoginForm: FunctionComponent<
                 <p>
                     <TranslatedHtml
                         data={{
-                            email: formEmail,
                             minutes: Math.round(expiry / 60),
                         }}
                         id={

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -163,7 +163,7 @@
             "error_server": "We couldn't send you a sign-in link. Please try again.",
             "error_not_found": "The entered email is not associated to an account. Please try with a different email.",
             "sent_header": "Check your inbox",
-            "sent_text": "Your sign-in link is on its way to <strong>{email}</strong>. This link expires in 15 minutes. If you don’t see it, check your junk folder.",
+            "sent_text": "If the entered email address is associated with this store, you will receive a sign-in link shortly. This link expires in 15 minutes. If you don't see it, check your junk folder.",
             "text": "Enter the email address associated to your account. We will send you a sign-in link.",
             "header": "Account sign-in link",
             "header_with_email": "Confirm your email address",


### PR DESCRIPTION
## What?
Remove email address from sign in link on passwordless login form.

## Why?
The customer’s passwordless login error message reveals whether or not a user has an account with the BC store. This might give an attacker insight to customers emails in the store allowing for potential other attack vectors.

## Testing / Proof
- CI

@bigcommerce/team-checkout
