### PR TITLE
chore(payment): STRIPE-525 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.689.0",
+        "@bigcommerce/checkout-sdk": "^1.691.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.689.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.689.0.tgz",
-      "integrity": "sha512-HLhEZon5JiWQ3BGzNIbGXTLjXhBV0ymp6Jxl9a88bFYTc+XLaCkSrbjc1KGWVm042o3MIAv806rcf2J8y3f6jw==",
+      "version": "1.691.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.691.0.tgz",
+      "integrity": "sha512-jhFZ5yX0ivz4nlTpXA7QUmwv8s7zYTMU12k2QmBUm2LDI+VRAbU9Fmf9aFsv932oHHjmGl3eRb0wvn5xh/z4iw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.689.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.689.0.tgz",
-      "integrity": "sha512-HLhEZon5JiWQ3BGzNIbGXTLjXhBV0ymp6Jxl9a88bFYTc+XLaCkSrbjc1KGWVm042o3MIAv806rcf2J8y3f6jw==",
+      "version": "1.691.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.691.0.tgz",
+      "integrity": "sha512-jhFZ5yX0ivz4nlTpXA7QUmwv8s7zYTMU12k2QmBUm2LDI+VRAbU9Fmf9aFsv932oHHjmGl3eRb0wvn5xh/z4iw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.689.0",
+    "@bigcommerce/checkout-sdk": "^1.691.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2739](https://github.com/bigcommerce/checkout-sdk-js/pull/2739)

## Testing / Proof
Unit, functional tests and manually tested, results in related PR

@bigcommerce/team-checkout
