### PR TITLE
feat(payment): PI-3089 Added Afterpay new logo for US stores

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -1,4 +1,4 @@
-import { CardInstrument, LanguageService, PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { CardInstrument, CheckoutSettings, LanguageService, PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { number } from 'card-validator';
 import { compact } from 'lodash';
 import React, { FunctionComponent, memo, ReactNode } from 'react';
@@ -8,6 +8,7 @@ import { CheckoutContextProps , PaymentFormValues } from '@bigcommerce/checkout/
 
 import { withCheckout } from '../../checkout';
 import { connectFormik, ConnectFormikProps } from '../../common/form';
+import { isExperimentEnabled } from '../../common/utility';
 import { CreditCardIconList, mapFromPaymentMethodCardType } from '../creditCard';
 
 import BraintreePaypalCreditDescription from './BraintreePaypalCreditDescription';
@@ -27,12 +28,16 @@ export interface PaymentMethodTitleProps {
 
 interface WithPaymentTitleProps {
     instruments: CardInstrument[];
+    checkoutSettings: CheckoutSettings;
+    storeCountryCode: string;
     cdnBasePath: string;
 }
 
 function getPaymentMethodTitle(
     language: LanguageService,
     basePath: string,
+    checkoutSettings: CheckoutSettings,
+    storeCountryCode: string,
 ): (method: PaymentMethod) => {
     logoUrl: string;
     titleText: string,
@@ -96,7 +101,7 @@ function getPaymentMethodTitle(
                 titleText: language.translate('payment.affirm_display_name_text'),
             },
             [PaymentMethodId.Afterpay]: {
-                logoUrl: cdnPath('/img/payment-providers/afterpay-badge-blackonmint.png'),
+                logoUrl: isExperimentEnabled(checkoutSettings, 'PROJECT-6993.change_afterpay_logo_for_us_stores') && storeCountryCode === 'US' ? cdnPath('/img/payment-providers/afterpay-new-us.svg') : cdnPath('/img/payment-providers/afterpay-badge-blackonmint.png'),
                 titleText: methodName,
             },
             [PaymentMethodId.AmazonPay]: {
@@ -276,9 +281,9 @@ const PaymentMethodTitle: FunctionComponent<
         WithLanguageProps &
         WithPaymentTitleProps &
         ConnectFormikProps<PaymentFormValues>
-> = ({ cdnBasePath, onUnhandledError, formik: { values }, instruments, isSelected, language, method }) => {
+> = ({ cdnBasePath, checkoutSettings, storeCountryCode, onUnhandledError, formik: { values }, instruments, isSelected, language, method }) => {
     const methodName = getPaymentMethodName(language)(method);
-    const { logoUrl, titleText, subtitle } = getPaymentMethodTitle(language, cdnBasePath)(method);
+    const { logoUrl, titleText, subtitle } = getPaymentMethodTitle(language, cdnBasePath, checkoutSettings, storeCountryCode)(method);
 
     const getSelectedCardType = () => {
         if (!isSelected) {
@@ -359,8 +364,12 @@ function mapToCheckoutProps({ checkoutState }: CheckoutContextProps): WithPaymen
         return null;
     }
 
+    const storeCountryCode = config.storeProfile.storeCountryCode
+
     return {
         instruments,
+        checkoutSettings: config.checkoutSettings,
+        storeCountryCode,
         cdnBasePath: config.cdnPath,
     };
 }


### PR DESCRIPTION
## What?
Added Afterpay new logo for US stores

## Why?
Due to the Afterpay request

## Testing / Proof

Old logo:
<img width="1511" alt="Screenshot 2025-04-02 at 17 24 29" src="https://github.com/user-attachments/assets/b040c9ca-1e58-4a04-99ef-d6e4cd406386" />

New logo:
<img width="1499" alt="Screenshot 2025-04-02 at 17 23 39" src="https://github.com/user-attachments/assets/568b917b-bb00-4bd8-800d-b6278f70a6c5" />

@bigcommerce/team-checkout
