### PR TITLE
chore(payment): PAYPAL-5201 Bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.712.0",
+        "@bigcommerce/checkout-sdk": "^1.713.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.712.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.712.0.tgz",
-      "integrity": "sha512-kjGrB/LjY6kCRcLE1trzltPCnUSpPLx7MEl1Dr/sb8RPUcG9HPBrzuBHsAyw5PXosVbQeNv2QGJHxtV0grm6fQ==",
+      "version": "1.713.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.0.tgz",
+      "integrity": "sha512-ywC5XgSTY4ov9gxjFJiPp2JlX9X0QLQGn3VqZn2Y1AD576+wuqTjntXR11tRF0AG+S5AsdtvmqQKKfoTQe5Dsg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35077,9 +35077,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.712.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.712.0.tgz",
-      "integrity": "sha512-kjGrB/LjY6kCRcLE1trzltPCnUSpPLx7MEl1Dr/sb8RPUcG9HPBrzuBHsAyw5PXosVbQeNv2QGJHxtV0grm6fQ==",
+      "version": "1.713.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.0.tgz",
+      "integrity": "sha512-ywC5XgSTY4ov9gxjFJiPp2JlX9X0QLQGn3VqZn2Y1AD576+wuqTjntXR11tRF0AG+S5AsdtvmqQKKfoTQe5Dsg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.712.0",
+    "@bigcommerce/checkout-sdk": "^1.713.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2798
https://github.com/bigcommerce/checkout-sdk-js/pull/2791

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
