### PR TITLE
fix(payment): Fix Stripe Link Formik Issues

### DIFF
--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -1,6 +1,7 @@
 import { CustomerInitializeOptions, CustomerRequestOptions } from '@bigcommerce/checkout-sdk';
 import { FieldProps, FormikProps, withFormik } from 'formik';
 import React, { FunctionComponent, memo, ReactNode, useCallback, useEffect, useState } from 'react';
+import { object } from 'yup';
 
 import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString, withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
@@ -46,7 +47,8 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
     requiresMarketingConsent,
     privacyPolicyUrl,
     step,
-    status
+    status,
+    setFieldValue,
 }) => {
 
     const [continueAsAGuestButton, setContinueAsAGuestButton] = useState(true);
@@ -61,6 +63,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
         });
     };
     const setEmailCallback = useCallback((authenticated: boolean, email: string) => {
+        setFieldValue('email', email);
         onChangeEmail(email);
         setEmailValue(email);
         setContinueAsAGuestButton(!email);
@@ -270,6 +273,8 @@ export default withLanguage(
                             language,
                         })
                 }
+
+                return object({});
             },
         })(memo(StripeGuestForm))
 )


### PR DESCRIPTION
## What  
Fix Formik issues with Stripe Link.

### Issue 1  
![Screenshot 2025-05-15 at 12 40 50](https://github.com/user-attachments/assets/1d82012a-2202-4428-84e2-29c2d0866747)  
Stripe Link does not set a `validationSchema` by default. As a result, Formik throws validation errors, as shown in the screenshot.

### Issue 2  
The Stripe Link guest form cannot be submitted because the email value is not propagated to the Formik context, and as a result, the validation fails.

## Why  
To ensure shoppers can successfully use Stripe Link during checkout.

## Testing / Proof  

https://github.com/user-attachments/assets/02a1d7c3-c34c-45db-a3e7-a67918610bb3