### PR TITLE
feat(payment): PI-3539 sdk version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.719.3",
+        "@bigcommerce/checkout-sdk": "^1.721.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.719.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.3.tgz",
-      "integrity": "sha512-f3CNWGRmAbMN19QgYjSmq189sD225Wl7ChhZIAxRRxAdg/85XUiXpCNlihwmOnKO/CtcKE5q/YYuRNXg88RIdA==",
+      "version": "1.721.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.721.0.tgz",
+      "integrity": "sha512-irx02Ei74A/Bj/jaTxKN3iuXJj9hWDpyxY8jGWkPFqEhskeb3gw6n8TSyDEffjB9TKSpY8s3GYSSpgyktDD6kg==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35277,9 +35277,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.719.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.719.3.tgz",
-      "integrity": "sha512-f3CNWGRmAbMN19QgYjSmq189sD225Wl7ChhZIAxRRxAdg/85XUiXpCNlihwmOnKO/CtcKE5q/YYuRNXg88RIdA==",
+      "version": "1.721.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.721.0.tgz",
+      "integrity": "sha512-irx02Ei74A/Bj/jaTxKN3iuXJj9hWDpyxY8jGWkPFqEhskeb3gw6n8TSyDEffjB9TKSpY8s3GYSSpgyktDD6kg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.719.3",
+    "@bigcommerce/checkout-sdk": "^1.721.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/test-mocks/src/config.mock.ts
+++ b/packages/test-mocks/src/config.mock.ts
@@ -44,7 +44,7 @@ export function getStoreConfig(): StoreConfig {
             requiresMarketingConsent: false,
             features: {},
             remoteCheckoutProviders: [],
-            shouldRedirectToStorefrontLoginPage: false,
+            shouldRedirectToStorefrontForAuth: false,
         },
         currency: {
             code: 'USD',


### PR DESCRIPTION
## What?
Bump checkout-sdk version to `1.721.0`

## Why?
As part of the release: https://github.com/bigcommerce/checkout-sdk-js/pull/2813

## Testing / Proof
Manual testing

@bigcommerce/team-checkout
