### PR TITLE
chore(payment): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.750.0",
+        "@bigcommerce/checkout-sdk": "^1.751.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1976,9 +1976,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.750.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.750.0.tgz",
-      "integrity": "sha512-4qFv6bcu3Zob9OnXJufGWUsTUYJuiZSrTUIihyqoWDGyEiB54O2aCWF1LNFCiLNaB5VyntQKf1tQPapWvzAM6Q==",
+      "version": "1.751.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.751.1.tgz",
+      "integrity": "sha512-8WWYXxJhrtNAprgGxvOfLWHWazrjBygpCryMCG0KK4vFbUhykK1utof5MyGwiFOKe+RyF32NDRNsfT/UJyDaNg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.750.0",
+    "@bigcommerce/checkout-sdk": "^1.751.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/2884

## Testing / Proof

All tests passed
