### PR TITLE
chore(payment): PAYPAL-000 bump checkout version to 1.585.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.585.1",
+        "@bigcommerce/checkout-sdk": "^1.585.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.585.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.1.tgz",
-      "integrity": "sha512-7WExRSJihP4cOTqEg89jHfyqFwM585e1Hi/dN8pMA/Ox/n7UfZ/VvjBXYsMJExCtYHc7XQGiUfGgdpu1J6OG2w==",
+      "version": "1.585.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.2.tgz",
+      "integrity": "sha512-Gm82+hW/TAKwd+kkncrHOh3/fySxzTOhFYjDucu2kU4K09dkZbQiY8cpBUP0bXjSXE4a8wB2Tgyru5UuqmWGZw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.585.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.1.tgz",
-      "integrity": "sha512-7WExRSJihP4cOTqEg89jHfyqFwM585e1Hi/dN8pMA/Ox/n7UfZ/VvjBXYsMJExCtYHc7XQGiUfGgdpu1J6OG2w==",
+      "version": "1.585.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.2.tgz",
+      "integrity": "sha512-Gm82+hW/TAKwd+kkncrHOh3/fySxzTOhFYjDucu2kU4K09dkZbQiY8cpBUP0bXjSXE4a8wB2Tgyru5UuqmWGZw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.585.1",
+    "@bigcommerce/checkout-sdk": "^1.585.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.585.2

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2468

## Testing / Proof
Unit tests
Manual tests
CI