### PR TITLE
chore(payment): PAYPAL-3646 bump checkout-sdk version to 1.545.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.544.0",
+        "@bigcommerce/checkout-sdk": "^1.545.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.544.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.544.0.tgz",
-      "integrity": "sha512-Z5AhiPkgMo0Kskjnuuyj6g/nIPr1gZ88QfVZo0bGr8Era1jIZXJb4Rv4toCrqC1pi9+LGml76A9XUY2mHjY+xA==",
+      "version": "1.545.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.545.0.tgz",
+      "integrity": "sha512-M3qRdNPgJsT5HKSiRLdB20aJKqVbPmoMUxfbe3mSGeuceYLeCploQ/5xXSkiXQdS/sktBLVroAU3vCKuzYi/jw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.544.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.544.0.tgz",
-      "integrity": "sha512-Z5AhiPkgMo0Kskjnuuyj6g/nIPr1gZ88QfVZo0bGr8Era1jIZXJb4Rv4toCrqC1pi9+LGml76A9XUY2mHjY+xA==",
+      "version": "1.545.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.545.0.tgz",
+      "integrity": "sha512-M3qRdNPgJsT5HKSiRLdB20aJKqVbPmoMUxfbe3mSGeuceYLeCploQ/5xXSkiXQdS/sktBLVroAU3vCKuzYi/jw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.544.0",
+    "@bigcommerce/checkout-sdk": "^1.545.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout-sdk version to 1.545.0

## Why?
As part of checkout-sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2377
https://github.com/bigcommerce/checkout-sdk-js/pull/2376

## Testing / Proof
Unit tests
Manual tests
CI
