### PR TITLE
CHECKOUT-8519: Skip merging manifest files if the build is unsuccessful so Webpack can output compilation error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const { join } = require('path');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
-const { isArray, mergeWith } = require('lodash');
 
 const {
     AsyncHookPlugin,
@@ -299,7 +298,11 @@ function loaderConfig(options, argv) {
                         transform: assets => transformManifest(assets, appVersion),
                         output: 'manifest-loader.json',
                         integrity: true,
-                        done() {
+                        done(_, { compilation: { errors = [] } }) {
+                            if (errors.length) {
+                                return;
+                            }
+
                             const folder = isProduction ? 'dist' : 'build';
 
                             mergeManifests(


### PR DESCRIPTION
## What/Why?
Skip merging manifest files if the build is unsuccessful. Otherwise, compilation errors will not be displayed in the console during development.

## Testing / Proof
<img width="1118" alt="Screenshot 2024-10-03 at 4 31 29 PM" src="https://github.com/user-attachments/assets/c50501c8-cde2-4b6e-bb68-722fef5a0748">

@bigcommerce/team-checkout
