### PR TITLE
chore(payment): PAYPAL-3784 bump checkout-sdk version to 1.560.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.558.2",
+        "@bigcommerce/checkout-sdk": "^1.560.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.558.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.558.2.tgz",
-      "integrity": "sha512-fLrJO4ZK5taO6iQcTZLFB/fNxnuQXKeuzZi4x+1NaaALBu7LgnCikEuFN/fwUQ5FKR81Vl9qHz1tyNdWIC070w==",
+      "version": "1.560.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.560.0.tgz",
+      "integrity": "sha512-Nv4DKFNHrcvmEDxRuFEsnDMrKiim0cuwbhscZprdH0du/c/zfakK68LpZO5HuRmxy16zg7ktcjEaGDOayNU0QQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.558.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.558.2.tgz",
-      "integrity": "sha512-fLrJO4ZK5taO6iQcTZLFB/fNxnuQXKeuzZi4x+1NaaALBu7LgnCikEuFN/fwUQ5FKR81Vl9qHz1tyNdWIC070w==",
+      "version": "1.560.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.560.0.tgz",
+      "integrity": "sha512-Nv4DKFNHrcvmEDxRuFEsnDMrKiim0cuwbhscZprdH0du/c/zfakK68LpZO5HuRmxy16zg7ktcjEaGDOayNU0QQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.558.2",
+    "@bigcommerce/checkout-sdk": "^1.560.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.560.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2403
https://github.com/bigcommerce/checkout-sdk-js/pull/2404

## Testing / Proof
Unit tests
Manual tests
CI
