### PR TITLE
chore(checkout): CHECKOUT-0 Don't scanned forked

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,9 @@ workflows:
             <<: *pull_request_filter
       - security/scan:
           name: "Gitleaks secrets scan"
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
           context: org-global
           GITLEAKS_BLOCK: "false"
 


### PR DESCRIPTION
## What?
Fixing config for secret scanning

## Why?
So it doesn't break a scan on a fork

## Testing / Proof
Check CI results below

@bigcommerce/team-checkout
