### PR TITLE
fix(checkout): CHECKOUT-0000 Revert SDK to 1.582.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.585.1",
+        "@bigcommerce/checkout-sdk": "^1.582.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.585.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.1.tgz",
-      "integrity": "sha512-7WExRSJihP4cOTqEg89jHfyqFwM585e1Hi/dN8pMA/Ox/n7UfZ/VvjBXYsMJExCtYHc7XQGiUfGgdpu1J6OG2w==",
+      "version": "1.582.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.582.2.tgz",
+      "integrity": "sha512-nU2zqFxa6nU2zTiMj+RC7Eugh6wBW8xpdiLWgE2UTa5MV4bprXo1hSR72/gqoTG1nAu59xhRMnao2KDtj8vu9A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.585.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.1.tgz",
-      "integrity": "sha512-7WExRSJihP4cOTqEg89jHfyqFwM585e1Hi/dN8pMA/Ox/n7UfZ/VvjBXYsMJExCtYHc7XQGiUfGgdpu1J6OG2w==",
+      "version": "1.582.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.582.2.tgz",
+      "integrity": "sha512-nU2zqFxa6nU2zTiMj+RC7Eugh6wBW8xpdiLWgE2UTa5MV4bprXo1hSR72/gqoTG1nAu59xhRMnao2KDtj8vu9A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.585.1",
+    "@bigcommerce/checkout-sdk": "^1.582.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Revert SDK to 1.582.2.

## Why?
Using an older SDK version to determine if the problem is with the SDK release. 

## Testing / Proof
CI checks.

@bigcommerce/team-checkout
