### PR TITLE
chore(other): CHECKOUT-8509 Remove experiment wrapping code for CHECKOUT-4183.checkout_google_address_autocomplete_uk

### DIFF
--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -143,13 +143,9 @@ function mapToBillingProps({
         return null;
     }
 
-    const { enableOrderComments, googleMapsApiKey, features } = config.checkoutSettings;
+    const { enableOrderComments, googleMapsApiKey } = config.checkoutSettings;
 
-    const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ'];
-
-    if (features['CHECKOUT-4183.checkout_google_address_autocomplete_uk']) {
-        countriesWithAutocomplete.push('GB');
-    }
+    const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ', 'GB'];
 
     return {
         billingAddress: getBillingAddress(),

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -387,11 +387,7 @@ export function mapToShippingProps({
         isCreatingCustomerAddress();
     const shouldShowMultiShipping =
         hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
-    const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ'];
-
-    if (features['CHECKOUT-4183.checkout_google_address_autocomplete_uk']) {
-        countriesWithAutocomplete.push('GB');
-    }
+    const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ', 'GB'];
 
     const shippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();


### PR DESCRIPTION
## What?
Remove experiment wrapping for code to add autocomplete for UK addresses.

## Why?
We have rolled out google maps support for UK addresses for one year now, so seems like a good opportunity for removing the experiment code wrapping the change.

## Testing / Proof
- CI 

@bigcommerce/team-checkout
