### PR TITLE
feat(checkout): CHECKOUT-8300 Improve Extension Rendering Performance

### DIFF
--- a/packages/checkout-extension/src/ExtensionService.test.tsx
+++ b/packages/checkout-extension/src/ExtensionService.test.tsx
@@ -45,24 +45,23 @@ describe('ExtensionService', () => {
         jest.spyOn(checkoutService.getState().data, 'getCart').mockReturnValue(getCart());
         jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
         jest.spyOn(document, 'createElement');
-        jest.spyOn(document.head, 'appendChild');
+        jest.spyOn(document.body, 'appendChild');
 
         extensionService.preloadExtensions();
 
-        expect(document.createElement).toHaveBeenCalledWith('link');
-        expect(document.head.appendChild).toHaveBeenCalledTimes(2);
+        expect(document.createElement).toHaveBeenCalledWith('iframe');
+        expect(document.body.appendChild).toHaveBeenCalledTimes(2);
 
-        const linkItems = [
+        const iframeURLs = [
             'https://widget.foo.com/?extensionId=123&cartId=b20deef40f9699e48671bbc3fef6ca44dc80e3c7&parentOrigin=https%3A%2F%2Fstore-k1drp8k8.bcapp.dev',
             'https://widget.bar.com/?extensionId=456&cartId=b20deef40f9699e48671bbc3fef6ca44dc80e3c7&parentOrigin=https%3A%2F%2Fstore-k1drp8k8.bcapp.dev',
         ];
 
-        linkItems.forEach((linkItem, index) => {
-            expect(document.head.appendChild).toHaveBeenNthCalledWith(
+        iframeURLs.forEach((iframeURL, index) => {
+            expect(document.body.appendChild).toHaveBeenNthCalledWith(
                 index + 1,
                 expect.objectContaining({
-                    href: linkItem,
-                    rel: 'preload',
+                    src: iframeURL,
                 }),
             );
         });

--- a/packages/checkout-extension/src/ExtensionService.ts
+++ b/packages/checkout-extension/src/ExtensionService.ts
@@ -32,22 +32,36 @@ export class ExtensionService {
             return;
         }
 
+        const disabledPreloadRegions = [
+            ExtensionRegion.SummaryAfter,
+            ExtensionRegion.SummaryLastItemAfter,
+        ];
+
         extensions?.forEach((extension) => {
+            if (disabledPreloadRegions.includes(extension.region)) {
+                return;
+            }
+
             const url = new URL(extension.url);
 
             url.searchParams.set('extensionId', extension.id);
             url.searchParams.set('cartId', cartId);
             url.searchParams.set('parentOrigin', parentOrigin);
 
-            const link = document.createElement('link');
+            const iframe = document.createElement('iframe');
 
-            link.rel = 'preload';
-            link.as = 'document';
-            link.href = url.toString();
+            iframe.src = url.toString();
+            iframe.style.display = 'none';
 
-            const head = document.head;
+            const removeIframe = () => {
+                if (iframe.parentNode) {
+                    iframe.parentNode.removeChild(iframe);
+                }
+            };
 
-            head.appendChild(link);
+            iframe.addEventListener('load', removeIframe);
+
+            document.body.appendChild(iframe);
         });
     }
 


### PR DESCRIPTION
## What?
Improve the rendering time of a checkout extension.

### Limitations
- Applicable to regions not initially visible on the checkout page only.
- Requires an extension to enable server-side cache headers (e.g., `Cache-Control: public, max-age=3600`) for modern browsers to load the extension from cache on subsequent visits.

## Why?
Enhance the user experience of the checkout extension.

## Testing / Proof
### Manual Testing

https://github.com/user-attachments/assets/76ada22a-e16d-4bab-a31b-5c28d0c0d7ef

@bigcommerce/team-checkout
