### PR TITLE
fix(checkout): Update formik logic

### DIFF
--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -4,6 +4,7 @@ import {
     createEmbeddedCheckoutMessenger,
     EmbeddedCheckoutMessenger,
 } from '@bigcommerce/checkout-sdk';
+import faker from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
@@ -499,6 +500,56 @@ describe('Shipping step', () => {
 
             expect(checkoutService.updateBillingAddress).toHaveBeenCalled();
             expect(screen.getByText(payments[0].config.displayName)).toBeInTheDocument();
+        });
+
+        it('goes back to the shipping step as a guest and updates the shipping address form correctly', async () => {
+            checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+            checkout.updateCheckout(
+                'put',
+                '/checkouts/xxxxxxxxxx-xxxx-xxax-xxxx-xxxxxx/consignments/consignment-1',
+                {
+                    ...checkoutWithShippingAndBilling,
+                },
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await userEvent.click(screen.getAllByRole('button', {name: 'Edit'})[1]);
+
+            const randomAddress1 = JSON.parse(JSON.stringify({
+                firstName: faker.name.firstName(),
+                lastName: faker.name.lastName(),
+                address1: faker.address.streetAddress(),
+                city: faker.address.city(),
+                countryCode: 'CC',
+                stateOrProvince: 'dummy state',
+                postalCode: faker.address.zipCode(),
+            }));
+
+            await checkout.fillAddressForm(randomAddress1);
+
+            expect((checkoutService.updateShippingAddress as any).mock.calls.slice(-1)[0][0]).toEqual(
+                expect.objectContaining(randomAddress1)
+            );
+
+            const randomAddress2 = JSON.parse(JSON.stringify({
+                firstName: faker.name.firstName(),
+                lastName: faker.name.lastName(),
+                address1: faker.address.streetAddress(),
+                city: faker.address.city(),
+                countryCode: 'AU',
+                stateOrProvinceCode: faker.helpers.arrayElement(['NSW', 'VIC', 'QLD', 'TAS']),
+                postalCode: faker.address.zipCode(),
+            }));
+
+            await checkout.fillAddressForm(randomAddress2);
+
+            expect((checkoutService.updateShippingAddress as any).mock.calls.slice(-1)[0][0]).toEqual(
+                expect.objectContaining(randomAddress2)
+            );
         });
     });
 

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -530,9 +530,16 @@ describe('Shipping step', () => {
             }));
 
             await checkout.fillAddressForm(randomAddress1);
+            await userEvent.selectOptions(
+                screen.getByTestId('field_60Input-select'),
+                '2',
+            );
 
             expect((checkoutService.updateShippingAddress as any).mock.calls.slice(-1)[0][0]).toEqual(
-                expect.objectContaining(randomAddress1)
+                expect.objectContaining({
+                    ...randomAddress1,
+                    customFields: [{fieldId: 'field_60', fieldValue: '2'}],
+                }),
             );
 
             const randomAddress2 = JSON.parse(JSON.stringify({
@@ -546,9 +553,16 @@ describe('Shipping step', () => {
             }));
 
             await checkout.fillAddressForm(randomAddress2);
+            await userEvent.selectOptions(
+                screen.getByTestId('field_60Input-select'),
+                '1',
+            );
 
             expect((checkoutService.updateShippingAddress as any).mock.calls.slice(-1)[0][0]).toEqual(
-                expect.objectContaining(randomAddress2)
+                expect.objectContaining({
+                        ...randomAddress2,
+                        customFields: [{fieldId: 'field_60', fieldValue: '1'}],
+                }),
             );
         });
     });

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -160,7 +160,7 @@ class SingleShippingForm extends PureComponent<
         if (
             stateOrProvinceCodeFormField &&
             shippingAddress?.stateOrProvinceCode &&
-            values.shippingAddress?.stateOrProvinceCode !== shippingAddress.stateOrProvinceCode
+            !values.shippingAddress?.stateOrProvinceCode
         ) {
             setFieldValue('shippingAddress.stateOrProvinceCode', shippingAddress.stateOrProvinceCode);
         }

--- a/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
+++ b/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
@@ -293,11 +293,10 @@ export class CheckoutPageNodeObject {
                 screen.getByTestId('provinceCodeInput-select'),
                 address.stateOrProvinceCode,
             );
-        }
-
-        if (address.stateOrProvince) {
+        } else if (address.stateOrProvince) {
             await userEvent.clear(screen.getByLabelText('State/Province (Optional)'));
-            await userEvent.type(screen.getByLabelText('State/Province (Optional)'),
+            await userEvent.type(
+                screen.getByLabelText('State/Province (Optional)'),
                 address.stateOrProvince,
             );
         }

--- a/packages/test-framework/src/react-testing-library-support/mocks/countries.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/countries.ts
@@ -17,6 +17,55 @@ const countries = {
             requiresState: false,
             subdivisions: [],
         },
+        {
+            id: 13,
+            code: 'AU',
+            name: 'Australia',
+            hasPostalCodes: true,
+            requiresState: true,
+            subdivisions: [
+                {
+                    id: 208,
+                    code: 'ACT',
+                    name: 'Australian Capital Territory',
+                },
+                {
+                    id: 209,
+                    code: 'NSW',
+                    name: 'New South Wales',
+                },
+                {
+                    id: 210,
+                    code: 'NT',
+                    name: 'Northern Territory',
+                },
+                {
+                    id: 211,
+                    code: 'QLD',
+                    name: 'Queensland',
+                },
+                {
+                    id: 212,
+                    code: 'SA',
+                    name: 'South Australia',
+                },
+                {
+                    id: 213,
+                    code: 'TAS',
+                    name: 'Tasmania',
+                },
+                {
+                    id: 214,
+                    code: 'VIC',
+                    name: 'Victoria',
+                },
+                {
+                    id: 215,
+                    code: 'WA',
+                    name: 'Western Australia',
+                },
+            ],
+        },
     ],
     meta: {},
 };

--- a/packages/test-framework/src/react-testing-library-support/mocks/form-fields.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/form-fields.ts
@@ -226,6 +226,34 @@ const formFields = {
             type: 'string',
             fieldType: 'text',
         },
+        {
+            id: 'field_60',
+            name: 'field_60',
+            custom: true,
+            label: 'Shipping Instructions',
+            required: false,
+            default: null,
+            maxLength: null,
+            type: 'array',
+            fieldType: 'dropdown',
+            options: {
+                helperLabel: 'instructions',
+                items: [
+                    {
+                        value: '0',
+                        label: 'Put it in the mailbox',
+                    },
+                    {
+                        value: '1',
+                        label: 'Put it on the porch',
+                    },
+                    {
+                        value: '2',
+                        label: 'Put it in front of the door',
+                    },
+                ],
+            },
+        },
     ],
     customerAccount: [
         {


### PR DESCRIPTION
## What?
Refactor Formik logic to ensure proper handling of the province form field.

## Why?
To resolve the issue where shoppers are unable to select a province value when returning to the shipping step.

## Testing / Proof
CI.

@bigcommerce/team-checkout
