### PR TITLE
fix(payment): PAYPAL-4139 fixed the issue with mastercard card icon dispay in Fastlane Instruments Form

### DIFF
--- a/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeFastlaneInstrumentsForm.tsx
+++ b/packages/braintree-integration/src/BraintreeAcceleratedCheckout/components/BraintreeFastlaneInstrumentsForm.tsx
@@ -11,13 +11,16 @@ import { BraintreeFastlaneComponentRef } from '../BraintreeAcceleratedCheckoutPa
 import './BraintreeFastlaneInstrumentsForm.scss';
 
 function mapFromInstrumentCardType(type: string): string {
-    switch (type) {
+    switch (type.toLowerCase()) {
         case 'amex':
         case 'american_express':
             return 'american-express';
 
         case 'diners':
             return 'diners-club';
+
+        case 'master_card':
+            return 'mastercard';
 
         default:
             return type;

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.tsx
@@ -11,13 +11,16 @@ import { PayPalFastlaneCardComponentRef } from '../PayPalCommerceFastlanePayment
 import './PayPalCommerceFastlaneInstrumentsForm.scss';
 
 function mapFromInstrumentCardType(type: string): string {
-    switch (type) {
+    switch (type.toLowerCase()) {
         case 'amex':
         case 'american_express':
             return 'american-express';
 
         case 'diners':
             return 'diners-club';
+
+        case 'master_card':
+            return 'mastercard';
 
         default:
             return type;


### PR DESCRIPTION
## What?
Fixed the issue with MasterCard card icon display in PPCP and BT FastlaneInstrumentsForm

## Why?
There was an issue with card icon mapping because PayPal returns `MASTER_CARD` key

## Testing / Proof
Manual tests

Before:
<img width="682" alt="Screenshot 2024-06-07 at 11 51 32" src="https://github.com/bigcommerce/checkout-js/assets/25133454/b4f7a13a-290c-4466-b0d4-b8c8987906ee">

After:
<img width="669" alt="Screenshot 2024-06-07 at 12 02 51" src="https://github.com/bigcommerce/checkout-js/assets/25133454/9ce45889-b4a1-419f-adda-8e8571ef1dba">
