### PR TITLE
chore(payment): PAYPAL-4995 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.695.2",
+        "@bigcommerce/checkout-sdk": "^1.696.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.695.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.695.2.tgz",
-      "integrity": "sha512-RvfOTiSI3Rz+GVpp0AUj02rQ0RZZncbk3YaZWaFj5iR+Fq7fNdHU5LyWrg/2Ivctr/mbTYnML43qfeEE0zGceQ==",
+      "version": "1.696.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.0.tgz",
+      "integrity": "sha512-CpBYYB4TWWAcnSoN7bUCgPxWHB1uZoqA2vIz0pEKOVWFbDCvBRDXEBg0mOLvlxTIpOa7aC+9l0cvH55XaMVP2g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.695.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.695.2.tgz",
-      "integrity": "sha512-RvfOTiSI3Rz+GVpp0AUj02rQ0RZZncbk3YaZWaFj5iR+Fq7fNdHU5LyWrg/2Ivctr/mbTYnML43qfeEE0zGceQ==",
+      "version": "1.696.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.0.tgz",
+      "integrity": "sha512-CpBYYB4TWWAcnSoN7bUCgPxWHB1uZoqA2vIz0pEKOVWFbDCvBRDXEBg0mOLvlxTIpOa7aC+9l0cvH55XaMVP2g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.695.2",
+    "@bigcommerce/checkout-sdk": "^1.696.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver: https://github.com/bigcommerce/checkout-sdk-js/pull/2760

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
