### PR TITLE
chore(common): CHECKOUT-8523 Remove experiment code for CHECKOUT-4936_enable_custom_item_shipping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.642.2",
+        "@bigcommerce/checkout-sdk": "^1.643.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.642.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.642.2.tgz",
-      "integrity": "sha512-NLGAMPX/aVaeiyX1Z8LG+bdMJeLaVxHQQnLLituttnaaENqdwEVTdfjTQGGpYNC2r4GTOk9/1++db5GN0XrK/A==",
+      "version": "1.643.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.2.tgz",
+      "integrity": "sha512-yKbrY7dSmEWj+CBPfPBSv8DkpzJOi5AoPpyvONT4uL2khSBeHBA8+fF3S7uYN9My5/16uHKcHBBEcBcpV8aBGg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.642.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.642.2.tgz",
-      "integrity": "sha512-NLGAMPX/aVaeiyX1Z8LG+bdMJeLaVxHQQnLLituttnaaENqdwEVTdfjTQGGpYNC2r4GTOk9/1++db5GN0XrK/A==",
+      "version": "1.643.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.2.tgz",
+      "integrity": "sha512-yKbrY7dSmEWj+CBPfPBSv8DkpzJOi5AoPpyvONT4uL2khSBeHBA8+fF3S7uYN9My5/16uHKcHBBEcBcpV8aBGg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.642.2",
+    "@bigcommerce/checkout-sdk": "^1.643.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/shipping/itemsRequireShipping.spec.ts
+++ b/packages/core/src/app/shipping/itemsRequireShipping.spec.ts
@@ -13,7 +13,6 @@ describe('itemsRequireShipping()', () => {
     beforeEach(() => {
         cart = getCart();
         config = getStoreConfig();
-        config.checkoutSettings.features['CHECKOUT-4936.enable_custom_item_shipping'] = true;
     });
 
     it('returns false if there are no physical items or custom items', () => {

--- a/packages/core/src/app/shipping/itemsRequireShipping.ts
+++ b/packages/core/src/app/shipping/itemsRequireShipping.ts
@@ -9,10 +9,7 @@ const itemsRequireShipping = (cart?: Cart, config?: StoreConfig) => {
         return true;
     }
 
-    if (
-        config &&
-        config.checkoutSettings.features['CHECKOUT-4936.enable_custom_item_shipping'] &&
-        cart.lineItems.customItems
+    if (config && cart.lineItems.customItems
     ) {
         return cart.lineItems.customItems.length > 0;
     }


### PR DESCRIPTION
## What?
- Remove experiment code related to enabling shipping for custom items
- Bump SDK with related change https://github.com/bigcommerce/checkout-sdk-js/pull/2595
- Release https://github.com/bigcommerce/checkout-sdk-js/pull/2594 which was bumped before

## Why?
Remove experiment code related to enabling shipping for custom items, feature flag has been ramped up across platform for a while.

## Testing / Proof
- CI

@bigcommerce/team-checkout
