### PR TITLE
chore(payment): PI-2549 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.656.1",
+        "@bigcommerce/checkout-sdk": "^1.657.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.656.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.1.tgz",
-      "integrity": "sha512-qzEhqQc/mc+fdxtDIWGd53p1fyptq7qmAT5tFYY9sNAylabOXTIdYTglAtVq+oNYwZg3WuWRx30mqTI7NGz4Qg==",
+      "version": "1.657.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.657.0.tgz",
+      "integrity": "sha512-rficYmQaU8bCtvHxvuM/EwSxls4S8yXYUtX6jzkfr5pJwMfmWFAYZFsZ9nLwqxZ5pBJQLERrjwd+LVaNBZesnA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.656.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.656.1.tgz",
-      "integrity": "sha512-qzEhqQc/mc+fdxtDIWGd53p1fyptq7qmAT5tFYY9sNAylabOXTIdYTglAtVq+oNYwZg3WuWRx30mqTI7NGz4Qg==",
+      "version": "1.657.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.657.0.tgz",
+      "integrity": "sha512-rficYmQaU8bCtvHxvuM/EwSxls4S8yXYUtX6jzkfr5pJwMfmWFAYZFsZ9nLwqxZ5pBJQLERrjwd+LVaNBZesnA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.656.1",
+    "@bigcommerce/checkout-sdk": "^1.657.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2642](https://github.com/bigcommerce/checkout-sdk-js/pull/2642)

## Testing / Proof
Unit test and manually tested

@bigcommerce/team-checkout
