### PR TITLE
chore(payment): PAYPAL-4591 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.658.1",
+        "@bigcommerce/checkout-sdk": "^1.659.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.658.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.658.1.tgz",
-      "integrity": "sha512-kAJEWctW8hwyldcZenZFAOLv45ipXSbBZDmIJrPpEoqhjfEttJy4qcniR8lVit6c4mHbUppnebFd3dO2J/Al4A==",
+      "version": "1.659.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.659.0.tgz",
+      "integrity": "sha512-NZSb4XRXrw2ZgAVPaUevVc1W+FErLoGVI5j2AKH1Z/JFOrkeoUswJivNeViHtctupRA7nGyc5ypgjPl1XQewMw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.658.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.658.1.tgz",
-      "integrity": "sha512-kAJEWctW8hwyldcZenZFAOLv45ipXSbBZDmIJrPpEoqhjfEttJy4qcniR8lVit6c4mHbUppnebFd3dO2J/Al4A==",
+      "version": "1.659.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.659.0.tgz",
+      "integrity": "sha512-NZSb4XRXrw2ZgAVPaUevVc1W+FErLoGVI5j2AKH1Z/JFOrkeoUswJivNeViHtctupRA7nGyc5ypgjPl1XQewMw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.658.1",
+    "@bigcommerce/checkout-sdk": "^1.659.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
To update code
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2654

## Testing / Proof
Unit tests

@bigcommerce/team-checkout
