### PR TITLE
CHECKOUT-8850 address design comments for new multishipping UI

### DIFF
--- a/packages/core/src/app/address/AddressFormModal.tsx
+++ b/packages/core/src/app/address/AddressFormModal.tsx
@@ -3,7 +3,6 @@ import { FormikProps, withFormik } from 'formik';
 import React, { FunctionComponent } from 'react';
 import { lazy } from 'yup';
 
-import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString, withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
 
 import { Button, ButtonVariant } from '../ui/button';
@@ -59,13 +58,12 @@ const SaveAddress: FunctionComponent<
                 shouldShowSaveAddress={false}
             />
             <div className="form-actions">
-                <a
-                    className="button optimizedCheckout-buttonSecondary"
-                    href="#"
-                    onClick={preventDefault(onRequestClose)}
-                >
+                <Button
+                    onClick={onRequestClose}
+                    variant={ButtonVariant.Secondary}>
                     <TranslatedString id="common.cancel_action" />
-                </a>
+                </Button>
+
 
                 <Button
                     disabled={isLoading}

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -21,7 +21,7 @@ export interface AddressSelectProps {
     showSingleLineAddress?: boolean;
     onSelectAddress(address: Address): void;
     onUseNewAddress(currentAddress?: Address): void;
-    placeholderText?: string;
+    placeholderText?: React.JSX.Element;
 }
 
 const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -21,6 +21,7 @@ export interface AddressSelectProps {
     showSingleLineAddress?: boolean;
     onSelectAddress(address: Address): void;
     onUseNewAddress(currentAddress?: Address): void;
+    placeholderText?: string;
 }
 
 const AddressSelectMenu: FunctionComponent<AddressSelectProps> = ({
@@ -65,6 +66,7 @@ const AddressSelect = ({
     showSingleLineAddress,
     onSelectAddress,
     onUseNewAddress,
+    placeholderText,
 }: AddressSelectProps) => {
     const { shouldShowPayPalFastlaneLabel } = usePayPalFastlaneAddress();
 
@@ -94,6 +96,7 @@ const AddressSelect = ({
                 >
                     <AddressSelectButton
                         addresses={addresses}
+                        placeholderText={placeholderText}
                         selectedAddress={selectedAddress}
                         showSingleLineAddress={showSingleLineAddress}
                         type={type}

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -21,11 +21,7 @@ const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLang
 
     const SelectedAddress = () => {
         if (!selectedAddress) {
-            if (placeholderText) {
-                return <TranslatedString id={placeholderText} />;
-            }
-
-            return <TranslatedString id="address.enter_address_action" />;
+            return placeholderText ?? <TranslatedString id="address.enter_address_action" />;
         }
 
         return showSingleLineAddress

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -5,21 +5,26 @@ import { TranslatedString, withLanguage, WithLanguageProps } from '@bigcommerce/
 
 
 import { AddressSelectProps } from './AddressSelect';
-import StaticAddress from './StaticAddress';
 import SingleLineStaticAddress from './SingleLineStaticAddress';
+import StaticAddress from './StaticAddress';
 
-type AddressSelectButtonProps = Pick<AddressSelectProps, 'selectedAddress' | 'addresses' | 'type' | 'showSingleLineAddress'>;
+type AddressSelectButtonProps = Pick<AddressSelectProps, 'selectedAddress' | 'addresses' | 'type' | 'showSingleLineAddress' | 'placeholderText'>;
 
 const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLanguageProps> = ({
     selectedAddress,
     language,
     type,
     showSingleLineAddress,
+    placeholderText,
 }) => {
     const [ariaExpanded, setAriaExpanded] = useState(false);
 
     const SelectedAddress = () => {
         if (!selectedAddress) {
+            if (placeholderText) {
+                return <TranslatedString id={placeholderText} />;
+            }
+
             return <TranslatedString id="address.enter_address_action" />;
         }
 

--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -31,6 +31,7 @@ interface AllocateItemsModalProps {
     assignedItems?: MultiShippingTableData;
     onAllocateItems(consignmentLineItems: ConsignmentLineItem[]): void;
     onUnassignItem?(itemToDelete: MultiShippingTableItemWithType): void;
+    isLoading: boolean;
 }
 
 const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProps<AllocateItemsModalFormValues>> = ({
@@ -46,6 +47,7 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
     submitForm,
     errors,
     onUnassignItem,
+    isLoading,
 }: AllocateItemsModalProps & FormikProps<AllocateItemsModalFormValues>) => {
 
     const allocatedOrSelectedItemsMessage = useMemo(() => {
@@ -103,8 +105,21 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
 
     const modalFooter = (
         <>
-            <Button onClick={onRequestClose} variant={ButtonVariant.Secondary}><TranslatedString id="shipping.multishipping_items_allocate_cancel" /></Button>
-            <Button disabled={!dirty} onClick={submitForm} type="submit" variant={ButtonVariant.Primary}>{hasItemsAssigned ? <TranslatedString id="shipping.multishipping_items_allocate_save" /> : <TranslatedString id="shipping.multishipping_items_allocate_allocate" />}</Button>
+            <Button onClick={onRequestClose} variant={ButtonVariant.Secondary}>
+                <TranslatedString id="shipping.multishipping_items_allocate_cancel" />
+            </Button>
+            <Button
+                disabled={!dirty}
+                isLoading={isLoading}
+                onClick={submitForm}
+                type="submit"
+                variant={ButtonVariant.Primary}
+            >
+                {hasItemsAssigned 
+                    ? <TranslatedString id="shipping.multishipping_items_allocate_save" /> 
+                    : <TranslatedString id="shipping.multishipping_items_allocate_allocate" />
+                }
+            </Button>
         </>
     );
 

--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -105,7 +105,11 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
 
     const modalFooter = (
         <>
-            <Button onClick={onRequestClose} variant={ButtonVariant.Secondary}>
+            <Button
+                disabled={isLoading}
+                onClick={onRequestClose}
+                variant={ButtonVariant.Secondary}
+            >
                 <TranslatedString id="shipping.multishipping_items_allocate_cancel" />
             </Button>
             <Button

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -146,6 +146,7 @@ const ConsignmentAddressSelector = ({
                 addresses={addresses}
                 onSelectAddress={handleSelectAddress}
                 onUseNewAddress={handleUseNewAddress}
+                placeholderText="shipping.choose_shipping_address"
                 selectedAddress={selectedAddress}
                 showSingleLineAddress
                 type={AddressType.Shipping}

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -146,7 +146,7 @@ const ConsignmentAddressSelector = ({
                 addresses={addresses}
                 onSelectAddress={handleSelectAddress}
                 onUseNewAddress={handleUseNewAddress}
-                placeholderText="shipping.choose_shipping_address"
+                placeholderText={<TranslatedString id="shipping.choose_shipping_address" />}
                 selectedAddress={selectedAddress}
                 showSingleLineAddress
                 type={AddressType.Shipping}

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -20,9 +20,10 @@ interface ConsignmentLineItemProps {
     consignmentNumber: number;
     consignment: MultiShippingConsignmentData;
     onUnhandledError(error: Error): void;
+    isLoading: boolean;
 }
 
-const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ consignmentNumber, consignment, onUnhandledError }: ConsignmentLineItemProps) => {
+const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ consignmentNumber, consignment, onUnhandledError, isLoading }: ConsignmentLineItemProps) => {
     const [isOpenAllocateItemsModal, setIsOpenAllocateItemsModal] = useState(false);
     const [showItems, setShowItems] = useState(true);
 
@@ -85,6 +86,7 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({ cons
                 address={consignment.shippingAddress}
                 assignedItems={consignment}
                 consignmentNumber={consignmentNumber}
+                isLoading={isLoading}
                 isOpen={isOpenAllocateItemsModal}
                 onAllocateItems={handleAssignItems}
                 onRequestClose={toggleAllocateItemsModal}

--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -67,6 +67,7 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
             <ConsignmentLineItem
                 consignment={consignment}
                 consignmentNumber={consignmentNumber}
+                isLoading={isLoading}
                 onUnhandledError={onUnhandledError}
             />
             <MultiShippingOptionsV2

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -77,6 +77,12 @@ $allocate-items-table-image-width-small-screen: 40%;
     }
 }
 
+.modal.modal--afterOpen {
+    .button--tertiary {
+        border: none;
+    }
+}
+
 .modal.modal--afterOpen.modal.modal--confirm {
     min-height: 0;
     top: 50%;

--- a/packages/core/src/app/shipping/MultiShippingFormV2.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.tsx
@@ -21,6 +21,7 @@ interface MultiShippingFormV2Values {
 }
 
 export interface MultiShippingFormV2Props {
+    cartHasChanged: boolean;
     customerMessage: string;
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
@@ -34,6 +35,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
     defaultCountryCode,
     isLoading,
     onUnhandledError,
+    cartHasChanged,
 }: MultiShippingFormV2Props) => {
     const [isAddShippingDestination, setIsAddShippingDestination] = useState(false);
     const [errorConsignmentNumber, setErrorConsignmentNumber] = useState<number | undefined>();
@@ -138,6 +140,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
                 </div>
             )}
             <MultiShippingFormV2Footer
+                cartHasChanged={cartHasChanged}
                 isLoading={isLoading}
                 shouldDisableSubmit={shouldDisableSubmit}
                 shouldShowOrderComments={shouldShowOrderComments}

--- a/packages/core/src/app/shipping/MultiShippingFormV2Footer.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2Footer.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from 'react';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
 import { OrderComments } from '../orderComments';
+import { Alert, AlertType } from '../ui/alert';
 import { Button, ButtonVariant } from '../ui/button';
 import { Form } from '../ui/form';
 
@@ -10,15 +11,24 @@ export interface ShippingFormFooterProps {
     shouldShowOrderComments: boolean;
     shouldDisableSubmit: boolean;
     isLoading: boolean;
+    cartHasChanged: boolean;
 }
 
 const MultiShippingFormV2Footer: FunctionComponent<ShippingFormFooterProps> = ({
     shouldShowOrderComments,
     shouldDisableSubmit,
     isLoading,
+    cartHasChanged,
 }) => {
     return (
         <Form>
+            {cartHasChanged && (
+                <Alert type={AlertType.Error}>
+                    <strong>
+                        <TranslatedString id="shipping.cart_change_error" />
+                    </strong>
+                </Alert>
+            )}
             {shouldShowOrderComments && <OrderComments />}
 
             <div className="form-actions">

--- a/packages/core/src/app/shipping/MultiShippingV2.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingV2.test.tsx
@@ -130,7 +130,7 @@ describe('Multi-shipping V2', () => {
         // eslint-disable-next-line testing-library/no-unnecessary-act
         await act(async () => {
             await userEvent.click(screen.getByText(/Ship to multiple addresses/i));
-            await userEvent.click(screen.getByText(/Enter a new address/i));
+            await userEvent.click(screen.getByText(/Choose a shipping address/i));
             await userEvent.click(screen.getByText(/789 Test Ave/i));
             await userEvent.click(screen.getByText(/Allocate items/i));
             await userEvent.click(screen.getByText(/Select all items left/i));

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -99,6 +99,7 @@ const NewConsignment = ({
                 <AllocateItemsModal
                     address={selectedAddress}
                     consignmentNumber={consignmentNumber}
+                    isLoading={isLoading}
                     isOpen={isOpenAllocateItemsModal}
                     onAllocateItems={handleAllocateItems}
                     onRequestClose={toggleAllocateItemsModal}

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -117,6 +117,7 @@ const ShippingForm = ({
 
         if (isNewMultiShippingUIEnabled) {
             return <MultiShippingFormV2
+                cartHasChanged={cartHasChanged}
                 countriesWithAutocomplete={countriesWithAutocomplete}
                 customerMessage={customerMessage}
                 defaultCountryCode={shippingAddress?.countryCode}

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -551,7 +551,8 @@
             "quantity_invalid_error": "Quantity must be a number",
             "quantity_max_error": "Quantity cannot exceed \"Left to allocate\" amount.",
             "quantity_min_error": "Quantity cannot be less than 0",
-            "custom_item_quantity_error": "All quantities of this custom product must be allocated to the same destination, as it was created specifically for this draft order."
+            "custom_item_quantity_error": "All quantities of this custom product must be allocated to the same destination, as it was created specifically for this draft order.",
+            "choose_shipping_address": "Choose a shipping address"
         },
         "social": {
             "share_action": "Share",


### PR DESCRIPTION
## What?

1. Add loader to `Allocate` button in the allocate items modal.
2. In the address selector, the placeholder text should be 'Choose a shipping address'
3. For the 'Add New Address' modal, let's use the 'Cancel' button style from the consignment modal for consistency
4. Show cart has changed popup if the cart is changed via some external sources.

## Why?
To improve the UI/UX for checkout multishipping 
 
## Testing / Proof
**Manual testing** 

<img width="684" alt="Screenshot 2024-11-22 at 2 40 05 PM" src="https://github.com/user-attachments/assets/f8b88339-7e90-4897-b463-b656e0e7efe4">
<img width="736" alt="Screenshot 2024-11-22 at 2 39 51 PM" src="https://github.com/user-attachments/assets/c1f13a18-a937-4df8-8406-ece9f8ef5f65">
<img width="565" alt="Screenshot 2024-11-22 at 2 40 20 PM" src="https://github.com/user-attachments/assets/7d2fe417-b379-43ab-8ea7-6946f2325d91">
<img width="729" alt="Screenshot 2024-11-22 at 2 40 41 PM" src="https://github.com/user-attachments/assets/ec7985d4-c7ff-453b-b1b0-8627322bc8e0">

https://github.com/user-attachments/assets/345dc2d2-b470-4314-8d4a-ff190f1daf84


@bigcommerce/team-checkout
