### PR TITLE
chore(payment): PI-1831 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.592.1",
+        "@bigcommerce/checkout-sdk": "^1.593.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.592.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.592.1.tgz",
-      "integrity": "sha512-+/z5oMFewQM16v5DljvPo+XaKcKP1CrTdm9ihwoWOYaA3aE0D33OPOywmf8+6FFmnuz/tzTUmAITOxgG/XzIbw==",
+      "version": "1.593.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.0.tgz",
+      "integrity": "sha512-tyWvpcXvckuwnri7LpSJ0BgxE4WTtF9G/AmTtRLIpvO4VumfdV6hAUw0uY34gUKMWg6w5gVe0qH3PinNOYxN+Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.592.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.592.1.tgz",
-      "integrity": "sha512-+/z5oMFewQM16v5DljvPo+XaKcKP1CrTdm9ihwoWOYaA3aE0D33OPOywmf8+6FFmnuz/tzTUmAITOxgG/XzIbw==",
+      "version": "1.593.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.0.tgz",
+      "integrity": "sha512-tyWvpcXvckuwnri7LpSJ0BgxE4WTtF9G/AmTtRLIpvO4VumfdV6hAUw0uY34gUKMWg6w5gVe0qH3PinNOYxN+Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.592.1",
+    "@bigcommerce/checkout-sdk": "^1.593.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2433

## Why?
For better separation between payment integrations and core Checkout SDK

## Testing / Proof
Manually tested 

https://github.com/bigcommerce/checkout-js/assets/130039975/ab1aafc6-b760-43b3-aa91-e45f189520f2



@bigcommerce/team-checkout
