### PR TITLE
chore(payment): PAYPAL-4681 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.661.6",
+        "@bigcommerce/checkout-sdk": "^1.662.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.661.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.6.tgz",
-      "integrity": "sha512-VoJIMJNhjeAeahxqtkN17IQUku9HH2nHKfLlwOh6zYkCFEmmnew6mJH60oNsnSPzVjZUAXg9rV9mko0I4mSNnA==",
+      "version": "1.662.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.662.0.tgz",
+      "integrity": "sha512-IxF6XVqRkDwFyjG1VYyPiG7kYMrokreEVAxYM0IP7iGc4O1W7hakDmVK+XEoGgB8ji1DiRrwN6U84FodjTIuHA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -34973,9 +34973,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.661.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.661.6.tgz",
-      "integrity": "sha512-VoJIMJNhjeAeahxqtkN17IQUku9HH2nHKfLlwOh6zYkCFEmmnew6mJH60oNsnSPzVjZUAXg9rV9mko0I4mSNnA==",
+      "version": "1.662.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.662.0.tgz",
+      "integrity": "sha512-IxF6XVqRkDwFyjG1VYyPiG7kYMrokreEVAxYM0IP7iGc4O1W7hakDmVK+XEoGgB8ji1DiRrwN6U84FodjTIuHA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.661.6",
+    "@bigcommerce/checkout-sdk": "^1.662.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2669

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
