### PR TITLE
chore(payment): PAYPAL-3600 bump checkout-sdk version to 1.622.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.621.1",
+        "@bigcommerce/checkout-sdk": "^1.622.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.621.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.621.1.tgz",
-      "integrity": "sha512-uijipea930rA/lATEiLweAmJ8VpksUmECdMjD7U3K+WTDmxrv3JLC0Q+vu+06qGb9zn5LJTsQSYsLywGbFgJeA==",
+      "version": "1.622.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.622.1.tgz",
+      "integrity": "sha512-WbXkii0eNwTr2NGaZx7Rr/3Bba/siS8LsKA77DSnJ/+JL3lTWjxbwpnkZZgh07m876y9ekCY5DA8eqHZ73yMLw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.621.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.621.1.tgz",
-      "integrity": "sha512-uijipea930rA/lATEiLweAmJ8VpksUmECdMjD7U3K+WTDmxrv3JLC0Q+vu+06qGb9zn5LJTsQSYsLywGbFgJeA==",
+      "version": "1.622.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.622.1.tgz",
+      "integrity": "sha512-WbXkii0eNwTr2NGaZx7Rr/3Bba/siS8LsKA77DSnJ/+JL3lTWjxbwpnkZZgh07m876y9ekCY5DA8eqHZ73yMLw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.621.1",
+    "@bigcommerce/checkout-sdk": "^1.622.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.622.1

## Why?
As part of release: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2546
https://github.com/bigcommerce/checkout-sdk-js/pull/2533

## Testing / Proof
Unit tests
Manual tests
CI
