### PR TITLE
Fix Module '"card-validator"' has no exported member 'creditCardType'

### DIFF
--- a/packages/instrument-utils/tsconfig.json
+++ b/packages/instrument-utils/tsconfig.json
@@ -4,5 +4,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
+  ],
+  "files": [
+    "../core/types/card-validator.d.ts"
   ]
 }


### PR DESCRIPTION
## What?
Fix typescript issue.
```
TS2305: Module '"card-validator"' has no exported member 'creditCardType'.
```
## Why?
Improve code quality.

## Testing / Proof
### Before
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/69394bda-2b42-4971-9364-6e95ff7f9bb7" />

### After
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/37b630fc-632f-434c-b81b-937ab18bce00" />
