### PR TITLE
chore(payment): PAYPAL-4231 bump checkout sdk version to 1.618.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.617.0",
+        "@bigcommerce/checkout-sdk": "^1.618.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.617.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.617.0.tgz",
-      "integrity": "sha512-Qc8/O5iWq2sNNmFp6NpVcQPhmu2vq4zC3Um93gbgo4er9XqttE2YSoxtCl7ayt5/zA79SUZJExejRpl3Ibf9zg==",
+      "version": "1.618.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.0.tgz",
+      "integrity": "sha512-Tgcbdj+RopKCtaLTcYsgCj6EYBZGB1dF1uBwLhMofPlVy5sb5XOpxNly7/VZ61zed54LyK6gvMJa+QM4SYsy1g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.617.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.617.0.tgz",
-      "integrity": "sha512-Qc8/O5iWq2sNNmFp6NpVcQPhmu2vq4zC3Um93gbgo4er9XqttE2YSoxtCl7ayt5/zA79SUZJExejRpl3Ibf9zg==",
+      "version": "1.618.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.0.tgz",
+      "integrity": "sha512-Tgcbdj+RopKCtaLTcYsgCj6EYBZGB1dF1uBwLhMofPlVy5sb5XOpxNly7/VZ61zed54LyK6gvMJa+QM4SYsy1g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.617.0",
+    "@bigcommerce/checkout-sdk": "^1.618.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.618.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2536
https://github.com/bigcommerce/checkout-sdk-js/pull/2535
https://github.com/bigcommerce/checkout-sdk-js/pull/2534

## Testing / Proof
Unit tests
Manual tests
CI
