### PR TITLE
CHECKOUT-8519: Load scripts with integrity hashes to meet PCI4 requirements

### DIFF
--- a/scripts/webpack/index.js
+++ b/scripts/webpack/index.js
@@ -3,5 +3,6 @@ module.exports = {
     BuildHookPlugin: require('./build-hook-plugin'),
     getNextVersion: require('./get-next-version'),
     transformManifest: require('./transform-manifest'),
+    mergeManifests: require('./merge-manifests'),
     getLoaderPackages: require('./get-loader-packages'),
 };

--- a/scripts/webpack/merge-manifests.js
+++ b/scripts/webpack/merge-manifests.js
@@ -1,0 +1,23 @@
+const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { isArray, mergeWith } = require('lodash');
+
+function mergeManifests(outputPath, sourcePathA, sourcePathB) {
+    if (!existsSync(sourcePathA) || !existsSync(sourcePathB)) {
+        throw new Error('Unable to merge manifests as one of the sources does not exist');
+    }
+
+    const manifestA = JSON.parse(readFileSync(sourcePathA, 'utf8'));
+    const manifestB = JSON.parse(readFileSync(sourcePathB, 'utf8'));
+
+    const result = mergeWith(manifestA, manifestB, (valueA, valueB) => {
+        if (!isArray(valueA) || !isArray(valueB)) {
+            return undefined;
+        }
+
+        return valueA.concat(valueB);
+    });
+
+    writeFileSync(outputPath, JSON.stringify(result, null, 2), 'utf8');
+}
+
+module.exports = mergeManifests;

--- a/scripts/webpack/transform-manifest.js
+++ b/scripts/webpack/transform-manifest.js
@@ -5,22 +5,37 @@ function transformManifest(assets, appVersion) {
     const [entries] = Object.values(assets.entrypoints);
     const entrypoints = omitBy(entries.assets, (_val, key) => key.toLowerCase().endsWith('.map'));
     const entrypointPaths = reduce(entrypoints, (result, files) => [...result, ...files], []);
-    const dynamicChunks = Object.values(assets).filter(path => {
-        return (
-            typeof path === 'string' && 
-            !path.toLowerCase().endsWith('.map') &&
-            !includes(entrypointPaths, path)
-        );
-    });
+
+    const dynamicChunks = Object.values(assets)
+        .filter(({ src }) => {
+            if (!src || includes(entrypointPaths, src)) {
+                return false;
+            }
+
+            return src.toLowerCase().endsWith('.js') || src.toLowerCase().endsWith('.css');
+        })
+        .map(({ src }) => src);
+
     const dynamicChunkGroups = groupBy(dynamicChunks, chunk => 
         extname(chunk).replace(/^\./, '')
     );
+
+    const integrityHashes = Object.values(assets)
+        .filter(({ src }) => {
+            if (!src) {
+                return false;
+            }
+
+            return src.toLowerCase().endsWith('.js') || src.toLowerCase().endsWith('.css');
+        })
+        .reduce((result, { src, integrity }) => ({ ...result, [src]: integrity }), {});
 
     return {
         version: 2,
         appVersion,
         dynamicChunks: dynamicChunkGroups,
         ...entrypoints,
+        integrity: integrityHashes,
     };
 }
 


### PR DESCRIPTION
## What?
Include integrity hashes in `manifest.json` to be added to the scripts and stylesheets used during checkout. Any script or stylesheet that doesn't match its corresponding subresource integrity hash ([SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)) will not be executed.

## Why?
To comply with the script integrity requirement ([6.4.3](https://www.pcisecuritystandards.org/wp-content/uploads/2023/09/05.Scaling-6.4.3-and-11.6.1-Browser-Script-Management-and-The-Large-Enterprise-Journey-to-Compliance.pdf)) of PCI4, which ensures that scripts executed during checkout have not been tampered with by a malicious attacker.

## Testing / Proof
<img width="887" alt="Screenshot 2024-09-23 at 4 06 31 PM" src="https://github.com/user-attachments/assets/74d6b3e8-7a8c-47f1-8bbc-e3969387bab2">

@bigcommerce/team-checkout
