### PR TITLE
feat(payment): STRIPE-460 Add custom list item

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.spec.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.spec.tsx
@@ -4,7 +4,7 @@ import { Formik } from 'formik';
 import { noop, range } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
-import { Checklist, ChecklistItem } from '../../ui/form';
+import { Checklist, ChecklistItem, CustomChecklistItem } from '../../ui/form';
 import { getMobilePaymentMethod, getPaymentMethod } from '../payment-methods.mock';
 
 import PaymentMethodList, { PaymentMethodListProps } from './PaymentMethodList';
@@ -30,6 +30,7 @@ describe('PaymentMethodList', () => {
         const component = mount(<PaymentMethodListTest methods={methods} />);
 
         expect(component.find(ChecklistItem)).toHaveLength(methods.length);
+        expect(component.find(CustomChecklistItem)).toHaveLength(0);
     });
 
     it('renders mobile payment methods as checklist on mobile device', () => {
@@ -94,5 +95,14 @@ describe('PaymentMethodList', () => {
         const component = mount(<PaymentMethodListTest methods={methods} />);
 
         expect(component.find(Checklist).prop('defaultSelectedItemId')).toEqual(methods[0].id);
+    });
+
+    it('renders custom list item for provider with custom item', () => {
+        methods[0].initializationData.isCustomChecklistItem = true;
+        
+        const component = mount(<PaymentMethodListTest methods={methods} />);
+
+        expect(component.find(ChecklistItem)).toHaveLength(methods.length - 1);
+        expect(component.find(CustomChecklistItem)).toHaveLength(1);
     });
 });

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -4,7 +4,7 @@ import React, { FunctionComponent, memo, useCallback, useMemo } from 'react';
 
 import { connectFormik, ConnectFormikProps } from '../../common/form';
 import { isMobile } from '../../common/utility';
-import { Checklist, ChecklistItem } from '../../ui/form';
+import { Checklist, ChecklistItem, CustomChecklistItem } from '../../ui/form';
 
 import getUniquePaymentMethodId, { parseUniquePaymentMethodId } from './getUniquePaymentMethodId';
 import PaymentMethodTitle from './PaymentMethodTitle';
@@ -115,6 +115,15 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
         (isSelected: boolean) => <PaymentMethodTitle isSelected={isSelected} method={method} onUnhandledError={onUnhandledError} />,
         [method],
     );
+
+    if (method.initializationData?.isCustomChecklistItem) {
+        return (
+            <CustomChecklistItem
+                content={renderPaymentMethod}
+                htmlId={`radio-${value}`}
+            />
+        );
+    }
 
     return (
         <ChecklistItem

--- a/packages/core/src/app/ui/form/CustomChecklistItem.test.tsx
+++ b/packages/core/src/app/ui/form/CustomChecklistItem.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import CustomChecklistItem from './CustomChecklistItem';
+
+describe('CustomChecklistItem', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders custom checklist item', () => {
+        render(<CustomChecklistItem
+            content="Content"
+            htmlId="htmlId"
+        />);
+
+        const listItem = screen.getByText('Content');
+
+        expect(listItem).toBeInTheDocument();
+        expect(listItem).toHaveAttribute('id', 'htmlId');
+    });
+});

--- a/packages/core/src/app/ui/form/CustomChecklistItem.tsx
+++ b/packages/core/src/app/ui/form/CustomChecklistItem.tsx
@@ -1,0 +1,22 @@
+import React, { FunctionComponent, memo, ReactNode } from 'react';
+
+export interface CustomChecklistItemProps {
+    content?: ReactNode;
+    htmlId?: string;
+}
+
+const CustomChecklistItem: FunctionComponent<CustomChecklistItemProps> = ({
+    content,
+    htmlId,
+}) => {
+    return (
+        <li
+            className="form-checklist-item optimizedCheckout-form-checklist-item custom-checklist-item"
+            id={htmlId}
+        >
+            {content}
+        </li>
+    );
+};
+
+export default memo(CustomChecklistItem);

--- a/packages/core/src/app/ui/form/index.ts
+++ b/packages/core/src/app/ui/form/index.ts
@@ -6,6 +6,7 @@ export { default as BasicFormField, BasicFormFieldProps } from './BasicFormField
 export { default as CheckboxFormField, CheckboxFormFieldProps } from './CheckboxFormField';
 export { default as Checklist, ChecklistProps } from './Checklist';
 export { default as ChecklistItem, ChecklistItemProps } from './ChecklistItem';
+export { default as CustomChecklistItem } from './CustomChecklistItem';
 export { default as FormFieldError, FormFieldErrorProps } from './FormFieldError';
 export { default as FormFieldContainer } from './FormFieldContainer';
 export { default as Input, InputProps } from './Input';


### PR DESCRIPTION
## What?
Add Custom Checklist item.

## Why?
To use it on payments step. For payment methods that don't need checklist header and all logic for checklist selection, and have all this logic on provider side. For example new Stripe implementation.

## Testing / Proof

https://github.com/user-attachments/assets/e79bfd32-e011-4649-9c7e-c78763b57fad

Unit tests and manually tested.
<img width="2552" alt="Screenshot 2024-10-03 at 14 36 57" src="https://github.com/user-attachments/assets/1380495d-8d13-4f34-8f5b-8d80d8f25b3f">
<img width="2550" alt="Screenshot 2024-10-03 at 14 56 46" src="https://github.com/user-attachments/assets/bc5e1e41-b030-403a-9b9b-8b5d975ec105">


@bigcommerce/team-checkout
