### PR TITLE
chore(payment): PAYPAL-4591 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.660.1",
+        "@bigcommerce/checkout-sdk": "^1.661.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.660.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.660.1.tgz",
-      "integrity": "sha512-2i/Rut3cFKG4hk7ARD++O387W29Hq00URe0mD6JjQZqo7hZ6hq1ZlVCMhjRwJy7Z9JR6H3C6K3/7jYlJvxkXbg==",
+      "version": "1.661.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.0.tgz",
+      "integrity": "sha512-kk8b+xy7/7iiMG2jbabSQvKeScrrg1p62knXFiGe6SM5x8qou1+M/CvrVt1FD3cdafc8DQ1WQ4efNu3d7HKjww==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.660.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.660.1.tgz",
-      "integrity": "sha512-2i/Rut3cFKG4hk7ARD++O387W29Hq00URe0mD6JjQZqo7hZ6hq1ZlVCMhjRwJy7Z9JR6H3C6K3/7jYlJvxkXbg==",
+      "version": "1.661.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.0.tgz",
+      "integrity": "sha512-kk8b+xy7/7iiMG2jbabSQvKeScrrg1p62knXFiGe6SM5x8qou1+M/CvrVt1FD3cdafc8DQ1WQ4efNu3d7HKjww==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.660.1",
+    "@bigcommerce/checkout-sdk": "^1.661.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2658

## Testing / Proof
unit tests

@bigcommerce/team-checkout
