### PR TITLE
fix(payment): PI-2103 fix bluesnap direct styling

### DIFF
--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.spec.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.spec.tsx
@@ -526,4 +526,82 @@ describe('HostedCreditCardPaymentMethod', () => {
             },
         });
     });
+
+    it('should pass correct styles when cvv is required for the card validation', async () => {
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+            ...getCart(),
+            lineItems: {
+                ...getCart().lineItems,
+            },
+        });
+
+        const component = mount(<HostedCreditCardPaymentMethodTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const getHostedFormOptions = component
+            .find(CreditCardPaymentMethodComponent)
+            .prop('getHostedFormOptions');
+        const instrument = {
+            ...getCardInstrument(),
+            trustedShippingAddress: false,
+        };
+
+        if (!getHostedFormOptions) throw new Error('getHostedFormOptions undefined');
+
+        const { styles } = await getHostedFormOptions(instrument);
+
+        expect(styles).toEqual({
+            default: { color: 'rgb(0, 0, 0)' },
+            error: { color: 'rgb(255, 0, 0)' },
+            focus: { color: 'rgb(0, 0, 255)' },
+        });
+    });
+
+    it('should pass correct styles when cvv is not required for the card validation', async () => {
+        const { language } = createLocaleContext(getStoreConfig());
+        const config = {
+            ...getPaymentMethod().config,
+            id: 'bluesnapdirect',
+        };
+
+        defaultProps = {
+            method: { ...getPaymentMethod(), config },
+            checkoutService,
+            checkoutState,
+            paymentForm,
+            language,
+            onUnhandledError: jest.fn(),
+        };
+
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+            ...getCart(),
+            lineItems: {
+                ...getCart().lineItems,
+            },
+        });
+
+        const component = mount(<HostedCreditCardPaymentMethodTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const getHostedFormOptions = component
+            .find(CreditCardPaymentMethodComponent)
+            .prop('getHostedFormOptions');
+        const instrument = {
+            ...getCardInstrument(),
+            trustedShippingAddress: false,
+            provider: 'bluesnapdirect',
+        };
+
+        if (!getHostedFormOptions) throw new Error('getHostedFormOptions undefined');
+
+        const { styles } = await getHostedFormOptions(instrument);
+
+        expect(styles).toEqual({
+            default: { color: 'rgb(0, 0, 0)' },
+            error: { color: 'rgb(255, 0, 0)' },
+            focus: { color: 'rgb(0, 0, 255)' },
+        });
+    });
 });

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -64,11 +64,17 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             const isInstrumentCardCodeRequired = selectedInstrument
                 ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
                 : false;
-            const styleContainerId = selectedInstrument
-                ? isInstrumentCardCodeRequired
-                    ? getHostedFieldId('ccCvv')
-                    : undefined
-                : getHostedFieldId('ccNumber');
+            let styleContainerId;
+
+            if (selectedInstrument) {
+                if (isInstrumentCardCodeRequired) {
+                    styleContainerId = getHostedFieldId('ccCvv');
+                } else if (isInstrumentCardNumberRequired) {
+                    styleContainerId = getHostedFieldId('ccNumber');
+                }
+            } else {
+                styleContainerId = getHostedFieldId('ccNumber');
+            }
 
             return {
                 fields: selectedInstrument


### PR DESCRIPTION
## What?
Fixed hosted input styling for providers that doesn't need cvv verification

## Why?
Due to our mechanics to get Stencil styles in the checkout we need to mount hidden input and from that we're taking styles.
We use cvv input as an element where we should mount that hidden input for the stored card .
Some providers like BluesnapDirect don't have such input so we should mount it near the card number input.


## Testing / Proof
Before fix:
![Screenshot 2024-05-28 at 16 29 23](https://github.com/bigcommerce/checkout-js/assets/79574476/3f5e418a-fbc7-459f-b464-3bab6cef0ede)

After fix:
![Screenshot 2024-05-28 at 16 24 30](https://github.com/bigcommerce/checkout-js/assets/79574476/13e928e4-2b54-4f5f-a8d7-5cfcb9ac2c19)


@bigcommerce/team-checkout
