### PR TITLE
chore(payment): PAYPAL-4716 bump checkout-sdk version to 1.661.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.661.0",
+        "@bigcommerce/checkout-sdk": "^1.661.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.661.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.0.tgz",
-      "integrity": "sha512-kk8b+xy7/7iiMG2jbabSQvKeScrrg1p62knXFiGe6SM5x8qou1+M/CvrVt1FD3cdafc8DQ1WQ4efNu3d7HKjww==",
+      "version": "1.661.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.1.tgz",
+      "integrity": "sha512-AsB+GIyRO1DsUacUeOJHN15FUJ4TCSZLDEVd+0ZmyOWfJlZASOWOYbWA0gqfXe0F0BvPbXBZEK1iYW/E4eOiyA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35689,9 +35689,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.661.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.0.tgz",
-      "integrity": "sha512-kk8b+xy7/7iiMG2jbabSQvKeScrrg1p62knXFiGe6SM5x8qou1+M/CvrVt1FD3cdafc8DQ1WQ4efNu3d7HKjww==",
+      "version": "1.661.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.1.tgz",
+      "integrity": "sha512-AsB+GIyRO1DsUacUeOJHN15FUJ4TCSZLDEVd+0ZmyOWfJlZASOWOYbWA0gqfXe0F0BvPbXBZEK1iYW/E4eOiyA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.661.0",
+    "@bigcommerce/checkout-sdk": "^1.661.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.661.1

## Why?
To release the revert: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2663

## Testing / Proof
Manual tests
