### PR TITLE
feat(checkout): CHECKOUT-8777 Delete a consignment

### DIFF
--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -1,9 +1,15 @@
 import React, { FunctionComponent } from 'react';
 
+import { preventDefault } from "@bigcommerce/checkout/dom-utils";
+import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
+
+import { IconClose, IconSize } from "../ui/icon";
+
 import ConsignmentAddressSelector from './ConsignmentAddressSelector';
 import ConsignmentLineItem from './ConsignmentLineItem';
 import { MultiShippingConsignmentData } from './MultishippingV2Type';
 import { MultiShippingOptionsV2 } from './shippingOption/MultiShippingOptionsV2';
+
 
 export interface ConsignmentListItemProps {
     consignment: MultiShippingConsignmentData;
@@ -24,9 +30,26 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
     shippingQuoteFailedMessage,
     onUnhandledError,
 }: ConsignmentListItemProps) => {
+
+    const { checkoutService: { deleteConsignment } } = useCheckout();
+
+    const handleClose = async () => {
+        await deleteConsignment(consignment.id);
+    }
+
     return (
-        <div className="consignment-container">
-            <h3 className="consignment-header">Destination #{consignmentNumber}</h3>
+        <div className='consignment-container'>
+            <div className='consignment-header'>
+                <h3>Destination #{consignmentNumber}</h3>
+                    <a
+                        className="delete-consignment"
+                        data-test="delete-consignment-button"
+                        href="#"
+                        onClick={preventDefault(handleClose)}
+                    >
+                        <IconClose size={IconSize.Small}/>
+                    </a>
+            </div>
             <ConsignmentAddressSelector
                 consignment={consignment}
                 countriesWithAutocomplete={countriesWithAutocomplete}

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -17,8 +17,13 @@ $allocate-items-table-image-width: 20%;
 }
 
 .consignment-header {
-    font-size: fontSize("small");
-    margin: 0 0 spacing("single");
+    display: flex;
+    justify-content: space-between;
+
+    h3 {
+        font-size: fontSize("small");
+        margin: 0 0 spacing("single");
+    }
 }
 
 .add-consignment-button {

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -185,12 +185,12 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         isInitialValueLoaded={shouldRenderWhileLoading ? !isInitializing : true}
                         isMultiShippingMode={isMultiShippingMode}
                         isNewMultiShippingUIEnabled={isNewMultiShippingUIEnabled}
-                        validateGoogleMapAutoCompleteMaxLength={validateGoogleMapAutoCompleteMaxLength}
                         onMultiShippingSubmit={this.handleMultiShippingSubmit}
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}
                         onUseNewAddress={this.handleUseNewAddress}
                         shouldShowSaveAddress={!isGuest}
                         updateAddress={updateShippingAddress}
+                        validateGoogleMapAutoCompleteMaxLength={validateGoogleMapAutoCompleteMaxLength}
                     />
                 </div>
             </AddressFormSkeleton>
@@ -362,6 +362,7 @@ export function mapToShippingProps({
             isLoadingShippingCountries,
             isUpdatingBillingAddress,
             isUpdatingCheckout,
+            isDeletingConsignment,
         },
     } = checkoutState;
 
@@ -393,7 +394,8 @@ export function mapToShippingProps({
         isCreatingConsignments() ||
         isUpdatingBillingAddress() ||
         isUpdatingCheckout() ||
-        isCreatingCustomerAddress();
+        isCreatingCustomerAddress() ||
+        isDeletingConsignment();
     const shouldShowMultiShipping =
         hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
     const isNewMultiShippingUIEnabled =


### PR DESCRIPTION
## What?
Introduce a button to allow the deletion of a consignment.

## Why?
Able to delete a consignment in new multi consignment UI

## Testing / Proof
- [x] unit test
- [x] manual test

https://github.com/user-attachments/assets/734d78ca-8a7d-4afe-abc9-f5f521013bea



@bigcommerce/team-checkout
