### PR TITLE
chore(payment): PI-1558 bump checkout-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.576.1",
+        "@bigcommerce/checkout-sdk": "^1.577.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.576.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.576.1.tgz",
-      "integrity": "sha512-kd4HBp3n4CX/V62nr0/ZtiXyt0bqAuUHwoXOfoDhs/uxxdESrQ8UiFhQU1WeCzA72jKGzGpeULh2w1sfW/XL2Q==",
+      "version": "1.577.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.0.tgz",
+      "integrity": "sha512-m6k4auUJ2b+6r7plYEpI2K9kR3fF9ITTKsPFq7ecwwSJAoVHM0PwtkDQULmgc44OWQWOYYqVOqrJVmlu65Yi8g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.576.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.576.1.tgz",
-      "integrity": "sha512-kd4HBp3n4CX/V62nr0/ZtiXyt0bqAuUHwoXOfoDhs/uxxdESrQ8UiFhQU1WeCzA72jKGzGpeULh2w1sfW/XL2Q==",
+      "version": "1.577.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.0.tgz",
+      "integrity": "sha512-m6k4auUJ2b+6r7plYEpI2K9kR3fF9ITTKsPFq7ecwwSJAoVHM0PwtkDQULmgc44OWQWOYYqVOqrJVmlu65Yi8g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.576.1",
+    "@bigcommerce/checkout-sdk": "^1.577.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/2432

1. Add Google Pay button strategy for Worldpay Access
2. Refactor existing logic for:
    - Authorize Net
    - Checkout Com
    - Cybersource / BNZ
    - Orbital
    - Stripe v3 / Stripe UPE

## Why?
To checkout using Google Pay  Refactor

## Testing / Proof
Tested manually/units



@bigcommerce/team-checkout
