### PR TITLE
chore(payment): PAYPAL-5213 bump checkout-sdk version (1.714.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.713.2",
+        "@bigcommerce/checkout-sdk": "^1.714.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.713.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.2.tgz",
-      "integrity": "sha512-MqAOcDtgjyv4XT4lw2vxyC9dPIHy0eGjRaez+woHDm9wHgjuSdBTWgaTscUfXRIEsRU3/IM7Vj2ZOOG5aM8oBA==",
+      "version": "1.714.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.714.0.tgz",
+      "integrity": "sha512-ezKfRk+VWy5bAPDUUmfhLdy6CN4hVgAUoMtFuE+n7ZzxBKc1rnWjgAJUF7IUPmlXGAZO2qyzrjqC6vX8gq3TPg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35077,9 +35077,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.713.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.713.2.tgz",
-      "integrity": "sha512-MqAOcDtgjyv4XT4lw2vxyC9dPIHy0eGjRaez+woHDm9wHgjuSdBTWgaTscUfXRIEsRU3/IM7Vj2ZOOG5aM8oBA==",
+      "version": "1.714.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.714.0.tgz",
+      "integrity": "sha512-ezKfRk+VWy5bAPDUUmfhLdy6CN4hVgAUoMtFuE+n7ZzxBKc1rnWjgAJUF7IUPmlXGAZO2qyzrjqC6vX8gq3TPg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.713.2",
+    "@bigcommerce/checkout-sdk": "^1.714.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
As part of release: https://github.com/bigcommerce/checkout-sdk-js/pull/2801

## Testing / Proof
Unit tests
Manual tests

US VPN location:
<img width="522" alt="Screenshot 2025-03-06 at 10 32 18" src="https://github.com/user-attachments/assets/67f0d603-9d2d-422e-9415-ad231b0ada3d" />

Non US VPN location:
<img width="549" alt="Screenshot 2025-03-06 at 10 32 34" src="https://github.com/user-attachments/assets/bd693818-ea52-4291-ba83-677d948bad15" />
