### PR TITLE
fix(core): CHECKOUT-000 Improve error message contrast for accessibility

### DIFF
--- a/packages/core/src/scss/settings/global/color/_color.scss
+++ b/packages/core/src/scss/settings/global/color/_color.scss
@@ -38,8 +38,8 @@ $color-highlightDarker:             darken($color-highlight, 25%);
 // States
 // -----------------------------------------------------------------------------
 
-$color-error:                       #ed6a6a;
-$color-errorLight:                  #fbeeee;
+$color-error:                       #d12727;
+$color-errorLight:                  #f8e8e8;
 
 $color-info:                        #5f5f5f;
 $color-infoLight:                   #f5f5f5;
@@ -81,4 +81,4 @@ $color-orderVerificationRequired:   #e89fae;
 //
 // -----------------------------------------------------------------------------
 
-$color-errorLighter:                #fffafa;
+$color-errorLighter:                #fdf5f5;


### PR DESCRIPTION
## What?
Improved the contrast ratio of error messages by darkening the error color from `#ed6a6a` to `#d12727`, and adjusted related error color shades for consistency.

Resolves #2339

## Why?
The previous error text color (`#ed6a6a`) on a white background (`#ffffff`) had a contrast ratio of approximately 3.05:1, which failed to meet WCAG AA requirements of 4.5:1 for normal text. This was an accessibility issue affecting users with visual impairments.

The new error color (`#d12727`) provides a contrast ratio of 5.21:1 against a white background, which successfully meets the WCAG AA requirement of 4.5:1 for normal text and 3:1 for large text.

## Testing / Proof
- Verified the new contrast ratio using the WebAIM Contrast Checker
- Improved the contrast ratio from 3.05:1 to 5.21:1, which successfully meets WCAG AA requirements for both normal text (4.5:1) and large text (3:1)
- Adjusted related error colors (`$color-errorLight` and `$color-errorLighter`) to maintain a consistent color scheme

Before: Contrast ratio of 3.05:1 (fails WCAG AA)
After: Contrast ratio of 5.21:1 (passes WCAG AA)

@bigcommerce/team-checkout
