### PR TITLE
chore(payment): PI-1138 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.562.1",
+        "@bigcommerce/checkout-sdk": "^1.562.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.562.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.562.1.tgz",
-      "integrity": "sha512-o87WP+a8UC3FR9M5QZT5T5pv+yueZlA+HnteCMZBBTU3D2TUG8fJ78L4p2iZXI7s123GXGNX1ErPKVahMW9uqQ==",
+      "version": "1.562.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.562.2.tgz",
+      "integrity": "sha512-50Q94uAerTpR/l1n3xNkgUjH7PdFKgHG1Fjq0F6DrCV7pKgVOgBMQVtXS0qncsGhU4AbXaEJ4Nbwdl6+am8Yng==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.562.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.562.1.tgz",
-      "integrity": "sha512-o87WP+a8UC3FR9M5QZT5T5pv+yueZlA+HnteCMZBBTU3D2TUG8fJ78L4p2iZXI7s123GXGNX1ErPKVahMW9uqQ==",
+      "version": "1.562.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.562.2.tgz",
+      "integrity": "sha512-50Q94uAerTpR/l1n3xNkgUjH7PdFKgHG1Fjq0F6DrCV7pKgVOgBMQVtXS0qncsGhU4AbXaEJ4Nbwdl6+am8Yng==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.562.1",
+    "@bigcommerce/checkout-sdk": "^1.562.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2411](https://github.com/bigcommerce/checkout-sdk-js/pull/2411)

## Testing / Proof
Manually tested and unit test

@bigcommerce/team-checkout
