### PR TITLE
feat(payment): Refactor code in order to use newly added skipRedirect…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.753.0",
+        "@bigcommerce/checkout-sdk": "^1.754.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.753.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.753.0.tgz",
-      "integrity": "sha512-Fgl4eI6ksbC8Nnu4T78SuAb1BX2nKeo/yOc2y9kVbcNY9p4odQpf6bBOWeLsZC18kHvGzYNgpHYkM5oj44YidA==",
+      "version": "1.754.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.754.0.tgz",
+      "integrity": "sha512-QNsquoVHXisUBNM+zqes4/v3aTuDJ25FzcEhdNsDHuefyrp2HqmMDLJu0Paf7c6Nl+3VXiJ7eQcTArOHHK1D9g==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.753.0",
+    "@bigcommerce/checkout-sdk": "^1.754.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -321,39 +321,12 @@ class Payment extends Component<
         const { defaultMethod, isSubmittingOrder, language } = this.props;
         const { selectedMethod = defaultMethod } = this.state;
 
-        // TODO: [PI-3551] Perhaps there is a better way to handle `adyen`, `afterpay`, `amazonpay`,
-        // `checkout.com`, `converge`, `sagepay`, `stripev3` and `sezzle`. They require
-        //  a redirection to another website during the payment flow but are not
-        //  categorised as hosted payment methods.
         if (
             !isSubmittingOrder ||
             !selectedMethod ||
             selectedMethod.type === PaymentMethodProviderType.Hosted ||
             selectedMethod.type === PaymentMethodProviderType.PPSDK ||
-            selectedMethod.gateway === PaymentMethodId.BlueSnapDirect ||
-            selectedMethod.gateway === PaymentMethodId.BlueSnapV2 ||
-            selectedMethod.id === PaymentMethodId.AmazonPay ||
-            selectedMethod.id === PaymentMethodId.CBAMPGS ||
-            selectedMethod.id === PaymentMethodId.Checkoutcom ||
-            selectedMethod.id === PaymentMethodId.CheckoutcomGooglePay ||
-            selectedMethod.id === PaymentMethodId.Converge ||
-            selectedMethod.id === PaymentMethodId.Humm ||
-            selectedMethod.id === PaymentMethodId.Laybuy ||
-            selectedMethod.id === PaymentMethodId.Quadpay ||
-            selectedMethod.id === PaymentMethodId.SagePay ||
-            selectedMethod.id === PaymentMethodId.Sezzle ||
-            selectedMethod.id === PaymentMethodId.WorldpayAccess ||
-            selectedMethod.id === PaymentMethodId.Zip ||
-            selectedMethod.gateway === PaymentMethodId.AdyenV2 ||
-            selectedMethod.gateway === PaymentMethodId.AdyenV2GooglePay ||
-            selectedMethod.gateway === PaymentMethodId.AdyenV3 ||
-            selectedMethod.gateway === PaymentMethodId.AdyenV3GooglePay ||
-            selectedMethod.gateway === PaymentMethodId.Afterpay ||
-            selectedMethod.gateway === PaymentMethodId.Clearpay ||
-            selectedMethod.gateway === PaymentMethodId.Checkoutcom ||
-            selectedMethod.gateway === PaymentMethodId.Mollie ||
-            selectedMethod.gateway === PaymentMethodId.StripeV3 ||
-            selectedMethod.gateway === PaymentMethodId.StripeUPE
+            selectedMethod.skipRedirectConfirmationAlert
         ) {
             return;
         }

--- a/packages/test-mocks/src/payment-methods.mock.ts
+++ b/packages/test-mocks/src/payment-methods.mock.ts
@@ -22,6 +22,7 @@ export function getPaymentMethod(): PaymentMethod {
             testMode: false,
         },
         type: 'PAYMENT_TYPE_API',
+        skipRedirectConfirmationAlert: false,
     };
 }
 
@@ -37,6 +38,7 @@ export function getPaypalCreditPaymentMethod(): PaymentMethod {
             payPalCreditProductBrandName: { credit: 'Pay in 3' },
         },
         type: 'PAYMENT_TYPE_API',
+        skipRedirectConfirmationAlert: false,
     };
 }
 
@@ -51,6 +53,7 @@ export function getBraintreeAchPaymentMethod(): PaymentMethod {
             isVaultingEnabled: false,
         },
         type: 'PAYMENT_TYPE_API',
+        skipRedirectConfirmationAlert: false,
     };
 }
 
@@ -76,6 +79,7 @@ export function getMobilePaymentMethod(): PaymentMethod {
             testMode: false,
         },
         type: 'PAYMENT_TYPE_API',
+        skipRedirectConfirmationAlert: false,
     };
 }
 
@@ -91,5 +95,6 @@ export function getBraintreePaypalPaymentMethod(): PaymentMethod {
         initializationData: {},
         clientToken: 'token',
         returnUrl: undefined,
+        skipRedirectConfirmationAlert: false,
     };
 }


### PR DESCRIPTION
…ConfirmationAlert

## What/Why?
In this PR we refactor how `„leaving the page”` message is omitted. Previously it was based on hardcoded providers. Now it is based on new `skipRedirectConfirmationAlert` property received from BE. 
**BCAPP part** - https://github.com/bigcommerce/bigcommerce/pull/63372

At the beginning the idea was to pass `skipRedirectConfirmationAlert` in `initializationData` however it was finally added outside it, due to internal discussion during work on BE ticket. Because of this we need to update `PaymentMethod` interface and this is done in this checkout-sdk PR:
**Checkout-sdk part** https://github.com/bigcommerce/checkout-sdk-js/pull/2900

CI checks are failing now but it should pass after merging checkout-sdk part.

## Testing / Proof
Tested manually
![Zrzut ekranu 2025-06-18 o 17 04 25](https://github.com/user-attachments/assets/94c54e27-4df3-4e3d-b2d2-796cdecb98e9)


https://github.com/user-attachments/assets/d0cee7d6-f505-48bf-9dcb-397de32f45a9

https://github.com/user-attachments/assets/fc0991ae-7aee-4efa-81a9-ce2ac6b0494d

https://github.com/user-attachments/assets/8251b8cf-9195-4bf8-a212-5105e0614b0e


https://github.com/user-attachments/assets/3c630a80-7205-4c57-b087-fdad6ca8d78c


https://github.com/user-attachments/assets/6d3266bd-7a30-4ad2-9ad5-70f7881516b7


https://github.com/user-attachments/assets/01838b3d-4579-4048-9c42-68bac915c47e


https://github.com/user-attachments/assets/5eacd73e-5d7f-46ca-aaa2-a207557247eb

![Elavon eCommerce Platform - Converge](https://github.com/user-attachments/assets/e350992a-a945-4a55-8666-9f877deb70bb)

https://github.com/user-attachments/assets/d48e6ac2-b038-4bfd-acb7-af87d56f8b70


https://github.com/user-attachments/assets/d6411b38-6439-4a60-85fc-cd52646e2338


https://github.com/user-attachments/assets/5c006402-804e-45f2-9772-adb9ab6a3040


https://github.com/user-attachments/assets/7f920d02-8954-4ca4-b9e6-512398e9ee0a


https://github.com/user-attachments/assets/6395f424-c457-4558-adc7-af4ca68b4412


https://github.com/user-attachments/assets/63c973cf-847a-4c84-9b03-225204d9e3cb

I added testing videos for majority if affected payment providers. With rest I had problems with onboarding it or having it displayed on payment step. However all providers are added in BCAPP part and should receive skipRedirectConfirmationAlert property correctly.


