### PR TITLE
chore(payment): PI-1655 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.552.0",
+        "@bigcommerce/checkout-sdk": "^1.553.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.552.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.552.0.tgz",
-      "integrity": "sha512-CKAF4cLq0ExCZT3ZGtPUEGRBnn1tXlystKBdO5T+aVI+EogdD8AmjBjpyIlX5xK18ZEsBocA3Q1hTuTWy2IVGw==",
+      "version": "1.553.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.553.0.tgz",
+      "integrity": "sha512-wwYPW/omHchmLj+1tOPx2aVWr4wp5uWhRmYSNP9jfAlBswRki+SOvGejDMx5Q3RWTgrWcfiPYQ8iU2TnwwdKUA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.552.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.552.0.tgz",
-      "integrity": "sha512-CKAF4cLq0ExCZT3ZGtPUEGRBnn1tXlystKBdO5T+aVI+EogdD8AmjBjpyIlX5xK18ZEsBocA3Q1hTuTWy2IVGw==",
+      "version": "1.553.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.553.0.tgz",
+      "integrity": "sha512-wwYPW/omHchmLj+1tOPx2aVWr4wp5uWhRmYSNP9jfAlBswRki+SOvGejDMx5Q3RWTgrWcfiPYQ8iU2TnwwdKUA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.552.0",
+    "@bigcommerce/checkout-sdk": "^1.553.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.553.0

## Why?
As a part of release: https://github.com/bigcommerce/checkout-sdk-js/pull/2374

## Testing / Proof
All tests passed

@bigcommerce/team-checkout
