### PR TITLE
chore(payment): PAYPAL-4294 bump checkout sdk version to 1.618.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.618.0",
+        "@bigcommerce/checkout-sdk": "^1.618.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.618.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.0.tgz",
-      "integrity": "sha512-Tgcbdj+RopKCtaLTcYsgCj6EYBZGB1dF1uBwLhMofPlVy5sb5XOpxNly7/VZ61zed54LyK6gvMJa+QM4SYsy1g==",
+      "version": "1.618.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.1.tgz",
+      "integrity": "sha512-xhdRkkdbvz+8ojn+d7o/amalUkfQfrfMyXBYWojkD0sjPGqh86VJ1INHYFWg37yrXPG2a5ofmvUMji3/DEo4OA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.618.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.0.tgz",
-      "integrity": "sha512-Tgcbdj+RopKCtaLTcYsgCj6EYBZGB1dF1uBwLhMofPlVy5sb5XOpxNly7/VZ61zed54LyK6gvMJa+QM4SYsy1g==",
+      "version": "1.618.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.1.tgz",
+      "integrity": "sha512-xhdRkkdbvz+8ojn+d7o/amalUkfQfrfMyXBYWojkD0sjPGqh86VJ1INHYFWg37yrXPG2a5ofmvUMji3/DEo4OA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.618.0",
+    "@bigcommerce/checkout-sdk": "^1.618.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.618.1

## Why?
As part of checkout-sdk release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2537

## Testing / Proof
Unit tests
Manual tests
CI
