### PR TITLE
chore(payment): PI-1925 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.585.2",
+        "@bigcommerce/checkout-sdk": "^1.585.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.585.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.2.tgz",
-      "integrity": "sha512-Gm82+hW/TAKwd+kkncrHOh3/fySxzTOhFYjDucu2kU4K09dkZbQiY8cpBUP0bXjSXE4a8wB2Tgyru5UuqmWGZw==",
+      "version": "1.585.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.4.tgz",
+      "integrity": "sha512-ZGZLLZMTEupKh8bo/gIUViI6AbbS6coZZEZKy/i30BUXzgBHIBkG1HlfJ46tytt3RQ3bnxZamaUm0dgIzHs7ug==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.585.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.2.tgz",
-      "integrity": "sha512-Gm82+hW/TAKwd+kkncrHOh3/fySxzTOhFYjDucu2kU4K09dkZbQiY8cpBUP0bXjSXE4a8wB2Tgyru5UuqmWGZw==",
+      "version": "1.585.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.585.4.tgz",
+      "integrity": "sha512-ZGZLLZMTEupKh8bo/gIUViI6AbbS6coZZEZKy/i30BUXzgBHIBkG1HlfJ46tytt3RQ3bnxZamaUm0dgIzHs7ug==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.585.2",
+    "@bigcommerce/checkout-sdk": "^1.585.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2477](https://github.com/bigcommerce/checkout-sdk-js/pull/2477)

## Testing / Proof
Manually tested and unit tests

@bigcommerce/team-checkout
