### PR TITLE
chore(payment): STRIPE-414 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.692.0",
+        "@bigcommerce/checkout-sdk": "^1.694.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.692.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.692.0.tgz",
-      "integrity": "sha512-YDokqL/CtGso2n4VnposhwzuW6W8USUNNLEhxi5tUemTW/7YKQC5Zug4lBQbKg120jY0n7C/9SAEK+AoSUh7fw==",
+      "version": "1.694.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.694.0.tgz",
+      "integrity": "sha512-VbmgpvS/WCbvahEBZgJ6wJjPaI20dv1Iif8wuoi9P928l4YrBTOLv49jQmkOAyxhi/Uqb8V645iu80hX1pej4A==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.692.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.692.0.tgz",
-      "integrity": "sha512-YDokqL/CtGso2n4VnposhwzuW6W8USUNNLEhxi5tUemTW/7YKQC5Zug4lBQbKg120jY0n7C/9SAEK+AoSUh7fw==",
+      "version": "1.694.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.694.0.tgz",
+      "integrity": "sha512-VbmgpvS/WCbvahEBZgJ6wJjPaI20dv1Iif8wuoi9P928l4YrBTOLv49jQmkOAyxhi/Uqb8V645iu80hX1pej4A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.692.0",
+    "@bigcommerce/checkout-sdk": "^1.694.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2755](https://github.com/bigcommerce/checkout-sdk-js/pull/2755)

## Testing / Proof
Unit tests and manually tested

@bigcommerce/team-checkout
