### PR TITLE
feat(checkout): DATA-11983 Bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.677.3",
+        "@bigcommerce/checkout-sdk": "v1.679.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.677.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.3.tgz",
-      "integrity": "sha512-YAssjbHb2aWMyGxG7pnGvM2ci1PdPGaSpwfLHU5+0RkLiaKFpxO4U2rsk85ume9cARi/uCxAkxuZqTs/pOGSSQ==",
+      "version": "1.679.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.679.0.tgz",
+      "integrity": "sha512-5RwudGp3OxCcpenlrQJYPHxCTcRnpFDSpkTEw+P4VqaH8PhvJPDxPrcRn5Hhx5C0drtMfGhRXhKwNixVO5DJpw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.677.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.677.3.tgz",
-      "integrity": "sha512-YAssjbHb2aWMyGxG7pnGvM2ci1PdPGaSpwfLHU5+0RkLiaKFpxO4U2rsk85ume9cARi/uCxAkxuZqTs/pOGSSQ==",
+      "version": "1.679.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.679.0.tgz",
+      "integrity": "sha512-5RwudGp3OxCcpenlrQJYPHxCTcRnpFDSpkTEw+P4VqaH8PhvJPDxPrcRn5Hhx5C0drtMfGhRXhKwNixVO5DJpw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.677.3",
+    "@bigcommerce/checkout-sdk": "v1.679.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What? [DATA-11983](https://bigcommercecloud.atlassian.net/browse/DATA-11983)
Bump checkout-sdk version to pull changes for BODL events

## Why?
We need to populate the `coupon` discounts on line_item level in the `begin_checkout` and `order_purchased` `BODL` events

## Testing / Proof
Manually on dev store. See the related PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2725

@bigcommerce/team-checkout
