### PR TITLE
feat(payment): create container for Stripe OCS payment method

### DIFF
--- a/packages/stripe-integration/src/index.ts
+++ b/packages/stripe-integration/src/index.ts
@@ -1,2 +1,3 @@
+export { default as StripeOCSPaymentMethod } from './stripe-ocs/StripeOCSPaymentMethod';
 export { default as StripeUPEPaymentMethod } from './stripe-upe/StripeUPEPaymentMethod';
 export { default as StripeV3PaymentMethod } from './stripev3/StripeV3PaymentMethod';

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -1,0 +1,104 @@
+import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import { noop, some } from 'lodash';
+import React, { FunctionComponent, useCallback, useContext, useEffect, useRef } from 'react';
+
+import { HostedWidgetPaymentComponent } from '@bigcommerce/checkout/hosted-widget-integration';
+import {
+    isInstrumentCardCodeRequiredSelector,
+    isInstrumentCardNumberRequiredSelector,
+} from '@bigcommerce/checkout/instrument-utils';
+import {
+    PaymentMethodProps,
+    PaymentMethodResolveId,
+    toResolvableComponent,
+} from '@bigcommerce/checkout/payment-integration-api';
+import { AccordionContext } from '@bigcommerce/checkout/ui';
+
+const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
+    paymentForm,
+    checkoutState,
+    checkoutService,
+    method,
+    onUnhandledError = noop,
+    ...rest
+}) => {
+    const collapseStripeElement = useRef<() => void>();
+    const { onToggle, selectedItemId } = useContext(AccordionContext);
+    const containerId = `stripe-${method.id}-component-field`;
+    const paymentContext = paymentForm;
+
+    useEffect(() => {
+        if (selectedItemId?.includes('stripeupe-')) {
+            return;
+        }
+
+        collapseStripeElement.current?.();
+    }, [selectedItemId]);
+
+    const renderSubmitButton = useCallback(() => {
+        paymentContext.hidePaymentSubmitButton(method, false);
+    }, [paymentContext, method]);
+
+    const {
+        hidePaymentSubmitButton,
+        disableSubmit,
+        setFieldValue,
+        setSubmit,
+        setValidationSchema,
+    } = paymentForm;
+    const instruments = checkoutState.data.getInstruments(method) || [];
+
+    const {
+        data: { getCheckout, isPaymentDataRequired },
+        statuses: { isLoadingInstruments },
+    } = checkoutState;
+    const checkout = getCheckout();
+
+    const initializeStripePayment = useCallback(
+        async (options: PaymentInitializeOptions) => {
+            return checkoutService.initializePayment({
+                ...options,
+                stripeupe: {
+                    containerId,
+                    onError: onUnhandledError,
+                    render: renderSubmitButton,
+                    paymentMethodSelect: onToggle,
+                    handleClosePaymentMethod: (collapseElement: () => void) => {
+                        collapseStripeElement.current = collapseElement;
+                    },
+                },
+            });
+        },
+        [containerId, checkoutService, onUnhandledError, renderSubmitButton, onToggle],
+    );
+
+    return (
+        <HostedWidgetPaymentComponent
+            {...rest}
+            containerId={containerId}
+            deinitializePayment={checkoutService.deinitializePayment}
+            disableSubmit={disableSubmit}
+            hideContentWhenSignedOut
+            hidePaymentSubmitButton={hidePaymentSubmitButton}
+            initializePayment={initializeStripePayment}
+            instruments={instruments}
+            isInstrumentCardCodeRequired={isInstrumentCardCodeRequiredSelector(checkoutState)}
+            isInstrumentCardNumberRequired={isInstrumentCardNumberRequiredSelector(checkoutState)}
+            isInstrumentFeatureAvailable={false}
+            isLoadingInstruments={isLoadingInstruments()}
+            isPaymentDataRequired={isPaymentDataRequired()}
+            isSignedIn={some(checkout?.payments, { providerId: method.id })}
+            loadInstruments={checkoutService.loadInstruments}
+            method={method}
+            setFieldValue={setFieldValue}
+            setSubmit={setSubmit}
+            setValidationSchema={setValidationSchema}
+            signOut={checkoutService.signOutCustomer}
+        />
+    );
+};
+
+export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
+    StripeOCSPaymentMethod,
+    [{ gateway: 'stripeupe', id: 'stripe_ocs' }],
+);

--- a/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-upe/StripeUPEPaymentMethod.tsx
@@ -1,13 +1,6 @@
 import { PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { noop, some } from 'lodash';
-import React, {
-    FunctionComponent,
-    useCallback,
-    useContext,
-    useEffect,
-    useMemo,
-    useRef,
-} from 'react';
+import React, { FunctionComponent, useCallback, useMemo } from 'react';
 
 import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
 import { HostedWidgetPaymentComponent } from '@bigcommerce/checkout/hosted-widget-integration';
@@ -20,7 +13,6 @@ import {
     PaymentMethodResolveId,
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
-import { AccordionContext } from '@bigcommerce/checkout/ui';
 
 const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     paymentForm,
@@ -30,18 +22,8 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     onUnhandledError = noop,
     ...rest
 }) => {
-    const collapseStripeElement = useRef<() => void>();
-    const { onToggle, selectedItemId } = useContext(AccordionContext);
     const containerId = `stripe-${method.id}-component-field`;
     const paymentContext = paymentForm;
-
-    useEffect(() => {
-        if (selectedItemId?.includes('stripeupe-')) {
-            return;
-        }
-
-        collapseStripeElement.current?.();
-    }, [selectedItemId]);
 
     const renderSubmitButton = useCallback(() => {
         paymentContext.hidePaymentSubmitButton(method, false);
@@ -115,10 +97,6 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     },
                     onError: onUnhandledError,
                     render: renderSubmitButton,
-                    paymentMethodSelect: onToggle,
-                    handleClosePaymentMethod: (collapseElement: () => void) => {
-                        collapseStripeElement.current = collapseElement;
-                    },
                 },
             });
         },
@@ -129,7 +107,6 @@ const StripeUPEPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             method,
             paymentContext,
             renderSubmitButton,
-            onToggle,
         ],
     );
 


### PR DESCRIPTION
## What?
Add container for Stripe OCS payment method

## Why?
To develop and render new Stripe implementation in the new separate container

## Testing / Proof

https://github.com/user-attachments/assets/5290afe8-fe8e-4217-a389-ea0b980a6813


https://github.com/user-attachments/assets/0c75c329-96fe-45b4-ab0f-e7d2c23ac1ec



@bigcommerce/team-checkout
