### PR TITLE
refactor(checkout): PI-2169 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.621.0",
+        "@bigcommerce/checkout-sdk": "^1.621.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.621.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.621.0.tgz",
-      "integrity": "sha512-LPx2LFv8zoxpBLF/J0vHvw6DqrNmUlbisnL2k89JFfs+o98DAw3DAk2R03ssXUlNkyG0aYf7/oL2L5tfOqTH9w==",
+      "version": "1.621.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.621.1.tgz",
+      "integrity": "sha512-uijipea930rA/lATEiLweAmJ8VpksUmECdMjD7U3K+WTDmxrv3JLC0Q+vu+06qGb9zn5LJTsQSYsLywGbFgJeA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.621.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.621.0.tgz",
-      "integrity": "sha512-LPx2LFv8zoxpBLF/J0vHvw6DqrNmUlbisnL2k89JFfs+o98DAw3DAk2R03ssXUlNkyG0aYf7/oL2L5tfOqTH9w==",
+      "version": "1.621.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.621.1.tgz",
+      "integrity": "sha512-uijipea930rA/lATEiLweAmJ8VpksUmECdMjD7U3K+WTDmxrv3JLC0Q+vu+06qGb9zn5LJTsQSYsLywGbFgJeA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.621.0",
+    "@bigcommerce/checkout-sdk": "^1.621.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/2527

## Why?
Removed all code related to the GooglePay from the core package in the Checkout-sdk

## Testing / Proof
test section in the https://github.com/bigcommerce/checkout-sdk-js/pull/2527

@bigcommerce/team-checkout
