### PR TITLE
feat(payment): PAYPAL-2624 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.603.0",
+        "@bigcommerce/checkout-sdk": "^1.607.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.603.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.603.0.tgz",
-      "integrity": "sha512-WmclaqNZLN4LMONvFWaM3Yma51NGAP5s70prfol8H+mEBmR/yiGCJcifhswHuaNEPkDbqjiMl6D69jWeEUVHlQ==",
+      "version": "1.607.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.607.0.tgz",
+      "integrity": "sha512-M2btAT3fJiEoT9zp5KxdQMt/Fx43bjJgoytZfWO7s7BrFmglN2fYx2nESFE6XWsN/pxmWNII8ECDivIGOGvigA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.603.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.603.0.tgz",
-      "integrity": "sha512-WmclaqNZLN4LMONvFWaM3Yma51NGAP5s70prfol8H+mEBmR/yiGCJcifhswHuaNEPkDbqjiMl6D69jWeEUVHlQ==",
+      "version": "1.607.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.607.0.tgz",
+      "integrity": "sha512-M2btAT3fJiEoT9zp5KxdQMt/Fx43bjJgoytZfWO7s7BrFmglN2fYx2nESFE6XWsN/pxmWNII8ECDivIGOGvigA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.603.0",
+    "@bigcommerce/checkout-sdk": "^1.607.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2503

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
