### PR TITLE
test(checkout): CHECKOUT-9007 Guest Checkout Shipping Step Happy Path

### DIFF
--- a/packages/core/src/app/checkout/index.ts
+++ b/packages/core/src/app/checkout/index.ts
@@ -3,4 +3,3 @@ export { default as withCheckout, WithCheckoutProps } from './withCheckout';
 export { default as CheckoutSupport } from './CheckoutSupport';
 export { default as NoopCheckoutSupport } from './NoopCheckoutSupport';
 export { default as navigateToOrderConfirmation } from './navigateToOrderConfirmation';
-export { default as Checkout, CheckoutProps } from './Checkout';

--- a/packages/core/src/app/checkout/index.ts
+++ b/packages/core/src/app/checkout/index.ts
@@ -3,3 +3,4 @@ export { default as withCheckout, WithCheckoutProps } from './withCheckout';
 export { default as CheckoutSupport } from './CheckoutSupport';
 export { default as NoopCheckoutSupport } from './NoopCheckoutSupport';
 export { default as navigateToOrderConfirmation } from './navigateToOrderConfirmation';
+export { default as Checkout, CheckoutProps } from './Checkout';

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -30,7 +30,7 @@ import {
 } from '@bigcommerce/checkout/test-framework';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
-import { Checkout, CheckoutProps } from '../checkout';
+import Checkout, { CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
 import {
     createEmbeddedCheckoutStylesheet,

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -176,6 +176,8 @@ describe('Checkout', () => {
 
             expect(checkoutService.updateBillingAddress).toHaveBeenCalled();
             expect(screen.getByText(payments[0].config.displayName)).toBeInTheDocument();
+
+            jest.unmock('lodash');
         });
     });
 });

--- a/packages/core/src/app/shipping/ShippingComponent.test.tsx
+++ b/packages/core/src/app/shipping/ShippingComponent.test.tsx
@@ -1,0 +1,258 @@
+import '@testing-library/jest-dom';
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+} from '@bigcommerce/checkout-sdk';
+import userEvent from '@testing-library/user-event';
+import React, { FunctionComponent } from 'react';
+
+import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+} from '@bigcommerce/checkout/locale';
+import { CheckoutProvider, PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
+import { render, screen, within } from '@bigcommerce/checkout/test-utils';
+
+import { getAddressFormFields } from '../address/formField.mock';
+import { getCart } from '../cart/carts.mock';
+import { getPhysicalItem } from '../cart/lineItem.mock';
+import { getCheckout } from '../checkout/checkouts.mock';
+import CheckoutStepType from '../checkout/CheckoutStepType';
+import { getStoreConfig } from '../config/config.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getConsignment } from '../shipping/consignment.mock';
+
+import Shipping, { ShippingProps, WithCheckoutShippingProps } from './Shipping';
+import { getShippingAddress } from './shipping-addresses.mock';
+
+describe('Shipping component', () => {
+    let localeContext: LocaleContextType;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: ShippingProps;
+    let ComponentTest: FunctionComponent<ShippingProps> & Partial<WithCheckoutShippingProps>;
+
+    beforeEach(() => {
+        localeContext = createLocaleContext(getStoreConfig());
+        checkoutService = createCheckoutService();
+
+        checkoutState = checkoutService.getState();
+
+        defaultProps = {
+            isBillingSameAsShipping: true,
+            isMultiShippingMode: false,
+            onToggleMultiShipping: jest.fn(),
+            cartHasChanged: false,
+            onSignIn: jest.fn(),
+            step: {
+                isActive: true,
+                isComplete: true,
+                isEditable: true,
+                isRequired: true,
+                type: CheckoutStepType.Shipping
+            },
+            providerWithCustomCheckout: PaymentMethodId.StripeUPE,
+            isShippingMethodLoading: true,
+            navigateNextStep: jest.fn(),
+            onUnhandledError: jest.fn(),
+        };
+
+        jest.spyOn(checkoutService, 'loadShippingAddressFields').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        jest.spyOn(checkoutService, 'loadBillingAddressFields').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        jest.spyOn(checkoutService, 'loadShippingOptions').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        jest.spyOn(checkoutService, 'deleteConsignment').mockResolvedValue({} as CheckoutSelectors);
+
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+            ...getCart(),
+            lineItems: {
+                ...getCart().lineItems,
+                physicalItems: [
+                    {
+                        ...getPhysicalItem(),
+                        quantity: 3,
+                    },
+                ],
+            },
+        } as Cart);
+
+        jest.spyOn(checkoutState.data, 'getShippingAddress').mockReturnValue(getShippingAddress());
+
+        jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(undefined);
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+
+        jest.spyOn(checkoutState.data, 'getShippingAddressFields').mockReturnValue(
+            getAddressFormFields(),
+        );
+
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+            ...getCustomer(),
+            addresses: [],
+        });
+
+        jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([getConsignment()]);
+
+        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
+
+        jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+        jest.spyOn(checkoutService, 'updateCheckout').mockResolvedValue({} as CheckoutSelectors);
+        jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
+            {} as CheckoutSelectors,
+        );
+
+        ComponentTest = (props) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <ExtensionProvider checkoutService={checkoutService}>
+                        <Shipping {...props} />
+                    </ExtensionProvider>
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+
+    describe('when new multishipping ui is enabled', () => {
+        beforeEach(async () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                ...getStoreConfig(),
+                checkoutSettings: {
+                    ...getStoreConfig().checkoutSettings,
+                    hasMultiShippingEnabled: true,
+                    features: {
+                        ...getStoreConfig().checkoutSettings.features,
+                        "PROJECT-4159.improve_multi_address_shipping_ui": true,
+                    },
+                },
+            });
+        });
+
+        it('opens confirmation dialog on clicking the link and calls onToggleMultiShipping when confirm is clicked', async () => {
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
+
+            const shippingModeToggle = await screen.findByTestId("shipping-mode-toggle");
+
+            expect(shippingModeToggle.innerHTML).toBe('Ship to a single address');
+
+            await userEvent.click(shippingModeToggle);
+
+            const confirmationModal = await screen.findByRole('dialog');
+
+            expect(confirmationModal).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.ship_to_single_action'))).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.ship_to_single_message'))).toBeInTheDocument();
+
+            await userEvent.click(within(confirmationModal).getByText(localeContext.language.translate('common.proceed_action')));
+
+            expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
+        });
+
+        it('opens information dialog on clicking `ship to multiple address` when promotional item is present in the cart', async () => {
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 3,
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            id: '123',
+                            quantity: 1,
+                            addedByPromotion: true,
+                        }
+                    ],
+                },
+            } as Cart);
+            
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={false} />);
+
+            const shippingModeToggle = await screen.findByTestId("shipping-mode-toggle");
+
+            expect(shippingModeToggle.innerHTML).toBe(localeContext.language.translate('shipping.ship_to_multi'));
+
+            await userEvent.click(shippingModeToggle);
+
+            const confirmationModal = await screen.findByRole('dialog');
+
+            expect(confirmationModal).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.multishipping_unavailable_action'))).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.multishipping_unavailable_message'))).toBeInTheDocument();
+
+            await userEvent.click(within(confirmationModal).getByText(localeContext.language.translate('common.back_action')));
+
+            expect(defaultProps.onToggleMultiShipping).not.toHaveBeenCalled();
+        });
+
+        it('opens information dialog on mount and when multishipping mode is ON and promotional item is present in the cart', async () => {
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            quantity: 3,
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            id: '123',
+                            quantity: 1,
+                            addedByPromotion: true,
+                        }
+                    ],
+                },
+            } as Cart);
+            
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={true} />);
+
+            const confirmationModal = await screen.findByRole('dialog');
+
+            expect(confirmationModal).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.multishipping_unavailable_action'))).toBeInTheDocument();
+            expect(within(confirmationModal).getByText(localeContext.language.translate('shipping.checkout_switched_to_single_shipping'))).toBeInTheDocument();
+
+            await userEvent.click(within(confirmationModal).getByText(localeContext.language.translate('common.ok_action')));
+
+            expect(defaultProps.onToggleMultiShipping).toHaveBeenCalled();
+        });
+
+        it('does not show `ship to multiple address` if only 1 bundled product is present in the cart', async () => {
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            id: '123',
+                            parentId: getPhysicalItem().id,
+                        }
+                    ],
+                },
+            } as Cart);
+
+            render(<ComponentTest {...defaultProps} isMultiShippingMode={false} />);
+
+            expect(screen.queryByTestId("shipping-mode-toggle")).not.toBeInTheDocument();
+        });
+    });
+});

--- a/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
+++ b/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
@@ -1,5 +1,6 @@
 import { Checkout } from '@bigcommerce/checkout-sdk';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { RequestHandler, rest } from 'msw';
 import { SetupServer, setupServer } from 'msw/node';
 
@@ -20,8 +21,10 @@ import {
     checkoutWithShipping,
     checkoutWithShippingAndBilling,
     countries,
+    customer,
     formFields,
     payments,
+    shippingAddress,
 } from './mocks';
 
 export class CheckoutPageNodeObject {
@@ -205,5 +208,20 @@ export class CheckoutPageNodeObject {
 
     async waitForPaymentStep(): Promise<void> {
         await waitFor(() => screen.getByText(/place order/i));
+    }
+
+    async fillShippingAddress(): Promise<void> {
+        await userEvent.type(await screen.findByLabelText('First Name'), customer.firstName);
+        await userEvent.type(screen.getByLabelText('Last Name'), customer.lastName);
+        await userEvent.type(
+            screen.getByRole('textbox', { name: /address/i }),
+            shippingAddress.address1,
+        );
+        await userEvent.type(screen.getByLabelText('City'), shippingAddress.city);
+        await userEvent.selectOptions(
+            screen.getByTestId('countryCodeInput-select'),
+            shippingAddress.countryCode,
+        );
+        await userEvent.type(screen.getByLabelText('Postal Code'), shippingAddress.postalCode);
     }
 }

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
@@ -1,4 +1,4 @@
-import { Checkout, Consignment, PhysicalItem } from '@bigcommerce/checkout-sdk';
+import { Checkout, Consignment, Customer, PhysicalItem } from '@bigcommerce/checkout-sdk';
 
 const timeString = new Date().toISOString();
 
@@ -40,7 +40,7 @@ const shippingAddress1 = {
     city: 'Cityville',
     stateOrProvince: 'State',
     stateOrProvinceCode: 'ST',
-    country: 'Country',
+    country: 'Dummy Country Name',
     countryCode: 'CC',
     postalCode: '10000',
     phone: '0000000000',
@@ -127,6 +127,35 @@ const consignment: Consignment = {
             additionalDescription: '',
         },
     ],
+};
+
+const customer: Customer = {
+    id: 1,
+    isGuest: false,
+    email: 'user@example.com',
+    firstName: 'John',
+    lastName: 'Doe',
+    fullName: 'John Doe',
+    addresses: [
+        {
+            ...shippingAddress1,
+            id: 1,
+        },
+        {
+            id: 2,
+            ...shippingAddress2,
+        },
+        {
+            id: 3,
+            ...shippingAddress3,
+        },
+    ],
+    storeCredit: 0,
+    shouldEncourageSignIn: true,
+    customerGroup: {
+        id: 1,
+        name: 'Discount Group',
+    },
 };
 
 const checkout: Checkout = {
@@ -256,9 +285,9 @@ const checkoutWithShippingAndBilling: Checkout = {
     ...checkoutWithShipping,
     billingAddress: {
         id: 'billing-address-id',
-        firstName: 'checkout',
-        lastName: 'test',
-        email: 'test@example.com',
+        firstName: customer.firstName,
+        lastName: customer.lastName,
+        email: customer.email,
         company: '',
         address1: '130 Pitt St',
         address2: '',
@@ -305,34 +334,7 @@ const checkoutWithMultiShippingCart = {
             ],
         },
     },
-    customer: {
-        id: 1,
-        isGuest: false,
-        email: 'user@example.com',
-        firstName: 'John',
-        lastName: 'Doe',
-        fullName: 'John Doe',
-        addresses: [
-            {
-                ...shippingAddress1,
-                id: 1,
-            },
-            {
-                id: 2,
-                ...shippingAddress2,
-            },
-            {
-                id: 3,
-                ...shippingAddress3,
-            },
-        ],
-        storeCredit: 0,
-        shouldEncourageSignIn: true,
-        customerGroup: {
-            id: 1,
-            name: 'Discount Group',
-        },
-    },
+    customer,
     consignment: [],
 };
 
@@ -361,6 +363,8 @@ export {
     checkoutWithShipping,
     checkoutWithShippingAndBilling,
     consignment,
+    customer,
+    shippingAddress1 as shippingAddress,
     shippingAddress2,
     shippingAddress3,
 };

--- a/packages/test-framework/src/react-testing-library-support/mocks/countries.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/countries.ts
@@ -3,8 +3,8 @@ const countries = {
     data: [
         {
             id: 1,
-            code: 'AF',
-            name: 'Afghanistan',
+            code: 'CC',
+            name: 'Dummy Country Name',
             hasPostalCodes: true,
             requiresState: false,
             subdivisions: [],


### PR DESCRIPTION
## What?
Add a test for the happy path of the Guest Checkout Shipping step.

Test path:
- Entering the shipping step as a guest.
- Filling in essential address details.
- Triggering two API calls: a POST call to create a consignment and a PUT call to select the default shipping option.
- Asserting that “billing address is the same as shipping” is checked.
- Clicking “Entering” goes to the payment step.

## Why?
Enable us to upgrade to react 18.

## Testing / Proof
CI.