### PR TITLE
fix(checkout): CHECKOUT-8503 Disable steps on checkout page when order is being submitted

### DIFF
--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -215,12 +215,20 @@ const getPaymentStepStatus = createSelector(
     },
 );
 
+const getOrderSubmitStatus = createSelector(
+    ({ statuses }: CheckoutSelectors) => statuses.isSubmittingOrder(),
+    (status) => status,
+);
+
 const getCheckoutStepStatuses = createSelector(
     getCustomerStepStatus,
     getShippingStepStatus,
     getBillingStepStatus,
     getPaymentStepStatus,
-    (customerStep, shippingStep, billingStep, paymentStep) => {
+    getOrderSubmitStatus,
+    (customerStep, shippingStep, billingStep, paymentStep, orderStatus) => {
+        const isSubmittingOrder = orderStatus;
+
         const steps = compact([customerStep, shippingStep, billingStep, paymentStep]);
 
         const defaultActiveStep =
@@ -236,7 +244,7 @@ const getCheckoutStepStatuses = createSelector(
                 isActive: defaultActiveStep.type === step.type,
                 isBusy: false,
                 // A step is only editable if its previous step is complete or not required
-                isEditable: isPrevStepComplete && step.isEditable,
+                isEditable: isPrevStepComplete && step.isEditable && !isSubmittingOrder,
             };
         });
     },


### PR DESCRIPTION
## What?
Disable steps on checkout page when order is being submitted

## Why?
On the checkout page, selecting “Place Order” and then immediately attempting to edit the Billing details will result in the payment gateway infinitely attempting to load, which causes confusion. Hence disable clicking on fields and sections while an order is being submitted.

## Testing / Proof
- Screencast
- CI


https://github.com/user-attachments/assets/15916767-c804-4228-bec3-93ea49138a79



@bigcommerce/team-checkout
