### PR TITLE
fix(shipping): CHECKOUT-7560 add max length validation for address fields

### DIFF
--- a/packages/core/src/app/address/AddressFormModal.tsx
+++ b/packages/core/src/app/address/AddressFormModal.tsx
@@ -31,6 +31,7 @@ export interface AddressFormProps {
     getFields(countryCode?: string): FormField[];
     onSaveAddress(address: AddressFormValues): void;
     onRequestClose?(): void;
+    validateAddressFields: boolean;
 }
 
 const SaveAddress: FunctionComponent<
@@ -101,11 +102,12 @@ const SaveAddressForm = withLanguage(
             company: '',
             shouldSaveAddress: false,
         }),
-        validationSchema: ({ language, getFields }: AddressFormProps & WithLanguageProps) =>
+        validationSchema: ({ language, getFields, validateAddressFields }: AddressFormProps & WithLanguageProps) =>
             lazy<Partial<AddressFormValues>>((values) =>
                 getAddressFormFieldsValidationSchema({
                     language,
                     formFields: getFields(values && values.countryCode),
+                    validateAddressFields,
                 }),
             ),
     })(SaveAddress),

--- a/packages/core/src/app/address/AddressFormModal.tsx
+++ b/packages/core/src/app/address/AddressFormModal.tsx
@@ -31,7 +31,6 @@ export interface AddressFormProps {
     getFields(countryCode?: string): FormField[];
     onSaveAddress(address: AddressFormValues): void;
     onRequestClose?(): void;
-    validateAddressFields: boolean;
 }
 
 const SaveAddress: FunctionComponent<
@@ -102,12 +101,11 @@ const SaveAddressForm = withLanguage(
             company: '',
             shouldSaveAddress: false,
         }),
-        validationSchema: ({ language, getFields, validateAddressFields }: AddressFormProps & WithLanguageProps) =>
+        validationSchema: ({ language, getFields }: AddressFormProps & WithLanguageProps) =>
             lazy<Partial<AddressFormValues>>((values) =>
                 getAddressFormFieldsValidationSchema({
                     language,
                     formFields: getFields(values && values.countryCode),
-                    validateAddressFields,
                 }),
             ),
     })(SaveAddress),

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -5,8 +5,8 @@ import { TranslatedString, withLanguage, WithLanguageProps } from '@bigcommerce/
 
 
 import { AddressSelectProps } from './AddressSelect';
-import StaticAddress from './StaticAddress';
 import SingleLineStaticAddress from './SingleLineStaticAddress';
+import StaticAddress from './StaticAddress';
 
 type AddressSelectButtonProps = Pick<AddressSelectProps, 'selectedAddress' | 'addresses' | 'type' | 'showSingleLineAddress'>;
 

--- a/packages/core/src/app/address/SingleLineStaticAddress.test.tsx
+++ b/packages/core/src/app/address/SingleLineStaticAddress.test.tsx
@@ -9,6 +9,8 @@ import React, { FunctionComponent } from 'react';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
+import { getStoreConfig } from '../config/config.mock';
+
 import { getAddress } from './address.mock';
 import AddressType from './AddressType';
 import { getAddressFormFields } from './formField.mock';
@@ -27,6 +29,17 @@ describe('SingleLineStaticAddress Component', () => {
         defaultProps = {
             address: getAddress(),
         };
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                features: {
+                    ...getStoreConfig().checkoutSettings.features,
+                    "CHECKOUT-7560_address_fields_max_length_validation": false,
+                }
+            },
+        });
 
         jest.spyOn(checkoutState.data, 'getBillingAddressFields').mockReturnValue(
             getAddressFormFields(),
@@ -96,6 +109,31 @@ describe('SingleLineStaticAddress Component', () => {
                     customFields: [{ fieldId: 'foobar', fieldValue: '' }],
                 }}
                 type={AddressType.Billing}
+            />,
+        );
+
+        expect(screen.getByTestId('static-address')).toBeInTheDocument();
+    });
+
+    it('renders component even if required fields are missing when experiment is on', () => {
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                features: {
+                    ...getStoreConfig().checkoutSettings.features,
+                    "CHECKOUT-7560_address_fields_max_length_validation": true,
+                }
+            },
+        });
+
+        render(
+            <SingleLineStaticAddressTest
+                address={{
+                    ...defaultProps.address,
+                    address1: '',
+                }}
+                type={AddressType.Shipping}
             />,
         );
 

--- a/packages/core/src/app/address/SingleLineStaticAddress.tsx
+++ b/packages/core/src/app/address/SingleLineStaticAddress.tsx
@@ -1,5 +1,4 @@
 import { Address } from '@bigcommerce/checkout-sdk';
-import { isEmpty } from 'lodash';
 import React from "react";
 
 import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
@@ -7,7 +6,7 @@ import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
 import { isExperimentEnabled } from '../common/utility';
 
 import AddressType from "./AddressType";
-import isValidAddress from "./isValidAddress";
+import isValidStaticAddress from './isValidStaticAddress';
 
 export interface SingleLineStaticAddressProps {
     address: Address;
@@ -56,15 +55,7 @@ const SingleLineStaticAddress = ({ address, type }: SingleLineStaticAddressProps
                 ? getShippingAddressFields(address.countryCode)
                 : undefined;
 
-    let isValid = !isEmpty(address);
-    
-    if (!!fields && !validateAddressFields) {
-        isValid = isValidAddress(
-            address,
-            fields.filter((field) => !field.custom),
-        );
-    }
-
+    const isValid = isValidStaticAddress(address, validateAddressFields, fields);
 
     return !isValid ? null : (
         <div className="vcard checkout-address--static" data-test="static-address">

--- a/packages/core/src/app/address/SingleLineStaticAddress.tsx
+++ b/packages/core/src/app/address/SingleLineStaticAddress.tsx
@@ -43,7 +43,7 @@ const SingleLineStaticAddress = ({ address, type }: SingleLineStaticAddressProps
     } = useCheckout();
 
     const config = getConfig();
-    const validateAddressFieldsExperimentEnabled =
+    const validateAddressFields =
         isExperimentEnabled(
             config?.checkoutSettings,
             'CHECKOUT-7560_address_fields_max_length_validation',
@@ -58,7 +58,7 @@ const SingleLineStaticAddress = ({ address, type }: SingleLineStaticAddressProps
 
     let isValid = !isEmpty(address);
     
-    if (!!fields && !validateAddressFieldsExperimentEnabled) {
+    if (!!fields && !validateAddressFields) {
         isValid = isValidAddress(
             address,
             fields.filter((field) => !field.custom),

--- a/packages/core/src/app/address/StaticAddress.test.tsx
+++ b/packages/core/src/app/address/StaticAddress.test.tsx
@@ -9,6 +9,7 @@ import React, { FunctionComponent } from 'react';
 import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
+import { getStoreConfig } from '../config/config.mock';
 import { getCountries } from '../geography/countries.mock';
 
 import { getAddress } from './address.mock';
@@ -29,6 +30,17 @@ describe('StaticAddress Component', () => {
         defaultProps = {
             address: getAddress(),
         };
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                features: {
+                    ...getStoreConfig().checkoutSettings.features,
+                    "CHECKOUT-7560_address_fields_max_length_validation": false,
+                }
+            },
+        });
 
         jest.spyOn(checkoutState.data, 'getBillingCountries').mockReturnValue(getCountries());
         jest.spyOn(checkoutState.data, 'getShippingCountries').mockReturnValue(getCountries());
@@ -137,6 +149,31 @@ describe('StaticAddress Component', () => {
                     customFields: [{ fieldId: 'foobar', fieldValue: '' }],
                 }}
                 type={AddressType.Billing}
+            />,
+        );
+
+        expect(screen.getByTestId('static-address')).toBeInTheDocument();
+    });
+
+    it('renders component even if required fields are missing when experiment is on', () => {
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                features: {
+                    ...getStoreConfig().checkoutSettings.features,
+                    "CHECKOUT-7560_address_fields_max_length_validation": true,
+                }
+            },
+        });
+
+        render(
+            <StaticAddressTest
+                address={{
+                    ...defaultProps.address,
+                    address1: '',
+                }}
+                type={AddressType.Shipping}
             />,
         );
 

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -31,7 +31,7 @@ export interface StaticAddressEditableProps extends StaticAddressProps {
 interface WithCheckoutStaticAddressProps {
     countries?: Country[];
     fields?: FormField[];
-    validateAddressFieldsExperimentEnabled?: boolean;
+    validateAddressFields?: boolean;
 }
 
 const StaticAddress: FunctionComponent<
@@ -40,12 +40,12 @@ const StaticAddress: FunctionComponent<
         countries,
         fields,
         address: addressWithoutLocalization,
-        validateAddressFieldsExperimentEnabled
+        validateAddressFields
     }) => {
         const address = localizeAddress(addressWithoutLocalization, countries);
         let isValid = !isEmpty(address);
         
-        if (!!fields && !validateAddressFieldsExperimentEnabled) {
+        if (!!fields && !validateAddressFields) {
             isValid = isValidAddress(
                 address,
                 fields.filter((field) => !field.custom),
@@ -105,7 +105,7 @@ export function mapToStaticAddressProps(
 
     const config = getConfig();
 
-    const validateAddressFieldsExperimentEnabled =
+    const validateAddressFields =
         isExperimentEnabled(
             config?.checkoutSettings,
             'CHECKOUT-7560_address_fields_max_length_validation',
@@ -121,7 +121,7 @@ export function mapToStaticAddressProps(
                 : type === AddressType.Shipping
                 ? getShippingAddressFields(address.countryCode)
                 : undefined,
-        validateAddressFieldsExperimentEnabled,
+        validateAddressFields,
     };
 }
 

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -5,7 +5,6 @@ import {
     FormField,
     ShippingInitializeOptions,
 } from '@bigcommerce/checkout-sdk';
-import { isEmpty } from 'lodash';
 import React, { FunctionComponent, memo } from 'react';
 
 import { localizeAddress } from '@bigcommerce/checkout/locale';
@@ -15,7 +14,7 @@ import { withCheckout } from '../checkout';
 import { isExperimentEnabled } from '../common/utility';
 
 import AddressType from './AddressType';
-import isValidAddress from './isValidAddress';
+import isValidStaticAddress from './isValidStaticAddress';
 
 import './StaticAddress.scss';
 
@@ -40,17 +39,10 @@ const StaticAddress: FunctionComponent<
         countries,
         fields,
         address: addressWithoutLocalization,
-        validateAddressFields
+        validateAddressFields = false,
     }) => {
-        const address = localizeAddress(addressWithoutLocalization, countries);
-        let isValid = !isEmpty(address);
-        
-        if (!!fields && !validateAddressFields) {
-            isValid = isValidAddress(
-                address,
-                fields.filter((field) => !field.custom),
-            );
-        }
+    const address = localizeAddress(addressWithoutLocalization, countries);
+    const isValid = isValidStaticAddress(address, validateAddressFields, fields);
 
     return !isValid ? null : (
         <div className="vcard checkout-address--static" data-test="static-address">

--- a/packages/core/src/app/address/getAddressFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/address/getAddressFormFieldsValidationSchema.ts
@@ -12,6 +12,7 @@ export interface AddressFormFieldsValidationSchemaOptions {
     formFields: FormField[];
     language?: LanguageService;
     validateGoogleMapAutoCompleteMaxLength?: boolean;
+    validateAddressFields?: boolean;
 }
 
 export function getTranslateAddressError(
@@ -64,10 +65,12 @@ export default memoize(function getAddressFormFieldsValidationSchema({
     formFields,
     language,
     validateGoogleMapAutoCompleteMaxLength,
+    validateAddressFields,
 }: AddressFormFieldsValidationSchemaOptions): ObjectSchema<FormFieldValues> {
     return getFormFieldsValidationSchema({
         formFields,
         translate: getTranslateAddressError(language),
         validateGoogleMapAutoCompleteMaxLength,
+        validateAddressFields,
     });
 });

--- a/packages/core/src/app/address/isValidAddress.test.ts
+++ b/packages/core/src/app/address/isValidAddress.test.ts
@@ -71,14 +71,17 @@ describe('isValidAddress()', () => {
         it('returns false if address exceeds max length and experiment is on', () => {
             const formFieldsWithMaxLength = getFormFields().map(field => {
                 const { name } = field;
+                
                 if(name === 'address1') {
                     return { ...field, maxLength: 20 };
                 }
                 else if (name === 'address2') {
                     return { ...field, maxLength: 10 };
                 }
+                
                 return field;
             });
+            
             expect(isValidAddress({ ...getAddress(), address1: 'this is a long address 1 from somewhere' }, formFieldsWithMaxLength, true )).toBe(false);
             expect(isValidAddress({ ...getAddress(), address2: 'this is a long address 2' }, formFieldsWithMaxLength, true )).toBe(false);
         });
@@ -86,14 +89,17 @@ describe('isValidAddress()', () => {
         it('returns true if address exceeds max length and experiment is off', () => {
             const formFieldsWithMaxLength = getFormFields().map(field => {
                 const { name } = field;
+                
                 if(name === 'address1') {
                     return { ...field, maxLength: 20 };
                 }
                 else if (name === 'address2') {
                     return { ...field, maxLength: 10 };
                 }
+                
                 return field;
             });
+            
             expect(isValidAddress({ ...getAddress(), address1: 'this is a long address 1 from somewhere' }, formFieldsWithMaxLength, false )).toBe(true);
             expect(isValidAddress({ ...getAddress(), address2: 'this is a long address 2' }, formFieldsWithMaxLength, false )).toBe(true);
         });

--- a/packages/core/src/app/address/isValidAddress.test.ts
+++ b/packages/core/src/app/address/isValidAddress.test.ts
@@ -66,4 +66,37 @@ describe('isValidAddress()', () => {
             expect(output).toBe(false);
         });
     });
+
+    describe('address fields max length validation', () => {
+        it('returns false if address exceeds max length and experiment is on', () => {
+            const formFieldsWithMaxLength = getFormFields().map(field => {
+                const { name } = field;
+                if(name === 'address1') {
+                    return { ...field, maxLength: 20 };
+                }
+                else if (name === 'address2') {
+                    return { ...field, maxLength: 10 };
+                }
+                return field;
+            });
+            expect(isValidAddress({ ...getAddress(), address1: 'this is a long address 1 from somewhere' }, formFieldsWithMaxLength, true )).toBe(false);
+            expect(isValidAddress({ ...getAddress(), address2: 'this is a long address 2' }, formFieldsWithMaxLength, true )).toBe(false);
+        });
+
+        it('returns true if address exceeds max length and experiment is off', () => {
+            const formFieldsWithMaxLength = getFormFields().map(field => {
+                const { name } = field;
+                if(name === 'address1') {
+                    return { ...field, maxLength: 20 };
+                }
+                else if (name === 'address2') {
+                    return { ...field, maxLength: 10 };
+                }
+                return field;
+            });
+            expect(isValidAddress({ ...getAddress(), address1: 'this is a long address 1 from somewhere' }, formFieldsWithMaxLength, false )).toBe(true);
+            expect(isValidAddress({ ...getAddress(), address2: 'this is a long address 2' }, formFieldsWithMaxLength, false )).toBe(true);
+        });
+    })
+    
 });

--- a/packages/core/src/app/address/isValidAddress.ts
+++ b/packages/core/src/app/address/isValidAddress.ts
@@ -3,8 +3,12 @@ import { Address, FormField } from '@bigcommerce/checkout-sdk';
 import getAddressFormFieldsValidationSchema from './getAddressFormFieldsValidationSchema';
 import mapAddressToFormValues from './mapAddressToFormValues';
 
-export default function isValidAddress(address: Address, formFields: FormField[]): boolean {
-    const addressSchema = getAddressFormFieldsValidationSchema({ formFields });
+export default function isValidAddress(
+    address: Address,
+    formFields: FormField[],
+    validateAddressFields?: boolean
+): boolean {
+    const addressSchema = getAddressFormFieldsValidationSchema({ formFields, validateAddressFields });
 
     return addressSchema.isValidSync(mapAddressToFormValues(formFields, address));
 }

--- a/packages/core/src/app/address/isValidCustomerAddress.ts
+++ b/packages/core/src/app/address/isValidCustomerAddress.ts
@@ -8,8 +8,9 @@ export default function isValidCustomerAddress(
     address: Address | undefined,
     addresses: CustomerAddress[],
     formFields: FormField[],
+    validateAddressFields?: boolean,
 ): boolean {
-    if (!address || !isValidAddress(address, formFields)) {
+    if (!address || !isValidAddress(address, formFields, validateAddressFields)) {
         return false;
     }
 

--- a/packages/core/src/app/address/isValidStaticAddress.tsx
+++ b/packages/core/src/app/address/isValidStaticAddress.tsx
@@ -1,0 +1,21 @@
+import { Address, FormField } from "@bigcommerce/checkout-sdk";
+import { isEmpty } from "lodash";
+
+import isValidAddress from "./isValidAddress";
+
+export default function isValidStaticAddress(
+    address: Address, 
+    validateAddressFields: boolean,
+    fields?: FormField[], 
+): boolean {
+    let isValid = !isEmpty(address);
+        
+    if (fields && !validateAddressFields) {
+        isValid = isValidAddress(
+            address,
+            fields.filter((field) => !field.custom),
+        );
+    }
+
+    return isValid;
+}

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -172,13 +172,13 @@ const getShippingStepStatus = createSelector(
     },
     ({ data }: CheckoutSelectors) => data.getConfig(),
     (shippingAddress, consignments, cart, shippingAddressFields, config) => {
-        const validateAddressFieldsExperimentEnabled =
+        const validateAddressFields =
             isExperimentEnabled(
                 config?.checkoutSettings,
                 'CHECKOUT-7560_address_fields_max_length_validation'
             );
         const hasAddress = shippingAddress
-            ? isValidAddress(shippingAddress, shippingAddressFields, validateAddressFieldsExperimentEnabled)
+            ? isValidAddress(shippingAddress, shippingAddressFields, validateAddressFields)
             : false;
         const hasOptions = consignments ? hasSelectedShippingOptions(consignments) : false;
         const hasUnassignedItems =

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -172,8 +172,13 @@ const getShippingStepStatus = createSelector(
     },
     ({ data }: CheckoutSelectors) => data.getConfig(),
     (shippingAddress, consignments, cart, shippingAddressFields, config) => {
+        const validateAddressFieldsExperimentEnabled =
+            isExperimentEnabled(
+                config?.checkoutSettings,
+                'CHECKOUT-7560_address_fields_max_length_validation'
+            );
         const hasAddress = shippingAddress
-            ? isValidAddress(shippingAddress, shippingAddressFields)
+            ? isValidAddress(shippingAddress, shippingAddressFields, validateAddressFieldsExperimentEnabled)
             : false;
         const hasOptions = consignments ? hasSelectedShippingOptions(consignments) : false;
         const hasUnassignedItems =

--- a/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getCustomFormFieldsValidationSchema.ts
@@ -28,6 +28,7 @@ export interface FormFieldsValidationSchemaOptions {
     formFields: FormField[];
     translate?: TranslateValidationErrorFunction;
     validateGoogleMapAutoCompleteMaxLength?: boolean;
+    validateAddressFields?: boolean;
 }
 
 export interface CustomFormFieldValues {

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.spec.tsx
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.spec.tsx
@@ -128,6 +128,7 @@ describe('getFormFielsValidationSchema', () => {
         it('throws error for google maps autocomplete validation for max length', async () => {
             const formFieldsWithMaxLength = formFields.map(field => {
                 const { name } = field;
+                
                 return name === 'address1' ? { ...field, maxLength: 20 } : field;
             });
     
@@ -153,11 +154,12 @@ describe('getFormFielsValidationSchema', () => {
             const spy = jest.fn();
             const formFieldsWithMaxLength = formFields.map(field => {
                 const { name } = field;
+                
                 return name === 'address1' ? { ...field, maxLength: 20 } : field;
             });
     
-    
             const schema = getFormFieldsValidationSchema({ formFields: formFieldsWithMaxLength, translate });
+            
             await schema
                 .validate({
                     ...getShippingAddress(),
@@ -173,9 +175,11 @@ describe('getFormFielsValidationSchema', () => {
         it('throws error for address field 1 validation for max length', async () => {
             const formFieldsWithMaxLength = formFields.map(field => {
                 const { name } = field;
+                
                 if(name === 'address1') {
                     return { ...field, maxLength: 15 };
                 }
+                
                 return field;
             });
     
@@ -199,9 +203,11 @@ describe('getFormFielsValidationSchema', () => {
         it('throws error for address field 2 validation for max length', async () => {
             const formFieldsWithMaxLength = formFields.map(field => {
                 const { name } = field;
+                
                 if(name === 'address2') {
                     return { ...field, maxLength: 10 };
                 }
+                
                 return field;
             });
     
@@ -226,10 +232,12 @@ describe('getFormFielsValidationSchema', () => {
             const spy = jest.fn();
             const formFieldsWithMaxLength = formFields.map(field => {
                 const { name } = field;
+                
                 return name === 'address1' ? { ...field, maxLength: 20 } : field;
             });
     
             const schema = getFormFieldsValidationSchema({ formFields: formFieldsWithMaxLength, translate });
+            
             await schema
                 .validate({
                     ...getShippingAddress(),

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.spec.tsx
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.spec.tsx
@@ -168,4 +168,76 @@ describe('getFormFielsValidationSchema', () => {
             expect(spy).toHaveBeenCalled();
         });
     });
+
+    describe('address fields max length validation', () => {
+        it('throws error for address field 1 validation for max length', async () => {
+            const formFieldsWithMaxLength = formFields.map(field => {
+                const { name } = field;
+                if(name === 'address1') {
+                    return { ...field, maxLength: 15 };
+                }
+                return field;
+            });
+    
+            const schema = getFormFieldsValidationSchema({ formFields: formFieldsWithMaxLength, translate, validateAddressFields: true });
+            const errors = await schema
+                .validate({
+                    ...getShippingAddress(),
+                    address1: 'this is a long address 1 from somewhere',
+                })
+                .catch((error: ValidationError) => error.message);
+            
+
+            expect(translate).toHaveBeenCalledWith('max', {
+                label: 'Address Line 1',
+                name: 'address1',
+                max: 15,
+            });
+            expect(errors).toBe('address1 must be at most 15 characters');
+        });
+
+        it('throws error for address field 2 validation for max length', async () => {
+            const formFieldsWithMaxLength = formFields.map(field => {
+                const { name } = field;
+                if(name === 'address2') {
+                    return { ...field, maxLength: 10 };
+                }
+                return field;
+            });
+    
+            const schema = getFormFieldsValidationSchema({ formFields: formFieldsWithMaxLength, translate, validateAddressFields: true });
+            const errors = await schema
+                .validate({
+                    ...getShippingAddress(),
+                    address2: 'this is a long address 2 from somewhere',
+                })
+                .catch((error: ValidationError) => error.message);
+            
+
+            expect(translate).toHaveBeenCalledWith('max', {
+                label: 'Address Line 2',
+                name: 'address2',
+                max: 10,
+            });
+            expect(errors).toBe('address2 must be at most 10 characters');
+        });
+
+        it('throws no error for max length validation if address validation experiment is not enabled', async () => {
+            const spy = jest.fn();
+            const formFieldsWithMaxLength = formFields.map(field => {
+                const { name } = field;
+                return name === 'address1' ? { ...field, maxLength: 20 } : field;
+            });
+    
+            const schema = getFormFieldsValidationSchema({ formFields: formFieldsWithMaxLength, translate });
+            await schema
+                .validate({
+                    ...getShippingAddress(),
+                    address1: 'this is a long address 1 from somewhere',
+                })
+                .then(spy);
+
+            expect(spy).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
@@ -15,6 +15,7 @@ export default memoize(function getFormFieldsValidationSchema({
     formFields,
     translate = () => undefined,
     validateGoogleMapAutoCompleteMaxLength = false,
+    validateAddressFields = false,
 }: FormFieldsValidationSchemaOptions): ObjectSchema<FormFieldValues> {
     return object({
         ...formFields
@@ -29,6 +30,11 @@ export default memoize(function getFormFieldsValidationSchema({
                 }
 
                 if (name === 'address1' && maxLength && validateGoogleMapAutoCompleteMaxLength) {
+                    schema[name] = schema[name]
+                        .max(maxLength, translate('max', { label, name, max: maxLength }));
+                }
+
+                if ((name === 'address1' || name === 'address2') && maxLength && validateAddressFields) {
                     schema[name] = schema[name]
                         .max(maxLength, translate('max', { label, name, max: maxLength }));
                 }

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -6,7 +6,7 @@ import { useCheckout } from "@bigcommerce/checkout/payment-integration-api";
 
 import { AddressFormModal, AddressFormValues, AddressSelect, AddressType, isValidAddress, mapAddressFromFormValues } from "../address";
 import { ErrorModal } from "../common/error";
-import { EMPTY_ARRAY, isFloatingLabelEnabled } from "../common/utility";
+import { EMPTY_ARRAY, isExperimentEnabled, isFloatingLabelEnabled } from "../common/utility";
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
 import { MultiShippingConsignmentData } from "./MultishippingV2Type";
@@ -57,8 +57,14 @@ const ConsignmentAddressSelector = ({
         },
     } = config;
 
+    const validateAddressFields =
+        isExperimentEnabled(
+            config.checkoutSettings,
+            'CHECKOUT-7560_address_fields_max_length_validation',
+        );
+
     const handleSelectAddress = async (address: Address) => {
-        if (!isValidAddress(address, getFields(address.countryCode))) {
+        if (!isValidAddress(address, getFields(address.countryCode), validateAddressFields)) {
             return onUnhandledError(new AssignItemInvalidAddressError());
         }
 
@@ -96,7 +102,7 @@ const ConsignmentAddressSelector = ({
     const handleSaveAddress = async (addressFormValues: AddressFormValues) => {
         const address = mapAddressFromFormValues(addressFormValues);
 
-        if (!isValidAddress(address, getFields(address.countryCode))) {
+        if (!isValidAddress(address, getFields(address.countryCode), validateAddressFields)) {
             return onUnhandledError(new AssignItemInvalidAddressError());
         }
 
@@ -141,6 +147,7 @@ const ConsignmentAddressSelector = ({
                 isOpen={isOpenNewAddressModal}
                 onRequestClose={handleCloseAddAddressForm}
                 onSaveAddress={handleSaveAddress}
+                validateAddressFields={validateAddressFields}
             />
             <AddressSelect
                 addresses={addresses}

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -102,10 +102,6 @@ const ConsignmentAddressSelector = ({
     const handleSaveAddress = async (addressFormValues: AddressFormValues) => {
         const address = mapAddressFromFormValues(addressFormValues);
 
-        if (!isValidAddress(address, getFields(address.countryCode), validateAddressFields)) {
-            return onUnhandledError(new AssignItemInvalidAddressError());
-        }
-
         await handleSelectAddress(address);
 
         try {
@@ -147,7 +143,6 @@ const ConsignmentAddressSelector = ({
                 isOpen={isOpenNewAddressModal}
                 onRequestClose={handleCloseAddAddressForm}
                 onSaveAddress={handleSaveAddress}
-                validateAddressFields={validateAddressFields}
             />
             <AddressSelect
                 addresses={addresses}

--- a/packages/core/src/app/shipping/MultiShippingForm.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.tsx
@@ -101,7 +101,6 @@ class MultiShippingForm extends PureComponent<
             countriesWithAutocomplete,
             googleMapsApiKey,
             isFloatingLabelEnabled,
-            validateAddressFields,
         } = this.props;
 
         const { items, itemAddingAddress, createCustomerAddressError } = this.state;
@@ -130,7 +129,6 @@ class MultiShippingForm extends PureComponent<
                     isOpen={!!itemAddingAddress}
                     onRequestClose={this.handleCloseAddAddressForm}
                     onSaveAddress={this.handleSaveAddress}
-                    validateAddressFields={validateAddressFields}
                 />
 
                 <Form>

--- a/packages/core/src/app/shipping/MultiShippingForm.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.tsx
@@ -49,6 +49,7 @@ export interface MultiShippingFormProps {
     googleMapsApiKey?: string;
     isFloatingLabelEnabled?: boolean;
     isInitialValueLoaded: boolean;
+    validateAddressFields: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     createCustomerAddress(address: AddressRequestBody): void;
     getFields(countryCode?: string): FormField[];
@@ -100,6 +101,7 @@ class MultiShippingForm extends PureComponent<
             countriesWithAutocomplete,
             googleMapsApiKey,
             isFloatingLabelEnabled,
+            validateAddressFields,
         } = this.props;
 
         const { items, itemAddingAddress, createCustomerAddressError } = this.state;
@@ -128,6 +130,7 @@ class MultiShippingForm extends PureComponent<
                     isOpen={!!itemAddingAddress}
                     onRequestClose={this.handleCloseAddAddressForm}
                     onSaveAddress={this.handleSaveAddress}
+                    validateAddressFields={validateAddressFields}
                 />
 
                 <Form>
@@ -216,9 +219,9 @@ class MultiShippingForm extends PureComponent<
         itemId: string,
         itemKey: string,
     ) => Promise<void> = async (address, itemId, itemKey) => {
-        const { assignItem, onUnhandledError, getFields } = this.props;
+        const { assignItem, onUnhandledError, getFields, validateAddressFields } = this.props;
 
-        if (!isValidAddress(address, getFields(address.countryCode))) {
+        if (!isValidAddress(address, getFields(address.countryCode), validateAddressFields)) {
             return onUnhandledError(new AssignItemInvalidAddressError());
         }
 

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -72,6 +72,7 @@ export interface WithCheckoutShippingProps {
     providerWithCustomCheckout?: string;
     isFloatingLabelEnabled?: boolean;
     validateGoogleMapAutoCompleteMaxLength: boolean;
+    validateAddressFields: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitializeShippingMethod(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -129,6 +130,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
             shouldShowMultiShipping,
             isNewMultiShippingUIEnabled,
             validateGoogleMapAutoCompleteMaxLength,
+            validateAddressFields,
             customer,
             updateShippingAddress,
             initializeShippingMethod,
@@ -192,6 +194,7 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps, Ship
                         onUseNewAddress={this.handleUseNewAddress}
                         shouldShowSaveAddress={!isGuest}
                         updateAddress={updateShippingAddress}
+                        validateAddressFields={validateAddressFields}
                         validateGoogleMapAutoCompleteMaxLength={validateGoogleMapAutoCompleteMaxLength}
                     />
                 </div>
@@ -425,6 +428,12 @@ export function mapToShippingProps({
             'CHECKOUT-8776.google_autocomplete_max_length_validation',
         ) && Boolean(googleMapsApiKey);
 
+    const validateAddressFields =
+        isExperimentEnabled(
+            config.checkoutSettings,
+            'CHECKOUT-7560_address_fields_max_length_validation',
+        );
+
     const shippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();
 
@@ -461,6 +470,7 @@ export function mapToShippingProps({
         shouldShowMultiShipping,
         isNewMultiShippingUIEnabled,
         validateGoogleMapAutoCompleteMaxLength,
+        validateAddressFields,
         shouldShowOrderComments: enableOrderComments,
         signOut: checkoutService.signOutCustomer,
         unassignItem: checkoutService.unassignItemsToAddress,

--- a/packages/core/src/app/shipping/ShippingAddress.tsx
+++ b/packages/core/src/app/shipping/ShippingAddress.tsx
@@ -31,6 +31,7 @@ export interface ShippingAddressProps {
     shouldShowSaveAddress?: boolean;
     hasRequestedShippingOptions: boolean;
     isFloatingLabelEnabled?: boolean;
+    validateAddressFields: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
     onAddressSelect(address: Address): void;
@@ -56,6 +57,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
         addresses,
         shouldShowSaveAddress,
         isFloatingLabelEnabled,
+        validateAddressFields,
     } = props;
 
     const { shouldShowPayPalFastlaneShippingForm } = usePayPalFastlaneAddress();
@@ -103,6 +105,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
             onFieldChange={handleFieldChange}
             onUseNewAddress={onUseNewAddress}
             shouldShowSaveAddress={shouldShowSaveAddress}
+            validateAddressFields={validateAddressFields}
         />
     );
 };

--- a/packages/core/src/app/shipping/ShippingAddressForm.tsx
+++ b/packages/core/src/app/shipping/ShippingAddressForm.tsx
@@ -25,6 +25,7 @@ export interface ShippingAddressFormProps {
     formFields: FormField[];
     shouldShowSaveAddress?: boolean;
     isFloatingLabelEnabled?: boolean;
+    validateAddressFields: boolean;
     onUseNewAddress(): void;
     onFieldChange(fieldName: string, value: string): void;
     onAddressSelect(address: Address): void;
@@ -51,6 +52,7 @@ class ShippingAddressForm extends Component<
             formik: {
                 values: { shippingAddress: formAddress },
             },
+            validateAddressFields,
         } = this.props;
 
         const hasAddresses = addresses && addresses.length > 0;
@@ -58,6 +60,7 @@ class ShippingAddressForm extends Component<
             shippingAddress,
             addresses,
             formFields,
+            validateAddressFields,
         );
 
         return (

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -46,6 +46,7 @@ export interface ShippingFormProps {
     isInitialValueLoaded: boolean;
     isNewMultiShippingUIEnabled: boolean;
     validateGoogleMapAutoCompleteMaxLength: boolean;
+    validateAddressFields: boolean;
     assignItem(consignment: ConsignmentAssignmentRequestBody): Promise<CheckoutSelectors>;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
@@ -101,6 +102,7 @@ const ShippingForm = ({
     isInitialValueLoaded,
     isNewMultiShippingUIEnabled,
     validateGoogleMapAutoCompleteMaxLength,
+    validateAddressFields,
 }: ShippingFormProps & WithLanguageProps) => {
     const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
 
@@ -146,6 +148,7 @@ const ShippingForm = ({
             onUnhandledError={onUnhandledError}
             onUseNewAddress={onUseNewAddress}
             shouldShowOrderComments={shouldShowOrderComments}
+            validateAddressFields={validateAddressFields}
         />;
     };
 
@@ -178,6 +181,7 @@ const ShippingForm = ({
             shouldShowSaveAddress={shouldShowSaveAddress}
             signOut={signOut}
             updateAddress={updateAddress}
+                validateAddressFields={validateAddressFields}
             validateGoogleMapAutoCompleteMaxLength={validateGoogleMapAutoCompleteMaxLength}
         />
     );

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -58,6 +58,7 @@ export interface SingleShippingFormProps {
     isFloatingLabelEnabled?: boolean;
     isInitialValueLoaded: boolean;
     validateGoogleMapAutoCompleteMaxLength: boolean;
+    validateAddressFields: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
     getFields(countryCode?: string): FormField[];
@@ -157,6 +158,7 @@ class SingleShippingForm extends PureComponent<
             values: { shippingAddress: addressForm },
             isShippingStepPending,
             isFloatingLabelEnabled,
+            validateAddressFields,
         } = this.props;
 
         const { isResettingAddress, isUpdatingShippingData, hasRequestedShippingOptions } =
@@ -190,6 +192,7 @@ class SingleShippingForm extends PureComponent<
                         onUseNewAddress={this.onUseNewAddress}
                         shippingAddress={shippingAddress}
                         shouldShowSaveAddress={shouldShowSaveAddress}
+                        validateAddressFields={validateAddressFields}
                     />
                     {shouldShowBillingSameAsShipping && (
                         <div className="form-body">
@@ -350,6 +353,7 @@ export default withLanguage(
             getFields,
             methodId,
             validateGoogleMapAutoCompleteMaxLength,
+            validateAddressFields,
         }: SingleShippingFormProps & WithLanguageProps) =>
             shouldHaveCustomValidation(methodId)
                 ? object({
@@ -366,6 +370,7 @@ export default withLanguage(
                               language,
                               formFields: getFields(formValues && formValues.countryCode),
                               validateGoogleMapAutoCompleteMaxLength,
+                              validateAddressFields
                           }),
                       ),
                   }),


### PR DESCRIPTION
## What?
Add validation of form field for max length for address fields. Do not allow to continue shipping if address fields are invalid.

## Why?
**To fix:** You are able to bypass the Address line character limit on Checkout if a customer already has a saved address

## Testing / Proof

- CI checks
- Manual testing 

**Experiment off**

https://github.com/user-attachments/assets/a690bf08-9fa0-46c8-ae36-dc0ccf0c50fc

**Experiment on**

https://github.com/user-attachments/assets/a23af2c0-e5c8-42d6-8cc5-650e251d98dd



@bigcommerce/team-checkout
