### PR TITLE
feat(payment): PI-2283 Add Google Pay on TD Online Mart - checkout pa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.623.2",
+        "@bigcommerce/checkout-sdk": "^1.624.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.623.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.623.2.tgz",
-      "integrity": "sha512-HYLfMXNE1WjrpE+McOMNfWxfDlxE5qXMuZDIrXgT/CGLD/YgNknajuSz3nwWbBnkXnW66g34QJcerRYpL3nLVA==",
+      "version": "1.624.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.624.0.tgz",
+      "integrity": "sha512-PePi4HTm6DR8TsupldQrtbHfIcXTze639x6UKalppLA1lbw4moX7lp21tXkOx7ocKw2Jtikvsij5GJP3J2P0Og==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.623.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.623.2.tgz",
-      "integrity": "sha512-HYLfMXNE1WjrpE+McOMNfWxfDlxE5qXMuZDIrXgT/CGLD/YgNknajuSz3nwWbBnkXnW66g34QJcerRYpL3nLVA==",
+      "version": "1.624.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.624.0.tgz",
+      "integrity": "sha512-PePi4HTm6DR8TsupldQrtbHfIcXTze639x6UKalppLA1lbw4moX7lp21tXkOx7ocKw2Jtikvsij5GJP3J2P0Og==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.623.2",
+    "@bigcommerce/checkout-sdk": "^1.624.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.spec.tsx
@@ -90,6 +90,7 @@ describe('when using Google Pay payment', () => {
         [PaymentMethodId.StripeGooglePay],
         [PaymentMethodId.StripeUPEGooglePay],
         [PaymentMethodId.WorldpayAccessGooglePay],
+        [PaymentMethodId.TdOnlineMartGooglePay],
     ]).it('initializes %s with required config', (id) => {
         method.id = id;
 

--- a/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/GooglePayPaymentMethod.tsx
@@ -100,6 +100,11 @@ const GooglePayPaymentMethod: FunctionComponent<GooglePayPaymentMethodProps> = (
             onError: onUnhandledError,
             onPaymentSelect: () => reinitializePayment(mergedOptions),
           },
+          googlepaytdonlinemart: {
+            walletButton: 'walletButton',
+            onError: onUnhandledError,
+            onPaymentSelect: () => reinitializePayment(mergedOptions),
+          },
         };
 
             return initializePayment(mergedOptions);

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -122,7 +122,8 @@ const PaymentMethodComponent: FunctionComponent<
         method.id === PaymentMethodId.OrbitalGooglePay ||
         method.id === PaymentMethodId.StripeGooglePay ||
         method.id === PaymentMethodId.StripeUPEGooglePay ||
-        method.id === PaymentMethodId.WorldpayAccessGooglePay
+        method.id === PaymentMethodId.WorldpayAccessGooglePay ||
+        method.id === PaymentMethodId.TdOnlineMartGooglePay
     ) {
         return <GooglePayPaymentMethod {...props} />;
     }

--- a/packages/payment-integration-api/src/PaymentMethodId.ts
+++ b/packages/payment-integration-api/src/PaymentMethodId.ts
@@ -66,6 +66,7 @@ enum PaymentMethodId {
     WorldpayAccess = 'worldpayaccess',
     WorldpayAccessGooglePay = 'googlepayworldpayaccess',
     Zip = 'zip',
+    TdOnlineMartGooglePay = 'googlepaytdonlinemart',
 }
 
 export default PaymentMethodId;


### PR DESCRIPTION
…yment step
checkout-sdk part: https://github.com/bigcommerce/checkout-sdk-js/pull/2552

## What?
Add Google Pay on TD Online Mart in checkout payment step

## Why?
As a merchant I want to be able to offer my shoppers Google Pay wallet through TD Online Mart


## Testing / Proof
Tested manually
Work on backend part of this project is not started yet. Therefore added part of the code will not execute before BE part will be ready.

@bigcommerce/team-checkout
