### PR TITLE
feat(checkout): CHECKOUT-8600 Add digital item no shipping banner

### DIFF
--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -96,6 +96,7 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
             isOpen={isOpen}
             onRequestClose={onRequestClose}
         >
+                        
             <Form>
                 <h4>{getAddressContent(address)}</h4>
                 {formErrors.length > 0 && (
@@ -104,6 +105,11 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
                             <Alert key={index} type={AlertType.Error}>{error}</Alert>
                         ))}
                     </div>
+                )}
+                {unassignedItems.hasDigitalItems && (
+                            <Alert type={AlertType.Info}>
+                                <TranslatedString id="shipping.multishipping_digital_item_no_shipping_banner" />
+                                </Alert>
                 )}
                 {unassignedItems.lineItems.length
                     ? <>

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -189,6 +189,8 @@ describe('MultiShippingFormV2 Component', () => {
 
         expect(allocateItemsModalHeader).toBeInTheDocument();
 
+        expect(screen.getByText('Shipping isn\'t required for digital products, thus it\'s not displayed here.')).toBeInTheDocument();
+
         await waitFor(() => {
             expect(within(allocateItemsModal).queryByText('Product 1')).not.toBeInTheDocument();
         });

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -190,7 +190,7 @@ describe('MultiShippingFormV2 Component', () => {
 
         expect(allocateItemsModalHeader).toBeInTheDocument();
 
-        expect(screen.queryByText('Shipping isn\'t required for digital products, thus it\'s not displayed here.')).not.toBeInTheDocument();
+        expect(screen.queryByText(localeContext.language.translate('shipping.multishipping_digital_item_no_shipping_banner'))).not.toBeInTheDocument();
 
         await waitFor(() => {
             expect(within(allocateItemsModal).queryByText('Product 1')).not.toBeInTheDocument();
@@ -294,7 +294,7 @@ describe('MultiShippingFormV2 Component', () => {
 
         expect(allocateItemsModalHeader).toBeInTheDocument();
 
-        expect(screen.getByText('Shipping isn\'t required for digital products, thus it\'s not displayed here.')).toBeInTheDocument();
+        expect(screen.getByText(localeContext.language.translate('shipping.multishipping_digital_item_no_shipping_banner'))).toBeInTheDocument();
     });
 
     it('displays 1 item left to allocate banner', async () => {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -516,6 +516,7 @@
             "multishipping_guest_create": "or <a href=\"{url}\" target=\"_blank\">create an account</a> prior to proceeding.",
             "multishipping_item_to_allocate_message": "{count, plural, one{1 item left to allocate} other{{count} items left to allocate}}",
             "multishipping_all_items_allocated_message": "All items are allocated.",
+            "multishipping_digital_item_no_shipping_banner": "Shipping isn't required for digital products, thus it's not displayed here.",
             "ship_to_multi": "Ship to multiple addresses",
             "ship_to_single": "Ship to a single address",
             "shipping_heading": "Shipping",


### PR DESCRIPTION
## What?
Add digital item no shipping banner

## Why?
To show no shipping for digital item when a cart contains digital item

## Testing / Proof
- [x] unit test
- [x] manual test
<img width="730" alt="image" src="https://github.com/user-attachments/assets/94481fc8-6245-489e-b3da-622e08ad9b10">
@bigcommerce/team-checkout
