### PR TITLE
test(checkout): CHECKOUT-8932 Add tests for single shipping form for customer with saved addresses

### DIFF
--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -416,7 +416,7 @@ describe('Shipping step', () => {
             expect(screen.getByText(payments[0].config.displayName)).toBeInTheDocument();
         });
 
-        it('selects the invalid customer address and completes the shipping step', async () => {
+        it('selects the invalid customer address, fills the address form and finally completes the shipping step', async () => {
             checkout.use(CheckoutPreset.CheckoutWithCustomerHavingInvalidAddress);
 
             const { container } = render(<CheckoutTest {...defaultProps} />);
@@ -470,7 +470,6 @@ describe('Shipping step', () => {
 
             expect(checkoutService.updateShippingAddress).toHaveBeenCalled();
 
-            // screen.debug(undefined, Infinity);
             expect(
                 screen.getByRole('radio', { name: 'Pickup In Store $3.00' }),
             ).toBeInTheDocument();

--- a/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
+++ b/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
@@ -14,6 +14,7 @@ import {
     checkoutSettingsWithRemoteProviders,
     checkoutSettingsWithUnsupportedProvider,
     checkoutWithBillingEmail,
+    checkoutWithCustomerHavingInvalidAddress,
     checkoutWithCustomShippingAndBilling,
     checkoutWithDigitalCart,
     checkoutWithLoggedInCustomer,
@@ -134,6 +135,14 @@ export class CheckoutPageNodeObject {
                 this.server.use(
                     rest.get('/api/storefront/checkout/*', (_, res, ctx) =>
                         res(ctx.json(checkoutWithLoggedInCustomer)),
+                    ),
+                );
+                break;
+
+            case CheckoutPreset.CheckoutWithCustomerHavingInvalidAddress:
+                this.server.use(
+                    rest.get('/api/storefront/checkout/*', (_, res, ctx) =>
+                        res(ctx.json(checkoutWithCustomerHavingInvalidAddress)),
                     ),
                 );
                 break;

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
@@ -326,8 +326,8 @@ const checkoutWithCustomShippingAndBilling = {
     ],
 };
 
-const checkoutWithMultiShippingCart = {
-    ...checkout,
+const checkoutWithMultiShippingCart: Checkout = {
+    ...checkoutWithBillingEmail,
     cart: {
         ...checkout.cart,
         lineItems: {
@@ -352,6 +352,27 @@ const checkoutWithLoggedInCustomer: Checkout = {
     customer: customerWithoutSavedAddresses,
 };
 
+const checkoutWithCustomerHavingInvalidAddress: Checkout = {
+    ...checkoutWithBillingEmail,
+    cart: {
+        ...checkout.cart,
+        customerId: customerWithoutSavedAddresses.id,
+    },
+    customer: {
+        ...customer,
+        addresses: [
+            ...customer.addresses,
+            {
+                id: 4,
+                ...shippingAddress1,
+                firstName: 'Fourth',
+                lastName: 'Address',
+                address1: '',
+            },
+        ],
+    },
+};
+
 enum CheckoutPreset {
     CheckoutWithBillingEmail = 'CheckoutWithBillingEmail',
     CheckoutWithBillingEmailAndCustomFormFields = 'CheckoutWithBillingEmailAndCustomFormFields',
@@ -366,6 +387,7 @@ enum CheckoutPreset {
     UnsupportedProvider = 'UnsupportedProvider',
     RemoteProviders = 'RemoteProviders',
     CheckoutWithLoggedInCustomer = 'CheckoutWithLoggedInCustomer',
+    CheckoutWithCustomerHavingInvalidAddress = 'CheckoutWithCustomerHavingInvalidAddress',
 }
 
 export {
@@ -382,6 +404,7 @@ export {
     customer,
     customerWithoutSavedAddresses,
     checkoutWithLoggedInCustomer,
+    checkoutWithCustomerHavingInvalidAddress,
     shippingAddress1 as shippingAddress,
     shippingAddress2,
     shippingAddress3,


### PR DESCRIPTION
## What?
Create Tests for Customer's Single Shipping Use Cases with Saved Addresses.

## Why?
In order to be able to move all the enzyme tests to RTL which enables us to move to React 18.

## Testing / Proof

- CI checks

@bigcommerce/team-checkout
