### PR TITLE
chore(payment): PI-1679 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.554.0",
+        "@bigcommerce/checkout-sdk": "^1.555.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.554.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.554.0.tgz",
-      "integrity": "sha512-7bRN6lfMfmm56AqoGC2VX7I5ppZ+mculNshPCKSAUjcAoMGWteIUig92yChKyFvD+G9fLR5xUgAsFbIvj2WJpQ==",
+      "version": "1.555.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.555.0.tgz",
+      "integrity": "sha512-PCpZTNPjUQwAOoIQMaqFh2BVYLVIA9Dn/++N2/RLMnvEGsUr+TIAxE+JpRA0zM82bqo3pzxjWkser9BFByHayg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.554.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.554.0.tgz",
-      "integrity": "sha512-7bRN6lfMfmm56AqoGC2VX7I5ppZ+mculNshPCKSAUjcAoMGWteIUig92yChKyFvD+G9fLR5xUgAsFbIvj2WJpQ==",
+      "version": "1.555.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.555.0.tgz",
+      "integrity": "sha512-PCpZTNPjUQwAOoIQMaqFh2BVYLVIA9Dn/++N2/RLMnvEGsUr+TIAxE+JpRA0zM82bqo3pzxjWkser9BFByHayg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.554.0",
+    "@bigcommerce/checkout-sdk": "^1.555.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2390](https://github.com/bigcommerce/checkout-sdk-js/pull/2390)

## Testing / Proof
manually tested and unit test

@bigcommerce/team-checkout
