### PR TITLE
feat(payment): PI-3669 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.725.0",
+        "@bigcommerce/checkout-sdk": "^1.726.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.725.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.725.0.tgz",
-      "integrity": "sha512-s8JO01H7sxFn250PFcRG9wd/QuVrs+LZpoU2C7vI2pxlhxBowEYKvcLD7ysfYgvF422AFtGKw9GKFlKAB4PrJQ==",
+      "version": "1.726.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.726.0.tgz",
+      "integrity": "sha512-4uOsQlKQElYG7Hh7M53HTz8dZyyRWLUXShR8IntvX51lH/wdsfx8ZNxdlRM4OqJMaOktYZCdX9mt6cj/b0uD5Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -35278,9 +35278,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.725.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.725.0.tgz",
-      "integrity": "sha512-s8JO01H7sxFn250PFcRG9wd/QuVrs+LZpoU2C7vI2pxlhxBowEYKvcLD7ysfYgvF422AFtGKw9GKFlKAB4PrJQ==",
+      "version": "1.726.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.726.0.tgz",
+      "integrity": "sha512-4uOsQlKQElYG7Hh7M53HTz8dZyyRWLUXShR8IntvX51lH/wdsfx8ZNxdlRM4OqJMaOktYZCdX9mt6cj/b0uD5Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.725.0",
+    "@bigcommerce/checkout-sdk": "^1.726.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to `1.726.0`

## Why?
As part of the release: https://github.com/bigcommerce/checkout-sdk-js/pull/2827

## Testing / Proof
Manual Testing

@bigcommerce/team-checkout
