### PR TITLE
chore(payment): PAYPAL-4591 bump checkout sdk version to 1.659.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.659.0",
+        "@bigcommerce/checkout-sdk": "^1.659.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.659.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.659.0.tgz",
-      "integrity": "sha512-NZSb4XRXrw2ZgAVPaUevVc1W+FErLoGVI5j2AKH1Z/JFOrkeoUswJivNeViHtctupRA7nGyc5ypgjPl1XQewMw==",
+      "version": "1.659.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.659.1.tgz",
+      "integrity": "sha512-x+FDI2NQVV/8os7fSFJWTTIvEXGHYLVeCekEr8g5M1OONNQZrF1N8S5fRyXXFAel/PHcSYT+KN0dlEqjPHmw3w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.659.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.659.0.tgz",
-      "integrity": "sha512-NZSb4XRXrw2ZgAVPaUevVc1W+FErLoGVI5j2AKH1Z/JFOrkeoUswJivNeViHtctupRA7nGyc5ypgjPl1XQewMw==",
+      "version": "1.659.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.659.1.tgz",
+      "integrity": "sha512-x+FDI2NQVV/8os7fSFJWTTIvEXGHYLVeCekEr8g5M1OONNQZrF1N8S5fRyXXFAel/PHcSYT+KN0dlEqjPHmw3w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.659.0",
+    "@bigcommerce/checkout-sdk": "^1.659.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version to 1.659.1

## Why?
As part of revert:
https://github.com/bigcommerce/checkout-sdk-js/pull/2656

## Testing / Proof
CI
