### PR TITLE
refactor(payment): PAYPAL-3597 renamed different paypal connect methods from paypal-fastlane-integration package

### DIFF
--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutInstrumentSelect.test.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutInstrumentSelect.test.tsx
@@ -11,8 +11,8 @@ import BraintreeAcceleratedCheckoutInstrumentSelect from './BraintreeAccelerated
 
 jest.mock('@bigcommerce/checkout/paypal-fastlane-integration', () => ({
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    PoweredByPaypalConnectLabel: jest.fn(() => (
-        <div data-test="powered-by-paypal-connect-label">PoweredByPaypalConnectLabel</div>
+    PoweredByPayPalFastlaneLabel: jest.fn(() => (
+        <div data-test="powered-by-paypal-fastlane-label">PoweredByPayPalFastlaneLabel</div>
     )),
 }));
 
@@ -42,7 +42,7 @@ describe('BraintreeAcceleratedCheckoutInstrumentSelect', () => {
         expect(view).toMatchSnapshot();
     });
 
-    it('renders form to create new instrument and does not render paypal connect label under instruments select', () => {
+    it('renders form to create new instrument and does not render paypal fastlane label under instruments select', () => {
         const cardInstrument = getCardInstrument();
 
         render(
@@ -64,6 +64,6 @@ describe('BraintreeAcceleratedCheckoutInstrumentSelect', () => {
             </Formik>,
         );
 
-        expect(screen.queryByTestId('powered-by-paypal-connect-label')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('powered-by-paypal-fastlane-label')).not.toBeInTheDocument();
     });
 });

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutInstrumentSelect.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeAcceleratedCheckoutInstrumentSelect.tsx
@@ -3,7 +3,7 @@ import { FieldProps } from 'formik';
 import React, { FunctionComponent, useEffect } from 'react';
 
 import { usePaymentFormContext } from '@bigcommerce/checkout/payment-integration-api';
-import { PoweredByPaypalConnectLabel } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { PoweredByPayPalFastlaneLabel } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { DropdownTrigger } from '@bigcommerce/checkout/ui';
 
 import BraintreeAcceleratedCheckoutInstrumentMenu from './BraintreeAcceleratedCheckoutInstrumentMenu';
@@ -50,7 +50,7 @@ const BraintreeAcceleratedCheckoutInstrumentSelect: FunctionComponent<
                 <input type="hidden" {...field} />
             </DropdownTrigger>
 
-            {selectedInstrument && <PoweredByPaypalConnectLabel />}
+            {selectedInstrument && <PoweredByPayPalFastlaneLabel />}
         </div>
     );
 };

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/__snapshots__/BraintreeAcceleratedCheckoutInstrumentSelect.test.tsx.snap
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/__snapshots__/BraintreeAcceleratedCheckoutInstrumentSelect.test.tsx.snap
@@ -83,9 +83,9 @@ Object {
           />
         </div>
         <div
-          data-test="powered-by-paypal-connect-label"
+          data-test="powered-by-paypal-fastlane-label"
         >
-          PoweredByPaypalConnectLabel
+          PoweredByPayPalFastlaneLabel
         </div>
       </div>
     </div>
@@ -169,9 +169,9 @@ Object {
         />
       </div>
       <div
-        data-test="powered-by-paypal-connect-label"
+        data-test="powered-by-paypal-fastlane-label"
       >
-        PoweredByPaypalConnectLabel
+        PoweredByPayPalFastlaneLabel
       </div>
     </div>
   </div>,

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/hooks/useBraintreeAcceleratedCheckoutInstruments.ts
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/hooks/useBraintreeAcceleratedCheckoutInstruments.ts
@@ -2,7 +2,7 @@ import { CardInstrument } from '@bigcommerce/checkout-sdk';
 import { useState } from 'react';
 
 import { useCheckout, usePaymentFormContext } from '@bigcommerce/checkout/payment-integration-api';
-import { isPayPalConnectAcceleratedCheckoutCustomer } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { isPayPalFastlaneCustomer } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 export const useBraintreeAcceleratedCheckoutInstruments = () => {
     const [isAddingNewInstrument, setIsAddingNewInstrument] = useState<boolean>(false);
@@ -13,14 +13,12 @@ export const useBraintreeAcceleratedCheckoutInstruments = () => {
     const paymentProviderCustomer = getPaymentProviderCustomer();
     const { paymentForm } = usePaymentFormContext();
 
-    const paypalConnectPaymentProviderCustomer = isPayPalConnectAcceleratedCheckoutCustomer(
-        paymentProviderCustomer,
-    )
+    const paypalFastlaneCustomer = isPayPalFastlaneCustomer(paymentProviderCustomer)
         ? paymentProviderCustomer
         : {};
 
-    const paypalConnectInstruments = paypalConnectPaymentProviderCustomer.instruments || [];
-    const selectedInstrument = paypalConnectInstruments.find(
+    const paypalFastlaneInstruments = paypalFastlaneCustomer.instruments || [];
+    const selectedInstrument = paypalFastlaneInstruments.find(
         (instrument: CardInstrument) => instrument.bigpayToken === selectedInstrumentId,
     );
 
@@ -37,7 +35,7 @@ export const useBraintreeAcceleratedCheckoutInstruments = () => {
     };
 
     return {
-        instruments: paypalConnectInstruments,
+        instruments: paypalFastlaneInstruments,
         isAddingNewInstrument,
         handleUseNewInstrument,
         handleSelectInstrument,

--- a/packages/core/src/app/address/AddressSelect.spec.tsx
+++ b/packages/core/src/app/address/AddressSelect.spec.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
-import { usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 import { getCheckout } from '../checkout/checkouts.mock';
 import { getStoreConfig } from '../config/config.mock';
@@ -16,11 +16,11 @@ import AddressSelect from './AddressSelect';
 import StaticAddress from './StaticAddress';
 
 jest.mock('@bigcommerce/checkout/paypal-fastlane-integration', () => ({
-    usePayPalConnectAddress: jest.fn(() => ({
-        shouldShowPayPalConnectLabel: false,
+    usePayPalFastlaneAddress: jest.fn(() => ({
+        shouldShowPayPalFastlaneLabel: false,
     })),
-    PoweredByPaypalConnectLabel: jest.fn(() => (
-        <div data-test="powered-by-pp-connect-label">PoweredByPaypalConnectLabel</div>
+    PoweredByPayPalFastlaneLabel: jest.fn(() => (
+        <div data-test="powered-by-pp-fastlane-label">PoweredByPayPalFastlaneLabel</div>
     )),
 }));
 
@@ -140,10 +140,10 @@ describe('AddressSelect Component', () => {
         expect(onSelectAddress).not.toHaveBeenCalled();
     });
 
-    it('shows Powered By PP Connect label', () => {
+    it('shows Powered By PP Fastlane label', () => {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (usePayPalConnectAddress as jest.Mock).mockReturnValue({
-            shouldShowPayPalConnectLabel: true,
+        (usePayPalFastlaneAddress as jest.Mock).mockReturnValue({
+            shouldShowPayPalFastlaneLabel: true,
         });
 
         component = mount(
@@ -158,6 +158,6 @@ describe('AddressSelect Component', () => {
             </CheckoutProvider>,
         );
 
-        expect(component.find('[data-test="powered-by-pp-connect-label"]').text()).toBe('PoweredByPaypalConnectLabel');
+        expect(component.find('[data-test="powered-by-pp-fastlane-label"]').text()).toBe('PoweredByPayPalFastlaneLabel');
     });
 });

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, memo } from 'react';
 
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
-import { PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { PoweredByPayPalFastlaneLabel, usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 import { DropdownTrigger } from '../ui/dropdown';
 
@@ -56,7 +56,7 @@ const AddressSelect = ({
     onSelectAddress,
     onUseNewAddress,
 }: AddressSelectProps) => {
-    const { shouldShowPayPalConnectLabel } = usePayPalConnectAddress();
+    const { shouldShowPayPalFastlaneLabel } = usePayPalFastlaneAddress();
 
     const handleSelectAddress = (newAddress: Address) => {
         if (!isEqualAddress(selectedAddress, newAddress)) {
@@ -90,7 +90,7 @@ const AddressSelect = ({
                 </DropdownTrigger>
             </div>
 
-            {shouldShowPayPalConnectLabel && <PoweredByPaypalConnectLabel />}
+            {shouldShowPayPalFastlaneLabel && <PoweredByPayPalFastlaneLabel />}
         </div>
     );
 }

--- a/packages/core/src/app/address/StaticAddress.spec.tsx
+++ b/packages/core/src/app/address/StaticAddress.spec.tsx
@@ -7,7 +7,7 @@ import { mount, render } from 'enzyme';
 import React, { FunctionComponent } from 'react';
 
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
-import { usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 import { getCountries } from '../geography/countries.mock';
 
@@ -18,14 +18,14 @@ import StaticAddress, { StaticAddressProps } from './StaticAddress';
 
 jest.mock('@bigcommerce/checkout/ui', () => ({
     ...jest.requireActual('@bigcommerce/checkout/ui'),
-    IconPayPalConnectSmall: () => (<div data-test="pp-connect-icon">IconPayPalConnectSmall</div>)
+    IconPayPalConnectSmall: () => (<div data-test="pp-fastlane-icon">IconPayPalFastlaneSmall</div>)
 }));
 
 jest.mock('@bigcommerce/checkout/paypal-fastlane-integration', () => ({
     ...jest.requireActual('@bigcommerce/checkout/paypal-fastlane-integration'),
-    usePayPalConnectAddress: jest.fn(() => ({
-        isPayPalAxoEnabled: true,
-        paypalConnectAddresses: [],
+    usePayPalFastlaneAddress: jest.fn(() => ({
+        isPayPalFastlaneEnabled: true,
+        paypalFastlaneAddresses: [],
     })),
 }));
 
@@ -164,21 +164,21 @@ describe('StaticAddress Component', () => {
     });
 
     describe('provider icon', () => {
-        it('should not show icon, address is not from PP Connect', () => {
+        it('should not show icon, address is not from PP Fastlane', () => {
             const container = render(
                 <StaticAddressTest
                     {...defaultProps}
                 />
             );
 
-            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(0);
+            expect(container.find('[data-test="pp-fastlane-icon"]')).toHaveLength(0);
         });
 
-        it('should show icon for PP Connect address', () => {
+        it('should show icon for PP Fastlane address', () => {
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            (usePayPalConnectAddress as jest.Mock).mockReturnValue({
-                isPayPalAxoEnabled: true,
-                paypalConnectAddresses: [defaultProps.address],
+            (usePayPalFastlaneAddress as jest.Mock).mockReturnValue({
+                isPayPalFastlaneEnabled: true,
+                paypalFastlaneAddresses: [defaultProps.address],
             });
 
             const container = render(
@@ -187,7 +187,7 @@ describe('StaticAddress Component', () => {
                 />
             );
 
-            expect(container.find('[data-test="pp-connect-icon"]')).toHaveLength(1);
+            expect(container.find('[data-test="pp-fastlane-icon"]')).toHaveLength(1);
         });
     });
 });

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -10,7 +10,7 @@ import { isEmpty } from 'lodash';
 import React, { FunctionComponent, memo } from 'react';
 
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
-import { isPayPalConnectAddress, usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { isPayPalFastlaneAddress, usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { IconPayPalConnectSmall } from '@bigcommerce/checkout/ui';
 
 import { withCheckout } from '../checkout';
@@ -38,7 +38,7 @@ interface WithCheckoutStaticAddressProps {
 const StaticAddress: FunctionComponent<
     StaticAddressEditableProps & WithCheckoutStaticAddressProps
 > = ({ countries, fields, address: addressWithoutLocalization }) => {
-    const { isPayPalAxoEnabled, paypalConnectAddresses } = usePayPalConnectAddress();
+    const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
     const address = localizeAddress(addressWithoutLocalization, countries);
     const isValid = !fields
         ? !isEmpty(address)
@@ -46,7 +46,7 @@ const StaticAddress: FunctionComponent<
               address,
               fields.filter((field) => !field.custom),
           );
-    const shouldShowProviderIcon = isPayPalAxoEnabled && isPayPalConnectAddress(addressWithoutLocalization, paypalConnectAddresses);
+    const shouldShowProviderIcon = isPayPalFastlaneEnabled && isPayPalFastlaneAddress(addressWithoutLocalization, paypalFastlaneAddresses);
 
     return !isValid ? null : (
         <div

--- a/packages/core/src/app/billing/BillingForm.spec.tsx
+++ b/packages/core/src/app/billing/BillingForm.spec.tsx
@@ -1,4 +1,4 @@
-import { usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { createCheckoutService } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
@@ -19,9 +19,9 @@ import BillingForm, { BillingFormProps } from './BillingForm';
 import StaticBillingAddress from './StaticBillingAddress';
 
 jest.mock('@bigcommerce/checkout/paypal-fastlane-integration', () => ({
-    usePayPalConnectAddress: jest.fn(() => ({
-        isPayPalAxoEnabled: false,
-        mergedBcAndPayPalConnectAddresses: [],
+    usePayPalFastlaneAddress: jest.fn(() => ({
+        isPayPalFastlaneEnabled: false,
+        mergedBcAndPayPalFastlaneAddresses: [],
     })),
 }));
 
@@ -171,16 +171,16 @@ describe('BillingForm Component', () => {
         expect(defaultProps.onSubmit).not.toHaveBeenCalled();
     });
 
-    it('renders form with PP Connect addresses', () => {
-        const mergedBcAndPayPalConnectAddresses = [{
+    it('renders form with PP Fastlane addresses', () => {
+        const mergedBcAndPayPalFastlaneAddresses = [{
             ...getAddress(),
-            address1: 'PP AXO address'
+            address1: 'PP Fastlane address'
         }];
 
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (usePayPalConnectAddress as jest.Mock).mockReturnValue({
-            isPayPalAxoEnabled: true,
-            mergedBcAndPayPalConnectAddresses,
+        (usePayPalFastlaneAddress as jest.Mock).mockReturnValue({
+            isPayPalFastlaneEnabled: true,
+            mergedBcAndPayPalFastlaneAddresses,
         });
 
         component = mount(
@@ -196,7 +196,7 @@ describe('BillingForm Component', () => {
         expect(addressSelectComponent).toHaveLength(1);
         expect(addressSelectComponent.props()).toEqual(
             expect.objectContaining({
-                addresses: mergedBcAndPayPalConnectAddresses,
+                addresses: mergedBcAndPayPalFastlaneAddresses,
             }),
         );
     });

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -10,7 +10,7 @@ import React, { RefObject, useRef, useState } from 'react';
 import { lazy } from 'yup';
 
 import { TranslatedString, withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
-import { usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
 
 import {
@@ -68,7 +68,7 @@ const BillingForm = ({
 }: BillingFormProps & WithLanguageProps & FormikProps<BillingFormValues>) => {
     const [isResettingAddress, setIsResettingAddress] = useState(false);
     const addressFormRef: RefObject<HTMLFieldSetElement> = useRef(null);
-    const { isPayPalAxoEnabled, mergedBcAndPayPalConnectAddresses } = usePayPalConnectAddress();
+    const { isPayPalFastlaneEnabled, mergedBcAndPayPalFastlaneAddresses } = usePayPalFastlaneAddress();
 
     const shouldRenderStaticAddress = methodId === 'amazonpay';
     const allFormFields = getFields(values.countryCode);
@@ -76,7 +76,7 @@ const BillingForm = ({
     const hasCustomFormFields = customFormFields.length > 0;
     const editableFormFields =
         shouldRenderStaticAddress && hasCustomFormFields ? customFormFields : allFormFields;
-    const billingAddresses = isPayPalAxoEnabled ? mergedBcAndPayPalConnectAddresses : addresses;
+    const billingAddresses = isPayPalFastlaneEnabled ? mergedBcAndPayPalFastlaneAddresses : addresses;
     const hasAddresses = billingAddresses?.length > 0;
     const hasValidCustomerAddress =
         billingAddress &&

--- a/packages/core/src/app/billing/StaticBillingAddress.spec.tsx
+++ b/packages/core/src/app/billing/StaticBillingAddress.spec.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent } from 'react';
 
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
-import { usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 import { StaticAddress } from '../address';
 import { getAddress } from '../address/address.mock';
@@ -19,12 +19,12 @@ import StaticBillingAddress, { StaticBillingAddressProps } from './StaticBilling
 
 jest.mock('@bigcommerce/checkout/paypal-fastlane-integration', () => ({
     ...jest.requireActual('@bigcommerce/checkout/paypal-fastlane-integration'),
-    usePayPalConnectAddress: jest.fn(() => ({
-        isPayPalAxoEnabled: false,
-        paypalConnectAddresses: [],
+    usePayPalFastlaneAddress: jest.fn(() => ({
+        isPayPalFastlaneEnabled: false,
+        paypalFastlaneAddresses: [],
     })),
-    PoweredByPaypalConnectLabel: jest.fn(() => (
-        <div data-test="powered-by-paypal-connect-label">PoweredByPaypalConnectLabel</div>
+    PoweredByPayPalFastlaneLabel: jest.fn(() => (
+        <div data-test="powered-by-paypal-fastlane-label">PoweredByPayPalFastlaneLabel</div>
     )),
 }));
 
@@ -82,36 +82,36 @@ describe('StaticBillingAddress', () => {
         );
     });
 
-    describe('with PayPal Connect flow', () => {
-        it('should not show label if PayPal Axo is disabled', () => {
+    describe('with PayPal Fastlane flow', () => {
+        it('should not show label if PayPal Fastlane is disabled', () => {
             const container = mount(<StaticBillingAddressTest {...defaultProps} />);
 
-            expect(container.find('[data-test="powered-by-paypal-connect-label"]')).toHaveLength(0);
+            expect(container.find('[data-test="powered-by-paypal-fastlane-label"]')).toHaveLength(0);
         });
 
-        it('should not show label if PayPal Axo is enabled but no PP addresses available', () => {
+        it('should not show label if PayPal Fastlane is enabled but no PP addresses available', () => {
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            (usePayPalConnectAddress as jest.Mock).mockReturnValue({
-                isPayPalAxoEnabled: true,
-                paypalConnectAddresses: [],
+            (usePayPalFastlaneAddress as jest.Mock).mockReturnValue({
+                isPayPalFastlaneEnabled: true,
+                paypalFastlaneAddresses: [],
             });
 
             const container = mount(<StaticBillingAddressTest {...defaultProps} />);
 
-            expect(container.find('[data-test="powered-by-paypal-connect-label"]')).toHaveLength(0);
+            expect(container.find('[data-test="powered-by-paypal-fastlane-label"]')).toHaveLength(0);
         });
 
         it('should show label if PayPal Axo is enabled and address match to PP address', () => {
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            (usePayPalConnectAddress as jest.Mock).mockReturnValue({
-                isPayPalAxoEnabled: true,
-                paypalConnectAddresses: [getAddress()],
-                shouldShowPayPalConnectLabel: true,
+            (usePayPalFastlaneAddress as jest.Mock).mockReturnValue({
+                isPayPalFastlaneEnabled: true,
+                paypalFastlaneAddresses: [getAddress()],
+                shouldShowPayPalFastlaneLabel: true,
             });
 
             const container = mount(<StaticBillingAddressTest {...defaultProps} />);
 
-            expect(container.find('[data-test="powered-by-paypal-connect-label"]')).toHaveLength(1);
+            expect(container.find('[data-test="powered-by-paypal-fastlane-label"]')).toHaveLength(1);
         });
     });
 });

--- a/packages/core/src/app/billing/StaticBillingAddress.tsx
+++ b/packages/core/src/app/billing/StaticBillingAddress.tsx
@@ -3,7 +3,7 @@ import React, { FunctionComponent, memo } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
-import { isPayPalConnectAddress, PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { isPayPalFastlaneAddress, PoweredByPayPalFastlaneLabel, usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 import { AddressType, StaticAddress } from '../address';
 import { withCheckout } from '../checkout';
@@ -21,8 +21,8 @@ interface WithCheckoutStaticBillingAddressProps {
 const StaticBillingAddress: FunctionComponent<
     StaticBillingAddressProps & WithCheckoutStaticBillingAddressProps
 > = ({ address, payments = EMPTY_ARRAY }) => {
-    const { isPayPalAxoEnabled, paypalConnectAddresses } = usePayPalConnectAddress();
-    const showPayPalConnectAddressLabel = isPayPalAxoEnabled && isPayPalConnectAddress(address, paypalConnectAddresses);
+    const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
+    const showPayPalFastlaneLabel = isPayPalFastlaneEnabled && isPayPalFastlaneAddress(address, paypalFastlaneAddresses);
 
     if (payments.find((payment) => payment.providerId === 'amazonpay')) {
         return (
@@ -36,7 +36,7 @@ const StaticBillingAddress: FunctionComponent<
         <>
             <StaticAddress address={address} type={AddressType.Billing} />
 
-            {showPayPalConnectAddressLabel && <PoweredByPaypalConnectLabel />}
+            {showPayPalFastlaneLabel && <PoweredByPayPalFastlaneLabel />}
         </>
     );
 };

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -17,7 +17,7 @@ import React, { Component, ReactNode } from 'react';
 import { AnalyticsContextProps } from '@bigcommerce/checkout/analytics';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
-import { isPaypalConnectMethod } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { isPayPalFastlaneMethod } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { CustomerSkeleton } from '@bigcommerce/checkout/ui';
 
 import { withAnalytics } from '../analytics';
@@ -456,7 +456,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
         try {
             await signIn(credentials);
 
-            if (isPaypalConnectMethod(providerWithCustomCheckout)) {
+            if (isPayPalFastlaneMethod(providerWithCustomCheckout)) {
                 await executePaymentMethodCheckout({
                     methodId: providerWithCustomCheckout,
                     continueWithCheckoutCallback: onSignIn,
@@ -482,7 +482,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
         await createAccount(mapCreateAccountFromFormValues(values));
 
-        if (isPaypalConnectMethod(providerWithCustomCheckout)) {
+        if (isPayPalFastlaneMethod(providerWithCustomCheckout)) {
             await executePaymentMethodCheckout({
                 methodId: providerWithCustomCheckout,
                 continueWithCheckoutCallback: onAccountCreated,

--- a/packages/core/src/app/shipping/ShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.spec.tsx
@@ -1,4 +1,4 @@
-import { usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { CheckoutService, createCheckoutService, CustomerAddress } from '@bigcommerce/checkout-sdk';
 import { mount, ReactWrapper } from 'enzyme';
 import React from 'react';
@@ -26,9 +26,9 @@ import SingleShippingForm from './SingleShippingForm';
 
 jest.mock('@bigcommerce/checkout/paypal-fastlane-integration', () => ({
     ...jest.requireActual('@bigcommerce/checkout/paypal-fastlane-integration'),
-    usePayPalConnectAddress: jest.fn(() => ({
-        isPayPalAxoEnabled: false,
-        mergedBcAndPayPalConnectAddresses: []
+    usePayPalFastlaneAddress: jest.fn(() => ({
+        isPayPalFastlaneEnabled: false,
+        mergedBcAndPayPalFastlaneAddresses: []
     })),
 }));
 
@@ -374,8 +374,8 @@ describe('ShippingForm Component', () => {
         });
     });
 
-    describe('Braintree AXO', () => {
-        it('renders SingleShippingForm with default addresses list if PayPal AXO disabled', () => {
+    describe('Braintree Fastlane', () => {
+        it('renders SingleShippingForm with default addresses list if PayPal Fastlane disabled', () => {
             const initializeMock = jest.fn();
             const ShippingFormProps = {
                 ...defaultProps,
@@ -400,13 +400,13 @@ describe('ShippingForm Component', () => {
             expect(initializeMock).not.toHaveBeenCalled();
         });
 
-        it('renders SingleShippingForm with merged addresses list if PayPal AXO enabled', () => {
+        it('renders SingleShippingForm with merged addresses list if PayPal Fastlane enabled', () => {
             const initializeMock = jest.fn();
             const shippingFormProps = {
                 ...defaultProps,
                 initialize: initializeMock,
             };
-            const payPalConnectAddresses: CustomerAddress[] = [
+            const paypalFastlaneAddresses: CustomerAddress[] = [
                 {
                     ...getShippingAddress(),
                     id: 123,
@@ -415,10 +415,10 @@ describe('ShippingForm Component', () => {
             ];
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            (usePayPalConnectAddress as jest.Mock).mockReturnValue({
-                isPayPalAxoEnabled: true,
-                paypalConnectAddresses: payPalConnectAddresses,
-                mergedBcAndPayPalConnectAddresses: payPalConnectAddresses,
+            (usePayPalFastlaneAddress as jest.Mock).mockReturnValue({
+                isPayPalFastlaneEnabled: true,
+                paypalFastlaneAddresses,
+                mergedBcAndPayPalFastlaneAddresses: paypalFastlaneAddresses,
             });
 
             component = mount(
@@ -433,7 +433,7 @@ describe('ShippingForm Component', () => {
 
             expect(component.find(SingleShippingForm).props()).toEqual(
                 expect.objectContaining({
-                    addresses: payPalConnectAddresses,
+                    addresses: paypalFastlaneAddresses,
                 }),
             );
             expect(initializeMock).toHaveBeenCalledWith({
@@ -441,13 +441,13 @@ describe('ShippingForm Component', () => {
             });
         });
 
-        it('renders shipping for with paypal connect addresses without strategy initialization if there is preselected shipping method id', () => {
+        it('renders shipping for with paypal fastlane addresses without strategy initialization if there is preselected shipping method id', () => {
             const initializeMock = jest.fn();
             const shippingFormProps = {
                 ...defaultProps,
                 initialize: initializeMock,
             };
-            const payPalConnectAddresses: CustomerAddress[] = [
+            const paypalFastlaneAddresses: CustomerAddress[] = [
                 {
                     ...getShippingAddress(),
                     id: 123,
@@ -456,17 +456,17 @@ describe('ShippingForm Component', () => {
             ];
 
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            (usePayPalConnectAddress as jest.Mock).mockReturnValue({
-                isPayPalAxoEnabled: true,
-                paypalConnectAddresses: payPalConnectAddresses,
-                mergedBcAndPayPalConnectAddresses: payPalConnectAddresses,
+            (usePayPalFastlaneAddress as jest.Mock).mockReturnValue({
+                isPayPalFastlaneEnabled: true,
+                paypalFastlaneAddresses,
+                mergedBcAndPayPalFastlaneAddresses: paypalFastlaneAddresses,
             });
 
             component = mount(
                 <CheckoutProvider checkoutService={checkoutService}>
                     <LocaleContext.Provider value={localeContext}>
                         <ExtensionProvider checkoutService={checkoutService}>
-                            <ShippingForm {...shippingFormProps} methodId="notPPAXOMethodID" />
+                            <ShippingForm {...shippingFormProps} methodId="notPPFastlaneMethodID" />
                         </ExtensionProvider>
                     </LocaleContext.Provider>
                 </CheckoutProvider>,
@@ -474,7 +474,7 @@ describe('ShippingForm Component', () => {
 
             expect(component.find(SingleShippingForm).props()).toEqual(
                 expect.objectContaining({
-                    addresses: payPalConnectAddresses,
+                    addresses: paypalFastlaneAddresses,
                 }),
             );
             expect(initializeMock).not.toHaveBeenCalled();

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -17,7 +17,7 @@ import {
 import React, { useEffect } from 'react';
 
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
-import { isPaypalConnectMethod, usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { isPayPalFastlaneMethod, usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm';
 import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
@@ -96,11 +96,11 @@ const ShippingForm = ({
     isShippingStepPending,
     isFloatingLabelEnabled,
 }: ShippingFormProps & WithLanguageProps) => {
-    const { isPayPalAxoEnabled, mergedBcAndPayPalConnectAddresses } = usePayPalConnectAddress();
-    const shippingAddresses = isPayPalAxoEnabled ? mergedBcAndPayPalConnectAddresses : addresses;
+    const { isPayPalFastlaneEnabled, mergedBcAndPayPalFastlaneAddresses } = usePayPalFastlaneAddress();
+    const shippingAddresses = isPayPalFastlaneEnabled ? mergedBcAndPayPalFastlaneAddresses : addresses;
 
     useEffect(() => {
-        if (isPaypalConnectMethod(methodId) && isPayPalAxoEnabled) {
+        if (isPayPalFastlaneMethod(methodId) && isPayPalFastlaneEnabled) {
             initialize({ methodId });
         }
     });

--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -1,7 +1,7 @@
 import { Cart, Consignment } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, memo } from 'react';
 
-import { isPayPalConnectAddress, PoweredByPaypalConnectLabel, usePayPalConnectAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { isPayPalFastlaneAddress, PoweredByPayPalFastlaneLabel, usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 import { AddressType, StaticAddress } from '../address';
 
@@ -20,16 +20,16 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
     cart,
     compactView,
 }) => {
-    const { isPayPalAxoEnabled, paypalConnectAddresses } = usePayPalConnectAddress();
+    const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
     const { shippingAddress: address, selectedShippingOption } = consignment;
 
-    const showPayPalConnectAddressLabel = isPayPalAxoEnabled && isPayPalConnectAddress(address, paypalConnectAddresses);
+    const showPayPalFastlaneAddressLabel = isPayPalFastlaneEnabled && isPayPalFastlaneAddress(address, paypalFastlaneAddresses);
 
     return (
         <div className="staticConsignment">
             <StaticAddress address={address} type={AddressType.Shipping} />
 
-            {showPayPalConnectAddressLabel && <PoweredByPaypalConnectLabel />}
+            {showPayPalFastlaneAddressLabel && <PoweredByPayPalFastlaneLabel />}
 
             {!compactView && <StaticConsignmentItemList cart={cart} consignment={consignment} />}
 

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.tsx
@@ -3,7 +3,7 @@ import { CardInstrument } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent } from 'react';
 
 import { CreditCardIcon, Button, ButtonSize, ButtonVariant } from '@bigcommerce/checkout/ui';
-import { PoweredByPaypalConnectLabel } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { PoweredByPayPalFastlaneLabel } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
 import { PayPalFastlaneCardComponentRef } from '../PayPalCommerceFastlanePaymentMethod';
@@ -64,8 +64,7 @@ const PayPalCommerceFastlaneInstrumentsForm: FunctionComponent<
                     </div>
                 </div>
                 <div className="paypal-commerce-fastlane-instrument-branding">
-                    {/* TODO: update this component with Fastlane label */}
-                    <PoweredByPaypalConnectLabel />
+                    <PoweredByPayPalFastlaneLabel />
                 </div>
             </div>
 

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/hooks/usePayPalCommerceFastlaneInstruments.ts
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/hooks/usePayPalCommerceFastlaneInstruments.ts
@@ -2,16 +2,14 @@ import { CardInstrument } from '@bigcommerce/checkout-sdk';
 import { useState } from 'react';
 
 import { useCheckout, usePaymentFormContext } from '@bigcommerce/checkout/payment-integration-api';
-import { isPayPalConnectAcceleratedCheckoutCustomer } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { isPayPalFastlaneCustomer } from '@bigcommerce/checkout/paypal-fastlane-integration';
 
 export const usePayPalCommerceFastlaneInstruments = () => {
     const [selectedInstrument, setSelectedInstrument] = useState<CardInstrument>();
 
     const { getPaymentProviderCustomer } = useCheckout().checkoutState.data;
     const paymentProviderCustomer = getPaymentProviderCustomer();
-    const paypalConnectPaymentProviderCustomer = isPayPalConnectAcceleratedCheckoutCustomer(
-        paymentProviderCustomer,
-    )
+    const paypalFastlaneCustomer = isPayPalFastlaneCustomer(paymentProviderCustomer)
         ? paymentProviderCustomer
         : {};
 
@@ -23,7 +21,7 @@ export const usePayPalCommerceFastlaneInstruments = () => {
     };
 
     return {
-        instruments: paypalConnectPaymentProviderCustomer.instruments || [],
+        instruments: paypalFastlaneCustomer.instruments || [],
         handleSelectInstrument,
         selectedInstrument,
     };

--- a/packages/paypal-fastlane-integration/src/index.ts
+++ b/packages/paypal-fastlane-integration/src/index.ts
@@ -1,8 +1,7 @@
-// TODO: update assigned variables with Fastlane naming
-export { default as isPayPalConnectAddress } from './is-paypal-fastlane-address';
-export { default as isPayPalConnectAcceleratedCheckoutCustomer } from './is-paypal-fastlane-customer';
-export { default as isPaypalConnectMethod } from './is-paypal-fastlane-method';
-export { default as isBraintreeConnectMethod } from './is-braintree-fastlane-method';
-export { default as isPayPalCommerceConnectMethod } from './is-paypal-fastlane-method';
-export { default as PoweredByPaypalConnectLabel } from './PoweredByPayPalFastlaneLabel';
-export { default as usePayPalConnectAddress } from './usePayPalFastlaneAddress';
+export { default as isPayPalFastlaneAddress } from './is-paypal-fastlane-address';
+export { default as isPayPalFastlaneCustomer } from './is-paypal-fastlane-customer';
+export { default as isPayPalFastlaneMethod } from './is-paypal-fastlane-method';
+export { default as isBraintreeFastlaneMethod } from './is-braintree-fastlane-method';
+export { default as isPayPalCommerceFastlaneMethod } from './is-paypal-fastlane-method';
+export { default as PoweredByPayPalFastlaneLabel } from './PoweredByPayPalFastlaneLabel';
+export { default as usePayPalFastlaneAddress } from './usePayPalFastlaneAddress';

--- a/packages/paypal-fastlane-integration/src/usePayPalFastlaneAddress.ts
+++ b/packages/paypal-fastlane-integration/src/usePayPalFastlaneAddress.ts
@@ -32,13 +32,9 @@ const usePayPalFastlaneAddress = () => {
     const shouldShowPayPalFastlaneLabel = !!paypalFastlaneAddresses.length;
 
     return {
-        isPayPalAxoEnabled: isPayPalFastlaneEnabled, // TODO: remove this option when it when we remove all it usage in checkout project
         isPayPalFastlaneEnabled,
-        paypalConnectAddresses: paypalFastlaneAddresses, // TODO: remove this option when it when we remove all it usage in checkout project
         paypalFastlaneAddresses,
-        shouldShowPayPalConnectLabel: shouldShowPayPalFastlaneLabel, // TODO: remove this option when it when we remove all it usage in checkout project
         shouldShowPayPalFastlaneLabel,
-        mergedBcAndPayPalConnectAddresses: mergedBcAndPayPalFastlaneAddresses, // TODO: remove this option when it when we remove all it usage in checkout project
         mergedBcAndPayPalFastlaneAddresses,
     };
 };


### PR DESCRIPTION
## What?
Renamed different PayPal Connect methods from paypal-fastlane-integration package

## Why?
As part of PayPal Connect to Fastlane rebranding

## Testing / Proof
Unit tests
CI

<img width="740" alt="Screenshot 2024-03-01 at 16 19 08" src="https://github.com/bigcommerce/checkout-js/assets/25133454/0fc7bb61-924e-4a2e-8ce1-77ff993876dc">

