### PR TITLE
chore(other): CHECKOUT-8132 Update checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.577.2",
+        "@bigcommerce/checkout-sdk": "^1.577.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.577.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.2.tgz",
-      "integrity": "sha512-b/5v1/I4AvtTCeteuBAOmQ+icgeOxmiQxGsfUlBONX+QV0RlfEPkgF8Z+hGF5YxQIRRdAgC9I9Ssc2+LhOg/6A==",
+      "version": "1.577.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.3.tgz",
+      "integrity": "sha512-nRoEh/wtaFiapO4XqCD9u7MAQObKkQ/1C4RPWBGM1M4isJqvacBrgpHtwBJWvfepvO631//2nlTy4OEkqYxemg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.577.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.2.tgz",
-      "integrity": "sha512-b/5v1/I4AvtTCeteuBAOmQ+icgeOxmiQxGsfUlBONX+QV0RlfEPkgF8Z+hGF5YxQIRRdAgC9I9Ssc2+LhOg/6A==",
+      "version": "1.577.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.577.3.tgz",
+      "integrity": "sha512-nRoEh/wtaFiapO4XqCD9u7MAQObKkQ/1C4RPWBGM1M4isJqvacBrgpHtwBJWvfepvO631//2nlTy4OEkqYxemg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.577.2",
+    "@bigcommerce/checkout-sdk": "^1.577.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
As above

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/2440

## Testing / Proof
- CI

@bigcommerce/team-checkout
