### PR TITLE
chore(payment): STRIPE-461 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.674.0",
+        "@bigcommerce/checkout-sdk": "^1.675.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.674.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.674.0.tgz",
-      "integrity": "sha512-nTcWQKYTbTr70PxHdBG7B8eizrcBmXeEBjJ+xr3OZMO/UvC3cIJuBXJwheK4iJy79wi0cjPWW6LpHmJswHg4Zw==",
+      "version": "1.675.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.675.0.tgz",
+      "integrity": "sha512-nq9sOLyozD2AYPS8+MEZfGaCmUdZw4hEUC/vq5sj8elwKYFSBg7k8ScytCMkVs5DMjLB1tQtdDsFvVkIEwpXYA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.674.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.674.0.tgz",
-      "integrity": "sha512-nTcWQKYTbTr70PxHdBG7B8eizrcBmXeEBjJ+xr3OZMO/UvC3cIJuBXJwheK4iJy79wi0cjPWW6LpHmJswHg4Zw==",
+      "version": "1.675.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.675.0.tgz",
+      "integrity": "sha512-nq9sOLyozD2AYPS8+MEZfGaCmUdZw4hEUC/vq5sj8elwKYFSBg7k8ScytCMkVs5DMjLB1tQtdDsFvVkIEwpXYA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.674.0",
+    "@bigcommerce/checkout-sdk": "^1.675.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2710](https://github.com/bigcommerce/checkout-sdk-js/pull/2710)

## Testing / Proof
Unit test and manually tested

@bigcommerce/team-checkout
