### PR TITLE
fix(payment): Bump checkout-sdk with AmazonPay fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.726.0",
+        "@bigcommerce/checkout-sdk": "^1.728.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1777,9 +1777,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.726.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.726.0.tgz",
-      "integrity": "sha512-4uOsQlKQElYG7Hh7M53HTz8dZyyRWLUXShR8IntvX51lH/wdsfx8ZNxdlRM4OqJMaOktYZCdX9mt6cj/b0uD5Q==",
+      "version": "1.728.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.728.1.tgz",
+      "integrity": "sha512-IZ3gREXvhoxKUxNvLH3FSdqKi1BnRoHrQjjdCXVR87ISK/sNkmsyULO3IHIwroDCve4cguWfNbHsoZQve6KGLQ==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",
@@ -1808,8 +1809,8 @@
         "yup": "^1.2.0"
       },
       "engines": {
-        "node": "20",
-        "npm": "9"
+        "node": "22",
+        "npm": "10"
       },
       "optionalDependencies": {
         "@swc/core-linux-x64-gnu": "^1.5.29"
@@ -36175,9 +36176,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.726.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.726.0.tgz",
-      "integrity": "sha512-4uOsQlKQElYG7Hh7M53HTz8dZyyRWLUXShR8IntvX51lH/wdsfx8ZNxdlRM4OqJMaOktYZCdX9mt6cj/b0uD5Q==",
+      "version": "1.728.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.728.1.tgz",
+      "integrity": "sha512-IZ3gREXvhoxKUxNvLH3FSdqKi1BnRoHrQjjdCXVR87ISK/sNkmsyULO3IHIwroDCve4cguWfNbHsoZQve6KGLQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.726.0",
+    "@bigcommerce/checkout-sdk": "^1.728.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk with AmazonPay fix

## Why?
Due to the release of https://github.com/bigcommerce/checkout-sdk-js/pull/2838

## Testing / Proof
Look testing proof section [here](https://github.com/bigcommerce/checkout-sdk-js/pull/2838) 

@bigcommerce/team-checkout
