### PR TITLE
fix(payment): STRIPE-384 added Klarna id to the Stripe gateway

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@ package-lock.json @bigcommerce/team-checkout @bigcommerce/team-integrations @big
 /packages/mollie-integration @bigcommerce/team-integrations
 /packages/squarev2-integration @bigcommerce/team-integrations
 /packages/td-bank-integration @bigcommerce/team-integrations
+/packages/stripe-integration @bigcommerce/team-integrations
 
 # Core
 /packages/core/payment/paymentMethod/AffirmPaymentMethod.tsx @bigcommerce/team-integrations

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.643.3",
+        "@bigcommerce/checkout-sdk": "^1.643.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.643.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.3.tgz",
-      "integrity": "sha512-wJbgxuZ+DIsY66NFgXUBK8NjUGa50hnKoeHuwkKy+7EYqPIFoxu8rcXdWfcYds8zWU0kMVZ31Wn6Gfb8x//s2A==",
+      "version": "1.643.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.4.tgz",
+      "integrity": "sha512-kxMlk4rJjryOXhBIK92gZ2uFA8dVimKIuUAzJpwx3MWVd2WGDpn7noSZle1nJ4OfyfErn5jWuPy/lyLHU2Kydg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.643.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.3.tgz",
-      "integrity": "sha512-wJbgxuZ+DIsY66NFgXUBK8NjUGa50hnKoeHuwkKy+7EYqPIFoxu8rcXdWfcYds8zWU0kMVZ31Wn6Gfb8x//s2A==",
+      "version": "1.643.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.643.4.tgz",
+      "integrity": "sha512-kxMlk4rJjryOXhBIK92gZ2uFA8dVimKIuUAzJpwx3MWVd2WGDpn7noSZle1nJ4OfyfErn5jWuPy/lyLHU2Kydg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.643.3",
+    "@bigcommerce/checkout-sdk": "^1.643.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/stripe-integration/src/stripe/StripeUPEPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe/StripeUPEPaymentMethod.tsx
@@ -158,5 +158,5 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     StripeUPEPaymentMethod,
-    [{ gateway: 'stripeupe' }],
+    [{ gateway: 'stripeupe' }, { gateway: 'stripeupe', id: 'klarna' }],
 );


### PR DESCRIPTION
## What?
Added Klarna id to the Stripe gateway.
Related PR: https://github.com/bigcommerce/checkout-js/pull/1956

## Why?
Because we cannot open Klarna tab without this fix.

## Testing / Proof
Before:

https://github.com/user-attachments/assets/d09e87c1-d413-461b-b583-516177ab2680


After:

https://github.com/user-attachments/assets/c5159738-c8f3-4f5b-b103-c2d4dd936e92





@bigcommerce/team-checkout
