### PR TITLE
chore(other): ISSUE-1737 Update README.md with correct node/npm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Checkout JS is a browser-based application providing a seamless UI for BigCommer
 
 In order to build from the source code, you must have the following set up in your development environment.
 
-* Node >= v16.
-* NPM >= v8.
+* Node >= v18.
+* NPM >= v9.
 * Unix-based operating system. (WSL on Windows)
 
 One of the simplest ways to install Node is using [NVM](https://github.com/nvm-sh/nvm#installation-and-update). You can follow their instructions to set up your environment if it is not already set up.


### PR DESCRIPTION
Duplicates https://github.com/bigcommerce/checkout-js/pull/1736 with updated commit message.

## What?
As per the engines provided in package.json and the node version within .nvmrc, I've updated the readme to reflect the correct versions required.

Fixes #1737

## Why?
The incorrect versions are present within the readme, causing confusion to developers.

## Testing / Proof
```
$ cat .circleci/config.yml | grep node-version
        node-version: "18.17"
```

@bigcommerce/team-checkout