### PR TITLE
chore(payment): STRIPE-378 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.634.0",
+        "@bigcommerce/checkout-sdk": "^1.635.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.634.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.634.0.tgz",
-      "integrity": "sha512-YdINZOr9Wrj+CgaOKTog0999wlQSLc2SANgUZ001faC0LDKsWaUY//bmYz97zU5VPH/bjovaKYIn+qnEF6jWzw==",
+      "version": "1.635.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.635.0.tgz",
+      "integrity": "sha512-Ox2sswfMt6XSPH8Y8An3YfUYDKRDlXmEeffoZP5i3hpAbYTX4B5vrb+O2iizLZ7owK0PwCZKDXoH5/v6qCSNIw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.634.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.634.0.tgz",
-      "integrity": "sha512-YdINZOr9Wrj+CgaOKTog0999wlQSLc2SANgUZ001faC0LDKsWaUY//bmYz97zU5VPH/bjovaKYIn+qnEF6jWzw==",
+      "version": "1.635.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.635.0.tgz",
+      "integrity": "sha512-Ox2sswfMt6XSPH8Y8An3YfUYDKRDlXmEeffoZP5i3hpAbYTX4B5vrb+O2iizLZ7owK0PwCZKDXoH5/v6qCSNIw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.634.0",
+    "@bigcommerce/checkout-sdk": "^1.635.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2548](https://github.com/bigcommerce/checkout-sdk-js/pull/2548)

## Testing / Proof
Manual tested and unit test

@bigcommerce/team-checkout
