### PR TITLE
chore(other): CHECKOUT-8177 Improve output of scripts/sdk-live-checker.sh

### DIFF
--- a/scripts/sdk-live-checker.sh
+++ b/scripts/sdk-live-checker.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 
-npm ci
+npm ci --silent
+if [ $? -ne 0 ]; then
+  echo
+  echo '❌ Error: `npm ci` failed, aborting.'
+  exit 1
+fi
 
 # Make sure current version of @bigcommerce/checkout-sdk exists on the CDN
 CURRENT_VERSION=`npm list --depth=0 | grep checkout-sdk | sed -E 's/.*@//'`
+echo
+echo "ℹ️  Checking presence of checkout SDK on CDN..."
 HTTP_STATUS=`curl -s -o /dev/null -I -w "%{http_code}" https://checkout-sdk.bigcommerce.com/v1/loader-v${CURRENT_VERSION}.js`
 if [[ $HTTP_STATUS == "200" ]]; then
   # Status 200, return OK
+  echo "✅ Checkout-sdk version ${CURRENT_VERSION} found on CDN"
   exit 0
 else
   # Status not 200, return error
+  echo "⚠️ Checkout-sdk version ${CURRENT_VERSION} not found on CDN. HTTP status returned: ${HTTP_STATUS}"
   exit 1
 fi


### PR DESCRIPTION
## What?
Improve output of scripts/sdk-live-checker.sh

## Why?
Currently, when this fails, it doesn't show any meaningful output. That means you have to go to the script itself and check what it might have done and where it failed

## Testing / Proof
While running, `npm ci` still shows the following:
<img width="765" alt="Screenshot 2024-04-08 at 17 18 53" src="https://github.com/bigcommerce/checkout-js/assets/1606901/d9d9465c-036f-47e9-960a-85f8b9931dcd">

The result shown:
<img width="332" alt="Screenshot 2024-04-08 at 17 19 08" src="https://github.com/bigcommerce/checkout-js/assets/1606901/7f060353-a3ec-41bc-a5dd-67471aa39e66">

CI output on this PR:
<img width="497" alt="Screenshot 2024-04-08 at 17 22 11" src="https://github.com/bigcommerce/checkout-js/assets/1606901/141743d8-441a-4594-94dd-090db153394f">

@bigcommerce/team-checkout