### PR TITLE
fix(checkout): CHECKOUT-8919 resolve cosmetic ui issues for new multishipping

### DIFF
--- a/packages/core/src/app/shipping/AllocateItemsModal.tsx
+++ b/packages/core/src/app/shipping/AllocateItemsModal.tsx
@@ -113,7 +113,7 @@ const AllocateItemsModal: FunctionComponent<AllocateItemsModalProps & FormikProp
                 <TranslatedString id="shipping.multishipping_items_allocate_cancel" />
             </Button>
             <Button
-                disabled={!dirty}
+                disabled={!hasItemsAssigned && !dirty}
                 isLoading={isLoading}
                 onClick={submitForm}
                 type="submit"

--- a/packages/core/src/app/shipping/LeftToAllocateItem.tsx
+++ b/packages/core/src/app/shipping/LeftToAllocateItem.tsx
@@ -21,8 +21,8 @@ const LeftToAllocateItem: FunctionComponent<LeftToAllocateItemProps> = ({ item, 
                 <figure className="left-to-allocate-item-figure">
                     {item.imageUrl && <img alt={item.name} src={item.imageUrl} />}
                 </figure>
-                <div className="left-to-allocate-item-name">
-                    <p>{item.name}</p>
+                <div>
+                    <p className="left-to-allocate-item-name">{item.name}</p>
                     {item.options?.map(option => (
                         <p className="left-to-allocate-item-option" key={option.nameId}>{option.name}: {option.value}</p>
                     ))}

--- a/packages/core/src/app/shipping/MultiShippingFormV2.scss
+++ b/packages/core/src/app/shipping/MultiShippingFormV2.scss
@@ -80,6 +80,7 @@ $allocate-items-table-image-width-small-screen: 40%;
 .modal.modal--afterOpen {
     .button--tertiary {
         border: none;
+        background-color: transparent;
     }
 }
 
@@ -221,15 +222,15 @@ $allocate-items-table-image-width-small-screen: 40%;
                 }
 
                 .left-to-allocate-item-name {
-                    p {
-                        margin-bottom: 0;
-                    }
+                    margin-bottom: spacing("quarter");
+                    color: color("greys", "dark");
+                    font-weight: fontWeight("medium");
+                }
 
-                    .left-to-allocate-item-options {
-                        color: color("greys");
-                        font-size: fontSize("tiny");
-                        margin: 0;
-                    }
+                .left-to-allocate-item-option {
+                    font-size: fontSize("smallest");
+                    margin: 0;
+                    line-height: lineHeight("small");
                 }
             }
         }
@@ -260,7 +261,12 @@ $allocate-items-table-image-width-small-screen: 40%;
 
                 svg {
                     fill: color("greys", "dark");
+                    border-radius: $global-radius;
                     cursor: pointer;
+
+                    &:hover {
+                        background-color: color("greys", "light");;
+                    }
                 }
             }
 
@@ -291,6 +297,7 @@ $allocate-items-table-image-width-small-screen: 40%;
 }
 
 .shipping-option-header {
+    font-size: fontSize("base");
     margin: spacing("base") 0;
 }
 


### PR DESCRIPTION
## What?
Fix following UI issues 

- The variants/options font style should be different to the  item name's, so it provides a hierarchy and easy to read. Please refer to the design file for the font style.
- Implement a hover state for the "x" un-allocate button in the allocation modal so it looks more accessible. 
- The label for "shipping method" should be the same font size as "x item allocated" because we are not implicating one is more important than another in the hierarchy and looks cleaner with same label font.
- When the allocation modal is loading, the cancel button should not use the  "primary" button style.
- Keep "Cancel" but make "Save" enabled in Reallocate items modal.


## Why?
For better user experience.

## Testing / Proof

- Manual testing

https://github.com/user-attachments/assets/c4bd2e26-fc06-4a84-8daa-6af4fd507df2



@bigcommerce/team-checkout
