### PR TITLE
feat(checkout): CHECKOUT-9314 Improve Color Contrast to Meet WCAG 2.1 Standards

### DIFF
--- a/packages/core/src/scss/settings/global/color/_color.scss
+++ b/packages/core/src/scss/settings/global/color/_color.scss
@@ -40,14 +40,14 @@ $color-highlightDarkest:            #476BEF;
 // States
 // -----------------------------------------------------------------------------
 
-$color-error:                       #d12727;
-$color-errorLight:                  #f8e8e8;
+$color-error:                       #ad0000;
+$color-errorLight:                  #fff0f1;
 
 $color-info:                        #5f5f5f;
 $color-infoLight:                   #f5f5f5;
 
-$color-success:                     #51a551;
-$color-successLight:                #dfefdc;
+$color-success:                     #004d0d;
+$color-successLight:                #d3f5d9;
 
 $color-warning:                     #d1a162;
 $color-warningLight:                #fbf7ee;


### PR DESCRIPTION
## What?
Update alert and success messages' color contrast.

![image](https://github.com/user-attachments/assets/b1227311-f3c5-4a0d-9a93-4089216ad4f0)
![image](https://github.com/user-attachments/assets/9cfa536d-65f9-40ea-8622-4d1f006a721c)

## Why?
To meet WCAG 2.1 standards.

## Testing / Proof
![Screenshot 2025-06-23 at 14 48 03](https://github.com/user-attachments/assets/29d84920-bd66-4556-854d-4f31994d9104)
![Screenshot 2025-06-23 at 14 47 22](https://github.com/user-attachments/assets/98838ab3-fb4a-46fe-b83e-d45c94def3a7)