### PR TITLE
chore(payment): PAYPAL-4700 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.668.3",
+        "@bigcommerce/checkout-sdk": "^1.670.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.668.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.668.3.tgz",
-      "integrity": "sha512-JWhRzuNLjonv5jTclTVx077U6SpIRvZkSCKOk3aNnnF/NwQ857Q1nyUrs5O7oITRq7qbnge9uSJN2vwbX2dq8w==",
+      "version": "1.670.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.670.0.tgz",
+      "integrity": "sha512-DO6M4RWl6EF/cqnSYpMN3u1ID5VH1LUPJLcEW8zpKzNoFNwTc0K0/t5tXhi4DaESReIqb0DHPfGTL5ZpmWbF0w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.668.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.668.3.tgz",
-      "integrity": "sha512-JWhRzuNLjonv5jTclTVx077U6SpIRvZkSCKOk3aNnnF/NwQ857Q1nyUrs5O7oITRq7qbnge9uSJN2vwbX2dq8w==",
+      "version": "1.670.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.670.0.tgz",
+      "integrity": "sha512-DO6M4RWl6EF/cqnSYpMN3u1ID5VH1LUPJLcEW8zpKzNoFNwTc0K0/t5tXhi4DaESReIqb0DHPfGTL5ZpmWbF0w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.668.3",
+    "@bigcommerce/checkout-sdk": "^1.670.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2691
https://github.com/bigcommerce/checkout-sdk-js/pull/2687

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
