### PR TITLE
chore(payment): STRIPE-422 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.644.0",
+        "@bigcommerce/checkout-sdk": "^1.644.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.644.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.0.tgz",
-      "integrity": "sha512-Ra5YqObD4/RTmOLZC7oNqAwSJ1WwDv2T78MlYlalTxJ90lpbycLhP9l0sxAT8eH4HWH04+1OdSaYvwyElKdA7g==",
+      "version": "1.644.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.4.tgz",
+      "integrity": "sha512-Bw1OC28vmzUpzsml0F8vIIXeZDPXB6x38I1NiThsA1oNYyc31hvTTOi0s862c43v64jmXdrsPV9ZXO92BHD+2g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.644.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.0.tgz",
-      "integrity": "sha512-Ra5YqObD4/RTmOLZC7oNqAwSJ1WwDv2T78MlYlalTxJ90lpbycLhP9l0sxAT8eH4HWH04+1OdSaYvwyElKdA7g==",
+      "version": "1.644.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.644.4.tgz",
+      "integrity": "sha512-Bw1OC28vmzUpzsml0F8vIIXeZDPXB6x38I1NiThsA1oNYyc31hvTTOi0s862c43v64jmXdrsPV9ZXO92BHD+2g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.644.0",
+    "@bigcommerce/checkout-sdk": "^1.644.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/stripe-integration/e2e/support/stripeUPE.mock.js
+++ b/packages/stripe-integration/e2e/support/stripeUPE.mock.js
@@ -1,5 +1,26 @@
 (() => {
     const noop = () => Promise.resolve();
+    const stripeEventCallback = (event, callback) => {
+        let payload;
+
+        switch (event) {
+            case 'change':
+                payload = {
+                    values: {
+                        value: {
+                            type: 'card',
+                        },
+                    },
+                };
+                break;
+
+            case 'ready':
+            default:
+                break;
+        }
+
+        return callback(payload);
+    };
     const stripeElement = () => ({
         mount: (id) => {
             const element = document.createElement('div');
@@ -10,7 +31,7 @@
         unmount: noop,
         update: noop,
         destroy: noop,
-        on: (_, callback) => {callback()},
+        on: stripeEventCallback,
     });
 
     window.Stripe = () => ({


### PR DESCRIPTION
## What?
Bump checkout-sdk-version
Add mock for stripe events payload

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2611](https://github.com/bigcommerce/checkout-sdk-js/pull/2611)

## Testing / Proof
Unit test and manually tested

@bigcommerce/team-checkout
