### PR TITLE
fix(core): CHECKOUT-000 Fix redundant alt text on checkout sidebar product images

### DIFF
--- a/packages/core/src/app/order/getOrderSummaryItemImage.test.tsx
+++ b/packages/core/src/app/order/getOrderSummaryItemImage.test.tsx
@@ -1,3 +1,4 @@
+import { createLanguageService } from '@bigcommerce/checkout-sdk';
 import React from 'react';
 
 import { getPhysicalItem } from '../cart/lineItem.mock';
@@ -20,8 +21,12 @@ describe('getOrderSummaryItemImage()', () => {
         const lineLineItem = getPhysicalItem();
 
         it('returns image', () => {
+            // Create the same translated alt text that the component would create
+            const language = createLanguageService();
+            const expectedAltText = language.translate('cart.product_image_alt', { name: lineLineItem.name });
+
             expect(getOrderSummaryItemImage(lineLineItem)).toEqual(
-                <img alt={lineLineItem.name} data-test="cart-item-image" src={lineLineItem.imageUrl} />
+                <img alt={expectedAltText} data-test="cart-item-image" src={lineLineItem.imageUrl} />
             );
         });
     });

--- a/packages/core/src/app/order/getOrderSummaryItemImage.tsx
+++ b/packages/core/src/app/order/getOrderSummaryItemImage.tsx
@@ -1,10 +1,21 @@
-import { DigitalItem, PhysicalItem } from '@bigcommerce/checkout-sdk';
+import { createLanguageService, DigitalItem, PhysicalItem } from '@bigcommerce/checkout-sdk';
 import React, { ReactNode } from 'react';
+
+import { type LocaleContextType } from '@bigcommerce/checkout/locale';
 
 export default function getOrderSummaryItemImage(item: DigitalItem | PhysicalItem): ReactNode {
     if (!item.imageUrl) {
         return;
     }
 
-    return <img alt={item.name} data-test="cart-item-image" src={item.imageUrl} />;
+    // Get the language service to translate the alt text
+    const localeContext: LocaleContextType = { language: createLanguageService() };
+    // Use the language service to get a translated string for the alt attribute
+    const altText = localeContext.language.translate('cart.product_image_alt', { name: item.name });
+
+    return <img 
+        alt={altText}
+        data-test="cart-item-image" 
+        src={item.imageUrl} 
+    />;
 }

--- a/packages/locale/src/translations/de.json
+++ b/packages/locale/src/translations/de.json
@@ -79,7 +79,8 @@
             "taxes_text": "Steuern",
             "total_text": "Summe",
             "empty_cart_message": "Ihr Warenkorb ist leer, Sie werden weitergeleitet. Bitte klicken Sie <a href=\"{url}\" target=\"_top\">hier</a>, wenn Ihr Browser Sie nicht weiterleitet.",
-            "consistency_error": "Ihr Zahlungsvorgang konnte nicht bearbeitet werden, da sich einige Angaben geändert haben. Bitte überprüfen Sie Ihre Bestellung und versuchen Sie es erneut."
+            "consistency_error": "Ihr Zahlungsvorgang konnte nicht bearbeitet werden, da sich einige Angaben geändert haben. Bitte überprüfen Sie Ihre Bestellung und versuchen Sie es erneut.",
+            "product_image_alt": "Produktbild von {name}"
         },
         "common": {
             "back_action": "Zurück",

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -79,7 +79,8 @@
             "taxes_text": "Taxes",
             "total_text": "Total",
             "empty_cart_message": "Your cart is empty, you are being redirected. Please <a href=\"{url}\" target=\"_top\">click here</a> if your browser does not redirect you.",
-            "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again."
+            "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again.",
+            "product_image_alt": "{name}'s product image"
         },
         "common": {
             "back_action": "Back",


### PR DESCRIPTION
## What?
- Changed the product image alt text to use a proper translation string instead of just the product name
- Added translation keys for both English and German
- Updated the test to match the new implementation

## Why?
The current implementation uses the product name as alt text, which is redundant since the product name is already displayed as text next to the image. This causes accessibility issues for screen reader users who would hear the same information twice.

This PR addresses a warning-level European Accessibility Act (EAA) compliance issue described in issue #2332.

## Testing / Proof
- Updated unit tests to verify the new implementation
- Manually verified that the alt text now uses the translation string

@bigcommerce/team-checkout