### PR TITLE
chore(payment): PAYPAL-4441 bump checkout sdk version to 1.633.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.631.0",
+        "@bigcommerce/checkout-sdk": "^1.633.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.631.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.631.0.tgz",
-      "integrity": "sha512-YnEnEYasl+iFmosc+q7//kLsHZxulf9Wi6c9noBRnA94r7NpQzhbTwvzTCNYJuN8kx0/veNiYZBynpIW5GWQSg==",
+      "version": "1.633.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.633.0.tgz",
+      "integrity": "sha512-b+Sy4LB8fEv3xrv8S0anxFOPEeI6qc/MjK88ugBk09MehGXHL+m2Z32k9ArfuqjYKsMgHkVFbAELI3Zv14tlMQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.631.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.631.0.tgz",
-      "integrity": "sha512-YnEnEYasl+iFmosc+q7//kLsHZxulf9Wi6c9noBRnA94r7NpQzhbTwvzTCNYJuN8kx0/veNiYZBynpIW5GWQSg==",
+      "version": "1.633.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.633.0.tgz",
+      "integrity": "sha512-b+Sy4LB8fEv3xrv8S0anxFOPEeI6qc/MjK88ugBk09MehGXHL+m2Z32k9ArfuqjYKsMgHkVFbAELI3Zv14tlMQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.631.0",
+    "@bigcommerce/checkout-sdk": "^1.633.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.633.0

## Why?
As part of release checkout-sdk prs:
https://github.com/bigcommerce/checkout-sdk-js/pull/2576
https://github.com/bigcommerce/checkout-sdk-js/pull/2575

## Testing / Proof
Unit tests
Manual tests
CI
