### PR TITLE
feat(checkout): CHECKOUT-2368 Display Custom Shipping Method

### DIFF
--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -16,7 +16,10 @@ import {
 } from '@bigcommerce/checkout/analytics';
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
-import { CHECKOUT_ROOT_NODE_ID, CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
+import {
+    CHECKOUT_ROOT_NODE_ID,
+    CheckoutProvider,
+} from '@bigcommerce/checkout/payment-integration-api';
 import { CheckoutPageNodeObject } from '@bigcommerce/checkout/test-framework';
 
 import { createErrorLogger } from '../common/error';
@@ -253,6 +256,20 @@ describe('Checkout', () => {
                 }),
             ).toBeInTheDocument();
             expect(screen.getByText(/shipping method/i)).toBeInTheDocument();
+        });
+
+        it('renders custom shipping method and locks shipping component', async () => {
+            checkout.use('CartWithCustomShippingAndBilling');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(screen.getByText('Manual Order Custom Shipping Method')).toBeInTheDocument();
+            expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(2);
+            expect(screen.getByText(/test payment provider/i)).toBeInTheDocument();
+            expect(screen.getByText(/pay in store/i)).toBeInTheDocument();
+            expect(screen.getByText(/place order/i)).toBeInTheDocument();
         });
 
         it('logs unhandled error', async () => {

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 
 import { isValidAddress } from '../address';
-import { EMPTY_ARRAY } from '../common/utility';
+import { EMPTY_ARRAY, isCustomShippingEnabled } from '../common/utility';
 import { SUPPORTED_METHODS } from '../customer';
 import { PaymentMethodId } from '../payment/paymentMethod';
 import {
@@ -180,12 +180,18 @@ const getShippingStepStatus = createSelector(
             cart && consignments ? hasUnassignedLineItems(consignments, cart.lineItems) : true;
         const isComplete = hasAddress && hasOptions && !hasUnassignedItems;
         const isRequired = itemsRequireShipping(cart, config);
+        const isCompleteWithCustomShipping =
+            isCustomShippingEnabled(config?.checkoutSettings) &&
+            hasOptions &&
+            consignments?.some(
+                ({ selectedShippingOption }) => selectedShippingOption?.type === 'custom',
+            );
 
         return {
             type: CheckoutStepType.Shipping,
             isActive: false,
             isComplete,
-            isEditable: isComplete && isRequired,
+            isEditable: isComplete && isRequired && !isCompleteWithCustomShipping,
             isRequired,
         };
     },

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 
 import { isValidAddress } from '../address';
-import { EMPTY_ARRAY, isCustomShippingEnabled } from '../common/utility';
+import { EMPTY_ARRAY, isExperimentEnabled } from '../common/utility';
 import { SUPPORTED_METHODS } from '../customer';
 import { PaymentMethodId } from '../payment/paymentMethod';
 import {
@@ -180,8 +180,11 @@ const getShippingStepStatus = createSelector(
             cart && consignments ? hasUnassignedLineItems(consignments, cart.lineItems) : true;
         const isComplete = hasAddress && hasOptions && !hasUnassignedItems;
         const isRequired = itemsRequireShipping(cart, config);
-        const isCompleteWithCustomShipping =
-            isCustomShippingEnabled(config?.checkoutSettings) &&
+        const isCustomShippingSelected =
+            isExperimentEnabled(
+                config?.checkoutSettings,
+                'PROJECT-5015.manual_order.display_custom_shipping',
+            ) &&
             hasOptions &&
             consignments?.some(
                 ({ selectedShippingOption }) => selectedShippingOption?.type === 'custom',
@@ -191,7 +194,7 @@ const getShippingStepStatus = createSelector(
             type: CheckoutStepType.Shipping,
             isActive: false,
             isComplete,
-            isEditable: isComplete && isRequired && !isCompleteWithCustomShipping,
+            isEditable: isComplete && isRequired && !isCustomShippingSelected,
             isRequired,
         };
     },

--- a/packages/core/src/app/common/utility/index.ts
+++ b/packages/core/src/app/common/utility/index.ts
@@ -7,3 +7,4 @@ export { default as isMobile } from './isMobile';
 export { default as isApplePayWindow } from './is-apple-pay-window';
 export { default as isBuyNowCart } from './isBuyNowCart';
 export { default as isFloatingLabelEnabled } from './isFloatingLabelEnabled';
+export { default as isCustomShippingEnabled } from './isCustomShippingEnabled';

--- a/packages/core/src/app/common/utility/index.ts
+++ b/packages/core/src/app/common/utility/index.ts
@@ -7,4 +7,4 @@ export { default as isMobile } from './isMobile';
 export { default as isApplePayWindow } from './is-apple-pay-window';
 export { default as isBuyNowCart } from './isBuyNowCart';
 export { default as isFloatingLabelEnabled } from './isFloatingLabelEnabled';
-export { default as isCustomShippingEnabled } from './isCustomShippingEnabled';
+export { default as isExperimentEnabled } from './isExperimentEnabled';

--- a/packages/core/src/app/common/utility/isCustomShippingEnabled.ts
+++ b/packages/core/src/app/common/utility/isCustomShippingEnabled.ts
@@ -1,9 +1,0 @@
-import { CheckoutSettings } from '@bigcommerce/checkout-sdk';
-
-export default function isCustomShippingEnabled(
-    checkoutSettings: CheckoutSettings | undefined,
-): boolean {
-    return Boolean(
-        checkoutSettings?.features['PROJECT-5015.manual_order.display_custom_shipping'] ?? true,
-    );
-}

--- a/packages/core/src/app/common/utility/isCustomShippingEnabled.ts
+++ b/packages/core/src/app/common/utility/isCustomShippingEnabled.ts
@@ -1,0 +1,9 @@
+import { CheckoutSettings } from '@bigcommerce/checkout-sdk';
+
+export default function isCustomShippingEnabled(
+    checkoutSettings: CheckoutSettings | undefined,
+): boolean {
+    return Boolean(
+        checkoutSettings?.features['PROJECT-5015.manual_order.display_custom_shipping'] ?? true,
+    );
+}

--- a/packages/core/src/app/common/utility/isExperimentEnabled.ts
+++ b/packages/core/src/app/common/utility/isExperimentEnabled.ts
@@ -1,0 +1,8 @@
+import { CheckoutSettings } from '@bigcommerce/checkout-sdk';
+
+export default function isExperimentEnabled(
+    checkoutSettings: CheckoutSettings | undefined,
+    experimentName: string,
+): boolean {
+    return Boolean(checkoutSettings?.features[experimentName] ?? true);
+}

--- a/packages/core/src/app/shipping/hasSelectedShippingOptions.ts
+++ b/packages/core/src/app/shipping/hasSelectedShippingOptions.ts
@@ -16,7 +16,6 @@ export default function hasSelectedShippingOptions(consignments: Consignment[]):
                 consignment.availableShippingOptions.filter(
                     ({ id }) => id === consignment.selectedShippingOption?.id,
                 ).length) ||
-            (consignment.selectedShippingOption?.type === 'custom' &&
-                consignment.selectedShippingOption.cost >= 0),
+            consignment.selectedShippingOption?.type === 'custom',
     );
 }

--- a/packages/core/src/app/shipping/hasSelectedShippingOptions.ts
+++ b/packages/core/src/app/shipping/hasSelectedShippingOptions.ts
@@ -9,12 +9,14 @@ export default function hasSelectedShippingOptions(consignments: Consignment[]):
     return every(
         consignments,
         (consignment) =>
-            consignment.selectedShippingOption &&
-            consignment.selectedShippingOption.id &&
-            // Selected option is available
-            consignment.availableShippingOptions &&
-            consignment.availableShippingOptions.filter(
-                ({ id }) => id === consignment.selectedShippingOption?.id,
-            ).length,
+            (consignment.selectedShippingOption &&
+                consignment.selectedShippingOption.id &&
+                // Selected option is available
+                consignment.availableShippingOptions &&
+                consignment.availableShippingOptions.filter(
+                    ({ id }) => id === consignment.selectedShippingOption?.id,
+                ).length) ||
+            (consignment.selectedShippingOption?.type === 'custom' &&
+                consignment.selectedShippingOption.cost >= 0),
     );
 }

--- a/packages/test-framework/src/react-testing-library-support/API.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/API.mock.ts
@@ -573,6 +573,24 @@ const cartWithShippingAndBilling = {
     },
 };
 
+const cartWithCustomShippingAndBilling = {
+    ...cartWithShippingAndBilling,
+    consignments: [
+        {
+            ...cartWithShippingAndBilling.consignments[0],
+            selectedShippingOption: {
+                id: '',
+                type: 'custom',
+                description: 'Manual Order Custom Shipping Method',
+                imageUrl: '',
+                cost: 256,
+                transitTime: '',
+                additionalDescription: '',
+            },
+        },
+    ],
+};
+
 // intentionally shortened
 const countries = {
     data: [
@@ -954,6 +972,7 @@ export {
     cartWithPromotions,
     cartWithShippingAddress,
     cartWithShippingAndBilling,
+    cartWithCustomShippingAndBilling,
     cartWithoutPhysicalItem,
     checkoutSettings,
     checkoutSettingsWithCustomErrorFlashMessage,

--- a/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
+++ b/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
@@ -5,6 +5,7 @@ import { SetupServer, setupServer } from 'msw/node';
 import {
     cart,
     cartWithBillingEmail,
+    cartWithCustomShippingAndBilling,
     cartWithoutPhysicalItem,
     cartWithPromotions,
     cartWithShippingAddress,
@@ -35,6 +36,7 @@ export class CheckoutPageNodeObject {
             rest.post('/api/storefront/checkouts/*/billing-address', (_, res, ctx) =>
                 res(ctx.json(cartWithBillingEmail)),
             ),
+            rest.get('/api/storefront/checkout-extensions', (_, res, ctx) => res(ctx.json([]))),
         ];
 
         this.server = setupServer(...defaultHandlers);
@@ -84,6 +86,14 @@ export class CheckoutPageNodeObject {
                 this.server.use(
                     rest.get('/api/storefront/checkout/*', (_, res, ctx) =>
                         res(ctx.json(cartWithShippingAndBilling)),
+                    ),
+                );
+                break;
+
+            case 'CartWithCustomShippingAndBilling':
+                this.server.use(
+                    rest.get('/api/storefront/checkout/*', (_, res, ctx) =>
+                        res(ctx.json(cartWithCustomShippingAndBilling)),
                     ),
                 );
                 break;


### PR DESCRIPTION
## What?
Display custom shipping method created by manual order UI on the storefront checkout page.

## Why?
Support the use of a custom shipping method.

## Testing / Proof
### When the experiment is ON
Opening a draft order with a custom shipping method will jump to the payment step directly.

https://github.com/bigcommerce/checkout-js/assets/88361607/78e2ac4b-1245-41d4-9897-d39b820e6cc3

### When the experiment is OFF
The edit button of the shipping step appears on the page.

<img width="1350" alt="image" src="https://github.com/bigcommerce/checkout-js/assets/88361607/45a0766a-1d80-4cf9-880a-4c1ea25a0422">




@bigcommerce/team-checkout
