### PR TITLE
chore(payment): PAYPAL-4610 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.657.0",
+        "@bigcommerce/checkout-sdk": "^1.657.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.657.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.657.0.tgz",
-      "integrity": "sha512-rficYmQaU8bCtvHxvuM/EwSxls4S8yXYUtX6jzkfr5pJwMfmWFAYZFsZ9nLwqxZ5pBJQLERrjwd+LVaNBZesnA==",
+      "version": "1.657.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.657.1.tgz",
+      "integrity": "sha512-7zpAbhMlUekX2O7tqe03PQtsEpUQ8IgFKee+SqIlMwTL1qOdHaTQ0MRT5dpPnMZO9t7qbyqNCtLmAIz+EBlpJg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.657.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.657.0.tgz",
-      "integrity": "sha512-rficYmQaU8bCtvHxvuM/EwSxls4S8yXYUtX6jzkfr5pJwMfmWFAYZFsZ9nLwqxZ5pBJQLERrjwd+LVaNBZesnA==",
+      "version": "1.657.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.657.1.tgz",
+      "integrity": "sha512-7zpAbhMlUekX2O7tqe03PQtsEpUQ8IgFKee+SqIlMwTL1qOdHaTQ0MRT5dpPnMZO9t7qbyqNCtLmAIz+EBlpJg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.657.0",
+    "@bigcommerce/checkout-sdk": "^1.657.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver artifacts:

https://github.com/bigcommerce/checkout-sdk-js/pull/2632

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
