### PR TITLE
feat(checkout): CHECKOUT-8774 Display item split tooltip

### DIFF
--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -14,6 +14,7 @@ import { Form } from "../ui/form";
 import { Modal, ModalHeader } from "../ui/modal";
 
 import AllocatedItemsList from "./AllocatedItemsList";
+import { ItemSplitTooltip } from "./ItemSplitTooltip";
 import LeftToAllocateItemsTable from "./LeftToAllocateItemsTable";
 import { LineItemType, MultiShippingTableData, MultiShippingTableItemWithType } from "./MultishippingV2Type";
 
@@ -140,8 +141,14 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
                 {hasUnassignedItems
                     ? <>
                         <div className="left-to-allocate-items-table-actions">
-                            <p>{allocatedOrSelectedItemsMessage}</p>
-                            <div>
+                            <p>
+                                {allocatedOrSelectedItemsMessage}
+                                {unassignedItems.hasSplitItems && (
+                                    <ItemSplitTooltip />
+                                )}
+                            </p>
+
+                            <div className="button-group">
                                 <a
                                     data-test="clear-all-items-button"
                                     href="#"

--- a/packages/core/src/app/shipping/AllocatedItemsList.tsx
+++ b/packages/core/src/app/shipping/AllocatedItemsList.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { IconClose } from "../ui/icon";
 
 import { renderItemContent } from "./ConsignmentLineItemDetail";
+import { ItemSplitTooltip } from "./ItemSplitTooltip";
 import { MultiShippingTableData, MultiShippingTableItemWithType } from "./MultishippingV2Type";
 
 interface AllocatedItemsListProps {
@@ -13,7 +14,12 @@ interface AllocatedItemsListProps {
 const AllocatedItemsList = ({ assignedItems, onUnassignItem }: AllocatedItemsListProps) => {
     return (
         <div className="allocated-line-items">
-            <h3>{assignedItems.shippableItemsCount > 1 ? `${assignedItems.shippableItemsCount} items` : `${assignedItems.shippableItemsCount} item`} allocated</h3>
+            <h3>
+                {assignedItems.shippableItemsCount > 1 ? `${assignedItems.shippableItemsCount} items` : `${assignedItems.shippableItemsCount} item`} allocated 
+                {assignedItems.hasSplitItems && (
+                    <ItemSplitTooltip />
+                )}
+            </h3>
             <ul className="allocated-line-items-list">
                 {assignedItems.lineItems.map(item => (
                     <li key={item.id}>

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -11,6 +11,7 @@ import ConsignmentLineItemDetail from "./ConsignmentLineItemDetail";
 import { AssignItemFailedError, UnassignItemError } from "./errors";
 import { useDeallocateItem } from "./hooks/useDeallocateItem";
 import { useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
+import { ItemSplitTooltip } from "./ItemSplitTooltip";
 import { MultiShippingConsignmentData, MultiShippingTableItemWithType } from "./MultishippingV2Type";
 
 interface ConsignmentLineItemProps {
@@ -88,7 +89,12 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ cons
             />
             <div className="consignment-line-item-header">
                 <div>
-                    <h3>{itemsCount > 1 ? `${itemsCount} items` : `${itemsCount} item`} allocated</h3>
+                    <h3>{itemsCount > 1 ? `${itemsCount} items` : `${itemsCount} item`} allocated </h3>
+
+                    {consignment.hasSplitItems && (
+                        <ItemSplitTooltip />
+                    )}
+                    
                     <a
                         className="expand-items-button"
                         data-test="expand-items-button"

--- a/packages/core/src/app/shipping/ItemSplitTooltip.scss
+++ b/packages/core/src/app/shipping/ItemSplitTooltip.scss
@@ -1,0 +1,15 @@
+@import '../ui/Base';
+
+.item-split-tooltip {
+    .icon {
+        margin-left: spacing("quarter");
+        svg {
+            cursor: help;
+            padding-bottom: spacing("eighth");
+        }
+    }
+}
+
+.tooltip--basic {
+    border-radius: $global-radius;
+}

--- a/packages/core/src/app/shipping/ItemSplitTooltip.tsx
+++ b/packages/core/src/app/shipping/ItemSplitTooltip.tsx
@@ -1,0 +1,26 @@
+import React, { FunctionComponent } from "react";
+
+import { TranslatedString } from "@bigcommerce/checkout/locale";
+import { IconHelp, TooltipTrigger } from "@bigcommerce/checkout/ui";
+
+import { Tooltip } from "../ui/tooltip";
+import "./ItemSplitTooltip.scss";
+
+export const ItemSplitTooltip: FunctionComponent = () => {
+    return (
+        <TooltipTrigger
+            placement="right-start"
+            tooltip={
+                <Tooltip>
+                    <TranslatedString
+                        id="shipping.multishipping_item_split_tooltip_message"
+                    />
+                </Tooltip>
+            }
+        >
+            <span className="item-split-tooltip" data-test="split-item-tooltip">
+                <IconHelp />
+            </span>
+        </TooltipTrigger>
+    )
+};

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -95,7 +95,7 @@ $allocate-items-table-image-width: 20%;
                 margin-bottom: 0;
             }
 
-            div {
+            .button-group {
                 display: flex;
                 gap: spacing("single");
             }
@@ -200,16 +200,16 @@ $allocate-items-table-image-width: 20%;
                 li:not(:last-child) {
                     margin-bottom: spacing("quarter");
                 }
+
+                svg {
+                    fill: color("greys", "dark");
+                    cursor: pointer;
+                }
             }
 
             h3 {
                 margin-bottom: spacing("base");
                 font-size: fontSize("base");
-            }
-
-            svg {
-                fill: color("greys", "dark");
-                cursor: pointer;
             }
         }
     }

--- a/packages/core/src/app/shipping/MultishippingV2Type.ts
+++ b/packages/core/src/app/shipping/MultishippingV2Type.ts
@@ -24,6 +24,7 @@ export interface MultiShippingTableItemWithType extends MultiShippingTableItem {
 export interface MultiShippingTableData {
     lineItems: MultiShippingTableItemWithType[];
     hasDigitalItems: boolean;
+    hasSplitItems: boolean;
     shippableItemsCount: number;
 };
 

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -20,19 +20,19 @@ const hasSplitItem = (
   ): boolean => {
     const processedHashes = new Set<string>();
   
-    return items.some((item) => {
+    for (const item of items) {
       const hash = itemHashMap.get(item.id.toString());
+
+      if (!hash) continue;
   
-      if (hash && processedHashes.has(hash)) {
+      if (processedHashes.has(hash)) {
         return true;
       }
   
-      if (hash) {
-        processedHashes.add(hash);
-      }
+      processedHashes.add(hash);
+    }
   
-      return false;
-    });
+    return false;
   };
 
 function mapConsignmentsItems(

--- a/packages/core/src/app/shipping/utils/generateItemHash.tsx
+++ b/packages/core/src/app/shipping/utils/generateItemHash.tsx
@@ -1,0 +1,31 @@
+import { LineItem, LineItemOption } from "@bigcommerce/checkout-sdk";
+
+const generateHash = (values: string[]): string => {
+  return btoa(encodeURIComponent(values.join('-')));
+};
+
+const generateProductOptionsHash = (options: LineItemOption[] | undefined): string => {
+  if (!options) {
+    return '';
+  }
+
+  return generateHash(
+    options.map((option) =>
+      generateHash([
+        option.name,
+        option.nameId.toString(),
+        option.value,
+        option.valueId ? option.valueId.toString() : '',
+      ]),
+    ),
+  );
+};
+
+export const generateItemHash = (item: LineItem): string => {
+  return generateHash([
+    item.productId.toString(),
+    item.variantId.toString(),
+    item.sku,
+    generateProductOptionsHash(item.options),
+  ]);
+};

--- a/packages/core/src/app/shipping/utils/index.ts
+++ b/packages/core/src/app/shipping/utils/index.ts
@@ -1,0 +1,1 @@
+export { generateItemHash } from './generateItemHash';

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -520,6 +520,7 @@
             "multishipping_items_selected_message": "{count} items selected",
             "multishipping_all_items_allocated_message": "All items are allocated.",
             "multishipping_digital_item_no_shipping_banner": "Shipping isn't required for digital products, thus it's not displayed here.",
+            "multishipping_item_split_tooltip_message": "These item quantities are split into a separate row due to a quantity-based promotion or custom price.",
             "ship_to_multi": "Ship to multiple addresses",
             "ship_to_single": "Ship to a single address",
             "ship_to_single_action": "Ship to a Single Address instead",


### PR DESCRIPTION
## What?
Display item split tooltip when items split into individual item.

## Why?
To improve user experience

## Testing / Proof
- [x] unit test
- [x] manual test
![image](https://github.com/user-attachments/assets/a4d3630f-75ac-490f-9fd2-3d4ac47d5b8c)
![image](https://github.com/user-attachments/assets/a8424157-0bb4-41ea-b842-bd85085d1db0)
![image](https://github.com/user-attachments/assets/1aa24a3a-f042-4785-9c0a-e1dbc6870bd7)


@bigcommerce/team-checkout
