### PR TITLE
chore(payment): PAYPAL-4082 bump checkout-sdk version to 1.591.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.589.0",
+        "@bigcommerce/checkout-sdk": "^1.591.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.589.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.589.0.tgz",
-      "integrity": "sha512-TDIhyN768qo2iutUIyhXNW5UxIx62axzLpk+PphLlBdhBAyHoMxFavTXerT+0p8G2PfV7ygIwgOIY6zHtruf/g==",
+      "version": "1.591.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.591.0.tgz",
+      "integrity": "sha512-EIig/zvpIVsG5zcYuNFo2Z1Yq6614V3hmlmFFRY9j6Kk1GSuBQoIAFDiogXdYoftvjPlvH2PkenKQK+xnyyFtg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.589.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.589.0.tgz",
-      "integrity": "sha512-TDIhyN768qo2iutUIyhXNW5UxIx62axzLpk+PphLlBdhBAyHoMxFavTXerT+0p8G2PfV7ygIwgOIY6zHtruf/g==",
+      "version": "1.591.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.591.0.tgz",
+      "integrity": "sha512-EIig/zvpIVsG5zcYuNFo2Z1Yq6614V3hmlmFFRY9j6Kk1GSuBQoIAFDiogXdYoftvjPlvH2PkenKQK+xnyyFtg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.589.0",
+    "@bigcommerce/checkout-sdk": "^1.591.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.591.0

## Why?
As part of checkout-sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2479
https://github.com/bigcommerce/checkout-sdk-js/pull/2480

## Testing / Proof
Unit tests
Manual tests
CI

All proofs video proofs can be found in both checkout-sdk PRs
