### PR TITLE
CHECKOUT-9307: Re-run only the failed CI tests instead of the whole suite in case of transient failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,42 +26,58 @@ jobs:
   test-packages:
     <<: *node_executor
     resource_class: medium+
+    parallelism: 4
     steps:
       - ci/pre-setup
       - node/npm-install
       - run:
           name: "Run unit tests for packages"
-          command: npm run test:others
+          command: |
+            npx nx run-many --target=test --exclude=core,checkout-extension,instrument-utils -- --listTests | grep packages/ | sed "s|$(pwd)/||" | \
+            circleci tests run \
+              --command="xargs npm run test:others -- --ci --files" \
+              --verbose \
+              --split-by=timings
+      - run: node scripts/nx/collect-test-results.js
+      - store_test_results:
+          path: test-results
 
   test-extension:
-    <<: *node_executor
-    steps:
-      - ci/pre-setup
-      - node/npm-install
-      - run:
-          name: "Run unit tests for checkout extension"
-          command: npm run test:extension
-
-  test-core:
     <<: *node_executor
     parallelism: 2
     steps:
       - ci/pre-setup
       - node/npm-install
-      - run: mkdir ~/junit
+      - run:
+          name: "Run unit tests for checkout extension"
+          command: |
+            npx nx run-many --target=test --projects=instrument-utils,checkout-extension -- --listTests | grep packages/ | sed "s|$(pwd)/||" | \
+            circleci tests run \
+              --command="xargs npm run test:extension -- --ci --files" \
+              --verbose \
+              --split-by=timings
+      - run: node scripts/nx/collect-test-results.js
+      - store_test_results:
+          path: test-results
+
+  test-core:
+    <<: *node_executor
+    parallelism: 4
+    steps:
+      - ci/pre-setup
+      - node/npm-install
       - run:
           name: "Run unit tests for core package"
           command: |
-            TEST=$(circleci tests glob "packages/core/**/*.spec.ts" "packages/core/**/*.spec.tsx" "packages/core/**/*.test.ts" "packages/core/**/*.test.tsx" | circleci tests split --split-by=timings)
             npx nx run core:generate
-            npm run test:core $TEST -- --runInBand
-      - run:
-          command: cp junit.xml ~/junit/
-          when: always
+            npx nx test core -- --listTests | grep packages/ | sed "s|$(pwd)/||" | \
+            circleci tests run \
+              --command="xargs npm run test:core -- --ci --files" \
+              --verbose \
+              --split-by=timings
+      - run: node scripts/nx/collect-test-results.js
       - store_test_results:
-          path: ~/junit
-      - store_artifacts:
-          path: ~/junit
+          path: test-results
 
   lint:
     <<: *node_executor
@@ -98,6 +114,7 @@ jobs:
 
   e2e:
     <<: *node_executor
+    parallelism: 2
     resource_class: medium+
     steps:
       - ci/pre-setup
@@ -110,7 +127,15 @@ jobs:
           command: npx playwright install --with-deps
       - run:
           name: "Run e2e tests"
-          command: npx playwright test
+          command: |
+            TESTFILES=$(circleci tests glob "*/e2e/**/*.spec.ts")
+            echo "$TESTFILES" | \
+            circleci tests run \
+              --command="xargs npx playwright test --config=playwright.config.ts" \
+              --verbose \
+              --split-by=timings
+      - store_test_results:
+          path: packages/test-framework/test-results/junit.xml
       - store_artifacts:
           path: packages/test-framework/report
           destination: artifact-file

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:alpha": "npm run lint && npm run test -- --coverage && npm run nx:prerelease-build && npm run release:version",
     "release:version": "git add dist && standard-version -a",
-    "test:core": "jest --config packages/core/jest.config.js",
-    "test:others": "npx nx run-many --all --target=test --exclude='core,checkout-extension,instrument-utils' --parallel=5 -- --runInBand",
-    "test:extension": "npx nx run-many --target=test --projects=instrument-utils,checkout-extension",
+    "test:core": "node scripts/nx/run-tests.js --projects=core",
+    "test:others": "node scripts/nx/run-tests.js --exclude='core,checkout-extension,instrument-utils'",
+    "test:extension": "node scripts/nx/run-tests.js --projects=instrument-utils,checkout-extension",
     "generate": "npx nx run core:generate",
     "regenerate-har": "npx nx run test-framework:regenerate-har",
     "lint": "npx nx run-many --target=lint --all",
@@ -34,7 +34,8 @@
     "test:watch": "npx nx run-many --target=test --all --watch"
   },
   "jest-junit": {
-    "addFileAttribute": "true"
+    "addFileAttribute": "true",
+    "outputDirectory": "<rootDir>/test-results"
   },
   "repository": {
     "type": "git",

--- a/packages/checkout-extension/src/handler/commandHandlers/commandHandlers.test.ts
+++ b/packages/checkout-extension/src/handler/commandHandlers/commandHandlers.test.ts
@@ -29,16 +29,18 @@ describe('commandHandlers', () => {
     });
 
     describe('createReloadCheckoutHandler', () => {
-        it('reloads checkout', () => {
+        it('reloads checkout', async () => {
             const { handler } = createReloadCheckoutHandler(handlerProps);
 
-            const loadCheckout = jest.spyOn(checkoutService, 'loadCheckout');
+            jest.spyOn(checkoutService, 'loadCheckout').mockResolvedValue(
+                checkoutService.getState(),
+            );
 
-            void handler({
+            await handler({
                 type: ExtensionCommandType.ReloadCheckout,
             });
 
-            expect(loadCheckout).toHaveBeenCalled();
+            expect(checkoutService.loadCheckout).toHaveBeenCalled();
         });
     });
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,6 +43,10 @@ const config: PlaywrightTestConfig = {
             'html',
             { outputFolder: './packages/test-framework/report', open: 'never' },
         ],
+        [
+            'junit',
+            { outputFile: './packages/test-framework/test-results/junit.xml' },
+        ],
     ],
     use: {
         baseURL: `http://localhost:${process.env.PORT}`,

--- a/scripts/nx/collect-test-results.js
+++ b/scripts/nx/collect-test-results.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+
+try {
+    if (!fs.existsSync('test-results')) {
+        fs.mkdirSync('test-results');
+    }
+
+    const workspaceConfig = JSON.parse(fs.readFileSync('workspace.json', 'utf8'));
+    const packages = Object.keys(workspaceConfig.projects);
+
+    packages.forEach((packageName) => {
+        const packagePath = workspaceConfig.projects[packageName];
+        const junitFile = path.join(packagePath, 'test-results', 'junit.xml');
+
+        if (fs.existsSync(junitFile)) {
+            const targetDir = path.join('test-results', packageName);
+            const targetFile = path.join(targetDir, 'junit.xml');
+
+            if (!fs.existsSync(targetDir)) {
+                fs.mkdirSync(targetDir, { recursive: true });
+            }
+
+            fs.copyFileSync(junitFile, targetFile);
+        }
+    });
+
+    console.log('Test results collected.');
+} catch (error) {
+    console.error('Error collecting test results:', error.message);
+    process.exit(1);
+}

--- a/scripts/nx/run-tests.js
+++ b/scripts/nx/run-tests.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const { execSync } = require('child_process');
+const yargs = require('yargs');
+
+/**
+ * Script to run nx tests with package and file filtering
+ *
+ * Usage:
+ *   node scripts/run-tests.js --projects=package-a,package-b --files="src/foo.test.ts src/bar.spec.ts"
+ *   node scripts/run-tests.js --exclude=core,analytics --files="*.integration.test.ts"
+ *   node scripts/run-tests.js --projects=adyen-integration,stripe-integration
+ *   node scripts/run-tests.js --files="src/components/*.test.ts"
+ */
+
+function parseDelimited(delimiter) {
+    return (arg) =>
+        arg
+            ? arg
+                  .split(delimiter)
+                  .map((item) => item.trim())
+                  .filter(Boolean)
+            : [];
+}
+
+function parseArguments() {
+    const argv = yargs
+        .option('projects', {
+            describe: 'Include specific packages (comma-separated)',
+            type: 'string',
+            coerce: parseDelimited(','),
+        })
+        .option('exclude', {
+            describe: 'Exclude specific packages (comma-separated)',
+            type: 'string',
+            coerce: parseDelimited(','),
+        })
+        .option('files', {
+            describe: 'Filter test files by patterns (space or newline delimited)',
+            type: 'string',
+            coerce: parseDelimited(/[\s]+/),
+        })
+        .option('ci', {
+            describe: 'Run tests in CI mode',
+            type: 'boolean',
+        }).argv;
+
+    let files = argv.files || [];
+
+    if (argv._ && argv._.length > 0) {
+        const additionalFiles = argv._.filter(
+            (arg) => typeof arg === 'string' && !arg.startsWith('-'),
+        );
+
+        files = [...files, ...additionalFiles];
+    }
+
+    return {
+        projects: argv.projects || [],
+        exclude: argv.exclude || [],
+        files,
+        ci: argv.ci || false,
+    };
+}
+
+function getAllProjects() {
+    try {
+        const workspaceConfig = require('../../workspace.json');
+
+        return Object.keys(workspaceConfig.projects);
+    } catch (error) {
+        console.error('Error reading workspace.json:', error.message);
+
+        return [];
+    }
+}
+
+function getProjectsToTest(config) {
+    const allProjects = getAllProjects();
+
+    if (config.projects.length > 0) {
+        return config.projects;
+    }
+
+    if (config.exclude.length > 0) {
+        return allProjects.filter((project) => !config.exclude.includes(project));
+    }
+
+    return allProjects;
+}
+
+function filterFilesForProject(files, projectName) {
+    if (!files || files.length === 0) {
+        return [];
+    }
+
+    const projectPath = `packages/${projectName}`;
+
+    return files.filter((file) => file.includes(projectPath));
+}
+
+function buildJestCommand(projectName, config) {
+    const projectPath = `packages/${projectName}`;
+    const jestConfigPath = `${projectPath}/jest.config.js`;
+
+    let command = `npx jest --config=${jestConfigPath}`;
+
+    const projectFiles = filterFilesForProject(config.files, projectName);
+
+    if (projectFiles.length > 0) {
+        command += ` ${projectFiles.join(' ')}`;
+    }
+
+    command += ' --runInBand --passWithNoTests';
+
+    if (config.ci) {
+        command += ' --ci';
+    }
+
+    return command;
+}
+
+function main() {
+    const config = parseArguments();
+
+    if (config.projects.length > 0 && config.exclude.length > 0) {
+        console.error('Error: Cannot specify both --projects and --exclude options');
+        process.exit(1);
+    }
+
+    const projectsToTest = getProjectsToTest(config);
+    const failedProjects = [];
+    const skippedProjects = [];
+
+    console.log(
+        `Running tests for ${projectsToTest.length} projects: ${projectsToTest.join(', ')}`,
+    );
+
+    for (const project of projectsToTest) {
+        if (config.files.length > 0) {
+            const projectFiles = filterFilesForProject(config.files, project);
+
+            if (projectFiles.length === 0) {
+                console.log(`\n--- Skipping project: ${project} (no matching files) ---`);
+                skippedProjects.push(project);
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+        }
+
+        const command = buildJestCommand(project, config);
+
+        console.log(`\n--- Running tests for project: ${project} ---`);
+        console.log(`Command: ${command}`);
+
+        try {
+            execSync(command, {
+                stdio: 'inherit',
+                cwd: process.cwd(),
+            });
+            console.log(`✓ Tests passed for project: ${project}`);
+        } catch (error) {
+            console.error(`✗ Tests failed for project: ${project}`);
+            failedProjects.push({
+                project,
+                error: error.message,
+                status: error.status || 1,
+            });
+        }
+    }
+
+    // Report final results
+    console.log('\n=== Test Results Summary ===');
+    console.log(`Total projects: ${projectsToTest.length}`);
+    console.log(`Tested: ${projectsToTest.length - skippedProjects.length}`);
+    console.log(`Skipped: ${skippedProjects.length}`);
+    console.log(
+        `Passed: ${projectsToTest.length - failedProjects.length - skippedProjects.length}`,
+    );
+    console.log(`Failed: ${failedProjects.length}`);
+
+    if (skippedProjects.length > 0) {
+        console.log(`\nSkipped projects: ${skippedProjects.join(', ')}`);
+    }
+
+    if (failedProjects.length > 0) {
+        console.log('\nFailed projects:');
+        failedProjects.forEach(({ project, error }) => {
+            console.log(`  - ${project}: ${error}`);
+        });
+        process.exit(1);
+    }
+
+    console.log('\n✓ All tests passed!');
+}
+
+main();


### PR DESCRIPTION
## What/Why?
* Instead of re-running the entire test suite, `circleci tests run` command allows you to re-run just the failed tests, significantly reducing the time required for a re-run. See https://circleci.com/docs/rerun-failed-tests/
* Enable parallelism by splitting the tests across multiple containers using timing data. See https://circleci.com/blog/a-guide-to-test-splitting/
* Reduce test flakiness by ensuring that tests run sequentially within each container, since individual tests may have side effects.

## Testing / Proof

When a test job fails, we can now click on the "Rerun failed tests" to re-run the failed tests instead of the entire test suite.

<img width="838" alt="Screenshot 2025-06-19 at 2 12 42 pm" src="https://github.com/user-attachments/assets/a549137c-e28e-4dc5-885d-cfcab18923fb" />

<img width="1210" alt="Screenshot 2025-06-20 at 12 38 14 pm" src="https://github.com/user-attachments/assets/18ad71c7-42d7-4f6c-a044-e71ddbe94577" />

<img width="1209" alt="Screenshot 2025-06-20 at 12 37 36 pm" src="https://github.com/user-attachments/assets/ee7d57d9-5f1b-4e50-adde-3709e37903a2" />

