### PR TITLE
chore(checkout): Update webpack config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
         "semver": "^6.3.1",
         "setup-polly-jest": "^0.10.0",
         "source-map-loader": "^0.2.4",
+        "speed-measure-webpack-plugin": "^1.5.0",
         "standard-version": "^9.5.0",
         "style-loader": "^0.23.1",
         "stylelint": "^15.10.1",
@@ -31150,6 +31151,91 @@
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
+    "node_modules/speed-measure-webpack-plugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.5.0.tgz",
+      "integrity": "sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -58423,6 +58509,66 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
+    },
+    "speed-measure-webpack-plugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.5.0.tgz",
+      "integrity": "sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "split": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "semver": "^6.3.1",
     "setup-polly-jest": "^0.10.0",
     "source-map-loader": "^0.2.4",
+    "speed-measure-webpack-plugin": "^1.5.0",
     "standard-version": "^9.5.0",
     "style-loader": "^0.23.1",
     "stylelint": "^15.10.1",

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -22,7 +22,7 @@
     "dev": {
       "executor": "@nrwl/workspace:run-commands",
       "options": {
-        "command": "webpack --mode development --watch"
+        "command": "MEASURE_SPEED=false webpack --mode development --watch"
       },
       "dependsOn": [
         {

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -193,6 +193,10 @@ class Checkout extends Component<
             subscribeToConsignments,
         } = this.props;
 
+        console.log(
+            'adcadca', 'cadcssssss'
+        );
+
         try {
             const [{ data }] = await Promise.all([loadCheckout(checkoutId, {
                 params: {

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -193,10 +193,6 @@ class Checkout extends Component<
             subscribeToConsignments,
         } = this.props;
 
-        console.log(
-            'adcadca', 'cadcssssss'
-        );
-
         try {
             const [{ data }] = await Promise.all([loadCheckout(checkoutId, {
                 params: {

--- a/packages/core/src/scss/settings/global/layout/_layout.scss
+++ b/packages/core/src/scss/settings/global/layout/_layout.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 // =============================================================================
 // DIMENSIONS (Layout / Grid)
 // =============================================================================
@@ -32,9 +33,10 @@ $spacingRhythm:                 $fontSize-base * $lineHeight-base;
 $spacing-base:                  1rem;
 $spacing-single:                $spacingRhythm;
 $spacing-double:                $spacingRhythm * 2;
-$spacing-half:                  $spacingRhythm / 2;
-$spacing-third:                 $spacingRhythm / 3;
-$spacing-quarter:               $spacingRhythm / 4;
-$spacing-fifth:                 $spacingRhythm / 5;
-$spacing-sixth:                 $spacingRhythm / 6;
-$spacing-eighth:                $spacingRhythm / 8;
+
+$spacing-half:                  math.div($spacingRhythm, 2);
+$spacing-third:                 math.div($spacingRhythm, 3);
+$spacing-quarter:               math.div($spacingRhythm, 4);
+$spacing-fifth:                 math.div($spacingRhythm, 5);
+$spacing-sixth:                 math.div($spacingRhythm, 6);
+$spacing-eighth:                math.div($spacingRhythm, 8);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -147,12 +147,6 @@ function appConfig(options, argv) {
             ].filter(Boolean),
             module: {
                 rules: [
-                    // {
-                    //     test: /\.[tj]sx?$/,
-                    //     enforce: 'pre',
-                    //     loader: require.resolve('source-map-loader'),
-                    //     exclude: /node_modules/,
-                    // },
                     {
                         test: /\.tsx?$/,
                         include: tsLoaderIncludes,
@@ -195,7 +189,35 @@ function appConfig(options, argv) {
                         use: [
                             isProduction ? MiniCssExtractPlugin.loader : 'style-loader',
                             'css-loader',
-                            'sass-loader',
+                            {
+                                loader: 'sass-loader',
+                                options: {
+                                    // eslint-disable-next-line global-require
+                                    implementation: require('sass'),
+                                    sassOptions: {
+                                        logger: {
+                                            warn: (message, sassOptions) => {
+                                                // Ignore warnings from the Sass compiler from node modules
+                                                const sourcePath =
+                                                    sassOptions?.span?.url?.toString();
+
+                                                if (
+                                                    sourcePath &&
+                                                    sourcePath.includes('node_modules')
+                                                ) {
+                                                    return;
+                                                }
+
+                                                console.warn(`Sass Warning: ${message}`);
+
+                                                if (options?.deprecation) {
+                                                    console.warn(`Deprecation: ${sassOptions}`);
+                                                }
+                                            },
+                                        },
+                                    },
+                                },
+                            },
                         ],
                         sideEffects: true,
                     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -381,15 +381,17 @@ function loaderConfig(options, argv) {
     });
 }
 
-// module.exports = function (options, argv) {
-//     return Promise.all([appConfig(options, argv), loaderConfig(options, argv)]);
-// };
-
 module.exports = async function (options, argv) {
+    const isMeasureSpeed = process.env.MEASURE_SPEED === 'true';
+
     const app = appConfig(options, argv);
     const loader = loaderConfig(options, argv);
 
     const configArr = await Promise.all([app, loader]);
 
-    return smp.wrap(configArr);
+    if (isMeasureSpeed) {
+        return smp.wrap(configArr);
+    }
+
+    return configArr;
 };


### PR DESCRIPTION
## What?
Update webpack config to cache to filesystem, speeding up subsequent builds

## Why?
As part of work on optimizing builds: 
- add caching
- remove source map generation for node_modules
- suppress warnings for scss node_modules deprecation warnings. (This should be removed once we update citadel package or find a replacement)

## Testing / Proof
- CI

#### Cached build in around 9400ms
<img width="1252" alt="Screenshot 2025-04-16 at 10 35 45 pm" src="https://github.com/user-attachments/assets/a464c43a-116b-4892-aa61-6193f6f0ddd3" />


@bigcommerce/team-checkout
