### PR TITLE
test(checkout): CHECKOUT-9030 Single Shipping for customer with no saved addresses

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -20,4 +20,5 @@ module.exports = {
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
     snapshotSerializers: ['enzyme-to-json/serializer'],
+    testTimeout: 10000,
 };

--- a/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
+++ b/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
@@ -16,6 +16,7 @@ import {
     checkoutWithBillingEmail,
     checkoutWithCustomShippingAndBilling,
     checkoutWithDigitalCart,
+    checkoutWithLoggedInCustomer,
     checkoutWithMultiShippingCart,
     checkoutWithPromotions,
     checkoutWithShipping,
@@ -125,6 +126,14 @@ export class CheckoutPageNodeObject {
                                 ],
                             }),
                         ),
+                    ),
+                );
+                break;
+
+            case CheckoutPreset.CheckoutWithLoggedInCustomer:
+                this.server.use(
+                    rest.get('/api/storefront/checkout/*', (_, res, ctx) =>
+                        res(ctx.json(checkoutWithLoggedInCustomer)),
                     ),
                 );
                 break;

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
@@ -159,15 +159,8 @@ const customer: Customer = {
 };
 
 const customerWithoutSavedAddresses: Customer = {
-    id: 1,
-    isGuest: false,
-    email: 'user@example.com',
-    firstName: 'John',
-    lastName: 'Doe',
-    fullName: 'John Doe',
+    ...customer,
     addresses: [],
-    storeCredit: 0,
-    shouldEncourageSignIn: true,
 };
 
 const checkout: Checkout = {

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
@@ -158,6 +158,18 @@ const customer: Customer = {
     },
 };
 
+const customerWithoutSavedAddresses: Customer = {
+    id: 1,
+    isGuest: false,
+    email: 'user@example.com',
+    firstName: 'John',
+    lastName: 'Doe',
+    fullName: 'John Doe',
+    addresses: [],
+    storeCredit: 0,
+    shouldEncourageSignIn: true,
+};
+
 const checkout: Checkout = {
     id: 'xxxxxxxxxx-xxxx-xxax-xxxx-xxxxxx',
     cart: {
@@ -338,6 +350,15 @@ const checkoutWithMultiShippingCart = {
     consignment: [],
 };
 
+const checkoutWithLoggedInCustomer: Checkout = {
+    ...checkoutWithBillingEmail,
+    cart: {
+        ...checkout.cart,
+        customerId: customerWithoutSavedAddresses.id,
+    },
+    customer: customerWithoutSavedAddresses,
+};
+
 enum CheckoutPreset {
     CheckoutWithBillingEmail = 'CheckoutWithBillingEmail',
     CheckoutWithBillingEmailAndCustomFormFields = 'CheckoutWithBillingEmailAndCustomFormFields',
@@ -351,6 +372,7 @@ enum CheckoutPreset {
     ErrorFlashMessage = 'ErrorFlashMessage',
     UnsupportedProvider = 'UnsupportedProvider',
     RemoteProviders = 'RemoteProviders',
+    CheckoutWithLoggedInCustomer = 'CheckoutWithLoggedInCustomer',
 }
 
 export {
@@ -365,6 +387,8 @@ export {
     checkoutWithShippingAndBilling,
     consignment,
     customer,
+    customerWithoutSavedAddresses,
+    checkoutWithLoggedInCustomer,
     shippingAddress1 as shippingAddress,
     shippingAddress2,
     shippingAddress3,


### PR DESCRIPTION
## What?
Add RTL test for single shipping for logged in customer with no saved addresses. 

**Test path:**

- Enter the shipping step as a logged in customer.
- Fill in essential address details in the form.
- Verify the `Save this address in my address book` checkbox is present and selected.
- Click “Continue” to proceed to the payment step.

## Why?
In order to be able to move all the enzyme tests to RTL which enables us to move to React 18

## Testing / Proof

- CI checks

@bigcommerce/team-checkout
