### PR TITLE
fix(extension): CHECKOUT-8960 Fix Broadcast Interruption

### DIFF
--- a/packages/checkout-extension/src/ExtensionService.test.tsx
+++ b/packages/checkout-extension/src/ExtensionService.test.tsx
@@ -104,6 +104,8 @@ describe('ExtensionService', () => {
     });
 
     it('adds and removes command handlers', async () => {
+        jest.spyOn(checkoutService, 'clearExtensionCache');
+
         await extensionService.renderExtension(
             ExtensionRegionContainer.ShippingShippingAddressFormBefore,
             ExtensionRegion.ShippingShippingAddressFormBefore,
@@ -130,6 +132,7 @@ describe('ExtensionService', () => {
         extensionService.removeListeners(ExtensionRegion.ShippingShippingAddressFormBefore);
 
         expect(remover).toBeCalledTimes(3);
+        expect(checkoutService.clearExtensionCache).toHaveBeenCalled();
     });
 
     describe('isRegionInUse()', () => {

--- a/packages/checkout-extension/src/ExtensionService.ts
+++ b/packages/checkout-extension/src/ExtensionService.ts
@@ -78,6 +78,8 @@ export class ExtensionService {
     }
 
     removeListeners(region: ExtensionRegion): void {
+        this.checkoutService.clearExtensionCache(region);
+
         const extension = this.checkoutService.getState().data.getExtensionByRegion(region);
 
         if (!extension) {


### PR DESCRIPTION
## What?
Fix the issue of event broadcast interruption when an extension iframe is unmounted and subsequently remounted.

## Why?
The event poster within the extension messenger is not cleared/rebuilt after an iframe is unmounted.
As a result, continuing to deliver messages through this outdated poster leads to a loss of event broadcasts.

## Depends On
SDK update. Will bump SDK in this PR soon.

## Testing / Proof
https://github.com/user-attachments/assets/83c132a2-b798-4a81-868a-6d7af2ee3866


@bigcommerce/team-checkout