### PR TITLE
feat(payment): PI-2177 Pay with Amazon Button display issues at checkout

### DIFF
--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -17,6 +17,7 @@
 
     > .AmazonPayContainer {
         width: remCalc(200px);
+        height: 51px !important;
         #amazonpayCheckoutButton > div{
             width: 100% !important;
             height: 51px !important;

--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -19,6 +19,7 @@
         width: remCalc(200px);
         #amazonpayCheckoutButton > div{
             width: 100% !important;
+            height: 51px !important;
         }
     }
 


### PR DESCRIPTION
## What?
Adjusted AmazonPay button styling.

## Why?
After changing button design back to one with microtext, at Customer step the microtext is overlaping the button. This only occurs in Customer step as here we are setting all accelerated checkout buttons (paypal, gpay, amazonPay) height to 36px. 

**Before:**
![Zrzut ekranu 2024-06-6 o 11 48 25](https://github.com/bigcommerce/checkout-js/assets/130039975/9ffaf20b-114b-4d1f-b6ac-b92552e283b6)

**After:**
![Zrzut ekranu 2024-06-6 o 12 15 36](https://github.com/bigcommerce/checkout-js/assets/130039975/a633c4a2-679c-435b-ba48-dd0757befb40)


## Testing / Proof
Tested manually

@bigcommerce/team-checkout
