### PR TITLE
refactor(payment): PAYPAL-4157 removed unnecessary Fastlane shipping strategy initialization

### DIFF
--- a/packages/core/src/app/shipping/ShippingForm.spec.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.spec.tsx
@@ -436,9 +436,6 @@ describe('ShippingForm Component', () => {
                     addresses: paypalFastlaneAddresses,
                 }),
             );
-            expect(initializeMock).toHaveBeenCalledWith({
-                methodId: PaymentMethodId.BraintreeAcceleratedCheckout,
-            });
         });
 
         it('renders shipping for with paypal fastlane addresses without strategy initialization if there is preselected shipping method id', () => {

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -14,7 +14,7 @@ import {
     ShippingInitializeOptions,
     ShippingRequestOptions,
 } from '@bigcommerce/checkout-sdk';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
@@ -96,22 +96,11 @@ const ShippingForm = ({
     isFloatingLabelEnabled,
     isInitialValueLoaded,
 }: ShippingFormProps & WithLanguageProps) => {
-    // TODO: remove PayPal Fastlane related code and useEffect when PayPal Fastlane will not be available for Store members
-    const {
-        isPayPalFastlaneEnabled,
-        paypalFastlaneAddresses,
-        shouldShowPayPalFastlaneShippingForm,
-    } = usePayPalFastlaneAddress();
+    const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
 
     const shippingAddresses = isPayPalFastlaneEnabled && isGuest
         ? paypalFastlaneAddresses
         : addresses;
-
-    useEffect(() => {
-        if (isPayPalFastlaneEnabled && !shouldShowPayPalFastlaneShippingForm) {
-            initialize({ methodId });
-        }
-    }, [isPayPalFastlaneEnabled, shouldShowPayPalFastlaneShippingForm, methodId, initialize]);
 
     return isMultiShippingMode ? (
         <MultiShippingForm

--- a/packages/paypal-fastlane-integration/src/usePayPalFastlaneAddress.ts
+++ b/packages/paypal-fastlane-integration/src/usePayPalFastlaneAddress.ts
@@ -29,8 +29,7 @@ const usePayPalFastlaneAddress = () => {
         paypalFastlaneAddresses.length > 0 &&
         customerAuthenticationState &&
         customerAuthenticationState !== 'CANCELED' &&
-        customerAuthenticationState !== 'unrecognized' &&
-        getConfig()?.checkoutSettings.features['PAYPAL-3996.paypal_fastlane_shipping_update'];
+        customerAuthenticationState !== 'unrecognized';
 
     return {
         isPayPalFastlaneEnabled,


### PR DESCRIPTION
## What?
Removed unnecessary Fastlane shipping strategy initialization

## Why?
Recently for Fastlane we supported 2 different shipping flow:
1. Fastlane user uses core checkout shipping component (when experiment is disabled);
2. Fastlane user uses Fastlane shipping component (when experiment is enabled);

Since testing passed successfully and the feature was rolled out to all tiers couple months ago, we to cleanup some code just to keep feature working as it should.

## Testing / Proof
Unit tests
Manual tests
CI

https://github.com/user-attachments/assets/789b20fc-4ac3-473c-abe6-2d900b61cc23


