### PR TITLE
fix(checkout): CHECKOUT-8049 Use session storage to save subscription status in frontend

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -36,6 +36,7 @@ import {
     CustomerViewType,
 } from '../customer';
 import { getSupportedMethodIds } from '../customer/getSupportedMethods';
+import { SubscribeSessionStorage } from '../customer/SubscribeSessionStorage';
 import { EmbeddedCheckoutStylesheet, isEmbedded } from '../embeddedCheckout';
 import { PromotionBannerList } from '../promotion';
 import { hasSelectedShippingOptions, isUsingMultiShipping, StaticConsignment } from '../shipping';
@@ -305,7 +306,7 @@ class Checkout extends Component<
         }
 
         return (
-            <div id="checkout-page-container" data-test="checkout-page-container" className={classNames({ 'is-embedded': isEmbedded(), 'remove-checkout-step-numbers': isHidingStepNumbers })}>
+            <div className={classNames({ 'is-embedded': isEmbedded(), 'remove-checkout-step-numbers': isHidingStepNumbers })} data-test="checkout-page-container" id="checkout-page-container">
                 <div className="layout optimizedCheckout-contentPrimary">
                     {this.renderContent()}
                 </div>
@@ -608,6 +609,8 @@ class Checkout extends Component<
         if (this.embeddedMessenger) {
             this.embeddedMessenger.postComplete();
         }
+
+        SubscribeSessionStorage.removeSubscribeStatus();
 
         this.setState({ isRedirecting: true }, () => {
             navigateToOrderConfirmation(orderId);

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -37,6 +37,7 @@ import GuestForm, { GuestFormValues } from './GuestForm';
 import LoginForm from './LoginForm';
 import mapCreateAccountFromFormValues from './mapCreateAccountFromFormValues';
 import StripeGuestForm from './StripeGuestForm';
+import { SubscribeSessionStorage } from './SubscribeSessionStorage';
 
 export interface CustomerProps {
     viewType: CustomerViewType;
@@ -406,7 +407,10 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                     : updateSubscriptionWhenUnchecked,
             });
 
+
             onSubscribeToNewsletter(formValues.shouldSubscribe);
+
+            SubscribeSessionStorage.setSubscribeStatus(formValues.shouldSubscribe);
 
             const customer = data.getCustomer();
 

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -407,7 +407,6 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                     : updateSubscriptionWhenUnchecked,
             });
 
-
             onSubscribeToNewsletter(formValues.shouldSubscribe);
 
             SubscribeSessionStorage.setSubscribeStatus(formValues.shouldSubscribe);

--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -11,6 +11,15 @@ import { BasicFormField, Fieldset, Form, Legend } from '../ui/form';
 
 import EmailField from './EmailField';
 import SubscribeField from './SubscribeField';
+import { SubscribeSessionStorage } from './SubscribeSessionStorage';
+
+function getShouldSubscribeValue(requiresMarketingConsent: boolean, defaultShouldSubscribe: boolean) {
+    if (SubscribeSessionStorage.getSubscribeStatus()) {
+        return true;
+    }
+
+    return requiresMarketingConsent ? false : defaultShouldSubscribe
+}
 
 export interface GuestFormProps {
     canSubscribe: boolean;
@@ -125,7 +134,7 @@ export default withLanguage(
             requiresMarketingConsent,
         }) => ({
             email,
-            shouldSubscribe: requiresMarketingConsent ? false : defaultShouldSubscribe,
+            shouldSubscribe: getShouldSubscribeValue(requiresMarketingConsent, defaultShouldSubscribe),
             privacyPolicy: false,
         }),
         handleSubmit: (values, { props: { onContinueAsGuest } }) => {

--- a/packages/core/src/app/customer/SubscribeSessionStorage.test.ts
+++ b/packages/core/src/app/customer/SubscribeSessionStorage.test.ts
@@ -1,0 +1,13 @@
+import { SubscribeSessionStorage } from "./SubscribeSessionStorage";
+
+describe('SubscribeSessionStorage', () => {
+    it('sets, gets and removes subscribe status successfully', () => {
+        expect(SubscribeSessionStorage.getSubscribeStatus()).toBe(false);
+        SubscribeSessionStorage.setSubscribeStatus(true);
+
+        expect(SubscribeSessionStorage.getSubscribeStatus()).toBe(true);
+
+        SubscribeSessionStorage.removeSubscribeStatus();
+        expect(SubscribeSessionStorage.getSubscribeStatus()).toBe(false);
+    });
+});

--- a/packages/core/src/app/customer/SubscribeSessionStorage.ts
+++ b/packages/core/src/app/customer/SubscribeSessionStorage.ts
@@ -1,0 +1,17 @@
+export class SubscribeSessionStorage {
+    static key = 'shouldSubscribe';
+
+    static setSubscribeStatus(shouldSubscribe: boolean) {
+        sessionStorage.setItem(this.key, `${shouldSubscribe}`)
+    }
+
+    static getSubscribeStatus(): boolean {
+        const value = sessionStorage.getItem(this.key);
+
+        return value === 'true';
+    }
+
+    static removeSubscribeStatus() {
+        sessionStorage.removeItem(this.key);
+    }
+}


### PR DESCRIPTION
## What?
Use session storage to save subscription status.

## Why?
Once a user checks/unchecks the subscription checkbox and move and moves to next step. We send the relevant call to subscription API, but if the page refreshes we lose the state of subscription.

If the user goes back to customer step the state of checkbox is defaults to initial settings, which can be confusing for the user. 

## Testing / Proof
- CI 
- Screencast 

https://github.com/bigcommerce/checkout-js/assets/7134802/77923f83-73cb-4212-b0ea-a6c97b862a16


@bigcommerce/team-checkout
