### PR TITLE
fix(payment): PI-831 fixed mollie ApplePay redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.618.1",
+        "@bigcommerce/checkout-sdk": "^1.618.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.618.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.1.tgz",
-      "integrity": "sha512-xhdRkkdbvz+8ojn+d7o/amalUkfQfrfMyXBYWojkD0sjPGqh86VJ1INHYFWg37yrXPG2a5ofmvUMji3/DEo4OA==",
+      "version": "1.618.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.2.tgz",
+      "integrity": "sha512-sU607cmXZsLTGFwpmVDJ5QkeyZq/nklmA7rZON9O603uvmJQoYX5y3cA/cClAicTGBy99aYRmKcg4dTEtY1jtA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.618.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.1.tgz",
-      "integrity": "sha512-xhdRkkdbvz+8ojn+d7o/amalUkfQfrfMyXBYWojkD0sjPGqh86VJ1INHYFWg37yrXPG2a5ofmvUMji3/DEo4OA==",
+      "version": "1.618.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.2.tgz",
+      "integrity": "sha512-sU607cmXZsLTGFwpmVDJ5QkeyZq/nklmA7rZON9O603uvmJQoYX5y3cA/cClAicTGBy99aYRmKcg4dTEtY1jtA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.618.1",
+    "@bigcommerce/checkout-sdk": "^1.618.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Mollie ApplePay fix
release of https://github.com/bigcommerce/checkout-sdk-js/pull/2543

## Why?
Mollie ApplePay works via Mollie Redirect, so our ApplePay implementation is not working with Mollie.
I've changed Mollie payment strategy resolver to fix this problem

## Testing / Proof
Before fix:

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/88e7c41a-6853-4283-8870-bdf3498d73cb

After fix:

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/d865b987-307a-4457-8afd-2adcbd3781f6




@bigcommerce/team-checkout @bigcommerce/team-payments
