### PR TITLE
feat(payment): Move all Stripe OCS styling configs to checkout-js side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.743.2",
+        "@bigcommerce/checkout-sdk": "^1.744.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.743.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.743.2.tgz",
-      "integrity": "sha512-v+i40gW/2CjUHkhhaps5Umlj7cKq2VECiNISQVgNmHGNlDclyN6IVef8IUohO1P6CDhblpPU0z4GO+is4uG1NA==",
+      "version": "1.744.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.744.0.tgz",
+      "integrity": "sha512-vEFTjT4a0dvhpWv3RrnGaFfOY/D1DgLJODXh4J2C8WNKkenBWXhRy+ugMT7RJ4XzADFU6Nt1W5i+7jSe7p5cLA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.743.2",
+    "@bigcommerce/checkout-sdk": "^1.744.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/stripe-integration/.eslintrc.json
+++ b/packages/stripe-integration/.eslintrc.json
@@ -10,10 +10,11 @@
       }
     },
   {
-      "files": ["*.spec.tsx"],
+      "files": ["*.test.tsx", "*.test.ts"],
         "rules": {
           "@eslint-disable-next-line": "off",
-          "@typescript-eslint/consistent-type-assertions": "off"
+          "@typescript-eslint/consistent-type-assertions": "off",
+          "@typescript-eslint/no-unsafe-assignment": "off"
         }
     }
 ]

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -34,9 +34,14 @@ import { AccordionContext, AccordionContextProps } from '@bigcommerce/checkout/u
 import StripeOCSPaymentMethod from './StripeOCSPaymentMethod';
 
 jest.mock('./getStripeOCSStyles', () => ({
-    getStylesForOCSElement: () => {
-        return { color: '#cccccc' };
+    getAppearanceForOCSElement: () => {
+        return {
+            variables: {
+                color: '#cccccc',
+            },
+        };
     },
+    getFonts: () => [{ cssSrc: 'fontSrc' }],
 }));
 
 describe('when using Stripe OCS payment', () => {
@@ -130,7 +135,10 @@ describe('when using Stripe OCS payment', () => {
             [gatewayId]: {
                 containerId: expectedContainerId,
                 layout: defaultAccordionLayout,
-                style: { color: '#cccccc' },
+                appearance: {
+                    variables: { color: '#cccccc' },
+                },
+                fonts: [{ cssSrc: 'fontSrc' }],
                 onError: expect.any(Function),
                 render: expect.any(Function),
                 paymentMethodSelect: expect.any(Function),
@@ -156,7 +164,10 @@ describe('when using Stripe OCS payment', () => {
             [gatewayId]: {
                 containerId: expectedContainerId,
                 layout: defaultAccordionLayout,
-                style: { color: '#cccccc' },
+                appearance: {
+                    variables: { color: '#cccccc' },
+                },
+                fonts: [{ cssSrc: 'fontSrc' }],
                 onError: expect.any(Function),
                 render: expect.any(Function),
                 paymentMethodSelect: expect.any(Function),
@@ -175,7 +186,10 @@ describe('when using Stripe OCS payment', () => {
                 [gatewayId]: {
                     containerId: expectedContainerId,
                     layout: defaultAccordionLayout,
-                    style: { color: '#cccccc' },
+                    appearance: {
+                        variables: { color: '#cccccc' },
+                    },
+                    fonts: [{ cssSrc: 'fontSrc' }],
                     onError: expect.any(Function),
                     render: expect.any(Function),
                     paymentMethodSelect: expect.any(Function),
@@ -200,7 +214,10 @@ describe('when using Stripe OCS payment', () => {
                 [gatewayId]: {
                     containerId: expectedContainerId,
                     layout: defaultAccordionLayout,
-                    style: { color: '#cccccc' },
+                    appearance: {
+                        variables: { color: '#cccccc' },
+                    },
+                    fonts: [{ cssSrc: 'fontSrc' }],
                     onError: expect.any(Function),
                     render: expect.any(Function),
                     paymentMethodSelect: expect.any(Function),
@@ -229,7 +246,10 @@ describe('when using Stripe OCS payment', () => {
                         ...defaultAccordionLayout,
                         defaultCollapsed: true,
                     },
-                    style: { color: '#cccccc' },
+                    appearance: {
+                        variables: { color: '#cccccc' },
+                    },
+                    fonts: [{ cssSrc: 'fontSrc' }],
                     onError: expect.any(Function),
                     render: expect.any(Function),
                     paymentMethodSelect: expect.any(Function),
@@ -255,7 +275,10 @@ describe('when using Stripe OCS payment', () => {
                             ...defaultAccordionLayout,
                             defaultCollapsed: true,
                         },
-                        style: { color: '#cccccc' },
+                        appearance: {
+                            variables: { color: '#cccccc' },
+                        },
+                        fonts: [{ cssSrc: 'fontSrc' }],
                         onError: expect.any(Function),
                         render: expect.any(Function),
                         paymentMethodSelect: expect.any(Function),
@@ -275,7 +298,10 @@ describe('when using Stripe OCS payment', () => {
                     [gatewayId]: {
                         containerId: expectedContainerId,
                         layout: defaultAccordionLayout,
-                        style: { color: '#cccccc' },
+                        appearance: {
+                            variables: { color: '#cccccc' },
+                        },
+                        fonts: [{ cssSrc: 'fontSrc' }],
                         onError: expect.any(Function),
                         render: expect.any(Function),
                         paymentMethodSelect: expect.any(Function),

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -14,7 +14,7 @@ import {
 } from '@bigcommerce/checkout/payment-integration-api';
 import { AccordionContext } from '@bigcommerce/checkout/ui';
 
-import { getStylesForOCSElement } from './getStripeOCSStyles';
+import { getAppearanceForOCSElement, getFonts } from './getStripeOCSStyles';
 
 const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     paymentForm,
@@ -70,7 +70,8 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                         spacedAccordionItems: false,
                         visibleAccordionItemsCount: 0,
                     },
-                    style: getStylesForOCSElement(containerId),
+                    appearance: getAppearanceForOCSElement(containerId),
+                    fonts: getFonts(),
                     onError: onUnhandledError,
                     render: renderSubmitButton,
                     paymentMethodSelect: onToggle,

--- a/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.test.ts
+++ b/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.test.ts
@@ -1,193 +1,297 @@
 import * as domUtils from '@bigcommerce/checkout/dom-utils';
 
-import { getStylesForOCSElement } from './getStripeOCSStyles';
+import { getAppearanceForOCSElement, getFonts } from './getStripeOCSStyles';
 
-describe('getStylesForOCSElement', () => {
-    const containerId = 'stripe-ocs-container-id';
-    const fontLink = 'https://fonts.googleapis.com/font.woff2';
-    const defaultStyles: Record<string, Record<string, string | undefined>> = {
-        [`#${containerId}--input`]: {
-            color: 'black',
-            'background-color': 'white',
-            'border-color': 'gray',
-            'box-shadow': '0 0 5px rgba(0, 0, 0, 0.5)',
-            'font-family': 'Arial, sans-serif',
-        },
-        [`#${containerId}--label`]: {
-            color: 'blue',
-        },
-        [`#${containerId}--error`]: {
-            color: 'red',
-        },
-        [`#${containerId}--accordion-header .form-label`]: {
-            color: 'green',
-            'font-size': '16px',
-            'font-family': 'Monaco, sans-serif',
-            'font-weight': 'bold',
-            'padding-top': '10px',
-            'padding-right': '10px',
-            'padding-bottom': '10px',
-        },
-        '.checkout-step--payment .form-checklist': {
-            'border-bottom': '1px solid black',
-        },
-    };
+describe('getStripeOCSStyles', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
 
-    const mockGetAppliedStyles = (
-        properties: Record<string, Record<string, string | undefined>>,
-    ) => {
-        jest.spyOn(domUtils, 'getAppliedStyles').mockImplementation(
-            jest.fn().mockImplementation((element: HTMLElement) => {
-                const elementSelector = element.getAttribute('data-test-selector');
+    describe('getAppearanceForOCSElement', () => {
+        const containerId = 'stripe-ocs-container-id';
+        const defaultStyles: Record<string, Record<string, string | undefined>> = {
+            [`#${containerId}--input`]: {
+                color: 'black',
+                'background-color': 'white',
+                'border-color': 'gray',
+                'box-shadow': '0 0 5px rgba(0, 0, 0, 0.5)',
+                'font-family': 'Arial, sans-serif',
+            },
+            [`#${containerId}--label`]: {
+                color: 'blue',
+            },
+            [`#${containerId}--error`]: {
+                color: 'red',
+            },
+            [`#${containerId}--accordion-header .form-label`]: {
+                color: 'green',
+                'font-size': '16px',
+                'font-family': 'Monaco, sans-serif',
+                'font-weight': 'bold',
+                'padding-top': '10px',
+                'padding-right': '10px',
+                'padding-bottom': '10px',
+            },
+            '.checkout-step--payment .form-checklist': {
+                'border-bottom': '1px solid black',
+            },
+        };
 
-                return properties[elementSelector as keyof typeof defaultStyles];
-            }),
-        );
-    };
+        const mockGetAppliedStyles = (
+            properties: Record<string, Record<string, string | undefined>>,
+        ) => {
+            jest.spyOn(domUtils, 'getAppliedStyles').mockImplementation(
+                jest.fn().mockImplementation((element: HTMLElement) => {
+                    const elementSelector = element.getAttribute('data-test-selector');
 
-    beforeEach(() => {
-        jest.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
-            const element = document.createElement('div');
+                    return properties[elementSelector as keyof typeof defaultStyles];
+                }),
+            );
+        };
 
-            element.setAttribute('data-test-selector', selector);
+        beforeEach(() => {
+            jest.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+                const element = document.createElement('div');
 
-            return element;
+                element.setAttribute('data-test-selector', selector);
+
+                return element;
+            });
+
+            mockGetAppliedStyles(defaultStyles);
         });
 
+        it('returns the correct styles for the OCS element', () => {
+            expect(getAppearanceForOCSElement(containerId)).toEqual({
+                variables: {
+                    colorPrimary: '0 0 5px rgba(0, 0, 0, 0.5)',
+                    colorBackground: 'white',
+                    colorText: 'blue',
+                    colorDanger: 'red',
+                    colorTextSecondary: 'blue',
+                    colorTextPlaceholder: 'black',
+                    colorIcon: 'black',
+                    fontFamily: 'Monaco, sans-serif',
+                },
+                rules: {
+                    '.Input': {
+                        borderColor: 'gray',
+                        color: 'black',
+                        boxShadow: '0 0 5px rgba(0, 0, 0, 0.5)',
+                    },
+                    '.AccordionItem': {
+                        borderRadius: 0,
+                        borderWidth: 0,
+                        borderBottom: '1px solid black',
+                        boxShadow: 'none',
+                        fontSize: '16px',
+                        fontWeight: 'bold',
+                        color: 'green',
+                        padding: '10px 10px 10px 18px',
+                    },
+                    '.AccordionItem--selected': {
+                        fontWeight: 'bold',
+                        color: 'green',
+                    },
+                    '.TabLabel': {
+                        color: 'green',
+                    },
+                    '.RadioIcon': {
+                        width: '29.55px',
+                    },
+                    '.RadioIconInner': {
+                        r: '28.77px',
+                        fill: '#4496f6',
+                    },
+                    '.RadioIconOuter': {
+                        strokeWidth: '3.38px',
+                        stroke: '#ddd',
+                    },
+                    '.RadioIconOuter--checked': {
+                        stroke: '#4496f6',
+                    },
+                },
+            });
+        });
+
+        it('returns the field input font family styles when no accordion font family provided', () => {
+            mockGetAppliedStyles({
+                ...defaultStyles,
+                [`#${containerId}--accordion-header .form-label`]: {
+                    ...defaultStyles[`#${containerId}--accordion-header .form-label`],
+                    'font-family': undefined,
+                },
+            });
+
+            expect(getAppearanceForOCSElement(containerId)).toEqual(
+                expect.objectContaining({
+                    variables: expect.objectContaining({
+                        fontFamily: 'Arial, sans-serif',
+                    }),
+                }),
+            );
+        });
+
+        it('returns the default padding styles when no accordion paddings provided', () => {
+            mockGetAppliedStyles({
+                ...defaultStyles,
+                [`#${containerId}--accordion-header .form-label`]: {
+                    ...defaultStyles[`#${containerId}--accordion-header .form-label`],
+                    'padding-top': undefined,
+                    'padding-right': undefined,
+                    'padding-bottom': undefined,
+                },
+            });
+
+            expect(getAppearanceForOCSElement(containerId)).toEqual(
+                expect.objectContaining({
+                    rules: expect.objectContaining({
+                        '.AccordionItem': {
+                            borderRadius: 0,
+                            borderWidth: 0,
+                            borderBottom: '1px solid black',
+                            boxShadow: 'none',
+                            fontSize: '16px',
+                            fontWeight: 'bold',
+                            color: 'green',
+                            padding: '13px 18px 13px 18px',
+                        },
+                    }),
+                }),
+            );
+        });
+
+        it('returns the default Stripe styles when no BC accordion element provided', () => {
+            jest.spyOn(document, 'querySelector').mockReturnValue(null);
+
+            expect(getAppearanceForOCSElement(containerId)).toEqual({
+                variables: {
+                    colorPrimary: undefined,
+                    colorBackground: undefined,
+                    colorText: undefined,
+                    colorDanger: undefined,
+                    colorTextSecondary: undefined,
+                    colorTextPlaceholder: undefined,
+                    colorIcon: undefined,
+                    fontFamily: undefined,
+                },
+                rules: {
+                    '.Input': {
+                        borderColor: undefined,
+                        color: undefined,
+                        boxShadow: undefined,
+                    },
+                    '.AccordionItem': {
+                        borderRadius: 0,
+                        borderWidth: 0,
+                        borderBottom: undefined,
+                        boxShadow: 'none',
+                        fontSize: undefined,
+                        fontWeight: undefined,
+                        color: undefined,
+                        padding: undefined,
+                    },
+                    '.AccordionItem--selected': {
+                        fontWeight: 'bold',
+                        color: undefined,
+                    },
+                    '.TabLabel': {
+                        color: undefined,
+                    },
+                    '.RadioIcon': {
+                        width: '29.55px',
+                    },
+                    '.RadioIconInner': {
+                        r: '28.77px',
+                        fill: '#4496f6',
+                    },
+                    '.RadioIconOuter': {
+                        strokeWidth: '3.38px',
+                        stroke: '#ddd',
+                    },
+                    '.RadioIconOuter--checked': {
+                        stroke: '#4496f6',
+                    },
+                },
+            });
+        });
+
+        describe('Radio icon style', () => {
+            describe('RadioButton styling', () => {
+                it('should initialize with default style', () => {
+                    expect(getAppearanceForOCSElement(containerId)).toEqual(
+                        expect.objectContaining({
+                            rules: expect.objectContaining({
+                                '.RadioIcon': {
+                                    width: '29.55px',
+                                },
+                                '.RadioIconOuter': {
+                                    strokeWidth: '3.38px',
+                                    stroke: '#ddd',
+                                },
+                                '.RadioIconOuter--checked': {
+                                    stroke: '#4496f6',
+                                },
+                                '.RadioIconInner': {
+                                    r: '28.77px',
+                                    fill: '#4496f6',
+                                },
+                            }),
+                        }),
+                    );
+                });
+            });
+        });
+    });
+});
+
+describe('getFonts', () => {
+    const fontLink = 'https://fonts.googleapis.com/font.woff2';
+
+    beforeEach(() => {
         jest.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
             const element = document.createElement('div');
 
             element.setAttribute('data-test-selector', selector);
             element.setAttribute('href', fontLink);
 
-            return [element] as NodeListOf<Element>;
-        });
-
-        mockGetAppliedStyles(defaultStyles);
-    });
-
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
-
-    it('returns the correct styles for the OCS element', () => {
-        expect(getStylesForOCSElement(containerId)).toEqual({
-            labelText: 'blue',
-            fieldErrorText: 'red',
-            fieldText: 'black',
-            fieldPlaceholderText: 'black',
-            fieldBackground: 'white',
-            fieldInnerShadow: '0 0 5px rgba(0, 0, 0, 0.5)',
-            fieldBorder: 'gray',
-            fontFamily: 'Monaco, sans-serif',
-            accordionItemTitleFontSize: '16px',
-            accordionItemTitleFontWeight: 'bold',
-            accordionHeaderColor: 'green',
-            accordionHeaderPadding: '10px 10px 10px 18px',
-            accordionBorderBottom: '1px solid black',
-            fontsSrc: ['https://fonts.googleapis.com/font.woff2'],
+            return [element] as unknown as NodeListOf<Element>;
         });
     });
 
-    it('returns the field input font family styles when no accordion font family provided', () => {
-        mockGetAppliedStyles({
-            ...defaultStyles,
-            [`#${containerId}--accordion-header .form-label`]: {
-                ...defaultStyles[`#${containerId}--accordion-header .form-label`],
-                'font-family': undefined,
+    it('get font source for default selector', () => {
+        expect(getFonts()).toEqual([
+            {
+                cssSrc: fontLink,
             },
-        });
-
-        expect(getStylesForOCSElement(containerId)).toEqual({
-            labelText: 'blue',
-            fieldErrorText: 'red',
-            fieldText: 'black',
-            fieldPlaceholderText: 'black',
-            fieldBackground: 'white',
-            fieldInnerShadow: '0 0 5px rgba(0, 0, 0, 0.5)',
-            fieldBorder: 'gray',
-            fontFamily: 'Arial, sans-serif',
-            accordionItemTitleFontSize: '16px',
-            accordionItemTitleFontWeight: 'bold',
-            accordionHeaderColor: 'green',
-            accordionHeaderPadding: '10px 10px 10px 18px',
-            accordionBorderBottom: '1px solid black',
-            fontsSrc: ['https://fonts.googleapis.com/font.woff2'],
-        });
+        ]);
     });
 
-    it('returns the default padding styles when no accordion paddings provided', () => {
-        mockGetAppliedStyles({
-            ...defaultStyles,
-            [`#${containerId}--accordion-header .form-label`]: {
-                ...defaultStyles[`#${containerId}--accordion-header .form-label`],
-                'padding-top': undefined,
-                'padding-right': undefined,
-                'padding-bottom': undefined,
+    it('get font source for custom selector', () => {
+        expect(getFonts('link[href*="font"]')).toEqual([
+            {
+                cssSrc: fontLink,
             },
-        });
-
-        expect(getStylesForOCSElement(containerId)).toEqual({
-            labelText: 'blue',
-            fieldErrorText: 'red',
-            fieldText: 'black',
-            fieldPlaceholderText: 'black',
-            fieldBackground: 'white',
-            fieldInnerShadow: '0 0 5px rgba(0, 0, 0, 0.5)',
-            fieldBorder: 'gray',
-            fontFamily: 'Monaco, sans-serif',
-            accordionItemTitleFontSize: '16px',
-            accordionItemTitleFontWeight: 'bold',
-            accordionHeaderColor: 'green',
-            accordionHeaderPadding: '13px 18px 13px 18px',
-            accordionBorderBottom: '1px solid black',
-            fontsSrc: ['https://fonts.googleapis.com/font.woff2'],
-        });
+        ]);
     });
 
-    it('returns the default Stripe font family styles when no BC fonts found', () => {
-        jest.spyOn(document, 'querySelector').mockReturnValue(null);
+    it('returns empty array when element by selector does not found', () => {
         jest.spyOn(document, 'querySelectorAll').mockImplementation(() => {
-            return [null] as NodeListOf<Element>;
+            return [null] as unknown as NodeListOf<Element>;
         });
 
-        expect(getStylesForOCSElement(containerId)).toEqual({
-            labelText: undefined,
-            fieldErrorText: undefined,
-            fieldText: undefined,
-            fieldPlaceholderText: undefined,
-            fieldBackground: undefined,
-            fieldInnerShadow: undefined,
-            fieldBorder: undefined,
-            fontFamily: undefined,
-            accordionItemTitleFontSize: undefined,
-            accordionItemTitleFontWeight: undefined,
-            accordionHeaderColor: undefined,
-            accordionHeaderPadding: undefined,
-            accordionBorderBottom: undefined,
-            fontsSrc: [],
-        });
+        expect(getFonts()).toEqual([]);
     });
 
-    it('returns the default Stripe styles when no BC accordion element provided', () => {
-        jest.spyOn(document, 'querySelector').mockReturnValue(null);
-        jest.spyOn(document, 'querySelectorAll').mockReturnValue([] as NodeListOf<Element>);
+    it('returns empty array when element by selector does not have font source', () => {
+        jest.spyOn(document, 'querySelectorAll').mockImplementation((selector: string) => {
+            const element = document.createElement('div');
 
-        expect(getStylesForOCSElement(containerId)).toEqual({
-            labelText: undefined,
-            fieldErrorText: undefined,
-            fieldText: undefined,
-            fieldPlaceholderText: undefined,
-            fieldBackground: undefined,
-            fieldInnerShadow: undefined,
-            fieldBorder: undefined,
-            fontFamily: undefined,
-            accordionItemTitleFontSize: undefined,
-            accordionItemTitleFontWeight: undefined,
-            accordionHeaderColor: undefined,
-            accordionHeaderPadding: undefined,
-            accordionBorderBottom: undefined,
-            fontsSrc: [],
+            element.setAttribute('data-test-selector', selector);
+
+            return [element] as unknown as NodeListOf<Element>;
         });
+
+        expect(getFonts()).toEqual([]);
     });
 });


### PR DESCRIPTION
## What?
Move all styling options for Stripe OCS to checkoput-js side.
Checkout-sdk PR:  [https://github.com/bigcommerce/checkout-sdk-js/pull/2891](https://github.com/bigcommerce/checkout-sdk-js/pull/2891)

## Why?
To make Stripe widget more flexible for merchants with custom checkout. 

## Testing / Proof

https://github.com/user-attachments/assets/7a59c334-04aa-4a3c-b3c5-d51dba8de69b


<img width="2552" alt="Screenshot 2025-06-05 at 17 47 15" src="https://github.com/user-attachments/assets/069b42dc-d909-4bf9-9cf7-af3e21d9f51d" />
