### PR TITLE
chore(payment): added canMakePayments method

### DIFF
--- a/packages/apple-pay-integration/e2e/ApplePaySessionCustomerStepMockObject.ts
+++ b/packages/apple-pay-integration/e2e/ApplePaySessionCustomerStepMockObject.ts
@@ -14,6 +14,10 @@ const addApplePaySessionToChrome = () => {
             return true;
         }
 
+        static canMakePayments() {
+            return true;
+        }
+
         // eslint-disable-next-line @typescript-eslint/member-ordering
         constructor(version: number, paymentRequest: ApplePayJS.ApplePayPaymentRequest) {
             this.version = version;

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -265,7 +265,9 @@ describe('Checkout', () => {
         });
 
         it('renders checkout button container with ApplePay', async () => {
-            (window as any).ApplePaySession = {};
+            (window as any).ApplePaySession = {
+                canMakePayments: () => true,
+            };
 
             checkout.use(CheckoutPreset.RemoteProviders);
             checkout.use(CheckoutPreset.CheckoutWithBillingEmail);


### PR DESCRIPTION
## What?

Provided `canMakePayments` method to avoid potential failed tests

## Why?

To fix an issue related to apple pay e2e failed tests

## Testing / Proof

All tests passed

@bigcommerce/team-checkout
