### PR TITLE
fix(payment): PAYPAL-4646 fixed the issue with Google Pay button styling on top of checkout page

### DIFF
--- a/packages/checkout-button-integration/src/CheckoutButton.tsx
+++ b/packages/checkout-button-integration/src/CheckoutButton.tsx
@@ -8,6 +8,7 @@ import {
 
 const CheckoutButton: FunctionComponent<CheckoutButtonProps> = ({
     checkoutService: { deinitializeCustomer, initializeCustomer },
+    checkoutButtonContainerClass,
     containerId,
     methodId,
     onUnhandledError,
@@ -35,7 +36,7 @@ const CheckoutButton: FunctionComponent<CheckoutButtonProps> = ({
         onWalletButtonClick,
     ]);
 
-    return <div id={containerId} />;
+    return <div className={checkoutButtonContainerClass} id={containerId} />;
 };
 
 export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(

--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -63,6 +63,7 @@ exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] 
           />
         </div>
         <div
+          class="google-pay-top-button"
           id="googlepayauthorizenetCheckoutButton"
         />
       </div>
@@ -138,6 +139,7 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
           />
         </div>
         <div
+          class="google-pay-top-button"
           id="googlepayauthorizenetCheckoutButton"
         />
       </div>
@@ -213,6 +215,7 @@ exports[`CheckoutButtonContainer removes Paypal commerce wallet buttons when pay
           />
         </div>
         <div
+          class="google-pay-top-button"
           id="googlepayauthorizenetCheckoutButton"
         />
       </div>

--- a/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
+++ b/packages/core/src/scss/components/checkout/checkoutRemote/_checkoutRemote.scss
@@ -24,10 +24,11 @@
         }
     }
 
-    .gpay-button {
+    .gpay-button, .gpay-card-info-container {
         border-radius: $global-radius;
         height: $wallet-button-height;
         min-height: $wallet-button-height;
+        max-width: $wallet-button-max-width;
     }
 }
 

--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -168,26 +168,26 @@ $buttonWidthMap: (
     }
 
     .checkoutRemote > div:first-child:nth-last-child(2),div:first-child:nth-last-child(2) ~ div {
-        grid-column: buttonWidth('half');
+        @include breakpoint("small") {
+            grid-column: buttonWidth('half');
+        }
     }
 
     .checkoutRemote > div:first-child:nth-last-child(3) {
-        grid-column: buttonWidth('single');
-
         @include breakpoint("small") {
             grid-column: buttonWidth('third');
         }
     }
     .checkoutRemote > div:first-child:nth-last-child(3) ~ div:nth-child(n + 2){
-        grid-column: buttonWidth('half');
-
         @include breakpoint("small") {
             grid-column: buttonWidth('third');
         }
     }
 
     .checkoutRemote > div:first-child:nth-last-child(4),div:first-child:nth-last-child(4) ~ div {
-        grid-column: buttonWidth('half');
+        @include breakpoint("small") {
+            grid-column: buttonWidth('half');
+        }
 
         @include breakpoint("medium") {
             grid-column: buttonWidth('quarter');
@@ -203,25 +203,23 @@ $buttonWidthMap: (
     }
 
     .checkoutRemote > div:first-child:nth-last-child(5) {
-        grid-column: buttonWidth('single');
-
         @include breakpoint("small") {
             grid-column: buttonWidth('half');
         }
     }
     .checkoutRemote > div:first-child:nth-last-child(5) ~ div:nth-child(2){
-        grid-column: buttonWidth('half');
+        @include breakpoint("small") {
+            grid-column: buttonWidth('half');
+        }
     }
     .checkoutRemote > div:first-child:nth-last-child(5) ~ div:nth-child(n+3){
-        grid-column: buttonWidth('half');
-
         @include breakpoint("small") {
             grid-column: buttonWidth('third');
         }
     }
 
     .checkoutRemote > div {
-        grid-column: buttonWidth('half');
+        grid-column: buttonWidth('single');
 
         @include breakpoint("small") {
             grid-column: buttonWidth('third');

--- a/packages/google-pay-integration/src/GooglePayButton.scss
+++ b/packages/google-pay-integration/src/GooglePayButton.scss
@@ -1,0 +1,23 @@
+.google-pay-top-button {
+    & > div {
+        height: 100%;
+        width: 100%;
+    }
+
+    & .gpay-card-info-container {
+        height: 100%;
+        width: 100%;
+        min-width: 100%;
+        min-height: unset;
+    }
+
+    & .gpay-card-info-animation-container {
+        height: 100%;
+    }
+
+    & .gpay-card-info-container,
+    & .gpay-button {
+        outline: none;
+    }
+}
+

--- a/packages/google-pay-integration/src/GooglePayButton.spec.tsx
+++ b/packages/google-pay-integration/src/GooglePayButton.spec.tsx
@@ -27,6 +27,7 @@ describe('GooglePayButton', () => {
             language: createLanguageService(),
             methodId: 'googlepay',
             onUnhandledError: jest.fn(),
+            onWalletButtonClick: jest.fn(),
         };
     });
 

--- a/packages/google-pay-integration/src/GooglePayButton.tsx
+++ b/packages/google-pay-integration/src/GooglePayButton.tsx
@@ -9,6 +9,8 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
+import './GooglePayButton.scss';
+
 const GooglePayButton: FunctionComponent<CheckoutButtonProps> = (props) => {
     const { language, onUnhandledError } = props;
 
@@ -24,7 +26,7 @@ const GooglePayButton: FunctionComponent<CheckoutButtonProps> = (props) => {
         return null;
     }
 
-    return <CheckoutButton {...props} />;
+    return <CheckoutButton checkoutButtonContainerClass="google-pay-top-button" {...props} />;
 };
 
 export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(

--- a/packages/payment-integration-api/src/CheckoutButtonProps.tsx
+++ b/packages/payment-integration-api/src/CheckoutButtonProps.tsx
@@ -5,6 +5,7 @@ export default interface CheckoutButtonProps {
     containerId: string;
     checkoutService: CheckoutService;
     checkoutState: CheckoutSelectors;
+    checkoutButtonContainerClass?: string;
     language: LanguageService;
     onUnhandledError(error: Error): void;
     onWalletButtonClick(methodName: string): void;


### PR DESCRIPTION
## What?
Fixed the issue with Google Pay button styling on top of checkout page

## Why?
Because Google Pay button had different to other buttons style what did not match overall buttons styling on checkout page

## Testing / Proof
Manual tests

1 button:
<img width="1371" alt="Screenshot 2024-09-17 at 11 44 52" src="https://github.com/user-attachments/assets/0f906b86-6a93-4724-8567-eacf66d58f77">
<img width="768" alt="Screenshot 2024-09-17 at 11 44 38" src="https://github.com/user-attachments/assets/266dc41c-4f83-4f34-8e19-32e93c43d333">
<img width="318" alt="Screenshot 2024-09-17 at 11 44 28" src="https://github.com/user-attachments/assets/6b3348a9-0a71-46db-b65a-fa2aee84d88e">

2 buttons:
<img width="320" alt="Screenshot 2024-09-17 at 11 42 24" src="https://github.com/user-attachments/assets/a63f61e9-1867-4c78-b8bd-89d94e316358">
<img width="596" alt="Screenshot 2024-09-17 at 11 42 36" src="https://github.com/user-attachments/assets/c7c1ea25-6674-4f75-833d-f03f5e9ee867">
<img width="1073" alt="Screenshot 2024-09-17 at 11 42 43" src="https://github.com/user-attachments/assets/2985ac1e-5b8e-4afa-a0e0-b163f1c011f9">

3 buttons:
<img width="317" alt="Screenshot 2024-09-17 at 11 46 26" src="https://github.com/user-attachments/assets/e1c36c79-8e64-4d6a-9490-f2023c8ebcb2">
<img width="809" alt="Screenshot 2024-09-17 at 11 46 39" src="https://github.com/user-attachments/assets/294edd19-c9fc-4904-8665-362d5a64ff79">
<img width="1281" alt="Screenshot 2024-09-17 at 11 46 48" src="https://github.com/user-attachments/assets/b0ec901e-d0c8-4b09-9df7-429298218e6f">

4 buttons:

<img width="305" alt="Screenshot 2024-09-17 at 11 47 56" src="https://github.com/user-attachments/assets/dcb3fee8-9746-4d2d-9cb8-7e44fc8dff4a">
<img width="591" alt="Screenshot 2024-09-17 at 11 48 05" src="https://github.com/user-attachments/assets/0754d483-3a76-4987-8975-783d0e4a8e8f">
<img width="948" alt="Screenshot 2024-09-17 at 11 48 26" src="https://github.com/user-attachments/assets/ecad4aaa-7377-47be-936d-d3e2e7c75190">
<img width="1220" alt="Screenshot 2024-09-17 at 11 48 40" src="https://github.com/user-attachments/assets/522e7cda-8b5a-488d-925e-95fc5991571e">
<img width="1471" alt="Screenshot 2024-09-17 at 11 48 54" src="https://github.com/user-attachments/assets/00758e9b-9466-4f66-93e9-57005e4acc20">


5 buttons:
<img width="315" alt="Screenshot 2024-09-17 at 11 50 14" src="https://github.com/user-attachments/assets/12726fae-3897-4260-8d99-1a4495e85506">
<img width="583" alt="Screenshot 2024-09-17 at 11 50 25" src="https://github.com/user-attachments/assets/3d431316-d764-4490-8225-8591d99b201d">
<img width="1336" alt="Screenshot 2024-09-17 at 11 50 39" src="https://github.com/user-attachments/assets/d98825c5-6784-4d40-9a81-1d1b6a8d4612">


6 buttons:
<img width="322" alt="Screenshot 2024-09-17 at 11 52 06" src="https://github.com/user-attachments/assets/f25fb467-c627-44f6-a6ed-e93d659a15cf">
<img width="1374" alt="Screenshot 2024-09-17 at 11 51 47" src="https://github.com/user-attachments/assets/e97376a5-379b-4ec3-8b5c-4de5aa41cf35">
<img width="686" alt="Screenshot 2024-09-17 at 11 52 14" src="https://github.com/user-attachments/assets/d371c53d-70b5-4c34-a51f-b7b629c95b99">

