### PR TITLE
chore(shipping): CHECKOUT-9114 Parse custom error and map title to error for invalid shipping address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.719.0",
+        "@bigcommerce/checkout-sdk": "^1.719.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.719.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.0.tgz",
-      "integrity": "sha512-451qFtl82o4zUs2TlWJlu6AgjhB5hNrbKyKKXGCCqdcqqsYJPFMdx+jeTbZVpi9AW1VLOV9I4pWgjhA/MsRVsA==",
+      "version": "1.719.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.2.tgz",
+      "integrity": "sha512-9UQaGozYv/TxbPMEM+Yd/8UsCX7zYjbJdogc2+B4x7KQfPDUgZiHRjkFdnMGDxbbR6nmjv0PUMy6JlCo3ZOHVw==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35059,9 +35059,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.719.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.0.tgz",
-      "integrity": "sha512-451qFtl82o4zUs2TlWJlu6AgjhB5hNrbKyKKXGCCqdcqqsYJPFMdx+jeTbZVpi9AW1VLOV9I4pWgjhA/MsRVsA==",
+      "version": "1.719.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.2.tgz",
+      "integrity": "sha512-9UQaGozYv/TxbPMEM+Yd/8UsCX7zYjbJdogc2+B4x7KQfPDUgZiHRjkFdnMGDxbbR6nmjv0PUMy6JlCo3ZOHVw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.719.0",
+    "@bigcommerce/checkout-sdk": "^1.719.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
@@ -302,4 +302,15 @@ describe('mapSubmitOrderErrorTitle()', () => {
 
         expect(title).toEqual(translate('common.missing_shipping_method_heading'));
     });
+
+    it('returns correct title when error type is not "invalid_shipping_address"', () => {
+        const title = mapSubmitOrderErrorTitle(
+            {
+                type: 'invalid_shipping_address',
+            },
+            translate,
+        );
+
+        expect(title).toEqual(translate('common.invalid_shipping_address'));
+    });
 });

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
@@ -303,7 +303,7 @@ describe('mapSubmitOrderErrorTitle()', () => {
         expect(title).toEqual(translate('common.missing_shipping_method_heading'));
     });
 
-    it('returns correct title when error type is not "invalid_shipping_address"', () => {
+    it('returns correct title when error type is "invalid_shipping_address"', () => {
         const title = mapSubmitOrderErrorTitle(
             {
                 type: 'invalid_shipping_address',

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -75,5 +75,9 @@ export function mapSubmitOrderErrorTitle(
         return translate('common.missing_shipping_method_heading');
     }
 
+    if (error.type === 'invalid_shipping_address') {
+        return translate('common.invalid_shipping_address');
+    }
+
     return translate('common.error_heading');
 }

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -95,6 +95,7 @@
             "leave_warning": "Are you sure you want to leave? Data you have entered may not be saved.",
             "loading_text": "Loading",
             "missing_shipping_method_heading": "Shipping method unavailable",
+            "invalid_shipping_address": "Invalid shipping address",
             "ok_action": "Ok",
             "error_code": "Error code:",
             "request_id": "Request ID:",


### PR DESCRIPTION
## What?
Parse custom error and map title to error for invalid shipping address

## Why?
To display a better and more informed error heading to shopper map api error to custom error
Release https://github.com/bigcommerce/checkout-sdk-js/commit/57d00879ffaff768ba2a00da8cb3e9b52a897334

## Testing / Proof
- CI
- Screenshot

![Screenshot 2025-04-02 at 10 40 40 pm](https://github.com/user-attachments/assets/9d2d9120-bdbd-4e6c-9cda-cfe53cc7d88c)


@bigcommerce/team-checkout
