### PR TITLE
chore(payment): PAYPAL-5097 bump checkout-sdk to 1.715.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.714.0",
+        "@bigcommerce/checkout-sdk": "^1.715.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.714.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.714.0.tgz",
-      "integrity": "sha512-ezKfRk+VWy5bAPDUUmfhLdy6CN4hVgAUoMtFuE+n7ZzxBKc1rnWjgAJUF7IUPmlXGAZO2qyzrjqC6vX8gq3TPg==",
+      "version": "1.715.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.715.0.tgz",
+      "integrity": "sha512-yQbUbjhKJvRAC2C8Cxa1pfntw6sIY3J+mzlqzrxdv97kC9GfwC4aMUay23bMmDxmQ2UJ164BQlvq4SEXzZPxTw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35077,9 +35077,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.714.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.714.0.tgz",
-      "integrity": "sha512-ezKfRk+VWy5bAPDUUmfhLdy6CN4hVgAUoMtFuE+n7ZzxBKc1rnWjgAJUF7IUPmlXGAZO2qyzrjqC6vX8gq3TPg==",
+      "version": "1.715.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.715.0.tgz",
+      "integrity": "sha512-yQbUbjhKJvRAC2C8Cxa1pfntw6sIY3J+mzlqzrxdv97kC9GfwC4aMUay23bMmDxmQ2UJ164BQlvq4SEXzZPxTw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.714.0",
+    "@bigcommerce/checkout-sdk": "^1.715.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout-sdk to 1.715.0

## Why?
As part of release: https://github.com/bigcommerce/checkout-sdk-js/pull/2808

## Testing / Proof
Unit tests
Manual tests
CI
