### PR TITLE
chore(checkout): CHECKOUT-9052 Display correct error heading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.713.1",
+        "@bigcommerce/checkout-sdk": "^1.713.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.713.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.1.tgz",
-      "integrity": "sha512-O/eX+1BIdtdhiB7cmGzxDyYZnehWfgdaQOKzSD8ZujI5wAJMI2rzH7Qq1c7eggoj3lJckm+3/xG7vYxZ145jBA==",
+      "version": "1.713.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.2.tgz",
+      "integrity": "sha512-MqAOcDtgjyv4XT4lw2vxyC9dPIHy0eGjRaez+woHDm9wHgjuSdBTWgaTscUfXRIEsRU3/IM7Vj2ZOOG5aM8oBA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35077,9 +35077,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.713.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.1.tgz",
-      "integrity": "sha512-O/eX+1BIdtdhiB7cmGzxDyYZnehWfgdaQOKzSD8ZujI5wAJMI2rzH7Qq1c7eggoj3lJckm+3/xG7vYxZ145jBA==",
+      "version": "1.713.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.2.tgz",
+      "integrity": "sha512-MqAOcDtgjyv4XT4lw2vxyC9dPIHy0eGjRaez+woHDm9wHgjuSdBTWgaTscUfXRIEsRU3/IM7Vj2ZOOG5aM8oBA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.713.1",
+    "@bigcommerce/checkout-sdk": "^1.713.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.spec.ts
@@ -291,4 +291,15 @@ describe('mapSubmitOrderErrorTitle()', () => {
 
         expect(title).toEqual(translate('common.error_heading'));
     });
+
+    it('returns correct title when error type is not "missing_shipping_method"', () => {
+        const title = mapSubmitOrderErrorTitle(
+            {
+                type: 'missing_shipping_method',
+            },
+            translate,
+        );
+
+        expect(title).toEqual(translate('common.missing_shipping_method_heading'));
+    });
 });

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -71,5 +71,9 @@ export function mapSubmitOrderErrorTitle(
         return translate('common.unavailable_heading');
     }
 
+    if (error.type === 'missing_shipping_method') {
+        return translate('common.missing_shipping_method_heading');
+    }
+
     return translate('common.error_heading');
 }

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -94,6 +94,7 @@
             "error_heading": "Something's gone wrong",
             "leave_warning": "Are you sure you want to leave? Data you have entered may not be saved.",
             "loading_text": "Loading",
+            "missing_shipping_method_heading": "Missing shipping method",
             "ok_action": "Ok",
             "error_code": "Error code:",
             "request_id": "Request ID:",


### PR DESCRIPTION
## What?
Display correct error heading for missing shipping method.

## Why?
Display correct error heading for missing shipping method if shipping method is invalid.

## Testing / Proof
- CI 
- Screenshot

![Screenshot 2025-03-06 at 1 49 16 pm](https://github.com/user-attachments/assets/1b1d157d-5ace-47e6-9485-6da35499dd76)


@bigcommerce/team-checkout
