### PR TITLE
fix(common): fixed npm run release:alpha command run

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:server": "http-server build --cors",
     "e2e": "npm run build && npx playwright install && PORT=5005 MODE=REPLAY npx playwright test",
     "release": "echo 'Please do not release locally, use CircleCi'",
-    "release:alpha": "npm run lint && npm run test -- --coverage && npm run build -- --env prerelease=prerelease && npm run release:version",
+    "release:alpha": "npm run lint && npm run test -- --coverage && npm run nx:build -- --env prerelease=prerelease && npm run release:version",
     "release:version": "git add dist && standard-version -a",
     "test:core": "jest --config packages/core/jest.config.js",
     "test:others": "npx nx run-many --all --target=test --exclude=core, checkout-extension --parallel=5 -- --runInBand",


### PR DESCRIPTION
## What?
Updated `npm run release:alpha` command by updating by changing `npm run build` with `npm run nx:build`

## Why?
Because prev variant does not apply env variable and throws an error

## Testing / Proof
Before:
<img width="638" alt="Screenshot 2025-05-07 at 18 23 56" src="https://github.com/user-attachments/assets/c428b055-c741-4a19-b309-3c5c3b641c9a" />

After:
<img width="803" alt="Screenshot 2025-05-07 at 18 15 08" src="https://github.com/user-attachments/assets/4dfad139-d4a3-4b16-8ae6-233aae83499b" />

