### PR TITLE
chore(payment): PI-2161 bump checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.618.3",
+        "@bigcommerce/checkout-sdk": "^1.618.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.618.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.3.tgz",
-      "integrity": "sha512-7CvkBWIFLe2jknZqvkC8f9088nChLIX4u2uCHfAIlcZC5fxPdti1b/zMcdU8vl5vlVKOSjIArWoQFOmi5qjMSA==",
+      "version": "1.618.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.4.tgz",
+      "integrity": "sha512-i54HunSgHBKJ1uO3NqotDQpK5KVIy3acd3zIdZp26EglAWKf8fZAYypPl4eZTfPdTH49Lf9CkRUOPXu8FU0CHg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.618.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.3.tgz",
-      "integrity": "sha512-7CvkBWIFLe2jknZqvkC8f9088nChLIX4u2uCHfAIlcZC5fxPdti1b/zMcdU8vl5vlVKOSjIArWoQFOmi5qjMSA==",
+      "version": "1.618.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.4.tgz",
+      "integrity": "sha512-i54HunSgHBKJ1uO3NqotDQpK5KVIy3acd3zIdZp26EglAWKf8fZAYypPl4eZTfPdTH49Lf9CkRUOPXu8FU0CHg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.618.3",
+    "@bigcommerce/checkout-sdk": "^1.618.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/2540

## Testing / Proof
Unit + manual testing