### PR TITLE
chore(payment): PAYPAL-5020 bump checkout sdk version (1.700.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.700.1",
+        "@bigcommerce/checkout-sdk": "^1.700.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.700.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.1.tgz",
-      "integrity": "sha512-S7WcyKDcl88U1Fm/3YCSGZnQFrgU+bqoBG2VKLLuD3BhEdJF+fQYP2WPRAVv6jFTCPEDFX0+wO0FrWEbSrsuUw==",
+      "version": "1.700.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.2.tgz",
+      "integrity": "sha512-9HneuzU5BrqLnVs9Wo46zDG0131ww2D2xTAkUlVmqmGpqmMLOIHxFQOznLfW8Kth6CVvxuO5HliN9YisU9ALRw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.700.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.1.tgz",
-      "integrity": "sha512-S7WcyKDcl88U1Fm/3YCSGZnQFrgU+bqoBG2VKLLuD3BhEdJF+fQYP2WPRAVv6jFTCPEDFX0+wO0FrWEbSrsuUw==",
+      "version": "1.700.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.2.tgz",
+      "integrity": "sha512-9HneuzU5BrqLnVs9Wo46zDG0131ww2D2xTAkUlVmqmGpqmMLOIHxFQOznLfW8Kth6CVvxuO5HliN9YisU9ALRw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.700.1",
+    "@bigcommerce/checkout-sdk": "^1.700.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout sdk version (1.700.2)

## Why?
As part of release: https://github.com/bigcommerce/checkout-sdk-js/pull/2774

## Testing / Proof
Unit tests
CI
