### PR TITLE
feat(payment): PAYPAL-3597 bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.557.2",
+        "@bigcommerce/checkout-sdk": "^1.558.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.557.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.557.2.tgz",
-      "integrity": "sha512-uZBS/OiJFU9uExayUEe55PzJpc95RDnIH7v7BtY0WttLlf14+ZDW6JapT9Oi9qp+vPGt9p42k3QXHSeIcuQdsg==",
+      "version": "1.558.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.558.0.tgz",
+      "integrity": "sha512-VOa+YOuZqo7DcAHAtBMtP02UMJtUEwdAUaXpCtV1/OnBl1qKfWORIZChwjSTGZdABagITPKpFq8PVF+py983VQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.557.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.557.2.tgz",
-      "integrity": "sha512-uZBS/OiJFU9uExayUEe55PzJpc95RDnIH7v7BtY0WttLlf14+ZDW6JapT9Oi9qp+vPGt9p42k3QXHSeIcuQdsg==",
+      "version": "1.558.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.558.0.tgz",
+      "integrity": "sha512-VOa+YOuZqo7DcAHAtBMtP02UMJtUEwdAUaXpCtV1/OnBl1qKfWORIZChwjSTGZdABagITPKpFq8PVF+py983VQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.557.2",
+    "@bigcommerce/checkout-sdk": "^1.558.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
To update code 
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2389

## Testing / Proof
Tested on dev

@bigcommerce/team-checkout
