### PR TITLE
feat(shipping): CHECKOUT-8861 Handle promotional item in multishipping

### DIFF
--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -77,6 +77,7 @@ describe('Shipping component', () => {
         jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
             ...getCart(),
             lineItems: {
+                ...getCart().lineItems,
                 physicalItems: [
                     {
                         ...getPhysicalItem(),
@@ -158,6 +159,45 @@ describe('Shipping component', () => {
             await userEvent.click(within(confirmationModal).getByText(localeContext.language.translate('common.proceed_action')));
 
             expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
+        });
+
+        it('opens information dialog on clicking `ship to multiple address` when promotional item is present in the cart', async () => {
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 3,
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            id: '123',
+                            quantity: 1,
+                            addedByPromotion: true,
+                        }
+                    ],
+                },
+            } as Cart);
+            
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={false} />);
+
+            const shippingModeToggle = await screen.findByTestId("shipping-mode-toggle");
+
+            expect(shippingModeToggle.innerHTML).toBe(localeContext.language.translate('shipping.ship_to_multi'));
+
+            await userEvent.click(shippingModeToggle);
+
+            const confirmationModal = await screen.findByRole('dialog');
+
+            expect(confirmationModal).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.multishipping_unavailable_action'))).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.multishipping_unavailable_message'))).toBeInTheDocument();
+
+            await userEvent.click(within(confirmationModal).getByText(localeContext.language.translate('common.back_action')));
+
+            expect(defaultProps.onToggleMultiShipping).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -199,5 +199,38 @@ describe('Shipping component', () => {
 
             expect(defaultProps.onToggleMultiShipping).not.toHaveBeenCalled();
         });
+
+        it('opens information dialog on mount and when multishipping mode is ON and promotional item is present in the cart', async () => {
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 3,
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            id: '123',
+                            quantity: 1,
+                            addedByPromotion: true,
+                        }
+                    ],
+                },
+            } as Cart);
+            
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
+
+            const confirmationModal = await screen.findByRole('dialog');
+
+            expect(confirmationModal).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.multishipping_unavailable_action'))).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.checkout_switched_to_single_shipping'))).toBeInTheDocument();
+
+            await userEvent.click(within(confirmationModal).getByText(localeContext.language.translate('common.ok_action')));
+
+            expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -16,6 +16,7 @@ interface ShippingHeaderProps {
     shouldShowMultiShipping: boolean;
     onMultiShippingChange(): void;
     isNewMultiShippingUIEnabled: boolean;
+    cartHasPromotionalItems?: boolean;
 }
 
 const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
@@ -24,15 +25,18 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
     onMultiShippingChange,
     shouldShowMultiShipping,
     isNewMultiShippingUIEnabled,
+    cartHasPromotionalItems,
 }) => {
-    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isSingleShippingConfirmationModalOpen, setIsSingleShippingConfirmationModalOpen] = useState(false);
+    const [isMultiShippingUnavailableModalOpen, setIsMultiShippingUnavailableModalOpen] = useState(false);
 
     const handleShipToSingleConfirmation = () => {
-        setIsModalOpen(false);
+        setIsSingleShippingConfirmationModalOpen(false);
         onMultiShippingChange();
     }
 
     const showConfirmationModal = shouldShowMultiShipping && isNewMultiShippingUIEnabled && isMultiShippingMode;
+    const showMultiShippingUnavailableModal = shouldShowMultiShipping && isNewMultiShippingUIEnabled && !isMultiShippingMode && cartHasPromotionalItems;
 
     return (
         <>
@@ -56,20 +60,39 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
                             action={handleShipToSingleConfirmation}
                             actionButtonLabel={<TranslatedString id="common.proceed_action" />}
                             headerId="shipping.ship_to_single_action"
-                            isModalOpen={isModalOpen}
+                            isModalOpen={isSingleShippingConfirmationModalOpen}
                             messageId="shipping.ship_to_single_message"
-                            onRequestClose={() => setIsModalOpen(false)}
+                            onRequestClose={() => setIsSingleShippingConfirmationModalOpen(false)}
                         />
                         <a
                             data-test="shipping-mode-toggle"
                             href="#"
-                            onClick={preventDefault(() => setIsModalOpen(true))}
+                            onClick={preventDefault(() => setIsSingleShippingConfirmationModalOpen(true))}
                         >
                             <TranslatedString id="shipping.ship_to_single" />
                         </a>
                     </>
                 )}
-                {!showConfirmationModal && shouldShowMultiShipping && (
+                {showMultiShippingUnavailableModal && (
+                    <>
+                        <ConfirmationModal
+                            action={() => setIsMultiShippingUnavailableModalOpen(false)}
+                            actionButtonLabel={<TranslatedString id="common.back_action" />}
+                            headerId="shipping.multishipping_unavailable_action"
+                            isModalOpen={isMultiShippingUnavailableModalOpen}
+                            messageId="shipping.multishipping_unavailable_message"
+                            onRequestClose={() => setIsMultiShippingUnavailableModalOpen(false)}
+                        />
+                        <a
+                            data-test="shipping-mode-toggle"
+                            href="#"
+                            onClick={preventDefault(() => setIsMultiShippingUnavailableModalOpen(true))}
+                        >
+                            <TranslatedString id="shipping.ship_to_multi" />
+                        </a>
+                    </>
+                )}
+                {!showConfirmationModal && !showMultiShippingUnavailableModal && shouldShowMultiShipping && (
                     <a
                         data-test="shipping-mode-toggle"
                         href="#"

--- a/packages/core/src/app/shipping/hasPromotionalItems.tsx
+++ b/packages/core/src/app/shipping/hasPromotionalItems.tsx
@@ -1,0 +1,7 @@
+import { Cart } from '@bigcommerce/checkout-sdk';
+
+export default function hasPromotionalItems(cart: Cart): boolean {
+    const { digitalItems = [], physicalItems } = cart.lineItems;
+    
+    return [...digitalItems, ...physicalItems].filter((item) => item.addedByPromotion)?.length > 0;
+}

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -555,7 +555,8 @@
             "custom_item_quantity_error": "All quantities of this custom product must be allocated to the same destination, as it was created specifically for this draft order.",
             "choose_shipping_address": "Choose a shipping address",
             "multishipping_unavailable_action": "Multi-Address Shipping Unavailable",
-            "multishipping_unavailable_message": "Multi-address shipping is unavailable when a promotion adds a free item to your cart."
+            "multishipping_unavailable_message": "Multi-address shipping is unavailable when a promotion adds a free item to your cart.",
+            "checkout_switched_to_single_shipping": "Your checkout has been automatically updated to use a single shipping address. Shipping to multiple addresses is unavailable when a promotional free item is in your cart."
         },
         "social": {
             "share_action": "Share",

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -82,6 +82,7 @@
             "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again."
         },
         "common": {
+            "back_action": "Back",
             "confirm_action": "Confirm",
             "cancel_action": "Cancel",
             "close_action": "Close",
@@ -552,7 +553,9 @@
             "quantity_max_error": "Quantity cannot exceed \"Left to allocate\" amount.",
             "quantity_min_error": "Quantity cannot be less than 0",
             "custom_item_quantity_error": "All quantities of this custom product must be allocated to the same destination, as it was created specifically for this draft order.",
-            "choose_shipping_address": "Choose a shipping address"
+            "choose_shipping_address": "Choose a shipping address",
+            "multishipping_unavailable_action": "Multi-Address Shipping Unavailable",
+            "multishipping_unavailable_message": "Multi-address shipping is unavailable when a promotion adds a free item to your cart."
         },
         "social": {
             "share_action": "Share",

--- a/packages/ui/src/modal/ConfirmationModal.tsx
+++ b/packages/ui/src/modal/ConfirmationModal.tsx
@@ -1,3 +1,4 @@
+import { noop } from 'lodash';
 import React, { ReactNode } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -11,9 +12,10 @@ interface ConfirmationModalProps {
     headerId: string;
     messageId: string;
     isModalOpen: boolean;
-    onRequestClose: () => void;
+    onRequestClose?: () => void;
     action: () => void;
     actionButtonLabel?: ReactNode;
+    shouldShowCloseButton?: boolean;
 }
 
 const ConfirmationModal = ({
@@ -22,7 +24,8 @@ const ConfirmationModal = ({
     isModalOpen,
     action,
     actionButtonLabel,
-    onRequestClose,
+    onRequestClose = noop,
+    shouldShowCloseButton = true,
 }: ConfirmationModalProps) => {
     return (
         <Modal
@@ -41,7 +44,7 @@ const ConfirmationModal = ({
             }
             isOpen={isModalOpen}
             onRequestClose={onRequestClose}
-            shouldShowCloseButton={true}
+            shouldShowCloseButton={shouldShowCloseButton}
         >
             <p aria-live="assertive" role="alert">
                 <TranslatedString id={messageId} />


### PR DESCRIPTION
## What?

- Do not allow multiple shipping if the cart contains promotional items. Show the multi shipping unavailable modal.
- Switch to single shipping if customer edits cart after creating multi shipping consignments and adds a promotional item to the cart.

## Why?
This is because all free items are automatically assigned to the first address. This inflexibility in the underlying consignments api leads to a sub-optimal UX which results to a perception of poor quality.

## Testing / Proof

- CI checks
- Manual testing

https://github.com/user-attachments/assets/f639071a-aae2-418a-b08d-4b58f1629463



@bigcommerce/team-checkout
