### PR TITLE
chore(payment): PI-1579 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.565.1",
+        "@bigcommerce/checkout-sdk": "^1.566.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.565.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.565.1.tgz",
-      "integrity": "sha512-RnoZ+aXeGtFNti5yt/fJksJCi8D+btPfkXj+rgB7zdjXWJ7qf//b/+0WZ9lX3Stgkz/x15AbQc78FdrBFHLw3g==",
+      "version": "1.566.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.566.0.tgz",
+      "integrity": "sha512-/sp0yml6aXVWiYOqhcQ0fz0BXt2DfbXWEFRTxCgOiC+scK0K4bfkD0znqqOYO3oJ3QZ87A9zOEeOuAW/Wk1BVQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.565.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.565.1.tgz",
-      "integrity": "sha512-RnoZ+aXeGtFNti5yt/fJksJCi8D+btPfkXj+rgB7zdjXWJ7qf//b/+0WZ9lX3Stgkz/x15AbQc78FdrBFHLw3g==",
+      "version": "1.566.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.566.0.tgz",
+      "integrity": "sha512-/sp0yml6aXVWiYOqhcQ0fz0BXt2DfbXWEFRTxCgOiC+scK0K4bfkD0znqqOYO3oJ3QZ87A9zOEeOuAW/Wk1BVQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.565.1",
+    "@bigcommerce/checkout-sdk": "^1.566.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout-sdk version

## Why?
To release https://github.com/bigcommerce/checkout-sdk-js/pull/2406
## Testing / Proof
Unit and manual tests

@bigcommerce/team-checkout
