### PR TITLE
chore(other): CHECKOUT-8513 Remove experiment wrapping for adding new address for multi shipping

### DIFF
--- a/packages/core/src/app/shipping/ItemAddressSelect.tsx
+++ b/packages/core/src/app/shipping/ItemAddressSelect.tsx
@@ -9,7 +9,7 @@ export interface ItemAddressSelectProps {
     item: ShippableItem;
     addresses: CustomerAddress[];
     onSelectAddress(address: Address, itemId: string, itemKey: string): void;
-    onUseNewAddress(address: Address | undefined, itemId: string, itemKey: string): void;
+    onUseNewAddress(itemId: string, itemKey: string): void;
 }
 
 const ItemAddressSelect: FunctionComponent<ItemAddressSelectProps> = ({
@@ -19,8 +19,8 @@ const ItemAddressSelect: FunctionComponent<ItemAddressSelectProps> = ({
     onUseNewAddress,
 }) => {
     const handleUseNewAddress = useCallback(
-        (address: Address) => {
-            onUseNewAddress(address, id as string, key);
+        () => {
+            onUseNewAddress(id as string, key);
         },
         [id, onUseNewAddress, key],
     );

--- a/packages/core/src/app/shipping/MultiShippingForm.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.tsx
@@ -48,7 +48,6 @@ export interface MultiShippingFormProps {
     countries?: Country[];
     countriesWithAutocomplete: string[];
     googleMapsApiKey?: string;
-    shouldShowAddAddressInCheckout: boolean;
     isFloatingLabelEnabled?: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     onCreateAccount(): void;
@@ -216,19 +215,10 @@ class MultiShippingForm extends PureComponent<
         });
     };
 
-    private handleUseNewAddress: (address: Address, itemId: string, itemKey: string) => void = (
-        address,
+    private handleUseNewAddress: (itemId: string, itemKey: string) => void = (
         itemId,
         itemKey,
     ) => {
-        const { onUseNewAddress, shouldShowAddAddressInCheckout } = this.props;
-
-        if (!shouldShowAddAddressInCheckout) {
-            onUseNewAddress(address, itemId);
-
-            return;
-        }
-
         this.setState({
             itemAddingAddress: {
                 key: itemKey,

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -65,7 +65,6 @@ export interface WithCheckoutShippingProps {
     isShippingStepPending: boolean;
     methodId?: string;
     shippingAddress?: Address;
-    shouldShowAddAddressInCheckout: boolean;
     shouldShowMultiShipping: boolean;
     shouldShowOrderComments: boolean;
     providerWithCustomCheckout?: string;
@@ -369,7 +368,6 @@ export function mapToShippingProps({
     const {
         checkoutSettings: {
             enableOrderComments,
-            features,
             hasMultiShippingEnabled,
             googleMapsApiKey,
         },
@@ -422,8 +420,6 @@ export function mapToShippingProps({
         providerWithCustomCheckout,
         shippingAddress,
         shouldShowMultiShipping,
-        shouldShowAddAddressInCheckout:
-            features['CHECKOUT-4726.add_address_in_multishipping_checkout'],
         shouldShowOrderComments: enableOrderComments,
         signOut: checkoutService.signOutCustomer,
         unassignItem: checkoutService.unassignItemsToAddress,

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -40,7 +40,6 @@ export interface ShippingFormProps {
     shippingAddress?: Address;
     shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
-    shouldShowAddAddressInCheckout: boolean;
     isFloatingLabelEnabled?: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
@@ -90,7 +89,6 @@ const ShippingForm = ({
     shippingAddress,
     shouldShowOrderComments,
     shouldShowSaveAddress,
-    shouldShowAddAddressInCheckout,
     signOut,
     updateAddress,
     isShippingStepPending,
@@ -135,7 +133,6 @@ const ShippingForm = ({
             onSubmit={onMultiShippingSubmit}
             onUnhandledError={onUnhandledError}
             onUseNewAddress={onUseNewAddress}
-            shouldShowAddAddressInCheckout={shouldShowAddAddressInCheckout}
             shouldShowOrderComments={shouldShowOrderComments}
         />
     ) : (

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
@@ -24,7 +24,6 @@ export interface StripeShippingProps {
     isShippingStepPending: boolean;
     methodId?: string;
     shippingAddress?: Address;
-    shouldShowAddAddressInCheckout: boolean;
     shouldShowMultiShipping: boolean;
     shouldShowOrderComments: boolean;
     onReady?(): void;


### PR DESCRIPTION
## What?
Remove experiment wrapping for adding new address for multi shipping

## Why?
We added support for adding addresses in multi shipping mode https://github.com/bigcommerce/checkout-js/pull/501 3 years ago, and have since rolled out the experiment. Hence removing the experiment wrapping code.

## Testing / Proof
- CI

@bigcommerce/team-checkout
