### PR TITLE
chore(payment): PI-1606 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.586.0",
+        "@bigcommerce/checkout-sdk": "^1.587.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.586.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.586.0.tgz",
-      "integrity": "sha512-ALrOwMmNYIQwI8dNhL4NrQjlB62Yxg4wQmLGlw7puaEzYjQCVqJEcc6V3EEng4PJJ0sgSp6seFshBLejSWQEWA==",
+      "version": "1.587.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.587.0.tgz",
+      "integrity": "sha512-+OmrCnFNTvchM4WGQC8Ffdg/uIqfT5sdl0PJuLx0mH/kKiJRFwiSwBHw/XaCNdlb9ftj/xM+OhgnWV+LvDCRJg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.586.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.586.0.tgz",
-      "integrity": "sha512-ALrOwMmNYIQwI8dNhL4NrQjlB62Yxg4wQmLGlw7puaEzYjQCVqJEcc6V3EEng4PJJ0sgSp6seFshBLejSWQEWA==",
+      "version": "1.587.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.587.0.tgz",
+      "integrity": "sha512-+OmrCnFNTvchM4WGQC8Ffdg/uIqfT5sdl0PJuLx0mH/kKiJRFwiSwBHw/XaCNdlb9ftj/xM+OhgnWV+LvDCRJg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.586.0",
+    "@bigcommerce/checkout-sdk": "^1.587.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
Part of release: https://github.com/bigcommerce/checkout-sdk-js/pull/2446

## Testing / Proof
Unit + manual testing

@bigcommerce/team-checkout
