### PR TITLE
chore(payment): PI-650 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.585.0",
+        "@bigcommerce/checkout-sdk": "^1.585.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.585.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.0.tgz",
-      "integrity": "sha512-siGMV80p2fYL1IveaJOZoVC79iZ181UuZETj0KPk0fnNsS8gxI1UHD7IikTwvbWN6pXaFOctrSYeRU8l5Mf/SA==",
+      "version": "1.585.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.1.tgz",
+      "integrity": "sha512-7WExRSJihP4cOTqEg89jHfyqFwM585e1Hi/dN8pMA/Ox/n7UfZ/VvjBXYsMJExCtYHc7XQGiUfGgdpu1J6OG2w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.585.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.0.tgz",
-      "integrity": "sha512-siGMV80p2fYL1IveaJOZoVC79iZ181UuZETj0KPk0fnNsS8gxI1UHD7IikTwvbWN6pXaFOctrSYeRU8l5Mf/SA==",
+      "version": "1.585.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.1.tgz",
+      "integrity": "sha512-7WExRSJihP4cOTqEg89jHfyqFwM585e1Hi/dN8pMA/Ox/n7UfZ/VvjBXYsMJExCtYHc7XQGiUfGgdpu1J6OG2w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.585.0",
+    "@bigcommerce/checkout-sdk": "^1.585.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2452

## Why?
Due to the google pay refactoring

## Testing / Proof
[Testing section](https://github.com/bigcommerce/checkout-sdk-js/pull/2452) 

@bigcommerce/team-checkout
