### PR TITLE
chore(payment): PAYPAL-4952 bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.694.0",
+        "@bigcommerce/checkout-sdk": "^1.695.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.694.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.694.0.tgz",
-      "integrity": "sha512-VbmgpvS/WCbvahEBZgJ6wJjPaI20dv1Iif8wuoi9P928l4YrBTOLv49jQmkOAyxhi/Uqb8V645iu80hX1pej4A==",
+      "version": "1.695.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.695.0.tgz",
+      "integrity": "sha512-lUHgYsfJ91k33/r48wIWSgFfUg6qf6ztNwBOqHWTSFa4HhN3G2a0WKsmjLcfxzKv1PQVmTIvSuHWOf91BXL0Jg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.694.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.694.0.tgz",
-      "integrity": "sha512-VbmgpvS/WCbvahEBZgJ6wJjPaI20dv1Iif8wuoi9P928l4YrBTOLv49jQmkOAyxhi/Uqb8V645iu80hX1pej4A==",
+      "version": "1.695.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.695.0.tgz",
+      "integrity": "sha512-lUHgYsfJ91k33/r48wIWSgFfUg6qf6ztNwBOqHWTSFa4HhN3G2a0WKsmjLcfxzKv1PQVmTIvSuHWOf91BXL0Jg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.694.0",
+    "@bigcommerce/checkout-sdk": "^1.695.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk version

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2757

## Testing / Proof
Unit tests
Manual tests
CI
