### PR TITLE
fix(core): CHECKOUT-000 Add id attribute to order comments input for accessibility

### DIFF
--- a/packages/core/src/app/orderComments/OrderComments.tsx
+++ b/packages/core/src/app/orderComments/OrderComments.tsx
@@ -16,7 +16,7 @@ const OrderComments: FunctionComponent = () => {
     );
 
     const renderInput = useCallback(
-        ({ field }: FieldProps) => <TextInput {...field} autoComplete="off" maxLength={2000} />,
+        ({ field }: FieldProps) => <TextInput {...field} autoComplete="off" id="orderComment" maxLength={2000} />,
         [],
     );
 


### PR DESCRIPTION
## What?
Added the `id="orderComment"` attribute to the order comments input field to properly associate it with its label, fixing an accessibility issue.

Resolves #2335

## Why?
The order comments field was missing an `id` attribute on the input element, which is required for proper label association. This was an accessibility issue that failed to meet European Accessibility Act (EAA) standards.

Without the matching `id` on the actual input element, screen readers weren't able to associate the label with the input field correctly, making it difficult for users with screen readers to understand the purpose of the field.

## Testing / Proof
- Manually verified that the input element now has the proper `id="orderComment"` attribute
- Confirmed that the label's `htmlFor="orderComment"` attribute now correctly associates with the input
- Verified that screen readers can now properly announce the purpose of the input field

@bigcommerce/team-checkout
