### PR TITLE
chore(payment): PAYPAL-4704 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.662.0",
+        "@bigcommerce/checkout-sdk": "^1.662.5",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.662.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.662.0.tgz",
-      "integrity": "sha512-IxF6XVqRkDwFyjG1VYyPiG7kYMrokreEVAxYM0IP7iGc4O1W7hakDmVK+XEoGgB8ji1DiRrwN6U84FodjTIuHA==",
+      "version": "1.662.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.662.5.tgz",
+      "integrity": "sha512-YwF5bn4d8IlLXhvlifWvTuVXXfEziqPPyEdhdES7BS0J7Tcqc4gKJWPYSH0Emwkc/9/7sm++KnlQSrE6heMp7w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -34973,9 +34973,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.662.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.662.0.tgz",
-      "integrity": "sha512-IxF6XVqRkDwFyjG1VYyPiG7kYMrokreEVAxYM0IP7iGc4O1W7hakDmVK+XEoGgB8ji1DiRrwN6U84FodjTIuHA==",
+      "version": "1.662.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.662.5.tgz",
+      "integrity": "sha512-YwF5bn4d8IlLXhvlifWvTuVXXfEziqPPyEdhdES7BS0J7Tcqc4gKJWPYSH0Emwkc/9/7sm++KnlQSrE6heMp7w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.662.0",
+    "@bigcommerce/checkout-sdk": "^1.662.5",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped chechout-sdk-js version

## Why?
To deliver code
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2670

## Testing / Proof
Unit tests

@bigcommerce/team-checkout
