### PR TITLE
fix(checkout): CHECKOUT-7560 fix experiment name

### DIFF
--- a/packages/core/src/app/address/SingleLineStaticAddress.test.tsx
+++ b/packages/core/src/app/address/SingleLineStaticAddress.test.tsx
@@ -36,7 +36,7 @@ describe('SingleLineStaticAddress Component', () => {
                 ...getStoreConfig().checkoutSettings,
                 features: {
                     ...getStoreConfig().checkoutSettings.features,
-                    "CHECKOUT-7560_address_fields_max_length_validation": false,
+                    "CHECKOUT-7560.address_fields_max_length_validation": false,
                 }
             },
         });
@@ -122,7 +122,7 @@ describe('SingleLineStaticAddress Component', () => {
                 ...getStoreConfig().checkoutSettings,
                 features: {
                     ...getStoreConfig().checkoutSettings.features,
-                    "CHECKOUT-7560_address_fields_max_length_validation": true,
+                    "CHECKOUT-7560.address_fields_max_length_validation": true,
                 }
             },
         });

--- a/packages/core/src/app/address/SingleLineStaticAddress.tsx
+++ b/packages/core/src/app/address/SingleLineStaticAddress.tsx
@@ -45,7 +45,7 @@ const SingleLineStaticAddress = ({ address, type }: SingleLineStaticAddressProps
     const validateAddressFields =
         isExperimentEnabled(
             config?.checkoutSettings,
-            'CHECKOUT-7560_address_fields_max_length_validation',
+            'CHECKOUT-7560.address_fields_max_length_validation',
         );
 
     const fields =

--- a/packages/core/src/app/address/StaticAddress.test.tsx
+++ b/packages/core/src/app/address/StaticAddress.test.tsx
@@ -37,7 +37,7 @@ describe('StaticAddress Component', () => {
                 ...getStoreConfig().checkoutSettings,
                 features: {
                     ...getStoreConfig().checkoutSettings.features,
-                    "CHECKOUT-7560_address_fields_max_length_validation": false,
+                    "CHECKOUT-7560.address_fields_max_length_validation": false,
                 }
             },
         });
@@ -162,7 +162,7 @@ describe('StaticAddress Component', () => {
                 ...getStoreConfig().checkoutSettings,
                 features: {
                     ...getStoreConfig().checkoutSettings.features,
-                    "CHECKOUT-7560_address_fields_max_length_validation": true,
+                    "CHECKOUT-7560.address_fields_max_length_validation": true,
                 }
             },
         });

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -100,7 +100,7 @@ export function mapToStaticAddressProps(
     const validateAddressFields =
         isExperimentEnabled(
             config?.checkoutSettings,
-            'CHECKOUT-7560_address_fields_max_length_validation',
+            'CHECKOUT-7560.address_fields_max_length_validation',
         );
 
     return {

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -175,7 +175,7 @@ const getShippingStepStatus = createSelector(
         const validateAddressFields =
             isExperimentEnabled(
                 config?.checkoutSettings,
-                'CHECKOUT-7560_address_fields_max_length_validation'
+                'CHECKOUT-7560.address_fields_max_length_validation'
             );
         const hasAddress = shippingAddress
             ? isValidAddress(shippingAddress, shippingAddressFields, validateAddressFields)

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -71,7 +71,7 @@ const ConsignmentAddressSelector = ({
     const validateAddressFields =
         isExperimentEnabled(
             config.checkoutSettings,
-            'CHECKOUT-7560_address_fields_max_length_validation',
+            'CHECKOUT-7560.address_fields_max_length_validation',
         );
 
     const handleSelectAddress = async (address: Address) => {

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -431,7 +431,7 @@ export function mapToShippingProps({
     const validateAddressFields =
         isExperimentEnabled(
             config.checkoutSettings,
-            'CHECKOUT-7560_address_fields_max_length_validation',
+            'CHECKOUT-7560.address_fields_max_length_validation',
         );
 
     const shippingAddress =


### PR DESCRIPTION
## What?
Update experiment name from 
`CHECKOUT-7560_address_fields_max_length_validation` to 
`CHECKOUT-7560.address_fields_max_length_validation`

## Why?
To fix experiment name so that it picks up the value from LD.

## Testing / Proof
CI checks

@bigcommerce/team-checkout
