### PR TITLE
feat(payment): Stripe OCS accordion element styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.731.2",
+        "@bigcommerce/checkout-sdk": "^1.732.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.731.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.731.2.tgz",
-      "integrity": "sha512-c0/NHeN3IDclNal8yq1Dm1MmGooMFHn6324Opz9YYM6yD87Gp58N8EdLhoJTGQ8pW9QLMcsaJcszEjHHpiL2Jw==",
+      "version": "1.732.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.732.0.tgz",
+      "integrity": "sha512-vdElVPt4ACqqsdznzk0+ZwKncanY+jBcIi9aSrdZUMPLZs/BKOee2PbfcvXbeoXmSL09SaCpXmvqPQB/7VwhAw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.27.4",
@@ -36186,9 +36186,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.731.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.731.2.tgz",
-      "integrity": "sha512-c0/NHeN3IDclNal8yq1Dm1MmGooMFHn6324Opz9YYM6yD87Gp58N8EdLhoJTGQ8pW9QLMcsaJcszEjHHpiL2Jw==",
+      "version": "1.732.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.732.0.tgz",
+      "integrity": "sha512-vdElVPt4ACqqsdznzk0+ZwKncanY+jBcIi9aSrdZUMPLZs/BKOee2PbfcvXbeoXmSL09SaCpXmvqPQB/7VwhAw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.27.4",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.731.2",
+    "@bigcommerce/checkout-sdk": "^1.732.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -34,6 +34,12 @@ import { AccordionContext, AccordionContextProps } from '@bigcommerce/checkout/u
 
 import StripeOCSPaymentMethod from './StripeOCSPaymentMethod';
 
+jest.mock('./getStripeOCSStyles', () => ({
+    getStylesForOCSElement: () => {
+        return { color: '#cccccc' };
+    },
+}));
+
 describe('when using StripeUPE OCS payment', () => {
     let method: PaymentMethod;
     let checkoutService: CheckoutService;
@@ -77,12 +83,6 @@ describe('when using StripeUPE OCS payment', () => {
 
         jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(true);
 
-        jest.mock('@bigcommerce/checkout/dom-utils', () => ({
-            getAppliedStyles: () => {
-                return { color: '#cccccc' };
-            },
-        }));
-
         defaultProps = {
             method,
             checkoutService,
@@ -119,6 +119,7 @@ describe('when using StripeUPE OCS payment', () => {
             methodId: 'pay_now',
             stripeupe: {
                 containerId: 'stripe-pay_now-component-field',
+                style: { color: '#cccccc' },
                 onError: expect.any(Function),
                 render: expect.any(Function),
                 paymentMethodSelect: expect.any(Function),
@@ -143,6 +144,7 @@ describe('when using StripeUPE OCS payment', () => {
             methodId: 'pay_now',
             stripeupe: {
                 containerId: 'stripe-pay_now-component-field',
+                style: { color: '#cccccc' },
                 onError: expect.any(Function),
                 render: expect.any(Function),
                 paymentMethodSelect: expect.any(Function),
@@ -152,13 +154,6 @@ describe('when using StripeUPE OCS payment', () => {
     });
 
     it('initializes method with required config', () => {
-        const element = document.createElement('div');
-
-        element.style.color = 'red';
-        element.style.boxShadow = 'boxShadow';
-        element.style.borderColor = 'blue';
-
-        jest.spyOn(document, 'getElementById').mockReturnValue(element);
         render(<PaymentMethodTest {...defaultProps} method={method} />);
 
         expect(checkoutService.initializePayment).toHaveBeenCalledWith(
@@ -168,6 +163,7 @@ describe('when using StripeUPE OCS payment', () => {
                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                 [`${method.gateway}`]: {
                     containerId: `stripe-${method.id}-component-field`,
+                    style: { color: '#cccccc' },
                     onError: expect.any(Function),
                     render: expect.any(Function),
                     paymentMethodSelect: expect.any(Function),

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -14,6 +14,8 @@ import {
 } from '@bigcommerce/checkout/payment-integration-api';
 import { AccordionContext } from '@bigcommerce/checkout/ui';
 
+import { getStylesForOCSElement } from './getStripeOCSStyles';
+
 const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     paymentForm,
     checkoutState,
@@ -60,6 +62,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                 ...options,
                 stripeupe: {
                     containerId,
+                    style: getStylesForOCSElement(containerId),
                     onError: onUnhandledError,
                     render: renderSubmitButton,
                     paymentMethodSelect: onToggle,
@@ -72,29 +75,58 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         [containerId, checkoutService, onUnhandledError, renderSubmitButton, onToggle],
     );
 
+    const renderCheckoutThemeStylesForStripeOCS = () => {
+        return (
+            <div style={{ display: 'none' }}>
+                <div id={`${containerId}--accordion-header`}>
+                    <div className="form-checklist-checkbox" />
+                    <div className="form-label optimizedCheckout-form-label" />
+                </div>
+                <div
+                    className="optimizedCheckout-form-input"
+                    id={`${containerId}--input`}
+                    placeholder="1111"
+                >
+                    <div className="form-field--error">
+                        <div
+                            className="optimizedCheckout-form-label"
+                            id={`${containerId}--error`}
+                        />
+                    </div>
+                    <div className="optimizedCheckout-form-label" id={`${containerId}--label`} />
+                </div>
+            </div>
+        );
+    };
+
     return (
-        <HostedWidgetPaymentComponent
-            {...rest}
-            containerId={containerId}
-            deinitializePayment={checkoutService.deinitializePayment}
-            disableSubmit={disableSubmit}
-            hideContentWhenSignedOut
-            hidePaymentSubmitButton={hidePaymentSubmitButton}
-            initializePayment={initializeStripePayment}
-            instruments={instruments}
-            isInstrumentCardCodeRequired={isInstrumentCardCodeRequiredSelector(checkoutState)}
-            isInstrumentCardNumberRequired={isInstrumentCardNumberRequiredSelector(checkoutState)}
-            isInstrumentFeatureAvailable={false}
-            isLoadingInstruments={isLoadingInstruments()}
-            isPaymentDataRequired={isPaymentDataRequired()}
-            isSignedIn={some(checkout?.payments, { providerId: method.id })}
-            loadInstruments={checkoutService.loadInstruments}
-            method={method}
-            setFieldValue={setFieldValue}
-            setSubmit={setSubmit}
-            setValidationSchema={setValidationSchema}
-            signOut={checkoutService.signOutCustomer}
-        />
+        <>
+            <HostedWidgetPaymentComponent
+                {...rest}
+                containerId={containerId}
+                deinitializePayment={checkoutService.deinitializePayment}
+                disableSubmit={disableSubmit}
+                hideContentWhenSignedOut
+                hidePaymentSubmitButton={hidePaymentSubmitButton}
+                initializePayment={initializeStripePayment}
+                instruments={instruments}
+                isInstrumentCardCodeRequired={isInstrumentCardCodeRequiredSelector(checkoutState)}
+                isInstrumentCardNumberRequired={isInstrumentCardNumberRequiredSelector(
+                    checkoutState,
+                )}
+                isInstrumentFeatureAvailable={false}
+                isLoadingInstruments={isLoadingInstruments()}
+                isPaymentDataRequired={isPaymentDataRequired()}
+                isSignedIn={some(checkout?.payments, { providerId: method.id })}
+                loadInstruments={checkoutService.loadInstruments}
+                method={method}
+                setFieldValue={setFieldValue}
+                setSubmit={setSubmit}
+                setValidationSchema={setValidationSchema}
+                signOut={checkoutService.signOutCustomer}
+            />
+            {renderCheckoutThemeStylesForStripeOCS()}
+        </>
     );
 };
 

--- a/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.test.ts
+++ b/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.test.ts
@@ -1,0 +1,193 @@
+import * as domUtils from '@bigcommerce/checkout/dom-utils';
+
+import { getStylesForOCSElement } from './getStripeOCSStyles';
+
+describe('getStylesForOCSElement', () => {
+    const containerId = 'stripe-ocs-container-id';
+    const fontLink = 'https://fonts.googleapis.com/font.woff2';
+    const defaultStyles: Record<string, Record<string, string | undefined>> = {
+        [`#${containerId}--input`]: {
+            color: 'black',
+            'background-color': 'white',
+            'border-color': 'gray',
+            'box-shadow': '0 0 5px rgba(0, 0, 0, 0.5)',
+            'font-family': 'Arial, sans-serif',
+        },
+        [`#${containerId}--label`]: {
+            color: 'blue',
+        },
+        [`#${containerId}--error`]: {
+            color: 'red',
+        },
+        [`#${containerId}--accordion-header .form-label`]: {
+            color: 'green',
+            'font-size': '16px',
+            'font-family': 'Monaco, sans-serif',
+            'font-weight': 'bold',
+            'padding-top': '10px',
+            'padding-right': '10px',
+            'padding-bottom': '10px',
+        },
+        '.checkout-step--payment .form-checklist': {
+            'border-bottom': '1px solid black',
+        },
+    };
+
+    const mockGetAppliedStyles = (
+        properties: Record<string, Record<string, string | undefined>>,
+    ) => {
+        jest.spyOn(domUtils, 'getAppliedStyles').mockImplementation(
+            jest.fn().mockImplementation((element: HTMLElement) => {
+                const elementSelector = element.getAttribute('data-test-selector');
+
+                return properties[elementSelector as keyof typeof defaultStyles];
+            }),
+        );
+    };
+
+    beforeEach(() => {
+        jest.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+            const element = document.createElement('div');
+
+            element.setAttribute('data-test-selector', selector);
+
+            return element;
+        });
+
+        jest.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
+            const element = document.createElement('div');
+
+            element.setAttribute('data-test-selector', selector);
+            element.setAttribute('href', fontLink);
+
+            return [element] as NodeListOf<Element>;
+        });
+
+        mockGetAppliedStyles(defaultStyles);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns the correct styles for the OCS element', () => {
+        expect(getStylesForOCSElement(containerId)).toEqual({
+            labelText: 'blue',
+            fieldErrorText: 'red',
+            fieldText: 'black',
+            fieldPlaceholderText: 'black',
+            fieldBackground: 'white',
+            fieldInnerShadow: '0 0 5px rgba(0, 0, 0, 0.5)',
+            fieldBorder: 'gray',
+            fontFamily: 'Monaco, sans-serif',
+            accordionItemTitleFontSize: '16px',
+            accordionItemTitleFontWeight: 'bold',
+            accordionHeaderColor: 'green',
+            accordionHeaderPadding: '10px 10px 10px 18px',
+            accordionBorderBottom: '1px solid black',
+            fontsSrc: ['https://fonts.googleapis.com/font.woff2'],
+        });
+    });
+
+    it('returns the field input font family styles when no accordion font family provided', () => {
+        mockGetAppliedStyles({
+            ...defaultStyles,
+            [`#${containerId}--accordion-header .form-label`]: {
+                ...defaultStyles[`#${containerId}--accordion-header .form-label`],
+                'font-family': undefined,
+            },
+        });
+
+        expect(getStylesForOCSElement(containerId)).toEqual({
+            labelText: 'blue',
+            fieldErrorText: 'red',
+            fieldText: 'black',
+            fieldPlaceholderText: 'black',
+            fieldBackground: 'white',
+            fieldInnerShadow: '0 0 5px rgba(0, 0, 0, 0.5)',
+            fieldBorder: 'gray',
+            fontFamily: 'Arial, sans-serif',
+            accordionItemTitleFontSize: '16px',
+            accordionItemTitleFontWeight: 'bold',
+            accordionHeaderColor: 'green',
+            accordionHeaderPadding: '10px 10px 10px 18px',
+            accordionBorderBottom: '1px solid black',
+            fontsSrc: ['https://fonts.googleapis.com/font.woff2'],
+        });
+    });
+
+    it('returns the default padding styles when no accordion paddings provided', () => {
+        mockGetAppliedStyles({
+            ...defaultStyles,
+            [`#${containerId}--accordion-header .form-label`]: {
+                ...defaultStyles[`#${containerId}--accordion-header .form-label`],
+                'padding-top': undefined,
+                'padding-right': undefined,
+                'padding-bottom': undefined,
+            },
+        });
+
+        expect(getStylesForOCSElement(containerId)).toEqual({
+            labelText: 'blue',
+            fieldErrorText: 'red',
+            fieldText: 'black',
+            fieldPlaceholderText: 'black',
+            fieldBackground: 'white',
+            fieldInnerShadow: '0 0 5px rgba(0, 0, 0, 0.5)',
+            fieldBorder: 'gray',
+            fontFamily: 'Monaco, sans-serif',
+            accordionItemTitleFontSize: '16px',
+            accordionItemTitleFontWeight: 'bold',
+            accordionHeaderColor: 'green',
+            accordionHeaderPadding: '13px 18px 13px 18px',
+            accordionBorderBottom: '1px solid black',
+            fontsSrc: ['https://fonts.googleapis.com/font.woff2'],
+        });
+    });
+
+    it('returns the default Stripe font family styles when no BC fonts found', () => {
+        jest.spyOn(document, 'querySelector').mockReturnValue(null);
+        jest.spyOn(document, 'querySelectorAll').mockImplementation(() => {
+            return [null] as NodeListOf<Element>;
+        });
+
+        expect(getStylesForOCSElement(containerId)).toEqual({
+            labelText: undefined,
+            fieldErrorText: undefined,
+            fieldText: undefined,
+            fieldPlaceholderText: undefined,
+            fieldBackground: undefined,
+            fieldInnerShadow: undefined,
+            fieldBorder: undefined,
+            fontFamily: undefined,
+            accordionItemTitleFontSize: undefined,
+            accordionItemTitleFontWeight: undefined,
+            accordionHeaderColor: undefined,
+            accordionHeaderPadding: undefined,
+            accordionBorderBottom: undefined,
+            fontsSrc: [],
+        });
+    });
+
+    it('returns the default Stripe styles when no BC accordion element provided', () => {
+        jest.spyOn(document, 'querySelector').mockReturnValue(null);
+        jest.spyOn(document, 'querySelectorAll').mockReturnValue([] as NodeListOf<Element>);
+
+        expect(getStylesForOCSElement(containerId)).toEqual({
+            labelText: undefined,
+            fieldErrorText: undefined,
+            fieldText: undefined,
+            fieldPlaceholderText: undefined,
+            fieldBackground: undefined,
+            fieldInnerShadow: undefined,
+            fieldBorder: undefined,
+            fontFamily: undefined,
+            accordionItemTitleFontSize: undefined,
+            accordionItemTitleFontWeight: undefined,
+            accordionHeaderColor: undefined,
+            accordionHeaderPadding: undefined,
+            accordionBorderBottom: undefined,
+            fontsSrc: [],
+        });
+    });
+});

--- a/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.ts
+++ b/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.ts
@@ -1,0 +1,86 @@
+import { isEmpty } from 'lodash';
+
+import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
+
+const getStylesFromElement = (selector: string, properties: string[]) => {
+    const element = document.querySelector<HTMLElement>(selector);
+
+    return element ? getAppliedStyles(element, properties) : {};
+};
+
+const getFontsSrc = (selector: string) => {
+    const elementsList: NodeListOf<Element> = document.querySelectorAll(selector);
+    const fontsList: string[] = [];
+
+    elementsList.forEach((element: Element | null) => {
+        const fontSrc = element?.getAttribute('href');
+
+        if (fontSrc) {
+            fontsList.push(fontSrc);
+        }
+    });
+
+    return fontsList;
+};
+
+export const getStylesForOCSElement = (
+    containerId: string,
+): Record<string, string | string[] | undefined> => {
+    const formInputStyles = getStylesFromElement(`#${containerId}--input`, [
+        'color',
+        'background-color',
+        'border-color',
+        'box-shadow',
+        'font-family',
+    ]);
+    const formLabelStyles = getStylesFromElement(`#${containerId}--label`, ['color']);
+    const formErrorStyles = getStylesFromElement(`#${containerId}--error`, ['color']);
+    const accordionHeaderStyles = getStylesFromElement(
+        `#${containerId}--accordion-header .form-label`,
+        [
+            'color',
+            'font-size',
+            'font-family',
+            'font-weight',
+            'padding-top',
+            'padding-right',
+            'padding-bottom',
+        ],
+    );
+    const formChecklistStyles = getStylesFromElement(`.checkout-step--payment .form-checklist`, [
+        'border-bottom',
+    ]);
+    const fontsSrc = getFontsSrc('link[href*="font"]');
+
+    const defaultAccordionPaddingHorizontal = '18px';
+    const defaultAccordionPaddingVertical = '13px';
+    const {
+        color: accordionHeaderColor,
+        'font-size': accordionItemTitleFontSize,
+        'font-family': accordionHeaderFontFamily,
+        'font-weight': accordionItemTitleFontWeight,
+        'padding-top': accordionPaddingTop = defaultAccordionPaddingVertical,
+        'padding-right': accordionPaddingRight = defaultAccordionPaddingHorizontal,
+        'padding-bottom': accordionPaddingBottom = defaultAccordionPaddingVertical,
+    } = accordionHeaderStyles;
+    const accordionHeaderPadding = !isEmpty(accordionHeaderStyles)
+        ? `${accordionPaddingTop} ${accordionPaddingRight} ${accordionPaddingBottom} ${defaultAccordionPaddingHorizontal}`
+        : undefined;
+
+    return {
+        labelText: formLabelStyles.color,
+        fieldText: formInputStyles.color,
+        fieldPlaceholderText: formInputStyles.color,
+        fieldErrorText: formErrorStyles.color,
+        fieldBackground: formInputStyles['background-color'],
+        fieldInnerShadow: formInputStyles['box-shadow'],
+        fieldBorder: formInputStyles['border-color'],
+        accordionHeaderPadding,
+        fontFamily: accordionHeaderFontFamily || formInputStyles['font-family'],
+        accordionItemTitleFontSize,
+        accordionItemTitleFontWeight,
+        accordionHeaderColor,
+        accordionBorderBottom: formChecklistStyles['border-bottom'],
+        fontsSrc,
+    };
+};


### PR DESCRIPTION
## What?
Add basic customization options for Stripe OCS accordion
checkout-js PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2853](https://github.com/bigcommerce/checkout-sdk-js/pull/2853)

## Why?
To get ability for customization new Stripe accordion elememnt

## Testing / Proof

https://github.com/user-attachments/assets/394a94bd-9d99-4239-b596-64f3190cf0e4

<img width="1281" alt="Screenshot 2025-05-06 at 14 43 58" src="https://github.com/user-attachments/assets/9b4c3c3d-db54-4328-abe1-a4510f57e0f2" />


@bigcommerce/team-checkout
