### PR TITLE
fix(core): CHECKOUT-000 Fix redundant alt text on checkout sidebar product images

### DIFF
--- a/packages/core/src/app/order/getOrderSummaryItemImage.test.tsx
+++ b/packages/core/src/app/order/getOrderSummaryItemImage.test.tsx
@@ -21,7 +21,7 @@ describe('getOrderSummaryItemImage()', () => {
 
         it('returns image', () => {
             expect(getOrderSummaryItemImage(lineLineItem)).toEqual(
-                <img alt={lineLineItem.name} data-test="cart-item-image" src={lineLineItem.imageUrl} />
+                <img alt="" data-test="cart-item-image" src={lineLineItem.imageUrl} />
             );
         });
     });

--- a/packages/core/src/app/order/getOrderSummaryItemImage.tsx
+++ b/packages/core/src/app/order/getOrderSummaryItemImage.tsx
@@ -6,5 +6,5 @@ export default function getOrderSummaryItemImage(item: DigitalItem | PhysicalIte
         return;
     }
 
-    return <img alt={item.name} data-test="cart-item-image" src={item.imageUrl} />;
+    return <img alt="" data-test="cart-item-image" src={item.imageUrl} />;
 }


### PR DESCRIPTION
## What?
Fixed redundant alt text on product images in the checkout sidebar to comply with EAA (European Accessibility Act) standards.

Resolves #2332

## Why?
The current implementation uses the product name as alt text, which is redundant since the product name is already displayed next to the image in the UI. This creates a repetitive experience for screen reader users who will hear the same information twice.

According to accessibility best practices, when an image is purely decorative and its content is already conveyed through nearby text, an empty alt attribute (`alt=""`) should be used to prevent screen readers from announcing redundant information.

## Testing / Proof
- Unit tests have been updated to reflect the new implementation
- Manually verified with screen readers that the product information is properly conveyed without redundancy

@bigcommerce/team-checkout
