### PR TITLE
feat(payment): PAYPAL-4406 added Fastlane Privacy Settings

### DIFF
--- a/packages/core/src/app/customer/EmailWatermark.test.tsx
+++ b/packages/core/src/app/customer/EmailWatermark.test.tsx
@@ -1,0 +1,144 @@
+import { configure, render, screen } from '@testing-library/react';
+import React, { FunctionComponent } from 'react';
+
+import { getStoreConfig } from '../config/config.mock';
+import { EmailWatermark } from './';
+import {CheckoutContext, CheckoutProvider} from "@bigcommerce/checkout/payment-integration-api";
+import { WithCheckoutProps } from '../checkout';
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+} from '@bigcommerce/checkout-sdk';
+
+configure({
+    testIdAttribute: 'data-test-id',
+});
+
+describe('EmailWatermark Component',() => {
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let EmailWatermarkComponent: FunctionComponent<WithCheckoutProps>;
+    let defaultProps: WithCheckoutProps;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        defaultProps = {
+            checkoutService,
+            checkoutState,
+        };
+
+        EmailWatermarkComponent = () => (
+            <CheckoutContext.Provider value={{ checkoutService, checkoutState }}>
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <EmailWatermark />
+                </CheckoutProvider>
+            </CheckoutContext.Provider>
+        );
+    });
+
+    it('renders fastlane privacy settings container', async () => {
+        const braintreeFastlanePaymentMethod =  {
+            id: 'braintreeacceleratedcheckout',
+            logoUrl: '',
+            method: 'braintreeacceleratedcheckout',
+            supportedCards: [],
+            config: {
+                testMode: true,
+            },
+            initializationData: {
+                isFastlanePrivacySettingEnabled: true,
+            },
+            type: 'PAYMENT_TYPE_API',
+            clientToken: 'clientToken',
+        };
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                providerWithCustomCheckout: 'braintreeacceleratedcheckout',
+            }
+        });
+        jest.spyOn(checkoutState.data, 'getPaymentMethod').mockReturnValue(braintreeFastlanePaymentMethod);
+        Object.defineProperty(window, 'braintreeFastlane', {
+            value: {
+                FastlaneWatermarkComponent: () => new Promise(resolve => resolve),
+            },
+        });
+
+        render(<EmailWatermarkComponent {...defaultProps}/>);
+
+        const fastlanePrivacySettingsDiv = await screen.findAllByTestId('emailWatermark');
+
+        expect(fastlanePrivacySettingsDiv[0]).toBeInTheDocument();
+    });
+
+    it('renders braintreefastlane privacy settings', async () => {
+        const render = jest.fn();
+        const config = getStoreConfig();
+        const braintreeFastlanePaymentMethod =  {
+            id: 'braintreeacceleratedcheckout',
+            logoUrl: '',
+            method: 'braintreeacceleratedcheckout',
+            supportedCards: [],
+            config: {
+                testMode: true,
+            },
+            initializationData: {
+                isFastlanePrivacySettingEnabled: true,
+            },
+            type: 'PAYMENT_TYPE_API',
+            clientToken: 'clientToken',
+        };
+
+        jest.spyOn(checkoutState.data, 'getPaymentMethod').mockReturnValue(braintreeFastlanePaymentMethod);
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...config,
+            checkoutSettings: {
+                ...config.checkoutSettings,
+                providerWithCustomCheckout: 'braintreeacceleratedcheckout',
+            }
+        });
+        render(<EmailWatermarkComponent {...defaultProps}/>);
+
+        expect(render).toHaveBeenCalled();
+    });
+
+    it('renders paypalfastlane privacy settings', async () => {
+        const render = jest.fn();
+        const config = getStoreConfig();
+        const paypalFastlanePaymentMethod =  {
+            id: 'paypalcommerceacceleratedcheckout',
+            logoUrl: '',
+            method: 'paypalcommerceacceleratedcheckout',
+            supportedCards: [],
+            config: {
+                testMode: true,
+            },
+            initializationData: {
+                isFastlanePrivacySettingEnabled: true,
+            },
+            type: 'PAYMENT_TYPE_API',
+            clientToken: 'clientToken',
+        };
+
+        jest.spyOn(checkoutState.data, 'getPaymentMethod').mockReturnValue(paypalFastlanePaymentMethod);
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...config,
+            checkoutSettings: {
+                ...config.checkoutSettings,
+                providerWithCustomCheckout: 'paypalcommerceacceleratedcheckout',
+            }
+        });
+        Object.defineProperty(window, 'paypalFastlane', {
+            value: {
+                FastlaneWatermarkComponent: () => new Promise(() => render()),
+            },
+        });
+
+        render(<EmailWatermarkComponent {...defaultProps}/>);
+
+        expect(render).toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/app/customer/EmailWatermark.tsx
+++ b/packages/core/src/app/customer/EmailWatermark.tsx
@@ -1,0 +1,58 @@
+import React, { FunctionComponent, useEffect } from 'react';
+
+import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
+import { FastlanePrivacySettings, isFastlaneHostWindow } from '@bigcommerce/checkout/paypal-fastlane-integration';
+
+const EmailWatermark: FunctionComponent = () => {
+    const { checkoutState } = useCheckout();
+    const { getPaymentMethod } = checkoutState.data;
+    const providerWithCustomCheckout = checkoutState.data.getConfig()?.checkoutSettings?.providerWithCustomCheckout;
+    const isFastlaneProviderWithCustomCheckout =
+        providerWithCustomCheckout === 'braintree' ||
+        providerWithCustomCheckout === 'braintreeacceleratedcheckout' ||
+        providerWithCustomCheckout === 'paypalcommerce' ||
+        providerWithCustomCheckout === 'paypalcommerceacceleratedcheckout';
+
+    useEffect(() => {
+        if (isFastlaneProviderWithCustomCheckout) {
+            const paymentMethod = getPaymentMethod(providerWithCustomCheckout);
+
+            if(
+                paymentMethod?.initializationData?.isFastlanePrivacySettingEnabled &&
+                isFastlaneHostWindow(window)
+            ) {
+                const fastlane = window.braintreeFastlane || window.paypalFastlane;
+                fastlane.FastlaneWatermarkComponent({
+                    includeAdditionalInfo: true,
+                })
+                    .then((result: FastlanePrivacySettings) => {
+                        result.render('#emailWatermark');
+                    });
+            }
+        }
+    }, []);
+
+    const shouldRenderWatermark = (): boolean => {
+        if (isFastlaneProviderWithCustomCheckout) {
+            const paymentMethod = getPaymentMethod(providerWithCustomCheckout);
+
+            return isFastlaneHostWindow(window)
+                && !!(window.braintreeFastlane || window.paypalFastlane)
+                && paymentMethod?.initializationData?.isFastlanePrivacySettingEnabled
+        }
+
+        return false;
+    };
+
+    return (
+        shouldRenderWatermark() ? (
+            <div className='emailWatermark-container'>
+                <div id='emailWatermark' data-test-id='emailWatermark' />
+            </div>
+        ) : (
+            <></>
+        )
+    );
+}
+
+export default EmailWatermark;

--- a/packages/core/src/app/customer/GuestForm.spec.tsx
+++ b/packages/core/src/app/customer/GuestForm.spec.tsx
@@ -7,11 +7,19 @@ import { getStoreConfig } from '../config/config.mock';
 import { PrivacyPolicyField } from '../privacyPolicy';
 
 import GuestForm, { GuestFormProps } from './GuestForm';
+import { CheckoutContext } from '@bigcommerce/checkout/payment-integration-api';
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService
+} from '@bigcommerce/checkout-sdk/';
 
 describe('GuestForm', () => {
     let defaultProps: GuestFormProps;
     let localeContext: LocaleContextType;
     let TestComponent: FunctionComponent<Partial<GuestFormProps>>;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
 
     beforeEach(() => {
         defaultProps = {
@@ -24,13 +32,16 @@ describe('GuestForm', () => {
             onShowLogin: jest.fn(),
             requiresMarketingConsent: false,
         };
-
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
         localeContext = createLocaleContext(getStoreConfig());
 
         TestComponent = (props) => (
-            <LocaleContext.Provider value={localeContext}>
-                <GuestForm {...defaultProps} {...props} />
-            </LocaleContext.Provider>
+            <CheckoutContext.Provider value={{ checkoutService, checkoutState }}>
+                <LocaleContext.Provider value={localeContext}>
+                    <GuestForm {...defaultProps} {...props} />
+                </LocaleContext.Provider>
+            </CheckoutContext.Provider>
         );
     });
 

--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -12,6 +12,7 @@ import { BasicFormField, Fieldset, Form, Legend } from '../ui/form';
 import EmailField from './EmailField';
 import SubscribeField from './SubscribeField';
 import { SubscribeSessionStorage } from './SubscribeSessionStorage';
+import { EmailWatermark } from './index';
 
 function getShouldSubscribeValue(requiresMarketingConsent: boolean, defaultShouldSubscribe: boolean) {
     if (SubscribeSessionStorage.getSubscribeStatus()) {
@@ -79,7 +80,7 @@ const GuestForm: FunctionComponent<
                 <div className="customerEmail-container">
                     <div className="customerEmail-body">
                         <EmailField isFloatingLabelEnabled={isFloatingLabelEnabled} onChange={onChangeEmail}/>
-
+                        <EmailWatermark />
                         {(canSubscribe || requiresMarketingConsent) && (
                             <BasicFormField name="shouldSubscribe" render={renderField} />
                         )}

--- a/packages/core/src/app/customer/index.ts
+++ b/packages/core/src/app/customer/index.ts
@@ -11,3 +11,4 @@ export {
 } from './getPasswordRequirements';
 export { SUPPORTED_METHODS } from './CheckoutButtonList';
 export { default as CheckoutButtonContainer } from './CheckoutButtonContainer';
+export { default as EmailWatermark } from './EmailWatermark';

--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -24,6 +24,11 @@
     }
 }
 
+.emailWatermark-container {
+    display: flex;
+    justify-content: end;
+}
+
 .customerEmail-action {
     @include grid-column($collapse: true, $columns: $total-columns);
 

--- a/packages/paypal-fastlane-integration/src/index.ts
+++ b/packages/paypal-fastlane-integration/src/index.ts
@@ -4,5 +4,6 @@ export { default as isPayPalFastlaneMethod } from './is-paypal-fastlane-method';
 export { default as isBraintreeFastlaneMethod } from './is-braintree-fastlane-method';
 export { default as isPayPalCommerceFastlaneMethod } from './is-paypal-fastlane-method';
 export { default as PoweredByPayPalFastlaneLabel } from './PoweredByPayPalFastlaneLabel';
-export { default as PayPalFastlaneShippingAddressForm } from '././PayPalFastlaneShippingAddressForm';
+export { default as PayPalFastlaneShippingAddressForm } from './PayPalFastlaneShippingAddressForm';
 export { default as usePayPalFastlaneAddress } from './usePayPalFastlaneAddress';
+export { default as isFastlaneHostWindow, FastlanePrivacySettings } from './is-fastlane-window';

--- a/packages/paypal-fastlane-integration/src/is-fastlane-window.test.ts
+++ b/packages/paypal-fastlane-integration/src/is-fastlane-window.test.ts
@@ -1,0 +1,35 @@
+import isFastlaneHostWindow from './is-fastlane-window';
+
+describe('isFastlaneHostWindow', () => {
+    it('returns false if window doesnt have fastlane properties', () => {
+        const windowMock = Object.defineProperty(window, '', {
+            value: {
+                notFastlane: {},
+            },
+        });
+
+        expect(isFastlaneHostWindow(windowMock)).toEqual(false);
+    });
+
+    it('returns true if window have paypalFastlane property', () => {
+        const windowMock = Object.defineProperty(window, 'paypalFastlane', {
+            value: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                FastlaneWatermarkComponent: jest.fn(),
+            },
+        });
+
+        expect(isFastlaneHostWindow(windowMock)).toEqual(true);
+    });
+
+    it('returns true if window have braintreeFastlane property', () => {
+        const windowMock = Object.defineProperty(window, 'braintreeFastlane', {
+            value: {
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                FastlaneWatermarkComponent: jest.fn(),
+            },
+        });
+
+        expect(isFastlaneHostWindow(windowMock)).toEqual(true);
+    });
+});

--- a/packages/paypal-fastlane-integration/src/is-fastlane-window.ts
+++ b/packages/paypal-fastlane-integration/src/is-fastlane-window.ts
@@ -1,0 +1,23 @@
+export interface FastlaneWatermarkComponent {
+    FastlaneWatermarkComponent: (
+        options?: FastlaneWatermarkOptions,
+    ) => Promise<FastlanePrivacySettings>;
+}
+
+interface FastlaneWatermarkOptions {
+    includeAdditionalInfo: boolean;
+}
+
+export interface FastlanePrivacySettings {
+    render(container: string): void;
+}
+
+interface FastlaneHostWindow extends Window {
+    paypalFastlane: FastlaneWatermarkComponent;
+    braintreeFastlane: FastlaneWatermarkComponent;
+}
+
+export default function isFastlaneHostWindow(window: Window): window is FastlaneHostWindow {
+    /* eslint-disable no-prototype-builtins */
+    return window.hasOwnProperty('paypalFastlane') || window.hasOwnProperty('braintreeFastlane');
+}


### PR DESCRIPTION
## What?
Added Fastlane Privacy Settings component

## Why?
To display fastlane privacy settings

## Testing / Proof


https://github.com/user-attachments/assets/23f5eea9-699c-43fd-9a90-49e5b27eaeb1

With Fastlane Privacy Settings Feature Torned Off

<img width="1680" alt="Screenshot 2024-07-26 at 14 47 31" src="https://github.com/user-attachments/assets/bacc7cac-7106-4764-a6fc-e46291067a47">
<img width="1680" alt="Screenshot 2024-07-26 at 14 47 22" src="https://github.com/user-attachments/assets/c545428f-00f8-4398-8ca6-bb8c8a9267ae">


@bigcommerce/team-checkout
