### PR TITLE
chore(payment): PAYPAL-4618 bump checkout-sdk version to 1.650.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.649.0",
+        "@bigcommerce/checkout-sdk": "^1.650.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.649.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.649.0.tgz",
-      "integrity": "sha512-HXwAspBqMWZrfQGwhcHEVfl1eArYuT/Q1QQozlKnTmqG4vA8cREQydZ3lCKHkqnNzoYYSQgSJSzvuQWCPbhTjQ==",
+      "version": "1.650.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.650.0.tgz",
+      "integrity": "sha512-Vm1k6NUw5LKNMLI/F9mf2rm1c3fARTycDCcc1BdaZVei9Bv9rezmS87DiQy/MG8XEXmPdJboJ5ohgC61cS7czA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35664,9 +35664,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.649.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.649.0.tgz",
-      "integrity": "sha512-HXwAspBqMWZrfQGwhcHEVfl1eArYuT/Q1QQozlKnTmqG4vA8cREQydZ3lCKHkqnNzoYYSQgSJSzvuQWCPbhTjQ==",
+      "version": "1.650.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.650.0.tgz",
+      "integrity": "sha512-Vm1k6NUw5LKNMLI/F9mf2rm1c3fARTycDCcc1BdaZVei9Bv9rezmS87DiQy/MG8XEXmPdJboJ5ohgC61cS7czA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.649.0",
+    "@bigcommerce/checkout-sdk": "^1.650.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.650.0

## Why?
As part of release: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2627

## Testing / Proof
Unit tests
CI
