### PR TITLE
fix(shipping): reset value in formik on checkbox unmount

### DIFF
--- a/packages/core/src/app/ui/form/Checklist.tsx
+++ b/packages/core/src/app/ui/form/Checklist.tsx
@@ -1,3 +1,4 @@
+import { Accordion } from '@bigcommerce/checkout/ui';
 import { noop } from 'lodash';
 import React, {
     createContext,
@@ -5,10 +6,10 @@ import React, {
     memo,
     ReactNode,
     useCallback,
+    useEffect,
     useMemo,
 } from 'react';
 
-import { Accordion } from '@bigcommerce/checkout/ui';
 
 import { connectFormik, ConnectFormikProps } from '../../common/form';
 
@@ -29,6 +30,12 @@ export const ChecklistContext = createContext<ChecklistContextProps | undefined>
 const Checklist: FunctionComponent<
     ChecklistProps & ConnectFormikProps<{ [key: string]: string }>
 > = ({ formik: { setFieldValue }, name, onSelect = noop, ...props }) => {
+    useEffect(() => {
+        return () => {
+            setFieldValue(name, '');
+        };
+    }, []);
+
     const handleSelect = useCallback(
         (value: string) => {
             setFieldValue(name, value);


### PR DESCRIPTION
## What?
Reset value in formik on checkbox unmount

## Why?
Formik forms tend to save value in formik contexts across form renders. Clear form value when checklist item is unmounted.

## Testing / Proof
- CI
- TBD

@bigcommerce/team-checkout
