### PR TITLE
feat(checkout): CHECKOUT-8869 Remove Available Shipping Option Check

### DIFF
--- a/packages/core/src/app/shipping/hasSelectedShippingOptions.spec.ts
+++ b/packages/core/src/app/shipping/hasSelectedShippingOptions.spec.ts
@@ -1,6 +1,5 @@
 import { getConsignment } from './consignment.mock';
 import hasSelectedShippingOptions from './hasSelectedShippingOptions';
-import { getShippingOptionPickUpStore } from './shippingOption/shippingMethod.mock';
 
 describe('hasSelectedShippingOptions()', () => {
     it('returns false when has no consignments', () => {
@@ -23,7 +22,7 @@ describe('hasSelectedShippingOptions()', () => {
         expect(hasSelectedShippingOptions([getConsignment(), getConsignment()])).toBe(true);
     });
 
-    it('returns false when consignments have no shipping options', () => {
+    it('returns true when a consignment has no available shipping options but a selected shipping option', () => {
         expect(
             hasSelectedShippingOptions([
                 getConsignment(),
@@ -32,18 +31,6 @@ describe('hasSelectedShippingOptions()', () => {
                     availableShippingOptions: [],
                 },
             ]),
-        ).toBe(false);
-    });
-
-    it('returns false when consignments have mismatched shipping options', () => {
-        expect(
-            hasSelectedShippingOptions([
-                getConsignment(),
-                {
-                    ...getConsignment(),
-                    availableShippingOptions: [getShippingOptionPickUpStore()],
-                },
-            ]),
-        ).toBe(false);
+        ).toBe(true);
     });
 });

--- a/packages/core/src/app/shipping/hasSelectedShippingOptions.ts
+++ b/packages/core/src/app/shipping/hasSelectedShippingOptions.ts
@@ -9,13 +9,7 @@ export default function hasSelectedShippingOptions(consignments: Consignment[]):
     return every(
         consignments,
         (consignment) =>
-            (consignment.selectedShippingOption &&
-                consignment.selectedShippingOption.id &&
-                // Selected option is available
-                consignment.availableShippingOptions &&
-                consignment.availableShippingOptions.filter(
-                    ({ id }) => id === consignment.selectedShippingOption?.id,
-                ).length) ||
+            (consignment.selectedShippingOption && consignment.selectedShippingOption.id) ||
             consignment.selectedShippingOption?.type === 'custom',
     );
 }


### PR DESCRIPTION
## What?
Remove available shipping option check when determining if a consignment has selected a shipping method..

## Why?
This change will avoid always loading available shipping methods after a checkout page refresh.

## Testing / Proof
CI.
