### PR TITLE
feat(extension): CHECKOUT-8959 Introduce ReRenderShippingForm Command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.701.2",
+        "@bigcommerce/checkout-sdk": "^1.702.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.701.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.2.tgz",
-      "integrity": "sha512-ooGFoog+U0hirvF7EZsP1SB6FUO7LTjuBiWOCAoUTDI23OKvaIctszkLn4D5AXyNV2PDuqERwqjvCnyU3CuuAw==",
+      "version": "1.702.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.702.0.tgz",
+      "integrity": "sha512-+RBZse6mVm2ep9oh0/vsyTSlHyU8mHK1yX5yYrzZyJE04JQBqud6ShLxHuRWxwqHrf1ZHRaGFSyv+FL3z9BbMw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35065,9 +35065,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.701.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.701.2.tgz",
-      "integrity": "sha512-ooGFoog+U0hirvF7EZsP1SB6FUO7LTjuBiWOCAoUTDI23OKvaIctszkLn4D5AXyNV2PDuqERwqjvCnyU3CuuAw==",
+      "version": "1.702.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.702.0.tgz",
+      "integrity": "sha512-+RBZse6mVm2ep9oh0/vsyTSlHyU8mHK1yX5yYrzZyJE04JQBqud6ShLxHuRWxwqHrf1ZHRaGFSyv+FL3z9BbMw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.701.2",
+    "@bigcommerce/checkout-sdk": "^1.702.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/checkout-extension/src/ExtensionProvider.tsx
+++ b/packages/checkout-extension/src/ExtensionProvider.tsx
@@ -9,15 +9,17 @@ import { ExtensionService } from './ExtensionService';
 
 export interface ExtensionState {
     isShowingLoadingIndicator: boolean;
+    shippingFormRenderTimestamp: undefined | number;
 }
 
 export interface ExtensionAction {
     type: ExtensionActionType;
-    payload: boolean;
+    payload: boolean | number;
 }
 
 export enum ExtensionActionType {
     SHOW_LOADING_INDICATOR,
+    RE_RENDER_SHIPPING_FORM,
 }
 
 export interface ExtensionProviderProps {
@@ -33,6 +35,7 @@ export const ExtensionProvider = ({
 }: ExtensionProviderProps) => {
     const [extensionState, dispatch] = useReducer(extensionReducer, {
         isShowingLoadingIndicator: false,
+        shippingFormRenderTimestamp: undefined,
     });
     const extensionService = new ExtensionService(checkoutService, dispatch, errorLogger);
 

--- a/packages/checkout-extension/src/ExtensionReducer.ts
+++ b/packages/checkout-extension/src/ExtensionReducer.ts
@@ -6,9 +6,22 @@ export const extensionReducer = (
 ): ExtensionState => {
     switch (action.type) {
         case ExtensionActionType.SHOW_LOADING_INDICATOR:
-            return { ...state, isShowingLoadingIndicator: action.payload };
+            if (typeof action.payload === 'boolean') {
+                return { ...state, isShowingLoadingIndicator: action.payload };
+            }
+
+            break;
+
+        case ExtensionActionType.RE_RENDER_SHIPPING_FORM:
+            if (typeof action.payload === 'number') {
+                return { ...state, shippingFormRenderTimestamp: action.payload };
+            }
+
+            break;
 
         default:
             return state;
     }
+
+    return state;
 };

--- a/packages/checkout-extension/src/ExtensionService.test.tsx
+++ b/packages/checkout-extension/src/ExtensionService.test.tsx
@@ -133,6 +133,12 @@ describe('ExtensionService', () => {
             ExtensionCommandType.ShowLoadingIndicator,
             expect.any(Function),
         );
+        expect(checkoutService.handleExtensionCommand).toHaveBeenNthCalledWith(
+            4,
+            '123',
+            ExtensionCommandType.ReRenderShippingForm,
+            expect.any(Function),
+        );
         expect(checkoutService.handleExtensionQuery).toHaveBeenNthCalledWith(
             1,
             '123',
@@ -142,7 +148,7 @@ describe('ExtensionService', () => {
 
         extensionService.removeListeners(ExtensionRegion.ShippingShippingAddressFormBefore);
 
-        expect(commandHandlerRemover).toBeCalledTimes(3);
+        expect(commandHandlerRemover).toBeCalledTimes(4);
         expect(queryHandlerRemover).toBeCalledTimes(1);
         expect(checkoutService.clearExtensionCache).toHaveBeenCalled();
     });

--- a/packages/checkout-extension/src/ExtensionService.ts
+++ b/packages/checkout-extension/src/ExtensionService.ts
@@ -140,7 +140,6 @@ export class ExtensionService {
                     this.checkoutService.handleExtensionQuery(
                         extension.id,
                         handlerFactory.queryType,
-                        // eslint-disable-next-line @typescript-eslint/no-misused-promises
                         handlerFactory.handler,
                     ),
                 );

--- a/packages/checkout-extension/src/handler/commandHandlers/CommandHandler.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/CommandHandler.ts
@@ -11,5 +11,5 @@ export interface CommandHandlerProps {
 
 export interface CommandHandler<T extends keyof ExtensionCommandMap> {
     commandType: T;
-    handler: (command: ExtensionCommandMap[T]) => void;
+    handler: (command: ExtensionCommandMap[T]) => Promise<void> | void;
 }

--- a/packages/checkout-extension/src/handler/commandHandlers/commandHandlers.test.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/commandHandlers.test.ts
@@ -1,4 +1,5 @@
 import {
+    CheckoutSelectors,
     CheckoutService,
     createCheckoutService,
     ExtensionCommandType,
@@ -8,6 +9,7 @@ import { ExtensionActionType, getExtensions } from '../../index';
 
 import { CommandHandlerProps } from './CommandHandler';
 import { createReloadCheckoutHandler } from './createReloadCheckoutHandler';
+import { createReRenderShippingFormHandler } from './createReRenderShippingFormHandler';
 import { createSetIframeStyleHandler } from './createSetIframeStyleHandler';
 import { createShowLoadingIndicatorHandler } from './createShowLoadingIndicatorHandler';
 
@@ -28,11 +30,11 @@ describe('commandHandlers', () => {
 
     describe('createReloadCheckoutHandler', () => {
         it('reloads checkout', () => {
-            const handler = createReloadCheckoutHandler(handlerProps);
+            const { handler } = createReloadCheckoutHandler(handlerProps);
 
             const loadCheckout = jest.spyOn(checkoutService, 'loadCheckout');
 
-            handler.handler({
+            void handler({
                 type: ExtensionCommandType.ReloadCheckout,
             });
 
@@ -42,7 +44,7 @@ describe('commandHandlers', () => {
 
     describe('createSetIframeStyleHandler', () => {
         it('changes iframe style', () => {
-            const handler = createSetIframeStyleHandler(handlerProps);
+            const { handler } = createSetIframeStyleHandler(handlerProps);
             const container = document.createElement('div');
             const iframe = document.createElement('iframe');
             const style = { width: '100px', height: '200px' };
@@ -50,7 +52,7 @@ describe('commandHandlers', () => {
             jest.spyOn(document, 'querySelector').mockReturnValue(container);
             jest.spyOn(container, 'querySelector').mockReturnValue(iframe);
 
-            handler.handler({
+            void handler({
                 type: ExtensionCommandType.SetIframeStyle,
                 payload: {
                     style,
@@ -64,18 +66,40 @@ describe('commandHandlers', () => {
     describe('createShowLoadingIndicatorHandler', () => {
         it('dispatches an action', () => {
             const show = true;
-            const handler = createShowLoadingIndicatorHandler(handlerProps);
+            const { handler } = createShowLoadingIndicatorHandler(handlerProps);
 
-            handler.handler({
+            void handler({
                 type: ExtensionCommandType.ShowLoadingIndicator,
                 payload: {
                     show,
                 },
             });
 
-            expect(dispatch).toHaveBeenCalledWith({
+            expect(handlerProps.dispatch).toHaveBeenCalledWith({
                 type: ExtensionActionType.SHOW_LOADING_INDICATOR,
                 payload: show,
+            });
+        });
+    });
+
+    describe('createReRenderShippingFormHandler', () => {
+        it('reloads checkout and dispatches an action', async () => {
+            jest.spyOn(checkoutService, 'loadCheckout').mockResolvedValue(
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                {} as Promise<CheckoutSelectors>,
+            );
+
+            const { handler } = createReRenderShippingFormHandler(handlerProps);
+
+            await handler({
+                type: ExtensionCommandType.ReRenderShippingForm,
+            });
+
+            expect(checkoutService.loadCheckout).toHaveBeenCalled();
+            expect(handlerProps.dispatch).toHaveBeenCalledWith({
+                type: ExtensionActionType.RE_RENDER_SHIPPING_FORM,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                payload: expect.any(Number),
             });
         });
     });

--- a/packages/checkout-extension/src/handler/commandHandlers/createReRenderShippingFormHandler.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/createReRenderShippingFormHandler.ts
@@ -1,0 +1,27 @@
+import { ExtensionCommandType } from '@bigcommerce/checkout-sdk';
+
+import { ExtensionActionType } from '../../ExtensionProvider';
+
+import { CommandHandler, CommandHandlerProps } from './CommandHandler';
+
+export function createReRenderShippingFormHandler({
+    checkoutService,
+    dispatch,
+}: CommandHandlerProps): CommandHandler<ExtensionCommandType.ReRenderShippingForm> {
+    return {
+        commandType: ExtensionCommandType.ReRenderShippingForm,
+        handler: async () => {
+            await checkoutService.loadCheckout(checkoutService.getState().data.getCheckout()?.id, {
+                params: {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/consistent-type-assertions
+                    include: ['consignments.availableShippingOptions'] as any,
+                },
+            });
+
+            dispatch({
+                type: ExtensionActionType.RE_RENDER_SHIPPING_FORM,
+                payload: Date.now(),
+            });
+        },
+    };
+}

--- a/packages/checkout-extension/src/handler/commandHandlers/index.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/index.ts
@@ -1,3 +1,4 @@
 export { createReloadCheckoutHandler } from './createReloadCheckoutHandler';
 export { createSetIframeStyleHandler } from './createSetIframeStyleHandler';
 export { createShowLoadingIndicatorHandler } from './createShowLoadingIndicatorHandler';
+export { createReRenderShippingFormHandler } from './createReRenderShippingFormHandler';

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -22,6 +22,7 @@ import MultiShippingForm, { MultiShippingFormValues } from './MultiShippingForm'
 import MultiShippingFormV2 from './MultiShippingFormV2';
 import MultiShippingGuestForm from './MultiShippingGuestForm';
 import SingleShippingForm, { SingleShippingFormValues } from './SingleShippingForm';
+import { useExtensions } from '@bigcommerce/checkout/checkout-extension';
 
 export interface ShippingFormProps {
     addresses: CustomerAddress[];
@@ -104,6 +105,10 @@ const ShippingForm = ({
       validateAddressFields,
   }: ShippingFormProps & WithLanguageProps) => {
 
+    const {
+        extensionState: { shippingFormRenderTimestamp },
+    } = useExtensions();
+
     const getMultiShippingForm = () => {
         if (isGuest) {
             return (
@@ -172,6 +177,7 @@ const ShippingForm = ({
             onSubmit={onSingleShippingSubmit}
             onUnhandledError={onUnhandledError}
             shippingAddress={shippingAddress}
+            shippingFormRenderTimestamp={shippingFormRenderTimestamp}
             shouldShowOrderComments={shouldShowOrderComments}
             shouldShowSaveAddress={shouldShowSaveAddress}
             signOut={signOut}

--- a/packages/core/src/app/shipping/ShippingFormFooter.tsx
+++ b/packages/core/src/app/shipping/ShippingFormFooter.tsx
@@ -19,6 +19,7 @@ export interface ShippingFormFooterProps {
     shouldDisableSubmit: boolean;
     isInitialValueLoaded: boolean;
     isLoading: boolean;
+    shippingFormRenderTimestamp?: number;
 }
 
 const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
@@ -29,6 +30,7 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
     shouldDisableSubmit,
     isInitialValueLoaded,
     isLoading,
+    shippingFormRenderTimestamp,
 }) => {
     return (
         <>
@@ -55,6 +57,7 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                     isInitialValueLoaded={isInitialValueLoaded}
                     isMultiShippingMode={isMultiShippingMode}
                     isUpdatingAddress={isLoading}
+                    shippingFormRenderTimestamp={shippingFormRenderTimestamp}
                     shouldShowShippingOptions={shouldShowShippingOptions}
                 />
             </Fieldset>

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -31,6 +31,7 @@ describe('SingleShippingForm', () => {
         isInitialValueLoaded: true,
         isLoading: false,
         isShippingStepPending: false,
+        shippingFormRenderTimestamp: undefined,
         onSubmit: jest.fn(),
         getFields: jest.fn(() => addressFormFields),
         onUnhandledError: jest.fn(),
@@ -236,7 +237,7 @@ describe('SingleShippingForm', () => {
             countries: [],
             getFields: jest.fn(() => []),
         });
-        
+
         rerender(createSingleShippingFormComponent({
             updateAddress,
             isInitialValueLoaded: true,
@@ -360,5 +361,53 @@ describe('SingleShippingForm', () => {
         renderSingleShippingFormComponent({ methodId: 'amazonpay' });
 
         expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
+    });
+
+    it('re-renders itself when shippingFormRenderTimestamp is changed', async () => {
+        const customField = {
+            custom: true,
+            default: 'BigCommerce',
+            id: 'custom',
+            label: 'Custom',
+            name: 'custom',
+            required: false,
+        };
+
+        const { rerender } = renderSingleShippingFormComponent({
+            getFields: () => [...addressFormFields, customField],
+            shippingFormRenderTimestamp: 1,
+        });
+
+        expect(screen.getByTestId('customInput-text')).toHaveValue('BigCommerce');
+
+        rerender(
+            createSingleShippingFormComponent({
+                getFields: () => [
+                    ...addressFormFields,
+                    {
+                        ...customField,
+                        default: 'BigCommerce Sydney',
+                    },
+                ],
+                shippingFormRenderTimestamp: 1,
+            }),
+        );
+
+        expect(screen.getByTestId('customInput-text')).toHaveValue('BigCommerce');
+
+        rerender(
+            createSingleShippingFormComponent({
+                getFields: () => [
+                    ...addressFormFields,
+                    {
+                        ...customField,
+                        default: 'BigCommerce Sydney',
+                    },
+                ],
+                shippingFormRenderTimestamp: 2,
+            }),
+        );
+
+        expect(screen.getByTestId('customInput-text')).toHaveValue('BigCommerce Sydney');
     });
 });

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -59,6 +59,7 @@ export interface SingleShippingFormProps {
     isInitialValueLoaded: boolean;
     validateGoogleMapAutoCompleteMaxLength: boolean;
     validateAddressFields: boolean;
+    shippingFormRenderTimestamp: number | undefined;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
     getFields(countryCode?: string): FormField[];
@@ -87,7 +88,7 @@ interface SingleShippingFormState {
 function shouldHaveCustomValidation(methodId?: string): boolean {
     const methodIdsWithoutCustomValidation: string[] = [
         PaymentMethodId.BraintreeAcceleratedCheckout,
-        PaymentMethodId.PayPalCommerceAcceleratedCheckout
+        PaymentMethodId.PayPalCommerceAcceleratedCheckout,
     ];
 
     return Boolean(methodId && !methodIdsWithoutCustomValidation.includes(methodId));
@@ -135,6 +136,28 @@ class SingleShippingForm extends PureComponent<
             },
             props.shippingAutosaveDelay ?? SHIPPING_AUTOSAVE_DELAY,
         );
+    }
+
+    componentDidUpdate({ shippingFormRenderTimestamp }: SingleShippingFormProps) {
+        const {
+            shippingFormRenderTimestamp: newShippingFormRenderTimestamp,
+            setValues,
+            getFields,
+            shippingAddress,
+            isBillingSameAsShipping,
+            customerMessage,
+        } = this.props;
+
+        if (newShippingFormRenderTimestamp !== shippingFormRenderTimestamp) {
+            setValues({
+                billingSameAsShipping: isBillingSameAsShipping,
+                orderComment: customerMessage,
+                shippingAddress: mapAddressToFormValues(
+                    getFields(shippingAddress && shippingAddress.countryCode),
+                    shippingAddress,
+                ),
+            });
+        }
     }
 
     render(): ReactNode {
@@ -370,7 +393,7 @@ export default withLanguage(
                               language,
                               formFields: getFields(formValues && formValues.countryCode),
                               validateGoogleMapAutoCompleteMaxLength,
-                              validateAddressFields
+                              validateAddressFields,
                           }),
                       ),
                   }),

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -59,7 +59,7 @@ export interface SingleShippingFormProps {
     isInitialValueLoaded: boolean;
     validateGoogleMapAutoCompleteMaxLength: boolean;
     validateAddressFields: boolean;
-    shippingFormRenderTimestamp: number | undefined;
+    shippingFormRenderTimestamp?: number;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     deleteConsignments(): Promise<Address | undefined>;
     getFields(countryCode?: string): FormField[];
@@ -182,6 +182,7 @@ class SingleShippingForm extends PureComponent<
             isShippingStepPending,
             isFloatingLabelEnabled,
             validateAddressFields,
+            shippingFormRenderTimestamp,
         } = this.props;
 
         const { isResettingAddress, isUpdatingShippingData, hasRequestedShippingOptions } =
@@ -229,6 +230,7 @@ class SingleShippingForm extends PureComponent<
                     isInitialValueLoaded={isInitialValueLoaded}
                     isLoading={isLoading || isUpdatingShippingData}
                     isMultiShippingMode={false}
+                    shippingFormRenderTimestamp={shippingFormRenderTimestamp}
                     shouldDisableSubmit={this.shouldDisableSubmit()}
                     shouldShowOrderComments={shouldShowOrderComments}
                     shouldShowShippingOptions={isValid}

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptions.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptions.tsx
@@ -15,6 +15,7 @@ export interface ShippingOptionsProps {
     isMultiShippingMode: boolean;
     isUpdatingAddress?: boolean;
     shouldShowShippingOptions: boolean;
+    shippingFormRenderTimestamp?: number;
 }
 
 export interface WithCheckoutShippingOptionsProps {

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.spec.tsx
@@ -12,7 +12,7 @@ import { CheckoutProvider } from '@bigcommerce/checkout/payment-integration-api'
 import { getCart } from '../../cart/carts.mock';
 import { getConsignment } from '../consignment.mock';
 
-import ShippingOptionsForm, { ShippingOptionsFormProps } from './ShippingOptionsForm';
+import ShippingOptionsForm from './ShippingOptionsForm';
 import ShippingOptionsList from './ShippingOptionsList';
 
 describe('ShippingOptions Component', () => {
@@ -27,7 +27,7 @@ describe('ShippingOptions Component', () => {
         },
     ];
     let triggerConsignmentsUpdated: (state: CheckoutSelectors) => void;
-    const defaultProps: ShippingOptionsFormProps = {
+    const defaultProps = {
         isInitialValueLoaded: true,
         isMultiShippingMode: true,
         consignments,
@@ -40,6 +40,8 @@ describe('ShippingOptions Component', () => {
         }) as any,
         selectShippingOption: jest.fn(() => Promise.resolve()) as any,
         isLoading: jest.fn(() => false),
+        shippingFormRenderTimestamp: undefined,
+        setValues: jest.fn(),
     };
 
     const checkoutService = createCheckoutService();
@@ -68,6 +70,17 @@ describe('ShippingOptions Component', () => {
         expect(component.find(ShippingOptionsList)).toHaveLength(2);
 
         expect(component.find('.shippingOptions-panel-message')).toHaveLength(0);
+    });
+
+    it('does not reset the form when shippingFormRenderTimestamp is undefined', async () => {
+        const component = mount(
+            <TestWrap>
+                <ShippingOptionsForm {...defaultProps} />
+            </TestWrap>,
+        );
+
+        expect(component.find(ShippingOptionsList)).toHaveLength(2);
+        expect(defaultProps.setValues).not.toHaveBeenCalled();
     });
 
     it('selects default shipping option once per consignment when updated consignment has no shipping option', async () => {


### PR DESCRIPTION
## What?
Introduce a new checkout extension command.

## Why?
To support the force re-rendering of the shipping form.

## Out of the scope
Displaying an external change to the Google AutoComplete address field (address line one when enabled) is not supported, as its value is managed by the Downshift library.

## Testing / Proof

*Clicking on the emoji triggers the `ReRenderShippingForm` command.

### Update Shipping Form Fields
The update to the delivery date form field on another page is applied once the command is triggered.

https://github.com/user-attachments/assets/3113abbf-a662-4a22-bae5-c7f779266b75

### Update Selected Shipping Option

https://github.com/user-attachments/assets/063640fc-0a7d-4c8f-bbbe-a492476df4c0

### Multi-shipping
The update to the shipping option on another page is applied once the command is triggered.

https://github.com/user-attachments/assets/39d4f152-f549-41f3-854b-c53b8bfab41a


