### PR TITLE
chore(payment): PI-2548 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.655.2",
+        "@bigcommerce/checkout-sdk": "^1.656.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.655.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.655.2.tgz",
-      "integrity": "sha512-T2WjCkFTE+c0jJ2WtRmX4/HTjOqgjYLpYhxZJqz4TNCEbV7PYeKfrXdiD7r9YhQbgz5WdlIpYhcfi+pQPJGb2Q==",
+      "version": "1.656.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.0.tgz",
+      "integrity": "sha512-5xokn1w+b4ObiJ25IKD08g8eF4kSL626g31O85rqptHGom7SHGmp04YsolAcXIbU/ALJRd9b3oc8NyfNwNd1bw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.655.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.655.2.tgz",
-      "integrity": "sha512-T2WjCkFTE+c0jJ2WtRmX4/HTjOqgjYLpYhxZJqz4TNCEbV7PYeKfrXdiD7r9YhQbgz5WdlIpYhcfi+pQPJGb2Q==",
+      "version": "1.656.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.0.tgz",
+      "integrity": "sha512-5xokn1w+b4ObiJ25IKD08g8eF4kSL626g31O85rqptHGom7SHGmp04YsolAcXIbU/ALJRd9b3oc8NyfNwNd1bw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.655.2",
+    "@bigcommerce/checkout-sdk": "^1.656.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2640](https://github.com/bigcommerce/checkout-sdk-js/pull/2640)

## Testing / Proof
Unit tests and manually tested

@bigcommerce/team-checkout
