### PR TITLE
fix(payment): STRIPE-725 Fix styling for custom hosted payment element

### DIFF
--- a/packages/core/src/scss/components/checkout/checklist/_checklist.scss
+++ b/packages/core/src/scss/components/checkout/checklist/_checklist.scss
@@ -33,6 +33,13 @@
     background-color: container("fill", "dark");
 }
 
+.custom-checklist-item {
+    .paymentMethod--hosted,
+    .widget {
+        padding: 0;
+    }
+}
+
 //
 // CHECKLIST HEADER
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## What?
Fix styling for custom hosted payment element.
Original PR: [https://github.com/bigcommerce/checkout-js/pull/2036](https://github.com/bigcommerce/checkout-js/pull/2036)

## Why?
To keep custom check list container clear, remove unnecessary paddings.

## Testing / Proof
Before:
<img width="663" alt="Screenshot 2025-04-15 at 16 14 52" src="https://github.com/user-attachments/assets/d4c6d1eb-90ea-4a60-990c-ec7fcee6a043" />

After:
<img width="638" alt="Screenshot 2025-04-15 at 16 28 25" src="https://github.com/user-attachments/assets/158764bf-5109-437f-985f-f30dc34c2e18" />


@bigcommerce/team-checkout
