### PR TITLE
fix(payment): fixed eslint errors in paypal-commerce-integration package

### DIFF
--- a/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.test.tsx
@@ -40,7 +40,7 @@ describe('PayPalCommerceButton', () => {
         expect(checkoutService.initializeCustomer).toHaveBeenCalledWith({
             methodId: defaultProps.methodId,
             paypalcommerce: {
-                container: "paypalcommerce-button-container",
+                container: 'paypalcommerce-button-container',
                 onClick: expect.any(Function),
                 onComplete: expect.any(Function),
                 onError: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommerceButton.tsx
@@ -14,12 +14,15 @@ const PayPalCommerceButton: FunctionComponent<CheckoutButtonProps> = (props) => 
         onError: props.onUnhandledError,
     };
 
-    return <CheckoutButton additionalInitializationOptions={additionalInitializationOptions} {...props} />;
+    return (
+        <CheckoutButton
+            additionalInitializationOptions={additionalInitializationOptions}
+            {...props}
+        />
+    );
 };
 
 export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(
     PayPalCommerceButton,
-    [
-        { id: 'paypalcommerce' },
-    ],
+    [{ id: 'paypalcommerce' }],
 );

--- a/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommercePaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommercePaymentMethod.test.tsx
@@ -15,6 +15,7 @@ import { getPaymentFormServiceMock, getStoreConfig } from '@bigcommerce/checkout
 import { act } from '@bigcommerce/checkout/test-utils';
 
 import { getPayPalCommerceMethod } from '../mocks/paymentMethods.mock';
+
 import PayPalCommercePaymentMethod from './PayPalCommercePaymentMethod';
 
 describe('PayPalCommercePaymentMethod', () => {

--- a/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommercePaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerce/PayPalCommercePaymentMethod.tsx
@@ -13,6 +13,7 @@ import {
 import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 
 import PayPalCommercePaymentMethodComponent from '../components/PayPalCommercePaymentMethodComponent';
+
 import usePaypalCommerceInstrument from './hooks/usePaypalCommerceInstruments';
 
 const PayPalCommercePaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {

--- a/packages/paypal-commerce-integration/src/PayPalCommerce/hooks/usePaypalCommerceInstruments.ts
+++ b/packages/paypal-commerce-integration/src/PayPalCommerce/hooks/usePaypalCommerceInstruments.ts
@@ -30,7 +30,6 @@ const usePaypalCommerceInstrument = (method: PaymentMethod) => {
     const isInstrumentFeatureAvailable =
         !customer?.isGuest &&
         Boolean(method.config.isVaultingEnabled) &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         !method.initializationData.isComplete;
     const shouldShowInstrumentFieldset = isInstrumentFeatureAvailable && hasAccountInstruments;
 

--- a/packages/paypal-commerce-integration/src/PayPalCommerceAPMs/PayPalCommerceAPMsPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceAPMs/PayPalCommerceAPMsPaymentMethod.test.tsx
@@ -1,14 +1,13 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
-
-import { getPaymentFormServiceMock } from '@bigcommerce/checkout/test-mocks';
-
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
+import { getPaymentFormServiceMock } from '@bigcommerce/checkout/test-mocks';
 
 import { getPayPalCommerceAPMsMethod } from '../mocks/paymentMethods.mock';
+
 import PayPalCommerceAPMsPaymentMethod from './PayPalCommerceAPMsPaymentMethod';
 
 describe('PayPalCommerceAPMsPaymentMethod', () => {

--- a/packages/paypal-commerce-integration/src/PayPalCommerceAPMs/PayPalCommerceAPMsPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceAPMs/PayPalCommerceAPMsPaymentMethod.tsx
@@ -4,19 +4,18 @@ import {
     getUniquePaymentMethodId,
     PaymentMethodProps,
     PaymentMethodResolveId,
-    toResolvableComponent
+    toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
 import PayPalCommercePaymentMethodComponent from '../components/PayPalCommercePaymentMethodComponent';
 
-const PayPalCommerceAPMsPaymentMethod: FunctionComponent<PaymentMethodProps> = props => {
+const PayPalCommerceAPMsPaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {
     const { method } = props;
     const isPaymentDataRequired = props.checkoutState.data.isPaymentDataRequired();
 
     if (!isPaymentDataRequired) {
         return null;
     }
-
 
     const widgetContainerId = getUniquePaymentMethodId(method.id, method.gateway);
     const extraOptions = {
@@ -50,11 +49,10 @@ const PayPalCommerceAPMsPaymentMethod: FunctionComponent<PaymentMethodProps> = p
 
     return (
         <PayPalCommercePaymentMethodComponent
-            providerOptionsKey="paypalcommercealternativemethods"
             providerOptionsData={extraOptions}
+            providerOptionsKey="paypalcommercealternativemethods"
             {...props}
         >
-
             <div
                 className={`widget widget--${props.method.id} payment-widget`}
                 id={widgetContainerId}

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.test.tsx
@@ -40,7 +40,7 @@ describe('PayPalCommerceCreditButton', () => {
         expect(checkoutService.initializeCustomer).toHaveBeenCalledWith({
             methodId: defaultProps.methodId,
             paypalcommercecredit: {
-                container: "paypalcommercecredit-button-container",
+                container: 'paypalcommercecredit-button-container',
                 onClick: expect.any(Function),
                 onComplete: expect.any(Function),
                 onError: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditButton.tsx
@@ -14,12 +14,15 @@ const PayPalCommerceCreditButton: FunctionComponent<CheckoutButtonProps> = (prop
         onError: props.onUnhandledError,
     };
 
-    return <CheckoutButton additionalInitializationOptions={additionalInitializationOptions} {...props} />;
+    return (
+        <CheckoutButton
+            additionalInitializationOptions={additionalInitializationOptions}
+            {...props}
+        />
+    );
 };
 
 export default toResolvableComponent<CheckoutButtonProps, CheckoutButtonResolveId>(
     PayPalCommerceCreditButton,
-    [
-        { id: 'paypalcommercecredit' },
-    ],
+    [{ id: 'paypalcommercecredit' }],
 );

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditPaymentMethod.test.tsx
@@ -1,13 +1,13 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getPayPalCommerceCreditMethod } from '../mocks/paymentMethods.mock';
-import PayPalCommerceCreditPaymentMethod from './PayPalCommerceCreditPaymentMethod';
 
+import PayPalCommerceCreditPaymentMethod from './PayPalCommerceCreditPaymentMethod';
 
 describe('PayPalCommerceCreditPaymentMethod', () => {
     const checkoutService = createCheckoutService();
@@ -16,9 +16,9 @@ describe('PayPalCommerceCreditPaymentMethod', () => {
         method: getPayPalCommerceCreditMethod(),
         checkoutService,
         checkoutState,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+
         paymentForm: jest.fn() as unknown as PaymentFormService,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+
         language: { translate: jest.fn() } as unknown as LanguageService,
         onUnhandledError: jest.fn(),
     };
@@ -37,11 +37,11 @@ describe('PayPalCommerceCreditPaymentMethod', () => {
                 ...checkoutState,
                 data: {
                     ...checkoutState.data,
-                    isPaymentDataRequired: jest.fn().mockReturnValue(false)
-                }
+                    isPaymentDataRequired: jest.fn().mockReturnValue(false),
+                },
             },
-            children: mockChild
-        }
+            children: mockChild,
+        };
         const { container } = render(<PayPalCommerceCreditPaymentMethod {...localProps} />);
 
         expect(container).toBeEmptyDOMElement();

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCredit/PayPalCommerceCreditPaymentMethod.tsx
@@ -3,22 +3,24 @@ import React, { FunctionComponent } from 'react';
 import {
     PaymentMethodProps,
     PaymentMethodResolveId,
-    toResolvableComponent
+    toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
 import PayPalCommercePaymentMethodComponent from '../components/PayPalCommercePaymentMethodComponent';
 
-const PayPalCommerceCreditPaymentMethod: FunctionComponent<PaymentMethodProps> = props => {
+const PayPalCommerceCreditPaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {
     const isPaymentDataRequired = props.checkoutState.data.isPaymentDataRequired();
 
     if (!isPaymentDataRequired) {
         return null;
     }
 
-    return <PayPalCommercePaymentMethodComponent
-        providerOptionsKey="paypalcommercecredit"
-        {...props}
-    />;
+    return (
+        <PayPalCommercePaymentMethodComponent
+            providerOptionsKey="paypalcommercecredit"
+            {...props}
+        />
+    );
 };
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent, useEffect, useRef } from 'react';
 import { CardInstrument } from '@bigcommerce/checkout-sdk';
+import React, { FunctionComponent, useEffect, useRef } from 'react';
 
 import { LocaleProvider } from '@bigcommerce/checkout/locale';
 import {

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneCreditCardForm.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneCreditCardForm.tsx
@@ -19,9 +19,9 @@ const PayPalCommerceFastlaneCreditCardForm: FunctionComponent<
 
     return (
         <div
+            className="paypal-commerce-fastlane-cc-form-container"
             data-test="paypal-commerce-fastlane-cc-form-container"
             id="paypal-commerce-fastlane-cc-form-container"
-            className="paypal-commerce-fastlane-cc-form-container"
         />
     );
 };

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneForm.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneForm.test.tsx
@@ -59,6 +59,8 @@ describe('PayPalCommerceFastlaneForm', () => {
     it('shows paypal fastlane credit card form if customer does not have any instrument', () => {
         render(<PayPalCommerceFastlaneFormMock />);
 
-        expect(screen.getByTestId('paypal-commerce-fastlane-cc-form-container')).toBeInTheDocument();
+        expect(
+            screen.getByTestId('paypal-commerce-fastlane-cc-form-container'),
+        ).toBeInTheDocument();
     });
 });

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneForm.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneForm.tsx
@@ -1,8 +1,6 @@
 import React, { FunctionComponent, useEffect } from 'react';
 
-import {
-    usePayPalCommerceFastlaneInstruments
-} from '../hooks/usePayPalCommerceFastlaneInstruments';
+import { usePayPalCommerceFastlaneInstruments } from '../hooks/usePayPalCommerceFastlaneInstruments';
 import { PayPalFastlaneCardComponentRef } from '../PayPalCommerceFastlanePaymentMethod';
 
 import PayPalCommerceFastlaneCreditCardForm from './PayPalCommerceFastlaneCreditCardForm';
@@ -13,14 +11,12 @@ interface PayPalCommerceFastlaneFormProps {
     showPayPalCardSelector?: PayPalFastlaneCardComponentRef['showPayPalCardSelector'];
 }
 
-const PayPalCommerceFastlaneForm: FunctionComponent<
-    PayPalCommerceFastlaneFormProps
-> = ({ renderPayPalCardComponent, showPayPalCardSelector }) => {
-    const {
-        instruments,
-        handleSelectInstrument,
-        selectedInstrument,
-    } = usePayPalCommerceFastlaneInstruments();
+const PayPalCommerceFastlaneForm: FunctionComponent<PayPalCommerceFastlaneFormProps> = ({
+    renderPayPalCardComponent,
+    showPayPalCardSelector,
+}) => {
+    const { instruments, handleSelectInstrument, selectedInstrument } =
+        usePayPalCommerceFastlaneInstruments();
 
     const shouldShowInstrumentsForm = instruments.length > 0;
 

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.test.tsx
@@ -1,12 +1,12 @@
+import { CardInstrument } from '@bigcommerce/checkout-sdk';
+import { fireEvent } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom';
 
-import { render, screen } from '@bigcommerce/checkout/test-utils';
 import { getCardInstrument } from '@bigcommerce/checkout/test-mocks';
+import { render, screen } from '@bigcommerce/checkout/test-utils';
 
 import PayPalCommerceFastlaneInstrumentsForm from './PayPalCommerceFastlaneInstrumentsForm';
-import { CardInstrument } from '@bigcommerce/checkout-sdk';
-import { fireEvent } from '@testing-library/react';
 
 describe('PayPalCommerceAcceleratedCheckoutInstrumentsForm', () => {
     const selectedInstrumentMock = getCardInstrument();
@@ -17,7 +17,7 @@ describe('PayPalCommerceAcceleratedCheckoutInstrumentsForm', () => {
                 handleSelectInstrument={jest.fn()}
                 onChange={jest.fn()}
                 selectedInstrument={selectedInstrumentMock}
-            />
+            />,
         );
 
         expect(container).toMatchSnapshot();
@@ -38,7 +38,7 @@ describe('PayPalCommerceAcceleratedCheckoutInstrumentsForm', () => {
                 handleSelectInstrument={handleSelectInstrument}
                 onChange={onChange}
                 selectedInstrument={selectedInstrumentMock}
-            />
+            />,
         );
 
         const actionButton = screen.getByTestId('paypal-commerce-fastlane-instrument-change');

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/components/PayPalCommerceFastlaneInstrumentsForm.tsx
@@ -1,10 +1,9 @@
 import { CardInstrument } from '@bigcommerce/checkout-sdk';
-
 import React, { FunctionComponent } from 'react';
 
-import { CreditCardIcon, Button, ButtonSize, ButtonVariant } from '@bigcommerce/checkout/ui';
-import { PoweredByPayPalFastlaneLabel } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { PoweredByPayPalFastlaneLabel } from '@bigcommerce/checkout/paypal-fastlane-integration';
+import { CreditCardIcon, Button, ButtonSize, ButtonVariant } from '@bigcommerce/checkout/ui';
 
 import { PayPalFastlaneCardComponentRef } from '../PayPalCommerceFastlanePaymentMethod';
 
@@ -35,11 +34,7 @@ interface PayPalCommerceFastlaneInstrumentsFormProps {
 
 const PayPalCommerceFastlaneInstrumentsForm: FunctionComponent<
     PayPalCommerceFastlaneInstrumentsFormProps
-> = ({
-    onChange,
-    handleSelectInstrument,
-    selectedInstrument,
-}) => {
+> = ({ onChange, handleSelectInstrument, selectedInstrument }) => {
     const cardType = mapFromInstrumentCardType(selectedInstrument.brand).toLowerCase();
 
     const handleChange = async () => {
@@ -50,7 +45,7 @@ const PayPalCommerceFastlaneInstrumentsForm: FunctionComponent<
                 handleSelectInstrument(result);
             }
         }
-    }
+    };
 
     return (
         <div
@@ -61,7 +56,10 @@ const PayPalCommerceFastlaneInstrumentsForm: FunctionComponent<
                 <div className="paypal-commerce-fastlane-instrument-details">
                     <CreditCardIcon cardType={cardType} />
 
-                    <div className="instrumentSelect-card" data-test="paypal-fastlane-instrument-last4">
+                    <div
+                        className="instrumentSelect-card"
+                        data-test="paypal-fastlane-instrument-last4"
+                    >
                         {/* &#9679; is a ● */}
                         <span>&#9679;&#9679;&#9679;&#9679; {selectedInstrument.last4}</span>
                     </div>
@@ -73,10 +71,10 @@ const PayPalCommerceFastlaneInstrumentsForm: FunctionComponent<
 
             <div className="paypal-commerce-fastlane-instrument-change-action">
                 <Button
+                    onClick={handleChange}
                     size={ButtonSize.Tiny}
                     testId="paypal-commerce-fastlane-instrument-change"
                     variant={ButtonVariant.Secondary}
-                    onClick={handleChange}
                 >
                     <TranslatedString id="common.change_action" />
                 </Button>

--- a/packages/paypal-commerce-integration/src/PayPalCommerceRatepay/validation-schema/getPaypalCommerceRatePayValidationSchema.ts
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceRatepay/validation-schema/getPaypalCommerceRatePayValidationSchema.ts
@@ -16,39 +16,46 @@ export default memoize(function getPaypalCommerceRatePayValidationSchema({
     };
 
     return object(
-        formFieldData.reduce((schema, { id, required }) => {
-            if (required) {
-                if (requiredFieldErrorTranslationIds[id]) {
-                    schema[id] = string()
-                        .nullable()
-                        .required(
-                            language.translate(`payment.ratepay.errors.isRequired`, {
-                                fieldName: language.translate(requiredFieldErrorTranslationIds[id]),
-                            }),
-                        );
+        formFieldData.reduce(
+            (schema, { id, required }) => {
+                if (required) {
+                    if (requiredFieldErrorTranslationIds[id]) {
+                        schema[id] = string()
+                            .nullable()
+                            .required(
+                                language.translate(`payment.ratepay.errors.isRequired`, {
+                                    fieldName: language.translate(
+                                        requiredFieldErrorTranslationIds[id],
+                                    ),
+                                }),
+                            );
 
-                    if (id === 'ratepayPhoneCountryCode') {
-                        schema[id] = schema[id].matches(
-                            /^\+\d{2,}$/,
-                            language.translate('payment.ratepay.errors.isInvalid', {
-                                fieldName: language.translate('payment.ratepay.phone_country_code'),
-                            }),
-                        );
-                    }
+                        if (id === 'ratepayPhoneCountryCode') {
+                            schema[id] = schema[id].matches(
+                                /^\+\d{2,}$/,
+                                language.translate('payment.ratepay.errors.isInvalid', {
+                                    fieldName: language.translate(
+                                        'payment.ratepay.phone_country_code',
+                                    ),
+                                }),
+                            );
+                        }
 
-                    if (id === 'ratepayPhoneNumber') {
-                        schema[id] = schema[id].matches(
-                            /^\d{7,11}$/,
-                            language.translate('payment.ratepay.errors.isInvalid', {
-                                fieldName: language.translate('payment.ratepay.phone_number'),
-                            }),
-                        );
+                        if (id === 'ratepayPhoneNumber') {
+                            schema[id] = schema[id].matches(
+                                /^\d{7,11}$/,
+                                language.translate('payment.ratepay.errors.isInvalid', {
+                                    fieldName: language.translate('payment.ratepay.phone_number'),
+                                }),
+                            );
+                        }
                     }
                 }
-            }
 
-            return schema;
+                return schema;
+            },
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        }, {} as { [key: string]: StringSchema<string | null> }),
+            {} as { [key: string]: StringSchema<string | null> },
+        ),
     );
 });

--- a/packages/paypal-commerce-integration/src/PayPalCommerceVenmo/PayPalCommerceVenmoPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceVenmo/PayPalCommerceVenmoPaymentMethod.test.tsx
@@ -1,11 +1,12 @@
 import { createCheckoutService, LanguageService } from '@bigcommerce/checkout-sdk';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 import React from 'react';
 
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 
 import { getPayPalCommerceVenmoMethod } from '../mocks/paymentMethods.mock';
+
 import PayPalCommerceVenmoPaymentMethod from './PayPalCommerceVenmoPaymentMethod';
 
 describe('PayPalCommerceVenmoPaymentMethod', () => {
@@ -15,9 +16,9 @@ describe('PayPalCommerceVenmoPaymentMethod', () => {
         method: getPayPalCommerceVenmoMethod(),
         checkoutService,
         checkoutState,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+
         paymentForm: jest.fn() as unknown as PaymentFormService,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+
         language: { translate: jest.fn() } as unknown as LanguageService,
         onUnhandledError: jest.fn(),
     };
@@ -36,11 +37,11 @@ describe('PayPalCommerceVenmoPaymentMethod', () => {
                 ...checkoutState,
                 data: {
                     ...checkoutState.data,
-                    isPaymentDataRequired: jest.fn().mockReturnValue(false)
-                }
+                    isPaymentDataRequired: jest.fn().mockReturnValue(false),
+                },
             },
-            children: mockChild
-        }
+            children: mockChild,
+        };
         const { container } = render(<PayPalCommerceVenmoPaymentMethod {...localProps} />);
 
         expect(container).toBeEmptyDOMElement();

--- a/packages/paypal-commerce-integration/src/PayPalCommerceVenmo/PayPalCommerceVenmoPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceVenmo/PayPalCommerceVenmoPaymentMethod.tsx
@@ -3,22 +3,21 @@ import React, { FunctionComponent } from 'react';
 import {
     PaymentMethodProps,
     PaymentMethodResolveId,
-    toResolvableComponent
+    toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
 import PayPalCommercePaymentMethodComponent from '../components/PayPalCommercePaymentMethodComponent';
 
-const PayPalCommerceVenmoPaymentMethod: FunctionComponent<PaymentMethodProps> = props => {
+const PayPalCommerceVenmoPaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {
     const isPaymentDataRequired = props.checkoutState.data.isPaymentDataRequired();
 
     if (!isPaymentDataRequired) {
         return null;
     }
 
-    return <PayPalCommercePaymentMethodComponent
-        providerOptionsKey="paypalcommercevenmo"
-        {...props}
-    />;
+    return (
+        <PayPalCommercePaymentMethodComponent providerOptionsKey="paypalcommercevenmo" {...props} />
+    );
 };
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(

--- a/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
+++ b/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
@@ -24,7 +24,7 @@ describe('PayPalCommercePaymentMethodComponent', () => {
     const props = {
         checkoutService,
         checkoutState,
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+
         language: { translate: jest.fn() } as unknown as LanguageService,
         method: getPayPalCommerceMethod(),
         onUnhandledError: jest.fn(),


### PR DESCRIPTION
## What?
Fixed eslint warnings and errors in paypal-commerce-integration package

## Why?
To keep paypal-commerce-integration codebase as clean as possible

## Testing / Proof
Unit tests
CI

Before:
<img width="699" alt="Screenshot 2025-06-24 at 12 39 20" src="https://github.com/user-attachments/assets/a532b583-3de9-4211-a7b3-2c079cdaed0a" />

After:
<img width="913" alt="Screenshot 2025-06-24 at 12 38 38" src="https://github.com/user-attachments/assets/955f1ba1-0228-4dfe-a698-342902a21ff7" />

