### PR TITLE
fix(payment): Fixed BT ACH Payment Form 

### DIFF
--- a/packages/braintree-integration/src/BraintreeAch/components/BraintreeAchPaymentForm.tsx
+++ b/packages/braintree-integration/src/BraintreeAch/components/BraintreeAchPaymentForm.tsx
@@ -76,7 +76,7 @@ const BraintreeAchPaymentForm: FunctionComponent<BraintreeAchPaymentFormProps> =
                 const braintreeAchFormValues = getFormValues();
                 const isValid = await validateBraintreeAchForm(braintreeAchFormValues);
 
-                if (!isValid) {
+                if (!isValid && getFieldValue('orderConsent')) {
                     setFieldValue('orderConsent', false);
                 }
 


### PR DESCRIPTION
## What?
Fixed BT ACH Payment Form

## Why?
BT ACH Payment form had infinite rerendering that makes checkout page freeze. Now everything works as expected

## Testing / Proof

https://github.com/user-attachments/assets/51e7efee-d032-4b65-a52f-680d91b23d0c



@bigcommerce/team-checkout
