### PR TITLE
feat(payment): STRIPE-488 add Google pay error text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.688.0",
+        "@bigcommerce/checkout-sdk": "^1.689.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.688.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.688.0.tgz",
-      "integrity": "sha512-UU3FJh6rfEa5LvdsZovwAusFAA0XrBuFnzuDZ0U90PL5YzAmBB6TFpdRaF7lJySZv31xqXwnlBUKUVj0e/qPoA==",
+      "version": "1.689.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.689.0.tgz",
+      "integrity": "sha512-HLhEZon5JiWQ3BGzNIbGXTLjXhBV0ymp6Jxl9a88bFYTc+XLaCkSrbjc1KGWVm042o3MIAv806rcf2J8y3f6jw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.688.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.688.0.tgz",
-      "integrity": "sha512-UU3FJh6rfEa5LvdsZovwAusFAA0XrBuFnzuDZ0U90PL5YzAmBB6TFpdRaF7lJySZv31xqXwnlBUKUVj0e/qPoA==",
+      "version": "1.689.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.689.0.tgz",
+      "integrity": "sha512-HLhEZon5JiWQ3BGzNIbGXTLjXhBV0ymp6Jxl9a88bFYTc+XLaCkSrbjc1KGWVm042o3MIAv806rcf2J8y3f6jw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.688.0",
+    "@bigcommerce/checkout-sdk": "^1.689.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -393,6 +393,7 @@
                 "expired_card": "Your card has expired. Please try again with a valid card.",
                 "gateway_error": "Something went wrong on the server. Please try again at a later time.",
                 "general_error": "Error while processing payment request.",
+                "google_pay_try_other_card": "Select a different card or log out of Google Pay to try the payment again.",
                 "hosted_form_error": "Unable to process the payment because invalid data was supplied with the transaction.",
                 "incorrect_address": "Your billing address couldn't be verified. Please check your billing address details and try again.",
                 "incorrect_amount": "Unable to process the payment because invalid data was supplied with the transaction.",


### PR DESCRIPTION
## What?
Added new code error.
Related PR: https://github.com/bigcommerce/bigpay/pull/8654

Bump checkout-sdk version:
https://github.com/bigcommerce/checkout-sdk-js/pull/2746

## Why?
Because we need to show the user an appropriate error if the first payment attempt fails.

## Testing / Proof
<img width="763" alt="Screenshot 2024-11-26 at 12 14 34" src="https://github.com/user-attachments/assets/d2e3ae5a-a57a-465f-a4c6-15fe000a473f">


@bigcommerce/team-checkout
