### PR TITLE
fix(payment): PAYPAL-4208 added extra mapping for paypalcommercecreditcards methodId

### DIFF
--- a/packages/core/src/app/payment/getProviderWithCustomCheckout.test.ts
+++ b/packages/core/src/app/payment/getProviderWithCustomCheckout.test.ts
@@ -14,8 +14,8 @@ describe('getProviderWithCustomCheckout', () => {
     });
 
     it('returns mapped method id', () => {
-        const providerWithCustomCheckout = getProviderWithCustomCheckout(PaymentMethodId.PaypalCommerce);
-
-        expect(providerWithCustomCheckout).toEqual(PaymentMethodId.PayPalCommerceAcceleratedCheckout);
+        expect(getProviderWithCustomCheckout(PaymentMethodId.PaypalCommerce)).toEqual(PaymentMethodId.PayPalCommerceAcceleratedCheckout);
+        expect(getProviderWithCustomCheckout(PaymentMethodId.PaypalCommerceCreditCards)).toEqual(PaymentMethodId.PayPalCommerceAcceleratedCheckout);
+        expect(getProviderWithCustomCheckout(PaymentMethodId.Braintree)).toEqual(PaymentMethodId.BraintreeAcceleratedCheckout);
     });
 });

--- a/packages/core/src/app/payment/getProviderWithCustomCheckout.ts
+++ b/packages/core/src/app/payment/getProviderWithCustomCheckout.ts
@@ -5,7 +5,7 @@ export default function getProviderWithCustomCheckout(methodId?: string | null):
         return undefined;
     }
 
-    if (methodId === PaymentMethodId.PaypalCommerce) {
+    if (methodId === PaymentMethodId.PaypalCommerce || methodId === PaymentMethodId.PaypalCommerceCreditCards) {
         return PaymentMethodId.PayPalCommerceAcceleratedCheckout;
     }
 


### PR DESCRIPTION
## What?
Added extra mapping for `paypalcommercecreditcards` methodId to convert it to `paypalcommerceacceleratedcheckout`

## Why?
During PPCP Fastlane Shipping Component testing we faced with the issue, that component does not render for cases when the page was loaded for unrecognised user. In this case BE sets paypalcommercecreditcards as providerWithCustomCheckout what does not have a right mapping to match the condition for component rendering.

So the solution is to add right methodId mapping to be able to render shipping component.

## Testing / Proof
Unit tests
CI
