### PR TITLE
chore(payment): PI-1596 bump checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.615.0",
+        "@bigcommerce/checkout-sdk": "^1.617.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.615.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.615.0.tgz",
-      "integrity": "sha512-hgfdU5dHucnFZo4PsyYgfOxHomBGkQCdUW6l3c9KWnWQ3anQGY7+gPEG5PHOUaMNgpPoX1H6f8ZgOPlgWUnvEw==",
+      "version": "1.617.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.617.0.tgz",
+      "integrity": "sha512-Qc8/O5iWq2sNNmFp6NpVcQPhmu2vq4zC3Um93gbgo4er9XqttE2YSoxtCl7ayt5/zA79SUZJExejRpl3Ibf9zg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.615.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.615.0.tgz",
-      "integrity": "sha512-hgfdU5dHucnFZo4PsyYgfOxHomBGkQCdUW6l3c9KWnWQ3anQGY7+gPEG5PHOUaMNgpPoX1H6f8ZgOPlgWUnvEw==",
+      "version": "1.617.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.617.0.tgz",
+      "integrity": "sha512-Qc8/O5iWq2sNNmFp6NpVcQPhmu2vq4zC3Um93gbgo4er9XqttE2YSoxtCl7ayt5/zA79SUZJExejRpl3Ibf9zg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.615.0",
+    "@bigcommerce/checkout-sdk": "^1.617.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
Part of the release: https://github.com/bigcommerce/checkout-sdk-js/pull/2529

## Testing / Proof
Unit + manual tests

@bigcommerce/team-checkout
