### PR TITLE
chore(payment): STRIPE-476 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.677.0",
+        "@bigcommerce/checkout-sdk": "^1.677.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,10 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.677.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.0.tgz",
-      "integrity": "sha512-TdliJVC4/pmE8vZ2IAhT6nCIs6R+AaSODuHSs8+Of0Yf4m+iRYkKgD124vR9onW7u53OcTHGDfM4rxjb0YBYhA==",
-      "license": "MIT",
+      "version": "1.677.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.3.tgz",
+      "integrity": "sha512-YAssjbHb2aWMyGxG7pnGvM2ci1PdPGaSpwfLHU5+0RkLiaKFpxO4U2rsk85ume9cARi/uCxAkxuZqTs/pOGSSQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35066,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.677.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.0.tgz",
-      "integrity": "sha512-TdliJVC4/pmE8vZ2IAhT6nCIs6R+AaSODuHSs8+Of0Yf4m+iRYkKgD124vR9onW7u53OcTHGDfM4rxjb0YBYhA==",
+      "version": "1.677.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.3.tgz",
+      "integrity": "sha512-YAssjbHb2aWMyGxG7pnGvM2ci1PdPGaSpwfLHU5+0RkLiaKFpxO4U2rsk85ume9cARi/uCxAkxuZqTs/pOGSSQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.677.0",
+    "@bigcommerce/checkout-sdk": "^1.677.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Revert Stripe UPE GPay with 3ds changes.

## Why?
Because of issue with Stripe V3 GPay with 3ds

## Testing / Proof
Unit tests

@bigcommerce/team-checkout
