### PR TITLE
feat(payment): PAYPAL-3850 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.572.0",
+        "@bigcommerce/checkout-sdk": "^1.573.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.572.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.572.0.tgz",
-      "integrity": "sha512-ZMDbkfj1ohygZGbuj+nAsswmFOoGjZNawV2dvEFMnjFbIlaZa7FTglBH078x7+G+ZGwI9iZHbVEOjNdhSEOgog==",
+      "version": "1.573.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.573.0.tgz",
+      "integrity": "sha512-L5weBoKYmgjUBshU4vWhzqB8AzMHc5rMTdDHtzX9MBQriyv2w9PeuNZF6N6ZO+w2vgSSKzvdDC+rwz8TaxyF6A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.572.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.572.0.tgz",
-      "integrity": "sha512-ZMDbkfj1ohygZGbuj+nAsswmFOoGjZNawV2dvEFMnjFbIlaZa7FTglBH078x7+G+ZGwI9iZHbVEOjNdhSEOgog==",
+      "version": "1.573.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.573.0.tgz",
+      "integrity": "sha512-L5weBoKYmgjUBshU4vWhzqB8AzMHc5rMTdDHtzX9MBQriyv2w9PeuNZF6N6ZO+w2vgSSKzvdDC+rwz8TaxyF6A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.572.0",
+    "@bigcommerce/checkout-sdk": "^1.573.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2434

## Testing / Proof

All test passed

@bigcommerce/team-checkout
