### PR TITLE
feat(payment): updated CheckoutButtonList component to use Wallet Buttons components directly from generated files

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonList.test.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.test.tsx
@@ -1,11 +1,6 @@
 import { noop } from 'lodash';
 import React from 'react';
 
-import {
-    createLocaleContext,
-    LocaleContext,
-    LocaleContextType,
-} from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
 import { getStoreConfig } from '../config/config.mock';
@@ -13,27 +8,16 @@ import { getStoreConfig } from '../config/config.mock';
 import CheckoutButtonList from './CheckoutButtonList';
 
 describe('CheckoutButtonList', () => {
-    let localeContext: LocaleContextType;
-
     const checkoutSettings = getStoreConfig().checkoutSettings;
 
-    beforeEach(() => {
-        localeContext = createLocaleContext(getStoreConfig());
-    });
-
     it('filters out unsupported methods', () => {
-        // Apple Pay is supported across all browsers since 2025
-        // no unsupported methods since then
-
         render(
-            <LocaleContext.Provider value={localeContext}>
-                <CheckoutButtonList
-                    checkoutSettings={checkoutSettings}
-                    deinitialize={noop}
-                    initialize={noop}
-                    methodIds={['applepay', 'amazonpay', 'braintreevisacheckout']}
-                />
-            </LocaleContext.Provider>,
+            <CheckoutButtonList
+                checkoutSettings={checkoutSettings}
+                deinitialize={noop}
+                initialize={noop}
+                methodIds={['applepay', 'amazonpay', 'braintreevisacheckout']}
+            />,
         );
 
         expect(screen.getAllByRole('generic')).toHaveLength(6);
@@ -41,13 +25,11 @@ describe('CheckoutButtonList', () => {
 
     it('does not crash when no methods are passed', () => {
         render(
-            <LocaleContext.Provider value={localeContext}>
-                <CheckoutButtonList
-                    checkoutSettings={checkoutSettings}
-                    deinitialize={noop}
-                    initialize={noop}
-                />
-            </LocaleContext.Provider>,
+            <CheckoutButtonList
+                checkoutSettings={checkoutSettings}
+                deinitialize={noop}
+                initialize={noop}
+            />,
         );
 
         expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
@@ -55,14 +37,12 @@ describe('CheckoutButtonList', () => {
 
     it('does not render if there are no supported methods', () => {
         render(
-            <LocaleContext.Provider value={localeContext}>
-                <CheckoutButtonList
-                    checkoutSettings={checkoutSettings}
-                    deinitialize={noop}
-                    initialize={noop}
-                    methodIds={['foobar']}
-                />
-            </LocaleContext.Provider>,
+            <CheckoutButtonList
+                checkoutSettings={checkoutSettings}
+                deinitialize={noop}
+                initialize={noop}
+                methodIds={['foobar']}
+            />,
         );
 
         expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
@@ -70,15 +50,13 @@ describe('CheckoutButtonList', () => {
 
     it('does not render the translated string when initializing', () => {
         render(
-            <LocaleContext.Provider value={localeContext}>
-                <CheckoutButtonList
-                    checkoutSettings={checkoutSettings}
-                    deinitialize={noop}
-                    initialize={noop}
-                    isInitializing={true}
-                    methodIds={['amazonpay', 'braintreevisacheckout']}
-                />
-            </LocaleContext.Provider>,
+            <CheckoutButtonList
+                checkoutSettings={checkoutSettings}
+                deinitialize={noop}
+                initialize={noop}
+                isInitializing={true}
+                methodIds={['amazonpay', 'braintreevisacheckout']}
+            />,
         );
 
         expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
@@ -92,20 +70,103 @@ describe('CheckoutButtonList', () => {
         });
 
         render(
-            <LocaleContext.Provider value={localeContext}>
-                <CheckoutButtonList
-                    checkEmbeddedSupport={checkEmbeddedSupport}
-                    checkoutSettings={checkoutSettings}
-                    deinitialize={noop}
-                    initialize={noop}
-                    methodIds={methodIds}
-                    onError={onError}
-                />
-            </LocaleContext.Provider>,
+            <CheckoutButtonList
+                checkEmbeddedSupport={checkEmbeddedSupport}
+                checkoutSettings={checkoutSettings}
+                deinitialize={noop}
+                initialize={noop}
+                methodIds={methodIds}
+                onError={onError}
+            />,
         );
 
         expect(checkEmbeddedSupport).toHaveBeenCalledWith(methodIds);
 
         expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    describe('when PAYPAL-5502.update_wallet_buttons_implementation_in_customer_step experiment is enabled', () => {
+        const checkoutSettingsWithExperimentEnabled = {
+            ...checkoutSettings,
+            features: {
+                ...checkoutSettings.features,
+                'PAYPAL-5502.update_wallet_buttons_implementation_in_customer_step': true,
+            },
+        };
+
+        it('filters out unsupported methods', () => {
+            render(
+                <CheckoutButtonList
+                    checkoutSettings={checkoutSettingsWithExperimentEnabled}
+                    deinitialize={noop}
+                    initialize={noop}
+                    methodIds={['applepay', 'amazonpay', 'braintreevisacheckout']}
+                />,
+            );
+
+            expect(screen.getAllByRole('generic')).toHaveLength(6);
+        });
+
+        it('does not crash when no methods are passed', () => {
+            render(
+                <CheckoutButtonList
+                    checkoutSettings={checkoutSettingsWithExperimentEnabled}
+                    deinitialize={noop}
+                    initialize={noop}
+                />,
+            );
+
+            expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
+        });
+
+        it('does not render if there are no supported methods', () => {
+            render(
+                <CheckoutButtonList
+                    checkoutSettings={checkoutSettingsWithExperimentEnabled}
+                    deinitialize={noop}
+                    initialize={noop}
+                    methodIds={['foobar']}
+                />,
+            );
+
+            expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
+        });
+
+        it('does not render the translated string when initializing', () => {
+            render(
+                <CheckoutButtonList
+                    checkoutSettings={checkoutSettingsWithExperimentEnabled}
+                    deinitialize={noop}
+                    initialize={noop}
+                    isInitializing={true}
+                    methodIds={['amazonpay', 'braintreevisacheckout']}
+                />,
+            );
+
+            expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
+        });
+
+        it('notifies parent if methods are incompatible with Embedded Checkout', () => {
+            const methodIds = ['amazonpay', 'braintreevisacheckout'];
+            const onError = jest.fn();
+            const checkEmbeddedSupport = jest.fn(() => {
+                throw new Error();
+            });
+
+            render(
+                <CheckoutButtonList
+                    checkEmbeddedSupport={checkEmbeddedSupport}
+                    checkoutSettings={checkoutSettingsWithExperimentEnabled}
+                    deinitialize={noop}
+                    initialize={noop}
+                    methodIds={methodIds}
+                    onError={onError}
+                />,
+            );
+
+            expect(checkEmbeddedSupport).toHaveBeenCalledWith(methodIds);
+
+            expect(onError).toHaveBeenCalledWith(expect.any(Error));
+        });
     });
 });

--- a/packages/google-pay-integration/src/GooglePayButton.scss
+++ b/packages/google-pay-integration/src/GooglePayButton.scss
@@ -5,7 +5,7 @@
     }
 
     & .gpay-card-info-container {
-        height: 100%;
+        height: 36px;
         width: 100%;
         min-width: 100%;
         min-height: unset;


### PR DESCRIPTION
## What?
Checkout has 2 places where wallet buttons can be rendered based on settings selected by merchant:
1. Wallet buttons on top of checkout page;
2. Wallet buttons in customer step under the form where customer enters guest email address;

Both implementations has different approaches. The first one has an ability to use generated files (components from integration packages), to render wallet buttons, however second approach did not have such thing. 

So this PR contains changes:
- updated CheckoutButtonList component with ResolvedCheckoutButton implementation;
- removed Amazon Pay button component from core package, since there is the same component present in amazon integration package;
- updated google pay styles to fix style glitch with button height when button renders in customer step;


## Why?
Changes in this PR simplifies wallet buttons rendering process and avoids components duplication. After release wallet buttons in customer step could be rendered via components from integration packages (through generated nx imports in core package)

## Testing / Proof
Wallet buttons on top of checkout page:
(Braintree PayPal, Amazon Pay, Apple Pay, Google Pay)
<img width="1300" alt="Screenshot 2025-05-12 at 11 14 52" src="https://github.com/user-attachments/assets/e64751a5-ea7b-4ac4-89f6-4a5a405cf503" />

(PayPal, PayPal PayLater, PayPal Venmo, Amazon Pay, Google Pay)
<img width="1298" alt="Screenshot 2025-05-12 at 11 36 05" src="https://github.com/user-attachments/assets/3a45af29-e6b9-4310-9680-6ea10879a029" />


Wallet buttons in customer step:
(Braintree PayPal, Amazon Pay, Apple Pay, Google Pay)
<img width="1213" alt="Screenshot 2025-05-12 at 11 22 52" src="https://github.com/user-attachments/assets/f5a60057-c39c-4a0c-9820-7260528d4825" />

(PayPal, PayPal PayLater, PayPal Venmo, Amazon Pay, Google Pay)
<img width="1245" alt="Screenshot 2025-05-12 at 11 35 16" src="https://github.com/user-attachments/assets/80770c0d-f35a-45b5-9102-efaa3a652570" />


