### PR TITLE
test(checkout): CHECKOUT-9145 convert ui/form tests enzyme to RTL - Part 3

### DIFF
--- a/packages/ui/src/form/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/ui/src/form/CheckboxInput/CheckboxInput.test.tsx
@@ -6,7 +6,16 @@ import CheckboxInput from './CheckboxInput';
 
 describe('CheckboxInput', () => {
     it('renders `input` element with passed props', () => {
-        render(<CheckboxInput checked={false} id="id" label="label" name="foobar" value="x" />);
+        render(
+            <CheckboxInput
+                checked={false}
+                id="id"
+                label="label"
+                name="foobar"
+                onChange={jest.fn()}
+                value="x"
+            />,
+        );
 
         expect(screen.getByRole('checkbox')).toBeInTheDocument();
         expect(screen.getByRole('checkbox')).toHaveAttribute('name', 'foobar');
@@ -15,7 +24,15 @@ describe('CheckboxInput', () => {
     });
 
     it('renders with class names', () => {
-        render(<CheckboxInput checked={false} label="label" name="foobar" value="x" />);
+        render(
+            <CheckboxInput
+                checked={false}
+                label="label"
+                name="foobar"
+                onChange={jest.fn()}
+                value="x"
+            />,
+        );
 
         expect(screen.getByRole('checkbox')).toHaveClass('form-checkbox');
         expect(screen.getByRole('checkbox')).toHaveClass('optimizedCheckout-form-checkbox');

--- a/packages/ui/src/form/ChecklistItemInput/ChecklistItemInput.test.tsx
+++ b/packages/ui/src/form/ChecklistItemInput/ChecklistItemInput.test.tsx
@@ -8,7 +8,12 @@ import ChecklistItemInput from './ChecklistItemInput';
 describe('ChecklistItemInput', () => {
     it('renders children inside label', () => {
         render(
-            <ChecklistItemInput isSelected={false} name="foobar" value="foobar_val">
+            <ChecklistItemInput
+                isSelected={false}
+                name="foobar"
+                onChange={jest.fn()}
+                value="foobar_val"
+            >
                 children text
             </ChecklistItemInput>,
         );
@@ -17,13 +22,27 @@ describe('ChecklistItemInput', () => {
     });
 
     it('renders input as checked when is selected', () => {
-        render(<ChecklistItemInput isSelected={true} name="foobar" value="foobar_val" />);
+        render(
+            <ChecklistItemInput
+                isSelected={true}
+                name="foobar"
+                onChange={jest.fn()}
+                value="foobar_val"
+            />,
+        );
 
         expect(screen.getByRole('radio')).toBeChecked();
     });
 
     it('renders input as unchecked when is not selected', () => {
-        render(<ChecklistItemInput isSelected={false} name="foobar" value="foobar_val" />);
+        render(
+            <ChecklistItemInput
+                isSelected={false}
+                name="foobar"
+                onChange={jest.fn()}
+                value="foobar_val"
+            />,
+        );
 
         expect(screen.getByRole('radio')).not.toBeChecked();
     });

--- a/packages/ui/src/form/Fieldset/Fieldset.test.tsx
+++ b/packages/ui/src/form/Fieldset/Fieldset.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable testing-library/no-container */
 import React from 'react';
 
 import { render, screen, within } from '@bigcommerce/checkout/test-utils';
@@ -13,11 +14,8 @@ describe('Fieldset', () => {
         );
 
         expect(screen.getByTestId('test')).toBeInTheDocument();
-        // eslint-disable-next-line testing-library/no-container
         expect(container.querySelector('fieldset')).toBeInTheDocument();
-        // eslint-disable-next-line testing-library/no-container
         expect(container.querySelector('legend')).toBeInTheDocument();
-        // eslint-disable-next-line testing-library/no-container
         expect(container.querySelector('legend')).toHaveTextContent('Hello world');
         expect(within(screen.getByTestId('test')).getByRole('textbox')).toBeInTheDocument();
     });

--- a/packages/ui/src/form/Input/Input.test.tsx
+++ b/packages/ui/src/form/Input/Input.test.tsx
@@ -1,0 +1,26 @@
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import Input from './Input';
+
+describe('Input', () => {
+    it('matches snapshot', () => {
+        render(<Input name="foobar" testId="test" />);
+
+        expect(screen.getByTestId('test')).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toHaveAttribute('name', 'foobar');
+    });
+
+    it('listens to DOM events', async () => {
+        const handleChange = jest.fn();
+
+        render(<Input name="foobar" onChange={handleChange} />);
+
+        await userEvent.type(screen.getByRole('textbox'), 'test');
+
+        expect(handleChange).toHaveBeenCalled();
+    });
+});

--- a/packages/ui/src/form/Label/Label.test.tsx
+++ b/packages/ui/src/form/Label/Label.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import Label from './Label';
+
+describe('Label', () => {
+    it('renders component with text', () => {
+        render(<Label>Hello world</Label>);
+
+        expect(screen.getByText('Hello world')).toBeInTheDocument();
+        expect(screen.getByText('Hello world')).toHaveClass('form-label');
+    });
+
+    it('renders component with test ID', () => {
+        render(<Label testId="test">Hello world</Label>);
+
+        expect(screen.getByTestId('test')).toBeInTheDocument();
+        expect(screen.getByTestId('test')).toHaveTextContent('Hello world');
+    });
+});

--- a/packages/ui/src/form/Legend/Legend.test.tsx
+++ b/packages/ui/src/form/Legend/Legend.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import Legend from './Legend';
+
+describe('Legend', () => {
+    it('renders component with text and test ID', () => {
+        render(<Legend testId="test">Hello world</Legend>);
+
+        expect(screen.getByText('Hello world')).toBeInTheDocument();
+        expect(screen.getByTestId('test')).toBeInTheDocument();
+        expect(screen.getByTestId('test')).toHaveTextContent('Hello world');
+    });
+
+    it('renders component as hidden', () => {
+        render(<Legend hidden>Hello world</Legend>);
+
+        expect(screen.getByText('Hello world')).toHaveClass('is-srOnly');
+    });
+
+    it('renders component as heading by default', () => {
+        render(<Legend>Hello world</Legend>);
+
+        expect(screen.getByText('Hello world')).toHaveClass('optimizedCheckout-headingSecondary');
+    });
+});

--- a/packages/ui/src/form/RadioInput/RadioInput.test.tsx
+++ b/packages/ui/src/form/RadioInput/RadioInput.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import RadioInput from './RadioInput';
+
+describe('RadioInput', () => {
+    it('renders `input` element', () => {
+        render(
+            <RadioInput
+                checked={false}
+                label="label"
+                name="foobar"
+                onChange={jest.fn()}
+                value="x"
+            />,
+        );
+
+        expect(screen.getByRole('radio')).toBeInTheDocument();
+    });
+
+    it('renders with passed props', () => {
+        render(
+            <RadioInput
+                checked={false}
+                id="id"
+                label="label"
+                name="foobar"
+                onChange={jest.fn()}
+                value="x"
+            />,
+        );
+
+        expect(screen.getByRole('radio')).toBeInTheDocument();
+        expect(screen.getByRole('radio')).toHaveAttribute('name', 'foobar');
+        expect(screen.getByRole('radio')).not.toBeChecked();
+        expect(screen.getByRole('radio')).toHaveAttribute('id', 'id');
+        expect(screen.getByLabelText('label')).toBeInTheDocument();
+    });
+
+    it('renders with class names', () => {
+        render(
+            <RadioInput
+                checked={false}
+                label="label"
+                name="foobar"
+                onChange={jest.fn()}
+                value="x"
+            />,
+        );
+
+        const component = screen.getByRole('radio');
+
+        expect(component).toHaveClass('form-radio');
+        expect(component).toHaveClass('optimizedCheckout-form-radio');
+    });
+});

--- a/packages/ui/src/form/TextArea/TextArea.test.tsx
+++ b/packages/ui/src/form/TextArea/TextArea.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import TextArea from './TextArea';
+
+describe('TextArea', () => {
+    it('renders `textarea` element', () => {
+        render(<TextArea name="foobar" />);
+
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toHaveAttribute('name', 'foobar');
+    });
+
+    it('renders with class names', () => {
+        render(<TextArea additionalClassName="foobar" name="foobar" />);
+
+        const component = screen.getByRole('textbox');
+
+        expect(component).toHaveClass('form-input');
+        expect(component).toHaveClass('optimizedCheckout-form-input');
+        expect(component).toHaveClass('foobar');
+    });
+});

--- a/packages/ui/src/form/TextInput/TextInput.test.tsx
+++ b/packages/ui/src/form/TextInput/TextInput.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import TextInput from './TextInput';
+
+describe('TextInput', () => {
+    it('renders Input element', () => {
+        render(<TextInput name="foobar" />);
+
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('renders with class names', () => {
+        render(<TextInput additionalClassName="foobar" name="foobar" />);
+
+        expect(screen.getByRole('textbox')).toHaveClass('form-input');
+        expect(screen.getByRole('textbox')).toHaveClass('optimizedCheckout-form-input');
+        expect(screen.getByRole('textbox')).toHaveClass('foobar');
+    });
+
+    it('appears focused if configured', () => {
+        render(<TextInput appearFocused name="foobar" />);
+
+        expect(screen.getByRole('textbox')).toHaveClass('form-input--focus');
+        expect(screen.getByRole('textbox')).toHaveClass('optimizedCheckout-form-input--focus');
+    });
+
+    it('does not appear focused unless configured', () => {
+        render(<TextInput appearFocused={false} name="foobar" />);
+
+        expect(screen.getByRole('textbox')).not.toHaveClass('form-input--focus');
+        expect(screen.getByRole('textbox')).not.toHaveClass('optimizedCheckout-form-input--focus');
+    });
+});

--- a/packages/ui/src/form/TextInputIframeContainer/TextInputIframeContainer.test.tsx
+++ b/packages/ui/src/form/TextInputIframeContainer/TextInputIframeContainer.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { render } from '@bigcommerce/checkout/test-utils';
+
+import TextInputIframeContainer from './TextInputIframeContainer';
+
+describe('TextInputIframeContainer', () => {
+    it('renders container with default input CSS classes', () => {
+        const { container } = render(<TextInputIframeContainer />);
+
+        expect(container.firstChild).toHaveClass('form-input');
+        expect(container.firstChild).toHaveClass('optimizedCheckout-form-input');
+    });
+
+    it('renders container with additional CSS classes', () => {
+        const { container } = render(<TextInputIframeContainer additionalClassName="has-icon" />);
+
+        expect(container.firstChild).toHaveClass('form-input');
+        expect(container.firstChild).toHaveClass('optimizedCheckout-form-input');
+        expect(container.firstChild).toHaveClass('has-icon');
+    });
+
+    it('renders container with focus styles', () => {
+        const { container } = render(<TextInputIframeContainer appearFocused />);
+
+        expect(container.firstChild).toHaveClass('form-input--focus');
+        expect(container.firstChild).toHaveClass('optimizedCheckout-form-input--focus');
+    });
+
+    it('does not render container with focus styles unless specified', () => {
+        const { container } = render(<TextInputIframeContainer appearFocused={false} />);
+
+        expect(container.firstChild).not.toHaveClass('form-input--focus');
+        expect(container.firstChild).not.toHaveClass('optimizedCheckout-form-input--focus');
+    });
+});


### PR DESCRIPTION
## What?
Remove enzyme tests from `packages/ui/src/form/`

1. Input
2. Label
3. Legend
4. RadioInput
5. TextArea
6. TextInput
7. TextInputIframeContainer

## Why?
Enable us to upgrade to React 19.

## Testing / Proof

- CI checks

**Coverage Before**
<img width="1423" alt="CHECKOUT-9145-BEFORE" src="https://github.com/user-attachments/assets/c699d9f1-a6f6-4b3d-9f21-a284fb1f5aef" />


**Coverage After**
<img width="1420" alt="CHECKOUT-9145-AFTER" src="https://github.com/user-attachments/assets/6cd622e6-50a8-4784-b689-f60dcec03283" />

@bigcommerce/team-checkout
