### PR TITLE
refactor(payment): PAYPAL-4283 removed unnecessary executePaymentMethodCheckout on sign in and sign up

### DIFF
--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -22,7 +22,7 @@ import CheckoutStepType from '../checkout/CheckoutStepType';
 import { getStoreConfig } from '../config/config.mock';
 import { PaymentMethodId } from '../payment/paymentMethod';
 
-import CreateAccountForm, { CreateAccountFormProps } from './CreateAccountForm';
+import CreateAccountForm from './CreateAccountForm';
 import Customer, { CustomerProps, WithCheckoutCustomerProps } from './Customer';
 import { getCustomer, getGuestCustomer } from './customers.mock';
 import CustomerViewType from './CustomerViewType';
@@ -664,46 +664,6 @@ describe('Customer', () => {
             });
         });
 
-        it('triggers execution method if customer is successfully signed in', async () => {
-            jest.spyOn(checkoutService, 'signInCustomer').mockReturnValue(
-                Promise.resolve(checkoutService.getState()),
-            );
-
-            jest.spyOn(checkoutService, 'executePaymentMethodCheckout').mockReturnValue(
-                Promise.resolve(checkoutService.getState()),
-            );
-
-            const handleSignedIn = jest.fn();
-            const component = mount(
-                <CustomerTest {...defaultProps}
-                    onSignIn={handleSignedIn}
-                    providerWithCustomCheckout={PaymentMethodId.BraintreeAcceleratedCheckout}
-                    viewType={CustomerViewType.Login}
-                />,
-            );
-
-            await new Promise((resolve) => process.nextTick(resolve));
-            component.update();
-
-            (component.find(LoginForm) as ReactWrapper<LoginFormProps>).prop('onSignIn')({
-                email: 'test@bigcommerce.com',
-                password: '*******',
-            });
-
-            expect(checkoutService.signInCustomer).toHaveBeenCalledWith({
-                email: 'test@bigcommerce.com',
-                password: '*******',
-            });
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(checkoutService.executePaymentMethodCheckout).toHaveBeenCalledWith({
-                methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
-                continueWithCheckoutCallback: handleSignedIn,
-                checkoutPaymentMethodExecuted: expect.any(Function),
-            });
-        });
-
         it('triggers completion callback if customer is successfully signed in', async () => {
             jest.spyOn(checkoutService, 'signInCustomer').mockReturnValue(
                 Promise.resolve(checkoutService.getState()),
@@ -805,65 +765,6 @@ describe('Customer', () => {
             expect((component.find(GuestForm) as ReactWrapper<GuestFormProps>).prop('email')).toBe(
                 'test@bigcommerce.com',
             );
-        });
-    });
-
-    describe('when view type is "create_account"', () => {
-        it('triggers execution method if customer is successfully signed in', async () => {
-            jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(undefined);
-
-            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
-                ...getStoreConfig(),
-                checkoutSettings: {
-                    ...getStoreConfig().checkoutSettings,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'createCustomerAccount').mockReturnValue(
-                Promise.resolve(checkoutService.getState()),
-            );
-
-            jest.spyOn(checkoutService, 'executePaymentMethodCheckout').mockReturnValue(
-                Promise.resolve(checkoutService.getState()),
-            );
-
-            const handleCreateAccount = jest.fn();
-            const component = mount(
-                <CustomerTest {...defaultProps}
-                    onAccountCreated={handleCreateAccount}
-                    providerWithCustomCheckout={PaymentMethodId.BraintreeAcceleratedCheckout}
-                    viewType={CustomerViewType.CreateAccount}
-                />,
-            );
-
-            const customerFormData = {
-                firstName: 'John',
-                lastName: 'Doe',
-                email: 'johndoe@test.com',
-                password: '*******!',
-            };
-
-            await new Promise((resolve) => process.nextTick(resolve));
-            component.update();
-
-            (component.find(CreateAccountForm) as ReactWrapper<CreateAccountFormProps>).prop('onSubmit')({
-                ...customerFormData,
-                customFields: {},
-            });
-
-            expect(checkoutService.createCustomerAccount).toHaveBeenCalledWith({
-                ...customerFormData,
-                acceptsMarketingEmails: undefined,
-                customFields: [],
-            });
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(checkoutService.executePaymentMethodCheckout).toHaveBeenCalledWith({
-                methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
-                continueWithCheckoutCallback: handleCreateAccount,
-                checkoutPaymentMethodExecuted: expect.any(Function),
-            });
         });
     });
 

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -17,7 +17,6 @@ import React, { Component, ReactNode } from 'react';
 import { AnalyticsContextProps } from '@bigcommerce/checkout/analytics';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
-import { isPayPalFastlaneMethod } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { CustomerSkeleton } from '@bigcommerce/checkout/ui';
 
 import { withAnalytics } from '../analytics';
@@ -449,25 +448,15 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
         credentials,
     ) => {
         const {
-            executePaymentMethodCheckout,
             signIn,
             onSignIn = noop,
             onSignInError = noop,
-            providerWithCustomCheckout,
         } = this.props;
 
         try {
             await signIn(credentials);
 
-            if (isPayPalFastlaneMethod(providerWithCustomCheckout)) {
-                await executePaymentMethodCheckout({
-                    methodId: providerWithCustomCheckout,
-                    continueWithCheckoutCallback: onSignIn,
-                    checkoutPaymentMethodExecuted: (payload) => this.checkoutPaymentMethodExecuted(payload)
-                });
-            } else {
-                onSignIn();
-            }
+            onSignIn();
 
             this.draftEmail = undefined;
         } catch (error) {
@@ -477,23 +466,13 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
     private handleCreateAccount: (values: CreateAccountFormValues) => void = async (values) => {
         const {
-            executePaymentMethodCheckout,
             createAccount = noop,
             onAccountCreated = noop,
-            providerWithCustomCheckout,
         } = this.props;
 
         await createAccount(mapCreateAccountFromFormValues(values));
 
-        if (isPayPalFastlaneMethod(providerWithCustomCheckout)) {
-            await executePaymentMethodCheckout({
-                methodId: providerWithCustomCheckout,
-                continueWithCheckoutCallback: onAccountCreated,
-                checkoutPaymentMethodExecuted: (payload) => this.checkoutPaymentMethodExecuted(payload)
-            });
-        } else {
-            onAccountCreated();
-        }
+        onAccountCreated();
     };
 
     private showCreateAccount: () => void = () => {


### PR DESCRIPTION
## What?
Removed unnecessary `executePaymentMethodCheckout` on sign in and sign up related to Fastlane experience

## Why?
PayPal Fastlane does not support store members experience, so there is no need to call `executePaymentMethodCheckout` anymore

## Testing / Proof
Unit tests
Manual tests
CI


The result of the work:
On sign up and sign in customer does not get Fastlane experience

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/2f182853-f98d-4d0a-b0fa-cbc54a689ccf


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/bcaf0e59-29b0-4752-b86f-503e22f41b8e


