### PR TITLE
feat(checkout): CHECKOUT-8959 Enable Shipping Form Reinitialization

### DIFF
--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -374,6 +374,6 @@ export default withLanguage(
                           }),
                       ),
                   }),
-        enableReinitialize: false,
+        enableReinitialize: true,
     })(SingleShippingForm),
 );

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.tsx
@@ -195,4 +195,5 @@ export default withAnalytics(withFormikExtended<ShippingOptionsFormProps, Shippi
 
         return { shippingOptionIds };
     },
+    enableReinitialize: true,
 })(ShippingOptionsForm));

--- a/packages/test-framework/src/fixture/pageObject/Checkout.ts
+++ b/packages/test-framework/src/fixture/pageObject/Checkout.ts
@@ -170,10 +170,6 @@ export class Checkout {
             addressAppendText,
         });
 
-        if (!isBillingAddressSame) await this.page.locator('label[for="sameAsBilling"]').click();
-        if (!shouldSaveAddress)
-            await this.page.locator('label[for="shippingAddress.shouldSaveAddress"]').click();
-
         await this.page.locator('#checkout-shipping-options').waitFor({ state: 'visible' });
 
         const firstShippingMethod = this.page
@@ -181,6 +177,15 @@ export class Checkout {
             .nth(0);
 
         await firstShippingMethod.click();
+
+        if (!shouldSaveAddress) {
+            await this.page.getByText('Save this address in my address book.').click();
+        }
+
+        if (!isBillingAddressSame) {
+            await this.page.locator('label[for="sameAsBilling"]').click();
+        }
+
         await this.page.locator('#checkout-shipping-continue').click();
     }
 


### PR DESCRIPTION
## What?
Enable the shipping address form to reinitialize itself to reflect the current checkout data state.

## Formik Note
- `initialValues` not available to the higher-order component, use `mapPropsToValues` instead. ([doc](https://formik.org/docs/api/formik#initialvalues-values))
- Setting `enableReinitialize` to `true` allows Formik to reset the form to the values defined in `mapPropsToValues` whenever any prop value of the nested component changes. (not documented in the Formik doc)

## Why?
To support use cases where a checkout extension updates data externally, the checkout UI can automatically display any changes after reloading the checkout data.

## Testing / Proof
Changing the shipping option on the right and then clicking the emoji on the left triggers a checkout reload, causing the shipping option extension to re-render.

https://github.com/user-attachments/assets/33ff651a-aeec-4046-aed6-9ce78dab0c43