### PR TITLE
chore(payment): PI-1726 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.570.0",
+        "@bigcommerce/checkout-sdk": "^1.570.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.570.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.0.tgz",
-      "integrity": "sha512-RT23be2EBQVv7MArK6GL/Z32mW3yzUFCobY2EBxUF9TwcImEBJL6hRm2Fd89vhJrB1fC2a2jviU+krNOOphRyA==",
+      "version": "1.570.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.1.tgz",
+      "integrity": "sha512-NgoJptsG4iGIw7/KeZFh+2MOQNeZEEknjB5afQ2oqMCEPh9TxfUNcWm8RBBIXpQgu+lZHqt8Z+Ygw5QRDBGOPg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.570.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.0.tgz",
-      "integrity": "sha512-RT23be2EBQVv7MArK6GL/Z32mW3yzUFCobY2EBxUF9TwcImEBJL6hRm2Fd89vhJrB1fC2a2jviU+krNOOphRyA==",
+      "version": "1.570.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.1.tgz",
+      "integrity": "sha512-NgoJptsG4iGIw7/KeZFh+2MOQNeZEEknjB5afQ2oqMCEPh9TxfUNcWm8RBBIXpQgu+lZHqt8Z+Ygw5QRDBGOPg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.570.0",
+    "@bigcommerce/checkout-sdk": "^1.570.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
to deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2396](https://github.com/bigcommerce/checkout-sdk-js/pull/2396)

## Testing / Proof
unit test and manually tested

@bigcommerce/team-checkout
