### PR TITLE
fix(payment): PAYPAL-4582 fixed the issue with using addresses from address book for logged in shoppers when Fastlane is enabled

### DIFF
--- a/packages/core/src/app/shipping/ShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.spec.tsx
@@ -400,11 +400,12 @@ describe('ShippingForm Component', () => {
             expect(initializeMock).not.toHaveBeenCalled();
         });
 
-        it('renders SingleShippingForm with merged addresses list if PayPal Fastlane enabled', () => {
+        it('renders SingleShippingForm with paypal addresses list for guests when PayPal Fastlane enabled', () => {
             const initializeMock = jest.fn();
             const shippingFormProps = {
                 ...defaultProps,
                 initialize: initializeMock,
+                isGuest: true,
             };
             const paypalFastlaneAddresses: CustomerAddress[] = [
                 {
@@ -444,6 +445,7 @@ describe('ShippingForm Component', () => {
             const shippingFormProps = {
                 ...defaultProps,
                 initialize: initializeMock,
+                isGuest: true,
             };
             const paypalFastlaneAddresses: CustomerAddress[] = [
                 {

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -101,7 +101,7 @@ const ShippingForm = ({
         shouldShowPayPalFastlaneShippingForm,
     } = usePayPalFastlaneAddress();
 
-    const shippingAddresses = isPayPalFastlaneEnabled
+    const shippingAddresses = isPayPalFastlaneEnabled && isGuest
         ? paypalFastlaneAddresses
         : addresses;
 


### PR DESCRIPTION
## What?
Fixed the issue with using addresses from address book for logged in shoppers when Fastlane is enabled

## Why?
Fastlane is a feature which should be available for Guest shoppers only. Therefore for Logged in shoppers the checkout flow should have default (core) behaviour.

## Testing / Proof
Manual tests
Unit tests
CI

Before:


https://github.com/user-attachments/assets/61970d9d-4b04-478d-bd37-77cb381711c6



After:

https://github.com/user-attachments/assets/5dda1a03-555c-4506-9594-ac253888faa7


