### PR TITLE
CHECKOUT-8434: Fix item count display for bundled items

### DIFF
--- a/packages/core/src/app/cart/CartSummary.tsx
+++ b/packages/core/src/app/cart/CartSummary.tsx
@@ -13,7 +13,6 @@ import withRedeemable from './withRedeemable';
 export type WithCheckoutCartSummaryProps = {
     checkout: Checkout;
     cartUrl: string;
-    isUpdatedCartSummayModal: boolean;
     storeCurrency: StoreCurrency;
     shopperCurrency: ShopperCurrency;
     storeCreditAmount?: number;

--- a/packages/core/src/app/cart/mapToCartSummaryProps.ts
+++ b/packages/core/src/app/cart/mapToCartSummaryProps.ts
@@ -23,7 +23,6 @@ export default function mapToCartSummaryProps(
 
     const { isStoreCreditApplied, grandTotal } = checkout;
     const { storeCredit } = customer;
-    const updatedCartModal = config?.checkoutSettings.features['CHECKOUT-7403.updated_cart_summary_modal'] ?? false;
 
     return {
         checkout,
@@ -31,7 +30,6 @@ export default function mapToCartSummaryProps(
         cartUrl: config.links.cartLink,
         storeCurrency: config.currency,
         storeCreditAmount: isStoreCreditApplied ? Math.min(grandTotal, storeCredit) : undefined,
-        isUpdatedCartSummayModal: updatedCartModal,
         ...redeemableProps,
     };
 }

--- a/packages/core/src/app/cart/withRedeemable.tsx
+++ b/packages/core/src/app/cart/withRedeemable.tsx
@@ -18,7 +18,6 @@ export default function withRedeemable(
             onRemovedCoupon,
             onRemovedGiftCertificate,
             storeCreditAmount,
-            isUpdatedCartSummayModal = false,
             ...redeemableProps
         } = props;
 
@@ -35,7 +34,6 @@ export default function withRedeemable(
                     />
                 }
                 headerLink={headerLink}
-                isUpdatedCartSummayModal={isUpdatedCartSummayModal}
                 lineItems={checkout.cart.lineItems}
                 onRemovedCoupon={onRemovedCoupon}
                 onRemovedGiftCertificate={onRemovedGiftCertificate}

--- a/packages/core/src/app/order/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation.tsx
@@ -232,7 +232,6 @@ class OrderConfirmation extends Component<
                                     headerLink={
                                         <PrintLink className="modal-header-link cart-modal-link" />
                                     }
-                                    isUpdatedCartSummayModal={false}
                                     lineItems={order.lineItems}
                                     shopperCurrency={shopperCurrency}
                                     storeCurrency={currency}

--- a/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
@@ -95,7 +95,7 @@ describe('OrderSummaryDrawer', () => {
 
             expect(orderSummary.find(OrderSummaryModal).props()).toMatchObject({
                 ...mapToOrderSummarySubtotalsProps(getOrder()),
-                lineItems: getOrder().lineItems,
+                items: getOrder().lineItems,
                 total: getOrder().orderAmount,
                 storeCurrency: getStoreConfig().currency,
                 shopperCurrency: getStoreConfig().shopperCurrency,
@@ -116,7 +116,7 @@ describe('OrderSummaryDrawer', () => {
 
             expect(orderSummary.find(OrderSummaryModal).props()).toMatchObject({
                 ...mapToOrderSummarySubtotalsProps(getOrder()),
-                lineItems: getOrder().lineItems,
+                items: getOrder().lineItems,
                 total: getOrder().orderAmount,
                 storeCurrency: getStoreConfig().currency,
                 shopperCurrency: getStoreConfig().shopperCurrency,

--- a/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.spec.tsx
@@ -124,4 +124,28 @@ describe('OrderSummaryDrawer', () => {
             });
         });
     });
+
+    it('renders correct summary for line items for bundled products', () => {
+        order.lineItems.physicalItems.push({ ...getPhysicalItem(), id: '888', parentId: 'test' });
+
+        orderSummary = mount(
+            <CheckoutProvider checkoutService={createCheckoutService()}>
+                <LocaleContext.Provider value={localeContext}>
+                    <OrderSummaryDrawer
+                        {...mapToOrderSummarySubtotalsProps(order)}
+                        additionalLineItems="foo"
+                        headerLink={<PrintLink />}
+                        lineItems={order.lineItems}
+                        shopperCurrency={getStoreConfig().shopperCurrency}
+                        storeCurrency={getStoreConfig().currency}
+                        total={order.orderAmount}
+                    />
+                </LocaleContext.Provider>
+            </CheckoutProvider>,
+        );
+
+        const summaryModal = orderSummary.find(OrderSummaryModal);
+
+        expect(summaryModal.props().items.physicalItems).toHaveLength(1);
+    });
 });

--- a/packages/core/src/app/order/OrderSummaryDrawer.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.tsx
@@ -4,7 +4,7 @@ import {
     StoreCurrency,
 } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
-import React, { FunctionComponent, memo, ReactNode, useCallback } from 'react';
+import React, { FunctionComponent, memo, ReactNode, useCallback, useMemo } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
@@ -16,6 +16,7 @@ import getItemsCount from './getItemsCount';
 import getLineItemsCount from './getLineItemsCount';
 import OrderSummaryModal from './OrderSummaryModal';
 import { OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
+import removeBundledItems from './removeBundledItems';
 
 export interface OrderSummaryDrawerProps {
     lineItems: LineItemMap;
@@ -51,6 +52,8 @@ const OrderSummaryDrawer: FunctionComponent<
     total,
     fees,
 }) => {
+    const nonBundledLineItems = useMemo(() => removeBundledItems(lineItems), [lineItems]);
+
     const renderModal = useCallback(
         (props) => (
             <OrderSummaryModal
@@ -65,7 +68,7 @@ const OrderSummaryDrawer: FunctionComponent<
                 headerLink={headerLink}
                 isTaxIncluded={isTaxIncluded}
                 isUpdatedCartSummayModal={isUpdatedCartSummayModal}
-                lineItems={lineItems}
+                items={nonBundledLineItems}
                 onRemovedCoupon={onRemovedCoupon}
                 onRemovedGiftCertificate={onRemovedGiftCertificate}
                 shippingAmount={shippingAmount}
@@ -85,7 +88,7 @@ const OrderSummaryDrawer: FunctionComponent<
             handlingAmount,
             headerLink,
             isTaxIncluded,
-            lineItems,
+            nonBundledLineItems,
             onRemovedCoupon,
             onRemovedGiftCertificate,
             giftWrappingAmount,
@@ -111,15 +114,15 @@ const OrderSummaryDrawer: FunctionComponent<
                 >
                     <figure
                         className={classNames('cartDrawer-figure', {
-                            'cartDrawer-figure--stack': getLineItemsCount(lineItems) > 1,
+                            'cartDrawer-figure--stack': getLineItemsCount(nonBundledLineItems) > 1,
                         })}
                     >
-                        <div className="cartDrawer-imageWrapper">{getImage(lineItems)}</div>
+                        <div className="cartDrawer-imageWrapper">{getImage(nonBundledLineItems)}</div>
                     </figure>
                     <div className="cartDrawer-body">
                         <h3 className="cartDrawer-items optimizedCheckout-headingPrimary">
                             <TranslatedString
-                                data={{ count: getItemsCount(lineItems) }}
+                                data={{ count: getItemsCount(nonBundledLineItems) }}
                                 id="cart.item_count_text"
                             />
                         </h3>

--- a/packages/core/src/app/order/OrderSummaryDrawer.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.tsx
@@ -22,7 +22,6 @@ export interface OrderSummaryDrawerProps {
     lineItems: LineItemMap;
     total: number;
     headerLink: ReactNode;
-    isUpdatedCartSummayModal?: boolean,
     storeCurrency: StoreCurrency;
     shopperCurrency: ShopperCurrencyType;
     additionalLineItems?: ReactNode;
@@ -38,7 +37,6 @@ const OrderSummaryDrawer: FunctionComponent<
     handlingAmount,
     headerLink,
     isTaxIncluded,
-    isUpdatedCartSummayModal,
     lineItems,
     onRemovedCoupon,
     onRemovedGiftCertificate,
@@ -67,7 +65,6 @@ const OrderSummaryDrawer: FunctionComponent<
                 handlingAmount={handlingAmount}
                 headerLink={headerLink}
                 isTaxIncluded={isTaxIncluded}
-                isUpdatedCartSummayModal={isUpdatedCartSummayModal}
                 items={nonBundledLineItems}
                 onRemovedCoupon={onRemovedCoupon}
                 onRemovedGiftCertificate={onRemovedGiftCertificate}

--- a/packages/core/src/app/order/OrderSummaryModal.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.spec.tsx
@@ -43,37 +43,6 @@ describe('OrderSummaryModal', () => {
         expect(orderSummary).toMatchSnapshot();
     });
 
-    describe('it renders order summary modal for bundled items', () => {
-        it('filters bundled items from line items', () => {
-            const lineItems: LineItemMap = {
-                physicalItems: [],
-                digitalItems: [],
-                giftCertificates: [],
-                customItems: [],
-            };
-
-            lineItems.physicalItems.push(getPhysicalItem(), { ...getPhysicalItem(), id: '888', parentId: 'test' })
-
-            const order = { ...getOrder(), lineItems };
-
-            orderSummary = shallow(
-                <OrderSummaryModal
-                    isOpen={true}
-                    {...mapToOrderSummarySubtotalsProps(order)}
-                    additionalLineItems="foo"
-                    lineItems={order.lineItems}
-                    shopperCurrency={getStoreConfig().shopperCurrency}
-                    storeCurrency={getStoreConfig().currency}
-                    total={order.orderAmount}
-                />,
-            );
-
-            const itemsComponent = orderSummary.find(OrderSummaryItems);
-
-            expect(itemsComponent.props().items.physicalItems).toHaveLength(1);
-        });
-    })
-
     describe('when taxes are inclusive', () => {
         it('displays tax as summary section', () => {
             const taxIncludedOrder = {
@@ -126,7 +95,6 @@ describe('OrderSummaryModal', () => {
                     <OrderSummaryModal
                         {...mapToOrderSummarySubtotalsProps(getOrder())}
                         isOpen={true}
-                        isUpdatedCartSummayModal={true}
                         items={getOrder().lineItems}
                         shopperCurrency={getStoreConfig().shopperCurrency}
                         storeCurrency={getStoreConfig().currency}

--- a/packages/core/src/app/order/OrderSummaryModal.spec.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.spec.tsx
@@ -31,7 +31,7 @@ describe('OrderSummaryModal', () => {
                 isOpen={true}
                 {...mapToOrderSummarySubtotalsProps(order)}
                 additionalLineItems="foo"
-                lineItems={order.lineItems}
+                items={order.lineItems}
                 shopperCurrency={getStoreConfig().shopperCurrency}
                 storeCurrency={getStoreConfig().currency}
                 total={order.orderAmount}
@@ -85,7 +85,7 @@ describe('OrderSummaryModal', () => {
                 <OrderSummaryModal
                     {...mapToOrderSummarySubtotalsProps(taxIncludedOrder)}
                     isOpen={true}
-                    lineItems={taxIncludedOrder.lineItems}
+                    items={taxIncludedOrder.lineItems}
                     shopperCurrency={getStoreConfig().shopperCurrency}
                     storeCurrency={getStoreConfig().currency}
                     total={taxIncludedOrder.orderAmount}
@@ -127,7 +127,7 @@ describe('OrderSummaryModal', () => {
                         {...mapToOrderSummarySubtotalsProps(getOrder())}
                         isOpen={true}
                         isUpdatedCartSummayModal={true}
-                        lineItems={getOrder().lineItems}
+                        items={getOrder().lineItems}
                         shopperCurrency={getStoreConfig().shopperCurrency}
                         storeCurrency={getStoreConfig().currency}
                         total={getOrder().orderAmount}

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -10,7 +10,6 @@ import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { Button, IconCloseWithBorder } from '@bigcommerce/checkout/ui';
 
 import { ShopperCurrency } from '../currency';
-import { IconClose } from '../ui/icon';
 import { Modal, ModalHeader } from '../ui/modal';
 import { isSmallScreen } from '../ui/responsive';
 
@@ -39,7 +38,6 @@ const OrderSummaryModal: FunctionComponent<
     additionalLineItems,
     children,
     isTaxIncluded,
-    isUpdatedCartSummayModal = false,
     taxes,
     onRequestClose,
     onAfterOpen,
@@ -60,7 +58,7 @@ const OrderSummaryModal: FunctionComponent<
         storeCurrencyCode={storeCurrency.code}
     />;
 
-    const continueButton = isUpdatedCartSummayModal && isSmallScreen() && <Button
+    const continueButton = isSmallScreen() && <Button
         className='cart-modal-continue'
         data-test="manage-instrument-cancel-button"
         onClick={preventDefault(onRequestClose)}>
@@ -69,13 +67,12 @@ const OrderSummaryModal: FunctionComponent<
 
     return <Modal
         additionalBodyClassName="cart-modal-body optimizedCheckout-orderSummary"
-        additionalHeaderClassName={`cart-modal-header optimizedCheckout-orderSummary${isUpdatedCartSummayModal ? ' with-continue-button' : ''}`}
-        additionalModalClassName={isUpdatedCartSummayModal ? 'optimizedCheckout-cart-modal' : ''}
+        additionalHeaderClassName="cart-modal-header optimizedCheckout-orderSummary with-continue-button"
+        additionalModalClassName="optimizedCheckout-cart-modal"
         footer={continueButton}
         header={renderHeader({
             headerLink,
             subHeaderText,
-            isUpdatedCartSummayModal,
             onRequestClose,
         })}
         isOpen={isOpen}
@@ -83,7 +80,7 @@ const OrderSummaryModal: FunctionComponent<
         onRequestClose={onRequestClose}
     >
         <OrderSummarySection>
-            <OrderSummaryItems displayLineItemsCount={!isUpdatedCartSummayModal} items={nonBundledLineItems} />
+            <OrderSummaryItems displayLineItemsCount={false} items={items} />
         </OrderSummarySection>
         <OrderSummarySection>
             <OrderSummarySubtotals isTaxIncluded={isTaxIncluded} taxes={taxes} {...orderSummarySubtotalsProps} />
@@ -120,25 +117,8 @@ const OrderSummaryModal: FunctionComponent<
 const renderHeader: FunctionComponent<{
     headerLink?: ReactNode & React.HTMLProps<HTMLDivElement>;
     subHeaderText: ReactNode;
-    isUpdatedCartSummayModal: boolean;
     onRequestClose?(): void;
-}> = ({ onRequestClose, headerLink, subHeaderText, isUpdatedCartSummayModal }) => {
-    if (!isUpdatedCartSummayModal) {
-       return <>
-            <a className="cart-modal-close" href="#" onClick={preventDefault(onRequestClose)}>
-                <span className="is-srOnly">
-                    <TranslatedString id="common.close_action" />
-                </span>
-                <IconClose />
-            </a>
-            <ModalHeader additionalClassName="cart-modal-title">
-                <TranslatedString id="cart.cart_heading" />
-            </ModalHeader>
-
-            {headerLink}
-        </>;
-    }
-
+}> = ({ onRequestClose, headerLink, subHeaderText }) => {
     let newHeaderLink;
 
     if (isValidElement(headerLink)) {

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -3,7 +3,7 @@ import {
     ShopperCurrency as ShopperCurrencyType,
     StoreCurrency,
 } from '@bigcommerce/checkout-sdk';
-import React, { cloneElement, FunctionComponent, isValidElement, ReactNode, useMemo } from 'react';
+import React, { cloneElement, FunctionComponent, isValidElement, ReactNode } from 'react';
 
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -20,11 +20,10 @@ import OrderSummaryPrice from './OrderSummaryPrice';
 import OrderSummarySection from './OrderSummarySection';
 import OrderSummarySubtotals, { OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
 import OrderSummaryTotal from './OrderSummaryTotal';
-import removeBundledItems from './removeBundledItems';
 
 export interface OrderSummaryDrawerProps {
     additionalLineItems?: ReactNode;
-    lineItems: LineItemMap;
+    items: LineItemMap;
     total: number;
     storeCurrency: StoreCurrency;
     shopperCurrency: ShopperCurrencyType;
@@ -48,16 +47,15 @@ const OrderSummaryModal: FunctionComponent<
     shopperCurrency,
     isOpen,
     headerLink,
-    lineItems,
+    items,
     total,
     ...orderSummarySubtotalsProps
 }) => {
-    const nonBundledLineItems = useMemo(() => removeBundledItems(lineItems), [lineItems]);
     const displayInclusiveTax = isTaxIncluded && taxes && taxes.length > 0;
 
     const subHeaderText = <OrderModalSummarySubheader
         amountWithCurrency={<ShopperCurrency amount={total} />}
-        items={lineItems}
+        items={items}
         shopperCurrencyCode={shopperCurrency.code}
         storeCurrencyCode={storeCurrency.code}
     />;

--- a/packages/core/src/app/order/OrderSummarySubtotals.tsx
+++ b/packages/core/src/app/order/OrderSummarySubtotals.tsx
@@ -15,7 +15,6 @@ export interface OrderSummarySubtotalsProps {
     taxes?: Tax[];
     fees?: Fee[] | OrderFee[];
     giftWrappingAmount?: number;
-    isUpdatedCartSummayModal?: boolean,
     shippingAmount?: number;
     handlingAmount?: number;
     storeCreditAmount?: number;

--- a/packages/core/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
+++ b/packages/core/src/app/order/__snapshots__/OrderSummaryModal.spec.tsx.snap
@@ -3,11 +3,93 @@
 exports[`OrderSummaryModal renders order summary 1`] = `
 <Modal
   additionalBodyClassName="cart-modal-body optimizedCheckout-orderSummary"
-  additionalHeaderClassName="cart-modal-header optimizedCheckout-orderSummary"
-  additionalModalClassName=""
+  additionalHeaderClassName="cart-modal-header optimizedCheckout-orderSummary with-continue-button"
+  additionalModalClassName="optimizedCheckout-cart-modal"
   footer={false}
   header={
     <React.Fragment>
+      <ModalHeader
+        additionalClassName="cart-modal-title"
+      >
+        <div>
+          <TranslatedString
+            id="cart.cart_heading"
+          />
+          <div
+            className="cart-heading-subheader"
+          >
+            <Memo(OrderModalSummarySubheader)
+              amountWithCurrency={
+                <WithCurrency(ShopperCurrency)
+                  amount={190}
+                />
+              }
+              items={
+                Object {
+                  "customItems": Array [],
+                  "digitalItems": Array [],
+                  "giftCertificates": Array [
+                    Object {
+                      "amount": 100,
+                      "id": "bd391ead-8c58-4105-b00e-d75d233b429a",
+                      "message": "message",
+                      "name": "$100 Gift Certificate",
+                      "recipient": Object {
+                        "email": "lu@is.com",
+                        "name": "luis",
+                      },
+                      "sender": Object {
+                        "email": "pa@blo.com",
+                        "name": "pablo",
+                      },
+                      "taxable": false,
+                      "theme": "General",
+                    },
+                  ],
+                  "physicalItems": Array [
+                    Object {
+                      "addedByPromotion": false,
+                      "brand": "OFS",
+                      "categoryNames": Array [
+                        "Cat 1",
+                      ],
+                      "comparisonPrice": 200,
+                      "couponAmount": 0,
+                      "discountAmount": 0,
+                      "discounts": Array [],
+                      "extendedComparisonPrice": 250,
+                      "extendedListPrice": 200,
+                      "extendedSalePrice": 200,
+                      "id": "666",
+                      "imageUrl": "/images/canvas-laundry-cart.jpg",
+                      "isShippingRequired": true,
+                      "isTaxable": true,
+                      "listPrice": 200,
+                      "name": "Canvas Laundry Cart",
+                      "options": Array [
+                        Object {
+                          "name": "n",
+                          "nameId": 1,
+                          "value": "v",
+                          "valueId": 3,
+                        },
+                      ],
+                      "productId": 103,
+                      "quantity": 1,
+                      "salePrice": 200,
+                      "sku": "CLC",
+                      "url": "/canvas-laundry-cart/",
+                      "variantId": 71,
+                    },
+                  ],
+                }
+              }
+              shopperCurrencyCode="USD"
+              storeCurrencyCode="USD"
+            />
+          </div>
+        </div>
+      </ModalHeader>
       <a
         className="cart-modal-close"
         href="#"
@@ -22,20 +104,13 @@ exports[`OrderSummaryModal renders order summary 1`] = `
         </span>
         <Memo />
       </a>
-      <ModalHeader
-        additionalClassName="cart-modal-title"
-      >
-        <TranslatedString
-          id="cart.cart_heading"
-        />
-      </ModalHeader>
     </React.Fragment>
   }
   isOpen={true}
 >
   <OrderSummarySection>
     <OrderSummaryItems
-      displayLineItemsCount={true}
+      displayLineItemsCount={false}
       items={
         Object {
           "customItems": Array [],
@@ -161,11 +236,93 @@ exports[`OrderSummaryModal renders order summary 1`] = `
 exports[`OrderSummaryModal when taxes are inclusive displays tax as summary section 1`] = `
 <Modal
   additionalBodyClassName="cart-modal-body optimizedCheckout-orderSummary"
-  additionalHeaderClassName="cart-modal-header optimizedCheckout-orderSummary"
-  additionalModalClassName=""
+  additionalHeaderClassName="cart-modal-header optimizedCheckout-orderSummary with-continue-button"
+  additionalModalClassName="optimizedCheckout-cart-modal"
   footer={false}
   header={
     <React.Fragment>
+      <ModalHeader
+        additionalClassName="cart-modal-title"
+      >
+        <div>
+          <TranslatedString
+            id="cart.cart_heading"
+          />
+          <div
+            className="cart-heading-subheader"
+          >
+            <Memo(OrderModalSummarySubheader)
+              amountWithCurrency={
+                <WithCurrency(ShopperCurrency)
+                  amount={190}
+                />
+              }
+              items={
+                Object {
+                  "customItems": Array [],
+                  "digitalItems": Array [],
+                  "giftCertificates": Array [
+                    Object {
+                      "amount": 100,
+                      "id": "bd391ead-8c58-4105-b00e-d75d233b429a",
+                      "message": "message",
+                      "name": "$100 Gift Certificate",
+                      "recipient": Object {
+                        "email": "lu@is.com",
+                        "name": "luis",
+                      },
+                      "sender": Object {
+                        "email": "pa@blo.com",
+                        "name": "pablo",
+                      },
+                      "taxable": false,
+                      "theme": "General",
+                    },
+                  ],
+                  "physicalItems": Array [
+                    Object {
+                      "addedByPromotion": false,
+                      "brand": "OFS",
+                      "categoryNames": Array [
+                        "Cat 1",
+                      ],
+                      "comparisonPrice": 200,
+                      "couponAmount": 0,
+                      "discountAmount": 0,
+                      "discounts": Array [],
+                      "extendedComparisonPrice": 250,
+                      "extendedListPrice": 200,
+                      "extendedSalePrice": 200,
+                      "id": "666",
+                      "imageUrl": "/images/canvas-laundry-cart.jpg",
+                      "isShippingRequired": true,
+                      "isTaxable": true,
+                      "listPrice": 200,
+                      "name": "Canvas Laundry Cart",
+                      "options": Array [
+                        Object {
+                          "name": "n",
+                          "nameId": 1,
+                          "value": "v",
+                          "valueId": 3,
+                        },
+                      ],
+                      "productId": 103,
+                      "quantity": 1,
+                      "salePrice": 200,
+                      "sku": "CLC",
+                      "url": "/canvas-laundry-cart/",
+                      "variantId": 71,
+                    },
+                  ],
+                }
+              }
+              shopperCurrencyCode="USD"
+              storeCurrencyCode="USD"
+            />
+          </div>
+        </div>
+      </ModalHeader>
       <a
         className="cart-modal-close"
         href="#"
@@ -180,20 +337,13 @@ exports[`OrderSummaryModal when taxes are inclusive displays tax as summary sect
         </span>
         <Memo />
       </a>
-      <ModalHeader
-        additionalClassName="cart-modal-title"
-      >
-        <TranslatedString
-          id="cart.cart_heading"
-        />
-      </ModalHeader>
     </React.Fragment>
   }
   isOpen={true}
 >
   <OrderSummarySection>
     <OrderSummaryItems
-      displayLineItemsCount={true}
+      displayLineItemsCount={false}
       items={
         Object {
           "customItems": Array [],


### PR DESCRIPTION
## What?

- Fix item count display on order summary modal in small screens.
- Remove experiment `CHECKOUT-7403.updated_cart_summary_modal`

## Why?

- To fix the  item count display on order summary modal on small screens for bundled items.
- `CHECKOUT-7403.updated_cart_summary_modal` is rolled out 100% from a year

## Testing / Proof
**BEFORE**
<img width="367" alt="Screenshot 2024-07-19 at 1 54 42 PM" src="https://github.com/user-attachments/assets/a21a6eae-d9e0-4432-842d-cdaaed5a3606">
<img width="363" alt="Screenshot 2024-07-19 at 1 56 33 PM" src="https://github.com/user-attachments/assets/5d653e2f-3900-41f4-ac83-77922157eebc">

**AFTER**
<img width="368" alt="Screenshot 2024-07-19 at 1 52 30 PM" src="https://github.com/user-attachments/assets/a31f17b1-d9dc-458f-b7ea-bf4df424307c">
<img width="404" alt="Screenshot 2024-07-19 at 1 52 18 PM" src="https://github.com/user-attachments/assets/a4544df8-fbce-4c37-9054-352a9046e1bc">


@bigcommerce/team-checkout
