### PR TITLE
chore(payment): PAYPAL-3896 bump checkout sdk version to 1.575.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.573.0",
+        "@bigcommerce/checkout-sdk": "^1.575.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.573.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.573.0.tgz",
-      "integrity": "sha512-L5weBoKYmgjUBshU4vWhzqB8AzMHc5rMTdDHtzX9MBQriyv2w9PeuNZF6N6ZO+w2vgSSKzvdDC+rwz8TaxyF6A==",
+      "version": "1.575.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.575.0.tgz",
+      "integrity": "sha512-PdeV1yyYacjD+y5/SsyhXYZ0Up+EYUmRjOjBEOlVwGXRCuCM337A/jxvzB2p0TkuedQF+aP1E/NC9PJG0GpggA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.573.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.573.0.tgz",
-      "integrity": "sha512-L5weBoKYmgjUBshU4vWhzqB8AzMHc5rMTdDHtzX9MBQriyv2w9PeuNZF6N6ZO+w2vgSSKzvdDC+rwz8TaxyF6A==",
+      "version": "1.575.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.575.0.tgz",
+      "integrity": "sha512-PdeV1yyYacjD+y5/SsyhXYZ0Up+EYUmRjOjBEOlVwGXRCuCM337A/jxvzB2p0TkuedQF+aP1E/NC9PJG0GpggA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.573.0",
+    "@bigcommerce/checkout-sdk": "^1.575.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.575.0

## Why?
As part of checkout-sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2443
https://github.com/bigcommerce/checkout-sdk-js/pull/2441

## Testing / Proof
Unit tests
Manual tests
CI