### PR TITLE
chore(payment): PAYPAL-5258 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.723.0",
+        "@bigcommerce/checkout-sdk": "^1.724.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,10 +1778,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.723.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.723.0.tgz",
-      "integrity": "sha512-AWGUDWNw+hBhvvcL2l3K10UtKUO/Qps9YWZWKWKqx0zmXQNSQ1QBLgwUmOukyNet9V4fxmHj22lpjwfmsm0rtQ==",
-      "license": "MIT",
+      "version": "1.724.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.724.0.tgz",
+      "integrity": "sha512-Pk8oMEXMV4Omv2yx7ncifXMAsFyLTzFWBcu4STB+ID6OxnT/4MmLQqXnIx4d89KPBkcgBB5hjNWSGueLazUX+w==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35279,9 +35278,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.723.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.723.0.tgz",
-      "integrity": "sha512-AWGUDWNw+hBhvvcL2l3K10UtKUO/Qps9YWZWKWKqx0zmXQNSQ1QBLgwUmOukyNet9V4fxmHj22lpjwfmsm0rtQ==",
+      "version": "1.724.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.724.0.tgz",
+      "integrity": "sha512-Pk8oMEXMV4Omv2yx7ncifXMAsFyLTzFWBcu4STB+ID6OxnT/4MmLQqXnIx4d89KPBkcgBB5hjNWSGueLazUX+w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.723.0",
+    "@bigcommerce/checkout-sdk": "^1.724.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bumped checkout-sdk-js version

## Why?
To update code 
checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/2822

## Testing / Proof
Unit tests

@bigcommerce/team-checkout
