### PR TITLE
feat(payment): STRIPE-489 Stripe accordion toggle

### DIFF
--- a/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
@@ -1,6 +1,13 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { noop, some } from 'lodash';
-import React, { FunctionComponent, useCallback, useMemo } from 'react';
+import React, {
+    FunctionComponent,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+} from 'react';
 
 import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
 import { HostedWidgetPaymentComponent } from '@bigcommerce/checkout/hosted-widget-integration';
@@ -13,6 +20,7 @@ import {
     PaymentMethodResolveId,
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
+import { AccordionContext } from '@bigcommerce/checkout/ui';
 
 const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     paymentForm,
@@ -22,8 +30,18 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     onUnhandledError = noop,
     ...rest
 }) => {
+    const collapseStripeElement = useRef<() => void>();
+    const { onToggle, selectedItemId } = useContext(AccordionContext);
     const containerId = `stripe-${method.id}-component-field`;
     const paymentContext = paymentForm;
+
+    useEffect(() => {
+        if (selectedItemId?.includes('stripeupe-')) {
+            return;
+        }
+
+        collapseStripeElement.current?.();
+    }, [selectedItemId]);
 
     const renderSubmitButton = useCallback(() => {
         paymentContext.hidePaymentSubmitButton(method, false);
@@ -97,6 +115,10 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     },
                     onError: onUnhandledError,
                     render: renderSubmitButton,
+                    paymentMethodSelect: onToggle,
+                    handleClosePaymentMethod: (collapseElement: () => void) => {
+                        collapseStripeElement.current = collapseElement;
+                    },
                 },
             });
         },
@@ -107,6 +129,7 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             method,
             paymentContext,
             renderSubmitButton,
+            onToggle,
         ],
     );
 


### PR DESCRIPTION
## What?
Add accordion toggle events handlers to Stripe element

## Why?
To synchronise toggle of BC and Stripe accordion items

## Testing / Proof
Stripe UPE

https://github.com/user-attachments/assets/2b137a4f-123b-43f7-b807-fb3a20e68f00

Stripe OCS

https://github.com/user-attachments/assets/227bfb88-a6eb-4638-8c1b-fa35e61d384f



@bigcommerce/team-checkout
