### PR TITLE
refactor(payment): PI-1558 release checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.600.0",
+        "@bigcommerce/checkout-sdk": "^1.600.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.600.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.600.0.tgz",
-      "integrity": "sha512-2s9E1uuQVKKFUBT+1trB3McTuVzJnkUjGdl42qYZaRfunk8RMvEx3aK62GiJdtWg0pf4Sq7Jca68n3fhPrO3OQ==",
+      "version": "1.600.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.600.1.tgz",
+      "integrity": "sha512-IQ02+MgNToJMjMV1Vb116o54OerTxo/FYh5ZxhwD1hAeljH+Xm8d4XOwfGYT83yfCuWN1hHaQ4bbCK1PL5p9/w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.600.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.600.0.tgz",
-      "integrity": "sha512-2s9E1uuQVKKFUBT+1trB3McTuVzJnkUjGdl42qYZaRfunk8RMvEx3aK62GiJdtWg0pf4Sq7Jca68n3fhPrO3OQ==",
+      "version": "1.600.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.600.1.tgz",
+      "integrity": "sha512-IQ02+MgNToJMjMV1Vb116o54OerTxo/FYh5ZxhwD1hAeljH+Xm8d4XOwfGYT83yfCuWN1hHaQ4bbCK1PL5p9/w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.600.0",
+    "@bigcommerce/checkout-sdk": "^1.600.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of the https://github.com/bigcommerce/checkout-sdk-js/pull/2496

## Why?
Due to the google pay refactoring

## Testing / Proof
[Testing proof](https://github.com/bigcommerce/checkout-sdk-js/pull/2496) 

@bigcommerce/team-checkout
