### PR TITLE
chore(checkout): CHECKOUT-9032 Small fix of missing shipping method error heading

### DIFF
--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -94,7 +94,7 @@
             "error_heading": "Something's gone wrong",
             "leave_warning": "Are you sure you want to leave? Data you have entered may not be saved.",
             "loading_text": "Loading",
-            "missing_shipping_method_heading": "Missing shipping method",
+            "missing_shipping_method_heading": "Shipping method unavailable",
             "ok_action": "Ok",
             "error_code": "Error code:",
             "request_id": "Request ID:",


### PR DESCRIPTION
## What?
Small fix of missing shipping method error heading
from "Missing shipping method" to "Shipping method unavailable"

## Why?
to make it more clear shipping method is unavailable even shopper selected it before.

## Testing / Proof
vm:
<img width="864" alt="Screenshot 2025-03-12 at 1 36 05 PM" src="https://github.com/user-attachments/assets/32b18895-f084-4cc8-afde-1eaa0f2e33da" />


@bigcommerce/team-checkout
