### PR TITLE
feat(checkout): CHECKOUT-9167 Redirect to storefront logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.722.0",
+        "@bigcommerce/checkout-sdk": "^1.723.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,9 +1778,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.722.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.722.0.tgz",
-      "integrity": "sha512-zLz5aW0Y05tlvaPHXaUwQ+Tmi4jOiXt66GdnYMv8T9pXStHe22UsZuMzI7W+l/QLeBnGBcvYlZ2EP1Yb+dOIfg==",
+      "version": "1.723.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.723.0.tgz",
+      "integrity": "sha512-AWGUDWNw+hBhvvcL2l3K10UtKUO/Qps9YWZWKWKqx0zmXQNSQ1QBLgwUmOukyNet9V4fxmHj22lpjwfmsm0rtQ==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35278,9 +35279,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.722.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.722.0.tgz",
-      "integrity": "sha512-zLz5aW0Y05tlvaPHXaUwQ+Tmi4jOiXt66GdnYMv8T9pXStHe22UsZuMzI7W+l/QLeBnGBcvYlZ2EP1Yb+dOIfg==",
+      "version": "1.723.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.723.0.tgz",
+      "integrity": "sha512-AWGUDWNw+hBhvvcL2l3K10UtKUO/Qps9YWZWKWKqx0zmXQNSQ1QBLgwUmOukyNet9V4fxmHj22lpjwfmsm0rtQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.722.0",
+    "@bigcommerce/checkout-sdk": "^1.723.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/config/config.mock.ts
+++ b/packages/core/src/app/config/config.mock.ts
@@ -41,6 +41,7 @@ export function getStoreConfig(): StoreConfig {
             shippingQuoteFailedMessage:
                 "Unfortunately one or more items in your cart can't be shipped to your \
             location.Please choose a different delivery address.",
+            shouldRedirectToStorefrontForAuth: false,
             realtimeShippingProviders: ['Fedex', 'UPS', 'USPS'],
             requiresMarketingConsent: false,
             features: {},
@@ -60,6 +61,7 @@ export function getStoreConfig(): StoreConfig {
             createAccountLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=create_account',
             forgotPasswordLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password',
             loginLink: 'https://store-k1drp8k8.bcapp.dev/login.php',
+            logoutLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=logout',
             siteLink: 'https://store-k1drp8k8.bcapp.dev',
             orderConfirmationLink: 'https://store-k1drp8k8.bcapp.dev/checkout/order-confirmation',
         },

--- a/packages/core/src/app/customer/CustomerInfo.tsx
+++ b/packages/core/src/app/customer/CustomerInfo.tsx
@@ -113,7 +113,7 @@ function mapToWithCheckoutCustomerInfoProps({
         return null;
     }
 
-    const {checkoutSettings, links: { logoutLink }} = config;
+    const { checkoutSettings, links: { logoutLink } } = config;
 
     const isRedirectExperimentEnabled = isExperimentEnabled(checkoutSettings, 'CHECKOUT-9138.redirect_to_storefront_for_auth');
 

--- a/packages/core/src/app/customer/CustomerInfo.tsx
+++ b/packages/core/src/app/customer/CustomerInfo.tsx
@@ -7,6 +7,7 @@ import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-
 
 import { withCheckout } from '../checkout';
 import { isErrorWithType } from '../common/error';
+import { isExperimentEnabled } from '../common/utility';
 import { Button, ButtonSize, ButtonVariant } from '../ui/button';
 
 import canSignOut, { isSupportedSignoutMethod } from './canSignOut';
@@ -23,8 +24,11 @@ export interface CustomerSignOutEvent {
 interface WithCheckoutCustomerInfoProps {
     email: string;
     methodId: string;
+    isRedirectExperimentEnabled: boolean;
     isSignedIn: boolean;
     isSigningOut: boolean;
+    logoutLink: string;
+    shouldRedirectToStorefrontForAuth: boolean;
     signOut(options?: CustomerRequestOptions): Promise<CheckoutSelectors>;
 }
 
@@ -33,12 +37,21 @@ const CustomerInfo: FunctionComponent<CustomerInfoProps & WithCheckoutCustomerIn
     methodId,
     isSignedIn,
     isSigningOut,
+    isRedirectExperimentEnabled,
+    logoutLink,
+    shouldRedirectToStorefrontForAuth,
     onSignOut = noop,
     onSignOutError = noop,
     signOut,
 }) => {
     const handleSignOut: () => Promise<void> = async () => {
         try {
+            if (isRedirectExperimentEnabled && shouldRedirectToStorefrontForAuth) {
+                window.location.assign(logoutLink);
+
+                return;
+            }
+
             if (isSupportedSignoutMethod(methodId)) {
                 await signOut({ methodId });
                 onSignOut({ isCartEmpty: false });
@@ -87,17 +100,22 @@ function mapToWithCheckoutCustomerInfoProps({
     checkoutState,
 }: CheckoutContextProps): WithCheckoutCustomerInfoProps | null {
     const {
-        data: { getBillingAddress, getCheckout, getCustomer },
+        data: { getBillingAddress, getCheckout, getCustomer, getConfig },
         statuses: { isSigningOut },
     } = checkoutState;
 
     const billingAddress = getBillingAddress();
     const checkout = getCheckout();
     const customer = getCustomer();
+    const config = getConfig();
 
-    if (!billingAddress || !checkout || !customer) {
+    if (!billingAddress || !checkout || !customer || !config) {
         return null;
     }
+
+    const {checkoutSettings, links: { logoutLink }} = config;
+
+    const isRedirectExperimentEnabled = isExperimentEnabled(checkoutSettings, 'CHECKOUT-9138.redirect_to_storefront_for_auth');
 
     const methodId =
         checkout.payments && checkout.payments.length === 1 ? checkout.payments[0].providerId : '';
@@ -105,8 +123,11 @@ function mapToWithCheckoutCustomerInfoProps({
     return {
         email: billingAddress.email || customer.email,
         methodId,
+        isRedirectExperimentEnabled,
         isSignedIn: canSignOut(customer, checkout, methodId),
         isSigningOut: isSigningOut(),
+        logoutLink,
+        shouldRedirectToStorefrontForAuth: checkoutSettings.shouldRedirectToStorefrontForAuth,
         signOut: checkoutService.signOutCustomer,
     };
 }

--- a/packages/test-mocks/src/config.mock.ts
+++ b/packages/test-mocks/src/config.mock.ts
@@ -60,6 +60,7 @@ export function getStoreConfig(): StoreConfig {
             createAccountLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=create_account',
             forgotPasswordLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password',
             loginLink: 'https://store-k1drp8k8.bcapp.dev/login.php',
+            logoutLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=logout',
             siteLink: 'https://store-k1drp8k8.bcapp.dev',
             orderConfirmationLink: 'https://store-k1drp8k8.bcapp.dev/checkout/order-confirmation',
         },


### PR DESCRIPTION
## What?
Redirect to storefront logout when shouldRedirectToStorefrontForAuth is true and sign out link is provided

## Why?
As part of headless offering, redirect shoppers to storefront logout page to logout

## Testing / Proof
- [x] unit test
- [x] manual test

### when shouldRedirectToStorefrontForAuth is True 
https://github.com/user-attachments/assets/5775a180-4308-4d7d-b068-19de81e8714e



@bigcommerce/team-checkout
