### PR TITLE
feat(payment): PAYPAL-4066 localizeAddress moved to shared package

### DIFF
--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -9,12 +9,12 @@ import { isEmpty } from 'lodash';
 import React, { FunctionComponent, memo } from 'react';
 
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
+import { localizeAddress } from '@bigcommerce/checkout/locale';
 
 import { withCheckout } from '../checkout';
 
 import AddressType from './AddressType';
 import isValidAddress from './isValidAddress';
-import localizeAddress from './localizeAddress';
 
 import './StaticAddress.scss';
 

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -5,7 +5,6 @@ export { default as AddressFormModal } from './AddressFormModal';
 export { default as AddressSelect } from './AddressSelect';
 export { default as AddressType } from './AddressType';
 export { default as StaticAddress } from './StaticAddress';
-export { default as localizeAddress } from './localizeAddress';
 export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';

--- a/packages/locale/src/address.mock.ts
+++ b/packages/locale/src/address.mock.ts
@@ -1,0 +1,19 @@
+import { Address } from '@bigcommerce/checkout-sdk';
+
+export function getAddress(): Address {
+    return {
+        firstName: 'Test',
+        lastName: 'Tester',
+        company: 'Bigcommerce',
+        address1: '12345 Testing Way',
+        address2: '',
+        city: 'Some City',
+        stateOrProvince: 'California',
+        stateOrProvinceCode: 'CA',
+        country: 'United States',
+        countryCode: 'US',
+        postalCode: '95555',
+        phone: '555-555-5555',
+        customFields: [],
+    };
+}

--- a/packages/locale/src/countries.mock.ts
+++ b/packages/locale/src/countries.mock.ts
@@ -1,0 +1,41 @@
+import { Country } from '@bigcommerce/checkout-sdk';
+
+export function getCountries(): Country[] {
+    return [getAustralia(), getUnitedStates(), getJapan()];
+}
+
+export function getAustralia(): Country {
+    return {
+        code: 'AU',
+        name: 'Australia',
+        subdivisions: [
+            { code: 'NSW', name: 'New South Wales' },
+            { code: 'VIC', name: 'Victoria' },
+        ],
+        hasPostalCodes: true,
+        requiresState: true,
+    };
+}
+
+export function getUnitedStates(): Country {
+    return {
+        code: 'US',
+        name: 'United States',
+        hasPostalCodes: true,
+        requiresState: true,
+        subdivisions: [
+            { code: 'CA', name: 'California' },
+            { code: 'TX', name: 'Texas' },
+        ],
+    };
+}
+
+export function getJapan(): Country {
+    return {
+        code: 'JP',
+        name: 'Japan',
+        hasPostalCodes: false,
+        requiresState: false,
+        subdivisions: [],
+    };
+}

--- a/packages/locale/src/index.ts
+++ b/packages/locale/src/index.ts
@@ -15,5 +15,6 @@ export { default as LocaleProvider } from './LocaleProvider';
 export { default as TranslatedHtml, TranslatedHtmlProps } from './TranslatedHtml';
 export { default as TranslatedLink, TranslatedLinkProps } from './TranslatedLink';
 export { default as TranslatedString, TranslatedStringProps } from './TranslatedString';
+export { default as localizeAddress } from './localizeAddress';
 export { getLocaleContext } from './localeContext.mock';
 export { FALLBACK_TRANSLATIONS } from './translations';

--- a/packages/locale/src/localizeAddress.test.ts
+++ b/packages/locale/src/localizeAddress.test.ts
@@ -1,6 +1,6 @@
 import { Address } from '@bigcommerce/checkout-sdk';
 
-import { getCountries } from '../geography/countries.mock';
+import { getCountries } from './countries.mock';
 
 import { getAddress } from './address.mock';
 import localizeAddress from './localizeAddress';

--- a/packages/locale/src/localizeAddress.ts
+++ b/packages/locale/src/localizeAddress.ts
@@ -1,7 +1,10 @@
 import { Address, Country } from '@bigcommerce/checkout-sdk';
 import { find, isEmpty } from 'lodash';
 
-import { LocalizedGeography } from '../geography';
+interface LocalizedGeography {
+    localizedCountry: string;
+    localizedProvince: string;
+}
 
 const localizeAddress = <T1 extends Address>(
     address: T1,


### PR DESCRIPTION
## What?
localizeAddress moved from `core` to shared `locale` package

## Why?
Because we need to use this method out of `core` package

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
