### PR TITLE
fix(common): fixed checkout prerelease version generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "nx:build": "nx run core:build",
+    "nx:prerelease-build": "nx run core:prerelease-build",
     "nx:dev": "nx run core:dev",
     "preinstall": "npx check-node-version --package",
     "prebuild": "rm -rf dist && rm -rf packages/test-framework/report",
@@ -21,7 +22,7 @@
     "dev:server": "http-server build --cors",
     "e2e": "npm run build && npx playwright install && PORT=5005 MODE=REPLAY npx playwright test",
     "release": "echo 'Please do not release locally, use CircleCi'",
-    "release:alpha": "npm run lint && npm run test -- --coverage && npm run nx:build -- --env prerelease=prerelease && npm run release:version",
+    "release:alpha": "npm run lint && npm run test -- --coverage && npm run nx:prerelease-build && npm run release:version",
     "release:version": "git add dist && standard-version -a",
     "test:core": "jest --config packages/core/jest.config.js",
     "test:others": "npx nx run-many --all --target=test --exclude='core,checkout-extension,instrument-utils' --parallel=5 -- --runInBand",

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -19,6 +19,21 @@
         }
       ]
     },
+    "prerelease-build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "PRERELEASE=prerelease webpack --mode production"
+      },
+      "dependsOn": [
+        {
+          "target": "generate"
+        },
+        {
+          "target": "build",
+          "dependencies": true
+        }
+      ]
+    },
     "dev": {
       "executor": "nx:run-commands",
       "options": {

--- a/scripts/webpack/get-next-version.js
+++ b/scripts/webpack/get-next-version.js
@@ -6,23 +6,6 @@ const packageJson = require('../../package.json');
 
 let nextVersion;
 
-function getEnvArgsMap() {
-    const obj = {};
-
-    const args = argv.env && argv.env.split(' ');
-
-    if (!args) {
-        return obj;
-    }
-
-    args.forEach(arg => {
-        const argArray = arg.split('=');
-        obj[argArray[0]] = argArray[1];
-    });
-
-    return obj;
-}
-
 function getNextVersion() {
     if (!nextVersion) {
         nextVersion = new Promise((resolve, reject) => {
@@ -31,14 +14,14 @@ function getNextVersion() {
             }
 
             conventionalRecommendedBump({ preset: 'angular' }, (err, release) => {
-                const argsObject = getEnvArgsMap();
+                const prerelease = process.env.PRERELEASE;
 
                 if (err) {
                     return reject(err);
                 }
 
-                if (argsObject.prerelease) {
-                    const prereleaseType = typeof argsObject.prerelease === 'string' ? argsObject.prerelease : 'alpha';
+                if (prerelease) {
+                    const prereleaseType = typeof prerelease === 'string' ? prerelease : 'alpha';
 
                     return resolve(semver.inc(packageJson.version, 'prerelease', prereleaseType).replace(/\.\d+$/, `.${Date.now()}`));
                 }


### PR DESCRIPTION
## What?
Fixed checkout prerelease version generation

## Why?
Current command run throws an error and tells that --env option should be an object, however when --env.prerelease=prerelease are used in the command then this change does not reflect in argv object - env variable does not contain prerelease key with provided value.

In this case the best solution is to provide prerelease env option through process.env variable passed through webpack command directly.

## Testing / Proof
Before:
As a result of command run an error occurs
<img width="944" alt="Screenshot 2025-05-28 at 20 26 43" src="https://github.com/user-attachments/assets/79367c99-eec5-485a-8520-40eba9b99274" />

After:
As a result of command run a valid prerelease checkout version is generated
<img width="934" alt="Screenshot 2025-05-28 at 20 31 25" src="https://github.com/user-attachments/assets/a218ea99-ee04-4f2e-b1b5-13530b023d81" />

