### PR TITLE
feat(payment): STRIPE-546 allow billing address editing for all Google Pay providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.691.0",
+        "@bigcommerce/checkout-sdk": "^1.692.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.691.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.691.0.tgz",
-      "integrity": "sha512-jhFZ5yX0ivz4nlTpXA7QUmwv8s7zYTMU12k2QmBUm2LDI+VRAbU9Fmf9aFsv932oHHjmGl3eRb0wvn5xh/z4iw==",
+      "version": "1.692.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.692.0.tgz",
+      "integrity": "sha512-YDokqL/CtGso2n4VnposhwzuW6W8USUNNLEhxi5tUemTW/7YKQC5Zug4lBQbKg120jY0n7C/9SAEK+AoSUh7fw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.691.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.691.0.tgz",
-      "integrity": "sha512-jhFZ5yX0ivz4nlTpXA7QUmwv8s7zYTMU12k2QmBUm2LDI+VRAbU9Fmf9aFsv932oHHjmGl3eRb0wvn5xh/z4iw==",
+      "version": "1.692.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.692.0.tgz",
+      "integrity": "sha512-YDokqL/CtGso2n4VnposhwzuW6W8USUNNLEhxi5tUemTW/7YKQC5Zug4lBQbKg120jY0n7C/9SAEK+AoSUh7fw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.691.0",
+    "@bigcommerce/checkout-sdk": "^1.692.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/checkout/checkouts.mock.ts
+++ b/packages/core/src/app/checkout/checkouts.mock.ts
@@ -42,10 +42,10 @@ export function getCheckout(): Checkout {
     };
 }
 
-export function getCheckoutWithPayments(): Checkout {
+export function getCheckoutWithPayments(providerId?: string): Checkout {
     return {
         ...getCheckout(),
-        payments: [getCheckoutPayment()],
+        payments: [getCheckoutPayment(providerId)],
     };
 }
 
@@ -56,9 +56,9 @@ export function getCheckoutWithPromotions(): Checkout {
     };
 }
 
-export function getCheckoutPayment(): CheckoutPayment {
+export function getCheckoutPayment(providerId?: string): CheckoutPayment {
     return {
-        providerId: 'amazonpay',
+        providerId: providerId || 'amazonpay',
         gatewayId: undefined,
         providerType: 'PAYMENT_TYPE_HOSTED',
         detail: {

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.spec.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.spec.ts
@@ -276,6 +276,44 @@ describe('getCheckoutStepStatuses()', () => {
                 );
             });
         });
+
+        describe('googlepay', () => {
+            it('should be editable if experiment is on', () => {
+                jest.spyOn(state.data, 'getCheckout').mockReturnValue(getCheckoutWithPayments('googlepaystripe'));
+                jest.spyOn(state.data, 'getBillingAddress').mockReturnValue(getBillingAddress());
+                jest.spyOn(state.data, 'getConfig').mockReturnValue({
+                    ...getStoreConfig(),
+                    checkoutSettings: {
+                        ...getStoreConfig().checkoutSettings,
+                        features: {
+                            'STRIPE-546.allow_billing_address_editing_for_all_Google_Pay_providers': true,
+                        }
+                    }
+                });
+
+                const steps = getCheckoutStepStatuses(state);
+
+                expect(find(steps, { type: CheckoutStepType.Billing })!.isEditable).toBe(true);
+            });
+
+            it('should NOT be editable if experiment is off', () => {
+                jest.spyOn(state.data, 'getCheckout').mockReturnValue(getCheckoutWithPayments('googlepaystripe'));
+                jest.spyOn(state.data, 'getBillingAddress').mockReturnValue(getBillingAddress());
+                jest.spyOn(state.data, 'getConfig').mockReturnValue({
+                    ...getStoreConfig(),
+                    checkoutSettings: {
+                        ...getStoreConfig().checkoutSettings,
+                        features: {
+                            'STRIPE-546.allow_billing_address_editing_for_all_Google_Pay_providers': false,
+                        }
+                    }
+                });
+
+                const steps = getCheckoutStepStatuses(state);
+
+                expect(find(steps, { type: CheckoutStepType.Billing })!.isEditable).toBe(false);
+            });
+        })
     });
 
     describe('shipping step', () => {

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -89,7 +89,8 @@ const getBillingStepStatus = createSelector(
             ? data.getBillingAddressFields(billingAddress.countryCode)
             : EMPTY_ARRAY;
     },
-    (checkout, billingAddress, billingAddressFields) => {
+    ({ data }: CheckoutSelectors) => data.getConfig(),
+    (checkout, billingAddress, billingAddressFields, config) => {
         const hasAddress = billingAddress
             ? isValidAddress(billingAddress, billingAddressFields)
             : false;
@@ -120,6 +121,25 @@ const getBillingStepStatus = createSelector(
                 isActive: false,
                 isComplete: isAmazonPayBillingStepComplete,
                 isEditable: isAmazonPayBillingStepComplete && hasCustomFields,
+                isRequired: true,
+            };
+        }
+
+        const isGooglePayBillingAddressEditingEnabled = isExperimentEnabled(
+            config?.checkoutSettings,
+            'STRIPE-546.allow_billing_address_editing_for_all_Google_Pay_providers',
+        );
+        const isUsingGooglePay =
+            isGooglePayBillingAddressEditingEnabled && (checkout && checkout.payments
+                ? checkout.payments.some((payment) => (payment?.providerId || '').startsWith('googlepay'))
+                : false);
+
+        if (isUsingGooglePay) {
+            return {
+                type: CheckoutStepType.Billing,
+                isActive: false,
+                isComplete: hasAddress,
+                isEditable: hasAddress,
                 isRequired: true,
             };
         }


### PR DESCRIPTION
## What?
Allow billing address editing for all Google Pay providers.

Related PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/2747

## Why?
Because sometimes the locality field from GP is empty, we will add stateOrProvinceCode instead, and also allow the user to edit the billing address if needed.

## Testing / Proof
Manual testing.
Before:
<img width="631" alt="before" src="https://github.com/user-attachments/assets/d43c95fa-3ff5-42e5-8365-d9d73f12fbc4">
After:
<img width="782" alt="after" src="https://github.com/user-attachments/assets/86b80e82-9aa0-46b1-8564-7b9aca3b9278">

Stripe Google Pay

https://github.com/user-attachments/assets/9ed50aac-ea91-4dad-9c0c-1e4d5d4dd655

PPCP Google Pay

https://github.com/user-attachments/assets/a9f35bad-d32f-4f24-9ace-13e9e5b99882


@bigcommerce/team-checkout
