### PR TITLE
fix(payment): PAYPAL-3849 updated paypal commerce fastlane instrument details css class name

### DIFF
--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.scss
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.scss
@@ -1,4 +1,4 @@
-.paypal-commerce-axo-instrument {
+.paypal-commerce-fastlane-instrument {
   display: flex;
   justify-content: space-between;
   padding-bottom: 1rem;


### PR DESCRIPTION
## What?
Updated paypal commerce fastlane instrument details css class name

## Why?
Previously we updated PayPal Commerce related component style class names but forgot to update naming in scss file

## Testing / Proof
Manual tests

Before:
<img width="844" alt="Screenshot 2024-03-19 at 11 28 05" src="https://github.com/bigcommerce/checkout-js/assets/25133454/f3e47ad0-7542-4e05-b7c0-2438aa5fbc9b">


After:
<img width="842" alt="Screenshot 2024-03-19 at 11 27 44" src="https://github.com/bigcommerce/checkout-js/assets/25133454/f8a0e116-ba94-4e44-98e1-efa2f0cc21de">
