### PR TITLE
fix(payment): PAYPAL-5026 updated import source for isPayPalCommerceFastlaneMethod method

### DIFF
--- a/packages/paypal-fastlane-integration/src/index.ts
+++ b/packages/paypal-fastlane-integration/src/index.ts
@@ -4,7 +4,7 @@ export { default as isPayPalFastlaneAddress } from './is-paypal-fastlane-address
 export { default as isPayPalFastlaneCustomer } from './is-paypal-fastlane-customer';
 export { default as isPayPalFastlaneMethod } from './is-paypal-fastlane-method';
 export { default as isBraintreeFastlaneMethod } from './is-braintree-fastlane-method';
-export { default as isPayPalCommerceFastlaneMethod } from './is-paypal-fastlane-method';
+export { default as isPayPalCommerceFastlaneMethod } from './is-paypal-commerce-fastlane-method';
 export { default as PoweredByPayPalFastlaneLabel } from './PoweredByPayPalFastlaneLabel';
 export { default as PayPalFastlaneShippingAddressForm } from './PayPalFastlaneShippingAddressForm';
 export { default as PayPalFastlaneWatermark } from './PayPalFastlaneWatermark';


### PR DESCRIPTION
## What?
Updated import source for isPayPalCommerceFastlaneMethod method

## Why?
To fix the issue with Braintree Fastlane shipping option selection

## Testing / Proof
Manual tests
CI


https://github.com/user-attachments/assets/b8a6a67e-2773-4f1a-a992-b57c6f4097d4


