### PR TITLE
feat(payment): PAYPAL-3585 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.550.0",
+        "@bigcommerce/checkout-sdk": "^1.551.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.550.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.550.0.tgz",
-      "integrity": "sha512-yNrCY2fro9OLXa1jqjtvQThQG0rLl+O9V7H+vOeIzDfEOk3SASmILZTIn1rppvhhlJTBRJdUSa0z0Xoz25Q9UQ==",
+      "version": "1.551.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.551.0.tgz",
+      "integrity": "sha512-LcTHNtCVElj0G3SD+DjmKOD8Z854trN8206G9CwB7KgmvDM2OS67S/FaIHqodtQOdExY+sggd35vT58ItqzAdQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.550.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.550.0.tgz",
-      "integrity": "sha512-yNrCY2fro9OLXa1jqjtvQThQG0rLl+O9V7H+vOeIzDfEOk3SASmILZTIn1rppvhhlJTBRJdUSa0z0Xoz25Q9UQ==",
+      "version": "1.551.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.551.0.tgz",
+      "integrity": "sha512-LcTHNtCVElj0G3SD+DjmKOD8Z854trN8206G9CwB7KgmvDM2OS67S/FaIHqodtQOdExY+sggd35vT58ItqzAdQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.550.0",
+    "@bigcommerce/checkout-sdk": "^1.551.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
To update code
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2388

## Testing / Proof
Tested on dev and int

@bigcommerce/team-checkout
