### PR TITLE
chore(payment): STRIPE-385 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.622.1",
+        "@bigcommerce/checkout-sdk": "^1.623.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1757,9 +1757,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.622.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.622.1.tgz",
-      "integrity": "sha512-WbXkii0eNwTr2NGaZx7Rr/3Bba/siS8LsKA77DSnJ/+JL3lTWjxbwpnkZZgh07m876y9ekCY5DA8eqHZ73yMLw==",
+      "version": "1.623.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.623.2.tgz",
+      "integrity": "sha512-HYLfMXNE1WjrpE+McOMNfWxfDlxE5qXMuZDIrXgT/CGLD/YgNknajuSz3nwWbBnkXnW66g34QJcerRYpL3nLVA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35560,9 +35560,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.622.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.622.1.tgz",
-      "integrity": "sha512-WbXkii0eNwTr2NGaZx7Rr/3Bba/siS8LsKA77DSnJ/+JL3lTWjxbwpnkZZgh07m876y9ekCY5DA8eqHZ73yMLw==",
+      "version": "1.623.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.623.2.tgz",
+      "integrity": "sha512-HYLfMXNE1WjrpE+McOMNfWxfDlxE5qXMuZDIrXgT/CGLD/YgNknajuSz3nwWbBnkXnW66g34QJcerRYpL3nLVA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.622.1",
+    "@bigcommerce/checkout-sdk": "^1.623.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk js version

## Why?
To deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2551](https://github.com/bigcommerce/checkout-sdk-js/pull/2551)
[https://github.com/bigcommerce/checkout-sdk-js/pull/2550](https://github.com/bigcommerce/checkout-sdk-js/pull/2550)
[https://github.com/bigcommerce/checkout-sdk-js/pull/2553](https://github.com/bigcommerce/checkout-sdk-js/pull/2553)

## Testing / Proof
Unit test and manually tested

@bigcommerce/team-checkout
