### PR TITLE
chore(payment): bump checkout-sdk version to 1.732.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.732.0",
+        "@bigcommerce/checkout-sdk": "^1.732.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1975,12 +1975,11 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.732.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.732.0.tgz",
-      "integrity": "sha512-vdElVPt4ACqqsdznzk0+ZwKncanY+jBcIi9aSrdZUMPLZs/BKOee2PbfcvXbeoXmSL09SaCpXmvqPQB/7VwhAw==",
-      "license": "MIT",
+      "version": "1.732.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.732.2.tgz",
+      "integrity": "sha512-YruggvEMr29SrFWh1x2R88Knim0J5ICN0dYbPs/dbL1uNZBe58uTsl3OWRlCrBlnDsrnyN5QDdurgSkGW/xfYg==",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.27.4",
+        "@bigcommerce/bigpay-client": "^5.28.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.5.0",
         "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.732.0",
+    "@bigcommerce/checkout-sdk": "^1.732.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.732.2

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2861
https://github.com/bigcommerce/checkout-sdk-js/pull/2871

## Testing / Proof
Unit tests
Manual tests
CI
