### PR TITLE
chore(shipping): SHIPPING-3183 bump checkout-sdk to 1.646.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.645.2",
+        "@bigcommerce/checkout-sdk": "^1.646.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.645.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.2.tgz",
-      "integrity": "sha512-2EQT6Bfx/9nk8c4w3u9F0Rfeer0KjXuxyjlIRJxBF1o3fNDgATfB9t5Bv5aLl6AcyYwoe0S507Erjf7E9rf7xg==",
+      "version": "1.646.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.646.0.tgz",
+      "integrity": "sha512-h60pfRSBL9VGi2CqDoLqjqx6RCcWP3KAiAwycWLGXJ8Vi4io9+N5iXjO0C/BpzSooniMcmr10queCKmqT724rQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.645.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.2.tgz",
-      "integrity": "sha512-2EQT6Bfx/9nk8c4w3u9F0Rfeer0KjXuxyjlIRJxBF1o3fNDgATfB9t5Bv5aLl6AcyYwoe0S507Erjf7E9rf7xg==",
+      "version": "1.646.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.646.0.tgz",
+      "integrity": "sha512-h60pfRSBL9VGi2CqDoLqjqx6RCcWP3KAiAwycWLGXJ8Vi4io9+N5iXjO0C/BpzSooniMcmr10queCKmqT724rQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.645.2",
+    "@bigcommerce/checkout-sdk": "^1.646.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/adyen-integration/e2e/__har__/Adyenv2-ACH-in-Payment-Step_1196775541/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv2-ACH-in-Payment-Step_1196775541/recording.har
@@ -556,8 +556,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 60851,

--- a/packages/adyen-integration/e2e/__har__/Adyenv2-Credit-Card-in-Payment-Step_220184964/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv2-Credit-Card-in-Payment-Step_220184964/recording.har
@@ -556,8 +556,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 60851,

--- a/packages/adyen-integration/e2e/__har__/Adyenv3-ACH-in-Payment-Step_873791026/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv3-ACH-in-Payment-Step_873791026/recording.har
@@ -427,8 +427,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/adyen-integration/e2e/__har__/Adyenv3-Credit-Card-in-Payment-Step_3229115791/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv3-Credit-Card-in-Payment-Step_3229115791/recording.har
@@ -427,8 +427,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/affirm-integration/e2e/__har__/Affirm-in-Payment-Step_519329631/recording.har
+++ b/packages/affirm-integration/e2e/__har__/Affirm-in-Payment-Step_519329631/recording.har
@@ -439,8 +439,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/apple-pay-integration/e2e/__har__/ApplePay-in-Payment-Step_2100856370/recording.har
+++ b/packages/apple-pay-integration/e2e/__har__/ApplePay-in-Payment-Step_2100856370/recording.har
@@ -504,8 +504,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 42447,

--- a/packages/barclay-integration/e2e/__har__/Barclay_3915322175/recording.har
+++ b/packages/barclay-integration/e2e/__har__/Barclay_3915322175/recording.har
@@ -387,8 +387,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,
@@ -1456,8 +1461,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/ACH-with-BlueSnapv2-in-Payment-Step_1030426958/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/ACH-with-BlueSnapv2-in-Payment-Step_1030426958/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Bank-Transfer-with-BlueSnapv2-in-Payment-Step_3241051483/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Bank-Transfer-with-BlueSnapv2-in-Payment-Step_3241051483/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnap-in-Payment-Step_2136680895/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnap-in-Payment-Step_2136680895/recording.har
@@ -504,8 +504,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnapv2-in-Payment-Step_2247692055/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnapv2-in-Payment-Step_2247692055/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/ECP-with-BlueSnap-in-Payment-Step_75403566/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/ECP-with-BlueSnap-in-Payment-Step_75403566/recording.har
@@ -375,8 +375,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/External-APM-with-BlueSnap-in-Payment-Step_1599217875/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/External-APM-with-BlueSnap-in-Payment-Step_1599217875/recording.har
@@ -387,8 +387,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Moneybookers-with-BlueSnapv2-in-Payment-Step_558909199/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Moneybookers-with-BlueSnapv2-in-Payment-Step_558909199/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Paysafecard-with-BlueSnapv2-in-Payment-Step_448808695/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Paysafecard-with-BlueSnapv2-in-Payment-Step_448808695/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/SEPA-with-BlueSnap-in-Payment-Step_2879624599/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/SEPA-with-BlueSnap-in-Payment-Step_2879624599/recording.har
@@ -387,8 +387,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Wire-with-BlueSnapv2-in-Payment-Step_3120654321/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Wire-with-BlueSnapv2-in-Payment-Step_3120654321/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/checkoutcom-integration/e2e/__har__/Credit-Card-with-Checkoutcom-in-Payment-Step_3718073430/recording.har
+++ b/packages/checkoutcom-integration/e2e/__har__/Credit-Card-with-Checkoutcom-in-Payment-Step_3718073430/recording.har
@@ -395,8 +395,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/checkoutcom-integration/e2e/__har__/Fawry-with-Checkoutcom-in-Payment-Step_4061538748/recording.har
+++ b/packages/checkoutcom-integration/e2e/__har__/Fawry-with-Checkoutcom-in-Payment-Step_4061538748/recording.har
@@ -395,8 +395,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/core/e2e/__har__/Adding-and-Removing-free-shipping-coupon_4050863903/recording.har
+++ b/packages/core/e2e/__har__/Adding-and-Removing-free-shipping-coupon_4050863903/recording.har
@@ -451,8 +451,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,
@@ -1141,8 +1146,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,
@@ -2405,8 +2415,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,
@@ -2944,8 +2959,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/core/e2e/__har__/Multi-Shipping-with-Customer-checkout_2370051488/recording.har
+++ b/packages/core/e2e/__har__/Multi-Shipping-with-Customer-checkout_2370051488/recording.har
@@ -1002,8 +1002,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/core/e2e/__har__/Shipping-with-Customer-checkout_2160979277/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-Customer-checkout_2160979277/recording.har
@@ -970,8 +970,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/core/e2e/__har__/Shipping-with-Guest-checkout_658786807/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-Guest-checkout_658786807/recording.har
@@ -625,8 +625,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/core/e2e/__har__/Shipping-with-different-billing-address_981343935/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-different-billing-address_981343935/recording.har
@@ -625,8 +625,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/digitalriver-integration/e2e/__har__/Digital-River-Credit-Card-in-Payment-Step_3405653337/recording.har
+++ b/packages/digitalriver-integration/e2e/__har__/Digital-River-Credit-Card-in-Payment-Step_3405653337/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61230,

--- a/packages/digitalriver-integration/e2e/__har__/Digital-River-wire-transfer-in-Payment-Step_3932186716/recording.har
+++ b/packages/digitalriver-integration/e2e/__har__/Digital-River-wire-transfer-in-Payment-Step_3932186716/recording.har
@@ -391,8 +391,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61230,

--- a/packages/hosted-credit-card-integration/e2e/__har__/CC-with-BlueSnap-in-Payment-Step_3392749462/recording.har
+++ b/packages/hosted-credit-card-integration/e2e/__har__/CC-with-BlueSnap-in-Payment-Step_3392749462/recording.har
@@ -375,8 +375,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/hosted-payment-integration/e2e/__har__/Humm-in-Payment-Step_487368341/recording.har
+++ b/packages/hosted-payment-integration/e2e/__har__/Humm-in-Payment-Step_487368341/recording.har
@@ -439,8 +439,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 509,

--- a/packages/mollie-integration/e2e/__har__/Bancontact-with-Mollie-in-Payment-Step_2670522601/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Bancontact-with-Mollie-in-Payment-Step_2670522601/recording.har
@@ -439,8 +439,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/CC-with-Mollie-in-Payment-Step_668330648/recording.har
+++ b/packages/mollie-integration/e2e/__har__/CC-with-Mollie-in-Payment-Step_668330648/recording.har
@@ -572,8 +572,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Klarnapaylater-with-Mollie-in-Payment-Step_2902091219/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Klarnapaylater-with-Mollie-in-Payment-Step_2902091219/recording.har
@@ -439,8 +439,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Klarnapaynow-with-Mollie-in-Payment-Step_802259869/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Klarnapaynow-with-Mollie-in-Payment-Step_802259869/recording.har
@@ -439,8 +439,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Klarnasliceit-with-Mollie-in-Payment-Step_2481485656/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Klarnasliceit-with-Mollie-in-Payment-Step_2481485656/recording.har
@@ -439,8 +439,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Sofort-with-Mollie-in-Payment-Step_2796910677/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Sofort-with-Mollie-in-Payment-Step_2796910677/recording.har
@@ -439,8 +439,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/offline-payment-integration/e2e/__har__/Cash-on-Delivery_227544541/recording.har
+++ b/packages/offline-payment-integration/e2e/__har__/Cash-on-Delivery_227544541/recording.har
@@ -411,8 +411,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 42447,

--- a/packages/offline-payment-integration/e2e/__har__/Pay-in-Store_2088335945/recording.har
+++ b/packages/offline-payment-integration/e2e/__har__/Pay-in-Store_2088335945/recording.har
@@ -411,8 +411,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 42447,

--- a/packages/squarev2-integration/e2e/__har__/SquareV2-in-Payment-Step_656806659/recording.har
+++ b/packages/squarev2-integration/e2e/__har__/SquareV2-in-Payment-Step_656806659/recording.har
@@ -375,8 +375,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-Alipay-in-Payment-Step_1327921107/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-Alipay-in-Payment-Step_1327921107/recording.har
@@ -580,8 +580,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-Credit-Cards-in-Payment-Step_2742926991/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-Credit-Cards-in-Payment-Step_2742926991/recording.har
@@ -580,8 +580,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-US-Bank-Account-in-Payment-Step_2989821772/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-US-Bank-Account-in-Payment-Step_2989821772/recording.har
@@ -580,8 +580,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-Wechat-in-Payment-Step_3313051439/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-Wechat-in-Payment-Step_3313051439/recording.har
@@ -580,8 +580,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,


### PR DESCRIPTION
## What?
- Bump checkout-sdk-js version to 1.646.0. 
   - This change incorporates everything in this [PR](https://github.com/bigcommerce/checkout-sdk-js/pull/2579).
   - Here is the version
![Screenshot 2024-08-20 at 10 28 14 AM](https://github.com/user-attachments/assets/eeeb9685-c668-4ab8-9103-005b12997a7e)
   - Ran `npm install @bigcommerce/checkout-sdk@1.646.0`




## Why?
We want to release a newer version of checkout-sdk-js for checkout-js to consume and have access to channel information in checkout country selector.

## Testing / Proof
N/A. Testing was performed in the checkout-sdk-js PR?

@bigcommerce/team-checkout
