### PR TITLE
feat(checkout): CHECKOUT-8824 Add Consignment Not Completed Message

### DIFF
--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -21,6 +21,7 @@ export interface ConsignmentListItemProps {
     isLoading: boolean;
     shippingQuoteFailedMessage: string;
     onUnhandledError(error: Error): void;
+    resetErrorConsignmentNumber(): void;
 }
 
 const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
@@ -31,13 +32,15 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
     isLoading,
     shippingQuoteFailedMessage,
     onUnhandledError,
+    resetErrorConsignmentNumber,
 }: ConsignmentListItemProps) => {
 
     const { checkoutService: { deleteConsignment } } = useCheckout();
 
     const handleClose = async () => {
         await deleteConsignment(consignment.id);
-    }
+        resetErrorConsignmentNumber();
+    };
 
     return (
         <div className='consignment-container'>
@@ -68,6 +71,7 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
             <MultiShippingOptionsV2
                 consignment={consignment}
                 isLoading={isLoading}
+                resetErrorConsignmentNumber={resetErrorConsignmentNumber}
                 shippingQuoteFailedMessage={shippingQuoteFailedMessage}
             />
         </div>

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -8,7 +8,11 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
-import { createLocaleContext, LocaleContext } from '@bigcommerce/checkout/locale';
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+} from '@bigcommerce/checkout/locale';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 import { render, screen, waitFor, within } from '@bigcommerce/checkout/test-utils';
 
@@ -162,7 +166,12 @@ describe('MultiShippingFormV2 Component', () => {
         expect(screen.getByText('Destination #2')).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Please complete the address, item allocation, and method selection for Destination #2.',
+                localeContext.language.translate(
+                    'shipping.multishipping_incomplete_consignment_error',
+                    {
+                        consignmentNumber: 2,
+                    },
+                ),
             ),
         ).toBeInTheDocument();
 

--- a/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.test.tsx
@@ -152,9 +152,19 @@ describe('MultiShippingFormV2 Component', () => {
         const addShippingDestinationButton = screen.getByRole('button', { name: 'Add new destination' });
 
         expect(addShippingDestinationButton).toBeInTheDocument();
+
+        await userEvent.click(addShippingDestinationButton);
+
+        expect(screen.queryByText(/Please complete the address/i)).not.toBeInTheDocument();
+
         await userEvent.click(addShippingDestinationButton);
 
         expect(screen.getByText('Destination #2')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Please complete the address, item allocation, and method selection for Destination #2.',
+            ),
+        ).toBeInTheDocument();
 
         await waitFor(() => {
             expect(screen.queryByText('No items allocated')).not.toBeInTheDocument();
@@ -521,7 +531,7 @@ describe('MultiShippingFormV2 Component', () => {
         jest.spyOn(checkoutService, 'deleteConsignment').mockReturnValue(
             Promise.resolve(checkoutService.getState()),
         );
-        
+
         jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
             ...getCheckout(),
             consignments: [{

--- a/packages/core/src/app/shipping/MultiShippingFormV2.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.tsx
@@ -65,11 +65,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
     } = config;
 
     const handleAddShippingDestination = () => {
-        if (
-            consignments.length > 0 &&
-            !isAddShippingDestination &&
-            !isEveryConsignmentHasShippingOption
-        ) {
+        if (!isAddShippingDestination && !isEveryConsignmentHasShippingOption) {
             const errorConsignmentIndex = consignments.findIndex(
                 (consignment) => !consignment.selectedShippingOption,
             );
@@ -136,7 +132,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
                     <span className="form-inlineMessage">
                         <TranslatedString
                             data={{ consignmentNumber: errorConsignmentNumber }}
-                            id="shipping.multishipping_consignment_not_completed_error"
+                            id="shipping.multishipping_incomplete_consignment_error"
                         />
                     </span>
                 </div>

--- a/packages/core/src/app/shipping/MultiShippingV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingV2.test.tsx
@@ -42,6 +42,8 @@ describe('Multi-shipping V2', () => {
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
     let analyticsTracker: AnalyticsEvents;
 
+    const language = getLanguageService();
+
     beforeAll(() => {
         checkout = new CheckoutPageNodeObject();
         checkout.goto();
@@ -158,7 +160,9 @@ describe('Multi-shipping V2', () => {
         ).toBeInTheDocument();
         expect(
             screen.getByText(
-                'Please complete the address, item allocation, and method selection for Destination #1.',
+                language.translate('shipping.multishipping_incomplete_consignment_error', {
+                    consignmentNumber: 1,
+                }),
             ),
         ).toBeInTheDocument();
 
@@ -198,7 +202,9 @@ describe('Multi-shipping V2', () => {
         expect(selectedShippingOptionValue2).toBe('option-id-flat-rate');
         expect(
             screen.queryByText(
-                'Please complete the address, item allocation, and method selection for Destination #1.',
+                language.translate('shipping.multishipping_incomplete_consignment_error', {
+                    consignmentNumber: 1,
+                }),
             ),
         ).not.toBeInTheDocument();
     });

--- a/packages/core/src/app/shipping/shippingOption/MultiShippingOptionsV2.tsx
+++ b/packages/core/src/app/shipping/shippingOption/MultiShippingOptionsV2.tsx
@@ -12,16 +12,21 @@ interface MultiShippingOptionsV2Props {
     consignment: Consignment;
     isLoading: boolean;
     shippingQuoteFailedMessage: string;
+    resetErrorConsignmentNumber(): void;
 }
 
 export const MultiShippingOptionsV2 = ({
     consignment,
     isLoading,
+    resetErrorConsignmentNumber,
     shippingQuoteFailedMessage,
 }: MultiShippingOptionsV2Props) => {
     const { checkoutService, checkoutState } = useCheckout();
 
-    const selectShippingOption = checkoutService.selectConsignmentShippingOption;
+    const selectShippingOption = async (consignmentId: string, shippingOptionId: string) => {
+        await checkoutService.selectConsignmentShippingOption(consignmentId, shippingOptionId);
+        resetErrorConsignmentNumber();
+    };
     const isLoadingOptions = isLoadingSelector(checkoutState, isLoading)(consignment.id);
 
     return (

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -510,7 +510,7 @@
             "select_shipping_address_text": "Please select a shipping address in order to see shipping quotes",
             "shipping_address_heading": "Shipping Address",
             "multishipping_consignment_index_heading": "Destination #{consignmentNumber}",
-            "multishipping_consignment_not_completed_error": "Please complete the address, item allocation, and method selection for Destination #{consignmentNumber}.",
+            "multishipping_incomplete_consignment_error": "Please complete the address, item allocation, and method selection for Destination #{consignmentNumber}.",
             "multishipping_address_heading": "Choose where to ship each item",
             "multishipping_address_heading_guest": "Please sign in first",
             "multishipping_guest_intro": "To ship your items to multiple addresses you need to",

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -510,6 +510,7 @@
             "select_shipping_address_text": "Please select a shipping address in order to see shipping quotes",
             "shipping_address_heading": "Shipping Address",
             "multishipping_consignment_index_heading": "Destination #{consignmentNumber}",
+            "multishipping_consignment_not_completed_error": "Please complete the address, item allocation, and method selection for Destination #{consignmentNumber}.",
             "multishipping_address_heading": "Choose where to ship each item",
             "multishipping_address_heading_guest": "Please sign in first",
             "multishipping_guest_intro": "To ship your items to multiple addresses you need to",


### PR DESCRIPTION
## What?
Show a message when a shopper is trying to create another one but an existing consignment is not finished yet.
Also, hide the message when the previous consignment is done.

## Why?
Improve UX.

## Testing / Proof
### Show the error message when adding a new consignment is not finsihed

https://github.com/user-attachments/assets/bef22cab-47b2-4ce6-9ccf-6aa6680a3956

### Show the error message when an existing consignment is not finsihed

https://github.com/user-attachments/assets/13da5a50-9ebb-4e75-ab69-e8be66fef13a

### Hide the error message after selecting shipping method

https://github.com/user-attachments/assets/7bbaff3d-1dcb-4c3e-ba92-078e003c2379

### Hide the error message after consignment deletion

https://github.com/user-attachments/assets/e6616f9f-c9eb-43bf-b1b9-44ab271e9428





@bigcommerce/team-checkout
