### PR TITLE
chore(payment): STRIPE-421 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.643.2",
+        "@bigcommerce/checkout-sdk": "^1.643.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.643.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.2.tgz",
-      "integrity": "sha512-yKbrY7dSmEWj+CBPfPBSv8DkpzJOi5AoPpyvONT4uL2khSBeHBA8+fF3S7uYN9My5/16uHKcHBBEcBcpV8aBGg==",
+      "version": "1.643.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.3.tgz",
+      "integrity": "sha512-wJbgxuZ+DIsY66NFgXUBK8NjUGa50hnKoeHuwkKy+7EYqPIFoxu8rcXdWfcYds8zWU0kMVZ31Wn6Gfb8x//s2A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.643.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.2.tgz",
-      "integrity": "sha512-yKbrY7dSmEWj+CBPfPBSv8DkpzJOi5AoPpyvONT4uL2khSBeHBA8+fF3S7uYN9My5/16uHKcHBBEcBcpV8aBGg==",
+      "version": "1.643.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.3.tgz",
+      "integrity": "sha512-wJbgxuZ+DIsY66NFgXUBK8NjUGa50hnKoeHuwkKy+7EYqPIFoxu8rcXdWfcYds8zWU0kMVZ31Wn6Gfb8x//s2A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.643.2",
+    "@bigcommerce/checkout-sdk": "^1.643.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2599](https://github.com/bigcommerce/checkout-sdk-js/pull/2599)

## Testing / Proof
manually tested and unit test

@bigcommerce/team-checkout
