### PR TITLE
chore(payment): PAYPAL-3273 bump checkout-sdk version to 1.620.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.618.4",
+        "@bigcommerce/checkout-sdk": "^1.620.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.618.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.4.tgz",
-      "integrity": "sha512-i54HunSgHBKJ1uO3NqotDQpK5KVIy3acd3zIdZp26EglAWKf8fZAYypPl4eZTfPdTH49Lf9CkRUOPXu8FU0CHg==",
+      "version": "1.620.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.620.0.tgz",
+      "integrity": "sha512-HqNQXhJ8iiGBdGl8g+1o7EwCUN6ZUmUtUCIMi34grKkuxyt9D/vCUD5dWtdAkmSkV80jCo+eiBKwWx+nxtOe0w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.618.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.618.4.tgz",
-      "integrity": "sha512-i54HunSgHBKJ1uO3NqotDQpK5KVIy3acd3zIdZp26EglAWKf8fZAYypPl4eZTfPdTH49Lf9CkRUOPXu8FU0CHg==",
+      "version": "1.620.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.620.0.tgz",
+      "integrity": "sha512-HqNQXhJ8iiGBdGl8g+1o7EwCUN6ZUmUtUCIMi34grKkuxyt9D/vCUD5dWtdAkmSkV80jCo+eiBKwWx+nxtOe0w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.618.4",
+    "@bigcommerce/checkout-sdk": "^1.620.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.620.0

## Why?
As part of release: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2542
https://github.com/bigcommerce/checkout-sdk-js/pull/2541
https://github.com/bigcommerce/checkout-sdk-js/pull/2538

## Testing / Proof
Unit tests
Manual tests
CI
