### PR TITLE
fix(checkout): Fix Newsletter Subscription Checkbox

### DIFF
--- a/packages/core/src/app/customer/CustomerGuest.test.tsx
+++ b/packages/core/src/app/customer/CustomerGuest.test.tsx
@@ -206,6 +206,14 @@ describe('Customer Guest', () => {
         });
     });
 
+    it('selects `Subscribe to our newsletter` checkbox by default', async () => {
+        const props = {...defaultProps, isSubscribed:true};
+
+        render(<CustomerTest viewType={CustomerViewType.Guest} {...props} />);
+
+        expect(screen.getByTestId('should-subscribe-checkbox')).toBeChecked();
+    });
+
     it('displays error message if privacy policy is required and not checked', async () => {
         const email = faker.internet.email();
 

--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { FieldProps, FormikProps, withFormik } from 'formik';
-import React, { FunctionComponent, memo, ReactNode, useCallback } from 'react';
+import React, { FunctionComponent, memo, ReactNode, useCallback, useEffect } from 'react';
 import { object, string } from 'yup';
 
 import { TranslatedString, withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
@@ -52,6 +52,7 @@ const GuestForm: FunctionComponent<
     canSubscribe,
     checkoutButtons,
     continueAsGuestButtonLabelId,
+    defaultShouldSubscribe,
     isLoading,
     onChangeEmail,
     onShowLogin,
@@ -60,11 +61,12 @@ const GuestForm: FunctionComponent<
     isExpressPrivacyPolicy,
     isFloatingLabelEnabled,
     shouldShowEmailWatermark,
+    setFieldValue,
 }) => {
     const {
-        checkoutState: { 
-            data: { getConfig } 
-        }    
+        checkoutState: {
+            data: { getConfig }
+        }
     } = useCheckout();
 
     const config = getConfig();
@@ -75,6 +77,13 @@ const GuestForm: FunctionComponent<
         ),
         [requiresMarketingConsent],
     );
+
+    useEffect(() => {
+        void setFieldValue(
+            'shouldSubscribe',
+            getShouldSubscribeValue(requiresMarketingConsent, defaultShouldSubscribe),
+            );
+    }, [requiresMarketingConsent, defaultShouldSubscribe]);
 
     if (!config) {
         return null;

--- a/packages/core/src/app/customer/StripeGuestForm.test.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.test.tsx
@@ -69,6 +69,19 @@ describe('StripeGuestForm', () => {
         expect(button).toBeDisabled();
     });
 
+    it('selects `Subscribe to our newsletter` checkbox by default', async () => {
+        render(
+            <TestComponent
+                defaultShouldSubscribe={true}
+                isLoading={true}
+                onContinueAsGuest={jest.fn()}
+                requiresMarketingConsent={false}
+            />
+        );
+
+        expect(screen.getByTestId('should-subscribe-checkbox')).toBeChecked();
+    });
+
     it('executes a function when the button is clicked', async () => {
         const handleContinueAsGuest = jest.fn();
 

--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -44,6 +44,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
     onContinueAsGuest,
     canSubscribe,
     checkoutButtons,
+    defaultShouldSubscribe,
     requiresMarketingConsent,
     privacyPolicyUrl,
     step,
@@ -114,6 +115,13 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
 
         return () => stripeDeinitialize();
     }, []);
+
+    useEffect(() => {
+        void setFieldValue(
+            'shouldSubscribe',
+            requiresMarketingConsent ? false : defaultShouldSubscribe,
+        );
+    }, [requiresMarketingConsent, defaultShouldSubscribe]);
 
     const getStylesFromElement = (
         id: string,


### PR DESCRIPTION
## What?
Fix the issue where the newsletter subscription checkbox does not reflect the merchant's selected option.

## Why?
Improve shopper experience.

## Testing / Proof
Email setting
<img width="658" alt="image" src="https://github.com/user-attachments/assets/01b1f1d2-9bb3-4bc3-9c86-16f490694875" />
Default guest form
<img width="658" alt="image" src="https://github.com/user-attachments/assets/01dee32f-2a8a-42cd-b387-5df5abb277c4" />

Default stripelink guest form
<img width="658" alt="image" src="https://github.com/user-attachments/assets/4f117613-06bf-4bb0-8f21-3b0fd28e26f1" />

