### PR TITLE
chore(payment): PI-000 bump checkout sdk to v1.596.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.593.2",
+        "@bigcommerce/checkout-sdk": "^1.596.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.593.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.2.tgz",
-      "integrity": "sha512-cPFeofv3gXcaxtqhj1sxEFndLFyyrmb2qYVSpcpd4bZASwAsgDu08gEt2bHG7CiCUJi16aJiOA9aif8zv2m9ow==",
+      "version": "1.596.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.596.0.tgz",
+      "integrity": "sha512-1ZSU01U8dVBoAh0prcXJ0epusWpod9IoCws9OM/202riJORG4YB5uEn8uhPVCEwffq8V2ev/q58lbJUiU19rfw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.593.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.593.2.tgz",
-      "integrity": "sha512-cPFeofv3gXcaxtqhj1sxEFndLFyyrmb2qYVSpcpd4bZASwAsgDu08gEt2bHG7CiCUJi16aJiOA9aif8zv2m9ow==",
+      "version": "1.596.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.596.0.tgz",
+      "integrity": "sha512-1ZSU01U8dVBoAh0prcXJ0epusWpod9IoCws9OM/202riJORG4YB5uEn8uhPVCEwffq8V2ev/q58lbJUiU19rfw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.593.2",
+    "@bigcommerce/checkout-sdk": "^1.596.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
As a part of the release: https://github.com/bigcommerce/checkout-sdk-js/pull/2491

## Testing / Proof
Unit + manual testing

@bigcommerce/team-checkout
