### PR TITLE
feat(payment): move Stripe OCS and UPE to separate modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.738.0",
+        "@bigcommerce/checkout-sdk": "^1.740.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1974,9 +1974,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.738.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.738.0.tgz",
-      "integrity": "sha512-7OBOADUJApgML5uXzV8amnVGJrzGrmY4X0ud9SEUIUIDxViZMSN6sJuqy943sOo23YQJcxT0ScBNkl9WTYBumA==",
+      "version": "1.740.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.740.0.tgz",
+      "integrity": "sha512-Xkz34+9AKp+USUg//F84AOcK+bJ3sw8Zl8/K/DqAfT2x9QXFPXmPhruXnNbiN1qBKYqAT2OdjTDFlwVBVSaXig==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.738.0",
+    "@bigcommerce/checkout-sdk": "^1.740.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -5,7 +5,7 @@ import {
     createLanguageService,
     PaymentInitializeOptions,
     PaymentMethod,
-    WithStripeUPEPaymentInitializeOptions,
+    WithStripeOCSPaymentInitializeOptions,
 } from '@bigcommerce/checkout-sdk';
 import { render } from '@testing-library/react';
 import { Formik } from 'formik';
@@ -19,7 +19,6 @@ import {
 } from '@bigcommerce/checkout/locale';
 import {
     CheckoutProvider,
-    PaymentMethodId,
     PaymentMethodProps,
 } from '@bigcommerce/checkout/payment-integration-api';
 import {
@@ -40,9 +39,9 @@ jest.mock('./getStripeOCSStyles', () => ({
     },
 }));
 
-describe('when using StripeUPE OCS payment', () => {
-    const methodId = 'stripe_ocs';
-    const gatewayId = PaymentMethodId.StripeUPE;
+describe('when using Stripe OCS payment', () => {
+    const methodId = 'optimized_checkout';
+    const gatewayId = 'stripeocs';
     const methodSelectorPrefix = `${gatewayId}-${methodId}`;
     const expectedContainerId = `${methodSelectorPrefix}-component-field`;
     const defaultAccordionLayout = {
@@ -290,8 +289,8 @@ describe('when using StripeUPE OCS payment', () => {
     describe('# Stripe OCS accordion actions', () => {
         it('should call collapse BC accordion when stripe accordion item is selected', () => {
             jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
-                (options: WithStripeUPEPaymentInitializeOptions) => {
-                    options.stripeupe?.paymentMethodSelect?.('methodId');
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    options.stripeocs?.paymentMethodSelect?.('methodId');
 
                     return Promise.resolve(checkoutState);
                 },
@@ -303,8 +302,8 @@ describe('when using StripeUPE OCS payment', () => {
 
         it('should collapse stripe accordion when BC accordion item selected', () => {
             jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
-                (options: WithStripeUPEPaymentInitializeOptions) => {
-                    options.stripeupe?.handleClosePaymentMethod?.(collapseElementMock);
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    options.stripeocs?.handleClosePaymentMethod?.(collapseElementMock);
 
                     return Promise.resolve(checkoutState);
                 },
@@ -321,8 +320,8 @@ describe('when using StripeUPE OCS payment', () => {
 
         it('should not collapse stripe accordion when Stripe accordion item selected', () => {
             jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
-                (options: WithStripeUPEPaymentInitializeOptions) => {
-                    options.stripeupe?.handleClosePaymentMethod?.(collapseElementMock);
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    options.stripeocs?.handleClosePaymentMethod?.(collapseElementMock);
 
                     return Promise.resolve(checkoutState);
                 },
@@ -330,7 +329,7 @@ describe('when using StripeUPE OCS payment', () => {
 
             const { rerender } = render(<PaymentMethodTest {...defaultProps} method={method} />);
 
-            accordionContextValues.selectedItemId = 'stripeupe-card';
+            accordionContextValues.selectedItemId = 'stripeocs-optimized_checkout';
 
             rerender(<PaymentMethodTest {...defaultProps} method={method} />);
 

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -161,5 +161,8 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     StripeOCSPaymentMethod,
-    [{ gateway: 'stripeupe', id: 'stripe_ocs' }],
+    [
+        { gateway: 'stripeupe', id: 'stripe_ocs' },
+        { gateway: 'stripeocs', id: 'optimized_checkout' },
+    ],
 );


### PR DESCRIPTION
## What?
Separate Stripe OCS from stripe UPE integration
Checkout sdk PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2881](https://github.com/bigcommerce/checkout-sdk-js/pull/2881)
[https://github.com/bigcommerce/checkout-sdk-js/pull/2882](https://github.com/bigcommerce/checkout-sdk-js/pull/2882)

## Why?
Stripe OCS will be implemented as new payment module.

## Testing / Proof
<img width="1003" alt="Screenshot 2025-05-28 at 17 18 18" src="https://github.com/user-attachments/assets/3a83ad6e-a20d-45e1-bdc5-adb88d5c162b" />
<img width="1001" alt="Screenshot 2025-05-28 at 17 18 28" src="https://github.com/user-attachments/assets/9d0074b5-c9aa-4791-af78-36a772898244" />
<img width="1000" alt="Screenshot 2025-05-28 at 17 58 36" src="https://github.com/user-attachments/assets/1bbb1e44-d7ca-4809-b7c2-efa6c6584b82" />

@bigcommerce/team-checkout
