### PR TITLE
feat(extension): CHECKOUT-8964 Introduce GetConsignment Command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.697.0",
+        "@bigcommerce/checkout-sdk": "^1.698.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.697.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.697.0.tgz",
-      "integrity": "sha512-FcqTz3xuUK1VkxC7Zdx+B27PHYp1Ir7J9tGygQIEbcZISoonP+YzFHMYV5r40atFiTHTKaxZy71M/00XAfi/kg==",
+      "version": "1.698.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.698.0.tgz",
+      "integrity": "sha512-PAcDY0TGjkYERDLdt73Sq/PpVkOsadMf3sqxGCnoahiDD8sDiGuFQcBHwXDGQtNQhLcrXg4sVe2amESrbIf0Xw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.697.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.697.0.tgz",
-      "integrity": "sha512-FcqTz3xuUK1VkxC7Zdx+B27PHYp1Ir7J9tGygQIEbcZISoonP+YzFHMYV5r40atFiTHTKaxZy71M/00XAfi/kg==",
+      "version": "1.698.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.698.0.tgz",
+      "integrity": "sha512-PAcDY0TGjkYERDLdt73Sq/PpVkOsadMf3sqxGCnoahiDD8sDiGuFQcBHwXDGQtNQhLcrXg4sVe2amESrbIf0Xw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.697.0",
+    "@bigcommerce/checkout-sdk": "^1.698.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/checkout-extension/src/ExtensionService.test.tsx
+++ b/packages/checkout-extension/src/ExtensionService.test.tsx
@@ -131,7 +131,7 @@ describe('ExtensionService', () => {
 
         extensionService.removeListeners(ExtensionRegion.ShippingShippingAddressFormBefore);
 
-        expect(remover).toBeCalledTimes(3);
+        expect(remover).toBeCalledTimes(4);
         expect(checkoutService.clearExtensionCache).toHaveBeenCalled();
     });
 

--- a/packages/checkout-extension/src/handlers/createGetConsignmentHandler.ts
+++ b/packages/checkout-extension/src/handlers/createGetConsignmentHandler.ts
@@ -1,0 +1,22 @@
+import { ExtensionCommandType, ExtensionMessageType } from '@bigcommerce/checkout-sdk';
+
+import { CommandHandler, HandlerProps } from './CommandHandler';
+
+export function createGetConsignmentHandler({
+    checkoutService,
+    extension,
+}: HandlerProps): CommandHandler<ExtensionCommandType.GetConsignments> {
+    return {
+        commandType: ExtensionCommandType.GetConsignments,
+        handler: () => {
+            const consignments = checkoutService.getState().data.getCheckout()?.consignments || [];
+
+            checkoutService.postMessageToExtension(extension.id, {
+                type: ExtensionMessageType.GetConsignments,
+                payload: {
+                    consignments,
+                },
+            });
+        },
+    };
+}

--- a/packages/checkout-extension/src/handlers/handlers.test.ts
+++ b/packages/checkout-extension/src/handlers/handlers.test.ts
@@ -1,12 +1,16 @@
 import {
+    Checkout,
     CheckoutService,
+    Consignment,
     createCheckoutService,
     ExtensionCommandType,
+    ExtensionMessageType,
 } from '@bigcommerce/checkout-sdk';
 
 import { ExtensionActionType, getExtensions } from '../';
 
 import { HandlerProps } from './CommandHandler';
+import { createGetConsignmentHandler } from './createGetConsignmentHandler';
 import { createReloadCheckoutHandler } from './createReloadCheckoutHandler';
 import { createSetIframeStyleHandler } from './createSetIframeStyleHandler';
 import { createShowLoadingIndicatorHandler } from './createShowLoadingIndicatorHandler';
@@ -34,9 +38,6 @@ describe('Handlers', () => {
 
             handler.handler({
                 type: ExtensionCommandType.ReloadCheckout,
-                payload: {
-                    extensionId: '123',
-                },
             });
 
             expect(loadCheckout).toHaveBeenCalled();
@@ -56,7 +57,6 @@ describe('Handlers', () => {
             handler.handler({
                 type: ExtensionCommandType.SetIframeStyle,
                 payload: {
-                    extensionId: '123',
                     style,
                 },
             });
@@ -73,7 +73,6 @@ describe('Handlers', () => {
             handler.handler({
                 type: ExtensionCommandType.ShowLoadingIndicator,
                 payload: {
-                    extensionId: '123',
                     show,
                 },
             });
@@ -82,6 +81,33 @@ describe('Handlers', () => {
                 type: ExtensionActionType.SHOW_LOADING_INDICATOR,
                 payload: show,
             });
+        });
+    });
+
+    describe('createGetConsignmentHandler', () => {
+        it('posts a message to an extension', () => {
+            const handler = createGetConsignmentHandler(handlerProps);
+            const consignments: Consignment[] = [];
+
+            jest.spyOn(checkoutService, 'postMessageToExtension');
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue({
+                consignments,
+            } as Checkout);
+
+            handler.handler({
+                type: ExtensionCommandType.GetConsignments,
+            });
+
+            expect(checkoutService.postMessageToExtension).toHaveBeenCalledWith(
+                getExtensions()[0].id,
+                {
+                    type: ExtensionMessageType.GetConsignments,
+                    payload: {
+                        consignments,
+                    },
+                },
+            );
         });
     });
 });

--- a/packages/checkout-extension/src/handlers/index.ts
+++ b/packages/checkout-extension/src/handlers/index.ts
@@ -1,3 +1,4 @@
 export { createReloadCheckoutHandler } from './createReloadCheckoutHandler';
 export { createSetIframeStyleHandler } from './createSetIframeStyleHandler';
 export { createShowLoadingIndicatorHandler } from './createShowLoadingIndicatorHandler';
+export { createGetConsignmentHandler } from './createGetConsignmentHandler';


### PR DESCRIPTION
## What?
Handle a new checkout extension command, `GetConsignments`

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/2766
* Will include the SDK bump in this PR.

## Why?
To pass consignment data to a checkout extension.

## Testing / Proof
![Screenshot 2025-01-21 at 11 17 42 AM](https://github.com/user-attachments/assets/e8946d5b-5b08-42c2-9c5d-30ed4e4318d9)
