### PR TITLE
chore(payment): PAYPAL-4580 bump checkout-sdk version - 1.658.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.658.0",
+        "@bigcommerce/checkout-sdk": "^1.658.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.658.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.658.0.tgz",
-      "integrity": "sha512-P4/WL6oKM1C84vNFg3YSKKxhgNKz3zA7nEkTnbi+G0atmbTGD3+DEFlTeF0B/4J6dpPOt4qnG8I9UpMD88H0Jg==",
+      "version": "1.658.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.658.1.tgz",
+      "integrity": "sha512-kAJEWctW8hwyldcZenZFAOLv45ipXSbBZDmIJrPpEoqhjfEttJy4qcniR8lVit6c4mHbUppnebFd3dO2J/Al4A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.658.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.658.0.tgz",
-      "integrity": "sha512-P4/WL6oKM1C84vNFg3YSKKxhgNKz3zA7nEkTnbi+G0atmbTGD3+DEFlTeF0B/4J6dpPOt4qnG8I9UpMD88H0Jg==",
+      "version": "1.658.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.658.1.tgz",
+      "integrity": "sha512-kAJEWctW8hwyldcZenZFAOLv45ipXSbBZDmIJrPpEoqhjfEttJy4qcniR8lVit6c4mHbUppnebFd3dO2J/Al4A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.658.0",
+    "@bigcommerce/checkout-sdk": "^1.658.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version - 1.658.1

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2652

## Testing / Proof
Unit tests
CI
