### PR TITLE
chore(payment): PI-1606 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.581.0",
+        "@bigcommerce/checkout-sdk": "^1.582.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.581.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.581.0.tgz",
-      "integrity": "sha512-hRGNIl6cUvihygdFPELMBGLGnjUDUSWy17H0dHq+P9tUYV8KTVeyXPcchlXX0k3jcTgD6vgYMTQVRinYfWF09A==",
+      "version": "1.582.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.582.0.tgz",
+      "integrity": "sha512-gb5t7NuRQ53WMUFl71dKBLCWxjYNJGJsjk6zBsfYRhlgdVKT+7Mf2zFVPJKFI5cZx/mJNRN4uE+XIDTqc+u3Eg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.581.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.581.0.tgz",
-      "integrity": "sha512-hRGNIl6cUvihygdFPELMBGLGnjUDUSWy17H0dHq+P9tUYV8KTVeyXPcchlXX0k3jcTgD6vgYMTQVRinYfWF09A==",
+      "version": "1.582.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.582.0.tgz",
+      "integrity": "sha512-gb5t7NuRQ53WMUFl71dKBLCWxjYNJGJsjk6zBsfYRhlgdVKT+7Mf2zFVPJKFI5cZx/mJNRN4uE+XIDTqc+u3Eg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.581.0",
+    "@bigcommerce/checkout-sdk": "^1.582.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
As part of the release: https://github.com/bigcommerce/checkout-sdk-js/pull/2453

## Testing / Proof
Unit + manual tests

@bigcommerce/team-checkout
