### PR TITLE
chore(payment): PI-3099 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.698.1",
+        "@bigcommerce/checkout-sdk": "^1.700.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.698.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.698.1.tgz",
-      "integrity": "sha512-3FY18lvwFxiyUK2CPh9Wqk+wrpMZ6RLWHiA2sYiq2078I3Whlll5LdiVUiVEWQAXTPc6cAse7Q+zIhFwLU3+bw==",
+      "version": "1.700.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.0.tgz",
+      "integrity": "sha512-Rismvc6g1Ev8vaSMaMs97YBdlyxugO6g3QvTA+snPYpj7ErsBXHcOM4Xdq+VDZRzgwgx8QreeZar8yBCEiH7Ew==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.698.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.698.1.tgz",
-      "integrity": "sha512-3FY18lvwFxiyUK2CPh9Wqk+wrpMZ6RLWHiA2sYiq2078I3Whlll5LdiVUiVEWQAXTPc6cAse7Q+zIhFwLU3+bw==",
+      "version": "1.700.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.0.tgz",
+      "integrity": "sha512-Rismvc6g1Ev8vaSMaMs97YBdlyxugO6g3QvTA+snPYpj7ErsBXHcOM4Xdq+VDZRzgwgx8QreeZar8yBCEiH7Ew==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.698.1",
+    "@bigcommerce/checkout-sdk": "^1.700.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
To release https://github.com/bigcommerce/checkout-sdk-js/pull/2772

## Testing / Proof
All tests passed