### PR TITLE
fix(checkout): CHECKOUT-9086 add available shipping option check

### DIFF
--- a/packages/core/src/app/shipping/MultiShippingForm.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.tsx
@@ -15,6 +15,7 @@ import MultiShippingFormFooter from './MultiShippingFormFooter';
 import { MultiShippingConsignmentData } from './MultishippingType';
 import './MultiShippingForm.scss';
 import NewConsignment from './NewConsignment';
+import isSelectedShippingOptionValid from './isSelectedShippingOptionValid';
 
 export interface MultiShippingFormValues {
     orderComment: string;
@@ -55,7 +56,7 @@ const MultiShippingForm: FunctionComponent<MultiShippingFormProps> = ({
 
     const isEveryConsignmentHasShippingOption = hasSelectedShippingOptions(consignments);
     const shouldDisableSubmit = useMemo(() => {
-        return isLoading || !!unassignedLineItems.length || !isEveryConsignmentHasShippingOption;
+        return isLoading || !!unassignedLineItems.length || !isEveryConsignmentHasShippingOption || !isSelectedShippingOptionValid(consignments);
     }, [isLoading, consignments]);
 
     if (!config) {

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -37,6 +37,7 @@ import hasSelectedShippingOptions from './hasSelectedShippingOptions';
 import ShippingAddress from './ShippingAddress';
 import { SHIPPING_ADDRESS_FIELDS } from './ShippingAddressFields';
 import ShippingFormFooter from './ShippingFormFooter';
+import isSelectedShippingOptionValid from './isSelectedShippingOptionValid';
 
 export interface SingleShippingFormProps {
     addresses: CustomerAddress[];
@@ -244,7 +245,7 @@ class SingleShippingForm extends PureComponent<
             return false;
         }
 
-        return isLoading || isUpdatingShippingData || !hasSelectedShippingOptions(consignments);
+        return isLoading || isUpdatingShippingData || !hasSelectedShippingOptions(consignments) || !isSelectedShippingOptionValid(consignments);
     };
 
     private handleFieldChange: (name: string) => void = async (name) => {

--- a/packages/core/src/app/shipping/index.ts
+++ b/packages/core/src/app/shipping/index.ts
@@ -7,3 +7,4 @@ export { default as hasSelectedShippingOptions } from './hasSelectedShippingOpti
 export { default as hasUnassignedLineItems } from './hasUnassignedLineItems';
 export { default as isUsingMultiShipping } from './isUsingMultiShipping';
 export { default as itemsRequireShipping } from './itemsRequireShipping';
+export { default as isSelectedShippingOptionValid } from './isSelectedShippingOptionValid';

--- a/packages/core/src/app/shipping/isSelectedShippingOptionValid.ts
+++ b/packages/core/src/app/shipping/isSelectedShippingOptionValid.ts
@@ -1,0 +1,17 @@
+import { Consignment } from '@bigcommerce/checkout-sdk';
+import { every } from 'lodash';
+
+export default function isSelectedShippingOptionValid(consignments: Consignment[]): boolean {
+    if (!consignments.length) {
+        return false;
+    }
+
+    return every(
+        consignments,
+        (consignment) =>
+        (consignment.availableShippingOptions &&
+            consignment.availableShippingOptions.filter(
+                ({ id }) => id === consignment.selectedShippingOption?.id,
+            ).length)
+    );
+}


### PR DESCRIPTION
## What?
Fix: If checkout has selected shipping method, but the shipping option id is not in available shipping methods list, on the UI the there is no shipping method selected, but shopper can just ignore and continue to the next step.

## Why?
We should block shopper continue to the next step if selected shipping option is not present in the list of available shipping options.

## Testing / Proof

- CI checks
- Manual testing proof [(here)](https://github.com/bigcommerce/checkout-js/pull/2213#issuecomment-2742011710)

@bigcommerce/team-checkout
