### PR TITLE
fix(shipping): CHECKOUT-8776 Add validation of form field for max length for google autocomplete

### DIFF
--- a/packages/core/src/app/address/getAddressFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/address/getAddressFormFieldsValidationSchema.ts
@@ -11,6 +11,7 @@ import {
 export interface AddressFormFieldsValidationSchemaOptions {
     formFields: FormField[];
     language?: LanguageService;
+    validateGoogleMapAutoCompleteMaxLength?: boolean;
 }
 
 export function getTranslateAddressError(
@@ -62,9 +63,11 @@ export function getTranslateAddressError(
 export default memoize(function getAddressFormFieldsValidationSchema({
     formFields,
     language,
+    validateGoogleMapAutoCompleteMaxLength,
 }: AddressFormFieldsValidationSchemaOptions): ObjectSchema<FormFieldValues> {
     return getFormFieldsValidationSchema({
         formFields,
         translate: getTranslateAddressError(language),
+        validateGoogleMapAutoCompleteMaxLength,
     });
 });

--- a/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
@@ -27,8 +27,7 @@ export type TranslateValidationErrorFunction = (
 export interface FormFieldsValidationSchemaOptions {
     formFields: FormField[];
     translate?: TranslateValidationErrorFunction;
-    googleMapsAutocompleteEnabled?: boolean;
-    googleAutocompleteMaxLengthExperiment?: boolean;
+    validateGoogleMapAutoCompleteMaxLength?: boolean;
 }
 
 export interface CustomFormFieldValues {

--- a/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
@@ -27,6 +27,8 @@ export type TranslateValidationErrorFunction = (
 export interface FormFieldsValidationSchemaOptions {
     formFields: FormField[];
     translate?: TranslateValidationErrorFunction;
+    googleMapsAutocompleteEnabled?: boolean;
+    googleAutocompleteMaxLengthExperiment?: boolean;
 }
 
 export interface CustomFormFieldValues {

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.spec.tsx
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.spec.tsx
@@ -123,4 +123,49 @@ describe('getFormFielsValidationSchema', () => {
             expect(spy).toHaveBeenCalled();
         });
     });
+
+    describe('google autocomplete validation', () => {
+        it('throws error for google maps autocomplete validation for max length', async () => {
+            const formFieldsWithMaxLength = formFields.map(field => {
+                const { name } = field;
+                return name === 'address1' ? { ...field, maxLength: 20 } : field;
+            });
+    
+    
+            const schema = getFormFieldsValidationSchema({ formFields: formFieldsWithMaxLength, translate, validateGoogleMapAutoCompleteMaxLength: true });
+            const errors = await schema
+                .validate({
+                    ...getShippingAddress(),
+                    address1: 'this is a long address 1 from somewhere',
+                })
+                .catch((error: ValidationError) => error.message);
+            
+
+            expect(translate).toHaveBeenCalledWith('max', {
+                label: 'Address Line 1',
+                name: 'address1',
+                max: 20,
+            });
+            expect(errors).toBe('address1 must be at most 20 characters');
+        });
+
+        it('throws no error for max length validation if google autocomplete is not enabled', async () => {
+            const spy = jest.fn();
+            const formFieldsWithMaxLength = formFields.map(field => {
+                const { name } = field;
+                return name === 'address1' ? { ...field, maxLength: 20 } : field;
+            });
+    
+    
+            const schema = getFormFieldsValidationSchema({ formFields: formFieldsWithMaxLength, translate });
+            await schema
+                .validate({
+                    ...getShippingAddress(),
+                    address1: 'this is a long address 1 from somewhere',
+                })
+                .then(spy);
+
+            expect(spy).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
@@ -18,13 +18,18 @@ export default memoize(function getFormFieldsValidationSchema({
     return object({
         ...formFields
             .filter(({ custom }) => !custom)
-            .reduce((schema, { name, required, label }) => {
+            .reduce((schema, { name, required, label, maxLength }) => {
                 schema[name] = string();
 
                 if (required) {
                     schema[name] = schema[name]
                         .trim()
-                        .required(translate('required', { label, name }));
+                        .required(translate('required', { label, name}));
+                }
+
+                if (name === 'address1' && maxLength) {
+                    schema[name] = schema[name]
+                        .max(maxLength, translate('max', { label, name, max: maxLength }));
                 }
 
                 schema[name] = schema[name].matches(

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
@@ -14,8 +14,7 @@ export interface FormFieldValues {
 export default memoize(function getFormFieldsValidationSchema({
     formFields,
     translate = () => undefined,
-    googleMapsAutocompleteEnabled = false,
-    googleAutocompleteMaxLengthExperiment = false,
+    validateGoogleMapAutoCompleteMaxLength = false,
 }: FormFieldsValidationSchemaOptions): ObjectSchema<FormFieldValues> {
     return object({
         ...formFields
@@ -29,7 +28,7 @@ export default memoize(function getFormFieldsValidationSchema({
                         .required(translate('required', { label, name}));
                 }
 
-                if (name === 'address1' && maxLength && googleMapsAutocompleteEnabled && googleAutocompleteMaxLengthExperiment) {
+                if (name === 'address1' && maxLength && validateGoogleMapAutoCompleteMaxLength) {
                     schema[name] = schema[name]
                         .max(maxLength, translate('max', { label, name, max: maxLength + 1 }));
                 }

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
@@ -30,7 +30,7 @@ export default memoize(function getFormFieldsValidationSchema({
 
                 if (name === 'address1' && maxLength && validateGoogleMapAutoCompleteMaxLength) {
                     schema[name] = schema[name]
-                        .max(maxLength, translate('max', { label, name, max: maxLength + 1 }));
+                        .max(maxLength, translate('max', { label, name, max: maxLength }));
                 }
 
                 schema[name] = schema[name].matches(

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
@@ -14,6 +14,8 @@ export interface FormFieldValues {
 export default memoize(function getFormFieldsValidationSchema({
     formFields,
     translate = () => undefined,
+    googleMapsAutocompleteEnabled = false,
+    googleAutocompleteMaxLengthExperiment = false,
 }: FormFieldsValidationSchemaOptions): ObjectSchema<FormFieldValues> {
     return object({
         ...formFields
@@ -27,9 +29,9 @@ export default memoize(function getFormFieldsValidationSchema({
                         .required(translate('required', { label, name}));
                 }
 
-                if (name === 'address1' && maxLength) {
+                if (name === 'address1' && maxLength && googleMapsAutocompleteEnabled && googleAutocompleteMaxLengthExperiment) {
                     schema[name] = schema[name]
-                        .max(maxLength, translate('max', { label, name, max: maxLength }));
+                        .max(maxLength, translate('max', { label, name, max: maxLength + 1 }));
                 }
 
                 schema[name] = schema[name].matches(

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -410,8 +410,6 @@ export function mapToShippingProps({
             'CHECKOUT-8776.google_autocomplete_max_length_validation',
         ) && Boolean(googleMapsApiKey);
 
-    console.log('validateGoogleMapAutoCompleteMaxLength', googleMapsApiKey, validateGoogleMapAutoCompleteMaxLength);
-
     const shippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();
 

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -71,6 +71,7 @@ export interface WithCheckoutShippingProps {
     shouldRenderWhileLoading: boolean;
     providerWithCustomCheckout?: string;
     isFloatingLabelEnabled?: boolean;
+    validateGoogleMapAutoCompleteMaxLength: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitializeShippingMethod(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -127,6 +128,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             isGuest,
             shouldShowMultiShipping,
             isNewMultiShippingUIEnabled,
+            validateGoogleMapAutoCompleteMaxLength,
             customer,
             updateShippingAddress,
             initializeShippingMethod,
@@ -183,6 +185,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         isInitialValueLoaded={shouldRenderWhileLoading ? !isInitializing : true}
                         isMultiShippingMode={isMultiShippingMode}
                         isNewMultiShippingUIEnabled={isNewMultiShippingUIEnabled}
+                        validateGoogleMapAutoCompleteMaxLength={validateGoogleMapAutoCompleteMaxLength}
                         onMultiShippingSubmit={this.handleMultiShippingSubmit}
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}
                         onUseNewAddress={this.handleUseNewAddress}
@@ -397,8 +400,17 @@ export function mapToShippingProps({
         isExperimentEnabled(
             config.checkoutSettings,
             'PROJECT-4159.improve_multi_address_shipping_ui',
-        ) 
+        );
+
     const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ', 'GB'];
+
+    const validateGoogleMapAutoCompleteMaxLength =
+        isExperimentEnabled(
+            config.checkoutSettings,
+            'CHECKOUT-8776.google_autocomplete_max_length_validation',
+        ) && Boolean(googleMapsApiKey);
+
+    console.log('validateGoogleMapAutoCompleteMaxLength', googleMapsApiKey, validateGoogleMapAutoCompleteMaxLength);
 
     const shippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();
@@ -435,6 +447,7 @@ export function mapToShippingProps({
         shouldRenderWhileLoading: features['CHECKOUT-8300.improve_extension_performance'] ?? true,
         shouldShowMultiShipping,
         isNewMultiShippingUIEnabled,
+        validateGoogleMapAutoCompleteMaxLength,
         shouldShowOrderComments: enableOrderComments,
         signOut: checkoutService.signOutCustomer,
         unassignItem: checkoutService.unassignItemsToAddress,

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -45,6 +45,7 @@ export interface ShippingFormProps {
     isFloatingLabelEnabled?: boolean;
     isInitialValueLoaded: boolean;
     isNewMultiShippingUIEnabled: boolean;
+    validateGoogleMapAutoCompleteMaxLength: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -99,6 +100,7 @@ const ShippingForm = ({
     isFloatingLabelEnabled,
     isInitialValueLoaded,
     isNewMultiShippingUIEnabled,
+    isGoogleMapsMaxLengthValidationExperimentEnabled,
 }: ShippingFormProps & WithLanguageProps) => {
     const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
 
@@ -176,6 +178,7 @@ const ShippingForm = ({
             shouldShowSaveAddress={shouldShowSaveAddress}
             signOut={signOut}
             updateAddress={updateAddress}
+            validateGoogleMapAutoCompleteMaxLength={validateGoogleMapAutoCompleteMaxLength}
         />
     );
 };

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -100,7 +100,7 @@ const ShippingForm = ({
     isFloatingLabelEnabled,
     isInitialValueLoaded,
     isNewMultiShippingUIEnabled,
-    isGoogleMapsMaxLengthValidationExperimentEnabled,
+    validateGoogleMapAutoCompleteMaxLength,
 }: ShippingFormProps & WithLanguageProps) => {
     const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
 

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -57,6 +57,7 @@ export interface SingleShippingFormProps {
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
     isInitialValueLoaded: boolean;
+    validateGoogleMapAutoCompleteMaxLength: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
     getFields(countryCode?: string): FormField[];
@@ -348,6 +349,7 @@ export default withLanguage(
             language,
             getFields,
             methodId,
+            validateGoogleMapAutoCompleteMaxLength,
         }: SingleShippingFormProps & WithLanguageProps) =>
             shouldHaveCustomValidation(methodId)
                 ? object({
@@ -363,6 +365,7 @@ export default withLanguage(
                           getAddressFormFieldsValidationSchema({
                               language,
                               formFields: getFields(formValues && formValues.countryCode),
+                              validateGoogleMapAutoCompleteMaxLength,
                           }),
                       ),
                   }),


### PR DESCRIPTION
## What?
Add validation of form field for max length for google autocomplete

## Why?
Add validation of form field for max length for google autocomplete since if a max length is set for address field then it is not respected for google autocomplete

## Testing / Proof
- CI
- Screencast

#### Experiment on & Google autocomplete enabled

https://github.com/user-attachments/assets/157a4457-fd9e-49ff-b99d-e2c231ee8805

#### Experiment off & Google autocomplete enabled

https://github.com/user-attachments/assets/d463b3b3-8de1-4088-8232-746aa73ddf2f

#### Experiment on & Google autocomplete disabled

https://github.com/user-attachments/assets/5b292cc5-521c-4813-81bb-dc62b47aa2b3


@bigcommerce/team-checkout
