### PR TITLE
feat(payment): PAYPAL-3586 Update Braintree Accelerated Checkout payment strategy to support Fastlane + Connect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.563.0",
+        "@bigcommerce/checkout-sdk": "^1.564.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.563.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.563.0.tgz",
-      "integrity": "sha512-NBNpG5TvM/XgFmquyj/XTovJdzPzysJ7BpBZz2YICV4JOG8RSsXXJyKYVlcUvMettSwCQDbxGiCnjZA3rkCgSA==",
+      "version": "1.564.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.564.0.tgz",
+      "integrity": "sha512-gIoGv/ieOP6b4hV1Xkfe6qWANdJGFZYvFz/Kvo4hwuP+LLmHsYDBiTAIT1HyoEig3i2P/m8CxEOzgQ7z+rL44g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.563.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.563.0.tgz",
-      "integrity": "sha512-NBNpG5TvM/XgFmquyj/XTovJdzPzysJ7BpBZz2YICV4JOG8RSsXXJyKYVlcUvMettSwCQDbxGiCnjZA3rkCgSA==",
+      "version": "1.564.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.564.0.tgz",
+      "integrity": "sha512-gIoGv/ieOP6b4hV1Xkfe6qWANdJGFZYvFz/Kvo4hwuP+LLmHsYDBiTAIT1HyoEig3i2P/m8CxEOzgQ7z+rL44g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.563.0",
+    "@bigcommerce/checkout-sdk": "^1.564.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.test.tsx
@@ -44,7 +44,7 @@ describe('BraintreeAcceleratedCheckoutPaymentMethod', () => {
 
         expect(initializePayment).toHaveBeenCalledWith({
             methodId: props.method.id,
-            braintreeacceleratedcheckout: {
+            braintreefastlane: {
                 onInit: expect.any(Function),
             },
         });

--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/BraintreeAcceleratedCheckoutPaymentMethod.tsx
@@ -31,7 +31,7 @@ const BraintreeAcceleratedCheckoutPaymentMethod: FunctionComponent<PaymentMethod
         try {
             await checkoutService.initializePayment({
                 methodId: method.id,
-                braintreeacceleratedcheckout: {
+                braintreefastlane: {
                     onInit: (renderPayPalConnectComponentMethod) => {
                         paypalConnectComponentRef.current.render =
                             renderPayPalConnectComponentMethod;


### PR DESCRIPTION
## What?
Updated Braintree Accelerated Checkout payment strategy to support Fastlane + Connect

## Why?
To integrate BT Fastlane

## Testing / Proof


@bigcommerce/team-checkout
