### PR TITLE
fix(checkout): CHECKOUT-8892 Update Digital Item Price Mapping

### DIFF
--- a/packages/core/src/app/order/__snapshots__/OrderSummaryItems.spec.tsx.snap
+++ b/packages/core/src/app/order/__snapshots__/OrderSummaryItems.spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`OrderSummaryItems when it has 4 line items or less renders product list
     key="667"
   >
     <Memo(OrderSummaryItem)
-      amount={200}
+      amount={250}
       amountAfterDiscount={200}
       id="667"
       image={

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -10,7 +10,7 @@ function mapFromDigital(item: DigitalItem): OrderSummaryItemProps {
     return {
         id: item.id,
         quantity: item.quantity,
-        amount: item.extendedListPrice,
+        amount: item.extendedComparisonPrice,
         amountAfterDiscount: item.extendedSalePrice,
         name: item.name,
         image: getOrderSummaryItemImage(item),


### PR DESCRIPTION
## What?
Update the price mapping for digital items to ensure the pre-tax price is not shown as the pre-discount price. 

This PR also aligns digital items with physical items by using same pricing property names.

## Why?
Reduce shopper confusion.

## Testing / Proof
### Before

![Screenshot 2024-12-17 at 12 41 01 PM](https://github.com/user-attachments/assets/9b59708c-4464-4b9a-b8e1-291ca308b8e0)

### After

![Screenshot 2024-12-17 at 12 40 37 PM](https://github.com/user-attachments/assets/18144d7c-5816-4e70-966c-42aa9cfffbfc)

@bigcommerce/team-checkout