### PR TITLE
CHECKOUT-8300: Reset Formik form once initial value is loaded in the shipping step

### DIFF
--- a/packages/core/src/app/common/form/index.ts
+++ b/packages/core/src/app/common/form/index.ts
@@ -1,2 +1,3 @@
 export { default as connectFormik } from './connectFormik';
 export { default as ConnectFormikProps, WithFormikProps } from './ConnectFormikProps';
+export { default as withFormikExtended, WithFormikExtendedProps } from './withFormikExtended';

--- a/packages/core/src/app/common/form/withFormikExtended.test.tsx
+++ b/packages/core/src/app/common/form/withFormikExtended.test.tsx
@@ -1,0 +1,62 @@
+import userEvent from '@testing-library/user-event';
+import React, { ComponentType } from 'react';
+import { object, string } from 'yup';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { Button, Input, Label } from '@bigcommerce/checkout/ui';
+
+import { Form } from '../../ui/form';
+
+import withFormikExtended from './withFormikExtended';
+
+describe('withFormikExtended', () => {
+    interface TestComponentProps {
+        defaultTitle?: string;
+        isInitialValueLoaded?: boolean;
+        submit(values: TestComponentValues): void;
+    }
+
+    interface TestComponentValues {
+        title?: string;
+    }
+
+    const TestComponent: ComponentType<TestComponentProps> = () => (
+        <Form>
+            <Label htmlFor="title">Title</Label>
+            <Input id="title" name="title" type="text" />
+            <Button type="submit">Submit</Button>
+        </Form>
+    );
+
+    const DecoratedTestComponent = withFormikExtended<TestComponentProps, TestComponentValues>({
+        handleSubmit(values, { props: { submit } }) {
+            submit(values);
+        },
+        mapPropsToValues({ defaultTitle }) {
+            return { title: defaultTitle };
+        },
+        isInitialValid({ defaultTitle }) {
+            return !!defaultTitle;
+        },
+        validationSchema: object({
+            title: string().required(),
+        }),
+    })(TestComponent);
+
+    it('resets form after initital value is loaded', async () => {
+        const submit = jest.fn();
+        const { rerender } = render(<DecoratedTestComponent isInitialValueLoaded={false} submit={ submit } />);
+
+        await userEvent.click(screen.getByText('Submit'));
+
+        // The initial value is invalid at this point therefore the submit function should not called
+        expect(submit).not.toHaveBeenCalled();
+
+        rerender(<DecoratedTestComponent defaultTitle="Hello" isInitialValueLoaded={true} submit={ submit } />);
+
+        await userEvent.click(screen.getByText('Submit'));
+
+        // The initial value is now valid therefore the submit function should be called
+        expect(submit).toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/app/common/form/withFormikExtended.tsx
+++ b/packages/core/src/app/common/form/withFormikExtended.tsx
@@ -1,0 +1,41 @@
+import { FormikProps, FormikValues, withFormik, WithFormikConfig } from 'formik';
+import React, { ComponentType, useEffect, useRef } from 'react';
+
+export interface WithFormikExtendedProps {
+    isInitialValueLoaded?: boolean;
+}
+
+/**
+ * This HOC extends the behavior of the default `withFormik` HOC. It can reset a form to its initial state when
+ * the `isInitialValueLoaded` prop is set to true. This is useful when a form needs to be rendered before its
+ * initial value is fully loaded.
+ */
+export default function withFormikExtended<TOuterProps, TValues extends FormikValues, TPayload = TValues>(
+    config: WithFormikConfig<TOuterProps, TValues, TPayload>
+) {
+    return (OriginalComponent: ComponentType<TOuterProps & FormikProps<TValues>>) => {
+        const DecoratedComponent: ComponentType<TOuterProps & FormikProps<TValues> & WithFormikExtendedProps> = (props) => {
+            const { resetForm, isInitialValueLoaded } = props;
+            const previousIsInitialValueLoadedRef = useRef(isInitialValueLoaded);
+
+            useEffect(() => {
+                if (
+                    previousIsInitialValueLoadedRef.current === false && 
+                    isInitialValueLoaded === true
+                ) {
+                    resetForm();
+                }
+
+                previousIsInitialValueLoadedRef.current = isInitialValueLoaded;
+            }, [isInitialValueLoaded]);
+
+            return <OriginalComponent {...props} />;
+        };
+
+        DecoratedComponent.displayName = `WithFormikExtended(${
+            OriginalComponent.displayName || OriginalComponent.name
+        })`;
+
+        return withFormik(config)(DecoratedComponent);
+    };
+}

--- a/packages/core/src/app/shipping/MultiShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.spec.tsx
@@ -45,6 +45,7 @@ describe('MultiShippingForm Component', () => {
             cartHasChanged: false,
             customerMessage: 'x',
             countriesWithAutocomplete: [],
+            isInitialValueLoaded: true,
             isLoading: false,
             consignments: [
                 { ...getConsignment(), id: 'foo' },

--- a/packages/core/src/app/shipping/MultiShippingForm.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.tsx
@@ -10,7 +10,7 @@ import {
     CustomerAddress,
     FormField,
 } from '@bigcommerce/checkout-sdk';
-import { FormikProps, withFormik } from 'formik';
+import { FormikProps } from 'formik';
 import React, { PureComponent, ReactNode } from 'react';
 
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
@@ -34,6 +34,7 @@ import ItemAddressSelect from './ItemAddressSelect';
 import ShippableItem from './ShippableItem';
 import ShippingFormFooter from './ShippingFormFooter';
 import updateShippableItems from './updateShippableItems';
+import { withFormikExtended } from '../common/form';
 
 export interface MultiShippingFormProps {
     addresses: CustomerAddress[];
@@ -49,6 +50,7 @@ export interface MultiShippingFormProps {
     countriesWithAutocomplete: string[];
     googleMapsApiKey?: string;
     isFloatingLabelEnabled?: boolean;
+    isInitialValueLoaded: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     onCreateAccount(): void;
     createCustomerAddress(address: AddressRequestBody): void;
@@ -97,6 +99,7 @@ class MultiShippingForm extends PureComponent<
             onCreateAccount,
             cartHasChanged,
             shouldShowOrderComments,
+            isInitialValueLoaded,
             isLoading,
             getFields,
             defaultCountryCode,
@@ -169,6 +172,7 @@ class MultiShippingForm extends PureComponent<
 
                     <ShippingFormFooter
                         cartHasChanged={cartHasChanged}
+                        isInitialValueLoaded={isInitialValueLoaded}
                         isLoading={isLoading}
                         isMultiShippingMode={true}
                         shouldDisableSubmit={this.shouldDisableSubmit()}
@@ -298,7 +302,7 @@ export interface MultiShippingFormValues {
 }
 
 export default withLanguage(
-    withFormik<MultiShippingFormProps & WithLanguageProps, MultiShippingFormValues>({
+    withFormikExtended<MultiShippingFormProps & WithLanguageProps, MultiShippingFormValues>({
         handleSubmit: (values, { props: { onSubmit } }) => {
             onSubmit(values);
         },

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -256,6 +256,7 @@ describe('Shipping Component', () => {
 
         component
             .find('input[name="shippingAddress.firstName"]')
+            .simulate('click')
             .simulate('change', { target: { value: 'bar', name: 'shippingAddress.firstName' } });
 
         component.find('form').simulate('submit');
@@ -281,10 +282,12 @@ describe('Shipping Component', () => {
 
         component
             .find('input[name="shippingAddress.firstName"]')
+            .simulate('click')
             .simulate('change', { target: { value: 'bar', name: 'shippingAddress.firstName' } });
 
         component
             .find('input[name="billingSameAsShipping"]')
+            .simulate('click')
             .simulate('change', { target: { checked: false, name: 'billingSameAsShipping' } });
 
         component.find('form').simulate('submit');
@@ -308,7 +311,7 @@ describe('Shipping Component', () => {
         const currentValue = saveAddressField.get(0).props.value;
         const changedValue = currentValue === 'true' ? 'false' : 'true';
 
-        saveAddressField.simulate('change', {
+        saveAddressField.simulate('click').simulate('change', {
             target: { value: changedValue, name: 'shippingAddress.shouldSaveAddress' },
         });
 
@@ -328,6 +331,7 @@ describe('Shipping Component', () => {
 
         component
             .find('input[name="orderComment"]')
+            .simulate('click')
             .simulate('change', { target: { value: 'foo', name: 'orderComment' } });
 
         component.find('form').simulate('submit');
@@ -346,6 +350,7 @@ describe('Shipping Component', () => {
 
         component
             .find('input[name="shippingAddress.firstName"]')
+            .simulate('click')
             .simulate('change', { target: { value: 'bar', name: 'shippingAddress.firstName' } });
 
         component.find('form').simulate('submit');
@@ -475,6 +480,7 @@ describe('Shipping Component', () => {
                 it('calls updateCheckout and navigateNextStep', async () => {
                     component
                         .find('input[name="orderComment"]')
+                        .simulate('click')
                         .simulate('change', { target: { value: 'foo', name: 'orderComment' } });
 
                     component.find('form').simulate('submit');

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -149,7 +149,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                 initialize={initializeShippingMethod}
                 isBillingSameAsShipping={isBillingSameAsShipping}
                 isGuest={ isGuest }
-                isInitialValueLoaded={!isInitializing}
+                isInitialValueLoaded={shouldRenderWhileLoading ? !isInitializing : true}
                 isLoading={ isInitializing }
                 isMultiShippingMode={isMultiShippingMode}
                 isShippingMethodLoading={ this.props.isLoading }
@@ -178,7 +178,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         isBillingSameAsShipping={isBillingSameAsShipping}
                         isFloatingLabelEnabled={isFloatingLabelEnabled}
                         isGuest={isGuest}
-                        isInitialValueLoaded={!isInitializing}
+                        isInitialValueLoaded={shouldRenderWhileLoading ? !isInitializing : true}
                         isMultiShippingMode={isMultiShippingMode}
                         onMultiShippingSubmit={this.handleMultiShippingSubmit}
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -149,6 +149,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                 initialize={initializeShippingMethod}
                 isBillingSameAsShipping={isBillingSameAsShipping}
                 isGuest={ isGuest }
+                isInitialValueLoaded={!isInitializing}
                 isLoading={ isInitializing }
                 isMultiShippingMode={isMultiShippingMode}
                 isShippingMethodLoading={ this.props.isLoading }
@@ -177,6 +178,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         isBillingSameAsShipping={isBillingSameAsShipping}
                         isFloatingLabelEnabled={isFloatingLabelEnabled}
                         isGuest={isGuest}
+                        isInitialValueLoaded={!isInitializing}
                         isMultiShippingMode={isMultiShippingMode}
                         onMultiShippingSubmit={this.handleMultiShippingSubmit}
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}

--- a/packages/core/src/app/shipping/ShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.spec.tsx
@@ -69,6 +69,7 @@ describe('ShippingForm Component', () => {
             shouldShowOrderComments: true,
             onMultiShippingSubmit: jest.fn(),
             onSingleShippingSubmit: jest.fn(),
+            isInitialValueLoaded: true,
             isLoading: false,
             isShippingStepPending: false,
             deleteConsignments: jest.fn(),

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -41,6 +41,7 @@ export interface ShippingFormProps {
     shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
+    isInitialValueLoaded: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -93,6 +94,7 @@ const ShippingForm = ({
     updateAddress,
     isShippingStepPending,
     isFloatingLabelEnabled,
+    isInitialValueLoaded,
 }: ShippingFormProps & WithLanguageProps) => {
     // TODO: remove PayPal Fastlane related code and useEffect when PayPal Fastlane will not be available for Store members
     const {
@@ -127,6 +129,7 @@ const ShippingForm = ({
             googleMapsApiKey={googleMapsApiKey}
             isFloatingLabelEnabled={isFloatingLabelEnabled}
             isGuest={isGuest}
+            isInitialValueLoaded={isInitialValueLoaded}
             isLoading={isLoading}
             onCreateAccount={onCreateAccount}
             onSignIn={onSignIn}
@@ -150,6 +153,7 @@ const ShippingForm = ({
             initialize={initialize}
             isBillingSameAsShipping={isBillingSameAsShipping}
             isFloatingLabelEnabled={isFloatingLabelEnabled}
+            isInitialValueLoaded={isInitialValueLoaded}
             isLoading={isLoading}
             isMultiShippingMode={isMultiShippingMode}
             isShippingStepPending={isShippingStepPending}

--- a/packages/core/src/app/shipping/ShippingFormFooter.tsx
+++ b/packages/core/src/app/shipping/ShippingFormFooter.tsx
@@ -17,6 +17,7 @@ export interface ShippingFormFooterProps {
     shouldShowOrderComments: boolean;
     shouldShowShippingOptions?: boolean;
     shouldDisableSubmit: boolean;
+    isInitialValueLoaded: boolean;
     isLoading: boolean;
 }
 
@@ -26,6 +27,7 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
     shouldShowOrderComments,
     shouldShowShippingOptions = true,
     shouldDisableSubmit,
+    isInitialValueLoaded,
     isLoading,
 }) => {
     return (
@@ -50,6 +52,7 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                 }
             >
                 <ShippingOptions
+                    isInitialValueLoaded={isInitialValueLoaded}
                     isMultiShippingMode={isMultiShippingMode}
                     isUpdatingAddress={isLoading}
                     shouldShowShippingOptions={shouldShowShippingOptions}

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -11,7 +11,7 @@ import {
     ShippingInitializeOptions,
     ShippingRequestOptions,
 } from '@bigcommerce/checkout-sdk';
-import { FormikProps, withFormik } from 'formik';
+import { FormikProps } from 'formik';
 import { debounce, isEqual, noop } from 'lodash';
 import React, { PureComponent, ReactNode } from 'react';
 import { lazy, object } from 'yup';
@@ -27,6 +27,7 @@ import {
     mapAddressFromFormValues,
     mapAddressToFormValues,
 } from '../address';
+import { withFormikExtended } from '../common/form';
 import { getCustomFormFieldsValidationSchema } from '../formFields';
 import { PaymentMethodId } from '../payment/paymentMethod';
 import { Fieldset, Form } from '../ui/form';
@@ -55,6 +56,7 @@ export interface SingleShippingFormProps {
     shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
+    isInitialValueLoaded: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
     getFields(countryCode?: string): FormField[];
@@ -137,6 +139,7 @@ class SingleShippingForm extends PureComponent<
         const {
             addresses,
             cartHasChanged,
+            isInitialValueLoaded,
             isLoading,
             onUnhandledError,
             methodId,
@@ -196,6 +199,7 @@ class SingleShippingForm extends PureComponent<
 
                 <ShippingFormFooter
                     cartHasChanged={cartHasChanged}
+                    isInitialValueLoaded={isInitialValueLoaded}
                     isLoading={isLoading || isUpdatingShippingData}
                     isMultiShippingMode={false}
                     shouldDisableSubmit={this.shouldDisableSubmit()}
@@ -317,7 +321,7 @@ class SingleShippingForm extends PureComponent<
 }
 
 export default withLanguage(
-    withFormik<SingleShippingFormProps & WithLanguageProps, SingleShippingFormValues>({
+    withFormikExtended<SingleShippingFormProps & WithLanguageProps, SingleShippingFormValues>({
         handleSubmit: (values, { props: { onSubmit } }) => {
             onSubmit(values);
         },

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptions.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptions.tsx
@@ -11,6 +11,7 @@ import getShippingMethodId from '../getShippingMethodId';
 import ShippingOptionsForm from './ShippingOptionsForm';
 
 export interface ShippingOptionsProps {
+    isInitialValueLoaded: boolean;
     isMultiShippingMode: boolean;
     isUpdatingAddress?: boolean;
     shouldShowShippingOptions: boolean;

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
@@ -28,6 +28,7 @@ describe('ShippingOptions Component', () => {
     ];
     let triggerConsignmentsUpdated: (state: CheckoutSelectors) => void;
     const defaultProps: ShippingOptionsFormProps = {
+        isInitialValueLoaded: true,
         isMultiShippingMode: true,
         consignments,
         invalidShippingMessage: 'foo',

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.tsx
@@ -1,5 +1,5 @@
 import { CheckoutSelectors, Consignment } from '@bigcommerce/checkout-sdk';
-import { FormikProps, withFormik } from 'formik';
+import { FormikProps } from 'formik';
 import { noop } from 'lodash';
 import React, { PureComponent, ReactNode } from 'react';
 
@@ -9,6 +9,7 @@ import { ChecklistSkeleton } from '@bigcommerce/checkout/ui';
 
 import { AddressType, StaticAddress } from '../../address';
 import { withAnalytics } from '../../analytics';
+import { withFormikExtended } from '../../common/form';
 import getRecommendedShippingOption from '../getRecommendedShippingOption';
 import StaticConsignmentItemList from '../StaticConsignmentItemList';
 
@@ -181,7 +182,7 @@ export interface ShippingOptionsFormValues {
     };
 }
 
-export default withAnalytics(withFormik<ShippingOptionsFormProps, ShippingOptionsFormValues>({
+export default withAnalytics(withFormikExtended<ShippingOptionsFormProps, ShippingOptionsFormValues>({
     handleSubmit: noop,
     mapPropsToValues({ consignments }) {
         const shippingOptionIds: { [id: string]: string } = {};

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
@@ -19,6 +19,7 @@ export interface StripeShippingProps {
     customerMessage: string;
     isGuest: boolean;
     isInitializing: boolean;
+    isInitialValueLoaded: boolean;
     isLoading: boolean;
     isShippingMethodLoading: boolean;
     isShippingStepPending: boolean;

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
@@ -9,7 +9,7 @@ import {
     ShippingInitializeOptions,
     ShippingRequestOptions,
 } from '@bigcommerce/checkout-sdk';
-import { FormikProps, withFormik } from 'formik';
+import { FormikProps } from 'formik';
 import { noop } from 'lodash';
 import React, { PureComponent, ReactNode } from 'react';
 import { lazy, object } from 'yup';
@@ -31,6 +31,7 @@ import hasSelectedShippingOptions from '../hasSelectedShippingOptions';
 import ShippingFormFooter from '../ShippingFormFooter';
 
 import StripeShippingAddress from './StripeShippingAddress';
+import { withFormikExtended } from '../../common/form';
 
 export interface SingleShippingFormProps {
     isBillingSameAsShipping: boolean;
@@ -45,6 +46,7 @@ export interface SingleShippingFormProps {
     shippingAddress?: Address;
     shouldShowOrderComments: boolean;
     step: CheckoutStepStatus;
+    isInitialValueLoaded: boolean;
     isStripeLoading?(): void;
     isStripeAutoStep?(): void;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
@@ -80,6 +82,7 @@ class StripeShippingForm extends PureComponent<
     render(): ReactNode {
         const {
             cartHasChanged,
+            isInitialValueLoaded,
             isLoading,
             countries,
             isStripeLoading,
@@ -121,6 +124,7 @@ class StripeShippingForm extends PureComponent<
 
                 <ShippingFormFooter
                     cartHasChanged={cartHasChanged}
+                    isInitialValueLoaded={isInitialValueLoaded}
                     isLoading={isLoading || isUpdatingShippingData}
                     isMultiShippingMode={false}
                     shouldDisableSubmit={this.shouldDisableSubmit()}
@@ -169,7 +173,7 @@ class StripeShippingForm extends PureComponent<
 }
 
 export default withLanguage(
-    withFormik<SingleShippingFormProps & WithLanguageProps, SingleShippingFormValues>({
+    withFormikExtended<SingleShippingFormProps & WithLanguageProps, SingleShippingFormValues>({
         handleSubmit: (values, { props: { onSubmit } }) => {
             onSubmit(values);
         },


### PR DESCRIPTION
## What?
Add the `withFormikExtended` HOC, which extends the behaviour of the default `withFormik` HOC. This enhancement allows a Formik form to be reset once its initial value is loaded, enabling it to render even before the initial value is ready. Without this functionality, the form might not be able to submit if its `isInitialValid` check requires the initial value to be present.

## Why?
This is necessary because some checkout extensions are located inside Formik forms. To render these extensions before their parent forms are fully loaded, we need a way to reinitialise the forms once the required data is ready, as explained above.

## Testing / Proof
### Before
This video shows that the shopper cannot submit the form because it is rendered before the initial value is loaded. Consequently, the `isInitialValid` check marks the form as invalid and prevents submission.

https://github.com/user-attachments/assets/09187d1e-5de2-417d-b83d-af470dbfc980

### After
This video shows that the shopper can submit the form because it is reinitialised after the initial value is loaded. As a result, the `isInitialValid` function has the necessary data to perform its check, allowing the form to be submitted if it is valid.

https://github.com/user-attachments/assets/7558bc2f-64d8-45c7-b195-3c77f357657e



@bigcommerce/team-checkout
