### PR TITLE
CHECKOUT-8602: Add validation and error handling for allocate items modal

### DIFF
--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -66,7 +66,7 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
     const formErrors = useMemo(() => {
         const errorKeys = Object.keys(errors);
 
-        return errorKeys.reduce((acc, key) => {
+        return errorKeys.reduce((acc: string[], key: string) => {
             const error = errors[key];
 
             if (error) {
@@ -74,7 +74,7 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
             }
 
             return Array.from(new Set(acc));
-        }, [] as string[]);
+        }, []);
     }, [errors]);
 
     const modalFooter = (

--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -158,17 +158,17 @@ export default withLanguage(
             return values;
         },
         enableReinitialize: true,
-        validationSchema: ({ unassignedItems }: AllocateItemsModalProps) => {
+        validationSchema: ({ language, unassignedItems }: AllocateItemsModalProps & WithLanguageProps) => {
             const createItemSchema = (item: MultiShippingTableItemWithType) => {
                 const baseSchema = number()
-                    .required('Quantity is required')
-                    .integer('Quantity must be an integer')
-                    .min(0, 'Quantity cannot be less than 0')
-                    .max(item.quantity, 'Quantity cannot exceed "Left to allocate" amount.')
+                    .required(language.translate('shipping.quantity_required_error'))
+                    .integer(language.translate('shipping.quantity_invalid_error'))
+                    .min(0, language.translate('shipping.quantity_min_error'))
+                    .max(item.quantity, language.translate('shipping.quantity_max_error'))
 
                 if (item.type === LineItemType.Custom) {
                     return baseSchema
-                        .oneOf([0, item.quantity], 'All quantities of this custom product must be allocated to the same destination, as it was created specifically for this draft order.')
+                        .oneOf([0, item.quantity], language.translate('shipping.custom_item_quantity_error'))
                 }
 
                 return baseSchema;

--- a/packages/core/src/app/shipping/LeftToAllocateItem.tsx
+++ b/packages/core/src/app/shipping/LeftToAllocateItem.tsx
@@ -29,6 +29,7 @@ const LeftToAllocateItem: FunctionComponent<LeftToAllocateItemProps> = ({ item, 
                     additionalClassName={error ? "form-field--error" : ""}
                     input={({ field }) => <TextInput
                         {...field}
+                        aria-label={`Quantity of ${item.name}`}
                         disabled={item.quantity === 0}
                         id={field.name}
                         min={0}

--- a/packages/core/src/app/shipping/LeftToAllocateItem.tsx
+++ b/packages/core/src/app/shipping/LeftToAllocateItem.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent } from "react";
+
+import { FormField, TextInput } from "../ui/form";
+
+import { MultiShippingTableItemWithType } from "./MultishippingV2Type";
+
+interface LeftToAllocateItemProps {
+    item: MultiShippingTableItemWithType;
+    error?: string;
+}
+
+const LeftToAllocateItem: FunctionComponent<LeftToAllocateItemProps> = ({ item, error }: LeftToAllocateItemProps) => {
+    return (
+        <tr>
+            <td className="left-to-allocate-item-name-container">
+                <figure className="left-to-allocate-item-figure">
+                    {item.imageUrl && <img alt={item.name} src={item.imageUrl} />}
+                </figure>
+                <div className="left-to-allocate-item-name">
+                    <p>{item.name}</p>
+                    {item.options?.map(option => (
+                        <p className="left-to-allocate-item-option" key={option.nameId}>{option.name}: {option.value}</p>
+                    ))}
+                </div>
+            </td>
+            <td>{item.quantity}</td>
+            <td>
+                <FormField
+                    additionalClassName={error ? "form-field--error" : ""}
+                    input={({ field }) => <TextInput
+                        {...field}
+                        disabled={item.quantity === 0}
+                        id={field.name}
+                        min={0}
+                        type="number"
+                    />}
+                    name={item.id.toString()}
+                />
+            </td>
+        </tr>
+    );
+}
+
+export default LeftToAllocateItem;

--- a/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
+++ b/packages/core/src/app/shipping/LeftToAllocateItemsTable.tsx
@@ -1,39 +1,16 @@
+import { FormikErrors } from "formik";
 import React, { FunctionComponent } from "react";
 
-import { FormField, TextInput } from "../ui/form";
-
+import { AllocateItemsModalFormValues } from "./AllocateItemsModal";
+import LeftToAllocateItem from "./LeftToAllocateItem";
 import { MultiShippingTableItemWithType } from "./MultishippingV2Type";
 
 interface LeftToAllocateItemsTableProps {
     items: MultiShippingTableItemWithType[];
+    formErrors: FormikErrors<AllocateItemsModalFormValues>;
 }
 
-const LeftToAllocateTableItem = ({ item }: { item: MultiShippingTableItemWithType }) => {
-    return (
-        <tr>
-            <td className="left-to-allocate-item-name-container">
-                <figure className="left-to-allocate-item-figure">
-                    {item.imageUrl && <img alt={item.name} src={item.imageUrl} />}
-                </figure>
-                <div className="left-to-allocate-item-name">
-                    <p>{item.name}</p>
-                    {item.options?.map(option => (
-                        <p className="left-to-allocate-item-option" key={option.nameId}>{option.name}: {option.value}</p>
-                    ))}
-                </div>
-            </td>
-            <td>{item.quantity}</td>
-            <td>
-                <FormField
-                    input={({ field }) => <TextInput {...field} disabled={item.quantity === 0} id={field.name} type="number" />}
-                    name={item.id.toString()}
-                />
-            </td>
-        </tr>
-    );
-}
-
-const LeftToAllocateItemsTable: FunctionComponent<LeftToAllocateItemsTableProps> = ({ items }: LeftToAllocateItemsTableProps) => {
+const LeftToAllocateItemsTable: FunctionComponent<LeftToAllocateItemsTableProps> = ({ items, formErrors }: LeftToAllocateItemsTableProps) => {
     return (
         <table className="table left-to-allocate-items-table">
             <thead>
@@ -45,7 +22,11 @@ const LeftToAllocateItemsTable: FunctionComponent<LeftToAllocateItemsTableProps>
             </thead>
             <tbody>
                 {items.map(item => (
-                    <LeftToAllocateTableItem item={item} key={item.id} />      
+                    <LeftToAllocateItem
+                        error={formErrors[item.id.toString()]}
+                        item={item}
+                        key={item.id}
+                    />      
                 ))}
             </tbody>
         </table>

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -79,9 +79,6 @@ $allocate-items-table-image-width: 20%;
 
         .form-errors {
             margin-bottom: spacing("base");
-            .alertBox {
-                border-radius: $global-radius;
-            }
         }
 
         .left-to-allocate-items-table-actions {

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -66,12 +66,106 @@ $allocate-items-table-image-width: 20%;
 }
 
 .allocate-items-modal {
+    .modal-header {
+        padding-bottom: spacing("base");
+    }
+
     .modal-body {
         padding-top: 0;
 
-        h3 {
-            margin-bottom: #{spacing("single") + spacing("half")};
-            font-weight: fontWeight("normal");
+        h4 {
+            margin-bottom: #{spacing("base")};
+        }
+
+        .form-errors {
+            margin-bottom: spacing("base");
+            .alertBox {
+                border-radius: $global-radius;
+            }
+        }
+
+        .left-to-allocate-items-table-actions {
+            display: flex;
+            margin-bottom: spacing("base");
+            justify-content: space-between;
+            
+            p {
+                margin-bottom: 0;
+            }
+    
+            div {
+                display: flex;
+                gap: spacing("single");
+            }
+        }
+    
+        .left-to-allocate-items-table {
+            margin-top: spacing("base");
+            border-left: none;
+            border-right: none;
+        
+            thead {
+                background: none;
+                tr {
+                    border-top: container("border");
+                    border-bottom: container("border");
+                    th:first-child {
+                        width: $allocate-items-table-first-column-width;
+                        text-align: left;
+                    }
+                    th {
+                        width: $allocate-items-table-column-width;
+                        padding: spacing("base");
+                        text-align: right;
+                    }
+                }
+            }
+    
+            
+            tbody {
+                tr {
+                    border-top: container("border");
+                    border-bottom: container("border");
+                    td:first-child {
+                        text-align: left;
+                    }
+                    td {
+                        padding: spacing("base");
+                        text-align: right;
+                        div {
+                            float: right;
+                            width: $quantity-input-container-width;
+                            input {
+                                text-align: right;
+                                padding: spacing("half");
+                            }
+                        }
+                    }
+                }
+            }
+    
+            .left-to-allocate-item-name-container {
+                display: flex;
+                align-items: center;
+    
+                .left-to-allocate-item-figure {
+                    margin: 0;
+                    width: $allocate-items-table-image-width;
+                    padding-right: spacing("half");
+                }
+                
+                .left-to-allocate-item-name {
+                    p {
+                        margin-bottom: 0;
+                    }
+    
+                    .left-to-allocate-item-options {
+                        color: color("greys");
+                        font-size: fontSize("tiny");
+                        margin: 0;
+                    }
+                }
+            }  
         }
     }
 
@@ -80,89 +174,5 @@ $allocate-items-table-image-width: 20%;
             margin-left: 0;
             border: none;
         }
-    }
-
-    .left-to-allocate-items-table-actions {
-        display: flex;
-        margin-bottom: spacing("base");
-        justify-content: space-between;
-        
-        p {
-            margin-bottom: 0;
-        }
-
-        div {
-            display: flex;
-            gap: spacing("half");
-        }
-    }
-
-    .left-to-allocate-items-table {
-        margin-top: spacing("base");
-        border-left: none;
-        border-right: none;
-    
-        thead {
-            background: none;
-            tr {
-                border-top: container("border");
-                border-bottom: container("border");
-                th:first-child {
-                    width: $allocate-items-table-first-column-width;
-                    text-align: left;
-                }
-                th {
-                    width: $allocate-items-table-column-width;
-                    padding: spacing("base");
-                    text-align: right;
-                }
-            }
-        }
-
-        
-        tbody {
-            tr {
-                border-top: container("border");
-                border-bottom: container("border");
-                td:first-child {
-                    text-align: left;
-                }
-                td {
-                    padding: spacing("base");
-                    text-align: right;
-                    div {
-                        float: right;
-                        width: $quantity-input-container-width;
-                        input {
-                            text-align: right;
-                            padding: spacing("half");
-                        }
-                    }
-                }
-            }
-        }
-
-        .left-to-allocate-item-name-container {
-            display: flex;
-            align-items: center;
-
-            .left-to-allocate-item-figure {
-                margin: 0;
-                width: $allocate-items-table-image-width;
-                padding-right: spacing("half");
-            }
-            
-            .left-to-allocate-item-name {
-                p {
-                    margin-bottom: 0;
-                }
-
-                .left-to-allocate-item-options {
-                    color: color("greys");
-                    font-size: fontSize("tiny");
-                    margin: 0;
-                }
-            }
-        }  
     }
 }

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -146,7 +146,7 @@ describe('MultiShippingFormV2 Component', () => {
         expect(screen.getByText('Destination #1')).toBeInTheDocument();
         expect(screen.getByText(getAddressContent(address))).toBeInTheDocument();
 
-        expect(screen.getByText('2 items left to allocate')).toBeInTheDocument();
+        expect(screen.getByText('3 items left to allocate')).toBeInTheDocument();
 
         const addShippingDestinationButton = screen.getByRole('button', { name: 'Add new destination' });
 

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -206,7 +206,7 @@ describe('MultiShippingFormV2 Component', () => {
         expect(within(allocateItemsModal).getByRole('button', { name: 'Allocate' })).toBeEnabled();
 
         await userEvent.click(within(allocateItemsModal).getByRole('button', { name: 'Allocate' }));
-        expect(within(allocateItemsModal).getByText('Quantity cannot exceed "Left to allocate" amount.')).toBeInTheDocument();
+        expect(within(allocateItemsModal).getByText(localeContext.language.translate('shipping.quantity_max_error'))).toBeInTheDocument();
 
         await userEvent.clear(physicalItemQuantityInput);
         await userEvent.type(physicalItemQuantityInput, '1');
@@ -222,7 +222,7 @@ describe('MultiShippingFormV2 Component', () => {
         expect(customItemQuantityInput).toHaveValue(5);
 
         await userEvent.click(within(allocateItemsModal).getByRole('button', { name: 'Allocate' }));
-        expect(within(allocateItemsModal).getByText('All quantities of this custom product must be allocated to the same destination, as it was created specifically for this draft order.')).toBeInTheDocument();
+        expect(within(allocateItemsModal).getByText(localeContext.language.translate('shipping.custom_item_quantity_error'))).toBeInTheDocument();
 
         await userEvent.clear(customItemQuantityInput);
         await userEvent.type(customItemQuantityInput, `${getCustomItem().quantity}`);

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -96,15 +96,8 @@ export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItem
     const { consignmentList, unassignedItems } =
         mapConsignmentsItems(lineItems, consignments);
 
-    const unassignedItemsResult: MultiShippingTableData = {
-        ...unassignedItems,
-        lineItems: [
-            ...unassignedItems.lineItems,
-        ],
-    };
-
     return {
-        unassignedItems: unassignedItemsResult,
+        unassignedItems,
         consignmentList,
     };
 };

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -522,7 +522,12 @@
             "shipping_method_label": "Shipping Method",
             "shipping_option_expired_error": "The shipping price you were quoted is no longer valid. Click OK to see the most up-to-date shipping prices.",
             "shipping_option_expired_heading": "Your shipping price has been updated",
-            "view_shipping_options_action": "See Other Options"
+            "view_shipping_options_action": "See Other Options",
+            "quantity_required_error": "Quantity is required",
+            "quantity_invalid_error": "Quantity must be a number",
+            "quantity_max_error": "Quantity cannot exceed \"Left to allocate\" amount.",
+            "quantity_min_error": "Quantity cannot be less than 0",
+            "custom_item_quantity_error": "All quantities of this custom product must be allocated to the same destination, as it was created specifically for this draft order."
         },
         "social": {
             "share_action": "Share",


### PR DESCRIPTION
## What?
Implement validation and validation error display on the allocate items modal for new SF mulshipping UI.

## Why?
Display validation errors for both physical and custom items quantity field on the allocate items modal and prevent form getting submitted.

## Testing / Proof

- CI checks
- Manual testing

https://github.com/user-attachments/assets/171ae0eb-7db6-41e6-8000-ed350e7828f0


@bigcommerce/team-checkout
