### PR TITLE
feat(extension): CHECKOUT-000 Pass consignment includes to reload checkout command

### DIFF
--- a/packages/checkout-extension/src/handlers/createReloadCheckoutHandler.ts
+++ b/packages/checkout-extension/src/handlers/createReloadCheckoutHandler.ts
@@ -8,7 +8,12 @@ export function createReloadCheckoutHandler({
     return {
         commandType: ExtensionCommandType.ReloadCheckout,
         handler: () => {
-            void checkoutService.loadCheckout(checkoutService.getState().data.getCheckout()?.id);
+            void checkoutService.loadCheckout(checkoutService.getState().data.getCheckout()?.id, {
+                params: {
+                    // eslint-disable-next-line
+                    include: ['consignments.availableShippingOptions'] as any,
+                },
+            });
         },
     };
 }


### PR DESCRIPTION
## What?
Pass consignment includes to reload checkout command.

## Why?
Based on feedback of the extension is able to select shipping option, then reload command can take the shopper back to shipping step since shipping options are not reloaded on calling `reloadCheckout` command.

## Testing / Proof
- CI

@bigcommerce/team-checkout
