### PR TITLE
chore(payment): STRIPE-484 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "v1.679.0",
+        "@bigcommerce/checkout-sdk": "v1.680.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.679.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.679.0.tgz",
-      "integrity": "sha512-5RwudGp3OxCcpenlrQJYPHxCTcRnpFDSpkTEw+P4VqaH8PhvJPDxPrcRn5Hhx5C0drtMfGhRXhKwNixVO5DJpw==",
+      "version": "1.680.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.680.0.tgz",
+      "integrity": "sha512-5WNeutJnhnLibuPituX0KsObV7+QzldtioAK6aLdMgG7yPE+Nxo5kIjRTyePkHsH78+AEKvVP9tdRTaCAgzCGw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.679.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.679.0.tgz",
-      "integrity": "sha512-5RwudGp3OxCcpenlrQJYPHxCTcRnpFDSpkTEw+P4VqaH8PhvJPDxPrcRn5Hhx5C0drtMfGhRXhKwNixVO5DJpw==",
+      "version": "1.680.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.680.0.tgz",
+      "integrity": "sha512-5WNeutJnhnLibuPituX0KsObV7+QzldtioAK6aLdMgG7yPE+Nxo5kIjRTyePkHsH78+AEKvVP9tdRTaCAgzCGw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "v1.679.0",
+    "@bigcommerce/checkout-sdk": "v1.680.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2732](https://github.com/bigcommerce/checkout-sdk-js/pull/2732)
[https://github.com/bigcommerce/checkout-sdk-js/pull/2730](https://github.com/bigcommerce/checkout-sdk-js/pull/2730)

## Testing / Proof
unit tests and manually tested

@bigcommerce/team-checkout
