### PR TITLE
chore(payment): PAYPAL-4488 bump checkout sdk version to 1.636.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.635.0",
+        "@bigcommerce/checkout-sdk": "^1.636.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.635.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.635.0.tgz",
-      "integrity": "sha512-Ox2sswfMt6XSPH8Y8An3YfUYDKRDlXmEeffoZP5i3hpAbYTX4B5vrb+O2iizLZ7owK0PwCZKDXoH5/v6qCSNIw==",
+      "version": "1.636.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.636.0.tgz",
+      "integrity": "sha512-wz2nco/am/T6Hg59uRaXiVwg2taZPJMu3WKQ8os7mLrmVcHvtg1OX4Zk4qaQgV2kwpqs/NyugUCIU7Cj8MJ/lg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.635.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.635.0.tgz",
-      "integrity": "sha512-Ox2sswfMt6XSPH8Y8An3YfUYDKRDlXmEeffoZP5i3hpAbYTX4B5vrb+O2iizLZ7owK0PwCZKDXoH5/v6qCSNIw==",
+      "version": "1.636.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.636.0.tgz",
+      "integrity": "sha512-wz2nco/am/T6Hg59uRaXiVwg2taZPJMu3WKQ8os7mLrmVcHvtg1OX4Zk4qaQgV2kwpqs/NyugUCIU7Cj8MJ/lg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.635.0",
+    "@bigcommerce/checkout-sdk": "^1.636.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.636.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2578

## Testing / Proof
Unit tests
Manual tests
CI