### PR TITLE
feat(payment): Placing order with Vaulted ACH account on checkout doesn't work

### DIFF
--- a/packages/braintree-integration/src/BraintreeAch/components/BraintreeAchPaymentForm.tsx
+++ b/packages/braintree-integration/src/BraintreeAch/components/BraintreeAchPaymentForm.tsx
@@ -38,7 +38,7 @@ const BraintreeAchPaymentForm: FunctionComponent<BraintreeAchPaymentFormProps> =
         shouldCreateNewInstrument,
         shouldConfirmInstrument,
     } = useBraintreeAchInstruments(method);
-    const { validateBraintreeAchForm } = useBraintreeAchValidation(method);
+    const { validateBraintreeAchForm, resetFormValidation } = useBraintreeAchValidation(method);
 
     const resetFormValues = () => {
         const { firstName, lastName } = checkoutState.data.getBillingAddress() || {};
@@ -84,8 +84,17 @@ const BraintreeAchPaymentForm: FunctionComponent<BraintreeAchPaymentFormProps> =
             };
 
             void validate();
+        } else {
+            resetFormValidation();
         }
-    }, [getFormValues, setFieldValue, setIsValidForm, shouldShowForm, validateBraintreeAchForm]);
+    }, [
+        getFormValues,
+        setFieldValue,
+        setIsValidForm,
+        shouldShowForm,
+        validateBraintreeAchForm,
+        resetFormValidation,
+    ]);
 
     useEffect(() => {
         const mandateTextConfirmationCheckboxValue = getFieldValue('orderConsent');

--- a/packages/braintree-integration/src/BraintreeAch/hooks/useBraintreeAchValidation.ts
+++ b/packages/braintree-integration/src/BraintreeAch/hooks/useBraintreeAchValidation.ts
@@ -1,5 +1,5 @@
 import { PaymentMethod } from '@bigcommerce/checkout-sdk';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { object, string, StringSchema } from 'yup';
 
 import { useLocale } from '@bigcommerce/checkout/locale';
@@ -97,6 +97,8 @@ const useBraintreeAchValidation = (method: PaymentMethod) => {
 
             const validationSchema = getValidationSchema();
 
+            paymentForm.setValidationSchema(method, validationSchema);
+
             const [
                 isValidAccountNumber,
                 isValidRoutingNumber,
@@ -121,12 +123,13 @@ const useBraintreeAchValidation = (method: PaymentMethod) => {
         [getValidationSchema],
     );
 
-    useEffect(() => {
-        paymentForm.setValidationSchema(method, getValidationSchema());
-    }, [method, paymentForm, getValidationSchema]);
+    const resetFormValidation = useCallback(() => {
+        paymentForm.setValidationSchema(method, null);
+    }, [paymentForm, method]);
 
     return {
         validateBraintreeAchForm,
+        resetFormValidation,
     };
 };
 


### PR DESCRIPTION
## What?

Fix of Braintree ACH validation

## Why?

To be able place an order using a vaulted ACH account

## Testing / Proof

https://github.com/bigcommerce/checkout-js/assets/99336044/e6c4db5f-70bd-4643-927d-6893af78fb42

@bigcommerce/team-checkout
