### PR TITLE
chore(payment): PAYPAL-4869 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.687.0",
+        "@bigcommerce/checkout-sdk": "^1.688.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.687.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.687.0.tgz",
-      "integrity": "sha512-ykD4JN5sJAWgL+N8TB+/p9pGApgzMvUlEe8Gc6TVX3BYrSk5q0t5gvv9zv2KBZqFrQGFxdkniHr1fklKGf96rg==",
+      "version": "1.688.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.688.0.tgz",
+      "integrity": "sha512-UU3FJh6rfEa5LvdsZovwAusFAA0XrBuFnzuDZ0U90PL5YzAmBB6TFpdRaF7lJySZv31xqXwnlBUKUVj0e/qPoA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.687.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.687.0.tgz",
-      "integrity": "sha512-ykD4JN5sJAWgL+N8TB+/p9pGApgzMvUlEe8Gc6TVX3BYrSk5q0t5gvv9zv2KBZqFrQGFxdkniHr1fklKGf96rg==",
+      "version": "1.688.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.688.0.tgz",
+      "integrity": "sha512-UU3FJh6rfEa5LvdsZovwAusFAA0XrBuFnzuDZ0U90PL5YzAmBB6TFpdRaF7lJySZv31xqXwnlBUKUVj0e/qPoA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.687.0",
+    "@bigcommerce/checkout-sdk": "^1.688.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2744
https://github.com/bigcommerce/checkout-sdk-js/pull/2751

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
