### PR TITLE
refactor(payment): PI-1901 release of checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.593.0",
+        "@bigcommerce/checkout-sdk": "^1.593.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.593.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.0.tgz",
-      "integrity": "sha512-tyWvpcXvckuwnri7LpSJ0BgxE4WTtF9G/AmTtRLIpvO4VumfdV6hAUw0uY34gUKMWg6w5gVe0qH3PinNOYxN+Q==",
+      "version": "1.593.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.2.tgz",
+      "integrity": "sha512-cPFeofv3gXcaxtqhj1sxEFndLFyyrmb2qYVSpcpd4bZASwAsgDu08gEt2bHG7CiCUJi16aJiOA9aif8zv2m9ow==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.593.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.0.tgz",
-      "integrity": "sha512-tyWvpcXvckuwnri7LpSJ0BgxE4WTtF9G/AmTtRLIpvO4VumfdV6hAUw0uY34gUKMWg6w5gVe0qH3PinNOYxN+Q==",
+      "version": "1.593.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.2.tgz",
+      "integrity": "sha512-cPFeofv3gXcaxtqhj1sxEFndLFyyrmb2qYVSpcpd4bZASwAsgDu08gEt2bHG7CiCUJi16aJiOA9aif8zv2m9ow==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.593.0",
+    "@bigcommerce/checkout-sdk": "^1.593.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2484
https://github.com/bigcommerce/checkout-sdk-js/pull/2483

## Why?
Due to the GooglePay refactoring

## Testing / Proof
https://github.com/bigcommerce/checkout-sdk-js/pull/2484
https://github.com/bigcommerce/checkout-sdk-js/pull/2483

@bigcommerce/team-checkout
