### PR TITLE
chore(payment): PAYPAL-4783 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "v1.680.0",
+        "@bigcommerce/checkout-sdk": "v1.682.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.680.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.680.0.tgz",
-      "integrity": "sha512-5WNeutJnhnLibuPituX0KsObV7+QzldtioAK6aLdMgG7yPE+Nxo5kIjRTyePkHsH78+AEKvVP9tdRTaCAgzCGw==",
+      "version": "1.682.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.682.0.tgz",
+      "integrity": "sha512-kAOFX5VYxaPWl02v4uLnF7Tv+l9slAkatyxWBXojDb4modHSorD2WSo+ytvU3Lnlt2IdFjGo+2lAE178ogLnpA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.680.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.680.0.tgz",
-      "integrity": "sha512-5WNeutJnhnLibuPituX0KsObV7+QzldtioAK6aLdMgG7yPE+Nxo5kIjRTyePkHsH78+AEKvVP9tdRTaCAgzCGw==",
+      "version": "1.682.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.682.0.tgz",
+      "integrity": "sha512-kAOFX5VYxaPWl02v4uLnF7Tv+l9slAkatyxWBXojDb4modHSorD2WSo+ytvU3Lnlt2IdFjGo+2lAE178ogLnpA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "v1.680.0",
+    "@bigcommerce/checkout-sdk": "v1.682.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
To update code
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2720

## Testing / Proof
Unit tests

@bigcommerce/team-checkout
