### PR TITLE
feat(payment): PI-3533 Remove the leftover code of Checkout.com credit card in paymentMethod

### DIFF
--- a/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
+++ b/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
@@ -75,5 +75,6 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
         { gateway: 'checkoutcom', id: 'boleto' },
         { gateway: 'checkoutcom', id: 'sepa' },
         { gateway: 'checkoutcom', id: 'qpay' },
+        { gateway: 'checkoutcom', id: 'p24' },
     ],
 );

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -65,15 +65,6 @@ const PaymentMethodComponent: FunctionComponent<
         return <CCAvenueMarsPaymentMethod {...props} />;
     }
 
-    if (method.gateway === PaymentMethodId.Checkoutcom) {
-        if (method.id === 'credit_card' || method.id === 'card') {
-            return <HostedCreditCardPaymentMethod {...props} />;
-        }
-
-
-        return <HostedPaymentMethod {...props} />;
-    }
-
     if (method.id === PaymentMethodId.Masterpass) {
         return <MasterpassPaymentMethod {...props} />;
     }


### PR DESCRIPTION
## What?
Remove the leftover code of Checkout.com credit card in paymentMethod

## Why?
To finish the extraction of Checkout.com to the new package

## Testing / Proof

https://github.com/user-attachments/assets/10168e17-6b66-443d-a980-5a8760deacdc


https://github.com/user-attachments/assets/ac0bf510-92c0-4767-ae6e-fc7999b6b23d


https://github.com/user-attachments/assets/9322abb4-a0ad-4924-9f96-eae200b8d8ca



