### PR TITLE
feat(checkout): CHECKOUT-8599 Add Confirmation Modal for Multi-shipping

### DIFF
--- a/packages/core/src/app/cart/CartSummary.spec.tsx
+++ b/packages/core/src/app/cart/CartSummary.spec.tsx
@@ -38,7 +38,7 @@ describe('CartSummary Component', () => {
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
                     <ExtensionProvider checkoutService={checkoutService}>
-                        <CartSummary />
+                        <CartSummary isMultiShippingMode={false} />
                     </ExtensionProvider>
                 </LocaleContext.Provider>
             </CheckoutProvider>,
@@ -58,7 +58,7 @@ describe('CartSummary Component', () => {
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
                     <ExtensionProvider checkoutService={checkoutService}>
-                        <CartSummary />
+                        <CartSummary isMultiShippingMode={false} />
                     </ExtensionProvider>
                 </LocaleContext.Provider>
             </CheckoutProvider>,

--- a/packages/core/src/app/cart/CartSummary.tsx
+++ b/packages/core/src/app/cart/CartSummary.tsx
@@ -16,15 +16,26 @@ export type WithCheckoutCartSummaryProps = {
     storeCurrency: StoreCurrency;
     shopperCurrency: ShopperCurrency;
     storeCreditAmount?: number;
+    isNewMultiShippingUIEnabled: boolean;
 } & RedeemableProps;
 
-const CartSummary: FunctionComponent<WithCheckoutCartSummaryProps> = ({ cartUrl, ...props }) => {
-    const headerLink = isBuyNowCart() ? null : <EditLink url={cartUrl} />;
+const CartSummary: FunctionComponent<
+    WithCheckoutCartSummaryProps & {
+        isMultiShippingMode: boolean;
+    }
+> = ({ cartUrl, isMultiShippingMode, isNewMultiShippingUIEnabled, ...props }) => {
+    const headerLink = isBuyNowCart() ? null : (
+        <EditLink
+            isMultiShippingMode={isNewMultiShippingUIEnabled && isMultiShippingMode}
+            url={cartUrl}
+        />
+    );
 
     return withRedeemable(OrderSummary)({
         ...props,
         cartUrl,
         headerLink,
+        isNewMultiShippingUIEnabled,
     });
 };
 

--- a/packages/core/src/app/cart/CartSummaryAndDrawer.test.tsx
+++ b/packages/core/src/app/cart/CartSummaryAndDrawer.test.tsx
@@ -31,7 +31,7 @@ describe('Edit Cart Component', () => {
     beforeEach(() => {
         Object.defineProperty(window, 'location', {
             value: {
-                replace: jest.fn(),
+                assign: jest.fn(),
                 pathname: '/checkout',
             },
             writable: true,
@@ -65,10 +65,13 @@ describe('Edit Cart Component', () => {
         );
 
         screen.getByText('Edit Cart').click();
-        expect(screen.getByTestId('edit-multi-shipping-cart-confirm-button')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Close'})).toBeInTheDocument();
+        expect(screen.getAllByRole('alert')).toHaveLength(2);
         screen.getByText('Confirm').click();
 
-        expect(window.top?.location.href).toBe('https://store-k1drp8k8.bcapp.dev/cart.php');
+        expect(window.location.assign).toHaveBeenCalledWith(
+            'https://store-k1drp8k8.bcapp.dev/cart.php',
+        );
     });
 
     it('renders confirmation modal when using multi-shipping and CartSummaryDawer', () => {
@@ -84,9 +87,12 @@ describe('Edit Cart Component', () => {
 
         screen.getByText('Show Details').click();
         screen.getByText('Edit Cart').click();
-        expect(screen.getByTestId('edit-multi-shipping-cart-confirm-button')).toBeInTheDocument();
+        expect(screen.getAllByRole('link', { name: 'Close'})).toHaveLength(2);
+        expect(screen.getAllByRole('alert')).toHaveLength(2);
         screen.getByText('Confirm').click();
 
-        expect(window.top?.location.href).toBe('https://store-k1drp8k8.bcapp.dev/cart.php');
+        expect(window.location.assign).toHaveBeenCalledWith(
+            'https://store-k1drp8k8.bcapp.dev/cart.php',
+        );
     });
 });

--- a/packages/core/src/app/cart/CartSummaryAndDrawer.test.tsx
+++ b/packages/core/src/app/cart/CartSummaryAndDrawer.test.tsx
@@ -1,0 +1,92 @@
+import '@testing-library/jest-dom';
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+} from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+} from '@bigcommerce/checkout/locale';
+import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import { getCheckout } from '../checkout/checkouts.mock';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getConsignment } from '../shipping/consignment.mock';
+
+import CartSummary from './CartSummary';
+import CartSummaryDrawer from './CartSummaryDrawer';
+
+describe('Edit Cart Component', () => {
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let localeContext: LocaleContextType;
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            value: {
+                replace: jest.fn(),
+                pathname: '/checkout',
+            },
+            writable: true,
+        });
+
+        localeContext = createLocaleContext(getStoreConfig());
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+            ...getCustomer(),
+            addresses: [],
+        });
+
+        jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([getConsignment()]);
+
+        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
+    });
+
+    it('renders confirmation modal when using multi-shipping and CartSummary', () => {
+        render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <ExtensionProvider checkoutService={checkoutService}>
+                        <CartSummary isMultiShippingMode={true} />
+                    </ExtensionProvider>
+                </LocaleContext.Provider>
+            </CheckoutProvider>,
+        );
+
+        screen.getByText('Edit Cart').click();
+        expect(screen.getByTestId('edit-multi-shipping-cart-confirm-button')).toBeInTheDocument();
+        screen.getByText('Confirm').click();
+
+        expect(window.top?.location.href).toBe('https://store-k1drp8k8.bcapp.dev/cart.php');
+    });
+
+    it('renders confirmation modal when using multi-shipping and CartSummaryDawer', () => {
+        render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <ExtensionProvider checkoutService={checkoutService}>
+                        <CartSummaryDrawer isMultiShippingMode={true} />
+                    </ExtensionProvider>
+                </LocaleContext.Provider>
+            </CheckoutProvider>,
+        );
+
+        screen.getByText('Show Details').click();
+        screen.getByText('Edit Cart').click();
+        expect(screen.getByTestId('edit-multi-shipping-cart-confirm-button')).toBeInTheDocument();
+        screen.getByText('Confirm').click();
+
+        expect(window.top?.location.href).toBe('https://store-k1drp8k8.bcapp.dev/cart.php');
+    });
+});

--- a/packages/core/src/app/cart/CartSummaryDrawer.spec.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawer.spec.tsx
@@ -28,7 +28,7 @@ describe('CartSummary Component', () => {
         component = mount(
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
-                    <CartSummaryDrawer />
+                    <CartSummaryDrawer isMultiShippingMode={false} />
                 </LocaleContext.Provider>
             </CheckoutProvider>,
         );

--- a/packages/core/src/app/cart/CartSummaryDrawer.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawer.tsx
@@ -8,14 +8,22 @@ import EditLink from './EditLink';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import withRedeemable from './withRedeemable';
 
-const CartSummaryDrawer: FunctionComponent<WithCheckoutCartSummaryProps> = ({
-    cartUrl,
-    ...props
-}) =>
+const CartSummaryDrawer: FunctionComponent<
+    WithCheckoutCartSummaryProps & {
+        isMultiShippingMode: boolean;
+    }
+> = ({ cartUrl, isMultiShippingMode, isNewMultiShippingUIEnabled, ...props }) =>
     withRedeemable(OrderSummaryDrawer)({
         ...props,
         cartUrl,
-        headerLink: <EditLink className="modal-header-link cart-modal-link" url={cartUrl} />,
+        headerLink: (
+            <EditLink
+                className="modal-header-link cart-modal-link"
+                isMultiShippingMode={isNewMultiShippingUIEnabled && isMultiShippingMode}
+                url={cartUrl}
+            />
+        ),
+        isNewMultiShippingUIEnabled,
     });
 
 export default withCheckout(mapToCartSummaryProps)(memo(CartSummaryDrawer));

--- a/packages/core/src/app/cart/EditLink.tsx
+++ b/packages/core/src/app/cart/EditLink.tsx
@@ -14,9 +14,7 @@ const EditLink: FunctionComponent<EditLinkProps> = ({ className, url, isMultiShi
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     const gotoCartPage = () => {
-        if (window.top) {
-            window.top.location.href = url;
-        }
+        window.location.assign(url);
     };
 
     if (isMultiShippingMode) {

--- a/packages/core/src/app/cart/EditLink.tsx
+++ b/packages/core/src/app/cart/EditLink.tsx
@@ -1,22 +1,58 @@
-import React, { FunctionComponent, memo } from 'react';
+import React, { FunctionComponent, memo, useState } from 'react';
 
+import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { ConfirmationModal } from '@bigcommerce/checkout/ui';
 
 export interface EditLinkProps {
     className?: string;
+    isMultiShippingMode: boolean;
     url: string;
 }
 
-const EditLink: FunctionComponent<EditLinkProps> = ({ className, url }) => (
-    <a
-        className={className || 'cart-header-link'}
-        data-test="cart-edit-link"
-        href={url}
-        id="cart-edit-link"
-        target="_top"
-    >
-        <TranslatedString id="cart.edit_cart_action" />
-    </a>
-);
+const EditLink: FunctionComponent<EditLinkProps> = ({ className, url, isMultiShippingMode }) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const gotoCartPage = () => {
+        if (window.top) {
+            window.top.location.href = url;
+        }
+    };
+
+    if (isMultiShippingMode) {
+        return (
+            <>
+                <ConfirmationModal
+                    action={gotoCartPage}
+                    headerId="cart.edit_cart_action"
+                    isModalOpen={isModalOpen}
+                    messageId="cart.edit_multi_shipping_cart_message"
+                    onRequestClose={() => setIsModalOpen(false)}
+                />
+                <a
+                    className={className || 'cart-header-link'}
+                    data-test="cart-edit-link"
+                    href="#"
+                    id="cart-edit-link"
+                    onClick={preventDefault(() => setIsModalOpen(true))}
+                >
+                    <TranslatedString id="cart.edit_cart_action" />
+                </a>
+            </>
+        );
+    }
+
+    return (
+        <a
+            className={className || 'cart-header-link'}
+            data-test="cart-edit-link"
+            href={url}
+            id="cart-edit-link"
+            target="_top"
+        >
+            <TranslatedString id="cart.edit_cart_action" />
+        </a>
+    );
+};
 
 export default memo(EditLink);

--- a/packages/core/src/app/cart/__snapshots__/CartSummary.spec.tsx.snap
+++ b/packages/core/src/app/cart/__snapshots__/CartSummary.spec.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`CartSummary Component renders OrderSummary with Edit Cart link 1`] = `
 <Memo(EditLink)
+  isMultiShippingMode={false}
   url="https://store-k1drp8k8.bcapp.dev/cart.php"
 />
 `;

--- a/packages/core/src/app/cart/__snapshots__/CartSummaryDrawer.spec.tsx.snap
+++ b/packages/core/src/app/cart/__snapshots__/CartSummaryDrawer.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`CartSummary Component renders OrderSummaryDrawer with Edit Cart link 1`] = `
 <Memo(EditLink)
   className="modal-header-link cart-modal-link"
+  isMultiShippingMode={false}
   url="https://store-k1drp8k8.bcapp.dev/cart.php"
 />
 `;

--- a/packages/core/src/app/cart/mapToCartSummaryProps.ts
+++ b/packages/core/src/app/cart/mapToCartSummaryProps.ts
@@ -1,5 +1,7 @@
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
 
+import { isExperimentEnabled } from '../common/utility';
+
 import { WithCheckoutCartSummaryProps } from './CartSummary';
 import mapToRedeemableProps from './mapToRedeemableProps';
 
@@ -23,8 +25,13 @@ export default function mapToCartSummaryProps(
 
     const { isStoreCreditApplied, grandTotal } = checkout;
     const { storeCredit } = customer;
+    const isNewMultiShippingUIEnabled = isExperimentEnabled(
+        config.checkoutSettings,
+        'PROJECT-4159.improve_multi_address_shipping_ui',
+    );
 
     return {
+        isNewMultiShippingUIEnabled,
         checkout,
         shopperCurrency: config.shopperCurrency,
         cartUrl: config.links.cartLink,

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -523,6 +523,8 @@ class Checkout extends Component<
     }
 
     private renderCartSummary(): ReactNode {
+        const { isMultiShippingMode } = this.state;
+
         return (
             <MobileView>
                 {(matched) => {
@@ -530,7 +532,7 @@ class Checkout extends Component<
                         return (
                             <LazyContainer>
                                 <Extension region={ExtensionRegion.SummaryAfter} />
-                                <CartSummaryDrawer />
+                                <CartSummaryDrawer isMultiShippingMode={isMultiShippingMode} />
                             </LazyContainer>
                         );
                     }
@@ -538,7 +540,7 @@ class Checkout extends Component<
                     return (
                         <aside className="layout-cart">
                             <LazyContainer>
-                                <CartSummary />
+                                <CartSummary isMultiShippingMode={isMultiShippingMode} />
                                 <Extension region={ExtensionRegion.SummaryAfter} />
                             </LazyContainer>
                         </aside>

--- a/packages/core/src/scss/components/foundation/modal/_modal.scss
+++ b/packages/core/src/scss/components/foundation/modal/_modal.scss
@@ -67,7 +67,7 @@
             }
         }
 
-        &.modal--error {
+        &.modal--error,&.modal--confirm {
             padding-bottom: spacing("half");
             padding-left: #{spacing("half") + spacing("double")};
             padding-right: spacing("double");

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -57,6 +57,7 @@
             "discount_text": "Discount",
             "downloads_action": "Go to Downloads",
             "edit_cart_action": "Edit Cart",
+            "edit_multi_shipping_cart_message": "New items will default to Shipping Destination #1. Reallocate if you want them shipped to other destinations.",
             "estimated_total_text": "Estimated Total",
             "free_text": "Free",
             "gift_certificate_text": "Gift Certificate",
@@ -81,6 +82,7 @@
             "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again."
         },
         "common": {
+            "confirm_action": "Confirm",
             "cancel_action": "Cancel",
             "close_action": "Close",
             "continue_action": "Continue",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -73,5 +73,11 @@ export {
     IconAch,
 } from './icon';
 export { LoadingOverlay, LoadingSpinner } from './loading';
-export { Modal, ModalHeader, ModalTrigger, ModalTriggerModalProps } from './modal';
+export {
+    ConfirmationModal,
+    Modal,
+    ModalHeader,
+    ModalTrigger,
+    ModalTriggerModalProps,
+} from './modal';
 export { TooltipTrigger } from './tooltip';

--- a/packages/ui/src/modal/ConfirmationModal.tsx
+++ b/packages/ui/src/modal/ConfirmationModal.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+
+import { Button, ButtonSize, ButtonVariant } from '../button';
+
+import Modal from './Modal';
+import ModalHeader from './ModalHeader';
+
+interface ConfirmationModalProps {
+    headerId: string;
+    messageId: string;
+    isModalOpen: boolean;
+    onRequestClose: () => void;
+    action: () => void;
+}
+
+const ConfirmationModal = ({
+    headerId,
+    messageId,
+    isModalOpen,
+    action,
+    onRequestClose,
+}: ConfirmationModalProps) => {
+    return (
+        <Modal
+            additionalModalClassName="modal--confirm"
+            footer={
+                <Button
+                    onClick={action}
+                    size={ButtonSize.Small}
+                    testId="edit-multi-shipping-cart-confirm-button"
+                    variant={ButtonVariant.Primary}
+                >
+                    <TranslatedString id="common.confirm_action" />
+                </Button>
+            }
+            header={
+                <ModalHeader>
+                    <span aria-live="assertive" role="alert">
+                        <TranslatedString id={headerId} />
+                    </span>
+                </ModalHeader>
+            }
+            isOpen={isModalOpen}
+            onRequestClose={onRequestClose}
+            shouldShowCloseButton={true}
+        >
+            <p aria-live="assertive" role="alert">
+                <TranslatedString id={messageId} />
+            </p>
+        </Modal>
+    );
+};
+
+export default ConfirmationModal;

--- a/packages/ui/src/modal/ConfirmationModal.tsx
+++ b/packages/ui/src/modal/ConfirmationModal.tsx
@@ -26,12 +26,7 @@ const ConfirmationModal = ({
         <Modal
             additionalModalClassName="modal--confirm"
             footer={
-                <Button
-                    onClick={action}
-                    size={ButtonSize.Small}
-                    testId="edit-multi-shipping-cart-confirm-button"
-                    variant={ButtonVariant.Primary}
-                >
+                <Button onClick={action} size={ButtonSize.Small} variant={ButtonVariant.Primary}>
                     <TranslatedString id="common.confirm_action" />
                 </Button>
             }

--- a/packages/ui/src/modal/index.ts
+++ b/packages/ui/src/modal/index.ts
@@ -2,3 +2,4 @@ export { default as ModalLink } from './ModalLink';
 export { default as Modal, ModalProps } from './Modal';
 export { default as ModalHeader } from './ModalHeader';
 export { default as ModalTrigger, ModalTriggerModalProps, ModalTriggerProps } from './ModalTrigger';
+export { default as ConfirmationModal } from './ConfirmationModal';


### PR DESCRIPTION
## What?
Show the warning popup before redirecting to cart page when multi-address shipping is enabled along with the new UI.

*The modal is expected to be reused when switching from multi-shipping to single shipping.
## Why?
Improving multi-shipping UX.

## Testing / Proof
### Mobile

https://github.com/user-attachments/assets/eaeb6c43-92e7-40de-9112-5c5fc6cfb920

### Desktop

https://github.com/user-attachments/assets/90aed54a-de69-4e68-b727-8448624c5457


@bigcommerce/team-checkout
