### PR TITLE
chore(payment): PAYPAL-3743 bump checkout sdk version to 1.557.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.555.0",
+        "@bigcommerce/checkout-sdk": "^1.557.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.555.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.555.0.tgz",
-      "integrity": "sha512-PCpZTNPjUQwAOoIQMaqFh2BVYLVIA9Dn/++N2/RLMnvEGsUr+TIAxE+JpRA0zM82bqo3pzxjWkser9BFByHayg==",
+      "version": "1.557.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.557.1.tgz",
+      "integrity": "sha512-zsBMyuW+Sg273rkV2A8apGlOpx0ne4I68/A91/gr4jf022vuCsdQB5mQ3IhoGhpxGHGdWU6AlQLeSMz2FJBFoQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.555.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.555.0.tgz",
-      "integrity": "sha512-PCpZTNPjUQwAOoIQMaqFh2BVYLVIA9Dn/++N2/RLMnvEGsUr+TIAxE+JpRA0zM82bqo3pzxjWkser9BFByHayg==",
+      "version": "1.557.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.557.1.tgz",
+      "integrity": "sha512-zsBMyuW+Sg273rkV2A8apGlOpx0ne4I68/A91/gr4jf022vuCsdQB5mQ3IhoGhpxGHGdWU6AlQLeSMz2FJBFoQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.555.0",
+    "@bigcommerce/checkout-sdk": "^1.557.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.557.1

## Why?
As part of checkout-sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2393
https://github.com/bigcommerce/checkout-sdk-js/pull/2392
https://github.com/bigcommerce/checkout-sdk-js/pull/2395

## Testing / Proof
Unit tests
CI
