### PR TITLE
feat(customer): CHECKOUT-9138 Redirect to storefront login page based on settings

### DIFF
--- a/packages/core/src/app/customer/Customer.test.tsx
+++ b/packages/core/src/app/customer/Customer.test.tsx
@@ -293,7 +293,7 @@ describe('Customer Component', () => {
             expect(window.location.assign).toHaveBeenCalled();
         });
 
-        it('redirects to the login page if experiment is off and shouldRedirectToStorefrontForAuth is true', async () => {
+        it('displays login form if experiment is off and shouldRedirectToStorefrontForAuth is true', async () => {
             const config = {
                 ...checkoutSettings,
                 storeConfig: {

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -201,13 +201,13 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
           ? null
           : <CheckoutButtonList
             checkEmbeddedSupport={checkEmbeddedSupport}
+            checkoutSettings={checkoutSettings}
             deinitialize={deinitializeCustomer}
             initialize={initializeCustomer}
             isInitializing={isInitializing}
             methodIds={checkoutButtonIds}
             onClick={onWalletButtonClick}
             onError={onUnhandledError}
-            checkoutSettings={checkoutSettings}
           />;
 
         const isLoadingGuestForm = isContinuingAsGuest || isExecutingPaymentMethodCheckout;
@@ -245,8 +245,8 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 onContinueAsGuest={this.handleContinueAsGuest}
                 onShowLogin={this.handleShowLogin}
                 privacyPolicyUrl={privacyPolicyUrl}
-                shouldShowEmailWatermark={isPayPalFastlaneMethod(providerWithCustomCheckout)}
                 requiresMarketingConsent={requiresMarketingConsent}
+                shouldShowEmailWatermark={isPayPalFastlaneMethod(providerWithCustomCheckout)}
             />
         );
     }

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout-settings.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout-settings.mock.ts
@@ -49,6 +49,7 @@ const checkoutSettings = {
                 walletButtonsOnTop: true,
                 floatingLabelEnabled: true,
             },
+            shouldRedirectToStorefrontForAuth: false,
         },
         currency: {
             code: 'USD',


### PR DESCRIPTION
## What?
If setting `shouldRedirectToStorefrontForAuth` is true then redirect shopper to login from storefront login page.

## Why?
As part of headless offering, redirect shoppers to storefront login page to login.

## Testing / Proof
- CI
- Screencast

#### shouldRedirectToStorefrontForAuth is False

https://github.com/user-attachments/assets/4f52378f-b0c5-46f6-900a-2f848b45ce2c

#### shouldRedirectToStorefrontForAuth is True and experiment off

https://github.com/user-attachments/assets/e0173c2c-a104-4c4f-8720-0b082b05087d



#### shouldRedirectToStorefrontForAuth is True and experiment is on

https://github.com/user-attachments/assets/54c650ea-4284-4b9a-9d99-14e02e6f2460






@bigcommerce/team-checkout
