### PR TITLE
fix(payment): PAYPAL-4987 fixed credit card duplication when initialize BT LPM

### DIFF
--- a/packages/core/src/app/payment/Payment.spec.tsx
+++ b/packages/core/src/app/payment/Payment.spec.tsx
@@ -206,6 +206,29 @@ describe('Payment', () => {
         );
     });
 
+    it('does not render methods with braintreelocalmethods id', async () => {
+        const expectedPaymentMethods = paymentMethods.filter(
+            (method) => method.id !== PaymentMethodId.BraintreeLocalPaymentMethod,
+        );
+
+        paymentMethods[3] = {
+            ...getPaymentMethod(),
+            id: 'braintreelocalmethods',
+        };
+
+        const container = mount(<PaymentTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+        container.update();
+
+        expect(container.find(PaymentForm).props()).toEqual(
+            expect.objectContaining({
+                methods: expectedPaymentMethods,
+                onSubmit: expect.any(Function),
+            }),
+        );
+    });
+
     it('passes initialisation status to payment form', async () => {
         jest.spyOn(checkoutState.statuses, 'isInitializingPayment').mockReturnValue(true);
 

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -645,6 +645,10 @@ export function mapToPaymentProps({
             return !!method.initializationData.showInCheckout;
         }
 
+        if (method.id === PaymentMethodId.BraintreeLocalPaymentMethod) {
+            return false;
+        }
+
         return true;
     });
 


### PR DESCRIPTION
## What?
Fixed credit card duplication when initialize BT LPM

## Why?
To avoid duplication of credit card 

## Testing / Proof




https://github.com/user-attachments/assets/a105c222-f67e-47ef-8be5-3e1f0a691bb1



@bigcommerce/team-checkout
