### PR TITLE
feat(payment): PI-3099 [AdyenV3] Remove iDEAL bank selection dropdown

### DIFF
--- a/packages/adyen-integration/src/adyenv3/AdyenV3Form.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3Form.tsx
@@ -75,6 +75,9 @@ const AdyenV3Form: FunctionComponent<AdyenV3FormProps & PaymentMethodProps> = ({
     const isInstrumentCardCodeRequired = isInstrumentCardCodeRequiredSelector(checkoutState);
     const isInstrumentCardNumberRequired = isInstrumentCardNumberRequiredSelector(checkoutState);
 
+    const { getConfig } = checkoutState.data;
+    const isIdealHostedPageExperimentOn =
+        getConfig()?.checkoutSettings.features['PI-2456.adyen_enable_ideal_hosted_page'];
     const {
         hidePaymentSubmitButton,
         disableSubmit,
@@ -92,6 +95,7 @@ const AdyenV3Form: FunctionComponent<AdyenV3FormProps & PaymentMethodProps> = ({
                 disableSubmit={disableSubmit}
                 hideContentWhenSignedOut
                 hidePaymentSubmitButton={hidePaymentSubmitButton}
+                hideWidget={method.method === 'ideal' && isIdealHostedPageExperimentOn}
                 initializePayment={initializePayment}
                 instruments={instruments}
                 isAccountInstrument={isAccountInstrument}


### PR DESCRIPTION
## What?
Remove iDEAL bank selection dropdown for Adyen under the experiment `PI-2456.adyen_enable_ideal_hosted_page`

## Why?
iDEAL have updated their central technical infrastructure.
It requires from us to:

remove the list of banks from their checkout pages.
redirect shoppers to the central iDEAL payment page.
The change is in the experimental phase, as Adyen plans to do so on April 1, [according to official documentation](https://docs.adyen.com/payment-methods/ideal/).

## Testing / Proof
before:

https://github.com/user-attachments/assets/a824a2ef-b43b-41c4-a158-d124d8fa4b7e

after:
https://github.com/user-attachments/assets/30b901f6-dd8c-4cef-aa16-9cbb8b2ebd63