### PR TITLE
feat(checkout): PI-2944 Update HostedFormOptions usage in checkout-js after renaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "v1.683.1",
+        "@bigcommerce/checkout-sdk": "^1.685.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.683.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.1.tgz",
-      "integrity": "sha512-6FauS3FHJI+flV4Q/vppX3kAlbqOEJPsLzo98VEmP2uZnL1QVwu8267+orV+9Nc9+PV/uhubOyZFinXjMPNJoQ==",
+      "version": "1.685.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.685.0.tgz",
+      "integrity": "sha512-dLicKLjh8sniWm2taUe/N13u56hHknYBBFBRPEe35ERmhx9QyqmCNaTfZlbWqbZ5qq4fFP+GJczLM+vB30AODA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.683.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.1.tgz",
-      "integrity": "sha512-6FauS3FHJI+flV4Q/vppX3kAlbqOEJPsLzo98VEmP2uZnL1QVwu8267+orV+9Nc9+PV/uhubOyZFinXjMPNJoQ==",
+      "version": "1.685.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.685.0.tgz",
+      "integrity": "sha512-dLicKLjh8sniWm2taUe/N13u56hHknYBBFBRPEe35ERmhx9QyqmCNaTfZlbWqbZ5qq4fFP+GJczLM+vB30AODA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "v1.683.1",
+    "@bigcommerce/checkout-sdk": "^1.685.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/withHostedCreditCardFieldset.tsx
@@ -1,7 +1,7 @@
 import {
     CardInstrument,
-    HostedFormOptions,
     Instrument,
+    LegacyHostedFormOptions,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
 import { compact, forIn } from 'lodash';
@@ -44,7 +44,7 @@ export interface WithInjectedHostedCreditCardFieldsetProps {
     hostedFieldset: ReactNode;
     hostedStoredCardValidationSchema: ObjectSchema<HostedInstrumentValidationSchemaShape>;
     hostedValidationSchema: ObjectSchema<HostedCreditCardValidationSchemaShape>;
-    getHostedFormOptions(selectedInstrument?: CardInstrument): Promise<HostedFormOptions>;
+    getHostedFormOptions(selectedInstrument?: CardInstrument): Promise<LegacyHostedFormOptions>;
     getHostedStoredCardValidationFieldset(selectedInstrument?: CardInstrument): ReactNode;
 }
 
@@ -89,7 +89,7 @@ export default function withHostedCreditCardFieldset<
 
         const getHostedFormOptions: (
             selectedInstrument?: CardInstrument,
-        ) => Promise<HostedFormOptions> = useCallback(
+        ) => Promise<LegacyHostedFormOptions> = useCallback(
             async (selectedInstrument) => {
                 const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
                 const isInstrumentCardNumberRequired = selectedInstrument

--- a/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.tsx
+++ b/packages/core/src/app/payment/hostedCreditCard/withHostedPayPalCommerceCreditCardFieldset.tsx
@@ -1,7 +1,7 @@
 import {
     CardInstrument,
-    HostedFormOptions,
     Instrument,
+    LegacyHostedFormOptions,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
 import { compact, forIn } from 'lodash';
@@ -44,7 +44,7 @@ export interface WithInjectedHostedCreditCardFieldsetProps {
     hostedFieldset: ReactNode;
     hostedStoredCardValidationSchema: ObjectSchema<HostedInstrumentValidationSchemaShape>;
     hostedValidationSchema: ObjectSchema<HostedCreditCardValidationSchemaShape>;
-    getHostedFormOptions(selectedInstrument?: CardInstrument): Promise<HostedFormOptions>;
+    getHostedFormOptions(selectedInstrument?: CardInstrument): Promise<LegacyHostedFormOptions>;
     getHostedStoredCardValidationFieldset(selectedInstrument?: CardInstrument): ReactNode;
 }
 
@@ -89,7 +89,7 @@ export default function withHostedPayPalCommerceCreditCardFieldset<
 
         const getHostedFormOptions: (
             selectedInstrument?: CardInstrument,
-        ) => Promise<HostedFormOptions> = useCallback(
+        ) => Promise<LegacyHostedFormOptions> = useCallback(
             async (selectedInstrument) => {
                 const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
 

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -2,8 +2,8 @@ import {
     CardInstrument,
     CheckoutSelectors,
     HostedFieldType,
-    HostedFormOptions,
     Instrument,
+    LegacyHostedFormOptions,
     PaymentInitializeOptions,
     PaymentInstrument,
     PaymentMethod,
@@ -48,7 +48,7 @@ export interface CreditCardPaymentMethodProps {
     deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
     getHostedFormOptions?(
         selectedInstrument?: CardInstrument | undefined,
-    ): Promise<HostedFormOptions>;
+    ): Promise<LegacyHostedFormOptions>;
     getStoredCardValidationFieldset?(selectedInstrument?: CardInstrument): ReactNode;
 }
 

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -1,4 +1,4 @@
-import { CardInstrument, HostedFormOptions } from '@bigcommerce/checkout-sdk';
+import { CardInstrument, LegacyHostedFormOptions } from '@bigcommerce/checkout-sdk';
 import { compact, forIn } from 'lodash';
 import React, { FunctionComponent, ReactNode, useCallback, useState } from 'react';
 
@@ -55,7 +55,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     const getHostedFormOptions: (
         selectedInstrument?: CardInstrument,
-    ) => Promise<HostedFormOptions> = useCallback(
+    ) => Promise<LegacyHostedFormOptions> = useCallback(
         async (selectedInstrument) => {
             const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
             const isInstrumentCardNumberRequired = selectedInstrument

--- a/packages/hosted-credit-card-integration/src/hooks/useHostedCreditCard.tsx
+++ b/packages/hosted-credit-card-integration/src/hooks/useHostedCreditCard.tsx
@@ -1,8 +1,8 @@
 import {
     CardInstrument,
     CheckoutSelectors,
-    HostedFormOptions,
     LanguageService,
+    LegacyHostedFormOptions,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
 import { compact, forIn } from 'lodash';
@@ -83,7 +83,7 @@ export const useHostedCreditCard = ({
         );
 
     const getHostedFormOptions = useCallback(
-        async (selectedInstrument: CardInstrument): Promise<HostedFormOptions> => {
+        async (selectedInstrument: CardInstrument): Promise<LegacyHostedFormOptions> => {
             const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
             const isInstrumentCardNumberRequired = selectedInstrument
                 ? isInstrumentCardNumberRequiredProp(selectedInstrument, method)

--- a/packages/mollie-integration/src/MolliePaymentMethod.tsx
+++ b/packages/mollie-integration/src/MolliePaymentMethod.tsx
@@ -1,6 +1,6 @@
 import {
     CardInstrument,
-    HostedFormOptions,
+    LegacyHostedFormOptions,
     PaymentInitializeOptions,
 } from '@bigcommerce/checkout-sdk';
 import { compact, forIn, some } from 'lodash';
@@ -75,7 +75,7 @@ const MolliePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     const getHostedFormOptions: (
         selectedInstrument?: CardInstrument,
-    ) => Promise<HostedFormOptions> = useCallback(
+    ) => Promise<LegacyHostedFormOptions> = useCallback(
         async (selectedInstrument) => {
             const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
             const isInstrumentCardNumberRequired = selectedInstrument


### PR DESCRIPTION
===> MERGE TOGETHER WITH CHECKOUT-SDK-JS PART https://github.com/bigcommerce/checkout-sdk-js/pull/2741

## What?
After renaming `HostedFormOptions` to `LegacyHostedFormOptions` in task https://bigcommercecloud.atlassian.net/browse/PI-2943 it is necessary to update its usage in checkout-js

## Why?
Because of changes in https://bigcommercecloud.atlassian.net/browse/PI-2943

## Testing / Proof
Tested manually

@bigcommerce/team-checkout
