### PR TITLE
feat(payment): STRIPE-444 New Stripe UPE (PoC)

### DIFF
--- a/packages/core/src/app/ui/form/index.ts
+++ b/packages/core/src/app/ui/form/index.ts
@@ -18,6 +18,5 @@ export { default as CheckboxInput } from './CheckboxInput';
 export { default as Label, LabelProps } from './Label';
 export { default as Legend, LegendProps } from './Legend';
 export { default as ChecklistItemInput, ChecklistItemInputProps } from './ChecklistItemInput';
-export { default as CustomChecklistItem, CustomChecklistItemProps } from './CustomChecklistItem';
 export { default as DynamicFormField } from './DynamicFormField';
 export { default as DynamicFormFieldType } from './DynamicFormFieldType';

--- a/packages/core/src/app/ui/form/index.ts
+++ b/packages/core/src/app/ui/form/index.ts
@@ -18,5 +18,6 @@ export { default as CheckboxInput } from './CheckboxInput';
 export { default as Label, LabelProps } from './Label';
 export { default as Legend, LegendProps } from './Legend';
 export { default as ChecklistItemInput, ChecklistItemInputProps } from './ChecklistItemInput';
+export { default as CustomChecklistItem, CustomChecklistItemProps } from './CustomChecklistItem';
 export { default as DynamicFormField } from './DynamicFormField';
 export { default as DynamicFormFieldType } from './DynamicFormFieldType';

--- a/packages/core/src/scss/components/checkout/checklist/_checklist.scss
+++ b/packages/core/src/scss/components/checkout/checklist/_checklist.scss
@@ -212,3 +212,14 @@
         will-change: $loading-skeleton-will-change;
     }
 }
+
+.custom-checklist-item {
+    margin: 0;
+    overflow: hidden;
+    border-bottom: 0;
+
+    .paymentMethod--hosted,
+    .widget {
+        padding: 0;
+    }
+}

--- a/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
@@ -1,6 +1,13 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { noop, some } from 'lodash';
-import React, { FunctionComponent, useCallback, useMemo } from 'react';
+import React, {
+    FunctionComponent,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+} from 'react';
 
 import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
 import { HostedWidgetPaymentComponent } from '@bigcommerce/checkout/hosted-widget-integration';
@@ -13,6 +20,7 @@ import {
     PaymentMethodResolveId,
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
+import { AccordionContext } from '@bigcommerce/checkout/ui';
 
 const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     paymentForm,
@@ -22,8 +30,18 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     onUnhandledError = noop,
     ...rest
 }) => {
+    const collapseStripeElement = useRef<() => void>();
+    const { onToggle, selectedItemId } = useContext(AccordionContext);
     const containerId = `stripe-${method.id}-component-field`;
     const paymentContext = paymentForm;
+
+    useEffect(() => {
+        if (selectedItemId?.includes('stripeupe-')) {
+            return;
+        }
+
+        collapseStripeElement.current?.();
+    }, [selectedItemId]);
 
     const renderSubmitButton = useCallback(() => {
         paymentContext.hidePaymentSubmitButton(method, false);
@@ -69,6 +87,10 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         return getAppliedStyles(parentContainer, properties);
     };
 
+    // const accordionCollapseListener = (collapseElement: () => void) => {
+    //     collapseStripeElement.current = collapseElement;
+    // };
+
     const initializeStripePayment = useCallback(
         async (options: PaymentInitializeOptions) => {
             const formInput = getStylesFromElement(`${containerId}--input`, [
@@ -97,6 +119,10 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     },
                     onError: onUnhandledError,
                     render: renderSubmitButton,
+                    paymentMethodSelect: onToggle,
+                    handleClosePaymentMethod: (collapseElement: () => void) => {
+                        collapseStripeElement.current = collapseElement;
+                    },
                 },
             });
         },
@@ -107,6 +133,7 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             method,
             paymentContext,
             renderSubmitButton,
+            onToggle,
         ],
     );
 

--- a/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
@@ -87,10 +87,6 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         return getAppliedStyles(parentContainer, properties);
     };
 
-    // const accordionCollapseListener = (collapseElement: () => void) => {
-    //     collapseStripeElement.current = collapseElement;
-    // };
-
     const initializeStripePayment = useCallback(
         async (options: PaymentInitializeOptions) => {
             const formInput = getStylesFromElement(`${containerId}--input`, [


### PR DESCRIPTION
## What?
PoC how we can implement custom view for payment method inside our default payment methods accordion.

In our case it is for new Stripe implementation which uses custom accordion view and group multiple payment methods in one payment element.
This custom accordion should be rendered inside our default payment methods list. Also it should be sorted by some additional logic and can be placed on any position in default accordion.
Current PoC does not contain all Stripe Element styling, because we are waiting for some fixes on stripe side.

Also Accordion ui and context was migrated to the shared UI package to be available for payment integration packages.

## Why?
...

## Testing / Proof

https://github.com/user-attachments/assets/e79bfd32-e011-4649-9c7e-c78763b57fad




@bigcommerce/team-checkout
