### PR TITLE
chore(payment): PAYPAL-4645 bump checkout sdk version to 1.653.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.650.3",
+        "@bigcommerce/checkout-sdk": "^1.653.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.650.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.650.3.tgz",
-      "integrity": "sha512-PTC6H1iH04NcH3E4ERBkOFAqhFoezKjJJUTI39eLovKIchNtF+W6/WqkdP5sdvOedij/9JY37jqWNP3GRmM4jA==",
+      "version": "1.653.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.653.0.tgz",
+      "integrity": "sha512-0CyM9FnSm+74ccxF9OR8T5ZqTVlURnCJOAxA1AGpCimHJBNyA8kcWeS6Qp6hX/I3zj8RpWPwCMTlfJTlvIohNQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35711,9 +35711,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.650.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.650.3.tgz",
-      "integrity": "sha512-PTC6H1iH04NcH3E4ERBkOFAqhFoezKjJJUTI39eLovKIchNtF+W6/WqkdP5sdvOedij/9JY37jqWNP3GRmM4jA==",
+      "version": "1.653.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.653.0.tgz",
+      "integrity": "sha512-0CyM9FnSm+74ccxF9OR8T5ZqTVlURnCJOAxA1AGpCimHJBNyA8kcWeS6Qp6hX/I3zj8RpWPwCMTlfJTlvIohNQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.650.3",
+    "@bigcommerce/checkout-sdk": "^1.653.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.653.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2635
https://github.com/bigcommerce/checkout-sdk-js/pull/2636
https://github.com/bigcommerce/checkout-sdk-js/pull/2634

## Testing / Proof
Unit tests
Manual tests
CI
