### PR TITLE
CHECKOUT-8519: Enable integrity hashes when experiment is on

### DIFF
--- a/packages/core/src/app/loader.spec.ts
+++ b/packages/core/src/app/loader.spec.ts
@@ -89,6 +89,22 @@ describe('loadFiles', () => {
         });
     });
 
+    it('loads required JS files listed in manifest when experiment is off', async () => {
+        await loadFiles({
+            ...options,
+            isIntegrityHashExperimentEnabled: false,
+        });
+
+        expect(getScriptLoader().loadScript).toHaveBeenCalledWith('https://cdn.foo.bar/vendor.js', {
+            async: false,
+            attributes: {},
+        });
+        expect(getScriptLoader().loadScript).toHaveBeenCalledWith('https://cdn.foo.bar/main.js', {
+            async: false,
+            attributes: {},
+        });
+    });
+
     it('loads required CSS files listed in manifest', async () => {
         await loadFiles(options);
 
@@ -105,6 +121,19 @@ describe('loadFiles', () => {
                 crossorigin: 'anonymous',
                 integrity: 'hash-main-css',
             },
+        });
+    });
+
+    it('loads required CSS files listed in manifest when experiment is off', async () => {
+        await loadFiles(options);
+
+        expect(getStylesheetLoader().loadStylesheet).toHaveBeenCalledWith('https://cdn.foo.bar/vendor.css', {
+            prepend: true,
+            attributes: {},
+        });
+        expect(getStylesheetLoader().loadStylesheet).toHaveBeenCalledWith('https://cdn.foo.bar/main.css', {
+            prepend: true,
+            attributes: {},
         });
     });
 

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -22,6 +22,7 @@ export interface AssetManifest {
 
 export interface LoadFilesOptions {
     publicPath?: string;
+    isIntegrityHashExperimentEnabled?: boolean;
 }
 
 export interface LoadFilesResult {
@@ -32,6 +33,7 @@ export interface LoadFilesResult {
 
 export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> {
     const publicPath = configurePublicPath(options && options.publicPath);
+    const isIntegrityHashExperimentEnabled = options?.isIntegrityHashExperimentEnabled ?? true;
     const {
         appVersion,
         css = [],
@@ -43,20 +45,20 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
     const scripts = Promise.all(js.filter(path => !path.startsWith('loader')).map((path) =>
         getScriptLoader().loadScript(joinPaths(publicPath, path), {
             async: false,
-            attributes: {
+            attributes: isIntegrityHashExperimentEnabled ? {
                 crossorigin: 'anonymous',
                 integrity: integrity[path],
-            }
+            } : {},
         })
     ));
 
     const stylesheets = Promise.all(css.map((path) =>
         getStylesheetLoader().loadStylesheet(joinPaths(publicPath, path), {
             prepend: true,
-            attributes: {
+            attributes: isIntegrityHashExperimentEnabled ? {
                 crossorigin: 'anonymous',
                 integrity: integrity[path],
-            }
+            } : {},
         })
     ));
 


### PR DESCRIPTION
## What?
Enable integrity hashes when `CHECKOUT-8519.add_integrity_hash_and_csp_nonce_to_checkout` experiment is on

## Why?
I realised this change (#2020) is not gated by the experiment.

## Testing / Proof
### When experiment is on
Scripts are loaded with integrity hashes
<img width="1278" alt="Screenshot 2024-10-01 at 3 00 40 PM" src="https://github.com/user-attachments/assets/aa26e9df-72ac-4955-ade2-681c2d2c6e3e">

### When experiment is off
Scripts are not loaded with integrity hashes
<img width="1278" alt="Screenshot 2024-10-01 at 3 03 16 PM" src="https://github.com/user-attachments/assets/927b8405-8ab8-45ef-9bd9-04d35228ca54">
