### PR TITLE
feat(payment): PI-1679 toggle Stripe terms text

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/StripeUPEPaymentMethod.tsx
@@ -46,7 +46,7 @@ const StripeUPEPaymentMethod: FunctionComponent<
 
     useEffect(() => {
         updateStripeElement.current({
-            shouldSaveInstrument: values?.shouldSaveInstrument,
+            shouldShowTerms: values?.shouldSaveInstrument,
         });
     }, [values?.shouldSaveInstrument]);
 
@@ -85,8 +85,8 @@ const StripeUPEPaymentMethod: FunctionComponent<
                         },
                         onError: onUnhandledError,
                         render: renderSubmitButton,
-                        initStripeElementUpdateTrigger: (updateTrigger) => {
-                            updateStripeElement.current = updateTrigger;
+                        initStripeElementUpdateTrigger: (stripeElementUpdateFn) => {
+                            updateStripeElement.current = stripeElementUpdateFn;
                         },
                     },
                 });


### PR DESCRIPTION
## What?
Add ability to hide Stripe terms text

## Why?
To hide terms text for saving credit card when shopper don't select save credit card option
Checkout-sdk-js PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2390](https://github.com/bigcommerce/checkout-sdk-js/pull/2390)

## Testing / Proof
Experiment disabled

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/5493da42-f4e4-4813-b2fb-f3f82ceec230

Experiment enabled

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/ff09a364-13cc-4856-9d6c-dffdde66df17




@bigcommerce/team-checkout
