### PR TITLE
chore(other): CHECKOUT-8264 Bump checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.701.0",
+        "@bigcommerce/checkout-sdk": "^1.701.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.701.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.0.tgz",
-      "integrity": "sha512-qalzBymEM2AoDGaDbNDTMaMutEi8v9pWdLS+6jD/nkoMFTGHt9PT6rSsHu+H9YyBJF+8eUtDcaBTlG9U0wFYhA==",
+      "version": "1.701.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.2.tgz",
+      "integrity": "sha512-ooGFoog+U0hirvF7EZsP1SB6FUO7LTjuBiWOCAoUTDI23OKvaIctszkLn4D5AXyNV2PDuqERwqjvCnyU3CuuAw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.701.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.0.tgz",
-      "integrity": "sha512-qalzBymEM2AoDGaDbNDTMaMutEi8v9pWdLS+6jD/nkoMFTGHt9PT6rSsHu+H9YyBJF+8eUtDcaBTlG9U0wFYhA==",
+      "version": "1.701.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.2.tgz",
+      "integrity": "sha512-ooGFoog+U0hirvF7EZsP1SB6FUO7LTjuBiWOCAoUTDI23OKvaIctszkLn4D5AXyNV2PDuqERwqjvCnyU3CuuAw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.701.0",
+    "@bigcommerce/checkout-sdk": "^1.701.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk 

## Why?
Release https://github.com/bigcommerce/checkout-sdk-js/pull/2776

## Testing / Proof
- CI
- Attached to SDK linked PR

@bigcommerce/team-checkout
