### PR TITLE
feat(payment): PAYPAL-3705 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.549.1",
+        "@bigcommerce/checkout-sdk": "^1.550.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.549.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.549.1.tgz",
-      "integrity": "sha512-4bh8yS2G+aUL+U8Fb5b4GKdPsc3wWIHdbrqPXyMEtUiO4sbHSl7Xyh6VHPVPyvhGlge+EZATvKmYy+mY0I07eA==",
+      "version": "1.550.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.550.0.tgz",
+      "integrity": "sha512-yNrCY2fro9OLXa1jqjtvQThQG0rLl+O9V7H+vOeIzDfEOk3SASmILZTIn1rppvhhlJTBRJdUSa0z0Xoz25Q9UQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.549.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.549.1.tgz",
-      "integrity": "sha512-4bh8yS2G+aUL+U8Fb5b4GKdPsc3wWIHdbrqPXyMEtUiO4sbHSl7Xyh6VHPVPyvhGlge+EZATvKmYy+mY0I07eA==",
+      "version": "1.550.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.550.0.tgz",
+      "integrity": "sha512-yNrCY2fro9OLXa1jqjtvQThQG0rLl+O9V7H+vOeIzDfEOk3SASmILZTIn1rppvhhlJTBRJdUSa0z0Xoz25Q9UQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.549.1",
+    "@bigcommerce/checkout-sdk": "^1.550.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to `1.550.0`
Release contains: https://github.com/bigcommerce/checkout-sdk-js/pull/2386

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
