### PR TITLE
chore(payment): STRIPE-509 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "v1.683.0",
+        "@bigcommerce/checkout-sdk": "v1.683.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.683.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.0.tgz",
-      "integrity": "sha512-SJkqwN3eG3H+SiAmhI/M/7yUrelJiPTUbzsNw1hCCGEGkNDDum8NsBDtUf0OJE42esvaypGHVIvnVwBi09wSTA==",
+      "version": "1.683.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.1.tgz",
+      "integrity": "sha512-6FauS3FHJI+flV4Q/vppX3kAlbqOEJPsLzo98VEmP2uZnL1QVwu8267+orV+9Nc9+PV/uhubOyZFinXjMPNJoQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.683.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.0.tgz",
-      "integrity": "sha512-SJkqwN3eG3H+SiAmhI/M/7yUrelJiPTUbzsNw1hCCGEGkNDDum8NsBDtUf0OJE42esvaypGHVIvnVwBi09wSTA==",
+      "version": "1.683.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.1.tgz",
+      "integrity": "sha512-6FauS3FHJI+flV4Q/vppX3kAlbqOEJPsLzo98VEmP2uZnL1QVwu8267+orV+9Nc9+PV/uhubOyZFinXjMPNJoQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "v1.683.0",
+    "@bigcommerce/checkout-sdk": "v1.683.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2736](https://github.com/bigcommerce/checkout-sdk-js/pull/2736)

## Testing / Proof
Unit tests and manually tested

@bigcommerce/team-checkout
