### PR TITLE
chore(payment): PAYPAL-3736 bump checkout-sdk version to 1.577.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.577.1",
+        "@bigcommerce/checkout-sdk": "^1.577.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.577.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.1.tgz",
-      "integrity": "sha512-Wg34QBL5kxshKbiKn/WNyZXDxc/vWMTSzcWyp95LbQ94iIldHMZesC3DBkJb/ay2Cowy0EhDFy0yS9BSiKXMEA==",
+      "version": "1.577.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.2.tgz",
+      "integrity": "sha512-b/5v1/I4AvtTCeteuBAOmQ+icgeOxmiQxGsfUlBONX+QV0RlfEPkgF8Z+hGF5YxQIRRdAgC9I9Ssc2+LhOg/6A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35599,9 +35599,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.577.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.1.tgz",
-      "integrity": "sha512-Wg34QBL5kxshKbiKn/WNyZXDxc/vWMTSzcWyp95LbQ94iIldHMZesC3DBkJb/ay2Cowy0EhDFy0yS9BSiKXMEA==",
+      "version": "1.577.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.2.tgz",
+      "integrity": "sha512-b/5v1/I4AvtTCeteuBAOmQ+icgeOxmiQxGsfUlBONX+QV0RlfEPkgF8Z+hGF5YxQIRRdAgC9I9Ssc2+LhOg/6A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.577.1",
+    "@bigcommerce/checkout-sdk": "^1.577.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.577.2

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2448
https://github.com/bigcommerce/checkout-sdk-js/pull/2447

## Testing / Proof
Unit tests
Manual tests
CI
