### PR TITLE
chore(payment): PAYPAL-4697 bump checkout-sdk to 1.674.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.672.2",
+        "@bigcommerce/checkout-sdk": "^1.674.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.672.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.672.2.tgz",
-      "integrity": "sha512-Q0CHNb8n6W9+vVV4ASp2d/Cfd5vwD7jb4gbTZWMtV8Ly9AGnDrbrovH2juPTaHbAsveCIYj4Y77uXR1Fv6+q4w==",
+      "version": "1.674.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.674.0.tgz",
+      "integrity": "sha512-nTcWQKYTbTr70PxHdBG7B8eizrcBmXeEBjJ+xr3OZMO/UvC3cIJuBXJwheK4iJy79wi0cjPWW6LpHmJswHg4Zw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.672.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.672.2.tgz",
-      "integrity": "sha512-Q0CHNb8n6W9+vVV4ASp2d/Cfd5vwD7jb4gbTZWMtV8Ly9AGnDrbrovH2juPTaHbAsveCIYj4Y77uXR1Fv6+q4w==",
+      "version": "1.674.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.674.0.tgz",
+      "integrity": "sha512-nTcWQKYTbTr70PxHdBG7B8eizrcBmXeEBjJ+xr3OZMO/UvC3cIJuBXJwheK4iJy79wi0cjPWW6LpHmJswHg4Zw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.672.2",
+    "@bigcommerce/checkout-sdk": "^1.674.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk to 1.674.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2657
https://github.com/bigcommerce/checkout-sdk-js/pull/2659

## Testing / Proof
Unit tests
Manual tests
CI
Verified by QA/SDET
