### PR TITLE
fix(customer): CHECKOUT-8559 Remove string override for customer password validation error

### DIFF
--- a/packages/core/src/app/customer/CreateAccountForm.spec.tsx
+++ b/packages/core/src/app/customer/CreateAccountForm.spec.tsx
@@ -67,7 +67,7 @@ describe('CreateAccountForm Component', () => {
     });
 
     it.each([
-        ['Password needs to contain a letter', '1234567'],
+        ['password must match the following: "/[a-zA-Z]/"', '1234567'],
         ['Password needs to contain a number', 'abcdefg'],
         ['Password is too short', '1a'],
     ])('renders correct error when %s', async (expected, passwordCase) => {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -142,7 +142,7 @@
             "password_confirmation_label": "Confirm Password",
             "password_confirmation_required_error": "This field is required",
             "password_label": "Password",
-            "password_letter_required_error": "Password needs to contain a letter",
+            "password_letter_required_error": "",
             "password_minimum_character_label": "character minimum, case sensitive",
             "password_number_required_error": "Password needs to contain a number",
             "password_over_maximum_length_error": "Password is too long",


### PR DESCRIPTION
## What?
Remove string override for regex validation

## Why?
We return the correct translated message as part of password requirements from checkout settings API, and the translation in checkout app can be incorrect so it's better to use API message. Merchants can still override theme files.

## Testing / Proof
- CI

![Screenshot 2024-08-27 at 3 39 19 PM](https://github.com/user-attachments/assets/f7ccf492-de08-4355-95dd-05bb2aa34e41)


@bigcommerce/team-checkout
