### PR TITLE
chore(payment): PAYPAL-2611 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.645.2",
+        "@bigcommerce/checkout-sdk": "^1.647.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1758,9 +1758,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.645.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.2.tgz",
-      "integrity": "sha512-2EQT6Bfx/9nk8c4w3u9F0Rfeer0KjXuxyjlIRJxBF1o3fNDgATfB9t5Bv5aLl6AcyYwoe0S507Erjf7E9rf7xg==",
+      "version": "1.647.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.647.0.tgz",
+      "integrity": "sha512-YjCheskzg6RbHj7V73Aq+vIt92S6gVnJ641n5HiqI1OfXR9u61oE5G2HrU5r1of3PAGjvh8HdiHGcgp+q9G/TA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35661,9 +35661,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.645.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.645.2.tgz",
-      "integrity": "sha512-2EQT6Bfx/9nk8c4w3u9F0Rfeer0KjXuxyjlIRJxBF1o3fNDgATfB9t5Bv5aLl6AcyYwoe0S507Erjf7E9rf7xg==",
+      "version": "1.647.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.647.0.tgz",
+      "integrity": "sha512-YjCheskzg6RbHj7V73Aq+vIt92S6gVnJ641n5HiqI1OfXR9u61oE5G2HrU5r1of3PAGjvh8HdiHGcgp+q9G/TA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.645.2",
+    "@bigcommerce/checkout-sdk": "^1.647.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
To update code
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2601

## Testing / Proof
Unit tests

@bigcommerce/team-checkout
