### PR TITLE
chore(customer): CHECKOUT-7961 Update padding for steps and customer step

### DIFF
--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -149,7 +149,7 @@ const GuestForm: FunctionComponent<
                 )}
 
                 {!isLoading && (
-                    <p>
+                    <p className="customer-login-link">
                         <TranslatedString id="customer.login_text" />{' '}
                         <a
                             data-test="customer-continue-button"

--- a/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -28,8 +28,6 @@
 }
 
 .checkout-view-header {
-    // margin-bottom: remCalc(10px);
-
     &:last-child {
         margin-bottom: 0;
     }

--- a/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
+++ b/packages/core/src/scss/components/checkout/checkoutSteps/_checkoutSteps.scss
@@ -20,7 +20,7 @@
 .checkout-step {
     border-bottom: container("border");
     counter-increment: $checkoutStep-counter;
-    padding: spacing("single") 0;
+    padding: #{spacing("fifth") + spacing("fifth")} 0;
 
     &:last-child {
         border: 0;
@@ -28,7 +28,7 @@
 }
 
 .checkout-view-header {
-    margin-bottom: remCalc(10px);
+    // margin-bottom: remCalc(10px);
 
     &:last-child {
         margin-bottom: 0;
@@ -111,7 +111,7 @@
     align-items: top;
     display: flex;
     flex-wrap: wrap;
-    padding: spacing("single") 0;
+    padding: #{spacing("half") + spacing("third")} 0;
 
     @include breakpoint("small") {
         flex-wrap: nowrap;

--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -64,7 +64,7 @@
 //
 // -----------------------------------------------------------------------------
 .customerHeader,
-.checkout-step--customer { 
+.checkout-step--customer {
     .stepHeader-body {
         overflow: visible;
     }
@@ -124,6 +124,10 @@ $buttonWidthMap: (
 
 .checkout-button-container {
     margin: spacing('double') 0 0;
+
+    p {
+        margin-bottom: #{spacing("half") + spacing("third")}
+    }
 
     .checkoutRemote {
         display: grid;
@@ -236,7 +240,7 @@ $buttonWidthMap: (
     display: flex;
     height: spacing("half");
     justify-content: space-between;
-    margin-top: spacing('double');
+    margin-top: #{spacing('base') + spacing('base')};
     text-align: center;
     width: 100%;
 

--- a/packages/core/src/scss/components/checkout/customer/_customer.scss
+++ b/packages/core/src/scss/components/checkout/customer/_customer.scss
@@ -9,7 +9,7 @@
     @include grid-row;
 
     @include breakpoint("small") {
-        margin-bottom: spacing("single");
+        margin-bottom: spacing("half");
     }
 
     .customerEmail-floating--enabled {
@@ -50,6 +50,10 @@
     width: 100%;
 }
 
+.customer-login-link {
+    margin-bottom: #{spacing("half") + spacing("third")};
+}
+
 .stripeCustomerEmail-button {
     bottom: 3px;
     padding: $customerEmail-button-padding;
@@ -60,7 +64,7 @@
 //
 // -----------------------------------------------------------------------------
 .customerHeader,
-.checkout-step--customer {
+.checkout-step--customer { 
     .stepHeader-body {
         overflow: visible;
     }

--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -40,6 +40,7 @@
 
     .form-field {
         position: relative;
+        margin: 0 0 spacing("half");
 
         &:last-child {
             margin-bottom: 0;


### PR DESCRIPTION
## What?
Update padding for customer steps and step sections.

## Why?
In order to remove empty white space and clean styles, reduce padding.

## Testing / Proof
- CI
- Screenshots
#### Before
<img width="1366" alt="Screenshot 2025-05-08 at 1 57 04 pm" src="https://github.com/user-attachments/assets/bd05fb20-cd31-4319-bb8f-5df981b73f43" />
<img width="1149" alt="Screenshot 2025-05-08 at 2 12 39 pm" src="https://github.com/user-attachments/assets/67b9cf81-2ee5-41ef-9a32-3fbac277bf7d" />

#### After
<img width="1366" alt="Screenshot 2025-05-08 at 1 57 30 pm" src="https://github.com/user-attachments/assets/99e1c0de-334d-46a4-aa26-681523180de4" />
<img width="1132" alt="Screenshot 2025-05-08 at 2 11 54 pm" src="https://github.com/user-attachments/assets/f1a62cb9-97b8-4799-ad23-f3d98c86133e" />


@bigcommerce/team-checkout
