### PR TITLE
refactor(payment): PAYPAL-3599 removed unnecessary PayPal Connect code form PPCP payment method

### DIFF
--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.test.tsx
@@ -44,7 +44,7 @@ describe('PayPalCommerceFastlanePaymentMethod', () => {
 
         expect(initializePayment).toHaveBeenCalledWith({
             methodId: props.method.id,
-            paypalcommerceacceleratedcheckout: {
+            paypalcommercefastlane: {
                 onInit: expect.any(Function),
                 onChange: expect.any(Function),
             },

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.tsx
@@ -33,7 +33,7 @@ const PayPalCommerceFastlanePaymentMethod: FunctionComponent<PaymentMethodProps>
         try {
             await checkoutService.initializePayment({
                 methodId: method.id,
-                paypalcommerceacceleratedcheckout: {
+                paypalcommercefastlane: {
                     onInit: (renderPayPalCardComponent) => {
                         paypalCardComponentRef.current.renderPayPalCardComponent =
                             renderPayPalCardComponent;

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneForm.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneForm.tsx
@@ -31,10 +31,7 @@ const PayPalCommerceFastlaneForm: FunctionComponent<
     }, [instruments, selectedInstrument]);
 
     return (
-        <div
-            className="paymentMethod paymentMethod--creditCard"
-        >
-            {/* Add vaulted element here */}
+        <div className="paymentMethod paymentMethod--creditCard">
             {shouldShowInstrumentsForm && (
                 <PayPalCommerceFastlaneInstrumentsForm
                     handleSelectInstrument={handleSelectInstrument}


### PR DESCRIPTION
## What?
Removed unnecessary PayPal Connect code form PPCP payment method

## Why?
As part of PayPal Connect cleanup

## Testing / Proof
Unit tests
CI
