### PR TITLE
CHECKOUT-8519: Upgrade yup to a version that does not trigger CSP error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "shallowequal": "^1.1.0",
         "tslib": "^2.5.3",
         "utility-types": "^2.1.0",
-        "yup": "^0.26.6"
+        "yup": "0.30.0"
       },
       "devDependencies": {
         "@babel/core": "^7.5.5",
@@ -1871,11 +1871,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@bigcommerce/checkout-sdk/node_modules/property-expr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "node_modules/@bigcommerce/checkout-sdk/node_modules/strict-uri-encode": {
       "version": "1.1.0",
@@ -16812,14 +16807,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "node_modules/fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha512-oIDB1rXf3BUnn00bh2jVM0byuqr94rBh6g7ZfdKcbmp1we2GQtPzKdloyvBXHs+q3fvxB8EqX5ecFba3RwCSjA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
@@ -28689,9 +28676,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
     },
     "node_modules/proto-list": {
       "version": "1.2.4",
@@ -31716,11 +31703,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/synchronous-promise": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
-      "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g=="
-    },
     "node_modules/synckit": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -33934,30 +33916,19 @@
       }
     },
     "node_modules/yup": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
-      "integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.30.0.tgz",
+      "integrity": "sha512-GX3vqpC9E+Ow0fmQPgqbEg7UV40XRrN1IOEgKF5v04v6T4ha2vBas/hu0thWgewk8L4wUEBLRO/EnXwYyP+p+A==",
       "dependencies": {
-        "@babel/runtime": "7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.10",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.5",
+        "@babel/runtime": "^7.10.5",
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.11",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
-    },
-    "node_modules/yup/node_modules/@babel/runtime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-      "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
-    "node_modules/yup/node_modules/regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     }
   },
   "dependencies": {
@@ -35156,11 +35127,6 @@
           "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.28.tgz",
           "integrity": "sha512-HGwpWuB83Kr+V0E+zT5UwIIY9OxiS8aLd0UVMRVWuO8SrQyKm9HKJ46+zoAb8tfJrpZftfxvbn2ayZWR7gqosA==",
           "optional": true
-        },
-        "property-expr": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
-          "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
         },
         "strict-uri-encode": {
           "version": "1.1.0",
@@ -46710,11 +46676,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha512-oIDB1rXf3BUnn00bh2jVM0byuqr94rBh6g7ZfdKcbmp1we2GQtPzKdloyvBXHs+q3fvxB8EqX5ecFba3RwCSjA=="
-    },
     "follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
@@ -55721,9 +55682,9 @@
       }
     },
     "property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
     },
     "proto-list": {
       "version": "1.2.4",
@@ -57968,11 +57929,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "synchronous-promise": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
-      "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g=="
-    },
     "synckit": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
@@ -59614,31 +59570,15 @@
       "dev": true
     },
     "yup": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
-      "integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.30.0.tgz",
+      "integrity": "sha512-GX3vqpC9E+Ow0fmQPgqbEg7UV40XRrN1IOEgKF5v04v6T4ha2vBas/hu0thWgewk8L4wUEBLRO/EnXwYyP+p+A==",
       "requires": {
-        "@babel/runtime": "7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.10",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.5",
+        "@babel/runtime": "^7.10.5",
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.11",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-          "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
-          "requires": {
-            "regenerator-runtime": "^0.12.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "shallowequal": "^1.1.0",
     "tslib": "^2.5.3",
     "utility-types": "^2.1.0",
-    "yup": "^0.26.6"
+    "yup": "0.30.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
@@ -53,7 +53,6 @@ export default memoize(function getCustomFormFieldsValidationSchema({
                         schema[name] = date()
                             // Transform NaN values to undefined to avoid empty string (empty input) to fail date
                             // validation when it's optional
-                            .strict(true)
                             .nullable(true)
                             .transform((value, originalValue) =>
                                 originalValue === '' ? null : value,
@@ -62,7 +61,6 @@ export default memoize(function getCustomFormFieldsValidationSchema({
                         schema[name] = number()
                             // Transform NaN values to undefined to avoid empty string (empty input) to fail number
                             // validation when it's optional
-                            .strict(true)
                             .transform((value) => (isNaN(value) ? undefined : value));
 
                         maxValue = typeof max === 'number' ? max : undefined;


### PR DESCRIPTION
## What?
Upgrade `yup` to a version that doesn't trigger CSP error.

## Why?
`yup` depends on an old version of `property-expr`, which evaluates arbitrary strings as JavaScript. The newer version of `yup` uses a version of `property-expr` that doesn't use `eval` anymore (see https://github.com/jquense/expr/pull/11).

I decided not to upgrade to the latest version of `yup` for now because it has several breaking changes (see https://github.com/jquense/yup/blob/master/CHANGELOG.md)

## Testing / Proof
### Before
This screenshot shows that `property-expr` package triggers CSP error when there is`script-src` policy.

<img width="1146" alt="Screenshot 2024-10-03 at 4 02 08 PM" src="https://github.com/user-attachments/assets/de19ca95-0e32-48c5-a9c2-6d9a22f81bb5">

### After
This screenshot shows that `property-expr` package no longer triggers CSP error when there is `script-src` policy.

<img width="1144" alt="Screenshot 2024-10-03 at 3 52 38 PM" src="https://github.com/user-attachments/assets/8ed90522-b0a0-4022-b2f1-fd60b5cc6856">


@bigcommerce/team-checkout
