### PR TITLE
chore(payment): STRIPE-496 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "v1.682.0",
+        "@bigcommerce/checkout-sdk": "v1.683.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.682.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.682.0.tgz",
-      "integrity": "sha512-kAOFX5VYxaPWl02v4uLnF7Tv+l9slAkatyxWBXojDb4modHSorD2WSo+ytvU3Lnlt2IdFjGo+2lAE178ogLnpA==",
+      "version": "1.683.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.0.tgz",
+      "integrity": "sha512-SJkqwN3eG3H+SiAmhI/M/7yUrelJiPTUbzsNw1hCCGEGkNDDum8NsBDtUf0OJE42esvaypGHVIvnVwBi09wSTA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.682.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.682.0.tgz",
-      "integrity": "sha512-kAOFX5VYxaPWl02v4uLnF7Tv+l9slAkatyxWBXojDb4modHSorD2WSo+ytvU3Lnlt2IdFjGo+2lAE178ogLnpA==",
+      "version": "1.683.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.0.tgz",
+      "integrity": "sha512-SJkqwN3eG3H+SiAmhI/M/7yUrelJiPTUbzsNw1hCCGEGkNDDum8NsBDtUf0OJE42esvaypGHVIvnVwBi09wSTA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "v1.682.0",
+    "@bigcommerce/checkout-sdk": "v1.683.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2734](https://github.com/bigcommerce/checkout-sdk-js/pull/2734)

## Testing / Proof
Unit test and manually tested

@bigcommerce/team-checkout
