### PR TITLE
refactor(payment): PAYPAL-3602 renamed PayPalCommerceConnectTracker with PayPalCommerceAnalyticTracker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.548.0",
+        "@bigcommerce/checkout-sdk": "^1.549.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.548.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.548.0.tgz",
-      "integrity": "sha512-TBGal+VYkgEYF+ilmAU/0vTTvnhRUJoSfqLwU9EGJn8QOC/DiRr1d0/dk527dwRptiSwgfN7Z4uctFCNNNUY+A==",
+      "version": "1.549.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.549.1.tgz",
+      "integrity": "sha512-4bh8yS2G+aUL+U8Fb5b4GKdPsc3wWIHdbrqPXyMEtUiO4sbHSl7Xyh6VHPVPyvhGlge+EZATvKmYy+mY0I07eA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.548.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.548.0.tgz",
-      "integrity": "sha512-TBGal+VYkgEYF+ilmAU/0vTTvnhRUJoSfqLwU9EGJn8QOC/DiRr1d0/dk527dwRptiSwgfN7Z4uctFCNNNUY+A==",
+      "version": "1.549.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.549.1.tgz",
+      "integrity": "sha512-4bh8yS2G+aUL+U8Fb5b4GKdPsc3wWIHdbrqPXyMEtUiO4sbHSl7Xyh6VHPVPyvhGlge+EZATvKmYy+mY0I07eA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.548.0",
+    "@bigcommerce/checkout-sdk": "^1.549.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/analytics/src/AnalyticsProvider.spec.tsx
+++ b/packages/analytics/src/AnalyticsProvider.spec.tsx
@@ -54,7 +54,7 @@ describe('AnalyticsProvider', () => {
     let stepTrackerMock: CheckoutSdk.StepTracker;
     let bodlServiceMock: CheckoutSdk.BodlService;
     let braintreeConnectTracker: CheckoutSdk.BraintreeConnectTrackerService;
-    let paypalCommerceConnectTracker: CheckoutSdk.PayPalCommerceConnectTrackerService;
+    let paypalCommerceAnalyticTracker: CheckoutSdk.PayPalCommerceAnalyticTrackerService;
 
     beforeEach(() => {
         jest.spyOn(createAnalyticsService, 'default').mockImplementation((createFn) => createFn);
@@ -95,14 +95,14 @@ describe('AnalyticsProvider', () => {
             () => braintreeConnectTracker,
         );
 
-        paypalCommerceConnectTracker = {
+        paypalCommerceAnalyticTracker = {
             customerPaymentMethodExecuted: jest.fn(),
             selectedPaymentMethod: jest.fn(),
             paymentComplete: jest.fn(),
             walletButtonClick: jest.fn(),
         };
-        jest.spyOn(CheckoutSdk, 'createPayPalCommerceConnectTracker').mockImplementation(
-            () => paypalCommerceConnectTracker,
+        jest.spyOn(CheckoutSdk, 'createPayPalCommerceAnalyticTracker').mockImplementation(
+            () => paypalCommerceAnalyticTracker,
         );
     });
 
@@ -192,8 +192,10 @@ describe('AnalyticsProvider', () => {
         });
         expect(braintreeConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalledTimes(1);
         expect(braintreeConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalled();
-        expect(paypalCommerceConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalledTimes(1);
-        expect(paypalCommerceConnectTracker.customerPaymentMethodExecuted).toHaveBeenCalled();
+        expect(paypalCommerceAnalyticTracker.customerPaymentMethodExecuted).toHaveBeenCalledTimes(
+            1,
+        );
+        expect(paypalCommerceAnalyticTracker.customerPaymentMethodExecuted).toHaveBeenCalled();
     });
 
     it('track show shipping methods', () => {
@@ -216,8 +218,8 @@ describe('AnalyticsProvider', () => {
         expect(braintreeConnectTracker.selectedPaymentMethod).toHaveBeenCalledWith(
             'paypalcreditcard',
         );
-        expect(paypalCommerceConnectTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
-        expect(paypalCommerceConnectTracker.selectedPaymentMethod).toHaveBeenCalledWith(
+        expect(paypalCommerceAnalyticTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(paypalCommerceAnalyticTracker.selectedPaymentMethod).toHaveBeenCalledWith(
             'paypalcreditcard',
         );
     });
@@ -229,8 +231,8 @@ describe('AnalyticsProvider', () => {
         expect(braintreeConnectTracker.walletButtonClick).toHaveBeenCalledWith(
             'paypalwalletbutton',
         );
-        expect(paypalCommerceConnectTracker.walletButtonClick).toHaveBeenCalledTimes(1);
-        expect(paypalCommerceConnectTracker.walletButtonClick).toHaveBeenCalledWith(
+        expect(paypalCommerceAnalyticTracker.walletButtonClick).toHaveBeenCalledTimes(1);
+        expect(paypalCommerceAnalyticTracker.walletButtonClick).toHaveBeenCalledWith(
             'paypalwalletbutton',
         );
     });

--- a/packages/analytics/src/AnalyticsProvider.tsx
+++ b/packages/analytics/src/AnalyticsProvider.tsx
@@ -5,9 +5,9 @@ import {
     CheckoutService,
     createBodlService,
     createBraintreeConnectTracker,
-    createPayPalCommerceConnectTracker,
+    createPayPalCommerceAnalyticTracker,
     createStepTracker,
-    PayPalCommerceConnectTrackerService,
+    PayPalCommerceAnalyticTrackerService,
     StepTracker,
 } from '@bigcommerce/checkout-sdk';
 import React, { ReactNode, useMemo } from 'react';
@@ -36,10 +36,10 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
             ]),
         [checkoutService],
     );
-    const getPayPalCommerceConnectTracker = useMemo(
+    const getPayPalCommerceAnalyticTracker = useMemo(
         () =>
-            createAnalyticsService<PayPalCommerceConnectTrackerService>(
-                createPayPalCommerceConnectTracker,
+            createAnalyticsService<PayPalCommerceAnalyticTrackerService>(
+                createPayPalCommerceAnalyticTracker,
                 [checkoutService],
             ),
         [checkoutService],
@@ -79,7 +79,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
     const customerPaymentMethodExecuted = (payload: BodlEventsPayload) => {
         getBodlService().customerPaymentMethodExecuted(payload);
         getBraintreeConnectTracker().customerPaymentMethodExecuted();
-        getPayPalCommerceConnectTracker().customerPaymentMethodExecuted();
+        getPayPalCommerceAnalyticTracker().customerPaymentMethodExecuted();
     };
 
     const showShippingMethods = () => {
@@ -89,7 +89,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
     const selectedPaymentMethod = (methodName: string, methodId: string) => {
         getBodlService().selectedPaymentMethod(methodName);
         getBraintreeConnectTracker().selectedPaymentMethod(methodId);
-        getPayPalCommerceConnectTracker().selectedPaymentMethod(methodId);
+        getPayPalCommerceAnalyticTracker().selectedPaymentMethod(methodId);
     };
 
     const clickPayButton = (payload: BodlEventsPayload) => {
@@ -103,7 +103,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
     const paymentComplete = () => {
         getBodlService().paymentComplete();
         getBraintreeConnectTracker().paymentComplete();
-        getPayPalCommerceConnectTracker().paymentComplete();
+        getPayPalCommerceAnalyticTracker().paymentComplete();
     };
 
     const exitCheckout = () => {
@@ -112,7 +112,7 @@ const AnalyticsProvider = ({ checkoutService, children }: AnalyticsProviderProps
 
     const walletButtonClick = (methodId: string) => {
         getBraintreeConnectTracker().walletButtonClick(methodId);
-        getPayPalCommerceConnectTracker().walletButtonClick(methodId);
+        getPayPalCommerceAnalyticTracker().walletButtonClick(methodId);
     };
 
     const analyticsTracker: AnalyticsEvents = {


### PR DESCRIPTION
## What?
Renamed PayPalCommerceConnectTracker with PayPalCommerceAnalyticTracker

## Why?
Due to the changes on checkout sdk side:
https://github.com/bigcommerce/checkout-sdk-js/pull/2385

## Testing / Proof
Unit tests
Local project commands run
CI
