### PR TITLE
refactor(checkout): PI-2297 moved WalletButton component to separate package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@ package-lock.json @bigcommerce/team-checkout @bigcommerce/team-integrations @big
 
 /packages/apple-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 /packages/google-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+packages/wallet-button-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
 
 ## Localization team
 /packages/locale/src/translations @bigcommerce/team-checkout

--- a/packages/ui/src/loading/LoadingSpinner.tsx
+++ b/packages/ui/src/loading/LoadingSpinner.tsx
@@ -10,7 +10,12 @@ const LoadingSpinner: FunctionComponent<LoadingSpinnerProps> = ({ isLoading }) =
     }
 
     return (
-        <div className="loadingSpinner loadingOverlay-container" style={{ height: 100 }}>
+        <div
+            aria-busy="true"
+            className="loadingSpinner loadingOverlay-container"
+            role="status"
+            style={{ height: 100 }}
+        >
             <div className="loadingOverlay optimizedCheckout-overlay" />
         </div>
     );

--- a/packages/wallet-button-integration/.eslintrc.json
+++ b/packages/wallet-button-integration/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/wallet-button-integration/README.md
+++ b/packages/wallet-button-integration/README.md
@@ -1,0 +1,11 @@
+# wallet-button-integration
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test wallet-button-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint wallet-button-integration` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/wallet-button-integration/jest.config.js
+++ b/packages/wallet-button-integration/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    displayName: 'wallet-button-integration',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+        },
+    },
+    transform: {
+        '^.+\\.[tj]sx?$': 'ts-jest',
+    },
+    setupFilesAfterEnv: ['../../jest-setup.ts'],
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: '../../coverage/packages/wallet-button-integration',
+};

--- a/packages/wallet-button-integration/project.json
+++ b/packages/wallet-button-integration/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "packages/wallet-button-integration",
+  "sourceRoot": "packages/wallet-button-integration/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/wallet-button-integration/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/wallet-button-integration"],
+      "options": {
+        "jestConfig": "packages/wallet-button-integration/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": ["scope:shared"]
+}

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
@@ -1,0 +1,387 @@
+import '@testing-library/jest-dom';
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+} from '@bigcommerce/checkout-sdk';
+import { Formik } from 'formik';
+import { merge, noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+} from '@bigcommerce/checkout/locale';
+import {
+    CheckoutProvider,
+    getPaymentMethodName,
+    PaymentFormContext,
+    PaymentFormService,
+} from '@bigcommerce/checkout/payment-integration-api';
+import {
+    getAddress,
+    getCheckout,
+    getCheckoutPayment,
+    getPaymentFormServiceMock,
+    getPaymentMethod,
+    getStoreConfig,
+} from '@bigcommerce/checkout/test-mocks';
+import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
+
+import WalletButtonPaymentMethodComponent, {
+    WalletButtonPaymentMethodProps,
+} from './WalletButtonPaymentMethodComponent';
+
+describe('WalletButtonPaymentMethod', () => {
+    let WalletButtonPaymentMethodTest: FunctionComponent<WalletButtonPaymentMethodProps>;
+    let defaultProps: WalletButtonPaymentMethodProps;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let localeContext: LocaleContextType;
+    let paymentForm: PaymentFormService;
+    let billingAddress;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+        paymentForm = getPaymentFormServiceMock();
+        billingAddress = {
+            ...getAddress(),
+            id: '1113412341',
+        };
+        defaultProps = {
+            checkoutService,
+            checkoutState,
+            language: localeContext.language,
+            paymentForm,
+            buttonId: 'button-container',
+            deinitializePayment: jest.fn(),
+            initializePayment: jest.fn(),
+            method: getPaymentMethod(),
+            onUnhandledError: jest.fn(),
+        };
+
+        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(billingAddress);
+
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(true);
+
+        WalletButtonPaymentMethodTest = (props) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <PaymentFormContext.Provider value={{ paymentForm }}>
+                    <LocaleContext.Provider value={localeContext}>
+                        <Formik initialValues={{}} onSubmit={noop}>
+                            <WalletButtonPaymentMethodComponent {...props} />
+                        </Formik>
+                    </LocaleContext.Provider>
+                </PaymentFormContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    it('initializes payment method when component mounts', () => {
+        render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+        expect(defaultProps.initializePayment).toHaveBeenCalled();
+    });
+
+    it('catches error during component initialization', async () => {
+        render(
+            <WalletButtonPaymentMethodTest
+                {...defaultProps}
+                initializePayment={() => Promise.reject(new Error('test error'))}
+            />,
+        );
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+    });
+
+    it('deinitializes payment method when component unmounts', () => {
+        const { unmount } = render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+        expect(defaultProps.deinitializePayment).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(defaultProps.deinitializePayment).toHaveBeenCalled();
+    });
+
+    it('catches error during component unmount', async () => {
+        const { unmount } = render(
+            <WalletButtonPaymentMethodTest
+                {...defaultProps}
+                deinitializePayment={() => Promise.reject(new Error('test error'))}
+            />,
+        );
+
+        unmount();
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+    });
+
+    it('renders loading overlay and hides conten while waiting for method to initialize', () => {
+        const { unmount } = render(
+            <WalletButtonPaymentMethodTest {...defaultProps} isInitializing />,
+        );
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.queryByTestId('loading-overlay')).not.toBeInTheDocument();
+        unmount();
+        render(<WalletButtonPaymentMethodTest {...defaultProps} isInitializing={false} />);
+
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('renders placeholder container with Sign In text', () => {
+        render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+        expect(
+            screen.getByText(
+                defaultProps.language.translate('remote.sign_in_action', {
+                    providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                }),
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('renders button for user to sign into their wallet', () => {
+        render(
+            <WalletButtonPaymentMethodTest
+                {...defaultProps}
+                signInButtonClassName="wallet-button"
+                signInButtonLabel="Sign into wallet"
+            />,
+        );
+
+        const element = screen.getByText('Sign into wallet');
+
+        expect(element).toBeInTheDocument();
+        expect(element).toHaveClass('wallet-button');
+    });
+
+    it('does not render sign out link', () => {
+        render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+        expect(screen.queryByText('Sign Out')).not.toBeInTheDocument();
+    });
+
+    it('disables submit button', () => {
+        render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+        const {
+            paymentForm: { disableSubmit },
+        } = defaultProps;
+
+        expect(disableSubmit).toHaveBeenCalledWith(defaultProps.method, true);
+    });
+
+    it('enables submit button if payment data is not required', () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
+
+        render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+        const {
+            paymentForm: { disableSubmit },
+        } = defaultProps;
+
+        expect(disableSubmit).toHaveBeenCalledWith(defaultProps.method, false);
+    });
+
+    it('toggles submit button if payment data become required', () => {
+        const { rerender } = render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+        const {
+            paymentForm: { disableSubmit },
+        } = defaultProps;
+
+        expect(disableSubmit).toHaveBeenCalledWith(defaultProps.method, true);
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
+
+        rerender(<WalletButtonPaymentMethodTest {...defaultProps} />);
+        expect(disableSubmit).toHaveBeenCalledWith(defaultProps.method, false);
+    });
+
+    describe('when user is signed into their payment method account and credit card is selected from their wallet', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: defaultProps.method.id }],
+            });
+
+            defaultProps = merge({}, defaultProps, {
+                method: {
+                    initializationData: {
+                        cardData: {
+                            accountMask: '1111',
+                            cardType: 'Visa',
+                            expMonth: '10',
+                            expYear: '22',
+                        },
+                    },
+                },
+            });
+        });
+
+        it('renders sign out link', () => {
+            render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+            const linkText = defaultProps.language.translate('remote.sign_out_action', {
+                providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+            });
+
+            expect(screen.getByText(linkText)).toBeInTheDocument();
+        });
+
+        it('enables submit button', () => {
+            render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+            const {
+                paymentForm: { disableSubmit },
+            } = defaultProps;
+
+            expect(disableSubmit).toHaveBeenCalledWith(defaultProps.method, false);
+        });
+
+        it('displays information of selected credit card', () => {
+            render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+            expect(screen.getByTestId('payment-method-wallet-card-name')).toHaveTextContent(
+                'Test Tester',
+            );
+            expect(screen.getByTestId('payment-method-wallet-card-type')).toHaveTextContent(
+                'Visa: **** 1111',
+            );
+            expect(screen.getByTestId('payment-method-wallet-card-expiry')).toHaveTextContent(
+                '10/22',
+            );
+        });
+
+        it('displays card information in `accountNum` format', () => {
+            const method = {
+                ...defaultProps.method,
+                initializationData: {
+                    accountMask: '1111',
+                    accountNum: '4111',
+                    expDate: '1022',
+                },
+            };
+
+            render(<WalletButtonPaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(screen.getByTestId('payment-method-wallet-card-type')).toHaveTextContent(
+                'Visa: **** 1111',
+            );
+
+            expect(screen.getByTestId('payment-method-wallet-card-expiry')).toHaveTextContent(
+                '10/22',
+            );
+        });
+
+        it('displays card information in `card_information` format', () => {
+            const method = {
+                ...defaultProps.method,
+                initializationData: {
+                    card_information: {
+                        number: '1111',
+                        type: 'Visa',
+                    },
+                },
+            };
+
+            render(<WalletButtonPaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(screen.getByTestId('payment-method-wallet-card-type')).toHaveTextContent(
+                'Visa: **** 1111',
+            );
+        });
+
+        it('renders button for user to edit their selected credit card', () => {
+            const editButtonLabel = 'Edit card';
+
+            render(
+                <WalletButtonPaymentMethodTest
+                    {...defaultProps}
+                    editButtonLabel={editButtonLabel}
+                    shouldShowEditButton
+                />,
+            );
+            expect(
+                screen.queryByText(
+                    defaultProps.language.translate('remote.select_different_card_action'),
+                ),
+            ).not.toBeInTheDocument();
+            expect(screen.getByText(editButtonLabel)).toBeInTheDocument();
+        });
+
+        it('does not render button for user to edit their selected card if not configured', () => {
+            render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+            expect(
+                screen.queryByText(
+                    defaultProps.language.translate('remote.select_different_card_action'),
+                ),
+            ).not.toBeInTheDocument();
+        });
+
+        it('signs out from payment method account of user when clicking on sign out link', async () => {
+            const handleSignOutError = jest.fn();
+
+            jest.spyOn(checkoutService, 'signOutCustomer').mockResolvedValue(checkoutState);
+
+            render(
+                <WalletButtonPaymentMethodTest
+                    {...defaultProps}
+                    onSignOutError={handleSignOutError}
+                />,
+            );
+
+            const actionButton = screen.getByText(
+                defaultProps.language.translate('remote.sign_out_action', {
+                    providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                }),
+            );
+
+            fireEvent.click(actionButton);
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.signOutCustomer).toHaveBeenCalledWith({
+                methodId: defaultProps.method.id,
+            });
+
+            expect(handleSignOutError).not.toHaveBeenCalled();
+        });
+
+        it('notifies parent component if unable to sign out', async () => {
+            const handleSignOutError = jest.fn();
+
+            jest.spyOn(checkoutService, 'signOutCustomer').mockRejectedValue(
+                new Error('Unknown error'),
+            );
+
+            render(
+                <WalletButtonPaymentMethodTest
+                    {...defaultProps}
+                    onSignOutError={handleSignOutError}
+                />,
+            );
+
+            const actionButton = screen.getByText(
+                defaultProps.language.translate('remote.sign_out_action', {
+                    providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                }),
+            );
+
+            fireEvent.click(actionButton);
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(handleSignOutError).toHaveBeenCalledWith(expect.any(Error));
+        });
+    });
+});

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
@@ -1,0 +1,243 @@
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    CustomerRequestOptions,
+    LanguageService,
+    PaymentInitializeOptions,
+    PaymentMethod,
+    PaymentRequestOptions,
+} from '@bigcommerce/checkout-sdk';
+import { noop, some } from 'lodash';
+import React, { Component, ReactNode } from 'react';
+
+import { preventDefault } from '@bigcommerce/checkout/dom-utils';
+import { SignOutLink } from '@bigcommerce/checkout/instrument-utils';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import {
+    getPaymentMethodName,
+    PaymentFormService,
+} from '@bigcommerce/checkout/payment-integration-api';
+import { LoadingOverlay } from '@bigcommerce/checkout/ui';
+
+import normalizeWalletPaymentData from './normalizeWalletPaymentData';
+
+export interface WalletButtonPaymentMethodProps {
+    checkoutService: CheckoutService;
+    checkoutState: CheckoutSelectors;
+    language: LanguageService;
+    paymentForm: PaymentFormService;
+    buttonId: string;
+    editButtonClassName?: string;
+    editButtonLabel?: ReactNode;
+    isInitializing?: boolean;
+    method: PaymentMethod;
+    shouldShowEditButton?: boolean;
+    signInButtonClassName?: string;
+    signInButtonLabel?: ReactNode;
+    deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
+    initializePayment(options: PaymentInitializeOptions): Promise<CheckoutSelectors>;
+    onSignOut?(): void;
+    onSignOutError?(error: Error): void;
+    onUnhandledError?(error: Error): void;
+}
+
+interface WalletButtonPaymentMethodDerivedProps {
+    accountMask?: string;
+    cardName?: string;
+    cardType?: string;
+    expiryMonth?: string;
+    expiryYear?: string;
+    isPaymentDataRequired: boolean;
+    isPaymentSelected: boolean;
+    signOut(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
+}
+
+class WalletButtonPaymentMethodComponent extends Component<WalletButtonPaymentMethodProps> {
+    async componentDidMount(): Promise<void> {
+        const { initializePayment, method, onUnhandledError = noop } = this.props;
+
+        this.toggleSubmit();
+
+        try {
+            await initializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    async componentWillUnmount(): Promise<void> {
+        const {
+            deinitializePayment,
+            paymentForm: { disableSubmit },
+            method,
+            onUnhandledError = noop,
+        } = this.props;
+
+        disableSubmit(method, false);
+
+        try {
+            await deinitializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        }
+    }
+
+    componentDidUpdate(
+        prevProps: Readonly<WalletButtonPaymentMethodProps & WalletButtonPaymentMethodDerivedProps>,
+    ): void {
+        const { method } = this.props;
+        const { isPaymentDataRequired } = this.getWalletButtonPaymentMethodDerivedProps();
+        const { method: prevMethod, isPaymentDataRequired: prevIsPaymentDataRequired } = prevProps;
+
+        if (
+            method.initializationData !== prevMethod.initializationData ||
+            isPaymentDataRequired !== prevIsPaymentDataRequired
+        ) {
+            this.toggleSubmit();
+        }
+    }
+
+    render(): ReactNode {
+        const { isInitializing = false } = this.props;
+        const { isPaymentSelected } = this.getWalletButtonPaymentMethodDerivedProps();
+
+        return (
+            <LoadingOverlay hideContentWhenLoading isLoading={isInitializing}>
+                <div className="paymentMethod paymentMethod--walletButton">
+                    {isPaymentSelected ? this.renderPaymentView() : this.renderSignInView()}
+                </div>
+            </LoadingOverlay>
+        );
+    }
+
+    private renderSignInView(): ReactNode {
+        const { buttonId, signInButtonClassName, signInButtonLabel, method, language } = this.props;
+
+        return (
+            // eslint-disable-next-line jsx-a11y/anchor-is-valid
+            <a className={signInButtonClassName} href="#" id={buttonId} onClick={preventDefault()}>
+                {signInButtonLabel || (
+                    <TranslatedString
+                        data={{ providerName: getPaymentMethodName(language)(method) }}
+                        id="remote.sign_in_action"
+                    />
+                )}
+            </a>
+        );
+    }
+
+    private renderPaymentView(): ReactNode {
+        const { buttonId, editButtonClassName, editButtonLabel, shouldShowEditButton, method } =
+            this.props;
+        const { accountMask, cardName, cardType, expiryMonth, expiryYear } =
+            this.getWalletButtonPaymentMethodDerivedProps();
+
+        return (
+            <>
+                {!!cardName && (
+                    <p data-test="payment-method-wallet-card-name">
+                        <strong>
+                            <TranslatedString id="payment.credit_card_name_label" />:
+                        </strong>{' '}
+                        {cardName}
+                    </p>
+                )}
+
+                {!!accountMask && !!cardType && (
+                    <p data-test="payment-method-wallet-card-type">
+                        <strong>{`${cardType}:`}</strong> {accountMask}
+                    </p>
+                )}
+
+                {!!expiryMonth && !!expiryYear && (
+                    <p data-test="payment-method-wallet-card-expiry">
+                        <strong>
+                            <TranslatedString id="payment.credit_card_expiration_date_label" />:
+                        </strong>{' '}
+                        {`${expiryMonth}/${expiryYear}`}
+                    </p>
+                )}
+
+                {!!shouldShowEditButton && (
+                    <p>
+                        {
+                            // eslint-disable-next-line jsx-a11y/anchor-is-valid
+                            <a
+                                className={editButtonClassName}
+                                href="#"
+                                id={buttonId}
+                                onClick={preventDefault()}
+                            >
+                                {editButtonLabel || (
+                                    <TranslatedString id="remote.select_different_card_action" />
+                                )}
+                            </a>
+                        }
+                    </p>
+                )}
+
+                <SignOutLink method={method} onSignOut={this.handleSignOut} />
+            </>
+        );
+    }
+
+    private toggleSubmit(): void {
+        const {
+            paymentForm: { disableSubmit },
+            method,
+        } = this.props;
+        const { isPaymentDataRequired } = this.getWalletButtonPaymentMethodDerivedProps();
+
+        if (normalizeWalletPaymentData(method.initializationData) || !isPaymentDataRequired) {
+            disableSubmit(method, false);
+        } else {
+            disableSubmit(method, true);
+        }
+    }
+
+    private handleSignOut: () => void = async () => {
+        const { method, onSignOut = noop, onSignOutError = noop } = this.props;
+        const { signOut } = this.getWalletButtonPaymentMethodDerivedProps();
+
+        try {
+            await signOut({ methodId: method.id });
+            onSignOut();
+            window.location.reload();
+        } catch (error) {
+            onSignOutError(error);
+        }
+    };
+
+    private getWalletButtonPaymentMethodDerivedProps(): WalletButtonPaymentMethodDerivedProps {
+        const { checkoutService, checkoutState, method } = this.props;
+        const {
+            data: { getBillingAddress, getCheckout, isPaymentDataRequired },
+        } = checkoutState;
+        const billingAddress = getBillingAddress();
+        const checkout = getCheckout();
+
+        if (!billingAddress || !checkout) {
+            throw new Error('Unable to get checkout');
+        }
+
+        const walletPaymentData = normalizeWalletPaymentData(method.initializationData);
+
+        return {
+            ...walletPaymentData,
+            // FIXME: I'm not sure how this would work for non-English names.
+            cardName:
+                walletPaymentData && [billingAddress.firstName, billingAddress.lastName].join(' '),
+            isPaymentDataRequired: isPaymentDataRequired(),
+            isPaymentSelected: some(checkout.payments, { providerId: method.id }),
+            signOut: checkoutService.signOutCustomer,
+        };
+    }
+}
+
+export default WalletButtonPaymentMethodComponent;

--- a/packages/wallet-button-integration/src/index.ts
+++ b/packages/wallet-button-integration/src/index.ts
@@ -1,0 +1,3 @@
+import WalletButtonPaymentMethodComponent from './WalletButtonPaymentMethodComponent';
+
+export { WalletButtonPaymentMethodComponent };

--- a/packages/wallet-button-integration/src/normalizeWalletPaymentData.ts
+++ b/packages/wallet-button-integration/src/normalizeWalletPaymentData.ts
@@ -1,0 +1,84 @@
+import { number } from 'card-validator';
+
+import { WalletButtonInitializationData } from './types';
+
+interface WalletPaymentData {
+    accountMask: string;
+    cardType: string;
+    expiryMonth?: string;
+    expiryYear?: string;
+}
+
+const formatAccountMask = (accountMask = '', padding = '****'): string =>
+    accountMask.indexOf('*') > -1 ? accountMask : `${padding} ${accountMask}`;
+
+const isWalletButtonInitializationData = (
+    object: unknown,
+): object is WalletButtonInitializationData => {
+    if (typeof object === 'object' && object !== null) {
+        if (
+            'card_information' in object &&
+            typeof object.card_information === 'object' &&
+            object.card_information !== null &&
+            'number' in object.card_information &&
+            'type' in object.card_information
+        ) {
+            return true;
+        }
+
+        if (
+            'cardData' in object &&
+            typeof object.cardData === 'object' &&
+            object.cardData !== null &&
+            'accountMask' in object.cardData &&
+            'cardType' in object.cardData &&
+            'expMonth' in object.cardData &&
+            'expYear' in object.cardData
+        ) {
+            return true;
+        }
+
+        if ('accountNum' in object && 'accountMask' in object && 'expDate' in object) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+// For some odd reason, `initializationData` is a schema-less object. So in
+// order to use it safely, we have to normalize it first.
+const normalizeWalletPaymentData = (data: unknown): WalletPaymentData | undefined => {
+    if (isWalletButtonInitializationData(data)) {
+        if (data.card_information) {
+            return {
+                accountMask: formatAccountMask(data.card_information.number),
+                cardType: data.card_information.type,
+            };
+        }
+
+        if (data.cardData) {
+            return {
+                accountMask: formatAccountMask(data.cardData.accountMask),
+                cardType: data.cardData.cardType,
+                expiryMonth: data.cardData.expMonth,
+                expiryYear: data.cardData.expYear,
+            };
+        }
+
+        if (data.accountNum) {
+            const { card } = number(data.accountNum);
+
+            return {
+                accountMask: formatAccountMask(data.accountMask),
+                expiryMonth: data.expDate && `${data.expDate}`.substr(0, 2),
+                expiryYear: data.expDate && `${data.expDate}`.substr(2, 2),
+                cardType: card ? card.niceType : '',
+            };
+        }
+    }
+
+    return undefined;
+};
+
+export default normalizeWalletPaymentData;

--- a/packages/wallet-button-integration/src/types.ts
+++ b/packages/wallet-button-integration/src/types.ts
@@ -1,0 +1,20 @@
+export interface WalletButtonInitializationDataCardData {
+    accountMask: string;
+    cardType: string;
+    expMonth: string;
+    expYear: string;
+}
+
+export interface WalletButtonInitializationDataCardInformation {
+    number: string;
+    type: string;
+}
+
+export interface WalletButtonInitializationData {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    card_information?: WalletButtonInitializationDataCardInformation;
+    cardData?: WalletButtonInitializationDataCardData;
+    accountNum?: string;
+    accountMask?: string;
+    expDate?: string;
+}

--- a/packages/wallet-button-integration/tsconfig.json
+++ b/packages/wallet-button-integration/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "files": ["../core/types/card-validator.d.ts"],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/wallet-button-integration/tsconfig.lib.json
+++ b/packages/wallet-button-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/packages/wallet-button-integration/tsconfig.spec.json
+++ b/packages/wallet-button-integration/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -85,6 +85,9 @@
       "@bigcommerce/checkout/test-mocks": ["packages/test-mocks/src/index.ts"],
       "@bigcommerce/checkout/test-utils": ["packages/test-utils/src/index.ts"],
       "@bigcommerce/checkout/ui": ["packages/ui/src/index.ts"],
+      "@bigcommerce/checkout/wallet-button-integration": [
+        "packages/wallet-button-integration/src/index.ts"
+      ],
       "@bigcommerce/checkout/workspace-tools": ["packages/workspace-tools/src/index.ts"]
     },
     "resolveJsonModule": true,

--- a/workspace.json
+++ b/workspace.json
@@ -36,6 +36,7 @@
     "test-mocks": "packages/test-mocks",
     "test-utils": "packages/test-utils",
     "ui": "packages/ui",
+    "wallet-button-integration": "packages/wallet-button-integration",
     "workspace-tools": "packages/workspace-tools"
   }
 }


### PR DESCRIPTION
## What?
Moved WalletButton Component to the separate package.
I haven't removed WalletButton Component from the core yet. It will be removed after the refactoring of the "core" payment methods that use him.
It's easier to review when you compare new module with [older one](https://github.com/bigcommerce/checkout-js/blob/master/packages/core/src/app/payment/paymentMethod/WalletButtonPaymentMethod.tsx)
## Why?
Due to the monorepo refactoring, it needed for further GooglePay, VisaCheckout, etc refactoring.

## Testing / Proof
<img width="1512" alt="image" src="https://github.com/bigcommerce/checkout-js/assets/79574476/f8e22958-d077-4ac7-b1cd-5b17387b0509">

@bigcommerce/team-checkout
