### PR TITLE
chore(payment): PAYPAL-4594 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.656.0",
+        "@bigcommerce/checkout-sdk": "^1.656.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.656.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.0.tgz",
-      "integrity": "sha512-5xokn1w+b4ObiJ25IKD08g8eF4kSL626g31O85rqptHGom7SHGmp04YsolAcXIbU/ALJRd9b3oc8NyfNwNd1bw==",
+      "version": "1.656.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.1.tgz",
+      "integrity": "sha512-qzEhqQc/mc+fdxtDIWGd53p1fyptq7qmAT5tFYY9sNAylabOXTIdYTglAtVq+oNYwZg3WuWRx30mqTI7NGz4Qg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.656.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.0.tgz",
-      "integrity": "sha512-5xokn1w+b4ObiJ25IKD08g8eF4kSL626g31O85rqptHGom7SHGmp04YsolAcXIbU/ALJRd9b3oc8NyfNwNd1bw==",
+      "version": "1.656.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.1.tgz",
+      "integrity": "sha512-qzEhqQc/mc+fdxtDIWGd53p1fyptq7qmAT5tFYY9sNAylabOXTIdYTglAtVq+oNYwZg3WuWRx30mqTI7NGz4Qg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.656.0",
+    "@bigcommerce/checkout-sdk": "^1.656.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
To update code
checkout-sdk-js PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/2645
https://github.com/bigcommerce/checkout-sdk-js/pull/2644

## Testing / Proof
Unit tests

@bigcommerce/team-checkout
