### PR TITLE
chore(payment): PAYPAL-4001 bump checkout-sdk version to 1.579.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.578.1",
+        "@bigcommerce/checkout-sdk": "^1.579.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.578.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.578.1.tgz",
-      "integrity": "sha512-mw6xldQjHY8QY2uAWjzUs2cJYQN4+ugjrrTEb3aFZLLC6z+E83H9np/j0LbPPF03yD5Nh/ZvmphXq8wBpP+aLQ==",
+      "version": "1.579.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.579.0.tgz",
+      "integrity": "sha512-ICWYfucRq3C18F/oGMfO1FsCNQfN+ElXvnz429v6uUr4INxq9LJ8Ig5NHCe/8Mri0LC8nikDooJn7UD8vtK8eA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.578.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.578.1.tgz",
-      "integrity": "sha512-mw6xldQjHY8QY2uAWjzUs2cJYQN4+ugjrrTEb3aFZLLC6z+E83H9np/j0LbPPF03yD5Nh/ZvmphXq8wBpP+aLQ==",
+      "version": "1.579.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.579.0.tgz",
+      "integrity": "sha512-ICWYfucRq3C18F/oGMfO1FsCNQfN+ElXvnz429v6uUr4INxq9LJ8Ig5NHCe/8Mri0LC8nikDooJn7UD8vtK8eA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.578.1",
+    "@bigcommerce/checkout-sdk": "^1.579.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.579.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2456

## Testing / Proof
Unit tests
Manual tests
CI

PayPal Commerce Fastlane:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/df1808a7-64aa-42be-9749-2b8f55837bbc

Braintree Fastlane:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/e42a1a38-284b-4445-ab13-4a8462b5b025


