### PR TITLE
chore(payment): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.747.1",
+        "@bigcommerce/checkout-sdk": "^1.749.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.747.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.747.1.tgz",
-      "integrity": "sha512-CE2yahAtijZz+nSu33GFc8ua18ZxdGxx9Yd73hIkYzAjj20t37i+cdnS6XbPRZ2q6Bgr1RI1yZzg5seu7HOYdw==",
+      "version": "1.749.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.749.0.tgz",
+      "integrity": "sha512-oLx0BVDSA87ltuBA+iFRAllD7HGXg1tCOcPeX5Jh8MqZMsuItrxVgDi7L0bTM3CYNXuMJYZnkooAG7X7U3CXsA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.747.1",
+    "@bigcommerce/checkout-sdk": "^1.749.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver: 
https://github.com/bigcommerce/checkout-sdk-js/pull/2895
https://github.com/bigcommerce/checkout-sdk-js/pull/2890

## Testing / Proof

All tests passed
