### PR TITLE
test(checkout): CHECKOUT-8931 Convert Enzyme Tests in storeCredit

### DIFF
--- a/packages/core/src/app/payment/storeCredit/StoreCreditOverlay.test.tsx
+++ b/packages/core/src/app/payment/storeCredit/StoreCreditOverlay.test.tsx
@@ -1,8 +1,8 @@
 import { LanguageService } from '@bigcommerce/checkout-sdk';
-import { mount, shallow } from 'enzyme';
 import React from 'react';
 
 import { createLocaleContext, LocaleContext, LocaleContextType } from '@bigcommerce/checkout/locale';
+import {render, screen} from '@bigcommerce/checkout/test-utils';
 
 import { getStoreConfig } from '../../config/config.mock';
 
@@ -18,20 +18,19 @@ describe('StoreCreditOverlay', () => {
     });
 
     it('displays "payment is not required" text', () => {
-        const component = mount(
+        render(
             <LocaleContext.Provider value={localeContext}>
                 <StoreCreditOverlay />
             </LocaleContext.Provider>,
         );
 
-        expect(component.text()).toEqual(
-            languageService.translate('payment.payment_not_required_text'),
-        );
+        expect(screen.getByText(languageService.translate('payment.payment_not_required_text'))).toBeInTheDocument();
     });
 
     it('renders component with expected class', () => {
-        const component = shallow(<StoreCreditOverlay />);
+        const { container } = render(<StoreCreditOverlay />);
 
-        expect(component.hasClass('storeCreditOverlay')).toBe(true);
+        // eslint-disable-next-line testing-library/no-container
+        expect(container.querySelector('.storeCreditOverlay')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## What?
Convert Enzyme Tests in `Payment/creditCard` folder.

Coverage 100%
![Screenshot 2025-03-12 at 15 09 58](https://github.com/user-attachments/assets/c9228dc8-a650-4597-8d82-6a98fcff883e)

## Why?
Enable us to upgrade to react 19.

## Testing / Proof
CI.

@bigcommerce/team-checkout
