### PR TITLE
chore(payment): PAYPAL-000 bump checkout-sdk version to 1.645.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.645.0",
+        "@bigcommerce/checkout-sdk": "^1.645.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.645.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.0.tgz",
-      "integrity": "sha512-O7N0kNdQ16EkFPuH/HOmsBhGt7736fHgg4DwXB7VS4stkKkVANvmURKtIdtb9698pRJFyzVKmzWakeZbmfdmOA==",
+      "version": "1.645.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.2.tgz",
+      "integrity": "sha512-2EQT6Bfx/9nk8c4w3u9F0Rfeer0KjXuxyjlIRJxBF1o3fNDgATfB9t5Bv5aLl6AcyYwoe0S507Erjf7E9rf7xg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.645.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.0.tgz",
-      "integrity": "sha512-O7N0kNdQ16EkFPuH/HOmsBhGt7736fHgg4DwXB7VS4stkKkVANvmURKtIdtb9698pRJFyzVKmzWakeZbmfdmOA==",
+      "version": "1.645.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.2.tgz",
+      "integrity": "sha512-2EQT6Bfx/9nk8c4w3u9F0Rfeer0KjXuxyjlIRJxBF1o3fNDgATfB9t5Bv5aLl6AcyYwoe0S507Erjf7E9rf7xg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.645.0",
+    "@bigcommerce/checkout-sdk": "^1.645.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.645.2

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2613
https://github.com/bigcommerce/checkout-sdk-js/pull/2614

## Testing / Proof
Manual tests
Unit tests
CI