### PR TITLE
chore(payment): PAYPAL-4607 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.663.0",
+        "@bigcommerce/checkout-sdk": "^1.665.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.663.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.663.0.tgz",
-      "integrity": "sha512-WDJZLzLwElaszEQVg/+h6Ny3JFf8kKgG1Yxvo2MgcPuO1T+yuT3GJj/DmkRldh5vjT2ld5XnDfZ7vWAFISZm2Q==",
+      "version": "1.665.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.665.0.tgz",
+      "integrity": "sha512-EXzYealWKKLQaCqmCmcR4eV+3TlplFIAAYCM7G7y+5By1fFrKCcatf+6kray+2MAo9sQUyi5uyAZyTGfM3oyBQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35037,9 +35037,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.663.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.663.0.tgz",
-      "integrity": "sha512-WDJZLzLwElaszEQVg/+h6Ny3JFf8kKgG1Yxvo2MgcPuO1T+yuT3GJj/DmkRldh5vjT2ld5XnDfZ7vWAFISZm2Q==",
+      "version": "1.665.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.665.0.tgz",
+      "integrity": "sha512-EXzYealWKKLQaCqmCmcR4eV+3TlplFIAAYCM7G7y+5By1fFrKCcatf+6kray+2MAo9sQUyi5uyAZyTGfM3oyBQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.663.0",
+    "@bigcommerce/checkout-sdk": "^1.665.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2672

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
