### PR TITLE
feat(payment): STRIPE-329 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.633.0",
+        "@bigcommerce/checkout-sdk": "^1.633.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.633.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.633.0.tgz",
-      "integrity": "sha512-b+Sy4LB8fEv3xrv8S0anxFOPEeI6qc/MjK88ugBk09MehGXHL+m2Z32k9ArfuqjYKsMgHkVFbAELI3Zv14tlMQ==",
+      "version": "1.633.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.633.1.tgz",
+      "integrity": "sha512-175vYmGsaJlhum/OqLcuwLGEN4+L6CZrNGAcSKa5KP3xrrHO+SjW+hSc99AC3kP7eLetgPtumEkZWtqzQY89bw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.633.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.633.0.tgz",
-      "integrity": "sha512-b+Sy4LB8fEv3xrv8S0anxFOPEeI6qc/MjK88ugBk09MehGXHL+m2Z32k9ArfuqjYKsMgHkVFbAELI3Zv14tlMQ==",
+      "version": "1.633.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.633.1.tgz",
+      "integrity": "sha512-175vYmGsaJlhum/OqLcuwLGEN4+L6CZrNGAcSKa5KP3xrrHO+SjW+hSc99AC3kP7eLetgPtumEkZWtqzQY89bw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.633.0",
+    "@bigcommerce/checkout-sdk": "^1.633.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to `1.633.1`

## Why?
As part of the release https://github.com/bigcommerce/checkout-sdk-js/pull/2573

## Testing / Proof
All tests have been passed

@bigcommerce/team-checkout
