### PR TITLE
feat(checkout): CHECKOUT-9107 disable continue button when checkout is reloading

### DIFF
--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -361,6 +361,7 @@ export function mapToShippingProps({
             isUpdatingBillingAddress,
             isUpdatingCheckout,
             isDeletingConsignment,
+            isLoadingCheckout,
         },
     } = checkoutState;
 
@@ -392,7 +393,8 @@ export function mapToShippingProps({
         isUpdatingBillingAddress() ||
         isUpdatingCheckout() ||
         isCreatingCustomerAddress() ||
-        isDeletingConsignment();
+        isDeletingConsignment() ||
+        isLoadingCheckout();
 
     const shippableItemsCount = getShippableItemsCount(cart);
     const shouldShowMultiShipping =

--- a/packages/core/src/app/shipping/ShippingComponent.test.tsx
+++ b/packages/core/src/app/shipping/ShippingComponent.test.tsx
@@ -251,4 +251,12 @@ describe('Shipping component', () => {
             expect(screen.queryByTestId("shipping-mode-toggle")).not.toBeInTheDocument();
         });
     });
+
+    it('disables continue button when checkout is loading', () => {
+        jest.spyOn(checkoutState.statuses, 'isLoadingCheckout').mockReturnValue(true);
+
+        render(<ComponentTest {...defaultProps} />);
+
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    });
 });


### PR DESCRIPTION
## What?
Disable Continue Button During Checkout Reload to Prevent Data Discrepancy

## Why?
To keep checkout data in sync and do not allow other checkout update calls when some are already in process.

## Testing / Proof

- Manual testing

**Without extension local testing**

https://github.com/user-attachments/assets/aab87547-6720-41d2-b46c-fd1e5c3fe85c

**With extension**

https://github.com/user-attachments/assets/0d9bafee-84d9-40cd-a601-259026997ee6


@bigcommerce/team-checkout
