### PR TITLE
chore(other): CHECKOUT-8392 Update checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.629.0",
+        "@bigcommerce/checkout-sdk": "^1.629.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.629.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.0.tgz",
-      "integrity": "sha512-3PhHud18W64OlRmNJu8nzKGbLH37NJEZ5BWvOwSXkuT0X2cSJ+LM54vnwCGyaDxMGidbPcSLkMrTDiENIRbC3w==",
+      "version": "1.629.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.1.tgz",
+      "integrity": "sha512-BJr+2gpWeIBoKMhN8CjHFfnaT+RQ3Qdmycx3g0o23bFYVshBCk0Ma5QH9rurh2VNMOKbLd3pL+SEZUVChhCx3w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.629.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.0.tgz",
-      "integrity": "sha512-3PhHud18W64OlRmNJu8nzKGbLH37NJEZ5BWvOwSXkuT0X2cSJ+LM54vnwCGyaDxMGidbPcSLkMrTDiENIRbC3w==",
+      "version": "1.629.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.1.tgz",
+      "integrity": "sha512-BJr+2gpWeIBoKMhN8CjHFfnaT+RQ3Qdmycx3g0o23bFYVshBCk0Ma5QH9rurh2VNMOKbLd3pL+SEZUVChhCx3w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.629.0",
+    "@bigcommerce/checkout-sdk": "^1.629.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to latest version.

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/2566

## Testing / Proof
- CI

@bigcommerce/team-checkout
