### PR TITLE
feat(payment): PAYPAL-3447 Allow editing of Billing Address for eWallet Buttons flow

### DIFF
--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -124,6 +124,31 @@ const getBillingStepStatus = createSelector(
             };
         }
 
+        const isUsingPaypal =
+            checkout && checkout.payments
+                ? checkout.payments.some(
+                    (payment) =>
+                        [
+                            'braintreepaypal',
+                            'braintreepaypalcredit',
+                            'braintreevenmo',
+                            'paypalcommerce',
+                            'paypalcommercecredit',
+                            'paypalcommercevenmo'
+                        ]
+                            .includes(payment.providerId))
+                : false;
+
+        if (isUsingPaypal) {
+            return {
+                type: CheckoutStepType.Billing,
+                isActive: false,
+                isComplete: hasAddress,
+                isEditable: hasAddress,
+                isRequired: true,
+            };
+        }
+
         return {
             type: CheckoutStepType.Billing,
             isActive: false,


### PR DESCRIPTION
## What?

Allow editing of Billing Address for eWallet Buttons flow

## Why?

Because of PayPal is not returning all required billing information for buyer accounts and hence upon order placement shoppers receive an error as they can’t return to the billing step and edit the billing information

## Testing / Proof

<img width="728" alt="Screenshot 2024-03-01 at 16 22 01" src="https://github.com/bigcommerce/checkout-js/assets/99336044/d670c9e8-aa99-4231-8fc9-1d5db3456657">


@bigcommerce/team-checkout

