### PR TITLE
feat(extension): CHECKOUT-8974 Introduce Query Handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.700.2",
+        "@bigcommerce/checkout-sdk": "^1.701.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.700.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.2.tgz",
-      "integrity": "sha512-9HneuzU5BrqLnVs9Wo46zDG0131ww2D2xTAkUlVmqmGpqmMLOIHxFQOznLfW8Kth6CVvxuO5HliN9YisU9ALRw==",
+      "version": "1.701.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.0.tgz",
+      "integrity": "sha512-qalzBymEM2AoDGaDbNDTMaMutEi8v9pWdLS+6jD/nkoMFTGHt9PT6rSsHu+H9YyBJF+8eUtDcaBTlG9U0wFYhA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.700.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.700.2.tgz",
-      "integrity": "sha512-9HneuzU5BrqLnVs9Wo46zDG0131ww2D2xTAkUlVmqmGpqmMLOIHxFQOznLfW8Kth6CVvxuO5HliN9YisU9ALRw==",
+      "version": "1.701.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.0.tgz",
+      "integrity": "sha512-qalzBymEM2AoDGaDbNDTMaMutEi8v9pWdLS+6jD/nkoMFTGHt9PT6rSsHu+H9YyBJF+8eUtDcaBTlG9U0wFYhA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.700.2",
+    "@bigcommerce/checkout-sdk": "^1.701.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/checkout-extension/src/ExtensionService.test.tsx
+++ b/packages/checkout-extension/src/ExtensionService.test.tsx
@@ -108,7 +108,7 @@ describe('ExtensionService', () => {
         );
     });
 
-    it('adds and removes command handlers', async () => {
+    it('adds and removes command or query handlers', async () => {
         jest.spyOn(checkoutService, 'clearExtensionCache').mockReturnValue();
 
         await extensionService.renderExtension(
@@ -133,20 +133,6 @@ describe('ExtensionService', () => {
             ExtensionCommandType.ShowLoadingIndicator,
             expect.any(Function),
         );
-
-        extensionService.removeListeners(ExtensionRegion.ShippingShippingAddressFormBefore);
-
-        expect(commandHandlerRemover).toBeCalledTimes(3);
-        expect(checkoutService.clearExtensionCache).toHaveBeenCalled();
-    });
-
-    it('adds and removes query handlers', async () => {
-        jest.spyOn(checkoutService, 'clearExtensionCache').mockReturnValue();
-
-        await extensionService.renderExtension(
-            ExtensionRegionContainer.ShippingShippingAddressFormBefore,
-            ExtensionRegion.ShippingShippingAddressFormBefore,
-        );
         expect(checkoutService.handleExtensionQuery).toHaveBeenNthCalledWith(
             1,
             '123',
@@ -156,7 +142,8 @@ describe('ExtensionService', () => {
 
         extensionService.removeListeners(ExtensionRegion.ShippingShippingAddressFormBefore);
 
-        expect(queryHandlerRemover).toBeCalledTimes(2);
+        expect(commandHandlerRemover).toBeCalledTimes(3);
+        expect(queryHandlerRemover).toBeCalledTimes(1);
         expect(checkoutService.clearExtensionCache).toHaveBeenCalled();
     });
 

--- a/packages/checkout-extension/src/ExtensionService.ts
+++ b/packages/checkout-extension/src/ExtensionService.ts
@@ -2,6 +2,7 @@ import {
     CheckoutService,
     Extension,
     ExtensionCommandMap,
+    ExtensionQueryMap,
     ExtensionRegion,
 } from '@bigcommerce/checkout-sdk';
 import React from 'react';
@@ -9,8 +10,9 @@ import React from 'react';
 import { ErrorLevelType, ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 
 import { ExtensionAction } from './ExtensionProvider';
-import * as handlerFactories from './handlers';
-import { CommandHandler } from './handlers/CommandHandler';
+import { CommandHandler, QueryHandler } from './handler';
+import * as commandHandlerFactories from './handler/commandHandlers';
+import * as queryHandlerFactories from './handler/queryHandlers';
 
 export class ExtensionService {
     private handlers: { [extensionId: string]: Array<() => void> } = {};
@@ -116,14 +118,28 @@ export class ExtensionService {
             this.handlers[extension.id] = [];
         }
 
-        Object.values(handlerFactories).forEach((createHandlerFactory) => {
-            const handlerFactory = createHandlerFactory(handlerProps);
+        Object.values(commandHandlerFactories).forEach((createCommandHandlerFactory) => {
+            const handlerFactory = createCommandHandlerFactory(handlerProps);
 
             if (this.isCommandHandler(handlerFactory.commandType, handlerFactory)) {
                 this.handlers[extension.id].push(
                     this.checkoutService.handleExtensionCommand(
                         extension.id,
                         handlerFactory.commandType,
+                        handlerFactory.handler,
+                    ),
+                );
+            }
+        });
+
+        Object.values(queryHandlerFactories).forEach((createQueryHandlerFactory) => {
+            const handlerFactory = createQueryHandlerFactory(handlerProps);
+
+            if (this.isQueryHandler(handlerFactory.queryType, handlerFactory)) {
+                this.handlers[extension.id].push(
+                    this.checkoutService.handleExtensionQuery(
+                        extension.id,
+                        handlerFactory.queryType,
                         handlerFactory.handler,
                     ),
                 );
@@ -136,5 +152,12 @@ export class ExtensionService {
         handler: CommandHandler<any>,
     ): handler is CommandHandler<T> {
         return handler.commandType === type;
+    }
+
+    private isQueryHandler<T extends keyof ExtensionQueryMap>(
+        type: T,
+        handler: QueryHandler<any>,
+    ): handler is QueryHandler<T> {
+        return handler.queryType === type;
     }
 }

--- a/packages/checkout-extension/src/ExtensionService.ts
+++ b/packages/checkout-extension/src/ExtensionService.ts
@@ -140,6 +140,7 @@ export class ExtensionService {
                     this.checkoutService.handleExtensionQuery(
                         extension.id,
                         handlerFactory.queryType,
+                        // eslint-disable-next-line @typescript-eslint/no-misused-promises
                         handlerFactory.handler,
                     ),
                 );

--- a/packages/checkout-extension/src/handler/commandHandlers/CommandHandler.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/CommandHandler.ts
@@ -1,9 +1,9 @@
 import { CheckoutService, Extension, ExtensionCommandMap } from '@bigcommerce/checkout-sdk';
 import React from 'react';
 
-import { ExtensionAction } from '../ExtensionProvider';
+import { ExtensionAction } from '../../ExtensionProvider';
 
-export interface HandlerProps {
+export interface CommandHandlerProps {
     checkoutService: CheckoutService;
     dispatch: React.Dispatch<ExtensionAction>;
     extension: Extension;

--- a/packages/checkout-extension/src/handler/commandHandlers/commandHandlers.test.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/commandHandlers.test.ts
@@ -1,22 +1,18 @@
 import {
-    Checkout,
     CheckoutService,
-    Consignment,
     createCheckoutService,
     ExtensionCommandType,
-    ExtensionMessageType,
 } from '@bigcommerce/checkout-sdk';
 
-import { ExtensionActionType, getExtensions } from '../';
+import { ExtensionActionType, getExtensions } from '../../index';
 
-import { HandlerProps } from './CommandHandler';
-import { createGetConsignmentHandler } from './createGetConsignmentHandler';
+import { CommandHandlerProps } from './CommandHandler';
 import { createReloadCheckoutHandler } from './createReloadCheckoutHandler';
 import { createSetIframeStyleHandler } from './createSetIframeStyleHandler';
 import { createShowLoadingIndicatorHandler } from './createShowLoadingIndicatorHandler';
 
-describe('Handlers', () => {
-    let handlerProps: HandlerProps;
+describe('commandHandlers', () => {
+    let handlerProps: CommandHandlerProps;
     let checkoutService: CheckoutService;
 
     const dispatch = jest.fn();
@@ -81,33 +77,6 @@ describe('Handlers', () => {
                 type: ExtensionActionType.SHOW_LOADING_INDICATOR,
                 payload: show,
             });
-        });
-    });
-
-    describe('createGetConsignmentHandler', () => {
-        it('posts a message to an extension', () => {
-            const handler = createGetConsignmentHandler(handlerProps);
-            const consignments: Consignment[] = [];
-
-            jest.spyOn(checkoutService, 'postMessageToExtension');
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue({
-                consignments,
-            } as Checkout);
-
-            handler.handler({
-                type: ExtensionCommandType.GetConsignments,
-            });
-
-            expect(checkoutService.postMessageToExtension).toHaveBeenCalledWith(
-                getExtensions()[0].id,
-                {
-                    type: ExtensionMessageType.GetConsignments,
-                    payload: {
-                        consignments,
-                    },
-                },
-            );
         });
     });
 });

--- a/packages/checkout-extension/src/handler/commandHandlers/createReloadCheckoutHandler.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/createReloadCheckoutHandler.ts
@@ -1,10 +1,10 @@
 import { ExtensionCommandType } from '@bigcommerce/checkout-sdk';
 
-import { CommandHandler, HandlerProps } from './CommandHandler';
+import { CommandHandler, CommandHandlerProps } from './CommandHandler';
 
 export function createReloadCheckoutHandler({
     checkoutService,
-}: HandlerProps): CommandHandler<ExtensionCommandType.ReloadCheckout> {
+}: CommandHandlerProps): CommandHandler<ExtensionCommandType.ReloadCheckout> {
     return {
         commandType: ExtensionCommandType.ReloadCheckout,
         handler: () => {

--- a/packages/checkout-extension/src/handler/commandHandlers/createSetIframeStyleHandler.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/createSetIframeStyleHandler.ts
@@ -1,10 +1,10 @@
 import { ExtensionCommandType } from '@bigcommerce/checkout-sdk';
 
-import { CommandHandler, HandlerProps } from './CommandHandler';
+import { CommandHandler, CommandHandlerProps } from './CommandHandler';
 
 export function createSetIframeStyleHandler({
     extension,
-}: HandlerProps): CommandHandler<ExtensionCommandType.SetIframeStyle> {
+}: CommandHandlerProps): CommandHandler<ExtensionCommandType.SetIframeStyle> {
     return {
         commandType: ExtensionCommandType.SetIframeStyle,
         handler: (data) => {

--- a/packages/checkout-extension/src/handler/commandHandlers/createShowLoadingIndicatorHandler.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/createShowLoadingIndicatorHandler.ts
@@ -1,12 +1,12 @@
 import { ExtensionCommandType } from '@bigcommerce/checkout-sdk';
 
-import { ExtensionActionType } from '../ExtensionProvider';
+import { ExtensionActionType } from '../../ExtensionProvider';
 
-import { CommandHandler, HandlerProps } from './CommandHandler';
+import { CommandHandler, CommandHandlerProps } from './CommandHandler';
 
 export function createShowLoadingIndicatorHandler({
     dispatch,
-}: HandlerProps): CommandHandler<ExtensionCommandType.ShowLoadingIndicator> {
+}: CommandHandlerProps): CommandHandler<ExtensionCommandType.ShowLoadingIndicator> {
     return {
         commandType: ExtensionCommandType.ShowLoadingIndicator,
         handler: (data) => {

--- a/packages/checkout-extension/src/handler/commandHandlers/index.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/index.ts
@@ -1,4 +1,3 @@
 export { createReloadCheckoutHandler } from './createReloadCheckoutHandler';
 export { createSetIframeStyleHandler } from './createSetIframeStyleHandler';
 export { createShowLoadingIndicatorHandler } from './createShowLoadingIndicatorHandler';
-export { createGetConsignmentHandler } from './createGetConsignmentHandler';

--- a/packages/checkout-extension/src/handler/index.ts
+++ b/packages/checkout-extension/src/handler/index.ts
@@ -1,0 +1,2 @@
+export { CommandHandler } from './commandHandlers/CommandHandler';
+export { QueryHandler } from './queryHandlers/QueryHandler';

--- a/packages/checkout-extension/src/handler/queryHandlers/QueryHandler.ts
+++ b/packages/checkout-extension/src/handler/queryHandlers/QueryHandler.ts
@@ -1,0 +1,15 @@
+import { CheckoutService, Extension, ExtensionQueryMap } from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { ExtensionAction } from '../../ExtensionProvider';
+
+export interface QueryHandlerProps {
+    checkoutService: CheckoutService;
+    dispatch: React.Dispatch<ExtensionAction>;
+    extension: Extension;
+}
+
+export interface QueryHandler<T extends keyof ExtensionQueryMap> {
+    queryType: T;
+    handler: (query: ExtensionQueryMap[T]) => Promise<void>;
+}

--- a/packages/checkout-extension/src/handler/queryHandlers/createGetConsignmentHandler.ts
+++ b/packages/checkout-extension/src/handler/queryHandlers/createGetConsignmentHandler.ts
@@ -1,14 +1,18 @@
-import { ExtensionCommandType, ExtensionMessageType } from '@bigcommerce/checkout-sdk';
+import { ExtensionMessageType, ExtensionQueryType } from '@bigcommerce/checkout-sdk';
 
-import { CommandHandler, HandlerProps } from './CommandHandler';
+import { QueryHandler, QueryHandlerProps } from './QueryHandler';
 
 export function createGetConsignmentHandler({
     checkoutService,
     extension,
-}: HandlerProps): CommandHandler<ExtensionCommandType.GetConsignments> {
+}: QueryHandlerProps): QueryHandler<ExtensionQueryType.GetConsignments> {
     return {
-        commandType: ExtensionCommandType.GetConsignments,
-        handler: () => {
+        queryType: ExtensionQueryType.GetConsignments,
+        handler: async (data) => {
+            if (!data.payload?.useCache) {
+                await checkoutService.loadCheckout();
+            }
+
             const consignments = checkoutService.getState().data.getCheckout()?.consignments || [];
 
             checkoutService.postMessageToExtension(extension.id, {

--- a/packages/checkout-extension/src/handler/queryHandlers/index.ts
+++ b/packages/checkout-extension/src/handler/queryHandlers/index.ts
@@ -1,0 +1,1 @@
+export { createGetConsignmentHandler } from './createGetConsignmentHandler';

--- a/packages/checkout-extension/src/handler/queryHandlers/queryHandlers.test.ts
+++ b/packages/checkout-extension/src/handler/queryHandlers/queryHandlers.test.ts
@@ -1,0 +1,76 @@
+import {
+    Checkout,
+    CheckoutService,
+    Consignment,
+    createCheckoutService,
+    ExtensionMessageType,
+    ExtensionQueryType,
+} from '@bigcommerce/checkout-sdk';
+
+import { getExtensions } from '../../index';
+
+import { createGetConsignmentHandler } from './createGetConsignmentHandler';
+import { QueryHandlerProps } from './QueryHandler';
+
+describe('queryHandlers', () => {
+    let handlerProps: QueryHandlerProps;
+    let checkoutService: CheckoutService;
+
+    const dispatch = jest.fn();
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        handlerProps = {
+            checkoutService,
+            dispatch,
+            extension: getExtensions()[0],
+        };
+    });
+
+    describe('createGetConsignmentHandler', () => {
+        it('posts consignments[] in cache to an extension', () => {
+            const handler = createGetConsignmentHandler(handlerProps);
+            const consignments: Consignment[] = [];
+
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue({
+                consignments,
+            } as Checkout);
+            jest.spyOn(checkoutService, 'postMessageToExtension');
+
+            void handler.handler({
+                type: ExtensionQueryType.GetConsignments,
+                payload: {
+                    useCache: true,
+                },
+            });
+
+            expect(checkoutService.postMessageToExtension).toHaveBeenCalledWith(
+                getExtensions()[0].id,
+                {
+                    type: ExtensionMessageType.GetConsignments,
+                    payload: {
+                        consignments,
+                    },
+                },
+            );
+        });
+
+        it('posts consignments[] in remote API to an extension', () => {
+            const handler = createGetConsignmentHandler(handlerProps);
+
+            jest.spyOn(checkoutService, 'loadCheckout').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            void handler.handler({
+                type: ExtensionQueryType.GetConsignments,
+                payload: {
+                    useCache: false,
+                },
+            });
+
+            expect(checkoutService.loadCheckout).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/checkout-extension/src/handler/queryHandlers/queryHandlers.test.ts
+++ b/packages/checkout-extension/src/handler/queryHandlers/queryHandlers.test.ts
@@ -56,7 +56,7 @@ describe('queryHandlers', () => {
             );
         });
 
-        it('posts consignments[] in remote API to an extension', () => {
+        it('reloads checkout if useCache is false', () => {
             const handler = createGetConsignmentHandler(handlerProps);
 
             jest.spyOn(checkoutService, 'loadCheckout').mockResolvedValue(


### PR DESCRIPTION
## What?
Introduce a new `query` concept that allows an extension to fetch any data from the checkout object by using a simple query key. 

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/2769

## Why?
An extension can fetch checkout data immediately.

## Testing / Proof
After the extension service initialization, clicking the emoji will run:
```
console.log(await service.getConsignments(useCache));
```
`useCache` is set to `true` at first. On the second time of clicking the emoji, `useCache` will be `false`, therefore, a `GET` checkout call is made.

https://github.com/user-attachments/assets/8e87cdfb-103c-4338-bf1b-73bf2f1d2e28

@bigcommerce/team-checkout @bigcommerce/team-payments
