### PR TITLE
chore(payment): STRIPE-422 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.644.0",
+        "@bigcommerce/checkout-sdk": "^1.644.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.644.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.0.tgz",
-      "integrity": "sha512-Ra5YqObD4/RTmOLZC7oNqAwSJ1WwDv2T78MlYlalTxJ90lpbycLhP9l0sxAT8eH4HWH04+1OdSaYvwyElKdA7g==",
+      "version": "1.644.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.1.tgz",
+      "integrity": "sha512-Teu8SdwXVMG9MinBGspQM4+12Q8EsW1lRYLiHuO84h6DYvcS6RhWqfeAKF7+XE40E1/Tx772dCvcT78Cz/+tmA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.644.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.0.tgz",
-      "integrity": "sha512-Ra5YqObD4/RTmOLZC7oNqAwSJ1WwDv2T78MlYlalTxJ90lpbycLhP9l0sxAT8eH4HWH04+1OdSaYvwyElKdA7g==",
+      "version": "1.644.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.1.tgz",
+      "integrity": "sha512-Teu8SdwXVMG9MinBGspQM4+12Q8EsW1lRYLiHuO84h6DYvcS6RhWqfeAKF7+XE40E1/Tx772dCvcT78Cz/+tmA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.644.0",
+    "@bigcommerce/checkout-sdk": "^1.644.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2605](https://github.com/bigcommerce/checkout-sdk-js/pull/2605)

## Testing / Proof
Unit tests and manually tested

@bigcommerce/team-checkout
