### PR TITLE
chore(payment): PAYPAL-4088 bump checkout-sdk version to 1.592.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.591.0",
+        "@bigcommerce/checkout-sdk": "^1.592.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.591.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.591.0.tgz",
-      "integrity": "sha512-EIig/zvpIVsG5zcYuNFo2Z1Yq6614V3hmlmFFRY9j6Kk1GSuBQoIAFDiogXdYoftvjPlvH2PkenKQK+xnyyFtg==",
+      "version": "1.592.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.592.1.tgz",
+      "integrity": "sha512-+/z5oMFewQM16v5DljvPo+XaKcKP1CrTdm9ihwoWOYaA3aE0D33OPOywmf8+6FFmnuz/tzTUmAITOxgG/XzIbw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.591.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.591.0.tgz",
-      "integrity": "sha512-EIig/zvpIVsG5zcYuNFo2Z1Yq6614V3hmlmFFRY9j6Kk1GSuBQoIAFDiogXdYoftvjPlvH2PkenKQK+xnyyFtg==",
+      "version": "1.592.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.592.1.tgz",
+      "integrity": "sha512-+/z5oMFewQM16v5DljvPo+XaKcKP1CrTdm9ihwoWOYaA3aE0D33OPOywmf8+6FFmnuz/tzTUmAITOxgG/XzIbw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.591.0",
+    "@bigcommerce/checkout-sdk": "^1.592.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.592.1

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2490
https://github.com/bigcommerce/checkout-sdk-js/pull/2481

## Testing / Proof
Unit tests
Manual tests
CI
