### PR TITLE
chore(payment): STRIPE-524 bump checkout-sdk-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.696.3",
+        "@bigcommerce/checkout-sdk": "^1.697.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.696.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.3.tgz",
-      "integrity": "sha512-ItnHyoEqJHr1LgLhUY5KLfBF797/6kC0NXDX/ImO033U6qF1GLJDhA2H5t+4pyWzc5X10s9tqb0oR2v2fEE2Gg==",
+      "version": "1.697.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.697.0.tgz",
+      "integrity": "sha512-FcqTz3xuUK1VkxC7Zdx+B27PHYp1Ir7J9tGygQIEbcZISoonP+YzFHMYV5r40atFiTHTKaxZy71M/00XAfi/kg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.696.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.696.3.tgz",
-      "integrity": "sha512-ItnHyoEqJHr1LgLhUY5KLfBF797/6kC0NXDX/ImO033U6qF1GLJDhA2H5t+4pyWzc5X10s9tqb0oR2v2fEE2Gg==",
+      "version": "1.697.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.697.0.tgz",
+      "integrity": "sha512-FcqTz3xuUK1VkxC7Zdx+B27PHYp1Ir7J9tGygQIEbcZISoonP+YzFHMYV5r40atFiTHTKaxZy71M/00XAfi/kg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.696.3",
+    "@bigcommerce/checkout-sdk": "^1.697.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2764](https://github.com/bigcommerce/checkout-sdk-js/pull/2764)

## Testing / Proof
Manually tested, automation and unit tests

@bigcommerce/team-checkout
