### PR TITLE
CHECKOUT-8596 Add product allocation modal

### DIFF
--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -1,7 +1,6 @@
 import { Address, ConsignmentLineItem } from "@bigcommerce/checkout-sdk";
 import { FormikProps } from "formik";
 import React, { FunctionComponent } from "react";
-import { number, object } from "yup";
 
 import { preventDefault } from "@bigcommerce/checkout/dom-utils";
 import { withLanguage, WithLanguageProps } from "@bigcommerce/checkout/locale";
@@ -13,8 +12,8 @@ import { Button } from "../ui/button";
 import { Form } from "../ui/form";
 import { Modal, ModalHeader } from "../ui/modal";
 
-import { MultiShippingTableItemWithType, UnassignedItems } from "./hooks/useMultishippingConsignmentItems";
 import LeftToAllocateItemsTable from "./LeftToAllocateItemsTable";
+import { UnassignedItems } from "./MultishippingV2Type";
 
 export interface AllocateItemsModalFormValues {
     [key: string]: number;
@@ -134,19 +133,5 @@ export default withLanguage(
             return values;
         },
         enableReinitialize: true,
-        validationSchema: ({ unassignedItems }: AllocateItemsModalProps) => {
-            // TODO: This will change when we get latest designs for error handling
-            const createItemSchema = (item: MultiShippingTableItemWithType) => {
-                return number()
-                    .integer()
-                    .min(0)
-                    .max(item.quantity, `You can't allocate more than ${item.quantity} items`)
-            };
-            const schemaObject = Object.fromEntries(
-                unassignedItems.lineItems.map((item) => [item.id.toString(), createItemSchema(item)]),
-            );
-
-            return object().shape(schemaObject);
-        }
     })(AllocateItemsModal),
 );

--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -13,7 +13,7 @@ import { Form } from "../ui/form";
 import { Modal, ModalHeader } from "../ui/modal";
 
 import LeftToAllocateItemsTable from "./LeftToAllocateItemsTable";
-import { UnassignedItems } from "./MultishippingV2Type";
+import { MultiShippingTableData } from "./MultishippingV2Type";
 
 export interface AllocateItemsModalFormValues {
     [key: string]: number;
@@ -24,7 +24,7 @@ interface AllocateItemsModalProps {
     isOpen: boolean;
     onRequestClose?(): void;
     address: Address;
-    unassignedItems: UnassignedItems;
+    unassignedItems: MultiShippingTableData;
     onAllocateItems(consignmentLineItems: ConsignmentLineItem[]): void;
 }
 

--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -1,0 +1,152 @@
+import { Address, ConsignmentLineItem } from "@bigcommerce/checkout-sdk";
+import { FormikProps } from "formik";
+import React, { FunctionComponent } from "react";
+import { number, object } from "yup";
+
+import { preventDefault } from "@bigcommerce/checkout/dom-utils";
+import { withLanguage, WithLanguageProps } from "@bigcommerce/checkout/locale";
+import { ButtonVariant } from "@bigcommerce/checkout/ui";
+
+import { getAddressContent } from "../address/SingleLineStaticAddress";
+import { withFormikExtended } from "../common/form";
+import { Button } from "../ui/button";
+import { Form } from "../ui/form";
+import { Modal, ModalHeader } from "../ui/modal";
+
+import { MultiShippingTableItemWithType, UnassignedItems } from "./hooks/useMultishippingConsignmentItems";
+import LeftToAllocateItemsTable from "./LeftToAllocateItemsTable";
+
+export interface AllocateItemsModalFormValues {
+    [key: string]: number;
+}
+
+interface AllocateItemsModalProps {
+    consignmentNumber: number;
+    isOpen: boolean;
+    onRequestClose?(): void;
+    address: Address;
+    unassignedItems: UnassignedItems;
+    onAllocateItems(consignmentLineItems: ConsignmentLineItem[]): void;
+}
+
+const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProps<AllocateItemsModalFormValues>> = ({
+    consignmentNumber,
+    isOpen,
+    onRequestClose,
+    address,
+    unassignedItems,
+    setValues,
+    dirty,
+    submitForm,
+}: AllocateItemsModalProps & FormikProps<AllocateItemsModalFormValues>) => {
+
+    const leftItemsTotal = unassignedItems.shippableItemsCount;
+
+    const allocationPendingMessage = `${leftItemsTotal} ${leftItemsTotal === 1 ? 'item left to allocate' : 'items left to allocate'
+        }`;
+
+    const handleSelectAll = () => {
+        const values: AllocateItemsModalFormValues = {};
+
+        unassignedItems.lineItems.forEach(item => {
+            values[item.id.toString()] = item.quantity;
+        });
+        setValues(values);
+    };
+
+    const handleClearAll = () => {
+        const values: AllocateItemsModalFormValues = {};
+
+        unassignedItems.lineItems.forEach(item => {
+            values[item.id.toString()] = 0;
+        });
+        setValues(values);
+    }
+
+    const modalFooter = (
+        <>
+            <Button disabled={!dirty} onClick={submitForm} type="submit" variant={ButtonVariant.Primary}>Allocate</Button>
+            <Button onClick={onRequestClose} variant={ButtonVariant.Secondary}>Cancel</Button>
+        </>
+    );
+
+    return (
+        <Modal
+            additionalModalClassName="allocate-items-modal"
+            footer={modalFooter}
+            header={
+                <ModalHeader>
+                    Destination #{consignmentNumber}
+                </ModalHeader>
+            }
+            isOpen={isOpen}
+            onRequestClose={onRequestClose}
+        >
+            <Form>
+                <h3>{getAddressContent(address)}</h3>
+                {unassignedItems.lineItems.length
+                    ? <>
+                        <div className="left-to-allocate-items-table-actions">
+                            <p>{allocationPendingMessage}</p>
+                            <div>
+                                <a
+                                    data-test="clear-all-items-button"
+                                    href="#"
+                                    onClick={preventDefault(handleClearAll)}
+                                >
+                                    Clear all
+                                </a>
+                                <a
+                                    data-test="allocate-all-items-button"
+                                    href="#"
+                                    onClick={preventDefault(handleSelectAll)}
+                                >
+                                    Select all items left
+                                </a>
+                            </div>
+                        </div>
+                        <LeftToAllocateItemsTable items={unassignedItems.lineItems} />
+                    </>
+                    : null
+                }
+            </Form>
+        </Modal>
+    )
+}
+
+export default withLanguage(
+    withFormikExtended<AllocateItemsModalProps & WithLanguageProps, AllocateItemsModalFormValues>({
+        handleSubmit: (values, { props: { onAllocateItems } }) => {
+            const consignmentLineItems = Object.keys(values).filter(key => values[key] > 0).map((lineItemId: string) => ({
+                itemId: lineItemId,
+                quantity: values[lineItemId],
+            }));
+
+            onAllocateItems(consignmentLineItems);
+        },
+        mapPropsToValues: ({ unassignedItems }) => {
+            const values: AllocateItemsModalFormValues = {};
+
+            unassignedItems.lineItems.forEach(item => {
+                values[item.id.toString()] = 0;
+            });
+
+            return values;
+        },
+        enableReinitialize: true,
+        validationSchema: ({ unassignedItems }: AllocateItemsModalProps) => {
+            // TODO: This will change when we get latest designs for error handling
+            const createItemSchema = (item: MultiShippingTableItemWithType) => {
+                return number()
+                    .integer()
+                    .min(0)
+                    .max(item.quantity, `You can't allocate more than ${item.quantity} items`)
+            };
+            const schemaObject = Object.fromEntries(
+                unassignedItems.lineItems.map((item) => [item.id.toString(), createItemSchema(item)]),
+            );
+
+            return object().shape(schemaObject);
+        }
+    })(AllocateItemsModal),
+);

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -9,10 +9,10 @@ import { ErrorModal } from "../common/error";
 import { EMPTY_ARRAY, isFloatingLabelEnabled } from "../common/utility";
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
-import { MappedDataConsignment } from "./MultishippingV2Type";
+import { MultiShippingConsignmentData } from "./MultishippingV2Type";
 
 interface ConsignmentAddressSelectorProps {
-    consignment?: MappedDataConsignment;
+    consignment?: MultiShippingConsignmentData;
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
     isLoading: boolean;

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -9,7 +9,7 @@ import { ErrorModal } from "../common/error";
 import { EMPTY_ARRAY, isFloatingLabelEnabled } from "../common/utility";
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
-import { MappedDataConsignment } from "./hooks/useMultishippingConsignmentItems";
+import { MappedDataConsignment } from "./MultishippingV2Type";
 
 interface ConsignmentAddressSelectorProps {
     consignment?: MappedDataConsignment;

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -1,4 +1,4 @@
-import { Address, Consignment, ConsignmentCreateRequestBody } from "@bigcommerce/checkout-sdk";
+import { Address, ConsignmentCreateRequestBody } from "@bigcommerce/checkout-sdk";
 import React, { useState } from "react";
 
 import { TranslatedString } from "@bigcommerce/checkout/locale";
@@ -9,9 +9,10 @@ import { ErrorModal } from "../common/error";
 import { EMPTY_ARRAY, isFloatingLabelEnabled } from "../common/utility";
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
+import { MappedDataConsignment } from "./hooks/useMultishippingConsignmentItems";
 
 interface ConsignmentAddressSelectorProps {
-    consignment?: Consignment;
+    consignment?: MappedDataConsignment;
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
     isLoading: boolean;
@@ -34,21 +35,21 @@ const ConsignmentAddressSelector = ({
 
     const {
         checkoutState: {
-            data: { getCart, getShippingCountries, getCustomer, getConfig, getShippingAddressFields: getFields },
+            data: { getShippingCountries, getCustomer, getConfig, getShippingAddressFields: getFields },
         },
         checkoutService: { assignItemsToAddress: assignItem, createCustomerAddress },
     } = useCheckout();
 
-    const cart = getCart();
     const countries = getShippingCountries() || EMPTY_ARRAY;
     const customer = getCustomer();
     const config = getConfig();
 
-    if (!config || !cart || !customer) {
+    if (!config || !customer) {
         return null;
     }
 
     const isFloatingLabelEnabledFlag = isFloatingLabelEnabled(config.checkoutSettings);
+    // TODO: add filter for addresses 
     const addresses = customer.addresses || EMPTY_ARRAY;
     const {
         checkoutSettings: {
@@ -71,15 +72,10 @@ const ConsignmentAddressSelector = ({
             return;
         }
 
-        const cartLineItems = [...cart.lineItems.physicalItems, ...(cart.lineItems.customItems || EMPTY_ARRAY)];
-        const consignmentLineItems = consignment.lineItemIds.map(lineItemId => (
-            { itemId: lineItemId, quantity: cartLineItems.find(({ id }) => id === lineItemId)?.quantity || 0 }
-        ));
-
         try {
             await assignItem({
                 address,
-                lineItems: consignmentLineItems,
+                lineItems: consignment.lineItems.map(({ id, quantity }) => ({ itemId: id, quantity })),
             });
 
         } catch (error) {

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -9,11 +9,11 @@ import { IconChevronDown, IconChevronUp } from "../ui/icon";
 import AllocateItemsModal from "./AllocateItemsModal";
 import { AssignItemFailedError } from "./errors";
 import { useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
-import { MappedDataConsignment } from "./MultishippingV2Type";
+import { MultiShippingConsignmentData } from "./MultishippingV2Type";
 
 interface ConsignmentLineItemProps {
     consignmentNumber: number;
-    consignment: MappedDataConsignment;
+    consignment: MultiShippingConsignmentData;
     onUnhandledError(error: Error): void;
 }
 
@@ -48,6 +48,8 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ cons
         setShowItems(!showItems);
     }
 
+    const itemsCount = consignment.shippableItemsCount;
+
     return (
         <div>
             <AllocateItemsModal
@@ -60,7 +62,7 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ cons
             />
             <div className="consignment-line-item-header">
                 <div>
-                    <h3>{consignment.lineItems.length} items allocated</h3>
+                    <h3>{itemsCount > 1 ? `${itemsCount} items` : `${itemsCount} item`} allocated</h3>
                     <a
                         className="expand-items-button"
                         data-test="expand-items-button"

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -1,0 +1,117 @@
+import { ConsignmentLineItem } from "@bigcommerce/checkout-sdk";
+import React, { FunctionComponent, useState } from "react";
+
+import { preventDefault } from "@bigcommerce/checkout/dom-utils";
+import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
+
+import { IconChevronDown, IconChevronUp } from "../ui/icon";
+
+import AllocateItemsModal from "./AllocateItemsModal";
+import { AssignItemFailedError } from "./errors";
+import { MappedDataConsignment, useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
+
+interface ConsignmentLineItemProps {
+    consignmentNumber: number;
+    consignment: MappedDataConsignment;
+    onUnhandledError(error: Error): void;
+}
+
+const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ consignmentNumber, consignment, onUnhandledError }: ConsignmentLineItemProps) => {
+    const [isOpenAllocateItemsModal, setIsOpenAllocateItemsModal] = useState(false);
+    const [showItems, setShowItems] = useState(true);
+    const { unassignedItems } = useMultiShippingConsignmentItems();
+
+    const { checkoutService: { assignItemsToAddress: assignItem } } = useCheckout();
+
+    const filteredLineItems = unassignedItems.lineItems.filter(
+        (item) => !consignment.lineItemIds.includes(item.id.toString()),
+    );
+    const filteredUnassignedItems = {
+        ...unassignedItems,
+        lineItems: filteredLineItems
+    };
+
+    const toggleAllocateItemsModal = () => {
+        setIsOpenAllocateItemsModal(!isOpenAllocateItemsModal);
+    }
+
+    const handleAllocateItems = async (consignmentLineItems: ConsignmentLineItem[]) => {
+        try {
+            await assignItem({
+                address: consignment.address,
+                lineItems: consignmentLineItems,
+            });
+
+        } catch (error) {
+            if (error instanceof Error) {
+                onUnhandledError(new AssignItemFailedError(error));
+            }
+        } finally {
+            toggleAllocateItemsModal();
+        }
+    }
+
+    const toggleShowItems = () => {
+        setShowItems(!showItems);
+    }
+
+    return (
+        <div>
+            <AllocateItemsModal
+                address={consignment.shippingAddress}
+                consignmentNumber={consignmentNumber}
+                isOpen={isOpenAllocateItemsModal}
+                onAllocateItems={handleAllocateItems}
+                onRequestClose={toggleAllocateItemsModal}
+                unassignedItems={filteredUnassignedItems}
+            />
+            <div className="consignment-line-item-header">
+                <div>
+                    <h3>{consignment.lineItems.length} items allocated</h3>
+                    <a
+                        className="expand-items-button"
+                        href="#"
+                        onClick={preventDefault(toggleShowItems)}
+                    >
+                        {showItems ? (
+                            <>
+                                Hide items
+                                <IconChevronUp />
+                            </>
+                        ) : (
+                            <>
+                                Show items
+                                <IconChevronDown />
+                            </>
+                        )}
+                    </a>
+                </div>
+                <a
+                    data-test="reallocate-items-button"
+                    href="#"
+                    onClick={preventDefault(toggleAllocateItemsModal)}
+                >
+                    Reallocate items
+                </a>
+            </div>
+            {showItems
+                ? <ul className="consignment-line-item-list">
+                    {consignment.lineItems.map(lineItem => (
+                        <li key={lineItem.id}>
+                            <span>
+                                <strong>{`${lineItem.quantity} x `}</strong>
+                                {lineItem.name}
+                                {lineItem.options?.length
+                                    ? <span className="line-item-options">{` - ${lineItem.options.map(option => option.value).join('/ ')}`}</span>
+                                    : ''}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+                : null
+            }       
+        </div>
+    )
+}
+
+export default ConsignmentLineItem;

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -8,7 +8,8 @@ import { IconChevronDown, IconChevronUp } from "../ui/icon";
 
 import AllocateItemsModal from "./AllocateItemsModal";
 import { AssignItemFailedError } from "./errors";
-import { MappedDataConsignment, useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
+import { useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
+import { MappedDataConsignment } from "./MultishippingV2Type";
 
 interface ConsignmentLineItemProps {
     consignmentNumber: number;
@@ -19,17 +20,9 @@ interface ConsignmentLineItemProps {
 const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ consignmentNumber, consignment, onUnhandledError }: ConsignmentLineItemProps) => {
     const [isOpenAllocateItemsModal, setIsOpenAllocateItemsModal] = useState(false);
     const [showItems, setShowItems] = useState(true);
+
     const { unassignedItems } = useMultiShippingConsignmentItems();
-
     const { checkoutService: { assignItemsToAddress: assignItem } } = useCheckout();
-
-    const filteredLineItems = unassignedItems.lineItems.filter(
-        (item) => !consignment.lineItemIds.includes(item.id.toString()),
-    );
-    const filteredUnassignedItems = {
-        ...unassignedItems,
-        lineItems: filteredLineItems
-    };
 
     const toggleAllocateItemsModal = () => {
         setIsOpenAllocateItemsModal(!isOpenAllocateItemsModal);
@@ -63,7 +56,7 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ cons
                 isOpen={isOpenAllocateItemsModal}
                 onAllocateItems={handleAllocateItems}
                 onRequestClose={toggleAllocateItemsModal}
-                unassignedItems={filteredUnassignedItems}
+                unassignedItems={unassignedItems}
             />
             <div className="consignment-line-item-header">
                 <div>

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -70,6 +70,7 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ cons
                     <h3>{consignment.lineItems.length} items allocated</h3>
                     <a
                         className="expand-items-button"
+                        data-test="expand-items-button"
                         href="#"
                         onClick={preventDefault(toggleShowItems)}
                     >

--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from "react";
 
 import ConsignmentAddressSelector from './ConsignmentAddressSelector';
 import ConsignmentLineItem from './ConsignmentLineItem';
-import { MappedDataConsignment } from './hooks/useMultishippingConsignmentItems';
+import { MappedDataConsignment } from './MultishippingV2Type';
 
 export interface ConsignmentListItemProps {
     consignment: MappedDataConsignment;

--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -2,10 +2,10 @@ import React, { FunctionComponent } from "react";
 
 import ConsignmentAddressSelector from './ConsignmentAddressSelector';
 import ConsignmentLineItem from './ConsignmentLineItem';
-import { MappedDataConsignment } from './MultishippingV2Type';
+import { MultiShippingConsignmentData } from './MultishippingV2Type';
 
 export interface ConsignmentListItemProps {
-    consignment: MappedDataConsignment;
+    consignment: MultiShippingConsignmentData;
     consignmentNumber: number;
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];

--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -1,10 +1,11 @@
-import { Consignment } from '@bigcommerce/checkout-sdk';
-import React from "react";
+import React, { FunctionComponent } from "react";
 
 import ConsignmentAddressSelector from './ConsignmentAddressSelector';
+import ConsignmentLineItem from './ConsignmentLineItem';
+import { MappedDataConsignment } from './hooks/useMultishippingConsignmentItems';
 
 export interface ConsignmentListItemProps {
-    consignment: Consignment;
+    consignment: MappedDataConsignment;
     consignmentNumber: number;
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
@@ -12,7 +13,7 @@ export interface ConsignmentListItemProps {
     onUnhandledError(error: Error): void;
 }
 
-const ConsignmentListItem = ({
+const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
     consignment,
     consignmentNumber,
     countriesWithAutocomplete,
@@ -20,10 +21,9 @@ const ConsignmentListItem = ({
     isLoading,
     onUnhandledError
 }: ConsignmentListItemProps) => {
-
     return (
         <div className='consignment-container'>
-            <h3 className='consignment-header'>Shipping destination {consignmentNumber}</h3>
+            <h3 className='consignment-header'>Destination #{consignmentNumber}</h3>
             <ConsignmentAddressSelector
                 consignment={consignment}
                 countriesWithAutocomplete={countriesWithAutocomplete}
@@ -31,6 +31,11 @@ const ConsignmentListItem = ({
                 isLoading={isLoading}
                 onUnhandledError={onUnhandledError}
                 selectedAddress={consignment.shippingAddress}
+            />
+            <ConsignmentLineItem
+                consignment={consignment}
+                consignmentNumber={consignmentNumber}
+                onUnhandledError={onUnhandledError}
             />
         </div>
     )

--- a/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
+++ b/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
@@ -1,0 +1,47 @@
+import React, { FunctionComponent } from "react";
+
+import { FormField, TextInput } from "../ui/form";
+
+import { MultiShippingTableItemWithType } from "./hooks/useMultishippingConsignmentItems";
+
+interface LeftToAllocateItemsTableProps {
+    items: MultiShippingTableItemWithType[];
+}
+
+const LeftToAllocateItemsTable: FunctionComponent<LeftToAllocateItemsTableProps> = ({ items }: LeftToAllocateItemsTableProps) => {
+    return <table className="table left-to-allocate-items-table">
+        <thead>
+            <tr>
+                <th>Item</th>
+                <th>Left to allocate</th>
+                <th>Quantity</th>
+            </tr>
+        </thead>
+        <tbody>
+            {items.map(item => (
+                <tr key={item.id}>
+                    <td className="left-to-allocate-item-name-container">
+                        <figure className="left-to-allocate-item-figure">
+                            {item.imageUrl && <img alt={item.name} src={item.imageUrl} />}
+                        </figure>
+                        <div className="left-to-allocate-item-name">
+                            <p>{item.name}</p>
+                            {item.options?.map(option => (
+                                <p className="left-to-allocate-item-option" key={option.nameId}>{option.name}: {option.value}</p>
+                            ))}
+                        </div>
+                    </td>
+                    <td>{item.quantity}</td>
+                    <td>
+                        <FormField
+                            input={({ field }) => <TextInput {...field} disabled={item.quantity === 0} id={field.name} type="number" />}
+                            name={item.id.toString()}
+                        />
+                    </td>
+                </tr>
+            ))}
+        </tbody>
+    </table>;
+}
+
+export default LeftToAllocateItemsTable;

--- a/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
+++ b/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from "react";
 
 import { FormField, TextInput } from "../ui/form";
 
-import { MultiShippingTableItemWithType } from "./hooks/useMultishippingConsignmentItems";
+import { MultiShippingTableItemWithType } from "./MultishippingV2Type";
 
 interface LeftToAllocateItemsTableProps {
     items: MultiShippingTableItemWithType[];

--- a/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
+++ b/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
@@ -8,40 +8,48 @@ interface LeftToAllocateItemsTableProps {
     items: MultiShippingTableItemWithType[];
 }
 
+const LeftToAllocateTableItem = ({ item }: { item: MultiShippingTableItemWithType }) => {
+    return (
+        <tr>
+            <td className="left-to-allocate-item-name-container">
+                <figure className="left-to-allocate-item-figure">
+                    {item.imageUrl && <img alt={item.name} src={item.imageUrl} />}
+                </figure>
+                <div className="left-to-allocate-item-name">
+                    <p>{item.name}</p>
+                    {item.options?.map(option => (
+                        <p className="left-to-allocate-item-option" key={option.nameId}>{option.name}: {option.value}</p>
+                    ))}
+                </div>
+            </td>
+            <td>{item.quantity}</td>
+            <td>
+                <FormField
+                    input={({ field }) => <TextInput {...field} disabled={item.quantity === 0} id={field.name} type="number" />}
+                    name={item.id.toString()}
+                />
+            </td>
+        </tr>
+    );
+}
+
 const LeftToAllocateItemsTable: FunctionComponent<LeftToAllocateItemsTableProps> = ({ items }: LeftToAllocateItemsTableProps) => {
-    return <table className="table left-to-allocate-items-table">
-        <thead>
-            <tr>
-                <th>Item</th>
-                <th>Left to allocate</th>
-                <th>Quantity</th>
-            </tr>
-        </thead>
-        <tbody>
-            {items.map(item => (
-                <tr key={item.id}>
-                    <td className="left-to-allocate-item-name-container">
-                        <figure className="left-to-allocate-item-figure">
-                            {item.imageUrl && <img alt={item.name} src={item.imageUrl} />}
-                        </figure>
-                        <div className="left-to-allocate-item-name">
-                            <p>{item.name}</p>
-                            {item.options?.map(option => (
-                                <p className="left-to-allocate-item-option" key={option.nameId}>{option.name}: {option.value}</p>
-                            ))}
-                        </div>
-                    </td>
-                    <td>{item.quantity}</td>
-                    <td>
-                        <FormField
-                            input={({ field }) => <TextInput {...field} disabled={item.quantity === 0} id={field.name} type="number" />}
-                            name={item.id.toString()}
-                        />
-                    </td>
+    return (
+        <table className="table left-to-allocate-items-table">
+            <thead>
+                <tr>
+                    <th>Item</th>
+                    <th>Left to allocate</th>
+                    <th>Quantity</th>
                 </tr>
-            ))}
-        </tbody>
-    </table>;
+            </thead>
+            <tbody>
+                {items.map(item => (
+                    <LeftToAllocateTableItem item={item} key={item.id} />      
+                ))}
+            </tbody>
+        </table>
+    );
 }
 
 export default LeftToAllocateItemsTable;

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -1,5 +1,10 @@
 @import '../ui/Base';
 
+$quantity-input-container-width: 60%;
+$allocate-items-table-first-column-width: 50%;
+$allocate-items-table-column-width: 25%;
+$allocate-items-table-image-width: 20%;
+
 .consignment-container {
     border: 1px solid color("greys", "light");
     border-radius: $global-radius;
@@ -99,11 +104,11 @@
                 border-top: container("border");
                 border-bottom: container("border");
                 th:first-child {
-                    width: 50%;
+                    width: $allocate-items-table-first-column-width;
                     text-align: left;
                 }
                 th {
-                    width: 25%;
+                    width: $allocate-items-table-column-width;
                     padding: spacing("base");
                     text-align: right;
                 }
@@ -116,16 +121,14 @@
                 border-top: container("border");
                 border-bottom: container("border");
                 td:first-child {
-                    width: 100%;
                     text-align: left;
                 }
                 td {
-                    width: 25%;
                     padding: spacing("base");
                     text-align: right;
                     div {
                         float: right;
-                        width: 60%;
+                        width: $quantity-input-container-width;
                         input {
                             text-align: right;
                             padding: spacing("half");
@@ -141,7 +144,7 @@
 
             .left-to-allocate-item-figure {
                 margin: 0;
-                width: 20%;
+                width: $allocate-items-table-image-width;
                 padding-right: spacing("half");
             }
             

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -8,10 +8,154 @@
 }
 
 .consignment-header {
-    font-size: fontSize("large");
+    font-size: fontSize("small");
     margin: 0 0 spacing("single");
 }
 
 .add-consignment-button {
     color: color("greys", "dark");
+}
+
+.consignment-line-item-list {
+    list-style: none;
+    margin-left: 0;
+    li {
+        font-size: fontSize("smallest");
+        line-height: lineHeight("large");
+        .line-item-options {
+            color: color("greys");
+        }
+    }
+}
+
+.new-consignment-line-item-header, .consignment-line-item-header {
+    display: flex;
+    h3 {
+        margin-bottom: spacing("base");
+        font-size: fontSize("base");
+    }
+    p {
+        margin: 0;
+    }
+    a {
+        margin-left: spacing("base");
+        font-size: fontSize("base");
+    }
+}
+
+.consignment-line-item-header {
+    justify-content: space-between;
+    div {
+        display: flex;
+        .expand-items-button {
+            display: flex;
+            svg {
+                fill: currentColor;
+            }
+        }
+    }
+}
+
+.allocate-items-modal {
+    .modal-body {
+        padding-top: 0;
+
+        h3 {
+            margin-bottom: #{spacing("single") + spacing("half")};
+            font-weight: fontWeight("normal");
+        }
+    }
+
+    .modal-footer {
+        button {
+            margin-left: 0;
+            border: none;
+        }
+    }
+
+    .left-to-allocate-items-table-actions {
+        display: flex;
+        margin-bottom: spacing("base");
+        justify-content: space-between;
+        
+        p {
+            margin-bottom: 0;
+        }
+
+        div {
+            display: flex;
+            gap: spacing("half");
+        }
+    }
+
+    .left-to-allocate-items-table {
+        margin-top: spacing("base");
+        border-left: none;
+        border-right: none;
+    
+        thead {
+            background: none;
+            tr {
+                border-top: container("border");
+                border-bottom: container("border");
+                th:first-child {
+                    width: 50%;
+                    text-align: left;
+                }
+                th {
+                    width: 25%;
+                    padding: spacing("base");
+                    text-align: right;
+                }
+            }
+        }
+
+        
+        tbody {
+            tr {
+                border-top: container("border");
+                border-bottom: container("border");
+                td:first-child {
+                    width: 100%;
+                    text-align: left;
+                }
+                td {
+                    width: 25%;
+                    padding: spacing("base");
+                    text-align: right;
+                    div {
+                        float: right;
+                        width: 60%;
+                        input {
+                            text-align: right;
+                            padding: spacing("half");
+                        }
+                    }
+                }
+            }
+        }
+
+        .left-to-allocate-item-name-container {
+            display: flex;
+            align-items: center;
+
+            .left-to-allocate-item-figure {
+                margin: 0;
+                width: 20%;
+                padding-right: spacing("half");
+            }
+            
+            .left-to-allocate-item-name {
+                p {
+                    margin-bottom: 0;
+                }
+
+                .left-to-allocate-item-options {
+                    color: color("greys");
+                    font-size: fontSize("tiny");
+                    margin: 0;
+                }
+            }
+        }  
+    }
 }

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -4,15 +4,18 @@ import {
     CheckoutService,
     createCheckoutService,
 } from '@bigcommerce/checkout-sdk';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
 import { createLocaleContext, LocaleContext } from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
-import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { render, screen, waitFor, within } from '@bigcommerce/checkout/test-utils';
 
 import { getAddressFormFields } from '../address/formField.mock';
 import { getAddressContent } from '../address/SingleLineStaticAddress';
+import { getCart } from '../cart/carts.mock';
+import { getPhysicalItem } from '../cart/lineItem.mock';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
@@ -56,20 +59,20 @@ describe('MultiShippingFormV2 Component', () => {
 
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
 
-        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
-            ...getCustomer(),
-            addresses: [],
-        });
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
 
         jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([getConsignment()]);
 
         jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
             ...getCheckout(),
-            consignments: [getConsignment()],
+            consignments: [{
+                ...getConsignment(),
+                lineItemIds: [getPhysicalItem().id],
+            }],
         });
     });
 
-    it('renders shipping destination 1', () => {
+    it('renders shipping destination 1', async () => {
         const address = getShippingAddress();
 
         render(
@@ -84,6 +87,101 @@ describe('MultiShippingFormV2 Component', () => {
 
         expect(screen.getByText('Destination #1')).toBeInTheDocument();
         expect(screen.getByText(getAddressContent(address))).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Add new destination' })).toBeInTheDocument();
+
+        // eslint-disable-next-line testing-library/no-node-access
+        const destination1 = screen.getByText('Destination #1').parentElement;
+
+        expect(within(destination1).getByText('Canvas Laundry Cart', { exact: false })).toBeInTheDocument();
+
+        const showItemsButton = screen.getByTestId('expand-items-button');
+
+        expect(showItemsButton).toBeInTheDocument();
+        await userEvent.click(showItemsButton);
+
+        await waitFor(() => {
+            expect(within(destination1).queryByText('Canvas Laundry Cart', { exact: false })).not.toBeInTheDocument();
+        });
+    });
+
+    it('adds new shipping destination and open allocate items modal', async () => {
+
+        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+            ...getCheckout(),
+            consignments: [{
+                ...getConsignment(),
+                lineItemIds: ['2']
+            }],
+            cart: {
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [{
+                        ...getPhysicalItem(),
+                        quantity: 2,
+                    },
+                    {
+                        ...getPhysicalItem(),
+                        id: '2',
+                        quantity: 1,
+                    }],
+                },
+            },
+        });
+
+        const address = getShippingAddress();
+
+        render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <ExtensionProvider checkoutService={checkoutService}>
+                        <MultiShippingFormV2 {...defaultProps} />
+                    </ExtensionProvider>
+                </LocaleContext.Provider>
+            </CheckoutProvider>,
+        );
+
+        expect(screen.getByText('Destination #1')).toBeInTheDocument();
+        expect(screen.getByText(getAddressContent(address))).toBeInTheDocument();
+
+        const addShippingDestinationButton = screen.getByRole('button', { name: 'Add new destination' });
+
+        expect(addShippingDestinationButton).toBeInTheDocument();
+        await userEvent.click(addShippingDestinationButton);
+
+        expect(screen.getByText('Destination #2')).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.queryByText('No items allocated')).not.toBeInTheDocument();
+        });
+
+        // eslint-disable-next-line testing-library/no-node-access
+        const destination2 = screen.getByText('Destination #2').parentElement;
+        const addressSelectButton = within(destination2).getByTestId('address-select-button');
+
+        await userEvent.click(addressSelectButton);
+
+        // eslint-disable-next-line testing-library/no-node-access
+        const addressOption = screen.getAllByTestId('address-select-option')[0].firstChild;
+
+        expect(addressOption).toBeInTheDocument();
+
+        if (addressOption) {
+            await userEvent.click(addressOption);
+        }
+
+        expect(screen.getByText('No items allocated')).toBeInTheDocument();
+
+        const allocateItemsButton = screen.getByTestId('allocate-items-button');
+
+        expect(allocateItemsButton).toBeInTheDocument();
+        await userEvent.click(allocateItemsButton);
+
+        const allocateItemsModal = screen.getByRole('dialog');
+
+        expect(allocateItemsModal).toBeInTheDocument();
+
+        const allocateItemsModalHeader = within(allocateItemsModal).getByText('Destination #2');
+
+        expect(allocateItemsModalHeader).toBeInTheDocument();
     });
 });

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -13,8 +13,6 @@ import { render, screen } from '@bigcommerce/checkout/test-utils';
 
 import { getAddressFormFields } from '../address/formField.mock';
 import { getAddressContent } from '../address/SingleLineStaticAddress';
-import { getCart } from '../cart/carts.mock';
-import { getPhysicalItem } from '../cart/lineItem.mock';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
@@ -51,17 +49,6 @@ describe('MultiShippingFormV2 Component', () => {
         jest.spyOn(checkoutState.data, 'getShippingAddressFields').mockReturnValue(
             getAddressFormFields(),
         );
-        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
-            ...getCart(),
-            lineItems: {
-                physicalItems: [
-                    {
-                        ...getPhysicalItem(),
-                        quantity: 3,
-                    },
-                ],
-            },
-        } as Cart);
 
         jest.spyOn(checkoutState.data, 'getShippingAddress').mockReturnValue(getShippingAddress());
 
@@ -76,7 +63,10 @@ describe('MultiShippingFormV2 Component', () => {
 
         jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([getConsignment()]);
 
-        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
+        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+            ...getCheckout(),
+            consignments: [getConsignment()],
+        });
     });
 
     it('renders shipping destination 1', () => {
@@ -92,8 +82,8 @@ describe('MultiShippingFormV2 Component', () => {
             </CheckoutProvider>,
         );
 
-        expect(screen.getByText('Shipping destination 1')).toBeInTheDocument();
+        expect(screen.getByText('Destination #1')).toBeInTheDocument();
         expect(screen.getByText(getAddressContent(address))).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Add shipping destination' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Add new destination' })).toBeInTheDocument();
     });
 });

--- a/packages/core/src/app/shipping/MultiShippingFormV2.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.tsx
@@ -9,8 +9,9 @@ import { Button, ButtonVariant } from '../ui/button';
 
 import ConsignmentListItem from './ConsignmentListItem';
 import hasSelectedShippingOptions from './hasSelectedShippingOptions';
-import { MappedDataConsignment, useMultiShippingConsignmentItems } from './hooks/useMultishippingConsignmentItems';
+import { useMultiShippingConsignmentItems } from './hooks/useMultishippingConsignmentItems';
 import MultiShippingFormV2Footer from './MultiShippingFormV2Footer';
+import { MappedDataConsignment } from './MultishippingV2Type';
 import './MultiShippingFormV2.scss';
 import NewConsignment from './NewConsignment';
 

--- a/packages/core/src/app/shipping/MultiShippingFormV2.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.tsx
@@ -11,7 +11,7 @@ import ConsignmentListItem from './ConsignmentListItem';
 import hasSelectedShippingOptions from './hasSelectedShippingOptions';
 import { useMultiShippingConsignmentItems } from './hooks/useMultishippingConsignmentItems';
 import MultiShippingFormV2Footer from './MultiShippingFormV2Footer';
-import { MappedDataConsignment } from './MultishippingV2Type';
+import { MultiShippingConsignmentData } from './MultishippingV2Type';
 import './MultiShippingFormV2.scss';
 import NewConsignment from './NewConsignment';
 
@@ -41,7 +41,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
             data: { getConsignments, getConfig },
         },
     } = useCheckout();
-    const { unassignedItems, mappedDataConsignmentsList } = useMultiShippingConsignmentItems();
+    const { unassignedItems, consignmentList } = useMultiShippingConsignmentItems();
 
     const consignments = getConsignments() || EMPTY_ARRAY;
     const config = getConfig();
@@ -66,7 +66,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
 
     return (
         <>
-            {mappedDataConsignmentsList.map((consignment: MappedDataConsignment) => (
+            {consignmentList.map((consignment: MultiShippingConsignmentData) => (
                 <ConsignmentListItem
                     consignment={consignment}
                     consignmentNumber={consignment.consignmentNumber}

--- a/packages/core/src/app/shipping/MultiShippingFormV2.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.tsx
@@ -1,4 +1,3 @@
-import { Consignment } from '@bigcommerce/checkout-sdk';
 import React, { FunctionComponent, useMemo, useState } from 'react';
 
 import { withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
@@ -10,6 +9,7 @@ import { Button, ButtonVariant } from '../ui/button';
 
 import ConsignmentListItem from './ConsignmentListItem';
 import hasSelectedShippingOptions from './hasSelectedShippingOptions';
+import { MappedDataConsignment, useMultiShippingConsignmentItems } from './hooks/useMultishippingConsignmentItems';
 import MultiShippingFormV2Footer from './MultiShippingFormV2Footer';
 import './MultiShippingFormV2.scss';
 import NewConsignment from './NewConsignment';
@@ -40,6 +40,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
             data: { getConsignments, getConfig },
         },
     } = useCheckout();
+    const { unassignedItems, mappedDataConsignmentsList } = useMultiShippingConsignmentItems();
 
     const consignments = getConsignments() || EMPTY_ARRAY;
     const config = getConfig();
@@ -64,10 +65,10 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
 
     return (
         <>
-            {consignments.map((consignment: Consignment, index: number) => (
+            {mappedDataConsignmentsList.map((consignment: MappedDataConsignment) => (
                 <ConsignmentListItem
                     consignment={consignment}
-                    consignmentNumber={index + 1}
+                    consignmentNumber={consignment.consignmentNumber}
                     countriesWithAutocomplete={countriesWithAutocomplete}
                     defaultCountryCode={defaultCountryCode}
                     isLoading={isLoading}
@@ -82,11 +83,14 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
                     defaultCountryCode={defaultCountryCode}
                     isLoading={isLoading}
                     onUnhandledError={onUnhandledError}
+                    setIsAddShippingDestination={setIsAddShippingDestination}
                 />)
             }
-            <Button className='add-consignment-button' onClick={handleAddShippingDestination} variant={ButtonVariant.Secondary}>
-                Add shipping destination
-            </Button>
+            {unassignedItems.shippableItemsCount > 0 && 
+                <Button className='add-consignment-button' onClick={handleAddShippingDestination} variant={ButtonVariant.Secondary}>
+                    Add new destination
+                </Button>
+            }
             <MultiShippingFormV2Footer
                 isLoading={isLoading}
                 shouldDisableSubmit={shouldDisableSubmit}

--- a/packages/core/src/app/shipping/MultishippingV2Type.ts
+++ b/packages/core/src/app/shipping/MultishippingV2Type.ts
@@ -1,0 +1,32 @@
+import { Consignment, LineItemOption, PhysicalItem } from "@bigcommerce/checkout-sdk";
+
+export enum LineItemType {
+    Physical,
+    Digital,
+    GiftCertificate,
+    Custom,
+}
+
+export interface MultiShippingTableItem {
+    name: string;
+    options?: LineItemOption[];
+    giftWrapping?: PhysicalItem['giftWrapping'];
+    sku: string;
+    quantity: number;
+    id: string | number;
+    imageUrl?: string;
+}
+
+export interface MultiShippingTableItemWithType extends MultiShippingTableItem {
+    type: LineItemType;
+}
+
+export interface UnassignedItems {
+    lineItems: MultiShippingTableItemWithType[];
+    hasDigitalItems: boolean;
+    shippableItemsCount: number;
+};
+
+export interface MappedDataConsignment extends Consignment, UnassignedItems {
+    consignmentNumber: number;
+}

--- a/packages/core/src/app/shipping/MultishippingV2Type.ts
+++ b/packages/core/src/app/shipping/MultishippingV2Type.ts
@@ -21,12 +21,12 @@ export interface MultiShippingTableItemWithType extends MultiShippingTableItem {
     type: LineItemType;
 }
 
-export interface UnassignedItems {
+export interface MultiShippingTableData {
     lineItems: MultiShippingTableItemWithType[];
     hasDigitalItems: boolean;
     shippableItemsCount: number;
 };
 
-export interface MappedDataConsignment extends Consignment, UnassignedItems {
+export interface MultiShippingConsignmentData extends Consignment, MultiShippingTableData {
     consignmentNumber: number;
 }

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -1,12 +1,16 @@
-import { ConsignmentCreateRequestBody } from "@bigcommerce/checkout-sdk";
+import { ConsignmentCreateRequestBody, ConsignmentLineItem } from "@bigcommerce/checkout-sdk";
 import { find } from "lodash";
 import React, { useMemo, useState } from "react";
 
+import { preventDefault } from "@bigcommerce/checkout/dom-utils";
 import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
 
 import { EMPTY_ARRAY } from "../common/utility";
 
+import AllocateItemsModal from "./AllocateItemsModal";
 import ConsignmentAddressSelector from './ConsignmentAddressSelector';
+import { AssignItemFailedError } from "./errors";
+import { useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
 
 interface NewConsignmentProps {
     consignmentNumber: number;
@@ -14,6 +18,7 @@ interface NewConsignmentProps {
     countriesWithAutocomplete: string[];
     isLoading: boolean;
     onUnhandledError(error: Error): void;
+    setIsAddShippingDestination: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const NewConsignment = ({
@@ -21,14 +26,18 @@ const NewConsignment = ({
     countriesWithAutocomplete,
     defaultCountryCode,
     isLoading,
-    onUnhandledError
+    onUnhandledError,
+    setIsAddShippingDestination,
 }: NewConsignmentProps) => {
     const [consignmentRequest, setConsignmentRequest] = useState<ConsignmentCreateRequestBody | undefined>();
+    const [isOpenAllocateItemsModal, setIsOpenAllocateItemsModal] = useState(false);
+    const { unassignedItems } = useMultiShippingConsignmentItems();
 
     const {
         checkoutState: {
             data: { getShippingCountries },
         },
+        checkoutService: { assignItemsToAddress: assignItem },
     } = useCheckout();
 
     const selectedAddress = useMemo(() => {
@@ -45,16 +54,63 @@ const NewConsignment = ({
         };
     }, [consignmentRequest]);
 
+
+    const toggleAllocateItemsModal = () => {
+        setIsOpenAllocateItemsModal(!isOpenAllocateItemsModal);
+    }
+
+    const handleAllocateItems = async (consignmentLineItems: ConsignmentLineItem[]) => {
+        if (!selectedAddress) {
+            return;
+        }
+
+        try {
+            await assignItem({
+                address: selectedAddress,
+                lineItems: consignmentLineItems,
+            });
+            setIsAddShippingDestination(false);
+        } catch (error) {
+            if (error instanceof AssignItemFailedError) {
+                onUnhandledError(error);
+            }
+        } finally {
+            toggleAllocateItemsModal();
+        }
+    }
+
     return (
         <div className='consignment-container'>
-            <h3 className='consignment-header'>Shipping destination {consignmentNumber}</h3>
+            <h3 className='consignment-header'>Destination #{consignmentNumber}</h3>
             <ConsignmentAddressSelector
                 countriesWithAutocomplete={countriesWithAutocomplete}
                 defaultCountryCode={defaultCountryCode}
                 isLoading={isLoading}
                 onUnhandledError={onUnhandledError}
                 selectedAddress={selectedAddress}
-                setConsignmentRequest={setConsignmentRequest} />
+                setConsignmentRequest={setConsignmentRequest}
+            />
+            {selectedAddress && (<>
+                <AllocateItemsModal
+                    address={selectedAddress}
+                    consignmentNumber={consignmentNumber}
+                    isOpen={isOpenAllocateItemsModal}
+                    onAllocateItems={handleAllocateItems}
+                    onRequestClose={toggleAllocateItemsModal}
+                    unassignedItems={unassignedItems}
+                />
+                <div className="new-consignment-line-item-header">
+                    <p>No items allocated</p>
+                    <a
+                        data-test="allocate-items-button"
+                        href="#"
+                        onClick={preventDefault(toggleAllocateItemsModal)}
+                    >
+                        Allocate items
+                    </a>
+                </div>
+            </>
+            )}
         </div>
     )
 }

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -5,7 +5,6 @@ import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
 import { LineItemType, MappedDataConsignment, MultiShippingTableItemWithType, UnassignedItems } from "../MultishippingV2Type";
 
 interface MultiShippingConsignmentItemsHook {
-    getMappedDataConsignmentById: (consignmentId: string) => MappedDataConsignment | undefined;
     unassignedItems: UnassignedItems;
     mappedDataConsignmentsList: MappedDataConsignment[];
 }
@@ -19,8 +18,7 @@ function mapConsignmentsItems(
     consignments: Consignment[],
 ): {
         mappedDataConsignmentsList: MappedDataConsignment[];
-    unassignedItems: UnassignedItems;
-    digitalItems: MultiShippingTableItemWithType[];
+        unassignedItems: UnassignedItems;
     } {
     const unassignedItemsMap = new Map<string, MultiShippingTableItemWithType>();
     const digitalItemsMap = new Map<string, MultiShippingTableItemWithType>();
@@ -66,13 +64,10 @@ function mapConsignmentsItems(
         shippableItemsCount: calculateShippableItemsCount(unassignedItemsList),
     };
 
-    const digitalItems = Array.from(digitalItemsMap.values());
-
-    return { mappedDataConsignmentsList, unassignedItems, digitalItems };
+    return { mappedDataConsignmentsList, unassignedItems };
 }
 
 const defaultMultiShippingConsignmentItems: MultiShippingConsignmentItemsHook = {
-    getMappedDataConsignmentById: () => undefined,
     unassignedItems: {
         lineItems: [],
         hasDigitalItems: false,
@@ -98,25 +93,17 @@ export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItem
         consignments,
     } = checkout;
 
-    const { digitalItems, mappedDataConsignmentsList, unassignedItems } =
+    const { mappedDataConsignmentsList, unassignedItems } =
         mapConsignmentsItems(lineItems, consignments);
-
-    const getMappedDataConsignmentById = (
-        consignmentId: string,
-    ): MappedDataConsignment | undefined => {
-        return mappedDataConsignmentsList.find((consignment) => consignment.id === consignmentId);
-    };
 
     const unassignedItemsResult: UnassignedItems = {
         ...unassignedItems,
         lineItems: [
             ...unassignedItems.lineItems,
-            ...digitalItems,
         ],
     };
 
     return {
-        getMappedDataConsignmentById,
         unassignedItems: unassignedItemsResult,
         mappedDataConsignmentsList,
     };

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -134,7 +134,7 @@ export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItem
         consignments,
     } = checkout;
 
-    const { mappedDataConsignmentsList, unassignedItems } =
+    const { digitalItems, mappedDataConsignmentsList, unassignedItems } =
         mapConsignmentsItems(lineItems, consignments);
 
     const getMappedDataConsignmentById = (
@@ -143,9 +143,17 @@ export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItem
         return mappedDataConsignmentsList.find((consignment) => consignment.id === consignmentId);
     };
 
+    const unassignedItemsResult: UnassignedItems = {
+        ...unassignedItems,
+        lineItems: [
+            ...unassignedItems.lineItems,
+            ...digitalItems,
+        ],
+    };
+
     return {
         getMappedDataConsignmentById,
-        unassignedItems,
+        unassignedItems: unassignedItemsResult,
         mappedDataConsignmentsList,
     };
 };

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -1,40 +1,8 @@
-import { Consignment, LineItemMap, LineItemOption, PhysicalItem } from "@bigcommerce/checkout-sdk";
+import { Consignment, LineItemMap } from "@bigcommerce/checkout-sdk";
 
 import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
 
-export enum LineItemType {
-    Physical,
-    Digital,
-    GiftCertificate,
-    Custom,
-}
-
-export interface MultiShippingTableItem {
-    name: string;
-    options?: LineItemOption[];
-    giftWrapping?: PhysicalItem['giftWrapping'];
-    sku: string;
-    quantity: number;
-    id: string | number;
-    imageUrl?: string;
-}
-
-export interface MultiShippingTableItemWithType extends MultiShippingTableItem {
-    type: LineItemType;
-}
-
-export interface ConsignmentItem {
-    lineItems: MultiShippingTableItemWithType[];
-    hasDigitalItems: boolean;
-    shippableItemsCount: number;
-}
-
-export type UnassignedItems = ConsignmentItem;
-
-export interface MappedDataConsignment extends Consignment, ConsignmentItem {
-    consignmentNumber: number;
-}
-
+import { LineItemType, MappedDataConsignment, MultiShippingTableItemWithType, UnassignedItems } from "../MultishippingV2Type";
 
 interface MultiShippingConsignmentItemsHook {
     getMappedDataConsignmentById: (consignmentId: string) => MappedDataConsignment | undefined;
@@ -50,12 +18,10 @@ function mapConsignmentsItems(
     lineItems: LineItemMap,
     consignments: Consignment[],
 ): {
-    mappedDataConsignmentsList: MappedDataConsignment[];
-    assignedItems: MultiShippingTableItemWithType[];
+        mappedDataConsignmentsList: MappedDataConsignment[];
     unassignedItems: UnassignedItems;
     digitalItems: MultiShippingTableItemWithType[];
-} {
-    const assignedItemsMap = new Map<string, MultiShippingTableItemWithType>();
+    } {
     const unassignedItemsMap = new Map<string, MultiShippingTableItemWithType>();
     const digitalItemsMap = new Map<string, MultiShippingTableItemWithType>();
 
@@ -78,7 +44,6 @@ function mapConsignmentsItems(
             const item = unassignedItemsMap.get(itemId);
 
             if (item) {
-                assignedItemsMap.set(itemId, item);
                 consignmentLineItems.push(item);
                 unassignedItemsMap.delete(itemId);
             }
@@ -102,9 +67,8 @@ function mapConsignmentsItems(
     };
 
     const digitalItems = Array.from(digitalItemsMap.values());
-    const assignedItems = Array.from(assignedItemsMap.values());
 
-    return { mappedDataConsignmentsList, assignedItems, unassignedItems, digitalItems };
+    return { mappedDataConsignmentsList, unassignedItems, digitalItems };
 }
 
 const defaultMultiShippingConsignmentItems: MultiShippingConsignmentItemsHook = {

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -2,11 +2,11 @@ import { Consignment, LineItemMap } from "@bigcommerce/checkout-sdk";
 
 import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
 
-import { LineItemType, MappedDataConsignment, MultiShippingTableItemWithType, UnassignedItems } from "../MultishippingV2Type";
+import { LineItemType, MultiShippingConsignmentData, MultiShippingTableData, MultiShippingTableItemWithType } from "../MultishippingV2Type";
 
 interface MultiShippingConsignmentItemsHook {
-    unassignedItems: UnassignedItems;
-    mappedDataConsignmentsList: MappedDataConsignment[];
+    unassignedItems: MultiShippingTableData;
+    consignmentList: MultiShippingConsignmentData[];
 }
 
 const calculateShippableItemsCount = (items: MultiShippingTableItemWithType[]): number => {
@@ -17,13 +17,13 @@ function mapConsignmentsItems(
     lineItems: LineItemMap,
     consignments: Consignment[],
 ): {
-        mappedDataConsignmentsList: MappedDataConsignment[];
-        unassignedItems: UnassignedItems;
+        consignmentList: MultiShippingConsignmentData[];
+        unassignedItems: MultiShippingTableData;
     } {
     const unassignedItemsMap = new Map<string, MultiShippingTableItemWithType>();
     const digitalItemsMap = new Map<string, MultiShippingTableItemWithType>();
 
-    const mappedDataConsignmentsList: MappedDataConsignment[] = [];
+    const consignmentList: MultiShippingConsignmentData[] = [];
 
     lineItems.physicalItems.forEach((item) =>
         unassignedItemsMap.set(item.id.toString(), { ...item, type: LineItemType.Physical }),
@@ -47,7 +47,7 @@ function mapConsignmentsItems(
             }
         });
 
-        mappedDataConsignmentsList.push({
+        consignmentList.push({
             ...consignment,
             consignmentNumber: index + 1,
             hasDigitalItems: false,
@@ -58,13 +58,13 @@ function mapConsignmentsItems(
 
     const unassignedItemsList = Array.from(unassignedItemsMap.values());
 
-    const unassignedItems: UnassignedItems = {
+    const unassignedItems: MultiShippingTableData = {
         lineItems: unassignedItemsList,
         hasDigitalItems: digitalItemsMap.size > 0,
         shippableItemsCount: calculateShippableItemsCount(unassignedItemsList),
     };
 
-    return { mappedDataConsignmentsList, unassignedItems };
+    return { consignmentList, unassignedItems };
 }
 
 const defaultMultiShippingConsignmentItems: MultiShippingConsignmentItemsHook = {
@@ -73,7 +73,7 @@ const defaultMultiShippingConsignmentItems: MultiShippingConsignmentItemsHook = 
         hasDigitalItems: false,
         shippableItemsCount: 0,
     },
-    mappedDataConsignmentsList: [],
+    consignmentList: [],
 };
 
 export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItemsHook => {
@@ -93,10 +93,10 @@ export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItem
         consignments,
     } = checkout;
 
-    const { mappedDataConsignmentsList, unassignedItems } =
+    const { consignmentList, unassignedItems } =
         mapConsignmentsItems(lineItems, consignments);
 
-    const unassignedItemsResult: UnassignedItems = {
+    const unassignedItemsResult: MultiShippingTableData = {
         ...unassignedItems,
         lineItems: [
             ...unassignedItems.lineItems,
@@ -105,6 +105,6 @@ export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItem
 
     return {
         unassignedItems: unassignedItemsResult,
-        mappedDataConsignmentsList,
+        consignmentList,
     };
 };

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -1,0 +1,151 @@
+import { Consignment, LineItemMap, LineItemOption, PhysicalItem } from "@bigcommerce/checkout-sdk";
+
+import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
+
+export enum LineItemType {
+    Physical,
+    Digital,
+    GiftCertificate,
+    Custom,
+}
+
+export interface MultiShippingTableItem {
+    name: string;
+    options?: LineItemOption[];
+    giftWrapping?: PhysicalItem['giftWrapping'];
+    sku: string;
+    quantity: number;
+    id: string | number;
+    imageUrl?: string;
+}
+
+export interface MultiShippingTableItemWithType extends MultiShippingTableItem {
+    type: LineItemType;
+}
+
+export interface ConsignmentItem {
+    lineItems: MultiShippingTableItemWithType[];
+    hasDigitalItems: boolean;
+    shippableItemsCount: number;
+}
+
+export type UnassignedItems = ConsignmentItem;
+
+export interface MappedDataConsignment extends Consignment, ConsignmentItem {
+    consignmentNumber: number;
+}
+
+
+interface MultiShippingConsignmentItemsHook {
+    getMappedDataConsignmentById: (consignmentId: string) => MappedDataConsignment | undefined;
+    unassignedItems: UnassignedItems;
+    mappedDataConsignmentsList: MappedDataConsignment[];
+}
+
+const calculateShippableItemsCount = (items: MultiShippingTableItemWithType[]): number => {
+    return items.reduce((total, item) => total + item.quantity, 0);
+};
+
+function mapConsignmentsItems(
+    lineItems: LineItemMap,
+    consignments: Consignment[],
+): {
+    mappedDataConsignmentsList: MappedDataConsignment[];
+    assignedItems: MultiShippingTableItemWithType[];
+    unassignedItems: UnassignedItems;
+    digitalItems: MultiShippingTableItemWithType[];
+} {
+    const assignedItemsMap = new Map<string, MultiShippingTableItemWithType>();
+    const unassignedItemsMap = new Map<string, MultiShippingTableItemWithType>();
+    const digitalItemsMap = new Map<string, MultiShippingTableItemWithType>();
+
+    const mappedDataConsignmentsList: MappedDataConsignment[] = [];
+
+    lineItems.physicalItems.forEach((item) =>
+        unassignedItemsMap.set(item.id.toString(), { ...item, type: LineItemType.Physical }),
+    );
+    lineItems.customItems?.forEach((item) =>
+        unassignedItemsMap.set(item.id, { ...item, type: LineItemType.Custom }),
+    );
+    lineItems.digitalItems.forEach((item) =>
+        digitalItemsMap.set(item.id.toString(), { ...item, type: LineItemType.Digital }),
+    );
+
+    consignments.forEach((consignment, index) => {
+        const consignmentLineItems: MultiShippingTableItemWithType[] = [];
+
+        consignment.lineItemIds.forEach((itemId) => {
+            const item = unassignedItemsMap.get(itemId);
+
+            if (item) {
+                assignedItemsMap.set(itemId, item);
+                consignmentLineItems.push(item);
+                unassignedItemsMap.delete(itemId);
+            }
+        });
+
+        mappedDataConsignmentsList.push({
+            ...consignment,
+            consignmentNumber: index + 1,
+            hasDigitalItems: false,
+            shippableItemsCount: calculateShippableItemsCount(consignmentLineItems),
+            lineItems: consignmentLineItems,
+        });
+    });
+
+    const unassignedItemsList = Array.from(unassignedItemsMap.values());
+
+    const unassignedItems: UnassignedItems = {
+        lineItems: unassignedItemsList,
+        hasDigitalItems: digitalItemsMap.size > 0,
+        shippableItemsCount: calculateShippableItemsCount(unassignedItemsList),
+    };
+
+    const digitalItems = Array.from(digitalItemsMap.values());
+    const assignedItems = Array.from(assignedItemsMap.values());
+
+    return { mappedDataConsignmentsList, assignedItems, unassignedItems, digitalItems };
+}
+
+const defaultMultiShippingConsignmentItems: MultiShippingConsignmentItemsHook = {
+    getMappedDataConsignmentById: () => undefined,
+    unassignedItems: {
+        lineItems: [],
+        hasDigitalItems: false,
+        shippableItemsCount: 0,
+    },
+    mappedDataConsignmentsList: [],
+};
+
+export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItemsHook => {
+    const { checkoutState: {
+        data: { getCheckout },
+    },
+    } = useCheckout();
+
+    const checkout = getCheckout();
+
+    if (!checkout) {
+        return defaultMultiShippingConsignmentItems;
+    }
+
+    const {
+        cart: { lineItems },
+        consignments,
+    } = checkout;
+
+    const { mappedDataConsignmentsList, unassignedItems } =
+        mapConsignmentsItems(lineItems, consignments);
+
+    const getMappedDataConsignmentById = (
+        consignmentId: string,
+    ): MappedDataConsignment | undefined => {
+        return mappedDataConsignmentsList.find((consignment) => consignment.id === consignmentId);
+    };
+
+    return {
+        getMappedDataConsignmentById,
+        unassignedItems,
+        mappedDataConsignmentsList,
+    };
+};


### PR DESCRIPTION
## What?

- Add allocate items modal for new SF multishipping UI

## Why?

- So that products can be assigned to an address in the new multi shipping experience.

## Testing / Proof

- CI checks
- Manual testing

https://github.com/user-attachments/assets/149bcfc2-58ba-4941-b3a6-5147dbbd3244



@bigcommerce/team-checkout
