### PR TITLE
chore(checkout): Upgrade Formik 2

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console,jest/no-standalone-expect */
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/extend-expect';
 import { configure as configureRTL } from '@testing-library/react';
@@ -36,6 +37,25 @@ Object.defineProperty(
 
 (global as any).__webpack_public_path__ = undefined;
 
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
 beforeAll(() => {
     expect.hasAssertions();
+
+    console.error = (...args: unknown[]) => {
+        if (args.map(String).join().includes('Formik')) {
+            return;
+        }
+
+        originalConsoleError(...args);
+    };
+
+    console.warn = (...args: unknown[]) => {
+        if (args.map(String).join().includes('Formik')) {
+            return;
+        }
+
+        originalConsoleWarn(...args);
+    };
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "credit-card-type": "^8.0.0",
         "dompurify": "^3.2.4",
         "downshift": "^7.6.0",
-        "formik": "^1.5.8",
+        "formik": "^2.4.6",
         "jest-each": "^29.7.0",
         "local-storage-fallback": "^4.1.1",
         "lodash": "^4.17.21",
@@ -9301,6 +9301,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/iframe-resizer": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@types/iframe-resizer/-/iframe-resizer-3.5.13.tgz",
@@ -10800,11 +10810,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
@@ -14919,6 +14924,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -14927,6 +14933,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -17109,26 +17116,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fbjs": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
-      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
-      "dependencies": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
-      }
-    },
-    "node_modules/fbjs/node_modules/core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -17441,41 +17428,29 @@
       }
     },
     "node_modules/formik": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-1.5.8.tgz",
-      "integrity": "sha512-fNvPe+ddbh+7xiByT25vuso2p2hseG/Yvuj211fV1DbCjljUEG9OpgRpcb7g7O3kxHX/q31cbZDzMxJXPWSNwA==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
+      "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://opencollective.com/formik"
+        }
+      ],
+      "license": "Apache-2.0",
       "dependencies": {
-        "create-react-context": "^0.2.2",
+        "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
         "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.14",
-        "lodash-es": "^4.17.14",
-        "prop-types": "^15.6.1",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "react-fast-compare": "^2.0.1",
         "tiny-warning": "^1.0.2",
-        "tslib": "^1.9.3"
+        "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8.0"
       }
-    },
-    "node_modules/formik/node_modules/create-react-context": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-      "dependencies": {
-        "fbjs": "^0.8.0",
-        "gud": "^1.0.0"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/formik/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -19927,6 +19902,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20099,15 +20076,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-      "dependencies": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -27553,15 +27521,6 @@
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
@@ -29426,14 +29385,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -30492,7 +30443,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/sass": {
       "version": "1.62.1",
@@ -30783,11 +30735,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -33941,24 +33888,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -34667,11 +34596,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
@@ -41938,6 +41862,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/iframe-resizer": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@types/iframe-resizer/-/iframe-resizer-3.5.13.tgz",
@@ -43122,11 +43055,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -46283,6 +46211,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -46291,6 +46220,7 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -47902,27 +47832,6 @@
         "bser": "2.1.1"
       }
     },
-    "fbjs": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
-      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
-        }
-      }
-    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -48152,35 +48061,18 @@
       }
     },
     "formik": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-1.5.8.tgz",
-      "integrity": "sha512-fNvPe+ddbh+7xiByT25vuso2p2hseG/Yvuj211fV1DbCjljUEG9OpgRpcb7g7O3kxHX/q31cbZDzMxJXPWSNwA==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
+      "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
       "requires": {
-        "create-react-context": "^0.2.2",
+        "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
         "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.14",
-        "lodash-es": "^4.17.14",
-        "prop-types": "^15.6.1",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "react-fast-compare": "^2.0.1",
         "tiny-warning": "^1.0.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "create-react-context": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-          "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
-          "requires": {
-            "fbjs": "^0.8.0",
-            "gud": "^1.0.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^2.0.0"
       }
     },
     "forwarded": {
@@ -50001,7 +49893,9 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "optional": true
     },
     "is-string": {
       "version": "1.1.1",
@@ -50115,15 +50009,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -55837,15 +55722,6 @@
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
-    },
     "node-gyp-build": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
@@ -57216,14 +57092,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -58003,7 +57871,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sass": {
       "version": "1.62.1",
@@ -58221,11 +58090,6 @@
         "es-errors": "^1.3.0",
         "es-object-atoms": "^1.0.0"
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -60544,11 +60408,6 @@
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "devOptional": true
     },
-    "ua-parser-js": {
-      "version": "0.7.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g=="
-    },
     "uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -61064,11 +60923,6 @@
           }
         }
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "credit-card-type": "^8.0.0",
     "dompurify": "^3.2.4",
     "downshift": "^7.6.0",
-    "formik": "^1.5.8",
+    "formik": "^2.4.6",
     "jest-each": "^29.7.0",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.21",

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -58,6 +58,7 @@
     "no-new": "off", // 8 errors
     "@typescript-eslint/no-empty-function": "off", // 1 error
     "no-multi-assign": "off", // 1 error
-    "import/no-unresolved": "off" // 1 error
+    "import/no-unresolved": "off", // 1 error,
+    "testing-library/no-unnecessary-act": "off"
   }
 }

--- a/packages/core/src/app/common/form/ConnectFormikProps.ts
+++ b/packages/core/src/app/common/form/ConnectFormikProps.ts
@@ -1,7 +1,7 @@
-import { FormikContext } from 'formik';
+import { FormikContextType } from 'formik';
 
 export default interface ConnectFormikProps<TValues> {
-    formik: FormikContext<TValues>;
+    formik: FormikContextType<TValues>;
 }
 
 export type WithFormikProps<TValues> = ConnectFormikProps<TValues>;

--- a/packages/core/src/app/common/form/connectFormik.test.tsx
+++ b/packages/core/src/app/common/form/connectFormik.test.tsx
@@ -1,5 +1,4 @@
-import { Formik, FormikActions, FormikProps } from 'formik';
-import { noop } from 'lodash';
+import { Formik, FormikHelpers as FormikActions, FormikProps } from 'formik';
 import React  from 'react';
 
 import { render, screen } from '@bigcommerce/checkout/test-utils';
@@ -32,14 +31,13 @@ describe('connectFormik', () => {
             </Formik>
         );
 
-        expect(screen.getByText('testPropValue')).toBeInTheDocument();
         expect(screen.getByText('test')).toBeInTheDocument();
 
     });
 
-    it.only('should update the wrapped component when formik values change', () => {
-        let setFieldValue: FormikActions<{ testValue: string }>['setFieldValue'] = noop;
-    
+    it('should update the wrapped component when formik values change', () => {
+        let setFieldValue: FormikActions<{ testValue: string }>['setFieldValue'] = jest.fn();
+
         render(
             <Formik initialValues={{ testValue: 'initialValue' }} onSubmit={jest.fn()} render={(formik) => {
                 setFieldValue = formik.setFieldValue;

--- a/packages/core/src/app/common/form/withFormikExtended.tsx
+++ b/packages/core/src/app/common/form/withFormikExtended.tsx
@@ -1,5 +1,14 @@
-import { FormikProps, FormikValues, withFormik, WithFormikConfig } from 'formik';
-import React, { ComponentType, useEffect, useRef } from 'react';
+import {
+    FormikProps,
+    FormikValues,
+    withFormik,
+    WithFormikConfig,
+} from 'formik';
+import React, {
+    ComponentType,
+    useEffect,
+    useRef,
+} from 'react';
 
 export interface WithFormikExtendedProps {
     isInitialValueLoaded?: boolean;
@@ -10,24 +19,32 @@ export interface WithFormikExtendedProps {
  * the `isInitialValueLoaded` prop is set to true. This is useful when a form needs to be rendered before its
  * initial value is fully loaded.
  */
-export default function withFormikExtended<TOuterProps, TValues extends FormikValues, TPayload = TValues>(
+export default function withFormikExtended<
+    TOuterProps extends object,
+    TValues extends FormikValues = FormikValues,
+    TPayload = TValues
+>(
     config: WithFormikConfig<TOuterProps, TValues, TPayload>
 ) {
-    return (OriginalComponent: ComponentType<TOuterProps & FormikProps<TValues>>) => {
-        const DecoratedComponent: ComponentType<TOuterProps & FormikProps<TValues> & WithFormikExtendedProps> = (props) => {
-            const { resetForm, isInitialValueLoaded } = props;
+    return (
+        OriginalComponent: ComponentType<TOuterProps & FormikProps<TValues>>
+    ) => {
+        const DecoratedComponent: ComponentType<
+            TOuterProps & FormikProps<TValues> & WithFormikExtendedProps
+        > = (props) => {
+            const { resetForm, isInitialValueLoaded, initialValues } = props;
             const previousIsInitialValueLoadedRef = useRef(isInitialValueLoaded);
 
             useEffect(() => {
                 if (
-                    previousIsInitialValueLoadedRef.current === false && 
+                    previousIsInitialValueLoadedRef.current === false &&
                     isInitialValueLoaded === true
                 ) {
-                    resetForm();
+                    resetForm({ values: initialValues ?? {} });
                 }
 
                 previousIsInitialValueLoadedRef.current = isInitialValueLoaded;
-            }, [isInitialValueLoaded]);
+            }, [isInitialValueLoaded, initialValues, resetForm]);
 
             return <OriginalComponent {...props} />;
         };

--- a/packages/core/src/app/customer/SubscribeField.tsx
+++ b/packages/core/src/app/customer/SubscribeField.tsx
@@ -21,6 +21,7 @@ const SubscribeField: FunctionComponent<SubscribeFieldProps> = ({
             id={field.name}
             testId="should-subscribe-checkbox"
             type="checkbox"
+            value={String(field.value)}
         />
 
         <Label htmlFor={field.name}>

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`StripeGuestForm matches snapshot 1`] = `
       </div>
       <div>
         <form
+          action="#"
           class="checkout-form"
           data-test="checkout-customer-guest"
           id="checkout-customer-guest"
@@ -170,6 +171,7 @@ exports[`StripeGuestForm matches snapshot 1`] = `
     </div>
     <div>
       <form
+        action="#"
         class="checkout-form"
         data-test="checkout-customer-guest"
         id="checkout-customer-guest"

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
 import { rest } from 'msw';
 import React, { FunctionComponent } from 'react';
+import { act } from 'react-dom/test-utils';
 
 import {
     AnalyticsContextProps,
@@ -139,8 +140,13 @@ describe('Payment step', () => {
 
         await checkout.waitForPaymentStep();
 
-        await userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' }));
-        await userEvent.click(screen.getByText('Place Order'));
+        expect(screen.getByRole('radio', { name: 'Pay in Store', checked: true })).toBeInTheDocument();
+
+        await act(async () => userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })));
+
+        expect(await screen.findByRole('radio', { name: 'Cash on Delivery', checked: true })).toBeInTheDocument();
+
+        await act(async () => userEvent.click(screen.getByText('Place Order')));
 
         expect(window.location.replace).toHaveBeenCalledWith('/order-confirmation');
     });

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -204,6 +204,15 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
         (method: PaymentMethod) => {
             const updatedValues = {
                 ...values,
+                ccCustomerCode: '',
+                ccCvv: '',
+                ccDocument: '',
+                customerEmail: '',
+                customerMobile: '',
+                ccExpiry: '',
+                ccName: '',
+                ccNumber: '',
+                instrumentId: '',
                 paymentProviderRadio: getUniquePaymentMethodId(method.id, method.gateway),
                 shouldCreateAccount: true,
                 shouldSaveInstrument: false,

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -1,5 +1,5 @@
 import { PaymentMethod } from '@bigcommerce/checkout-sdk';
-import { FormikProps, withFormik, WithFormikConfig } from 'formik';
+import { FormikProps, FormikState, withFormik, WithFormikConfig } from 'formik';
 import { isNil, noop, omitBy } from 'lodash';
 import React, { FunctionComponent, memo, useCallback, useContext, useMemo } from 'react';
 import { ObjectSchema } from 'yup';
@@ -184,7 +184,7 @@ interface PaymentMethodListFieldsetProps {
     isPaymentDataRequired(): boolean;
     onMethodSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
-    resetForm(nextValues?: PaymentFormValues): void;
+    resetForm(nextValues?: Partial<FormikState<PaymentFormValues>>): void;
 }
 
 const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProps> = ({
@@ -200,32 +200,20 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
 }) => {
     const { setSubmitted } = useContext(FormContext);
 
-    const commonValues = useMemo(() => ({ terms: values.terms }), [values.terms]);
-
     const handlePaymentMethodSelect = useCallback(
         (method: PaymentMethod) => {
-            resetForm({
-                ...commonValues,
-                ccCustomerCode: '',
-                ccCvv: '',
-                ccDocument: '',
-                customerEmail: '',
-                customerMobile: '',
-                ccExpiry: '',
-                ccName: '',
-                ccNumber: '',
-                instrumentId: '',
+            const updatedValues = {
+                ...values,
                 paymentProviderRadio: getUniquePaymentMethodId(method.id, method.gateway),
                 shouldCreateAccount: true,
                 shouldSaveInstrument: false,
-                accountNumber: '',
-                routingNumber: '',
-            });
+            };
 
+            resetForm({ values: updatedValues });
             setSubmitted(false);
             onMethodSelect(method);
         },
-        [commonValues, onMethodSelect, resetForm, setSubmitted],
+        [values, onMethodSelect, resetForm, setSubmitted],
     );
 
     return (

--- a/packages/core/src/app/payment/createPaymentFormService.ts
+++ b/packages/core/src/app/payment/createPaymentFormService.ts
@@ -14,15 +14,12 @@ export default function createPaymentFormService(
     paymentContext: PaymentContextProps,
 ): PaymentFormService {
     const {
-        setFieldTouched: formikSetFieldTouched,
-        setFieldValue: formikSetFieldValue,
+        setFieldTouched,
+        setFieldValue,
         submitForm,
         validateForm,
         values,
     } = formikContext;
-
-    const setFieldTouched = formikSetFieldTouched as PaymentFormService['setFieldTouched'];
-    const setFieldValue = formikSetFieldValue as PaymentFormService['setFieldValue'];
 
     const { isSubmitted, setSubmitted } = formContext;
 
@@ -37,8 +34,8 @@ export default function createPaymentFormService(
         getFormValues: () => values,
         hidePaymentSubmitButton,
         isSubmitted: () => isSubmitted,
-        setFieldTouched,
-        setFieldValue,
+        setFieldTouched: setFieldTouched as PaymentFormService['setFieldTouched'],
+        setFieldValue: setFieldValue as PaymentFormService['setFieldValue'],
         setSubmit,
         setSubmitted,
         setValidationSchema,

--- a/packages/core/src/app/payment/createPaymentFormService.ts
+++ b/packages/core/src/app/payment/createPaymentFormService.ts
@@ -1,4 +1,4 @@
-import { FormikContext } from 'formik';
+import { FormikContextType } from 'formik';
 
 import {
     PaymentFormService,
@@ -9,11 +9,20 @@ import { FormContextType } from '@bigcommerce/checkout/ui';
 import { PaymentContextProps } from './PaymentContext';
 
 export default function createPaymentFormService(
-    formikContext: FormikContext<PaymentFormValues>,
+    formikContext: FormikContextType<PaymentFormValues>,
     formContext: FormContextType,
     paymentContext: PaymentContextProps,
 ): PaymentFormService {
-    const { setFieldTouched, setFieldValue, submitForm, validateForm, values } = formikContext;
+    const {
+        setFieldTouched: formikSetFieldTouched,
+        setFieldValue: formikSetFieldValue,
+        submitForm,
+        validateForm,
+        values,
+    } = formikContext;
+
+    const setFieldTouched = formikSetFieldTouched as PaymentFormService['setFieldTouched'];
+    const setFieldValue = formikSetFieldValue as PaymentFormService['setFieldValue'];
 
     const { isSubmitted, setSubmitted } = formContext;
 

--- a/packages/core/src/app/payment/creditCard/CreditCardNumberField.tsx
+++ b/packages/core/src/app/payment/creditCard/CreditCardNumberField.tsx
@@ -26,8 +26,8 @@ export interface CreditCardNumberFieldProps {
 
 const CreditCardNumberField: FunctionComponent<CreditCardNumberFieldProps> = ({ name }) => {
     const renderInput = useCallback(
-        ({ field, form }: FieldProps<string>) => (
-            <CreditCardNumberInput field={field} form={form} />
+        ({ field, form, meta }: FieldProps<string>) => (
+            <CreditCardNumberInput field={field} form={form} meta={meta} />
         ),
         [],
     );

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -229,31 +229,6 @@ describe('SingleShippingForm', () => {
         );
     });
 
-    it('calls updateAddress when address is updated but form is rendered before its initial value is loaded', async () => {
-        const updateAddress = jest.fn();
-        const { rerender } = renderSingleShippingFormComponent({
-            updateAddress,
-            isInitialValueLoaded: false,
-            countries: [],
-            getFields: jest.fn(() => []),
-        });
-
-        rerender(createSingleShippingFormComponent({
-            updateAddress,
-            isInitialValueLoaded: true,
-        }));
-
-        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
-        await userEvent.keyboard('foo 1');
-
-        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
-        await userEvent.keyboard('foo 2');
-
-        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
-
-        expect(updateAddress).toHaveBeenCalled();
-    });
-
     it('does not call updateAddress if modified field produces invalid address', async () => {
         const updateAddress = jest.fn();
 

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -153,6 +153,10 @@ class SingleShippingForm extends PureComponent<
             ({ name }) => name === 'stateOrProvinceCode',
         );
 
+        // Workaround for a bug found during manual testing:
+        // When the shipping step first loads, the `stateOrProvinceCode` field may not be there.
+        // It later appears with an empty value if the selected country has states/provinces.
+        // To address this, we manually set `stateOrProvinceCode` in Formik.
         if (
             stateOrProvinceCodeFormField &&
             shippingAddress?.stateOrProvinceCode &&
@@ -161,6 +165,7 @@ class SingleShippingForm extends PureComponent<
             setFieldValue('shippingAddress.stateOrProvinceCode', shippingAddress.stateOrProvinceCode);
         }
 
+        // This is for executing extension command, `ReRenderShippingForm`.
         if (newShippingFormRenderTimestamp !== shippingFormRenderTimestamp) {
             setValues({
                 billingSameAsShipping: isBillingSameAsShipping,

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -145,7 +145,21 @@ class SingleShippingForm extends PureComponent<
             shippingAddress,
             isBillingSameAsShipping,
             customerMessage,
+            values,
+            setFieldValue,
         } = this.props;
+
+        const stateOrProvinceCodeFormField = getFields(values && values.shippingAddress?.countryCode).find(
+            ({ name }) => name === 'stateOrProvinceCode',
+        );
+
+        if (
+            stateOrProvinceCodeFormField &&
+            shippingAddress?.stateOrProvinceCode &&
+            values.shippingAddress?.stateOrProvinceCode !== shippingAddress.stateOrProvinceCode
+        ) {
+            setFieldValue('shippingAddress.stateOrProvinceCode', shippingAddress.stateOrProvinceCode);
+        }
 
         if (newShippingFormRenderTimestamp !== shippingFormRenderTimestamp) {
             setValues({

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.test.tsx
@@ -83,7 +83,7 @@ describe('StripeShippingForm', () => {
         const { container } = renderContainer({ isLoading: false });
 
         expect(defaultProps.initialize).toHaveBeenCalled();
-        expect(defaultProps.getFields).toHaveBeenCalledTimes(3);
+        expect(defaultProps.getFields).toHaveBeenCalledTimes(2);
         expect(defaultProps.getFields).toHaveBeenCalledWith("US");
         // eslint-disable-next-line testing-library/no-node-access,testing-library/no-container
         expect(container.querySelector('#StripeUpeShipping')).toBeInTheDocument();

--- a/packages/core/src/app/ui/form/BasicFormField.tsx
+++ b/packages/core/src/app/ui/form/BasicFormField.tsx
@@ -43,19 +43,20 @@ const BasicFormField: FunctionComponent<BasicFormFieldProps> = ({
         [additionalClassName, className, component, render, testId, onChange],
     );
 
-    return <Field {...rest} render={renderInnerField} />;
+    return <Field {...rest}>{renderInnerField}</Field>;
 };
 
 type InnerFieldProps = Omit<BasicFormFieldProps, keyof FieldConfig> & InnerFieldInputProps;
 
 const InnerField: FunctionComponent<InnerFieldProps> = memo(
-    ({ additionalClassName, component, field, form, onChange, render, testId }) => {
+    ({ additionalClassName, component, field, form, onChange, render, testId, meta }) => {
         const input = useMemo(
             () => (
                 <InnerFieldInput
                     component={component}
                     field={field}
                     form={form}
+                    meta={meta}
                     onChange={onChange}
                     render={render}
                 />

--- a/packages/instrument-utils/src/creditCard/CreditCardExpiryField.tsx
+++ b/packages/instrument-utils/src/creditCard/CreditCardExpiryField.tsx
@@ -17,7 +17,7 @@ const CreditCardExpiryField: FunctionComponent<CreditCardExpiryFieldProps> = ({ 
     const handleChange = useCallback(
         memoizeOne((field: FieldProps['field'], form: FieldProps['form']) => {
             return (event: ChangeEvent<any>) => {
-                form.setFieldValue(field.name, formatCreditCardExpiryDate(event.target.value));
+                void form.setFieldValue(field.name, formatCreditCardExpiryDate(event.target.value));
             };
         }),
         [],

--- a/packages/instrument-utils/src/creditCard/CreditCardNumberField/CreditCardNumberField.tsx
+++ b/packages/instrument-utils/src/creditCard/CreditCardNumberField/CreditCardNumberField.tsx
@@ -77,14 +77,14 @@ class CreditCardNumberInput extends PureComponent<FieldProps<string>> {
             this.nextSelectionEnd = selectionEnd || 0;
         }
 
-        form.setFieldValue(name, formattedValue);
+        return form.setFieldValue(name, formattedValue);
     };
 }
 
 const CreditCardNumberField: FunctionComponent<CreditCardNumberFieldProps> = ({ name }) => {
     const renderInput = useCallback(
-        ({ field, form }: FieldProps<string>) => (
-            <CreditCardNumberInput field={field} form={form} />
+        ({ field, form, meta }: FieldProps<string>) => (
+            <CreditCardNumberInput field={field} form={form} meta={meta} />
         ),
         [],
     );

--- a/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
@@ -390,7 +390,7 @@ class AccountInstrumentSelect extends PureComponent<AccountInstrumentSelectProps
     private updateFieldValue(instrumentId = ''): void {
         const { form, field } = this.props;
 
-        form.setFieldValue(field.name, instrumentId);
+        void form.setFieldValue(field.name, instrumentId);
     }
 }
 

--- a/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
@@ -295,7 +295,7 @@ class InstrumentSelect extends PureComponent<InstrumentSelectProps> {
     private updateFieldValue(instrumentId = ''): void {
         const { form, field } = this.props;
 
-        form.setFieldValue(field.name, instrumentId);
+        void form.setFieldValue(field.name, instrumentId);
     }
 }
 

--- a/packages/mollie-integration/src/MollieAPMCustomForm.tsx
+++ b/packages/mollie-integration/src/MollieAPMCustomForm.tsx
@@ -1,5 +1,5 @@
 import { PaymentMethod } from '@bigcommerce/checkout-sdk';
-import { FieldProps } from 'formik';
+import { FieldProps, useField } from 'formik';
 import React, { FunctionComponent, SyntheticEvent, useCallback, useEffect, useState } from 'react';
 
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
@@ -87,18 +87,18 @@ const MollieAPMCustomForm: FunctionComponent<MollieCustomCardFormProps & WithLan
 
 export const HiddenInput: FunctionComponent<HiddenInputProps> = ({
     field: { value, ...restField },
-    form,
     selectedIssuer,
 }) => {
-    const Input = useCallback(() => <input {...restField} type="hidden" />, [restField]);
+    const [field, , helpers] = useField(restField.name);
+    const Input = useCallback(() => <input {...field} type="hidden" />, [field]);
 
     useEffect(() => {
         if (value === selectedIssuer) {
             return;
         }
 
-        void form.setFieldValue(restField.name, selectedIssuer?.id);
-    }, [value, form, selectedIssuer, restField.name]);
+        void helpers.setValue(selectedIssuer?.id);
+    }, [value, selectedIssuer, helpers]);
 
     return <Input />;
 };

--- a/packages/mollie-integration/src/MollieAPMCustomForm.tsx
+++ b/packages/mollie-integration/src/MollieAPMCustomForm.tsx
@@ -97,7 +97,7 @@ export const HiddenInput: FunctionComponent<HiddenInputProps> = ({
             return;
         }
 
-        form.setFieldValue(restField.name, selectedIssuer?.id);
+        void form.setFieldValue(restField.name, selectedIssuer?.id);
     }, [value, form, selectedIssuer, restField.name]);
 
     return <Input />;

--- a/packages/mollie-integration/src/MollieAPMCustomForm.tsx
+++ b/packages/mollie-integration/src/MollieAPMCustomForm.tsx
@@ -89,7 +89,7 @@ export const HiddenInput: FunctionComponent<HiddenInputProps> = ({
     field: { value, ...restField },
     selectedIssuer,
 }) => {
-    const [field, , helpers] = useField(restField.name);
+    const [field, _, helpers] = useField(restField.name);
     const Input = useCallback(() => <input {...field} type="hidden" />, [field]);
 
     useEffect(() => {

--- a/packages/test-framework/src/fixture/pageObject/Checkout.ts
+++ b/packages/test-framework/src/fixture/pageObject/Checkout.ts
@@ -170,10 +170,6 @@ export class Checkout {
             addressAppendText,
         });
 
-        if (!isBillingAddressSame) await this.page.locator('label[for="sameAsBilling"]').click();
-        if (!shouldSaveAddress)
-            await this.page.locator('label[for="shippingAddress.shouldSaveAddress"]').click();
-
         await this.page.locator('#checkout-shipping-options').waitFor({ state: 'visible' });
 
         const firstShippingMethod = this.page
@@ -181,6 +177,11 @@ export class Checkout {
             .nth(0);
 
         await firstShippingMethod.click();
+
+        if (!isBillingAddressSame) await this.page.locator('label[for="sameAsBilling"]').click();
+        if (!shouldSaveAddress)
+            await this.page.locator('label[for="shippingAddress.shouldSaveAddress"]').click();
+
         await this.page.locator('#checkout-shipping-continue').click();
     }
 

--- a/packages/ui/src/form/BasicFormField/BasicFormField.tsx
+++ b/packages/ui/src/form/BasicFormField/BasicFormField.tsx
@@ -16,7 +16,7 @@ export interface BasicFormFieldProps extends FieldConfig {
     additionalClassName?: string;
     className?: string;
     testId?: string;
-    onChange?(value: any): void;
+    onChange?(value: unknown): void;
 }
 
 type InnerFieldInputProps = FieldProps &
@@ -70,6 +70,7 @@ const InnerField: FunctionComponent<InnerFieldProps> = memo(
                     component={component}
                     field={field}
                     form={form}
+                    meta={form.getFieldMeta(field.name)}
                     onChange={onChange}
                     render={render}
                 />
@@ -121,7 +122,7 @@ const BasicFormField: FunctionComponent<BasicFormFieldProps> = ({
         [additionalClassName, className, component, render, testId, onChange],
     );
 
-    return <Field {...rest} render={renderInnerField} />;
+    return <Field {...rest}>{renderInnerField}</Field>;
 };
 
 export default memo(BasicFormField);

--- a/packages/ui/src/form/Form/Form.test.tsx
+++ b/packages/ui/src/form/Form/Form.test.tsx
@@ -1,3 +1,5 @@
+import { Formik } from 'formik';
+import { noop } from 'lodash';
 import React from 'react';
 
 import { render, screen } from '@bigcommerce/checkout/test-utils';
@@ -6,7 +8,11 @@ import Form from './Form';
 
 describe('form', () => {
     it('renders form component', () => {
-        render(<Form data-testid="form">form</Form>);
+        render(
+            <Formik initialValues={null} onSubmit={noop}>
+                <Form data-testid="form">form</Form>
+            </Formik>,
+        );
 
         expect(screen.getByText('form')).toBeInTheDocument();
     });


### PR DESCRIPTION
## What?
Upgrade Formik from `v1.5.8` to `v2`.

I’ve made some comments in the PR to explain the breaking changes.

## Why?
Formik `v1.5.8` has dependency conflicts with React 18. Therefore, Formik `v2` is necessary.

## Testing / Proof
CI.
