### PR TITLE
feat(payment): PI-1841 removed unused card validation fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.568.0",
+        "@bigcommerce/checkout-sdk": "^1.568.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.568.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.568.0.tgz",
-      "integrity": "sha512-+7aGhGLh4H7u87EkpP8TYaWjqah/BnCG0TrcioevupuQv1699o/w3p2k/qfcjAIyBT2kcBZ8EksB3UdQ5CPHew==",
+      "version": "1.568.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.568.3.tgz",
+      "integrity": "sha512-l0U/zu/slydn/BGYv80SsxzqrAruDkNGaNvcpVoFojAjUrY/ipTPKl2SyRuEbwx7xzqzUEyB9sQHE3KVuNaO0Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.568.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.568.0.tgz",
-      "integrity": "sha512-+7aGhGLh4H7u87EkpP8TYaWjqah/BnCG0TrcioevupuQv1699o/w3p2k/qfcjAIyBT2kcBZ8EksB3UdQ5CPHew==",
+      "version": "1.568.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.568.3.tgz",
+      "integrity": "sha512-l0U/zu/slydn/BGYv80SsxzqrAruDkNGaNvcpVoFojAjUrY/ipTPKl2SyRuEbwx7xzqzUEyB9sQHE3KVuNaO0Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.568.0",
+    "@bigcommerce/checkout-sdk": "^1.568.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -61,7 +61,7 @@ interface CreditCardPaymentMethodDerivedProps {
     isPaymentDataRequired: boolean;
     shouldShowInstrumentFieldset: boolean;
     isInstrumentCardCodeRequired(instrument: Instrument, method: PaymentMethod): boolean;
-    isInstrumentCardNumberRequired(instrument: Instrument): boolean;
+    isInstrumentCardNumberRequired(instrument: Instrument, method: PaymentMethod): boolean;
     loadInstruments(): Promise<CheckoutSelectors>;
 }
 
@@ -206,7 +206,7 @@ class CreditCardPaymentMethodComponent extends Component<
         const shouldShowCreditCardFieldset = !shouldShowInstrumentFieldset || isAddingNewCard;
         const isLoading = isInitializing || isLoadingInstruments;
         const shouldShowNumberField = selectedInstrument
-            ? isInstrumentCardNumberRequiredProp(selectedInstrument)
+            ? isInstrumentCardNumberRequiredProp(selectedInstrument, method)
             : false;
         const shouldShowCardCodeField = selectedInstrument
             ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
@@ -314,7 +314,10 @@ class CreditCardPaymentMethodComponent extends Component<
                         selectedInstrument,
                         method,
                     ),
-                    isCardNumberRequired: isInstrumentCardNumberRequiredProp(selectedInstrument),
+                    isCardNumberRequired: isInstrumentCardNumberRequiredProp(
+                        selectedInstrument,
+                        method,
+                    ),
                     language,
                 })
             );

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -59,7 +59,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         async (selectedInstrument) => {
             const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
             const isInstrumentCardNumberRequired = selectedInstrument
-                ? isInstrumentCardNumberRequiredProp(selectedInstrument)
+                ? isInstrumentCardNumberRequiredProp(selectedInstrument, method)
                 : false;
             const isInstrumentCardCodeRequired = selectedInstrument
                 ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
@@ -207,7 +207,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         useCallback(
             (selectedInstrument) => {
                 const isInstrumentCardNumberRequired = selectedInstrument
-                    ? isInstrumentCardNumberRequiredProp(selectedInstrument)
+                    ? isInstrumentCardNumberRequiredProp(selectedInstrument, method)
                     : false;
                 const isInstrumentCardCodeRequired = selectedInstrument
                     ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
@@ -60,7 +60,7 @@ export interface WithCheckoutHostedWidgetPaymentMethodProps {
     isPaymentDataRequired: boolean;
     isSignedIn: boolean;
     isInstrumentCardCodeRequired(instrument: Instrument, method: PaymentMethod): boolean;
-    isInstrumentCardNumberRequired(instrument: Instrument): boolean;
+    isInstrumentCardNumberRequired(instrument: Instrument, method: PaymentMethod): boolean;
     loadInstruments(): Promise<CheckoutSelectors>;
     signOut(options: CustomerRequestOptions): void;
 }
@@ -284,6 +284,7 @@ class HostedWidgetPaymentComponent extends Component<
         const {
             hideVerificationFields,
             instruments,
+            method,
             isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
             validateInstrument,
         } = this.props;
@@ -296,7 +297,10 @@ class HostedWidgetPaymentComponent extends Component<
         if (selectedInstrument) {
             assertIsCardInstrument(selectedInstrument);
 
-            const shouldShowNumberField = isInstrumentCardNumberRequiredProp(selectedInstrument);
+            const shouldShowNumberField = isInstrumentCardNumberRequiredProp(
+                selectedInstrument,
+                method,
+            );
 
             if (hideVerificationFields) {
                 return;

--- a/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.spec.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.spec.ts
@@ -50,6 +50,20 @@ describe('isInstrumentCardCodeRequired()', () => {
         ).toBe(false);
     });
 
+    it('returns false if CVV validation unavailable for payment method', () => {
+        expect(
+            isInstrumentCardCodeRequired(
+                merge({}, state, {
+                    paymentMethod: merge({}, getPaymentMethod(), {
+                        initializationData: {
+                            isVaultingCardCodeValidationAvailable: false,
+                        },
+                    }),
+                }),
+            ),
+        ).toBe(false);
+    });
+
     it('returns true if there is digital item in cart', () => {
         expect(
             isInstrumentCardCodeRequired(

--- a/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardCodeRequired/isInstrumentCardCodeRequired.ts
@@ -13,7 +13,16 @@ export default function isInstrumentCardCodeRequired({
     lineItems,
     paymentMethod,
 }: IsInstrumentCardCodeRequiredState): boolean {
-    if (PROVIDERS_WITHOUT_CARD_CODE.includes(instrument.provider)) {
+    const {
+        config: { isVaultingCvvEnabled, cardCode },
+        initializationData,
+    } = paymentMethod;
+    const { isVaultingCardCodeValidationAvailable = true } = initializationData || {};
+
+    if (
+        PROVIDERS_WITHOUT_CARD_CODE.includes(instrument.provider) ||
+        !isVaultingCardCodeValidationAvailable
+    ) {
         return false;
     }
 
@@ -24,10 +33,10 @@ export default function isInstrumentCardCodeRequired({
 
     // If the shipping address is trusted, show CVV field based on the merchant's configuration
     if (instrument.trustedShippingAddress) {
-        return !!paymentMethod.config.isVaultingCvvEnabled;
+        return !!isVaultingCvvEnabled;
     }
 
     // Otherwise, if the shipping address is untrusted, show CVV field if the
     // merchant either requires it for regular card or stored card payments.
-    return !!(paymentMethod.config.isVaultingCvvEnabled || paymentMethod.config.cardCode);
+    return !!(isVaultingCvvEnabled || cardCode);
 }

--- a/packages/instrument-utils/src/guards/isInstrumentCardNumberRequired/isInstrumentCardNumberRequired.spec.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardNumberRequired/isInstrumentCardNumberRequired.spec.ts
@@ -1,4 +1,4 @@
-import { getCardInstrument, getCart } from '@bigcommerce/checkout/test-mocks';
+import { getCardInstrument, getCart, getPaymentMethod } from '@bigcommerce/checkout/test-mocks';
 
 import { isInstrumentCardNumberRequired, IsInstrumentCardNumberRequiredState } from '.';
 
@@ -16,6 +16,12 @@ describe('is instrument card number required', () => {
                 ...getCardInstrument(),
                 trustedShippingAddress: false,
             },
+            paymentMethod: {
+                ...getPaymentMethod(),
+                config: {
+                    cardCode: false,
+                },
+            },
         };
     });
 
@@ -27,5 +33,16 @@ describe('is instrument card number required', () => {
 
     it('returns value based on instrument', () => {
         expect(isInstrumentCardNumberRequired(state)).toBe(true);
+    });
+
+    it('returns false if card number validation unavailable for payment method', () => {
+        state.paymentMethod = {
+            ...getPaymentMethod(),
+            initializationData: {
+                isVaultingCardNumberValidationAvailable: false,
+            },
+        };
+
+        expect(isInstrumentCardNumberRequired(state)).toBe(false);
     });
 });

--- a/packages/instrument-utils/src/guards/isInstrumentCardNumberRequired/isInstrumentCardNumberRequired.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardNumberRequired/isInstrumentCardNumberRequired.ts
@@ -1,15 +1,20 @@
-import { Instrument, LineItemMap } from '@bigcommerce/checkout-sdk';
+import { Instrument, LineItemMap, PaymentMethod } from '@bigcommerce/checkout-sdk';
 
 export interface IsInstrumentCardNumberRequiredState {
     lineItems: LineItemMap;
     instrument: Instrument;
+    paymentMethod?: PaymentMethod;
 }
 
 export default function isInstrumentCardNumberRequired({
     lineItems,
     instrument,
+    paymentMethod,
 }: IsInstrumentCardNumberRequiredState): boolean {
-    if (lineItems.physicalItems.length === 0) {
+    const { isVaultingCardNumberValidationAvailable = true } =
+        paymentMethod?.initializationData || {};
+
+    if (lineItems.physicalItems.length === 0 || !isVaultingCardNumberValidationAvailable) {
         return false;
     }
 

--- a/packages/instrument-utils/src/guards/isInstrumentCardNumberRequiredSelector.ts
+++ b/packages/instrument-utils/src/guards/isInstrumentCardNumberRequiredSelector.ts
@@ -1,4 +1,4 @@
-import { CheckoutSelectors, Instrument } from '@bigcommerce/checkout-sdk';
+import { CheckoutSelectors, Instrument, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { createSelector } from 'reselect';
 
 import isInstrumentCardNumberRequired from './isInstrumentCardNumberRequired/isInstrumentCardNumberRequired';
@@ -9,7 +9,7 @@ const isInstrumentCardNumberRequiredSelector = createSelector(
 
         return cart && cart.lineItems;
     },
-    (lineItems) => (instrument: Instrument) => {
+    (lineItems) => (instrument: Instrument, paymentMethod?: PaymentMethod) => {
         if (!lineItems) {
             return false;
         }
@@ -17,6 +17,7 @@ const isInstrumentCardNumberRequiredSelector = createSelector(
         return isInstrumentCardNumberRequired({
             lineItems,
             instrument,
+            paymentMethod,
         });
     },
 );


### PR DESCRIPTION
## What?
Remove unused vaulted cards validation fields

## Why?
Some payment providers like TDBank generate single one time token based on whole credit card fields. In this case we can't get token for card verification based on only one or two card fields and then can't verify card without token or data from provider iFrames.
So in this case we need to hide card verification fields to not show unused fields and to not confuse shoppers.

## Testing / Proof
Provider without fields properties in initialisation data, both fields should be shown by default:
<img width="2560" alt="Screenshot 2024-03-25 at 17 12 36" src="https://github.com/bigcommerce/checkout-js/assets/9430298/19fab7af-4cdf-4c01-bf12-64849bd590bb">

Provider with only Card Code validation field (Card number field disabled):
<img width="2560" alt="Screenshot 2024-03-25 at 17 13 23" src="https://github.com/bigcommerce/checkout-js/assets/9430298/0eb1ace2-8435-4d2c-8f8e-594c3038f684">

Provider with only Card Number validation field (Card Code field disabled):
<img width="2560" alt="Screenshot 2024-03-25 at 17 14 18" src="https://github.com/bigcommerce/checkout-js/assets/9430298/8da8fa4e-1432-41b4-93ac-a673a146237c">

Provider with both fields disabled:
<img width="2560" alt="Screenshot 2024-03-25 at 17 15 12" src="https://github.com/bigcommerce/checkout-js/assets/9430298/798d8f23-a6d9-475c-a4b9-787d4d5b80db">

Provider with both fields enabled:
<img width="2560" alt="Screenshot 2024-03-25 at 17 16 27" src="https://github.com/bigcommerce/checkout-js/assets/9430298/8216e32b-6792-438f-aceb-a9a0a927c7ef">


@bigcommerce/team-checkout
