### PR TITLE
chore(payment): bump checkout-sdk version to 1.747.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.746.0",
+        "@bigcommerce/checkout-sdk": "^1.747.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.746.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.746.0.tgz",
-      "integrity": "sha512-I2v7i8H4uJwvPIbMpOYtI3SRtvFH8wCWKDpwrXyCoYeguPwrXOOo9gpwNCymXJQx73RWpzsExggPSB96b0H/BQ==",
+      "version": "1.747.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.747.0.tgz",
+      "integrity": "sha512-u4Sg/FrA2UA0kAa0h77zgY9ygvpnW6bdCDsS8I8KDXZaDLn8P6UlicSxL6BjL9S48duBetbKQ7YsHK03wA/ESQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.746.0",
+    "@bigcommerce/checkout-sdk": "^1.747.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk version to 1.747.0

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2849
https://github.com/bigcommerce/checkout-sdk-js/pull/2894

## Testing / Proof
Unit tests
Manual tests
CI
