### PR TITLE
chore(checkout): CHECKOUT-8653 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.661.1",
+        "@bigcommerce/checkout-sdk": "^1.661.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.661.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.1.tgz",
-      "integrity": "sha512-AsB+GIyRO1DsUacUeOJHN15FUJ4TCSZLDEVd+0ZmyOWfJlZASOWOYbWA0gqfXe0F0BvPbXBZEK1iYW/E4eOiyA==",
+      "version": "1.661.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.2.tgz",
+      "integrity": "sha512-EzBUpdJGLJssOzBFDkBd6WIyjRTaJLXrZ1mYpcgzUw0uXC/B8X4iSqnnxZnLQ+oR/xModOhMJiYhi1khzlaTRw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -1811,12 +1811,14 @@
         "reselect": "^4.1.8",
         "rxjs": "^6.6.7",
         "shallowequal": "^1.1.0",
-        "tslib": "^1.10.0",
         "yup": "^1.2.0"
       },
       "engines": {
         "node": "20",
         "npm": "9"
+      },
+      "optionalDependencies": {
+        "@swc/core-linux-x64-gnu": "^1.5.29"
       }
     },
     "node_modules/@bigcommerce/checkout-sdk/node_modules/@bigcommerce/request-sender": {
@@ -1851,6 +1853,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@bigcommerce/checkout-sdk/node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.7.28",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.28.tgz",
+      "integrity": "sha512-HGwpWuB83Kr+V0E+zT5UwIIY9OxiS8aLd0UVMRVWuO8SrQyKm9HKJ46+zoAb8tfJrpZftfxvbn2ayZWR7gqosA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@bigcommerce/checkout-sdk/node_modules/property-expr": {
@@ -34955,9 +34972,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.661.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.1.tgz",
-      "integrity": "sha512-AsB+GIyRO1DsUacUeOJHN15FUJ4TCSZLDEVd+0ZmyOWfJlZASOWOYbWA0gqfXe0F0BvPbXBZEK1iYW/E4eOiyA==",
+      "version": "1.661.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.2.tgz",
+      "integrity": "sha512-EzBUpdJGLJssOzBFDkBd6WIyjRTaJLXrZ1mYpcgzUw0uXC/B8X4iSqnnxZnLQ+oR/xModOhMJiYhi1khzlaTRw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -34966,6 +34983,7 @@
         "@bigcommerce/request-sender": "^1.2.4",
         "@bigcommerce/script-loader": "^2.2.2",
         "@braintree/browser-detection": "^1.16.0",
+        "@swc/core-linux-x64-gnu": "^1.5.29",
         "@types/card-validator": "^4.1.0",
         "@types/iframe-resizer": "^3.5.13",
         "@types/reselect": "^2.2.0",
@@ -34981,7 +34999,6 @@
         "reselect": "^4.1.8",
         "rxjs": "^6.6.7",
         "shallowequal": "^1.1.0",
-        "tslib": "^1.10.0",
         "yup": "^1.2.0"
       },
       "dependencies": {
@@ -35009,6 +35026,12 @@
               }
             }
           }
+        },
+        "@swc/core-linux-x64-gnu": {
+          "version": "1.7.28",
+          "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.28.tgz",
+          "integrity": "sha512-HGwpWuB83Kr+V0E+zT5UwIIY9OxiS8aLd0UVMRVWuO8SrQyKm9HKJ46+zoAb8tfJrpZftfxvbn2ayZWR7gqosA==",
+          "optional": true
         },
         "property-expr": {
           "version": "2.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.661.2",
+        "@bigcommerce/checkout-sdk": "^1.661.6",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.661.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.2.tgz",
-      "integrity": "sha512-EzBUpdJGLJssOzBFDkBd6WIyjRTaJLXrZ1mYpcgzUw0uXC/B8X4iSqnnxZnLQ+oR/xModOhMJiYhi1khzlaTRw==",
+      "version": "1.661.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.6.tgz",
+      "integrity": "sha512-VoJIMJNhjeAeahxqtkN17IQUku9HH2nHKfLlwOh6zYkCFEmmnew6mJH60oNsnSPzVjZUAXg9rV9mko0I4mSNnA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -1811,6 +1811,7 @@
         "reselect": "^4.1.8",
         "rxjs": "^6.6.7",
         "shallowequal": "^1.1.0",
+        "tslib": "^2.4.0",
         "yup": "^1.2.0"
       },
       "engines": {
@@ -32427,9 +32428,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -34972,9 +34973,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.661.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.2.tgz",
-      "integrity": "sha512-EzBUpdJGLJssOzBFDkBd6WIyjRTaJLXrZ1mYpcgzUw0uXC/B8X4iSqnnxZnLQ+oR/xModOhMJiYhi1khzlaTRw==",
+      "version": "1.661.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.6.tgz",
+      "integrity": "sha512-VoJIMJNhjeAeahxqtkN17IQUku9HH2nHKfLlwOh6zYkCFEmmnew6mJH60oNsnSPzVjZUAXg9rV9mko0I4mSNnA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -34999,6 +35000,7 @@
         "reselect": "^4.1.8",
         "rxjs": "^6.6.7",
         "shallowequal": "^1.1.0",
+        "tslib": "^2.4.0",
         "yup": "^1.2.0"
       },
       "dependencies": {
@@ -58367,9 +58369,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "tslint": {
       "version": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.661.1",
+    "@bigcommerce/checkout-sdk": "^1.661.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.661.2",
+    "@bigcommerce/checkout-sdk": "^1.661.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk `v1.661.6`.

## Why?
Release lastest SDK change(s):
* https://github.com/bigcommerce/checkout-sdk-js/pull/2668

## Testing / Proof
* CI checks.

@bigcommerce/team-checkout
