### PR TITLE
feat(payment): PAYPAL-3587 bumped checkout-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.575.0",
+        "@bigcommerce/checkout-sdk": "^1.576.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.575.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.575.0.tgz",
-      "integrity": "sha512-PdeV1yyYacjD+y5/SsyhXYZ0Up+EYUmRjOjBEOlVwGXRCuCM337A/jxvzB2p0TkuedQF+aP1E/NC9PJG0GpggA==",
+      "version": "1.576.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.576.0.tgz",
+      "integrity": "sha512-bG5imNhxSi7EYmRumkhpMfWwgXLDq+7DnL6uAvgwmaGzXhzMmQE6/mwtI/feQfJvJPsgkuyvvlAM25s3T9YBbA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.575.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.575.0.tgz",
-      "integrity": "sha512-PdeV1yyYacjD+y5/SsyhXYZ0Up+EYUmRjOjBEOlVwGXRCuCM337A/jxvzB2p0TkuedQF+aP1E/NC9PJG0GpggA==",
+      "version": "1.576.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.576.0.tgz",
+      "integrity": "sha512-bG5imNhxSi7EYmRumkhpMfWwgXLDq+7DnL6uAvgwmaGzXhzMmQE6/mwtI/feQfJvJPsgkuyvvlAM25s3T9YBbA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.575.0",
+    "@bigcommerce/checkout-sdk": "^1.576.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-js version

## Why?
To deliver code
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2437

## Testing / Proof
Tested on dev, unit tests

@bigcommerce/team-checkout
