### PR TITLE
chore(payment): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.737.0",
+        "@bigcommerce/checkout-sdk": "^1.738.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1974,9 +1974,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.737.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.737.0.tgz",
-      "integrity": "sha512-i4fkKhAeWXHyPEIV+S1+Wm+QuMYecRxkInmnwRqPRBDdnU6+/y0Tu5eZq1tO/KBzXi2Eg3VBzMGJsaZsvhiI+g==",
+      "version": "1.738.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.738.0.tgz",
+      "integrity": "sha512-7OBOADUJApgML5uXzV8amnVGJrzGrmY4X0ud9SEUIUIDxViZMSN6sJuqy943sOo23YQJcxT0ScBNkl9WTYBumA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.737.0",
+    "@bigcommerce/checkout-sdk": "^1.738.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver: https://github.com/bigcommerce/checkout-sdk-js

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
