### PR TITLE
fix(payment): PAYPAL-4248 updated customer step loading state to be able to continue with checkout even if wallet button is in loading state

### DIFF
--- a/packages/core/src/app/customer/Customer.spec.tsx
+++ b/packages/core/src/app/customer/Customer.spec.tsx
@@ -119,6 +119,41 @@ describe('Customer', () => {
             expect(component.find(GuestForm).exists()).toBe(true);
         });
 
+        it('renders guest form in loading state if the payment method is executing', async () => {
+            const component = mount(
+                <CustomerTest
+                    {...defaultProps}
+                    viewType={CustomerViewType.Guest}
+                    isExecutingPaymentMethodCheckout={true}
+                />
+            );
+
+            await new Promise((resolve) => process.nextTick(resolve));
+            component.update();
+
+            expect(component.find(GuestForm).props()).toMatchObject({
+                isLoading: true,
+            });
+        });
+
+        it('renders guest form in loading state if there is a process running before switching to the next step', async () => {
+            const component = mount(
+                <CustomerTest
+                    {...defaultProps}
+                    viewType={CustomerViewType.Guest}
+                    isExecutingPaymentMethodCheckout={false}
+                    isContinuingAsGuest={true}
+                />
+            );
+
+            await new Promise((resolve) => process.nextTick(resolve));
+            component.update();
+
+            expect(component.find(GuestForm).props()).toMatchObject({
+                isLoading: true,
+            });
+        });
+
         it('renders stripe guest form if enabled', async () => {
             const steps = { isActive: true,
                 isComplete: true,

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -206,9 +206,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             onError={onUnhandledError}
           />;
 
-        const isLoadingGuestForm = isWalletButtonsOnTop ?
-            isContinuingAsGuest || isExecutingPaymentMethodCheckout :
-            isContinuingAsGuest || isInitializing || isExecutingPaymentMethodCheckout;
+        const isLoadingGuestForm = isContinuingAsGuest || isExecutingPaymentMethodCheckout;
 
         return (
             shouldRenderStripeForm ?


### PR DESCRIPTION
## What?
Updated customer step loading state to be able to continue with checkout even if wallet button is in loading state

## Why?
Some users have pretty bad internet connection which might increase time for waiting on wallet buttons initialization. Therefore, it might be better to make wallet buttons loading state as an optional, to avoid blocking user from checkout.

## Testing / Proof
Manual tests was made with Network throttling 3g slow to emulate slow internet connection
CI

[Before] Continue button is disabled until wallet buttons finish their initialisation process: 

https://github.com/bigcommerce/checkout-js/assets/25133454/00b9c3e5-1965-4824-9231-2fbdf9b7839d


[After] Continue button is not disabled and can be used by customer even if wallet buttons still initialising on the page:


https://github.com/bigcommerce/checkout-js/assets/25133454/d8c55ebf-56e6-4467-bed7-27bd8b5e865c


