### PR TITLE
fix(payment): STRIPE-696 Remove browser alert before Stripe UPE iDEAL redirect

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -321,7 +321,7 @@ class Payment extends Component<
         const { defaultMethod, isSubmittingOrder, language } = this.props;
         const { selectedMethod = defaultMethod } = this.state;
 
-        // TODO: Perhaps there is a better way to handle `adyen`, `afterpay`, `amazonpay`,
+        // TODO: [PI-3551] Perhaps there is a better way to handle `adyen`, `afterpay`, `amazonpay`,
         // `checkout.com`, `converge`, `sagepay`, `stripev3` and `sezzle`. They require
         //  a redirection to another website during the payment flow but are not
         //  categorised as hosted payment methods.
@@ -352,7 +352,8 @@ class Payment extends Component<
             selectedMethod.gateway === PaymentMethodId.Clearpay ||
             selectedMethod.gateway === PaymentMethodId.Checkoutcom ||
             selectedMethod.gateway === PaymentMethodId.Mollie ||
-            selectedMethod.gateway === PaymentMethodId.StripeV3
+            selectedMethod.gateway === PaymentMethodId.StripeV3 ||
+            selectedMethod.gateway === PaymentMethodId.StripeUPE
         ) {
             return;
         }


### PR DESCRIPTION
## What?
Remove browser confirmation alert before redirect to Stripe UPE iDEAL confirmation page.

## Why?
Browser alert is causing confusion and customer churn when using redirect-based Stripe UPE iDEAL APM.

## Testing / Proof
Before:

https://github.com/user-attachments/assets/95c55e57-8c80-4bc6-9c59-3752c7961a3b

After:

https://github.com/user-attachments/assets/872bf0be-7002-417e-8335-3758ebef6650



@bigcommerce/team-checkout
