### PR TITLE
feat(payment): Stripe OCS accordion fix accordion borders

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -41,6 +41,10 @@ jest.mock('./getStripeOCSStyles', () => ({
 }));
 
 describe('when using StripeUPE OCS payment', () => {
+    const methodId = 'stripe_ocs';
+    const gatewayId = PaymentMethodId.StripeUPE;
+    const methodSelectorPrefix = `${gatewayId}-${methodId}`;
+    const expectedContainerId = `${methodSelectorPrefix}-component-field`;
     let method: PaymentMethod;
     let checkoutService: CheckoutService;
     let checkoutState: CheckoutSelectors;
@@ -61,14 +65,14 @@ describe('when using StripeUPE OCS payment', () => {
         checkoutService = createCheckoutService();
         checkoutState = checkoutService.getState();
         localeContext = createLocaleContext(getStoreConfig());
-        method = { ...getPaymentMethod(), id: 'pay_now', gateway: PaymentMethodId.StripeUPE };
+        method = { ...getPaymentMethod(), id: methodId, gateway: gatewayId };
         initializePayment = jest
             .spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
         onToggleMock = jest.fn();
         accordionContextValues = {
             onToggle: onToggleMock,
-            selectedItemId: 'stripeupe-stripe_ocs',
+            selectedItemId: methodSelectorPrefix,
         };
 
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
@@ -115,10 +119,10 @@ describe('when using StripeUPE OCS payment', () => {
         render(<PaymentMethodTest {...defaultProps} method={method} />);
 
         expect(initializePayment).toHaveBeenCalledWith({
-            gatewayId: 'stripeupe',
-            methodId: 'pay_now',
-            stripeupe: {
-                containerId: 'stripe-pay_now-component-field',
+            gatewayId,
+            methodId,
+            [gatewayId]: {
+                containerId: expectedContainerId,
                 style: { color: '#cccccc' },
                 onError: expect.any(Function),
                 render: expect.any(Function),
@@ -140,10 +144,10 @@ describe('when using StripeUPE OCS payment', () => {
         render(<PaymentMethodTest {...defaultProps} method={method} />);
 
         expect(initializePayment).toHaveBeenCalledWith({
-            gatewayId: 'stripeupe',
-            methodId: 'pay_now',
-            stripeupe: {
-                containerId: 'stripe-pay_now-component-field',
+            gatewayId,
+            methodId,
+            [gatewayId]: {
+                containerId: expectedContainerId,
                 style: { color: '#cccccc' },
                 onError: expect.any(Function),
                 render: expect.any(Function),
@@ -160,9 +164,32 @@ describe('when using StripeUPE OCS payment', () => {
             expect.objectContaining({
                 methodId: method.id,
                 gatewayId: method.gateway,
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                [`${method.gateway}`]: {
-                    containerId: `stripe-${method.id}-component-field`,
+                [gatewayId]: {
+                    containerId: expectedContainerId,
+                    style: { color: '#cccccc' },
+                    onError: expect.any(Function),
+                    render: expect.any(Function),
+                    paymentMethodSelect: expect.any(Function),
+                    handleClosePaymentMethod: expect.any(Function),
+                },
+            }),
+        );
+    });
+
+    it('initialize without error handler', () => {
+        const props = {
+            ...defaultProps,
+            onUnhandledError: undefined,
+        } as unknown as PaymentMethodProps;
+
+        render(<PaymentMethodTest {...props} method={method} />);
+
+        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+            expect.objectContaining({
+                methodId: method.id,
+                gatewayId: method.gateway,
+                [gatewayId]: {
+                    containerId: expectedContainerId,
                     style: { color: '#cccccc' },
                     onError: expect.any(Function),
                     render: expect.any(Function),

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -26,16 +26,16 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 }) => {
     const collapseStripeElement = useRef<() => void>();
     const { onToggle, selectedItemId } = useContext(AccordionContext);
-    const containerId = `stripe-${method.id}-component-field`;
+    const containerId = `${method.gateway}-${method.id}-component-field`;
     const paymentContext = paymentForm;
 
     useEffect(() => {
-        if (selectedItemId?.includes('stripeupe-')) {
+        if (selectedItemId?.includes(`${method.gateway}-`)) {
             return;
         }
 
         collapseStripeElement.current?.();
-    }, [selectedItemId]);
+    }, [selectedItemId, method.gateway]);
 
     const renderSubmitButton = useCallback(() => {
         paymentContext.hidePaymentSubmitButton(method, false);
@@ -77,25 +77,38 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     const renderCheckoutThemeStylesForStripeOCS = () => {
         return (
-            <div style={{ display: 'none' }}>
-                <div id={`${containerId}--accordion-header`}>
-                    <div className="form-checklist-checkbox" />
-                    <div className="form-label optimizedCheckout-form-label" />
-                </div>
-                <div
-                    className="optimizedCheckout-form-input"
-                    id={`${containerId}--input`}
-                    placeholder="1111"
-                >
-                    <div className="form-field--error">
-                        <div
-                            className="optimizedCheckout-form-label"
-                            id={`${containerId}--error`}
-                        />
+            <>
+                <style>
+                    {`
+                        .custom-checklist-item#radio-${method.gateway}-${method.id} {
+                            border-bottom: none;
+                        }
+                        .custom-checklist-item#radio-${method.gateway}-${method.id}:last-of-type {
+                            margin-bottom: -1px;
+                        }
+                    `}
+                </style>
+
+                <div style={{ display: 'none' }}>
+                    <div id={`${containerId}--accordion-header`}>
+                        <div className="form-checklist-checkbox" />
+                        <div className="form-label optimizedCheckout-form-label" />
                     </div>
-                    <div className="optimizedCheckout-form-label" id={`${containerId}--label`} />
+                    <div
+                        className="optimizedCheckout-form-input"
+                        id={`${containerId}--input`}
+                        placeholder="1111"
+                    >
+                        <div className="form-field--error">
+                            <div
+                                className="optimizedCheckout-form-label"
+                                id={`${containerId}--error`}
+                            />
+                        </div>
+                        <div className="optimizedCheckout-form-label" id={`${containerId}--label`} />
+                    </div>
                 </div>
-            </div>
+            </>
         );
     };
 


### PR DESCRIPTION
## What?
Fix issue with double borders for Stripe Accordion

## Why?
To remove double borders and make Stripe OCS accordion as native BC accordeon

## Testing / Proof
Before:
<img width="618" alt="Screenshot 2025-05-19 at 16 01 06" src="https://github.com/user-attachments/assets/9dcc7a5c-d195-401a-bc48-cb886f1cd868" />
<img width="626" alt="Screenshot 2025-05-19 at 16 05 37" src="https://github.com/user-attachments/assets/db2bc6d8-7400-4f6b-81a5-fe25ea3d4d19" />

After:
<img width="622" alt="Screenshot 2025-05-19 at 15 56 37" src="https://github.com/user-attachments/assets/270fc7fd-80c3-4691-a5f6-c44f29dbfb74" />
<img width="629" alt="Screenshot 2025-05-19 at 15 58 38" src="https://github.com/user-attachments/assets/5a9b2e15-0782-4a66-afd0-f272d2e036a8" />

Unit tests coverage
<img width="1792" alt="Screenshot 2025-05-19 at 15 56 03" src="https://github.com/user-attachments/assets/30a4ead4-6fb4-4d38-af13-8c7ed5c542c8" />


@bigcommerce/team-checkout
