### PR TITLE
chore(payment): PI-3029 bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.696.0",
+        "@bigcommerce/checkout-sdk": "^1.696.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.696.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.0.tgz",
-      "integrity": "sha512-CpBYYB4TWWAcnSoN7bUCgPxWHB1uZoqA2vIz0pEKOVWFbDCvBRDXEBg0mOLvlxTIpOa7aC+9l0cvH55XaMVP2g==",
+      "version": "1.696.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.1.tgz",
+      "integrity": "sha512-gMHN3caXoHm9XAICluFI4hp9SAU4+Nvfp1vYkUUK4VXTxZ0zd8IRfC16ZEuACU+LTe1r7QSzPxgD/AC2ngtl7g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.696.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.0.tgz",
-      "integrity": "sha512-CpBYYB4TWWAcnSoN7bUCgPxWHB1uZoqA2vIz0pEKOVWFbDCvBRDXEBg0mOLvlxTIpOa7aC+9l0cvH55XaMVP2g==",
+      "version": "1.696.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.1.tgz",
+      "integrity": "sha512-gMHN3caXoHm9XAICluFI4hp9SAU4+Nvfp1vYkUUK4VXTxZ0zd8IRfC16ZEuACU+LTe1r7QSzPxgD/AC2ngtl7g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.696.0",
+    "@bigcommerce/checkout-sdk": "^1.696.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## Why?
Release of https://github.com/bigcommerce/checkout-sdk-js/pull/2761

## Testing / Proof
Tested Manually

@bigcommerce/team-checkout
