### PR TITLE
CHECKOUT-8519: Switch `messageformat` library when experiment is enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.668.0",
+        "@bigcommerce/checkout-sdk": "^1.668.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.668.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.668.0.tgz",
-      "integrity": "sha512-QqhYg971aRFKg8+ns3AV9WFlmfxdQmfeN6liQkMnA62D7e+WBT+nDfbEOPSwOtB69AN+HLjiq4N0mewb8uIRJA==",
+      "version": "1.668.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.668.1.tgz",
+      "integrity": "sha512-EztAc0vQrkAPBxkBtJhgnSLZWc2O71OdTsPNSbxi5Zd2IVxrEfJkuutyjecevhyaH5c4CQH5BhUkLVs08nRqxQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -1804,6 +1804,7 @@
         "core-js": "^3.31.0",
         "current-script-polyfill": "^1.0.0",
         "iframe-resizer": "^3.6.6",
+        "intl-messageformat": "^10.5.14",
         "local-storage-fallback": "^4.1.2",
         "lodash": "^4.17.15",
         "messageformat": "^2.3.0",
@@ -2333,6 +2334,51 @@
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.0.tgz",
+      "integrity": "sha512-IpM+ev1E4QLtstniOE29W1rqH9eTdx5hQdNL8pzrflMj/gogfaoONZqL83LUeQScHAvyMbpqP5C9MzNf+fFwhQ==",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.1",
+        "@formatjs/intl-localematcher": "0.5.5",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.1.tgz",
+      "integrity": "sha512-XS2RcOSyWxmUB7BUjj3mlPH0exsUzlf6QfhhijgI941WaJhVxXQ6mEWkdUFIdnKi3TuTYxRdelsgv3mjieIGIA==",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.10.tgz",
+      "integrity": "sha512-wlQfqCZ7PURkUNL2+8VTEFavPovtADU/isSKLFvDbdFmV7QPZIYqFMkhklaDYgMyLSBJa/h2MVQ2aFvoEJhxgg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/icu-skeleton-parser": "1.8.4",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.4.tgz",
+      "integrity": "sha512-LMQ1+Wk1QSzU4zpd5aSu7+w5oeYhupRwZnMQckLPRYhSjf2/8JWQ882BauY9NyHxs5igpuQIXZDgfkaH3PoATg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.5.tgz",
+      "integrity": "sha512-t5tOGMgZ/i5+ALl2/offNqAQq/lfUnKLEw0mXQI4N4bqpedhrSE+fyKLpwnd22sK0dif6AV+ufQcTsKShB9J1g==",
+      "dependencies": {
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18745,6 +18791,17 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.0.tgz",
+      "integrity": "sha512-2P06M9jFTqJnEQzE072VGPjbAx6ZG1YysgopAwc8ui0ajSjtwX1MeQ6bXFXIzKcNENJTizKkcJIcZ0zlpl1zSg==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/fast-memoize": "2.2.1",
+        "@formatjs/icu-messageformat-parser": "2.7.10",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -35037,9 +35094,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.668.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.668.0.tgz",
-      "integrity": "sha512-QqhYg971aRFKg8+ns3AV9WFlmfxdQmfeN6liQkMnA62D7e+WBT+nDfbEOPSwOtB69AN+HLjiq4N0mewb8uIRJA==",
+      "version": "1.668.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.668.1.tgz",
+      "integrity": "sha512-EztAc0vQrkAPBxkBtJhgnSLZWc2O71OdTsPNSbxi5Zd2IVxrEfJkuutyjecevhyaH5c4CQH5BhUkLVs08nRqxQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35057,6 +35114,7 @@
         "core-js": "^3.31.0",
         "current-script-polyfill": "^1.0.0",
         "iframe-resizer": "^3.6.6",
+        "intl-messageformat": "^10.5.14",
         "local-storage-fallback": "^4.1.2",
         "lodash": "^4.17.15",
         "messageformat": "^2.3.0",
@@ -35429,6 +35487,51 @@
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz",
       "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==",
       "dev": true
+    },
+    "@formatjs/ecma402-abstract": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.0.tgz",
+      "integrity": "sha512-IpM+ev1E4QLtstniOE29W1rqH9eTdx5hQdNL8pzrflMj/gogfaoONZqL83LUeQScHAvyMbpqP5C9MzNf+fFwhQ==",
+      "requires": {
+        "@formatjs/fast-memoize": "2.2.1",
+        "@formatjs/intl-localematcher": "0.5.5",
+        "tslib": "^2.7.0"
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.1.tgz",
+      "integrity": "sha512-XS2RcOSyWxmUB7BUjj3mlPH0exsUzlf6QfhhijgI941WaJhVxXQ6mEWkdUFIdnKi3TuTYxRdelsgv3mjieIGIA==",
+      "requires": {
+        "tslib": "^2.7.0"
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.10.tgz",
+      "integrity": "sha512-wlQfqCZ7PURkUNL2+8VTEFavPovtADU/isSKLFvDbdFmV7QPZIYqFMkhklaDYgMyLSBJa/h2MVQ2aFvoEJhxgg==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/icu-skeleton-parser": "1.8.4",
+        "tslib": "^2.7.0"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.4.tgz",
+      "integrity": "sha512-LMQ1+Wk1QSzU4zpd5aSu7+w5oeYhupRwZnMQckLPRYhSjf2/8JWQ882BauY9NyHxs5igpuQIXZDgfkaH3PoATg==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "tslib": "^2.7.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.5.tgz",
+      "integrity": "sha512-t5tOGMgZ/i5+ALl2/offNqAQq/lfUnKLEw0mXQI4N4bqpedhrSE+fyKLpwnd22sK0dif6AV+ufQcTsKShB9J1g==",
+      "requires": {
+        "tslib": "^2.7.0"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -48104,6 +48207,17 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
+    },
+    "intl-messageformat": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.0.tgz",
+      "integrity": "sha512-2P06M9jFTqJnEQzE072VGPjbAx6ZG1YysgopAwc8ui0ajSjtwX1MeQ6bXFXIzKcNENJTizKkcJIcZ0zlpl1zSg==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/fast-memoize": "2.2.1",
+        "@formatjs/icu-messageformat-parser": "2.7.10",
+        "tslib": "^2.7.0"
+      }
     },
     "into-stream": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.668.0",
+    "@bigcommerce/checkout-sdk": "^1.668.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/loader.spec.ts
+++ b/packages/core/src/app/loader.spec.ts
@@ -202,13 +202,17 @@ describe('loadFiles', () => {
     });
 
     it('initializes language service with default translations', async () => {
-        await loadFiles(options);
+        await loadFiles({
+            ...options,
+            isCspNonceExperimentEnabled: true,
+        });
 
         expect(appExports.initializeLanguageService).toHaveBeenCalledWith({
             defaultTranslations: expect.any(Object),
             locale: expect.any(String),
             locales: expect.any(Object),
             translations: expect.any(Object),
+            isCspNonceExperimentEnabled: true,
         });
     });
 });

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -23,6 +23,7 @@ export interface AssetManifest {
 export interface LoadFilesOptions {
     publicPath?: string;
     isIntegrityHashExperimentEnabled?: boolean;
+    isCspNonceExperimentEnabled?: boolean;
 }
 
 export interface LoadFilesResult {
@@ -34,6 +35,7 @@ export interface LoadFilesResult {
 export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> {
     const publicPath = configurePublicPath(options && options.publicPath);
     const isIntegrityHashExperimentEnabled = options?.isIntegrityHashExperimentEnabled ?? true;
+    const isCspNonceExperimentEnabled = options?.isCspNonceExperimentEnabled ?? true;
     const {
         appVersion,
         css = [],
@@ -100,6 +102,7 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
             initializeLanguageService({
                 ...languageConfig,
                 defaultTranslations,
+                isCspNonceExperimentEnabled,
             });
 
             return {


### PR DESCRIPTION
## What?
Switch the translation library used by `checkout-sdk` from `messageformat` to `intl-messageformat` when `isCspNonceExperimentEnabled` is true.

## Why?
So that it could be compatible with a stricter CSP header. See https://github.com/bigcommerce/checkout-sdk-js/pull/2674 for more details.

## Testing / Proof
See related PR

@bigcommerce/team-checkout
