### PR TITLE
feat(payment): PAYPAL-3850 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.580.0",
+        "@bigcommerce/checkout-sdk": "^1.581.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.580.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.580.0.tgz",
-      "integrity": "sha512-LZyi5W0svTRs1y6o5spGUfeLewaySjITcL4wfLLqZPV4bHbFf2FgPwh3HkXuXisnFQc0+OzAHDVoBo7o30+JAA==",
+      "version": "1.581.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.581.0.tgz",
+      "integrity": "sha512-hRGNIl6cUvihygdFPELMBGLGnjUDUSWy17H0dHq+P9tUYV8KTVeyXPcchlXX0k3jcTgD6vgYMTQVRinYfWF09A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.580.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.580.0.tgz",
-      "integrity": "sha512-LZyi5W0svTRs1y6o5spGUfeLewaySjITcL4wfLLqZPV4bHbFf2FgPwh3HkXuXisnFQc0+OzAHDVoBo7o30+JAA==",
+      "version": "1.581.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.581.0.tgz",
+      "integrity": "sha512-hRGNIl6cUvihygdFPELMBGLGnjUDUSWy17H0dHq+P9tUYV8KTVeyXPcchlXX0k3jcTgD6vgYMTQVRinYfWF09A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.580.0",
+    "@bigcommerce/checkout-sdk": "^1.581.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2455

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
