### PR TITLE
chore(checkout): CHECKOUT-7859 Bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "v1.683.1",
+        "@bigcommerce/checkout-sdk": "^1.684.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.683.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.1.tgz",
-      "integrity": "sha512-6FauS3FHJI+flV4Q/vppX3kAlbqOEJPsLzo98VEmP2uZnL1QVwu8267+orV+9Nc9+PV/uhubOyZFinXjMPNJoQ==",
+      "version": "1.684.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.684.0.tgz",
+      "integrity": "sha512-VKsvdffM6DJ7vJ+ZisSHa58hkE4xDipMuv0msuzn2UgjABO8yFf4SJwqvWGIWLe3M/RcDpBHG13rEAqlAJJyXw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.683.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.683.1.tgz",
-      "integrity": "sha512-6FauS3FHJI+flV4Q/vppX3kAlbqOEJPsLzo98VEmP2uZnL1QVwu8267+orV+9Nc9+PV/uhubOyZFinXjMPNJoQ==",
+      "version": "1.684.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.684.0.tgz",
+      "integrity": "sha512-VKsvdffM6DJ7vJ+ZisSHa58hkE4xDipMuv0msuzn2UgjABO8yFf4SJwqvWGIWLe3M/RcDpBHG13rEAqlAJJyXw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "v1.683.1",
+    "@bigcommerce/checkout-sdk": "^1.684.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Release all SDK changes during the code freeze.
- https://github.com/bigcommerce/checkout-sdk-js/pull/2743
- https://github.com/bigcommerce/checkout-sdk-js/pull/2738
- https://github.com/bigcommerce/checkout-sdk-js/pull/2729

## Why?
Release SDK.

## Testing / Proof
- CI checks.

@bigcommerce/team-checkout
