### PR TITLE
chore(shipping): SHIPPING-3183 Bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.647.1",
+        "@bigcommerce/checkout-sdk": "^1.647.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1761,9 +1761,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.647.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.647.1.tgz",
-      "integrity": "sha512-ayx7Pk+Ti2joFKdm522mWe6MDjTGx6XT3O8iEiKatLnuHItcC/Q5nZL4veJ0s1I2pOLJ2668UrWElhnZQ6R8pA==",
+      "version": "1.647.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.647.2.tgz",
+      "integrity": "sha512-ZhiOxF/8VVlHu4X/MDeuNy5gVy6erRwZ8hqNUJF7vDYEHn94/gMmjkjyWEp4+A2X4ShlMEarGS0cx+RSszkefw==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35664,9 +35665,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.647.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.647.1.tgz",
-      "integrity": "sha512-ayx7Pk+Ti2joFKdm522mWe6MDjTGx6XT3O8iEiKatLnuHItcC/Q5nZL4veJ0s1I2pOLJ2668UrWElhnZQ6R8pA==",
+      "version": "1.647.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.647.2.tgz",
+      "integrity": "sha512-ZhiOxF/8VVlHu4X/MDeuNy5gVy6erRwZ8hqNUJF7vDYEHn94/gMmjkjyWEp4+A2X4ShlMEarGS0cx+RSszkefw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.647.1",
+    "@bigcommerce/checkout-sdk": "^1.647.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/adyen-integration/e2e/__har__/Adyenv2-ACH-in-Payment-Step_1196775541/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv2-ACH-in-Payment-Step_1196775541/recording.har
@@ -527,7 +527,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -546,8 +546,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 60851,

--- a/packages/adyen-integration/e2e/__har__/Adyenv2-Credit-Card-in-Payment-Step_220184964/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv2-Credit-Card-in-Payment-Step_220184964/recording.har
@@ -527,7 +527,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -546,8 +546,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 60851,

--- a/packages/adyen-integration/e2e/__har__/Adyenv3-ACH-in-Payment-Step_873791026/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv3-ACH-in-Payment-Step_873791026/recording.har
@@ -398,7 +398,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -417,8 +417,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/adyen-integration/e2e/__har__/Adyenv3-Credit-Card-in-Payment-Step_3229115791/recording.har
+++ b/packages/adyen-integration/e2e/__har__/Adyenv3-Credit-Card-in-Payment-Step_3229115791/recording.har
@@ -398,7 +398,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -417,8 +417,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/affirm-integration/e2e/__har__/Affirm-in-Payment-Step_519329631/recording.har
+++ b/packages/affirm-integration/e2e/__har__/Affirm-in-Payment-Step_519329631/recording.har
@@ -410,7 +410,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -429,8 +429,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/apple-pay-integration/e2e/__har__/ApplePay-in-Payment-Step_2100856370/recording.har
+++ b/packages/apple-pay-integration/e2e/__har__/ApplePay-in-Payment-Step_2100856370/recording.har
@@ -479,7 +479,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "80247e72f7d581074224ff9a977d234c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -495,7 +495,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=undefined"
         },
         "response": {
           "bodySize": 42447,

--- a/packages/barclay-integration/e2e/__har__/Barclay_3915322175/recording.har
+++ b/packages/barclay-integration/e2e/__har__/Barclay_3915322175/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -377,8 +377,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,
@@ -1421,7 +1426,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 1,
         "cache": {},
         "request": {
@@ -1436,8 +1441,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/ACH-with-BlueSnapv2-in-Payment-Step_1030426958/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/ACH-with-BlueSnapv2-in-Payment-Step_1030426958/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Bank-Transfer-with-BlueSnapv2-in-Payment-Step_3241051483/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Bank-Transfer-with-BlueSnapv2-in-Payment-Step_3241051483/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnap-in-Payment-Step_2136680895/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnap-in-Payment-Step_2136680895/recording.har
@@ -479,7 +479,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -494,8 +494,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnapv2-in-Payment-Step_2247692055/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Credit-Card-with-BlueSnapv2-in-Payment-Step_2247692055/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/ECP-with-BlueSnap-in-Payment-Step_75403566/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/ECP-with-BlueSnap-in-Payment-Step_75403566/recording.har
@@ -350,7 +350,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -365,8 +365,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/External-APM-with-BlueSnap-in-Payment-Step_1599217875/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/External-APM-with-BlueSnap-in-Payment-Step_1599217875/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -377,8 +377,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Moneybookers-with-BlueSnapv2-in-Payment-Step_558909199/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Moneybookers-with-BlueSnapv2-in-Payment-Step_558909199/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Paysafecard-with-BlueSnapv2-in-Payment-Step_448808695/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Paysafecard-with-BlueSnapv2-in-Payment-Step_448808695/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/bluesnap-direct-integration/e2e/__har__/SEPA-with-BlueSnap-in-Payment-Step_2879624599/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/SEPA-with-BlueSnap-in-Payment-Step_2879624599/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -377,8 +377,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/bluesnap-direct-integration/e2e/__har__/Wire-with-BlueSnapv2-in-Payment-Step_3120654321/recording.har
+++ b/packages/bluesnap-direct-integration/e2e/__har__/Wire-with-BlueSnapv2-in-Payment-Step_3120654321/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/checkoutcom-integration/e2e/__har__/Credit-Card-with-Checkoutcom-in-Payment-Step_3718073430/recording.har
+++ b/packages/checkoutcom-integration/e2e/__har__/Credit-Card-with-Checkoutcom-in-Payment-Step_3718073430/recording.har
@@ -366,7 +366,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -385,8 +385,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/checkoutcom-integration/e2e/__har__/Fawry-with-Checkoutcom-in-Payment-Step_4061538748/recording.har
+++ b/packages/checkoutcom-integration/e2e/__har__/Fawry-with-Checkoutcom-in-Payment-Step_4061538748/recording.har
@@ -366,7 +366,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -385,8 +385,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/core/e2e/__har__/Adding-and-Removing-free-shipping-coupon_4050863903/recording.har
+++ b/packages/core/e2e/__har__/Adding-and-Removing-free-shipping-coupon_4050863903/recording.har
@@ -422,7 +422,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -441,8 +441,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,
@@ -1112,7 +1117,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 1,
         "cache": {},
         "request": {
@@ -1131,8 +1136,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,
@@ -2366,7 +2376,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 2,
         "cache": {},
         "request": {
@@ -2385,8 +2395,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,
@@ -2905,7 +2920,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 3,
         "cache": {},
         "request": {
@@ -2924,8 +2939,13 @@
           "headersSize": 112,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 56697,

--- a/packages/core/e2e/__har__/Multi-Shipping-with-Customer-checkout_2370051488/recording.har
+++ b/packages/core/e2e/__har__/Multi-Shipping-with-Customer-checkout_2370051488/recording.har
@@ -973,7 +973,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -992,8 +992,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/core/e2e/__har__/Shipping-with-Customer-checkout_2160979277/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-Customer-checkout_2160979277/recording.har
@@ -945,7 +945,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -960,8 +960,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/core/e2e/__har__/Shipping-with-Guest-checkout_658786807/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-Guest-checkout_658786807/recording.har
@@ -600,7 +600,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -615,8 +615,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/core/e2e/__har__/Shipping-with-different-billing-address_981343935/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-different-billing-address_981343935/recording.har
@@ -600,7 +600,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -615,8 +615,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/digitalriver-integration/e2e/__har__/Digital-River-Credit-Card-in-Payment-Step_3405653337/recording.har
+++ b/packages/digitalriver-integration/e2e/__har__/Digital-River-Credit-Card-in-Payment-Step_3405653337/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61230,

--- a/packages/digitalriver-integration/e2e/__har__/Digital-River-wire-transfer-in-Payment-Step_3932186716/recording.har
+++ b/packages/digitalriver-integration/e2e/__har__/Digital-River-wire-transfer-in-Payment-Step_3932186716/recording.har
@@ -362,7 +362,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -381,8 +381,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61230,

--- a/packages/hosted-credit-card-integration/e2e/__har__/CC-with-BlueSnap-in-Payment-Step_3392749462/recording.har
+++ b/packages/hosted-credit-card-integration/e2e/__har__/CC-with-BlueSnap-in-Payment-Step_3392749462/recording.har
@@ -350,7 +350,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -365,8 +365,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/hosted-payment-integration/e2e/__har__/Humm-in-Payment-Step_487368341/recording.har
+++ b/packages/hosted-payment-integration/e2e/__har__/Humm-in-Payment-Step_487368341/recording.har
@@ -410,7 +410,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -429,8 +429,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 509,

--- a/packages/mollie-integration/e2e/__har__/Bancontact-with-Mollie-in-Payment-Step_2670522601/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Bancontact-with-Mollie-in-Payment-Step_2670522601/recording.har
@@ -410,7 +410,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -429,8 +429,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/CC-with-Mollie-in-Payment-Step_668330648/recording.har
+++ b/packages/mollie-integration/e2e/__har__/CC-with-Mollie-in-Payment-Step_668330648/recording.har
@@ -543,7 +543,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -562,8 +562,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Klarnapaylater-with-Mollie-in-Payment-Step_2902091219/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Klarnapaylater-with-Mollie-in-Payment-Step_2902091219/recording.har
@@ -410,7 +410,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -429,8 +429,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Klarnapaynow-with-Mollie-in-Payment-Step_802259869/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Klarnapaynow-with-Mollie-in-Payment-Step_802259869/recording.har
@@ -410,7 +410,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -429,8 +429,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Klarnasliceit-with-Mollie-in-Payment-Step_2481485656/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Klarnasliceit-with-Mollie-in-Payment-Step_2481485656/recording.har
@@ -410,7 +410,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -429,8 +429,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/mollie-integration/e2e/__har__/Sofort-with-Mollie-in-Payment-Step_2796910677/recording.har
+++ b/packages/mollie-integration/e2e/__har__/Sofort-with-Mollie-in-Payment-Step_2796910677/recording.har
@@ -410,7 +410,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -429,8 +429,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 61140,

--- a/packages/offline-payment-integration/e2e/__har__/Cash-on-Delivery_227544541/recording.har
+++ b/packages/offline-payment-integration/e2e/__har__/Cash-on-Delivery_227544541/recording.har
@@ -386,7 +386,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -401,8 +401,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 42447,

--- a/packages/offline-payment-integration/e2e/__har__/Pay-in-Store_2088335945/recording.har
+++ b/packages/offline-payment-integration/e2e/__har__/Pay-in-Store_2088335945/recording.har
@@ -386,7 +386,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -401,8 +401,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 42447,

--- a/packages/squarev2-integration/e2e/__har__/SquareV2-in-Payment-Step_656806659/recording.har
+++ b/packages/squarev2-integration/e2e/__har__/SquareV2-in-Payment-Step_656806659/recording.har
@@ -350,7 +350,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -365,8 +365,13 @@
           "headersSize": 92,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-Alipay-in-Payment-Step_1327921107/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-Alipay-in-Payment-Step_1327921107/recording.har
@@ -551,7 +551,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -570,8 +570,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-Credit-Cards-in-Payment-Step_2742926991/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-Credit-Cards-in-Payment-Step_2742926991/recording.har
@@ -551,7 +551,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -570,8 +570,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-US-Bank-Account-in-Payment-Step_2989821772/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-US-Bank-Account-in-Payment-Step_2989821772/recording.har
@@ -551,7 +551,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -570,8 +570,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,

--- a/packages/stripe-integration/e2e/__har__/Stripe-UPE-Wechat-in-Payment-Step_3313051439/recording.har
+++ b/packages/stripe-integration/e2e/__har__/Stripe-UPE-Wechat-in-Payment-Step_3313051439/recording.har
@@ -551,7 +551,7 @@
         }
       },
       {
-        "_id": "3c153628ade2aa3e7dcf9fad2b517b12",
+        "_id": "56d14f454c7d36d46413850a58a0314b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -570,8 +570,13 @@
           "headersSize": 147,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [],
-          "url": "https://4241.project/internalapi/v1/shipping/countries"
+          "queryString": [
+            {
+              "name": "channel_id",
+              "value": "1"
+            }
+          ],
+          "url": "https://4241.project/internalapi/v1/shipping/countries?channel_id=1"
         },
         "response": {
           "bodySize": 2723,


### PR DESCRIPTION
## What?
- Bump checkout-sdk-version to 1.647.2

![Screenshot 2024-08-26 at 2 37 34 PM](https://github.com/user-attachments/assets/4dcc1aa0-2536-4621-82c1-62b4d4c7aec5)


## Why?
We want to release a new version of the checkout-sdk for checkout-js to consume

## Testing / Proof

https://github.com/user-attachments/assets/39db2078-e888-4479-95fd-15107d74f6e2

Existing Unit Tests

ping @bigcommerce/team-checkout 