### PR TITLE
chore(payment): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.751.3",
+        "@bigcommerce/checkout-sdk": "^1.753.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,10 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.751.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.751.3.tgz",
-      "integrity": "sha512-qjRIXiL7V6KNHa/tX058p8IZw6+cB9Mom6La3bMFOJgQ1Hx4OVoQk+3MWGZJf7K9n7bx0wb2Ci/8hVBDkfTD2g==",
-      "license": "MIT",
+      "version": "1.753.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.753.0.tgz",
+      "integrity": "sha512-Fgl4eI6ksbC8Nnu4T78SuAb1BX2nKeo/yOc2y9kVbcNY9p4odQpf6bBOWeLsZC18kHvGzYNgpHYkM5oj44YidA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.751.3",
+    "@bigcommerce/checkout-sdk": "^1.753.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver: https://github.com/bigcommerce/checkout-sdk-js/pull/2904

## Testing / Proof

All tests passed
