### PR TITLE
feat(payment): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.744.0",
+        "@bigcommerce/checkout-sdk": "^1.744.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.744.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.744.0.tgz",
-      "integrity": "sha512-vEFTjT4a0dvhpWv3RrnGaFfOY/D1DgLJODXh4J2C8WNKkenBWXhRy+ugMT7RJ4XzADFU6Nt1W5i+7jSe7p5cLA==",
+      "version": "1.744.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.744.1.tgz",
+      "integrity": "sha512-QVi4Xuz/xAivy/YiZpwjOgalHNyYZIpMQSuvpqbH2Yih0lii+J7Lri0H04TLqVPYhScTo7UTc/A+nqM5l/mxgg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.744.0",
+    "@bigcommerce/checkout-sdk": "^1.744.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version

## Why?
As part of the release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2892

## Testing / Proof
All tests have been passed
