### PR TITLE
fix(checkout): CHECKOUT-8006 Optimise Shipping Option Updates

### DIFF
--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -85,6 +85,7 @@ export interface WithCheckoutShippingProps {
     updateCheckout(payload: CheckoutRequestBody): Promise<CheckoutSelectors>;
     updateShippingAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
     shouldRenderStripeForm: boolean;
+    moveCheckUpdatedAddressValueWithinDebouncedExperiment: boolean;
 }
 
 interface ShippingState {
@@ -134,6 +135,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             isFloatingLabelEnabled,
             shouldRenderStripeForm,
             shouldRenderWhileLoading,
+            moveCheckUpdatedAddressValueWithinDebouncedExperiment,
             ...shippingFormProps
         } = this.props;
 
@@ -180,6 +182,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         isGuest={isGuest}
                         isInitialValueLoaded={shouldRenderWhileLoading ? !isInitializing : true}
                         isMultiShippingMode={isMultiShippingMode}
+                        moveCheckUpdatedAddressValueWithinDebouncedExperiment={moveCheckUpdatedAddressValueWithinDebouncedExperiment}
                         onMultiShippingSubmit={this.handleMultiShippingSubmit}
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}
                         onUseNewAddress={this.handleUseNewAddress}
@@ -434,6 +437,7 @@ export function mapToShippingProps({
         updateShippingAddress: checkoutService.updateShippingAddress,
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
         shouldRenderStripeForm: providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart),
+        moveCheckUpdatedAddressValueWithinDebouncedExperiment: features['CHECKOUT-8006.move_check_updated_address_value_within_debounced'] ?? false,
     };
 }
 

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -85,7 +85,7 @@ export interface WithCheckoutShippingProps {
     updateCheckout(payload: CheckoutRequestBody): Promise<CheckoutSelectors>;
     updateShippingAddress(address: Partial<Address>): Promise<CheckoutSelectors>;
     shouldRenderStripeForm: boolean;
-    moveCheckUpdatedAddressValueWithinDebouncedExperiment: boolean;
+    isDebouncedCheckAndUpdateAddressExperiment: boolean;
 }
 
 interface ShippingState {
@@ -135,7 +135,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             isFloatingLabelEnabled,
             shouldRenderStripeForm,
             shouldRenderWhileLoading,
-            moveCheckUpdatedAddressValueWithinDebouncedExperiment,
+            isDebouncedCheckAndUpdateAddressExperiment,
             ...shippingFormProps
         } = this.props;
 
@@ -178,11 +178,11 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         deinitialize={deinitializeShippingMethod}
                         initialize={initializeShippingMethod}
                         isBillingSameAsShipping={isBillingSameAsShipping}
+                        isDebouncedCheckAndUpdateAddressExperiment={isDebouncedCheckAndUpdateAddressExperiment}
                         isFloatingLabelEnabled={isFloatingLabelEnabled}
                         isGuest={isGuest}
                         isInitialValueLoaded={shouldRenderWhileLoading ? !isInitializing : true}
                         isMultiShippingMode={isMultiShippingMode}
-                        moveCheckUpdatedAddressValueWithinDebouncedExperiment={moveCheckUpdatedAddressValueWithinDebouncedExperiment}
                         onMultiShippingSubmit={this.handleMultiShippingSubmit}
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}
                         onUseNewAddress={this.handleUseNewAddress}
@@ -437,7 +437,7 @@ export function mapToShippingProps({
         updateShippingAddress: checkoutService.updateShippingAddress,
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
         shouldRenderStripeForm: providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart),
-        moveCheckUpdatedAddressValueWithinDebouncedExperiment: features['CHECKOUT-8006.move_check_updated_address_value_within_debounced'] ?? false,
+        isDebouncedCheckAndUpdateAddressExperiment: features['CHECKOUT-8006.move_check_updated_address_value_within_debounced'] ?? false,
     };
 }
 

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -24,7 +24,7 @@ import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
 import { isEqualAddress, mapAddressFromFormValues } from '../address';
 import { withCheckout } from '../checkout';
 import CheckoutStepStatus from '../checkout/CheckoutStepStatus';
-import { EMPTY_ARRAY, isFloatingLabelEnabled } from '../common/utility';
+import { EMPTY_ARRAY, isExperimentEnabled, isFloatingLabelEnabled } from '../common/utility';
 import getProviderWithCustomCheckout from '../payment/getProviderWithCustomCheckout';
 import { PaymentMethodId } from '../payment/paymentMethod';
 
@@ -437,7 +437,7 @@ export function mapToShippingProps({
         updateShippingAddress: checkoutService.updateShippingAddress,
         isFloatingLabelEnabled: isFloatingLabelEnabled(config.checkoutSettings),
         shouldRenderStripeForm: providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart),
-        isDebouncedCheckAndUpdateAddressExperiment: features['CHECKOUT-8006.move_check_updated_address_value_within_debounced'] ?? false,
+        isDebouncedCheckAndUpdateAddressExperiment: isExperimentEnabled(config.checkoutSettings, 'CHECKOUT-8006.move_check_updated_address_value_within_debounced'),
     };
 }
 

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -38,7 +38,7 @@ export interface ShippingFormProps {
     isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
-    moveCheckUpdatedAddressValueWithinDebouncedExperiment: boolean;
+    isDebouncedCheckAndUpdateAddressExperiment: boolean;
     shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
@@ -91,7 +91,7 @@ const ShippingForm = ({
     shippingAddress,
     shouldShowOrderComments,
     shouldShowSaveAddress,
-    moveCheckUpdatedAddressValueWithinDebouncedExperiment,
+    isDebouncedCheckAndUpdateAddressExperiment,
     signOut,
     updateAddress,
     isShippingStepPending,
@@ -143,13 +143,13 @@ const ShippingForm = ({
             googleMapsApiKey={googleMapsApiKey}
             initialize={initialize}
             isBillingSameAsShipping={isBillingSameAsShipping}
+            isDebouncedCheckAndUpdateAddressExperiment={isDebouncedCheckAndUpdateAddressExperiment}
             isFloatingLabelEnabled={isFloatingLabelEnabled}
             isInitialValueLoaded={isInitialValueLoaded}
             isLoading={isLoading}
             isMultiShippingMode={isMultiShippingMode}
             isShippingStepPending={isShippingStepPending}
             methodId={methodId}
-            moveCheckUpdatedAddressValueWithinDebouncedExperiment={moveCheckUpdatedAddressValueWithinDebouncedExperiment}
             onSubmit={onSingleShippingSubmit}
             onUnhandledError={onUnhandledError}
             shippingAddress={shippingAddress}

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -38,6 +38,7 @@ export interface ShippingFormProps {
     isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
+    moveCheckUpdatedAddressValueWithinDebouncedExperiment: boolean;
     shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
@@ -90,6 +91,7 @@ const ShippingForm = ({
     shippingAddress,
     shouldShowOrderComments,
     shouldShowSaveAddress,
+    moveCheckUpdatedAddressValueWithinDebouncedExperiment,
     signOut,
     updateAddress,
     isShippingStepPending,
@@ -147,6 +149,7 @@ const ShippingForm = ({
             isMultiShippingMode={isMultiShippingMode}
             isShippingStepPending={isShippingStepPending}
             methodId={methodId}
+            moveCheckUpdatedAddressValueWithinDebouncedExperiment={moveCheckUpdatedAddressValueWithinDebouncedExperiment}
             onSubmit={onSingleShippingSubmit}
             onUnhandledError={onUnhandledError}
             shippingAddress={shippingAddress}

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -39,7 +39,7 @@ describe('SingleShippingForm', () => {
         initialize: jest.fn(),
         updateAddress: jest.fn(),
         deleteConsignments: jest.fn(),
-        moveCheckUpdatedAddressValueWithinDebouncedExperiment: true,
+        isDebouncedCheckAndUpdateAddressExperiment: true,
     };
 
     const shippingAutosaveDelay = 100;

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -39,6 +39,7 @@ describe('SingleShippingForm', () => {
         initialize: jest.fn(),
         updateAddress: jest.fn(),
         deleteConsignments: jest.fn(),
+        moveCheckUpdatedAddressValueWithinDebouncedExperiment: true,
     };
 
     const shippingAutosaveDelay = 100;
@@ -93,6 +94,22 @@ describe('SingleShippingForm', () => {
                 },
             },
         );
+    });
+
+    it('does not call updateAddress if the shipping form values do not change', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({ updateAddress });
+
+        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
+        await userEvent.keyboard('foo 1');
+
+        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
+        await userEvent.keyboard(getShippingAddress().address1);
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalledTimes(0);
     });
 
     it('calls updateAddress if modified field does not affect shipping but makes form valid', async () => {

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -53,7 +53,7 @@ export interface SingleShippingFormProps {
     methodId?: string;
     shippingAddress?: Address;
     shippingAutosaveDelay?: number;
-    moveCheckUpdatedAddressValueWithinDebouncedExperiment: boolean;
+    isDebouncedCheckAndUpdateAddressExperiment: boolean;
     shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
@@ -200,7 +200,7 @@ class SingleShippingForm extends PureComponent<
             values: { shippingAddress: addressForm },
             isShippingStepPending,
             isFloatingLabelEnabled,
-            moveCheckUpdatedAddressValueWithinDebouncedExperiment
+            isDebouncedCheckAndUpdateAddressExperiment
         } = this.props;
 
         const { isResettingAddress, isUpdatingShippingData, hasRequestedShippingOptions } =
@@ -225,7 +225,7 @@ class SingleShippingForm extends PureComponent<
                         hasRequestedShippingOptions={hasRequestedShippingOptions}
                         initialize={initialize}
                         isFloatingLabelEnabled={isFloatingLabelEnabled}
-                        isLoading={isResettingAddress || (moveCheckUpdatedAddressValueWithinDebouncedExperiment && isUpdatingShippingData)}
+                        isLoading={isResettingAddress || (isDebouncedCheckAndUpdateAddressExperiment && isUpdatingShippingData)}
                         isShippingStepPending={isShippingStepPending}
                         methodId={methodId}
                         onAddressSelect={this.handleAddressSelect}
@@ -268,7 +268,7 @@ class SingleShippingForm extends PureComponent<
     };
 
     private handleFieldChange: (name: string) => void = async (name) => {
-        const { setFieldValue, moveCheckUpdatedAddressValueWithinDebouncedExperiment } = this.props;
+        const { setFieldValue, isDebouncedCheckAndUpdateAddressExperiment } = this.props;
 
         if (name === 'countryCode') {
             setFieldValue('shippingAddress.stateOrProvince', '');
@@ -288,7 +288,7 @@ class SingleShippingForm extends PureComponent<
             return;
         }
 
-        if (moveCheckUpdatedAddressValueWithinDebouncedExperiment) {
+        if (isDebouncedCheckAndUpdateAddressExperiment) {
             this.debouncedUpdateAddressExperimentOn(isShippingField || !hasRequestedShippingOptions);
 
             return;


### PR DESCRIPTION
## What?  
Moved the shipping address form value change detection into the debounce function.

## Why?  
This ensures that the API call to fetch available shipping options is only triggered when the form values (like the postcode) have been updated and the user has stopped typing.

## Rollout/Rollback
Turn off experiment `CHECKOUT-8006.move_check_updated_address_value_within_debounced`

## Testing / Proof
- [x] unit test
- [x] manual test
### Setup  
- PostCode: `2000` - Free Shipping  
- PostCode: `20001` - Flat rate $6.65  

### Before  
When changing the postcode and switching back quickly, different shipping options were displayed due to immediate API calls.  

https://github.com/user-attachments/assets/54b3ec36-88dd-46ee-ba16-8ff692cb0e5c  

### After  
Now, the shipping options only update after typing has stopped, ensuring accuracy in the options displayed. Additionally, while the shipping options are refreshing, the shipping address form shows a loading icon to indicate that an update is in progress.  

https://github.com/user-attachments/assets/7674c645-ef6b-4844-bda0-789f77bc1012  

---

@bigcommerce/team-checkout