### PR TITLE
chore(payment): PI-1899 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.570.1",
+        "@bigcommerce/checkout-sdk": "^1.571.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.570.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.1.tgz",
-      "integrity": "sha512-NgoJptsG4iGIw7/KeZFh+2MOQNeZEEknjB5afQ2oqMCEPh9TxfUNcWm8RBBIXpQgu+lZHqt8Z+Ygw5QRDBGOPg==",
+      "version": "1.571.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.571.1.tgz",
+      "integrity": "sha512-INI8cxnCQbxhIWIZHwAUjA01NzyXg4QLg5XI0n/6EAZtpNtfD2FA30bTL75ikLtniitZ0651xJrrGbpOV6wwMA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.570.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.570.1.tgz",
-      "integrity": "sha512-NgoJptsG4iGIw7/KeZFh+2MOQNeZEEknjB5afQ2oqMCEPh9TxfUNcWm8RBBIXpQgu+lZHqt8Z+Ygw5QRDBGOPg==",
+      "version": "1.571.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.571.1.tgz",
+      "integrity": "sha512-INI8cxnCQbxhIWIZHwAUjA01NzyXg4QLg5XI0n/6EAZtpNtfD2FA30bTL75ikLtniitZ0651xJrrGbpOV6wwMA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.570.1",
+    "@bigcommerce/checkout-sdk": "^1.571.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
to deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2436](https://github.com/bigcommerce/checkout-sdk-js/pull/2436)

## Testing / Proof
Unit tests and manually tested

@bigcommerce/team-checkout
