### PR TITLE
feat(payment): PI-3048 [Checkout.com] Remove issuers dropdown and sending BIC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,6 @@ package-lock.json @bigcommerce/team-checkout @bigcommerce/team-integrations @big
 /packages/core/payment/paymentMethod/MasterpassPaymentMethod.tsx @bigcommerce/team-integrations
 /packages/core/payment/paymentMethod/MonerisPaymentMethod.tsx @bigcommerce/team-integrations
 /packages/core/payment/paymentMethod/OpyPaymentMethod.tsx @bigcommerce/team-integrations
-/packages/core/payment/paymentMethod/SquarePaymentMethod.tsx @bigcommerce/team-integrations
 /packages/core/payment/paymentMethod/StripePaymentMethod.tsx @bigcommerce/team-integrations
 /packages/core/payment/paymentMethod/StripeUPEPaymentMethod.tsx @bigcommerce/team-integrations
 /packages/core/payment/paymentMethod/StripeV3CustomCardForm.tsx @bigcommerce/team-integrations

--- a/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.spec.tsx
+++ b/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.spec.tsx
@@ -39,6 +39,7 @@ describe('when using Checkoutcom payment', () => {
     let defaultProps: PaymentMethodProps;
     let localeContext: LocaleContextType;
     let fawryMethod: PaymentMethod;
+    let idealMethod: PaymentMethod;
     let alternateMethodA: PaymentMethod;
     let alternateMethodB: PaymentMethod;
     let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
@@ -72,7 +73,11 @@ describe('when using Checkoutcom payment', () => {
             id: 'fawry',
             gateway: PaymentMethodId.Checkoutcom,
         };
-
+        idealMethod = {
+            ...getPaymentMethod(),
+            id: 'ideal',
+            gateway: PaymentMethodId.Checkoutcom,
+        };
         alternateMethodA = {
             ...getPaymentMethod(),
             id: 'oxxo',
@@ -216,5 +221,22 @@ describe('when using Checkoutcom payment', () => {
         await new Promise((resolve) => process.nextTick(resolve));
 
         expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+    });
+
+    it('does not render the fields when ideal experiment is on', () => {
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                features: {
+                    ...getStoreConfig().checkoutSettings.features,
+                    'PI-2979.checkoutcom_enable_ideal_hosted_page': true,
+                },
+            },
+        });
+
+        const { container } = render(<PaymentMethodTest {...defaultProps} method={idealMethod} />);
+
+        expect(container.firstChild).toBeNull();
     });
 });

--- a/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.spec.tsx
+++ b/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.spec.tsx
@@ -239,4 +239,21 @@ describe('when using Checkoutcom payment', () => {
 
         expect(container.firstChild).toBeNull();
     });
+
+    it('renders the fields for other APMs when ideal experiment is on', () => {
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                features: {
+                    ...getStoreConfig().checkoutSettings.features,
+                    'PI-2979.checkoutcom_enable_ideal_hosted_page': true,
+                },
+            },
+        });
+
+        const { container } = render(<PaymentMethodTest {...defaultProps} method={fawryMethod} />);
+
+        expect(container.firstChild).not.toBeNull();
+    });
 });

--- a/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
+++ b/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
@@ -29,6 +29,10 @@ const CheckoutcomCustomPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     checkoutState,
     ...rest
 }) => {
+    const { getConfig } = checkoutState.data;
+    const isIdealHostedPageExperimentOn =
+        getConfig()?.checkoutSettings.features['PI-2979.checkoutcom_enable_ideal_hosted_page'];
+
     const checkoutCustomMethod = method.id;
     const CheckoutcomCustomFieldset =
         checkoutCustomMethod in checkoutcomCustomFormFields
@@ -37,7 +41,7 @@ const CheckoutcomCustomPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     const billingAddress = checkoutState.data.getBillingAddress();
 
-    if (!isCheckoutcomPaymentMethod(checkoutCustomMethod)) {
+    if (!isCheckoutcomPaymentMethod(checkoutCustomMethod) || isIdealHostedPageExperimentOn) {
         return null;
     }
 

--- a/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
+++ b/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
@@ -41,7 +41,10 @@ const CheckoutcomCustomPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     const billingAddress = checkoutState.data.getBillingAddress();
 
-    if (!isCheckoutcomPaymentMethod(checkoutCustomMethod) || isIdealHostedPageExperimentOn) {
+    if (
+        !isCheckoutcomPaymentMethod(checkoutCustomMethod) ||
+        (checkoutCustomMethod === 'ideal' && isIdealHostedPageExperimentOn)
+    ) {
         return null;
     }
 


### PR DESCRIPTION
## What?
iDEAL have updated their central technical infrastructure.
It requires from us to stop calling GET /issuers endpoint on checkout.
The change is under the experiment because according to this [comment](https://bigcommercecloud.atlassian.net/browse/PI-2979?focusedCommentId=1902071)
we're waiting for official information from Checkoutcom team.

## Why?
According to the CheckoutCOM team, the new changes will take effect on April 1, 2025.
We should be informed and then projected rollout of an experiment is 100%.

revert,
disable experiment [PI-2979.checkoutcom_enable_ideal_hosted_page](https://app.launchdarkly.com/projects/default/flags/PI-2979.checkoutcom_enable_ideal_hosted_page/targeting?env=development&env=integration&env=production&selected-env=development)

## Testing / Proof
Before:
![image](https://github.com/user-attachments/assets/ac74543f-186f-4bdc-98a4-c3670690dc7c)

After:
https://github.com/user-attachments/assets/3766b8d8-dc1e-4f72-aa77-e6b8f7ea1caa

@bigcommerce/team-checkout
