### PR TITLE
feat(checkout): CHECKOUT-8790 Display detailed error when applying coupon fails on checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32532,9 +32532,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -58541,9 +58541,9 @@
       }
     },
     "tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tslint": {
       "version": "6.1.3",

--- a/packages/core/src/app/cart/Redeemable.spec.tsx
+++ b/packages/core/src/app/cart/Redeemable.spec.tsx
@@ -24,7 +24,13 @@ describe('CartSummary Component', () => {
         errors: [{ code: 'min_purchase' }],
     } as RequestError;
     const appliedError = {
+        errors: [{ code: '', message: 'Specific error message'}],
+    } as RequestError;
+    const appliedErrorWithoutMessage = {
         errors: [{}],
+    } as RequestError;
+    const appliedErrorWitEmptyStringMessage = {
+        errors: [{code: '', message: ''}],
     } as RequestError;
 
     const RedeemableTestComponent = (props: RedeemableProps) => (
@@ -86,6 +92,52 @@ describe('CartSummary Component', () => {
         });
     });
 
+    describe('when coupon code is not collapsed When there is applied error without error message', () => {
+        beforeEach(() => {
+            component = mount(
+              <RedeemableTestComponent
+                appliedRedeemableError={appliedErrorWithoutMessage}
+                applyCoupon={applyCoupon}
+                applyGiftCertificate={applyGiftCertificate}
+                clearError={clearError}
+                isApplyingRedeemable={true}
+                onRemovedCoupon={onRemovedCoupon}
+                onRemovedGiftCertificate={onRemovedGiftCertificate}
+                shouldCollapseCouponCode={false}
+              />,
+            );
+        });
+
+        it('renders the generic coupon invalid error', () => {
+            expect(component.find(Alert).find(TranslatedString).prop('id')).toBe(
+              'redeemable.code_invalid_error',
+            );
+        });
+    });
+
+    describe('when coupon code is not collapsed When there is applied error with empty error message', () => {
+        beforeEach(() => {
+            component = mount(
+              <RedeemableTestComponent
+                appliedRedeemableError={appliedErrorWitEmptyStringMessage}
+                applyCoupon={applyCoupon}
+                applyGiftCertificate={applyGiftCertificate}
+                clearError={clearError}
+                isApplyingRedeemable={true}
+                onRemovedCoupon={onRemovedCoupon}
+                onRemovedGiftCertificate={onRemovedGiftCertificate}
+                shouldCollapseCouponCode={false}
+              />,
+            );
+        });
+
+        it('renders the generic coupon invalid error', () => {
+            expect(component.find(Alert).find(TranslatedString).prop('id')).toBe(
+              'redeemable.code_invalid_error',
+            );
+        });
+    });
+
     describe('when coupon code is collapsed', () => {
         beforeEach(() => {
             component = mount(
@@ -115,9 +167,7 @@ describe('CartSummary Component', () => {
 
             it('renders error', () => {
                 expect(component.find(Alert)).toHaveLength(1);
-                expect(component.find(Alert).text()).toEqual(
-                    localeContext.language.translate('redeemable.code_invalid_error'),
-                );
+                expect(component.find(Alert).text()).toBe('Specific error message');
             });
 
             it('renders redeemable form', () => {
@@ -182,6 +232,68 @@ describe('CartSummary Component', () => {
 
                     expect(applyGiftCertificate).toHaveBeenCalledWith('foo');
                 });
+            });
+        });
+    });
+
+    describe('when coupon code is collapsed When there is applied error without error message', () => {
+        beforeEach(() => {
+            component = mount(
+              <RedeemableTestComponent
+                appliedRedeemableError={appliedErrorWithoutMessage}
+                applyCoupon={applyCoupon}
+                applyGiftCertificate={applyGiftCertificate}
+                clearError={clearError}
+                onRemovedCoupon={onRemovedCoupon}
+                onRemovedGiftCertificate={onRemovedGiftCertificate}
+                shouldCollapseCouponCode={true}
+              />,
+            );
+        });
+
+        it('renders redeemable toggle link', () => {
+            expect(component.find('[data-test="redeemable-label"]')).toHaveLength(1);
+            expect(component.find('.redeemable-entry')).toHaveLength(0);
+        });
+
+        describe('when redeemable is clicked', () => {
+            beforeEach(async () => {
+                component.find('[data-test="redeemable-label"]').simulate('click');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+            });
+
+            it('renders error', () => {
+                expect(component.find(Alert)).toHaveLength(1);
+                expect(component.find(Alert).text()).toEqual(
+                  localeContext.language.translate('redeemable.code_invalid_error'),
+                );
+            });
+
+            it('renders redeemable form', () => {
+                expect(component.find('.redeemable-entry')).toHaveLength(1);
+
+                const input = component.find('[data-test="redeemableEntry-input"]');
+
+                expect(input).toHaveLength(1);
+
+                const submit = component.find('[data-test="redeemableEntry-submit"]');
+
+                expect(submit).toHaveLength(1);
+                expect(submit.hasClass('is-loading')).toBe(false);
+                expect(submit.prop('disabled')).toBeFalsy();
+            });
+
+            it('renders form error when button is clicked', async () => {
+                component.find('[data-test="redeemableEntry-submit"]').simulate('click');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                component.update();
+
+                expect(
+                  component.find('[data-test="redeemable-code-field-error-message"]'),
+                ).toHaveLength(1);
             });
         });
     });

--- a/packages/core/src/app/cart/Redeemable.tsx
+++ b/packages/core/src/app/cart/Redeemable.tsx
@@ -127,7 +127,7 @@ const RedeemableForm: FunctionComponent<
         [],
     );
 
-    const renderErrorMessage = useCallback((errorCode: string) => {
+    const renderErrorMessage = useCallback((errorCode: string, errorMessage?: string) => {
         switch (errorCode) {
             case 'min_purchase':
                 return <TranslatedString id="redeemable.coupon_min_order_total" />;
@@ -136,7 +136,7 @@ const RedeemableForm: FunctionComponent<
                 return <TranslatedString id="redeemable.coupon_location_error" />;
 
             default:
-                return <TranslatedString id="redeemable.code_invalid_error" />;
+                return errorMessage || <TranslatedString id="redeemable.code_invalid_error" />;
         }
     }, []);
 
@@ -149,7 +149,7 @@ const RedeemableForm: FunctionComponent<
                             appliedRedeemableError.errors &&
                             appliedRedeemableError.errors[0] && (
                                 <Alert type={AlertType.Error}>
-                                    {renderErrorMessage(appliedRedeemableError.errors[0].code)}
+                                    {renderErrorMessage(appliedRedeemableError.errors[0].code, appliedRedeemableError.errors[0].message)}
                                 </Alert>
                             )}
 

--- a/packages/core/src/app/payment/storedInstrument/__snapshots__/ManageCardInstrumentsTable.spec.tsx.snap
+++ b/packages/core/src/app/payment/storedInstrument/__snapshots__/ManageCardInstrumentsTable.spec.tsx.snap
@@ -146,7 +146,7 @@ exports[`ManageCardInstrumentsTable matches snapshot with rendered output 1`] = 
           4444
         </td>
         <td
-          class=""
+          class="instrumentModal-instrumentExpiry--expired"
           data-test="manage-instrument-expiry"
         >
           10/2024

--- a/packages/instrument-utils/src/storedInstrument/ManageCardInstrumentsTable/__snapshots__/ManageCardInstrumentsTable.spec.tsx.snap
+++ b/packages/instrument-utils/src/storedInstrument/ManageCardInstrumentsTable/__snapshots__/ManageCardInstrumentsTable.spec.tsx.snap
@@ -80,7 +80,7 @@ exports[`ManageCardInstrumentsTable matches snapshot with rendered output 1`] = 
           4444
         </td>
         <td
-          class=""
+          class="instrumentModal-instrumentExpiry--expired"
           data-test="manage-instrument-expiry"
         >
           10/2024


### PR DESCRIPTION
## What?
return and show detailed error message when applying coupon fails on checkout page

## Why?
now if coupon apply error is not on two specific error code, it always display "The gift certificate or coupon code is invalid".

This confuses our shoppers as they don’t always understand why a coupon code doesn’t apply, e.g because of currency not support it.

## Testing / Proof

**case 1: apply a coupon not for current cart currency**

before change:
![image](https://github.com/user-attachments/assets/2768cef2-57ea-437e-a58f-1aaf9f16191a)

🚫 too generic and not reflect the reason of failure

after change:
![image](https://github.com/user-attachments/assets/5e32758f-1e73-4f19-8df1-6db0759c0f57)

✅ which matches the server side detailed message ()

**case 2: apply a coupon that does not exists**

befor change:
![image](https://github.com/user-attachments/assets/84c2963b-8264-4ba8-8a76-8148e2db9824)

after change:
![image](https://github.com/user-attachments/assets/5aefc8ee-2262-439f-9a52-9614e4a5884a)

✅ similar, but after change it fully reflect the error message service side send, not fixed.

**case 3: if apply coupon response has no detailed message or empty string**

after change:
<img width="457" alt="Screenshot 2024-10-31 at 11 42 09 AM" src="https://github.com/user-attachments/assets/9eccfdee-cec7-493a-aa51-4daefdcbd7a5">

✅ still use the default fallback value


@bigcommerce/team-checkout
