### PR TITLE
chore(checkout): CHECKOUT-0 - Add Gitleaks to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ version: 2.1
 orbs:
   ci: bigcommerce/internal@volatile
   node: bigcommerce/internal-node@volatile
+  security: bigcommerce/internal-security@volatile
 
 jobs:
   test-packages:
@@ -182,6 +183,10 @@ workflows:
       - ci/validate-commits:
           filters:
             <<: *pull_request_filter
+      - security/scan:
+          name: "Gitleaks secrets scan"
+          context: org-global
+          GITLEAKS_BLOCK: "false"
 
   release:
     jobs:


### PR DESCRIPTION
## What?
Adding GItleaks (secret scanner).

## Why?
For secrets detection to prevent accidental commits of secrets

## Testing / Proof
Passing of existing CI builds with gitleaks succesfully running as part of the process.

@bigcommerce/team-checkout
