### PR TITLE
CHECKOUT-9307: Fix secrets scan filter so PR workflow does not trigger on merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,8 +234,7 @@ workflows:
       - security/scan:
           name: "Gitleaks secrets scan"
           filters:
-            branches:
-              ignore: /pull\/[0-9]+/
+            <<: *pull_request_filter
           context: org-global
           GITLEAKS_BLOCK: "false"
       - microapp/upload-artifact:


### PR DESCRIPTION
## What/Why?
Currently, the "pull request" workflow is triggered when a PR is merged into master. This happens because the "Gitleaks secrets scan" job is missing the correct filter, unlike the other jobs in the same workflow.

<img width="1151" alt="Screenshot 2025-06-24 at 2 50 24 pm" src="https://github.com/user-attachments/assets/f52e27b9-ad0f-424a-ad6a-d79e53f8f8ac" />

## Testing / Proof
CircleCI
