### PR TITLE
chore(checkout): PI-1558 revert checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.577.0",
+        "@bigcommerce/checkout-sdk": "^1.577.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.577.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.0.tgz",
-      "integrity": "sha512-m6k4auUJ2b+6r7plYEpI2K9kR3fF9ITTKsPFq7ecwwSJAoVHM0PwtkDQULmgc44OWQWOYYqVOqrJVmlu65Yi8g==",
+      "version": "1.577.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.1.tgz",
+      "integrity": "sha512-Wg34QBL5kxshKbiKn/WNyZXDxc/vWMTSzcWyp95LbQ94iIldHMZesC3DBkJb/ay2Cowy0EhDFy0yS9BSiKXMEA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.577.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.0.tgz",
-      "integrity": "sha512-m6k4auUJ2b+6r7plYEpI2K9kR3fF9ITTKsPFq7ecwwSJAoVHM0PwtkDQULmgc44OWQWOYYqVOqrJVmlu65Yi8g==",
+      "version": "1.577.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.1.tgz",
+      "integrity": "sha512-Wg34QBL5kxshKbiKn/WNyZXDxc/vWMTSzcWyp95LbQ94iIldHMZesC3DBkJb/ay2Cowy0EhDFy0yS9BSiKXMEA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.577.0",
+    "@bigcommerce/checkout-sdk": "^1.577.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the checkout-sdk revert https://github.com/bigcommerce/checkout-sdk-js/pull/2449

## Why?
Due to the revert

## Testing / Proof
Tested manually

@bigcommerce/team-checkout
