### PR TITLE
fix(payments) fix consistent re-renders on payment step

### DIFF
--- a/packages/instrument-utils/src/storedInstrument/InstrumentStoreAsDefaultField/InstrumentStoreAsDefaultField.tsx
+++ b/packages/instrument-utils/src/storedInstrument/InstrumentStoreAsDefaultField/InstrumentStoreAsDefaultField.tsx
@@ -22,7 +22,9 @@ const InstrumentStoreAsDefaultField: FunctionComponent<InstrumentStoreAsDefaultF
         if (disabled) {
             paymentForm.setFieldValue('shouldSetAsDefaultInstrument', false);
         }
-    }, [disabled, paymentForm]);
+        // Ignoring paymentForm dependency as it causes sequential re-renders when included in array
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [disabled]);
 
     const labelContent = useMemo(() => <TranslatedString id={translationId} />, [translationId]);
 


### PR DESCRIPTION
## What?
 Fix consistent re-renders on payment step
 
## Why?
Because it was a blocker for payment UI

## Testing / Proof
Before changes:

https://github.com/user-attachments/assets/aaccb0a7-e389-4cad-bfa3-80a4b9746868

After changes Stripe UPE behaviour:

https://github.com/user-attachments/assets/38086683-1c5b-416b-a26a-12f86c034694

After changes Adyen behaviour:

https://github.com/user-attachments/assets/f72639ca-ae3b-4b5b-9f6d-5548e41192b3




@bigcommerce/team-checkout
