### PR TITLE
fix(shipping): CHECKOUT-8872 Fix Missing Shipping Option

### DIFF
--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -10,6 +10,7 @@ import { EMPTY_ARRAY, isFloatingLabelEnabled } from "../common/utility";
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
 import { MultiShippingConsignmentData } from "./MultishippingV2Type";
+import { setRecommendedOrMissingShippingOption } from './MultiShippingSelectShippingOption';
 
 interface ConsignmentAddressSelectorProps {
     consignment?: MultiShippingConsignmentData;
@@ -35,9 +36,19 @@ const ConsignmentAddressSelector = ({
 
     const {
         checkoutState: {
-            data: { getShippingCountries, getCustomer, getConfig, getShippingAddressFields: getFields },
+            data: {
+                getShippingCountries,
+                getCustomer,
+                getConfig,
+                getConsignments: getPreviousConsignments,
+                getShippingAddressFields: getFields,
+            },
         },
-        checkoutService: { assignItemsToAddress: assignItem, createCustomerAddress },
+        checkoutService: {
+            assignItemsToAddress: assignItem,
+            createCustomerAddress,
+            selectConsignmentShippingOption,
+        },
     } = useCheckout();
 
     const countries = getShippingCountries() || EMPTY_ARRAY;
@@ -49,7 +60,7 @@ const ConsignmentAddressSelector = ({
     }
 
     const isFloatingLabelEnabledFlag = isFloatingLabelEnabled(config.checkoutSettings);
-    // TODO: add filter for addresses 
+    // TODO: add filter for addresses
     const addresses = customer.addresses || EMPTY_ARRAY;
     const {
         checkoutSettings: {
@@ -73,11 +84,22 @@ const ConsignmentAddressSelector = ({
         }
 
         try {
-            await assignItem({
+            const {
+                data: { getConsignments },
+            } = await assignItem({
                 address,
                 lineItems: consignment.lineItems.map(({ id, quantity }) => ({ itemId: id, quantity })),
             });
 
+            const currentConsignments = getConsignments();
+
+            if (currentConsignments) {
+                await setRecommendedOrMissingShippingOption(
+                    getPreviousConsignments() ?? [],
+                    currentConsignments,
+                    selectConsignmentShippingOption,
+                );
+            }
         } catch (error) {
             if (error instanceof Error) {
                 onUnhandledError(new AssignItemFailedError(error));

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -10,7 +10,7 @@ import { EMPTY_ARRAY, isFloatingLabelEnabled } from "../common/utility";
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
 import { MultiShippingConsignmentData } from "./MultishippingV2Type";
-import { setRecommendedOrMissingShippingOption } from './MultiShippingSelectShippingOption';
+import { setRecommendedOrMissingShippingOption } from './utils';
 
 interface ConsignmentAddressSelectorProps {
     consignment?: MultiShippingConsignmentData;
@@ -93,7 +93,7 @@ const ConsignmentAddressSelector = ({
 
             const currentConsignments = getConsignments();
 
-            if (currentConsignments) {
+            if (currentConsignments && currentConsignments.length > 0) {
                 await setRecommendedOrMissingShippingOption(
                     getPreviousConsignments() ?? [],
                     currentConsignments,

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -102,7 +102,7 @@ $allocate-items-table-image-width-small-screen: 40%;
     bottom: auto;
     left: 50%;
     transform: translate(-50%, -50%);
-    
+
     @include breakpoint("small") {
         max-height: 75vh;
     }
@@ -289,9 +289,5 @@ $allocate-items-table-image-width-small-screen: 40%;
 }
 
 .shipping-option-item {
-    display: block;
-
-    ul{
-        margin: 0 0 spacing("quarter") 0;
-    }
+    margin: 0 0 spacing("quarter") 0;
 }

--- a/packages/core/src/app/shipping/MultiShippingFormV2.tsx
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.tsx
@@ -119,6 +119,7 @@ const MultiShippingFormV2: FunctionComponent<MultiShippingFormV2Props> = ({
                     defaultCountryCode={defaultCountryCode}
                     isLoading={isLoading}
                     onUnhandledError={onUnhandledError}
+                    resetErrorConsignmentNumber={resetErrorConsignmentNumber}
                     setIsAddShippingDestination={setIsAddShippingDestination}
                 />)
             }

--- a/packages/core/src/app/shipping/MultiShippingSelectShippingOption.ts
+++ b/packages/core/src/app/shipping/MultiShippingSelectShippingOption.ts
@@ -1,0 +1,39 @@
+import { CheckoutSelectors, Consignment, ShippingRequestOptions } from '@bigcommerce/checkout-sdk';
+
+const createShippingOptionsMap = (consignments: Consignment[]): Map<string, string | undefined> => {
+    return new Map(
+        consignments.map((consignment) => [consignment.id, consignment.selectedShippingOption?.id]),
+    );
+};
+
+export const setRecommendedOrMissingShippingOption = async (
+    previousConsignment: Consignment[],
+    currentConsignments: Consignment[],
+    selectConsignmentShippingOption: (
+        consignmentId: string,
+        shippingOptionId: string,
+        options?: ShippingRequestOptions<object> | undefined,
+    ) => Promise<CheckoutSelectors>,
+): Promise<void> => {
+    const previousShippingOptions = createShippingOptionsMap(previousConsignment);
+
+    for (const consignment of currentConsignments) {
+        if (!consignment.selectedShippingOption) {
+            const previousShippingOptionId = previousShippingOptions.get(consignment.id);
+
+            if (previousShippingOptionId) {
+                // eslint-disable-next-line no-await-in-loop
+                await selectConsignmentShippingOption(consignment.id, previousShippingOptionId);
+            } else {
+                const recommendedOption = consignment.availableShippingOptions?.find(
+                    (option) => option.isRecommended,
+                );
+
+                if (recommendedOption) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await selectConsignmentShippingOption(consignment.id, recommendedOption.id);
+                }
+            }
+        }
+    }
+};

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -12,7 +12,7 @@ import AllocateItemsModal from "./AllocateItemsModal";
 import ConsignmentAddressSelector from './ConsignmentAddressSelector';
 import { AssignItemFailedError } from "./errors";
 import { useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
-import { setRecommendedOrMissingShippingOption } from './MultiShippingSelectShippingOption';
+import { setRecommendedOrMissingShippingOption } from './utils';
 
 interface NewConsignmentProps {
     consignmentNumber: number;
@@ -88,7 +88,7 @@ const NewConsignment = ({
             setIsAddShippingDestination(false);
             resetErrorConsignmentNumber();
 
-            if (currentConsignments) {
+            if (currentConsignments && currentConsignments.length > 0) {
                 await setRecommendedOrMissingShippingOption(
                     getPreviousConsignments() ?? [],
                     currentConsignments,

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -1,4 +1,4 @@
-import { ConsignmentCreateRequestBody, ConsignmentLineItem } from "@bigcommerce/checkout-sdk";
+import { Consignment, ConsignmentCreateRequestBody, ConsignmentLineItem } from "@bigcommerce/checkout-sdk";
 import { find } from "lodash";
 import React, { useMemo, useState } from "react";
 
@@ -12,14 +12,16 @@ import AllocateItemsModal from "./AllocateItemsModal";
 import ConsignmentAddressSelector from './ConsignmentAddressSelector';
 import { AssignItemFailedError } from "./errors";
 import { useMultiShippingConsignmentItems } from "./hooks/useMultishippingConsignmentItems";
+import { setRecommendedOrMissingShippingOption } from './MultiShippingSelectShippingOption';
 
 interface NewConsignmentProps {
     consignmentNumber: number;
     defaultCountryCode?: string;
     countriesWithAutocomplete: string[];
     isLoading: boolean;
+    setIsAddShippingDestination: React.Dispatch<React.SetStateAction<boolean>>;
     onUnhandledError(error: Error): void;
-    setIsAddShippingDestination: React.Dispatch<React.SetStateAction<boolean>>
+    resetErrorConsignmentNumber(): void;
 }
 
 const NewConsignment = ({
@@ -28,6 +30,7 @@ const NewConsignment = ({
     defaultCountryCode,
     isLoading,
     onUnhandledError,
+    resetErrorConsignmentNumber,
     setIsAddShippingDestination,
 }: NewConsignmentProps) => {
     const [consignmentRequest, setConsignmentRequest] = useState<ConsignmentCreateRequestBody | undefined>();
@@ -36,9 +39,9 @@ const NewConsignment = ({
 
     const {
         checkoutState: {
-            data: { getShippingCountries },
+            data: { getShippingCountries, getConsignments: getPreviousConsignments },
         },
-        checkoutService: { assignItemsToAddress: assignItem },
+        checkoutService: { assignItemsToAddress: assignItem, selectConsignmentShippingOption },
     } = useCheckout();
 
     const selectedAddress = useMemo(() => {
@@ -61,15 +64,21 @@ const NewConsignment = ({
     }
 
     const handleAllocateItems = async (consignmentLineItems: ConsignmentLineItem[]) => {
+        let currentConsignments: Consignment[] | undefined;
+
         if (!selectedAddress) {
             return;
         }
 
         try {
-            await assignItem({
+            const {
+                data: { getConsignments },
+            } = await assignItem({
                 address: selectedAddress,
                 lineItems: consignmentLineItems,
             });
+
+            currentConsignments = getConsignments();
         } catch (error) {
             if (error instanceof AssignItemFailedError) {
                 onUnhandledError(error);
@@ -77,6 +86,15 @@ const NewConsignment = ({
         } finally {
             toggleAllocateItemsModal();
             setIsAddShippingDestination(false);
+            resetErrorConsignmentNumber();
+
+            if (currentConsignments) {
+                await setRecommendedOrMissingShippingOption(
+                    getPreviousConsignments() ?? [],
+                    currentConsignments,
+                    selectConsignmentShippingOption,
+                );
+            }
         }
     };
 

--- a/packages/core/src/app/shipping/shippingOption/MultiShippingOptionsListItemV2.tsx
+++ b/packages/core/src/app/shipping/shippingOption/MultiShippingOptionsListItemV2.tsx
@@ -1,5 +1,5 @@
 import { ShippingOption } from '@bigcommerce/checkout-sdk';
-import React, { FunctionComponent, useCallback, useEffect } from 'react';
+import React, { FunctionComponent } from 'react';
 
 import { RadioInput } from '@bigcommerce/checkout/ui';
 
@@ -9,7 +9,7 @@ interface MultiShippingOptionsListItemV2Props {
     consignmentId: string;
     selectedShippingOptionId?: string;
     shippingOption: ShippingOption;
-    handleSelect: (value: string) => void;
+    handleSelect: (consignmentId: string, shippingOptionId: string) => void;
 }
 
 export const MultiShippingOptionsListItemV2: FunctionComponent<
@@ -22,29 +22,22 @@ export const MultiShippingOptionsListItemV2: FunctionComponent<
         </>
     );
 
-    const selectThisOption = useCallback(() => {
-        handleSelect(shippingOption.id);
-    }, [handleSelect, shippingOption.id]);
-
-    useEffect(() => {
-        if (!selectedShippingOptionId && shippingOption.isRecommended) {
-            selectThisOption();
-        }
-    }, [selectedShippingOptionId, shippingOption.isRecommended, selectThisOption]);
+    const selectThisOption = () => {
+        handleSelect(consignmentId, shippingOption.id);
+    };
 
     return (
-        <button className="shipping-option-item" onClick={selectThisOption}>
-            <ul>
-                <RadioInput
-                    checked={selectedShippingOptionId === shippingOption.id}
-                    id={`shippingOption-${shippingOption.id}`}
-                    key={shippingOption.id}
-                    label={label}
-                    name={`${consignmentId}-shippingMethod`}
-                    readOnly
-                    value={shippingOption.id}
-                />
-            </ul>
-        </button>
+        <ul className="shipping-option-item">
+            <RadioInput
+                checked={selectedShippingOptionId === shippingOption.id}
+                id={`shippingOption-${consignmentId}-${shippingOption.id}`}
+                key={`key-${consignmentId}-${shippingOption.id}`}
+                label={label}
+                name={`${consignmentId}-shippingMethod`}
+                onClick={selectThisOption}
+                readOnly
+                value={shippingOption.id}
+            />
+        </ul>
     );
 };

--- a/packages/core/src/app/shipping/shippingOption/MultiShippingOptionsListV2.tsx
+++ b/packages/core/src/app/shipping/shippingOption/MultiShippingOptionsListV2.tsx
@@ -1,5 +1,5 @@
 import { ShippingOption } from '@bigcommerce/checkout-sdk';
-import React, { FunctionComponent, memo, useCallback } from 'react';
+import React, { FunctionComponent, memo } from 'react';
 
 import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 
@@ -20,19 +20,12 @@ const MultiShippingOptionsListV2: FunctionComponent<MultiShippingOptionsListV2Pr
     selectedShippingOptionId,
     onSelectedOption,
 }) => {
-    const handleSelect = useCallback(
-        (value: string) => {
-            onSelectedOption(consignmentId, value);
-        },
-        [consignmentId, onSelectedOption],
-    );
-
     return (
         <LoadingOverlay isLoading={isLoading}>
             {shippingOptions.map((shippingOption) => (
                 <MultiShippingOptionsListItemV2
                     consignmentId={consignmentId}
-                    handleSelect={handleSelect}
+                    handleSelect={onSelectedOption}
                     key={shippingOption.id}
                     selectedShippingOptionId={selectedShippingOptionId}
                     shippingOption={shippingOption}

--- a/packages/core/src/app/shipping/utils/index.ts
+++ b/packages/core/src/app/shipping/utils/index.ts
@@ -1,1 +1,2 @@
 export { generateItemHash } from './generateItemHash';
+export { setRecommendedOrMissingShippingOption } from './setRecommendedOrMissingShippingOption';

--- a/packages/core/src/app/shipping/utils/setRecommendedOrMissingShippingOption.ts
+++ b/packages/core/src/app/shipping/utils/setRecommendedOrMissingShippingOption.ts
@@ -24,15 +24,18 @@ export const setRecommendedOrMissingShippingOption = async (
             if (previousShippingOptionId) {
                 // eslint-disable-next-line no-await-in-loop
                 await selectConsignmentShippingOption(consignment.id, previousShippingOptionId);
-            } else {
-                const recommendedOption = consignment.availableShippingOptions?.find(
-                    (option) => option.isRecommended,
-                );
 
-                if (recommendedOption) {
-                    // eslint-disable-next-line no-await-in-loop
-                    await selectConsignmentShippingOption(consignment.id, recommendedOption.id);
-                }
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            const recommendedOption = consignment.availableShippingOptions?.find(
+                (option) => option.isRecommended,
+            );
+
+            if (recommendedOption) {
+                // eslint-disable-next-line no-await-in-loop
+                await selectConsignmentShippingOption(consignment.id, recommendedOption.id);
             }
         }
     }

--- a/packages/test-framework/src/react-testing-library-support/API.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/API.mock.ts
@@ -519,7 +519,10 @@ const cartReadyForMultiShipping = {
         ...cart.cart,
         lineItems: {
             ...cart.cart.lineItems,
-            physicalItems: [physicalItem, { ...physicalItem, id: 'y', quantity: 2, sku: 'CLC2' }],
+            physicalItems: [
+                physicalItem,
+                { ...physicalItem, id: 'y', quantity: 2, sku: 'CLC2', name: 'Item 2' },
+            ],
         },
     },
     customer: {
@@ -589,6 +592,7 @@ const cartReadyForMultiShipping = {
             name: 'Discount Group',
         },
     },
+    consignment: [consignment],
 };
 
 const cartWithoutPhysicalItem = {


### PR DESCRIPTION
## What?
### Fixed:
1.Selecting a shipping method for one consignment no longer updates the shipping method of another consignment.

2.When creating a new consignment, the selected shipping methods of existing consignments will no longer be randomly lost.

### Updated:
1.The recommended shipping method is now automatically selected at the time of consignment creation, moving the trigger from the display of shipping methods.

## Why?
Address existing API limitations and fix bugs.

## Testing / Proof
### Before

https://github.com/user-attachments/assets/fb6fa579-9c4e-4ce0-9826-80524ec1ee07

### After
#### Updating Shipping Method
https://github.com/user-attachments/assets/983e7956-c039-4936-9910-44802dcb413d
#### Creating New Consignment
https://github.com/user-attachments/assets/1f41695a-835d-424a-aa06-4462fa1a3669

