### PR TITLE
chore(payment): PAYPAL-4649 bump checkout-sdk version to 1.655.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.655.1",
+        "@bigcommerce/checkout-sdk": "^1.655.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.655.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.655.1.tgz",
-      "integrity": "sha512-g6C9rPXHB4YeBJjltXVd6W20bzCSw19JtWKWYR5byM4t3VXMOY+teswwtj1CnIXpURDkni91N8iFtNbb6pHtSQ==",
+      "version": "1.655.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.655.2.tgz",
+      "integrity": "sha512-T2WjCkFTE+c0jJ2WtRmX4/HTjOqgjYLpYhxZJqz4TNCEbV7PYeKfrXdiD7r9YhQbgz5WdlIpYhcfi+pQPJGb2Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.655.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.655.1.tgz",
-      "integrity": "sha512-g6C9rPXHB4YeBJjltXVd6W20bzCSw19JtWKWYR5byM4t3VXMOY+teswwtj1CnIXpURDkni91N8iFtNbb6pHtSQ==",
+      "version": "1.655.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.655.2.tgz",
+      "integrity": "sha512-T2WjCkFTE+c0jJ2WtRmX4/HTjOqgjYLpYhxZJqz4TNCEbV7PYeKfrXdiD7r9YhQbgz5WdlIpYhcfi+pQPJGb2Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.655.1",
+    "@bigcommerce/checkout-sdk": "^1.655.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.655.2

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2641

## Testing / Proof
Unit tests
Manual tests
CI
