### PR TITLE
chore(payment): PAYPAL-3774 bump checkout-sdk version to 1.563.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.562.2",
+        "@bigcommerce/checkout-sdk": "^1.563.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.562.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.562.2.tgz",
-      "integrity": "sha512-50Q94uAerTpR/l1n3xNkgUjH7PdFKgHG1Fjq0F6DrCV7pKgVOgBMQVtXS0qncsGhU4AbXaEJ4Nbwdl6+am8Yng==",
+      "version": "1.563.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.563.0.tgz",
+      "integrity": "sha512-NBNpG5TvM/XgFmquyj/XTovJdzPzysJ7BpBZz2YICV4JOG8RSsXXJyKYVlcUvMettSwCQDbxGiCnjZA3rkCgSA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.562.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.562.2.tgz",
-      "integrity": "sha512-50Q94uAerTpR/l1n3xNkgUjH7PdFKgHG1Fjq0F6DrCV7pKgVOgBMQVtXS0qncsGhU4AbXaEJ4Nbwdl6+am8Yng==",
+      "version": "1.563.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.563.0.tgz",
+      "integrity": "sha512-NBNpG5TvM/XgFmquyj/XTovJdzPzysJ7BpBZz2YICV4JOG8RSsXXJyKYVlcUvMettSwCQDbxGiCnjZA3rkCgSA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.562.2",
+    "@bigcommerce/checkout-sdk": "^1.563.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.563.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2413
https://github.com/bigcommerce/checkout-sdk-js/pull/2416

## Testing / Proof
Unit tests
Manual tests
CI
