### PR TITLE
fix(core): CHECKOUT-000 Fix broken ARIA references in shipping inputs

### DIFF
--- a/packages/core/src/app/ui/form/FormFieldError.tsx
+++ b/packages/core/src/app/ui/form/FormFieldError.tsx
@@ -1,4 +1,4 @@
-import { ErrorMessage } from 'formik';
+import { ErrorMessage, useFormikContext } from 'formik';
 import React, { FunctionComponent, memo, useCallback } from 'react';
 
 import { FormContext } from '@bigcommerce/checkout/ui';
@@ -10,30 +10,44 @@ export interface FormFieldErrorProps {
 }
 
 const FormFieldError: FunctionComponent<FormFieldErrorProps> = ({ name, testId, errorId }) => {
+    // Get form context to check for errors
+    const formikContext = useFormikContext<{ [key: string]: any }>();
+    const hasError = formikContext?.errors?.[name] && formikContext?.touched?.[name];
+    
     const renderMessage = useCallback(
         (message: string) => (
-            <ul className="form-field-errors" data-test={testId}>
-                <li className="form-field-error">
-                    <label
-                        aria-live="polite"
-                        className="form-inlineMessage"
-                        htmlFor={name}
-                        id={errorId}
-                        role="alert"
-                    >
-                        {message}
-                    </label>
-                </li>
-            </ul>
+            <label
+                aria-live="polite"
+                className="form-inlineMessage"
+                htmlFor={name}
+                id={errorId}
+                role="alert"
+            >
+                {message}
+            </label>
         ),
-        [errorId, name, testId],
+        [errorId, name],
     );
 
     return (
         <FormContext.Consumer>
-            {({ isSubmitted }) =>
-                isSubmitted && <ErrorMessage name={name} render={renderMessage} />
-            }
+            {({ isSubmitted }) => (
+                <ul className="form-field-errors" data-test={testId}>
+                    <li className="form-field-error">
+                        {/* Show error message when form is submitted and there's an error */}
+                        {isSubmitted && <ErrorMessage name={name} render={renderMessage} />}
+                        
+                        {/* When there's no error or form isn't submitted, render a hidden element with the same ID */}
+                        {(!isSubmitted || !hasError) && (
+                            <span 
+                                aria-hidden="true"
+                                className="is-srOnly" 
+                                id={errorId} 
+                            />
+                        )}
+                    </li>
+                </ul>
+            )}
         </FormContext.Consumer>
     );
 };


### PR DESCRIPTION
## What?
Fixed broken ARIA references in shipping input fields by ensuring that error message elements are always present in the DOM, even when there are no errors.

Resolves #2337

## Why?
Each shipping input had an `aria-labelledby` attribute that referenced two IDs:
1. The label element's ID (always present)
2. The error message element's ID (only present when there was an error)

This caused broken ARIA references when there were no errors, which fails WCAG A standards and is an EAA (European Accessibility Act) compliance issue.

The fix ensures that the error message elements are always present in the DOM, even when there are no errors, by rendering a hidden span with the correct ID when no error is present.

## Testing / Proof
- Manually verified that all aria-labelledby references now point to valid elements in the DOM
- Confirmed that error message elements are present even when there are no errors
- Verified that error elements are properly hidden when there are no errors
- Tested with browser console queries to ensure all referenced IDs exist

Console test code:
```javascript
// Get all shipping input fields
const shippingInputs = document.querySelectorAll('input[name^="shippingAddress."]');

// Check their aria-labelledby references
shippingInputs.forEach(input => {
  const ariaLabelledby = input.getAttribute('aria-labelledby');
  if (ariaLabelledby) {
    const ids = ariaLabelledby.split(' ');
    ids.forEach(id => {
      const element = document.getElementById(id);
      console.log(`Input ${input.name}, ID ${id} exists:`, !!element);
    });
  }
});
```

Console test results:
```
Input shippingAddress.firstName, ID firstNameInput-label exists: true
Input shippingAddress.firstName, ID firstNameInput-field-error-message exists: true
Input shippingAddress.lastName, ID lastNameInput-label exists: true
Input shippingAddress.lastName, ID lastNameInput-field-error-message exists: true
Input shippingAddress.company, ID companyInput-label exists: true
Input shippingAddress.company, ID companyInput-field-error-message exists: true
Input shippingAddress.phone, ID phoneInput-label exists: true
Input shippingAddress.phone, ID phoneInput-field-error-message exists: true
Input shippingAddress.address2, ID addressLine2Input-label exists: true
Input shippingAddress.address2, ID addressLine2Input-field-error-message exists: true
Input shippingAddress.city, ID cityInput-label exists: true
Input shippingAddress.city, ID cityInput-field-error-message exists: true
Input shippingAddress.stateOrProvince, ID provinceInput-label exists: true
Input shippingAddress.stateOrProvince, ID provinceInput-field-error-message exists: true
Input shippingAddress.postalCode, ID postCodeInput-label exists: true
Input shippingAddress.postalCode, ID postCodeInput-field-error-message exists: true
```

@bigcommerce/team-checkout
