### PR TITLE
chore(payment): PAYPAL-4379 bump checkout-sdk version to 1.630.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.629.1",
+        "@bigcommerce/checkout-sdk": "^1.630.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.629.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.1.tgz",
-      "integrity": "sha512-BJr+2gpWeIBoKMhN8CjHFfnaT+RQ3Qdmycx3g0o23bFYVshBCk0Ma5QH9rurh2VNMOKbLd3pL+SEZUVChhCx3w==",
+      "version": "1.630.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.630.1.tgz",
+      "integrity": "sha512-5bOhn8wXNqHQLf9TYDLs8wyyvhxhphmMRbq2oDNWt0Arql3Z0OGCyDAwqJpjNe4YWzj72SHQx3pGKjKFG7EehQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.629.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.629.1.tgz",
-      "integrity": "sha512-BJr+2gpWeIBoKMhN8CjHFfnaT+RQ3Qdmycx3g0o23bFYVshBCk0Ma5QH9rurh2VNMOKbLd3pL+SEZUVChhCx3w==",
+      "version": "1.630.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.630.1.tgz",
+      "integrity": "sha512-5bOhn8wXNqHQLf9TYDLs8wyyvhxhphmMRbq2oDNWt0Arql3Z0OGCyDAwqJpjNe4YWzj72SHQx3pGKjKFG7EehQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.629.1",
+    "@bigcommerce/checkout-sdk": "^1.630.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.630.1

## Why?
Due to: https://github.com/bigcommerce/checkout-sdk-js/pull/2568

## Testing / Proof
Unit tests
Manual tests
CI