### PR TITLE
CHECKOUT-8775: Toggle from multi shipping to single shipping and vice versa

### DIFF
--- a/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/CheckoutButtonContainer.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`CheckoutButtonContainer displays wallet buttons for guest checkout 1`] 
     </div>
     <div
       class="loading-skeleton"
-      style="position:absolute;left:100%;top:-100%"
+      style="position:absolute;left:0%;top:-300%"
     >
       <div
         class="checkoutRemote"
@@ -126,7 +126,7 @@ exports[`CheckoutButtonContainer hides wallet buttons with CSS when payment step
     </div>
     <div
       class="loading-skeleton"
-      style="position:absolute;left:100%;top:-100%"
+      style="position:absolute;left:0%;top:-300%"
     >
       <div
         class="checkoutRemote"
@@ -202,7 +202,7 @@ exports[`CheckoutButtonContainer removes Paypal commerce wallet buttons when pay
     </div>
     <div
       class="loading-skeleton"
-      style="position:absolute;left:100%;top:-100%"
+      style="position:absolute;left:0%;top:-300%"
     >
       <div
         class="checkoutRemote"

--- a/packages/core/src/app/shipping/AllocatedItemsList.tsx
+++ b/packages/core/src/app/shipping/AllocatedItemsList.tsx
@@ -2,17 +2,8 @@ import React from "react";
 
 import { IconClose } from "../ui/icon";
 
+import { getItemContent } from "./ConsignmentLineItemDetail";
 import { MultiShippingTableData, MultiShippingTableItemWithType } from "./MultishippingV2Type";
-
-export const getItemContent = (lineItem: MultiShippingTableItemWithType) => {
-    return <span>
-        <strong>{`${lineItem.quantity} x `}</strong>
-        {lineItem.name}
-        {lineItem.options?.length
-            ? <span className="line-item-options">{` - ${lineItem.options.map(option => option.value).join('/ ')}`}</span>
-            : ''}
-    </span>;
-};
 
 interface AllocatedItemsListProps {
     assignedItems: MultiShippingTableData;

--- a/packages/core/src/app/shipping/AllocatedItemsList.tsx
+++ b/packages/core/src/app/shipping/AllocatedItemsList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { IconClose } from "../ui/icon";
 
-import { getItemContent } from "./ConsignmentLineItemDetail";
+import { renderItemContent } from "./ConsignmentLineItemDetail";
 import { MultiShippingTableData, MultiShippingTableItemWithType } from "./MultishippingV2Type";
 
 interface AllocatedItemsListProps {
@@ -17,7 +17,7 @@ const AllocatedItemsList = ({ assignedItems, onUnassignItem }: AllocatedItemsLis
             <ul className="allocated-line-items-list">
                 {assignedItems.lineItems.map(item => (
                     <li key={item.id}>
-                        {getItemContent(item)}
+                        {renderItemContent(item)}
                         <span data-test={`remove-${item.id.toString()}-button`} onClick={() => onUnassignItem(item)}>
                             <IconClose />
                         </span>

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -6,8 +6,8 @@ import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
 
 import { IconChevronDown, IconChevronUp } from "../ui/icon";
 
-import { getItemContent } from "./AllocatedItemsList";
 import AllocateItemsModal from "./AllocateItemsModal";
+import ConsignmentLineItemDetail from "./ConsignmentLineItemDetail";
 import { AssignItemFailedError, UnassignItemError } from "./errors";
 import { useDeallocateItem } from "./hooks/useDeallocateItem";
 import { useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
@@ -117,13 +117,7 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ cons
                 </a>
             </div>
             {showItems
-                ? <ul className="consignment-line-item-list">
-                    {consignment.lineItems.map(lineItem => (
-                        <li key={lineItem.id}>
-                            {getItemContent(lineItem)}
-                        </li>
-                    ))}
-                </ul>
+                ? <ConsignmentLineItemDetail lineItems={consignment.lineItems} />
                 : null
             }       
         </div>

--- a/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
@@ -7,23 +7,30 @@ export interface ConsignmentLineItemDetailProps {
     lineItems: MultiShippingTableItemWithType[] | PhysicalItem[]
 }
 
+const renderProductOptionDetails = (item: MultiShippingTableItemWithType | PhysicalItem) => {
+    if (!item.options || !item.options.length) {
+        return null;
+    }
+
+    return (<span className="line-item-options">{` - ${item.options.map(option => option.value).join(' / ')}`}</span>);
+}
+
+export const getItemContent = (item: MultiShippingTableItemWithType | PhysicalItem) => {
+    return <span>
+        <strong>{item.quantity} x </strong>{item.name}
+        {renderProductOptionDetails(item)}
+    </span>;
+};
+
 const ConsignmentLineItemDetail: FunctionComponent<ConsignmentLineItemDetailProps> = ({
     lineItems,
 }) => {
-    const renderProductOptionDetails = (item: MultiShippingTableItemWithType | PhysicalItem) => {
-        if (!item.options || !item.options.length) {
-            return null;
-        }
-
-        return (<span className="line-item-options">{` - ${item.options.map(option => option.value).join(' / ')}`}</span>);
-    }
 
     return (
         <ul className="consignment-line-item-list">
         {lineItems.map((item) => (
             <li key={item.id}>
-                <strong>{item.quantity} x </strong>{item.name} 
-                {renderProductOptionDetails(item)}
+                {getItemContent(item)}
             </li>
         ))}
     </ul>

--- a/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
@@ -15,7 +15,7 @@ const renderProductOptionDetails = (item: MultiShippingTableItemWithType | Physi
     return (<span className="line-item-options">{` - ${item.options.map(option => option.value).join(' / ')}`}</span>);
 }
 
-export const getItemContent = (item: MultiShippingTableItemWithType | PhysicalItem) => {
+export const renderItemContent = (item: MultiShippingTableItemWithType | PhysicalItem) => {
     return <span>
         <strong>{item.quantity} x </strong>{item.name}
         {renderProductOptionDetails(item)}
@@ -30,7 +30,7 @@ const ConsignmentLineItemDetail: FunctionComponent<ConsignmentLineItemDetailProp
         <ul className="consignment-line-item-list">
         {lineItems.map((item) => (
             <li key={item.id}>
-                {getItemContent(item)}
+                {renderItemContent(item)}
             </li>
         ))}
     </ul>

--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -42,15 +42,17 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
     return (
         <div className='consignment-container'>
             <div className='consignment-header'>
-                <h3><TranslatedString data={{ consignmentNumber }} id="shipping.multishipping_consignment_index_heading" /></h3>
-                    <a
-                        className="delete-consignment"
-                        data-test="delete-consignment-button"
-                        href="#"
-                        onClick={preventDefault(handleClose)}
-                    >
-                        <IconClose size={IconSize.Small}/>
-                    </a>
+                <h3>
+                    <TranslatedString data={{ consignmentNumber }} id="shipping.multishipping_consignment_index_heading" />
+                </h3>
+                <a
+                    className="delete-consignment"
+                    data-test="delete-consignment-button"
+                    href="#"
+                    onClick={preventDefault(handleClose)}
+                >
+                    <IconClose size={IconSize.Small} />
+                </a>
             </div>
             <ConsignmentAddressSelector
                 consignment={consignment}

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -162,7 +162,7 @@ describe('MultiShippingFormV2 Component', () => {
 
         // eslint-disable-next-line testing-library/no-node-access
         const destination2 = screen.getByText('Destination #2').parentElement?.parentElement;
-        const addressSelectButton = within(destination2).getAllByTestId('address-select-button')[1];
+        const addressSelectButton = within(destination2).getByTestId('address-select-button');
 
         await userEvent.click(addressSelectButton);
 

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -82,9 +82,11 @@ const NewConsignment = ({
 
     return (
         <div className='consignment-container'>
-            <h3 className='consignment-header'>
-                <TranslatedString data={{ consignmentNumber }} id="shipping.multishipping_consignment_index_heading" />
-            </h3>
+            <div className='consignment-header'>
+                <h3>
+                    <TranslatedString data={{ consignmentNumber }} id="shipping.multishipping_consignment_index_heading" />
+                </h3>
+            </div>
             <ConsignmentAddressSelector
                 countriesWithAutocomplete={countriesWithAutocomplete}
                 defaultCountryCode={defaultCountryCode}

--- a/packages/core/src/app/shipping/Shipping.spec.tsx
+++ b/packages/core/src/app/shipping/Shipping.spec.tsx
@@ -444,6 +444,10 @@ describe('Shipping Component', () => {
                 checkoutSettings: {
                     ...getStoreConfig().checkoutSettings,
                     hasMultiShippingEnabled: true,
+                    features: {
+                        ...getStoreConfig().checkoutSettings.features,
+                        "PROJECT-4159.improve_multi_address_shipping_ui": false,
+                    }
                 },
             })
         });

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -140,7 +140,7 @@ describe('Shipping component', () => {
             });
         });
 
-        it.only('opens confirmation dialog on clicking the link and calls onToggleMultiShipping when confirm is clicked', async () => {
+        it('opens confirmation dialog on clicking the link and calls onToggleMultiShipping when confirm is clicked', async () => {
             render(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
 
             const shippingModeToggle = await screen.findByTestId("shipping-mode-toggle");

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -1,0 +1,163 @@
+import '@testing-library/jest-dom';
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+} from '@bigcommerce/checkout-sdk';
+import userEvent from '@testing-library/user-event';
+import React, { FunctionComponent } from 'react';
+
+import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+} from '@bigcommerce/checkout/locale';
+import { CheckoutProvider, PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
+import { render, screen, within } from '@bigcommerce/checkout/test-utils';
+
+import { getAddressFormFields } from '../address/formField.mock';
+import { getCart } from '../cart/carts.mock';
+import { getPhysicalItem } from '../cart/lineItem.mock';
+import { getCheckout } from '../checkout/checkouts.mock';
+import CheckoutStepType from '../checkout/CheckoutStepType';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getConsignment } from '../shipping/consignment.mock';
+
+import Shipping, { ShippingProps, WithCheckoutShippingProps } from './Shipping';
+import { getShippingAddress } from './shipping-addresses.mock';
+
+describe('Shipping component', () => {
+    let localeContext: LocaleContextType;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: ShippingProps;
+    let ComponentTest: FunctionComponent<ShippingProps> & Partial<WithCheckoutShippingProps>;
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        checkoutService = createCheckoutService();
+
+        checkoutState = checkoutService.getState();
+
+        defaultProps = {
+            isBillingSameAsShipping: true,
+            isMultiShippingMode: false,
+            onToggleMultiShipping: jest.fn(),
+            cartHasChanged: false,
+            onSignIn: jest.fn(),
+            step: {
+                isActive: true,
+                isComplete: true,
+                isEditable: true,
+                isRequired: true,
+                type: CheckoutStepType.Shipping
+            },
+            providerWithCustomCheckout: PaymentMethodId.StripeUPE,
+            isShippingMethodLoading: true,
+            navigateNextStep: jest.fn(),
+            onUnhandledError: jest.fn(),
+        };
+
+        jest.spyOn(checkoutService, 'loadShippingAddressFields').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        jest.spyOn(checkoutService, 'loadBillingAddressFields').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        jest.spyOn(checkoutService, 'loadShippingOptions').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        jest.spyOn(checkoutService, 'deleteConsignment').mockResolvedValue({} as CheckoutSelectors);
+
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+            ...getCart(),
+            lineItems: {
+                physicalItems: [
+                    {
+                        ...getPhysicalItem(),
+                        quantity: 3,
+                    },
+                ],
+            },
+        } as Cart);
+
+        jest.spyOn(checkoutState.data, 'getShippingAddress').mockReturnValue(getShippingAddress());
+
+        jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(undefined);
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getShippingAddressFields').mockReturnValue(
+            getAddressFormFields(),
+        );
+
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+            ...getCustomer(),
+            addresses: [],
+        });
+
+        jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([getConsignment()]);
+
+        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+        jest.spyOn(checkoutService, 'updateCheckout').mockResolvedValue({} as CheckoutSelectors);
+        jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        ComponentTest = (props) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <ExtensionProvider checkoutService={checkoutService}>
+                        <Shipping {...props} />
+                    </ExtensionProvider>
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+
+    describe('when new multishipping ui is enabled', () => {
+        beforeEach(async () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                ...getStoreConfig(),
+                checkoutSettings: {
+                    ...getStoreConfig().checkoutSettings,
+                    hasMultiShippingEnabled: true,
+                    features: {
+                        ...getStoreConfig().checkoutSettings.features,
+                        "PROJECT-4159.improve_multi_address_shipping_ui": true,
+                    },
+                },
+            });
+        });
+
+        it.only('opens confirmation dialog on clicking the link and calls onToggleMultiShipping when confirm is clicked', async () => {
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
+
+            const shippingModeToggle = await screen.findByTestId("shipping-mode-toggle");
+
+            expect(shippingModeToggle.innerHTML).toBe('Ship to a single address');
+
+            await userEvent.click(shippingModeToggle);
+
+            const confirmationModal = await screen.findByRole('dialog');
+
+            expect(confirmationModal).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.ship_to_single_action'))).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.ship_to_single_message'))).toBeInTheDocument();
+
+            await userEvent.click(within(confirmationModal).getByText('Confirm'));
+
+            expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -210,29 +210,19 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             deleteConsignments,
         } = this.props;
 
-        if (isMultiShippingMode && consignments.length > 1) {
+        try {
             this.setState({ isInitializing: true });
 
-            try {
+            if (isMultiShippingMode && consignments.length > 1) {
                 // Collapse all consignments into one
                 await updateShippingAddress(consignments[0].shippingAddress);
-            } catch (error) {
-                onUnhandledError(error);
-            } finally {
-                this.setState({ isInitializing: false });
-            }
-        }
-
-        if (!isMultiShippingMode && isNewMultiShippingUIEnabled) {
-            this.setState({ isInitializing: true });
-
-            try {
+            } else if (!isMultiShippingMode && isNewMultiShippingUIEnabled) {
                 await deleteConsignments();
-            } catch (error) {
-                onUnhandledError(error);
-            } finally {
-                this.setState({ isInitializing: false });
             }
+        } catch (error) {
+            onUnhandledError(error);
+        } finally {
+            this.setState({ isInitializing: false });
         }
 
         onToggleMultiShipping();

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -213,11 +213,18 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
         try {
             this.setState({ isInitializing: true });
 
-            if (isMultiShippingMode && consignments.length > 1) {
+            if (isNewMultiShippingUIEnabled) {
+                if (isMultiShippingMode && consignments.length) {
+                    // Collapse all consignments into one
+                    await updateShippingAddress(consignments[0].shippingAddress);
+                }
+                else {
+                    await deleteConsignments();
+                }
+            }
+            else if (isMultiShippingMode && consignments.length > 1) {
                 // Collapse all consignments into one
                 await updateShippingAddress(consignments[0].shippingAddress);
-            } else if (!isMultiShippingMode && isNewMultiShippingUIEnabled) {
-                await deleteConsignments();
             }
         } catch (error) {
             onUnhandledError(error);

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -156,6 +156,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                 isInitialValueLoaded={shouldRenderWhileLoading ? !isInitializing : true}
                 isLoading={ isInitializing }
                 isMultiShippingMode={isMultiShippingMode}
+                isNewMultiShippingUIEnabled={isNewMultiShippingUIEnabled}
                 isShippingMethodLoading={ this.props.isLoading }
                 onMultiShippingChange={ this.handleMultiShippingModeSwitch }
                 onSubmit={this.handleSingleShippingSubmit}
@@ -171,6 +172,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                     <ShippingHeader
                         isGuest={isGuest}
                         isMultiShippingMode={isMultiShippingMode}
+                        isNewMultiShippingUIEnabled={isNewMultiShippingUIEnabled}
                         onMultiShippingChange={this.handleMultiShippingModeSwitch}
                         shouldShowMultiShipping={shouldShowMultiShipping}
                     />
@@ -201,9 +203,11 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
         const {
             consignments,
             isMultiShippingMode,
+            isNewMultiShippingUIEnabled,
             onToggleMultiShipping = noop,
             onUnhandledError = noop,
             updateShippingAddress,
+            deleteConsignments,
         } = this.props;
 
         if (isMultiShippingMode && consignments.length > 1) {
@@ -212,6 +216,18 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             try {
                 // Collapse all consignments into one
                 await updateShippingAddress(consignments[0].shippingAddress);
+            } catch (error) {
+                onUnhandledError(error);
+            } finally {
+                this.setState({ isInitializing: false });
+            }
+        }
+
+        if (!isMultiShippingMode && isNewMultiShippingUIEnabled) {
+            this.setState({ isInitializing: true });
+
+            try {
+                await deleteConsignments();
             } catch (error) {
                 onUnhandledError(error);
             } finally {

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -1,9 +1,10 @@
 import { ExtensionRegion } from '@bigcommerce/checkout-sdk';
-import React, { FunctionComponent, memo } from 'react';
+import React, { FunctionComponent, memo, useState } from 'react';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { ConfirmationModal } from '@bigcommerce/checkout/ui';
 
 import { Legend } from '../ui/form';
 
@@ -12,6 +13,7 @@ interface ShippingHeaderProps {
     isGuest: boolean;
     shouldShowMultiShipping: boolean;
     onMultiShippingChange(): void;
+    isNewMultiShippingUIEnabled: boolean;
 }
 
 const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
@@ -19,7 +21,17 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
     isGuest,
     onMultiShippingChange,
     shouldShowMultiShipping,
+    isNewMultiShippingUIEnabled,
 }) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const handleShipToSingleConfirmation = () => {
+        setIsModalOpen(false);
+        onMultiShippingChange();
+    }
+
+    const showConfirmationModal = shouldShowMultiShipping && isNewMultiShippingUIEnabled && isMultiShippingMode;
+
     return (
         <>
             <Extension region={ExtensionRegion.ShippingShippingAddressFormBefore} />
@@ -36,7 +48,25 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
                     />
                 </Legend>
 
-                {shouldShowMultiShipping && (
+                {showConfirmationModal && (
+                    <>
+                        <ConfirmationModal
+                            action={handleShipToSingleConfirmation}
+                            headerId="shipping.ship_to_single_action"
+                            isModalOpen={isModalOpen}
+                            messageId="shipping.ship_to_single_message"
+                            onRequestClose={() => setIsModalOpen(false)}
+                        />
+                        <a
+                            data-test="shipping-mode-toggle"
+                            href="#"
+                            onClick={preventDefault(() => setIsModalOpen(true))}
+                        >
+                            <TranslatedString id="shipping.ship_to_single" />
+                        </a>
+                    </>
+                )}
+                {!showConfirmationModal && shouldShowMultiShipping && (
                     <a
                         data-test="shipping-mode-toggle"
                         href="#"

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.spec.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.spec.tsx
@@ -24,6 +24,7 @@ describe('Stripe Shipping Component', () => {
         defaultProps = {
             isBillingSameAsShipping: true,
             isMultiShippingMode: false,
+            isNewMultiShippingUIEnabled: false,
             cartHasChanged: false,
             step: {
                 isActive: true,

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
@@ -12,6 +12,7 @@ export interface StripeShippingProps {
     isBillingSameAsShipping: boolean;
     cartHasChanged: boolean;
     isMultiShippingMode: boolean;
+    isNewMultiShippingUIEnabled: boolean;
     step: CheckoutStepStatus;
     consignments: Consignment[];
     countries: Country[];
@@ -64,6 +65,7 @@ class StripeShipping extends Component<StripeShippingProps, StripeShippingState>
             initialize,
             deinitialize,
             isMultiShippingMode,
+            isNewMultiShippingUIEnabled,
             step,
             onSubmit,
             onMultiShippingChange,
@@ -83,6 +85,7 @@ class StripeShipping extends Component<StripeShippingProps, StripeShippingState>
                 <ShippingHeader
                     isGuest={isGuest}
                     isMultiShippingMode={isMultiShippingMode}
+                    isNewMultiShippingUIEnabled={isNewMultiShippingUIEnabled}
                     onMultiShippingChange={onMultiShippingChange}
                     shouldShowMultiShipping={shouldShowMultiShipping}
                 />

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -521,6 +521,8 @@
             "multishipping_digital_item_no_shipping_banner": "Shipping isn't required for digital products, thus it's not displayed here.",
             "ship_to_multi": "Ship to multiple addresses",
             "ship_to_single": "Ship to a single address",
+            "ship_to_single_action": "Ship to a Single Address instead",
+            "ship_to_single_message": "If you proceed, all progress for multiple addresses will be lost. This action cannot be undone.",
             "shipping_heading": "Shipping",
             "shipping_method_label": "Shipping Method",
             "shipping_option_expired_error": "The shipping price you were quoted is no longer valid. Click OK to see the most up-to-date shipping prices.",

--- a/packages/ui/src/form/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/packages/ui/src/form/LoadingSkeleton/LoadingSkeleton.tsx
@@ -21,7 +21,7 @@ export const LoadingSkeleton: FunctionComponent<LoadingSkeletonProps> = ({
                 <div
                     className="loading-skeleton"
                     style={
-                        isLoading ? { position: 'absolute', left: '100%', top: '-100%' } : undefined
+                        isLoading ? { position: 'absolute', left: '0%', top: '-300%' } : undefined
                     }
                 >
                     {children}


### PR DESCRIPTION
## What?
Handle actions when toggling from multi shipping to single shipping and vice versa

1. **When moving from single shipping to multi shipping in SF checkout**
- Delete the consignment so that multi shipping consignments can be freshly started.

2. **When moving from multi shipping to single shipping in SF checkout**
- Show the warning popup that all the consignments will be lost.

## Why?
To improve the multi shipping user experience

## Testing / Proof

- CI checks
- Manual testing

https://github.com/user-attachments/assets/0ac0148c-7f7c-4986-8b7b-75cc7482bbef



@bigcommerce/team-checkout
