### PR TITLE
feat(payment): PAYPAL-5038 Added onUnhandledError function to open a modal window when an error occurs during the payment initialization process

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/BraintreeCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/BraintreeCreditCardPaymentMethod.tsx
@@ -95,6 +95,7 @@ const BraintreeCreditCardPaymentMethod: FunctionComponent<
                 getStoredCardValidationFieldset={getHostedStoredCardValidationFieldset}
                 initializePayment={initializeBraintreePayment}
                 storedCardValidationSchema={hostedStoredCardValidationSchema}
+                onUnhandledError={onUnhandledError}
             />
 
             <Modal


### PR DESCRIPTION
## What?

Added `onUnhandledError` function to open a modal window when an error occurs during the payment initialization process

## Why?

For correct errors handling

## Testing / Proof

Manual testing

@bigcommerce/team-checkout
