### PR TITLE
feat(payment): PAYPAL-3910 PAYPAL-3881 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.568.3",
+        "@bigcommerce/checkout-sdk": "^1.570.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.568.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.568.3.tgz",
-      "integrity": "sha512-l0U/zu/slydn/BGYv80SsxzqrAruDkNGaNvcpVoFojAjUrY/ipTPKl2SyRuEbwx7xzqzUEyB9sQHE3KVuNaO0Q==",
+      "version": "1.570.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.0.tgz",
+      "integrity": "sha512-RT23be2EBQVv7MArK6GL/Z32mW3yzUFCobY2EBxUF9TwcImEBJL6hRm2Fd89vhJrB1fC2a2jviU+krNOOphRyA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.568.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.568.3.tgz",
-      "integrity": "sha512-l0U/zu/slydn/BGYv80SsxzqrAruDkNGaNvcpVoFojAjUrY/ipTPKl2SyRuEbwx7xzqzUEyB9sQHE3KVuNaO0Q==",
+      "version": "1.570.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.0.tgz",
+      "integrity": "sha512-RT23be2EBQVv7MArK6GL/Z32mW3yzUFCobY2EBxUF9TwcImEBJL6hRm2Fd89vhJrB1fC2a2jviU+krNOOphRyA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.568.3",
+    "@bigcommerce/checkout-sdk": "^1.570.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk from 1.568.3 to 1.570.0
Related prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/2429
https://github.com/bigcommerce/checkout-sdk-js/pull/2431

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
