### PR TITLE
feat(payment): PAYPAL-4081 PPCP Credit Card verification fields fix

### DIFF
--- a/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.spec.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.spec.tsx
@@ -245,6 +245,53 @@ describe('withHostedPayPalCommerceCreditCardFieldset', () => {
         });
     });
 
+    it('passes verification form with three required fields even if there is one is required', async () => {
+        const localProps = {
+            ...defaultProps,
+            isInstrumentCardCodeRequired: jest.fn().mockReturnValue(true),
+            isInstrumentCardNumberRequired: jest.fn().mockReturnValue(false)
+        }
+        const container = mount(<DecoratedPaymentMethodTest {...localProps} />);
+        const getHostedFormOptions = container
+            .find(InnerPaymentMethod)
+            .prop('getHostedFormOptions');
+
+        expect(
+            await getHostedFormOptions({
+                ...getCardInstrument(),
+                trustedShippingAddress: false,
+            }),
+        ).toEqual({
+            fields: {
+                cardCodeVerification: {
+                    accessibilityLabel: 'CVV',
+                    containerId: 'authorizenet-ccCvv',
+                    instrumentId: getCardInstrument().bigpayToken,
+                },
+                cardNumberVerification: {
+                    accessibilityLabel: 'Credit Card Number',
+                    containerId: 'authorizenet-ccNumber',
+                    instrumentId: getCardInstrument().bigpayToken,
+                },
+                cardExpiryVerification: {
+                    accessibilityLabel: 'optimized_checkout.payment.credit_card_expiry_label',
+                    containerId: 'authorizenet-ccExpiry',
+                    instrumentId: '123'
+                }
+            },
+            styles: {
+                default: expect.any(Object),
+                error: expect.any(Object),
+                focus: expect.any(Object),
+            },
+            onBlur: expect.any(Function),
+            onCardTypeChange: expect.any(Function),
+            onEnter: expect.any(Function),
+            onFocus: expect.any(Function),
+            onValidate: expect.any(Function),
+        });
+    });
+
     it('passes styling properties to hosted form', async () => {
         const container = mount(<DecoratedPaymentMethodTest {...defaultProps} />);
         const getHostedFormOptions = container

--- a/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.tsx
@@ -99,12 +99,11 @@ export default function withHostedPayPalCommerceCreditCardFieldset<
                 const isInstrumentCardCodeRequired = selectedInstrument
                     ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
                     : false;
-                const isInstrumentCardExpiryRequired = selectedInstrument
-                    ? !selectedInstrument.trustedShippingAddress
-                    : false;
+
+                const shouldRenderHostedFieldsWithInstrument = isInstrumentCardNumberRequired || isInstrumentCardCodeRequired;
 
                 const styleContainerId = selectedInstrument
-                    ? isInstrumentCardCodeRequired
+                    ? shouldRenderHostedFieldsWithInstrument
                         ? getHostedFieldId('ccCvv')
                         : undefined
                     : getHostedFieldId('ccNumber');
@@ -113,7 +112,7 @@ export default function withHostedPayPalCommerceCreditCardFieldset<
                     fields: selectedInstrument
                         ? {
                             cardCodeVerification:
-                                isInstrumentCardCodeRequired && selectedInstrument
+                                shouldRenderHostedFieldsWithInstrument && selectedInstrument
                                     ? {
                                         accessibilityLabel: language.translate(
                                             'payment.credit_card_cvv_label',
@@ -123,7 +122,7 @@ export default function withHostedPayPalCommerceCreditCardFieldset<
                                     }
                                     : undefined,
                             cardNumberVerification:
-                                isInstrumentCardNumberRequired && selectedInstrument
+                                shouldRenderHostedFieldsWithInstrument && selectedInstrument
                                     ? {
                                         accessibilityLabel: language.translate(
                                             'payment.credit_card_number_label',
@@ -133,7 +132,7 @@ export default function withHostedPayPalCommerceCreditCardFieldset<
                                     }
                                     : undefined,
                             cardExpiryVerification:
-                                isInstrumentCardExpiryRequired && selectedInstrument
+                                shouldRenderHostedFieldsWithInstrument && selectedInstrument
                                     ? {
                                           accessibilityLabel: language.translate(
                                               'payment.credit_card_expiry_label',
@@ -243,22 +242,21 @@ export default function withHostedPayPalCommerceCreditCardFieldset<
                 const isInstrumentCardCodeRequired = selectedInstrument
                     ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
                     : false;
-                const isInstrumentCardExpiryRequired = selectedInstrument
-                    ? !selectedInstrument.trustedShippingAddress
-                    : false;
+
+                const shouldRenderHostedFieldsWithInstrument = isInstrumentCardNumberRequired || isInstrumentCardCodeRequired;
 
                 return (
                     <HostedCreditCardValidation
                         cardCodeId={
-                            isInstrumentCardCodeRequired ? getHostedFieldId('ccCvv') : undefined
+                            shouldRenderHostedFieldsWithInstrument ? getHostedFieldId('ccCvv') : undefined
                         }
                         cardNumberId={
-                            isInstrumentCardNumberRequired
+                            shouldRenderHostedFieldsWithInstrument
                                 ? getHostedFieldId('ccNumber')
                                 : undefined
                         }
                         cardExpiryId={
-                            isInstrumentCardExpiryRequired
+                            shouldRenderHostedFieldsWithInstrument
                                 ? getHostedFieldId('ccExpiry')
                                 : undefined
                         }


### PR DESCRIPTION
## What?
Separate flags for rendering verification fields replaced by one `shouldRenderHostedFieldsWithInstrument`

## Why?
Because PPCP Card Fields will work only if we have all three containers for fields (number, cvv, expiry).

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
