### PR TITLE
chore(payment): PAYPAL-4167 bump checkout-sdk version to 1.644.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.644.0",
+        "@bigcommerce/checkout-sdk": "^1.644.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.644.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.0.tgz",
-      "integrity": "sha512-Ra5YqObD4/RTmOLZC7oNqAwSJ1WwDv2T78MlYlalTxJ90lpbycLhP9l0sxAT8eH4HWH04+1OdSaYvwyElKdA7g==",
+      "version": "1.644.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.3.tgz",
+      "integrity": "sha512-L4PJ/9djpCuiTBH+EpfvqW1vl1ju9Vji2KM6CTlCxn5ytEDfI1q8ZRlJxSdzWbIRXyLH/Y7JdRJ780FP+OdZ0g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.644.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.0.tgz",
-      "integrity": "sha512-Ra5YqObD4/RTmOLZC7oNqAwSJ1WwDv2T78MlYlalTxJ90lpbycLhP9l0sxAT8eH4HWH04+1OdSaYvwyElKdA7g==",
+      "version": "1.644.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.3.tgz",
+      "integrity": "sha512-L4PJ/9djpCuiTBH+EpfvqW1vl1ju9Vji2KM6CTlCxn5ytEDfI1q8ZRlJxSdzWbIRXyLH/Y7JdRJ780FP+OdZ0g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.644.0",
+    "@bigcommerce/checkout-sdk": "^1.644.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.644.3

## Why?
As part of release checkout sdk:
https://github.com/bigcommerce/checkout-sdk-js/pull/2607

## Testing / Proof
Manual tests
Unit tests
CI
