### PR TITLE
CHECKOUT-8917 Do not allow multi-shipping if the cart contains one bundle product

### DIFF
--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -232,5 +232,27 @@ describe('Shipping component', () => {
 
             expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
         });
+
+        it('does not show `ship to multiple address` if only 1 bundled product is present in the cart', async () => {
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            id: '123',
+                            parentId: getPhysicalItem().id,
+                        }
+                    ],
+                },
+            } as Cart);
+
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={false} />);
+
+            expect(screen.queryByTestId("shipping-mode-toggle")).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -430,7 +430,6 @@ export function mapToShippingProps({
     } = config;
 
     const methodId = getShippingMethodId(checkout, config);
-    const shippableItemsCount = getShippableItemsCount(cart);
     const isLoading =
         isLoadingShippingOptions() ||
         isSelectingShippingOption() ||
@@ -440,13 +439,15 @@ export function mapToShippingProps({
         isUpdatingCheckout() ||
         isCreatingCustomerAddress() ||
         isDeletingConsignment();
-    const shouldShowMultiShipping =
-        hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
+
     const isNewMultiShippingUIEnabled =
         isExperimentEnabled(
             config.checkoutSettings,
             'PROJECT-4159.improve_multi_address_shipping_ui',
         );
+    const shippableItemsCount = getShippableItemsCount(cart, isNewMultiShippingUIEnabled);
+    const shouldShowMultiShipping =
+        hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
 
     const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ', 'GB'];
 

--- a/packages/core/src/app/shipping/getShippableItemsCount.ts
+++ b/packages/core/src/app/shipping/getShippableItemsCount.ts
@@ -2,6 +2,10 @@ import { Cart } from '@bigcommerce/checkout-sdk';
 
 import getLineItemsCount from './getLineItemsCount';
 
-export default function getShippableItemsCount(cart: Cart): number {
+export default function getShippableItemsCount(cart: Cart, isNewMultiShippingUIEnabled: boolean = false): number {
+    if (isNewMultiShippingUIEnabled) {
+        return getLineItemsCount(cart.lineItems.physicalItems.filter((item) => !item.addedByPromotion && !item.parentId));
+    }
+
     return getLineItemsCount(cart.lineItems.physicalItems.filter((item) => !item.addedByPromotion));
 }

--- a/packages/core/src/app/shipping/getShippableItemsCount.ts
+++ b/packages/core/src/app/shipping/getShippableItemsCount.ts
@@ -2,7 +2,10 @@ import { Cart } from '@bigcommerce/checkout-sdk';
 
 import getLineItemsCount from './getLineItemsCount';
 
-export default function getShippableItemsCount(cart: Cart, isNewMultiShippingUIEnabled: boolean = false): number {
+export default function getShippableItemsCount(
+    cart: Cart,
+    isNewMultiShippingUIEnabled = false
+): number {
     if (isNewMultiShippingUIEnabled) {
         return getLineItemsCount(cart.lineItems.physicalItems.filter((item) => !item.addedByPromotion && !item.parentId));
     }


### PR DESCRIPTION
## What?
Do not present the shopper with the option to select multi-shipping on the checkout when their is one bundle product in the cart.

## Why?
Since it is a bundled product, so even if there are 2 products in the cart they will be shipped together to same destination, so multiple addresses should not be allowed.

## Testing / Proof

- CI checks
- Manual testing

**BEFORE**

https://github.com/user-attachments/assets/981fa802-0bb3-4fae-9d2e-d37db78f39ae


**AFTER (Experiment On - New Multi shipping UI)**

https://github.com/user-attachments/assets/9d107496-e7b3-40e4-ba99-b26dcc5d1ea7


**AFTER (Experiment Off - Old Multi shipping UI)**

https://github.com/user-attachments/assets/ee75db72-2f09-4234-b77e-9f4e6daed76c



@bigcommerce/team-checkout
