### PR TITLE
feat(payment): PI-2284 Add Google Pay on TD Online Mart - checkout customer step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.627.1",
+        "@bigcommerce/checkout-sdk": "^1.629.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.627.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.627.1.tgz",
-      "integrity": "sha512-qh87A7+wbYkwYaJ0Fq4ZYN42mnT8fCPb/VqIealy7guoGgBkrF9k/qP2mDpTOgMKXc/Nug4qH0Rl4nAaXYXBGw==",
+      "version": "1.629.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.0.tgz",
+      "integrity": "sha512-3PhHud18W64OlRmNJu8nzKGbLH37NJEZ5BWvOwSXkuT0X2cSJ+LM54vnwCGyaDxMGidbPcSLkMrTDiENIRbC3w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.627.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.627.1.tgz",
-      "integrity": "sha512-qh87A7+wbYkwYaJ0Fq4ZYN42mnT8fCPb/VqIealy7guoGgBkrF9k/qP2mDpTOgMKXc/Nug4qH0Rl4nAaXYXBGw==",
+      "version": "1.629.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.0.tgz",
+      "integrity": "sha512-3PhHud18W64OlRmNJu8nzKGbLH37NJEZ5BWvOwSXkuT0X2cSJ+LM54vnwCGyaDxMGidbPcSLkMrTDiENIRbC3w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.627.1",
+    "@bigcommerce/checkout-sdk": "^1.629.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/google-pay-integration/src/GooglePayButton.tsx
+++ b/packages/google-pay-integration/src/GooglePayButton.tsx
@@ -42,5 +42,6 @@ export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveI
         { id: 'googlepaystripe' },
         { id: 'googlepaystripeupe' },
         { id: 'googlepayworldpayaccess' },
+        { id: 'googlepaytdonlinemart' },
     ],
 );


### PR DESCRIPTION
checkout-sdk part: https://github.com/bigcommerce/checkout-sdk-js/pull/2557

## What?
Add Google Pay on TD Online Mart in button payment step

## Why?
As a merchant I want to be able to offer my shoppers Google Pay wallet through TD Online Mart

## Testing / Proof
Tested manually
Work on backend part of this project is not started yet. Therefore added part of the code will not execute before BE part will be ready.

@bigcommerce/team-checkout
