### PR TITLE
chore(checkout): CHECKOUT-000 bump sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.719.2",
+        "@bigcommerce/checkout-sdk": "^1.719.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.719.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.2.tgz",
-      "integrity": "sha512-9UQaGozYv/TxbPMEM+Yd/8UsCX7zYjbJdogc2+B4x7KQfPDUgZiHRjkFdnMGDxbbR6nmjv0PUMy6JlCo3ZOHVw==",
+      "version": "1.719.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.3.tgz",
+      "integrity": "sha512-f3CNWGRmAbMN19QgYjSmq189sD225Wl7ChhZIAxRRxAdg/85XUiXpCNlihwmOnKO/CtcKE5q/YYuRNXg88RIdA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35277,9 +35277,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.719.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.2.tgz",
-      "integrity": "sha512-9UQaGozYv/TxbPMEM+Yd/8UsCX7zYjbJdogc2+B4x7KQfPDUgZiHRjkFdnMGDxbbR6nmjv0PUMy6JlCo3ZOHVw==",
+      "version": "1.719.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.3.tgz",
+      "integrity": "sha512-f3CNWGRmAbMN19QgYjSmq189sD225Wl7ChhZIAxRRxAdg/85XUiXpCNlihwmOnKO/CtcKE5q/YYuRNXg88RIdA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.719.2",
+    "@bigcommerce/checkout-sdk": "^1.719.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/test-mocks/src/config.mock.ts
+++ b/packages/test-mocks/src/config.mock.ts
@@ -44,6 +44,7 @@ export function getStoreConfig(): StoreConfig {
             requiresMarketingConsent: false,
             features: {},
             remoteCheckoutProviders: [],
+            shouldRedirectToStorefrontLoginPage: false,
         },
         currency: {
             code: 'USD',


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?

- Release https://github.com/bigcommerce/checkout-sdk-js/pull/2823 and https://github.com/bigcommerce/checkout-sdk-js/pull/2819
- To fix failing release pipeline ([tag issue](https://app.circleci.com/pipelines/github/bigcommerce/checkout-js/12054/workflows/72bbec72-2f95-427e-a185-03ae1013c722/jobs/54440)) 

## Testing / Proof

- CI checks

@bigcommerce/team-checkout
