### PR TITLE
feat(payment): STRIPE-476 bump checkout-sdk version to 1.676.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.675.2",
+        "@bigcommerce/checkout-sdk": "^1.677.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.675.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.675.2.tgz",
-      "integrity": "sha512-TqIwOehNYZaYPDeSNVCDr38t27ucSdD2IS2U9W6DolhCvLntFyQVxwIMgKuS9cQIsO0RtD0jiaIrR6E6JnGKzg==",
+      "version": "1.677.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.0.tgz",
+      "integrity": "sha512-TdliJVC4/pmE8vZ2IAhT6nCIs6R+AaSODuHSs8+Of0Yf4m+iRYkKgD124vR9onW7u53OcTHGDfM4rxjb0YBYhA==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35066,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.675.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.675.2.tgz",
-      "integrity": "sha512-TqIwOehNYZaYPDeSNVCDr38t27ucSdD2IS2U9W6DolhCvLntFyQVxwIMgKuS9cQIsO0RtD0jiaIrR6E6JnGKzg==",
+      "version": "1.677.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.0.tgz",
+      "integrity": "sha512-TdliJVC4/pmE8vZ2IAhT6nCIs6R+AaSODuHSs8+Of0Yf4m+iRYkKgD124vR9onW7u53OcTHGDfM4rxjb0YBYhA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.675.2",
+    "@bigcommerce/checkout-sdk": "^1.677.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.677.0

## Why?
As part of the release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2707
https://github.com/bigcommerce/checkout-sdk-js/pull/2718

## Testing / Proof
All tests have been passed / manual testing

@bigcommerce/team-checkout
