### PR TITLE
chore(payment): PAYPAL-4884 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.685.0",
+        "@bigcommerce/checkout-sdk": "^1.686.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.685.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.685.0.tgz",
-      "integrity": "sha512-dLicKLjh8sniWm2taUe/N13u56hHknYBBFBRPEe35ERmhx9QyqmCNaTfZlbWqbZ5qq4fFP+GJczLM+vB30AODA==",
+      "version": "1.686.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.686.0.tgz",
+      "integrity": "sha512-NMxinLoHNQ0PZmqDiYdHBvGu0gHTU5EfT66zxXCFlrxMiQNnRw2t5u9dfvX/g8XvYl4f7C9CDushg3bQvPOkKQ==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.685.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.685.0.tgz",
-      "integrity": "sha512-dLicKLjh8sniWm2taUe/N13u56hHknYBBFBRPEe35ERmhx9QyqmCNaTfZlbWqbZ5qq4fFP+GJczLM+vB30AODA==",
+      "version": "1.686.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.686.0.tgz",
+      "integrity": "sha512-NMxinLoHNQ0PZmqDiYdHBvGu0gHTU5EfT66zxXCFlrxMiQNnRw2t5u9dfvX/g8XvYl4f7C9CDushg3bQvPOkKQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.685.0",
+    "@bigcommerce/checkout-sdk": "^1.686.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
As part of release: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2740

## Testing / Proof
Unit tests
Several sessions of manual tests
