### PR TITLE
fix(payment): PAYPAL-4090 updated submit button text with Place order while customer pays with PPCP account vaulted instrument

### DIFF
--- a/packages/core/src/app/payment/PaymentSubmitButton.test.tsx
+++ b/packages/core/src/app/payment/PaymentSubmitButton.test.tsx
@@ -93,6 +93,17 @@ describe('PaymentSubmitButton', () => {
         expect(screen.getByText(languageService.translate('payment.paypal_continue_action'))).toBeInTheDocument();
     });
 
+    it('renders button with "place order" label for PayPal when the order placement starts on checkout page', () => {
+        render(
+            <PaymentSubmitButtonTest
+                methodId={PaymentMethodId.PaypalCommerce}
+                methodType="paypal"
+            />,
+        );
+
+        expect(screen.getByText(languageService.translate('payment.place_order_action'))).toBeInTheDocument();
+    });
+
     it('renders button with special label for Braintree Venmo', () => {
         render(
             <PaymentSubmitButtonTest

--- a/packages/core/src/app/payment/PaymentSubmitButton.tsx
+++ b/packages/core/src/app/payment/PaymentSubmitButton.tsx
@@ -77,13 +77,13 @@ const PaymentSubmitButtonText: FunctionComponent<PaymentSubmitButtonTextProps> =
         }
 
         if (methodType === PaymentMethodType.Paypal) {
+            const continueActionId = methodId === PaymentMethodId.PaypalCommerce
+                ? 'payment.place_order_action'
+                : 'payment.paypal_continue_action';
+
             return <TranslatedString
                 data={{ isComplete }}
-                id={
-                    isComplete
-                        ? 'payment.paypal_complete_action'
-                        : 'payment.paypal_continue_action'
-                }
+                id={isComplete ? 'payment.paypal_complete_action' : continueActionId}
             />;
         }
 


### PR DESCRIPTION
## What?
Updated submit button text with Place order while customer pays with PPCP account vaulted instrument

## Why?
To avoid customer confusion while pays with PayPal stored instrument

## Testing / Proof
Unit tests
Manual tests
CI

Before:
<img width="747" alt="Screenshot 2024-04-29 at 10 51 43" src="https://github.com/bigcommerce/checkout-js/assets/25133454/683f66cc-9ab1-4f33-ac16-5852f7c0bea4">


After:
<img width="752" alt="Screenshot 2024-04-29 at 13 21 55" src="https://github.com/bigcommerce/checkout-js/assets/25133454/ce0d87a2-5d87-49ea-b449-f13e4b38c687">
