### PR TITLE
refactor(payment): created PayPalCommerceButton and PayPalCommerceCredit components in paypal-commerce-integration package

### DIFF
--- a/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.test.tsx
@@ -1,0 +1,51 @@
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+    createLanguageService,
+} from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { CheckoutButtonProps } from '@bigcommerce/checkout/payment-integration-api';
+import { render } from '@bigcommerce/checkout/test-utils';
+
+import PayPalCommerceButton from './PayPalCommerceButton';
+
+describe('PayPalCommerceButton', () => {
+    let defaultProps: CheckoutButtonProps;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+
+        jest.spyOn(checkoutService, 'initializeCustomer').mockResolvedValue(checkoutState);
+        jest.spyOn(checkoutService, 'deinitializeCustomer').mockResolvedValue(checkoutState);
+
+        defaultProps = {
+            checkoutService,
+            checkoutState,
+            containerId: 'paypalcommerce-button-container',
+            language: createLanguageService(),
+            methodId: 'paypalcommerce',
+            onUnhandledError: jest.fn(),
+            onWalletButtonClick: jest.fn(),
+        };
+    });
+
+    it('renders PayPalCommerceButton with provided props', () => {
+        render(<PayPalCommerceButton {...defaultProps} />);
+
+        expect(checkoutService.initializeCustomer).toHaveBeenCalledWith({
+            methodId: defaultProps.methodId,
+            paypalcommerce: {
+                container: "paypalcommerce-button-container",
+                onClick: expect.any(Function),
+                onComplete: expect.any(Function),
+                onError: expect.any(Function),
+                onUnhandledError: expect.any(Function),
+            },
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent } from 'react';
+
+import { CheckoutButton } from '@bigcommerce/checkout/checkout-button-integration';
+import {
+    CheckoutButtonProps,
+    CheckoutButtonResolveId,
+    toResolvableComponent,
+} from '@bigcommerce/checkout/payment-integration-api';
+import { navigateToOrderConfirmation } from '@bigcommerce/checkout/utility';
+
+const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = (props) => {
+    const additionalInitializationOptions = {
+        onComplete: navigateToOrderConfirmation,
+        onError: props.onUnhandledError,
+    };
+
+    return <CheckoutButton additionalInitializationOptions={additionalInitializationOptions} {...props} />;
+};
+
+export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(
+    PayPalCommerceButton,
+    [
+        { id: 'paypalcommerce' },
+    ],
+);

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.test.tsx
@@ -1,0 +1,51 @@
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+    createLanguageService,
+} from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { CheckoutButtonProps } from '@bigcommerce/checkout/payment-integration-api';
+import { render } from '@bigcommerce/checkout/test-utils';
+
+import PayPalCommerceCreditButton from './PayPalCommerceCreditButton';
+
+describe('PayPalCommerceCreditButton', () => {
+    let defaultProps: CheckoutButtonProps;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+
+        jest.spyOn(checkoutService, 'initializeCustomer').mockResolvedValue(checkoutState);
+        jest.spyOn(checkoutService, 'deinitializeCustomer').mockResolvedValue(checkoutState);
+
+        defaultProps = {
+            checkoutService,
+            checkoutState,
+            containerId: 'paypalcommercecredit-button-container',
+            language: createLanguageService(),
+            methodId: 'paypalcommercecredit',
+            onUnhandledError: jest.fn(),
+            onWalletButtonClick: jest.fn(),
+        };
+    });
+
+    it('renders PayPalCommerceCreditButton with provided props', () => {
+        render(<PayPalCommerceCreditButton {...defaultProps} />);
+
+        expect(checkoutService.initializeCustomer).toHaveBeenCalledWith({
+            methodId: defaultProps.methodId,
+            paypalcommercecredit: {
+                container: "paypalcommercecredit-button-container",
+                onClick: expect.any(Function),
+                onComplete: expect.any(Function),
+                onError: expect.any(Function),
+                onUnhandledError: expect.any(Function),
+            },
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent } from 'react';
+
+import { CheckoutButton } from '@bigcommerce/checkout/checkout-button-integration';
+import {
+    CheckoutButtonProps,
+    CheckoutButtonResolveId,
+    toResolvableComponent,
+} from '@bigcommerce/checkout/payment-integration-api';
+import { navigateToOrderConfirmation } from '@bigcommerce/checkout/utility';
+
+const PayPalCommerceCreditButton: FunctionComponent<CheckoutButtonProps> = (props) => {
+    const additionalInitializationOptions = {
+        onComplete: navigateToOrderConfirmation,
+        onError: props.onUnhandledError,
+    };
+
+    return <CheckoutButton additionalInitializationOptions={additionalInitializationOptions} {...props} />;
+};
+
+export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(
+    PayPalCommerceCreditButton,
+    [
+        { id: 'paypalcommercecredit' },
+    ],
+);

--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -1,6 +1,43 @@
+/**
+ *
+ * PayPal Commerce APMs
+ *
+ * */
 export { default as PayPalCommerceAPMsPaymentMethod } from './PayPalCommerceAPMs/PayPalCommerceAPMsPaymentMethod';
+
+/**
+ *
+ * PayPal Commerce Credit
+ *
+ * */
+export { default as PayPalCommerceCreditButton } from './PayPalCommerceCredit/PayPalCommerceCreditButton';
 export { default as PayPalCommerceCreditPaymentMethod } from './PayPalCommerceCredit/PayPalCommerceCreditPaymentMethod';
+
+/**
+ *
+ * PayPal Commerce Fastlane
+ *
+ * */
 export { default as PayPalCommerceFastlanePaymentMethod } from './PayPalCommerceFastlane';
+
+/**
+ *
+ * PayPal Commerce (PayPal)
+ *
+ * */
+export { default as PayPalCommerceButton } from './PayPalCommerce/PayPalCommerceButton';
 export { default as PayPalCommercePaymentMethod } from './PayPalCommerce/PayPalCommercePaymentMethod';
+
+/**
+ *
+ * PayPal Commerce Venmo
+ *
+ * */
 export { default as PayPalCommerceVenmoPaymentMethod } from './PayPalCommerceVenmo/PayPalCommerceVenmoPaymentMethod';
+
+/**
+ *
+ * PayPal Commerce RatePay
+ *
+ * */
 export { default as PaypalCommerceRatePayPaymentMethod } from './PayPalCommerceRatepay/PaypalCommerceRatePayPaymentMethod';


### PR DESCRIPTION
## What?
Created PayPalCommerceButton and PayPalCommerceCreditButton components in paypal-commerce-integration package

## Why?
As part of paypal commerce specific code migration from core to integration package. This change allows us to remove PayPalCommerceButton component from core package

## Testing / Proof
Unit tests
Manual tests

PayPalCommerceButton and PayPalCommerceCreditButton components are used for both "wallet buttons on top of checkout page" and "wallet buttons in customer step"

<img width="641" alt="Screenshot 2025-05-30 at 17 37 51" src="https://github.com/user-attachments/assets/60d05706-54f6-48f2-8b3a-9c0279a62526" />
<img width="639" alt="Screenshot 2025-05-30 at 17 39 09" src="https://github.com/user-attachments/assets/f3e95b42-f2c9-48f7-80ac-3dc90fbf26a5" />

