### PR TITLE
refactor(payment): created PayPalCommerceCreditCardsPaymentMethod in paypal-commerce-integration package to remove the same component from core

### DIFF
--- a/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.test.tsx
@@ -1,0 +1,449 @@
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+    createLanguageService,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk';
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React, { FunctionComponent } from 'react';
+
+import { CreditCardPaymentMethodValues } from '@bigcommerce/checkout/credit-card-integration';
+import {
+    createLocaleContext,
+    LocaleContext,
+    LocaleContextType,
+} from '@bigcommerce/checkout/locale';
+import {
+    CheckoutProvider,
+    PaymentFormContext,
+    PaymentFormService,
+    PaymentMethodProps,
+} from '@bigcommerce/checkout/payment-integration-api';
+import {
+    getCart,
+    getCheckout,
+    getConsignment,
+    getCustomer,
+    getPaymentFormServiceMock,
+    getPaymentMethod,
+    getStoreConfig,
+} from '@bigcommerce/checkout/test-mocks';
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import PayPalCommerceCreditCardPaymentMethod from './PayPalCommerceCreditCardsPaymentMethod';
+
+describe('PayPalCommerceCreditCardPaymentMethod', () => {
+    let initialValues: CreditCardPaymentMethodValues;
+    let method: PaymentMethod;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: PaymentMethodProps;
+    let localeContext: LocaleContextType;
+    let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
+    let paymentForm: PaymentFormService;
+
+    beforeEach(() => {
+        initialValues = {
+            ccCustomerCode: '',
+            ccCvv: '',
+            ccExpiry: '',
+            ccName: '',
+            ccNumber: '',
+            instrumentId: '',
+        };
+        paymentForm = getPaymentFormServiceMock();
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        localeContext = createLocaleContext(getStoreConfig());
+        method = { ...getPaymentMethod(), id: 'paypalcommercecreditcards' };
+
+        defaultProps = {
+            method,
+            checkoutService,
+            checkoutState,
+            paymentForm,
+            language: createLanguageService(),
+            onUnhandledError: jest.fn(),
+        };
+
+        jest.spyOn(checkoutService, 'loadInstruments').mockResolvedValue(checkoutState);
+        jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
+        jest.spyOn(checkoutService, 'initializePayment').mockResolvedValue(checkoutState);
+
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue(getCart());
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+        jest.spyOn(checkoutState.data, 'getConsignments').mockReturnValue([getConsignment()]);
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
+        jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(true);
+        jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
+
+        PaymentMethodTest = (props) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <PaymentFormContext.Provider value={{ paymentForm }}>
+                    <LocaleContext.Provider value={localeContext}>
+                        <Formik initialValues={initialValues} onSubmit={noop}>
+                            <PayPalCommerceCreditCardPaymentMethod {...props} />
+                        </Formik>
+                    </LocaleContext.Provider>
+                </PaymentFormContext.Provider>
+            </CheckoutProvider>
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders as credit card payment method component', () => {
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(document.querySelector('.paymentMethod--creditCard')).toBeInTheDocument();
+    });
+
+    it('initializes payment method when component mounts', async () => {
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(checkoutService.initializePayment).toHaveBeenCalled();
+    });
+
+    it('calls initializePayment with correct arguments', async () => {
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+            expect.objectContaining({
+                methodId: 'paypalcommercecreditcards',
+                paypalcommercecreditcards: expect.any(Object),
+            }),
+        );
+    });
+
+    it('calls deinitializePayment with correct arguments on unmount', () => {
+        const { unmount } = render(<PaymentMethodTest {...defaultProps} />);
+
+        unmount();
+
+        expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+            methodId: 'paypalcommercecreditcards',
+        });
+    });
+
+    it('calls getHostedFormOptions and returns styles with all expected child options', async () => {
+        render(<PaymentMethodTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        if (call.paypalcommercecreditcards?.form) {
+            const options = await call.paypalcommercecreditcards.form();
+
+            expect(options).toHaveProperty('styles');
+            ['default', 'error', 'focus'].forEach((styleKey) => {
+                expect(options.styles).toHaveProperty(styleKey);
+                expect(options.styles[styleKey]).toHaveProperty('color');
+                expect(options.styles[styleKey]).toHaveProperty('fontFamily');
+                expect(options.styles[styleKey]).toHaveProperty('fontSize');
+                expect(options.styles[styleKey]).toHaveProperty('fontWeight');
+            });
+        }
+    });
+
+    it('calls all functions in getHostedFormOptions', async () => {
+        render(<PaymentMethodTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        if (call.paypalcommercecreditcards?.form) {
+            const options = await call.paypalcommercecreditcards.form();
+
+            expect(typeof options.onBlur).toBe('function');
+            expect(typeof options.onCardTypeChange).toBe('function');
+            expect(typeof options.onEnter).toBe('function');
+            expect(typeof options.onFocus).toBe('function');
+            expect(typeof options.onValidate).toBe('function');
+
+            // Call each function to ensure they are callable
+            expect(() => options.onBlur({ fieldType: 'cardNumber' })).not.toThrow();
+            expect(() => options.onCardTypeChange({ cardType: 'visa' })).not.toThrow();
+            expect(() => options.onEnter()).not.toThrow();
+            expect(() => options.onFocus({ fieldType: 'cardNumber' })).not.toThrow();
+            expect(() =>
+                options.onValidate({
+                    errors: {
+                        cardNumber: [{ type: 'required' }],
+                    },
+                }),
+            ).not.toThrow();
+        }
+    });
+
+    it('getHostedFormOptions returns correct fields for selectedInstrument with required verifications', async () => {
+        // Simulate selectedInstrument with both isInstrumentCardNumberRequired and isInstrumentCardCodeRequired returning true
+        const selectedInstrument = {
+            bigpayToken: 'test-token',
+        };
+
+        const isInstrumentCardNumberRequiredSelector = jest.fn().mockReturnValue(true);
+        const isInstrumentCardCodeRequiredSelector = jest.fn().mockReturnValue(true);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (defaultProps.checkoutState as any).data.isInstrumentCardNumberRequired =
+            isInstrumentCardNumberRequiredSelector;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (defaultProps.checkoutState as any).data.isInstrumentCardCodeRequired =
+            isInstrumentCardCodeRequiredSelector;
+
+        render(<PaymentMethodTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        if (call.paypalcommercecreditcards?.form) {
+            const options = await call.paypalcommercecreditcards.form(selectedInstrument);
+
+            expect(options.fields.cardCodeVerification).toEqual(
+                expect.objectContaining({
+                    accessibilityLabel: expect.any(String),
+                    containerId: expect.any(String),
+                    instrumentId: selectedInstrument.bigpayToken,
+                }),
+            );
+            expect(options.fields.cardNumberVerification).toEqual(
+                expect.objectContaining({
+                    accessibilityLabel: expect.any(String),
+                    containerId: expect.any(String),
+                    instrumentId: selectedInstrument.bigpayToken,
+                }),
+            );
+            expect(options.fields.cardExpiryVerification).toEqual(
+                expect.objectContaining({
+                    accessibilityLabel: expect.any(String),
+                    containerId: expect.any(String),
+                    instrumentId: selectedInstrument.bigpayToken,
+                }),
+            );
+        }
+    });
+
+    it('getHostedFormOptions returns correct fields for selectedInstrument with no required verifications', async () => {
+        // Simulate selectedInstrument with both isInstrumentCardNumberRequired and isInstrumentCardCodeRequired returning false
+        const selectedInstrument = {
+            bigpayToken: 'test-token',
+        };
+
+        const isInstrumentCardNumberRequiredSelector = jest.fn().mockReturnValue(false);
+        const isInstrumentCardCodeRequiredSelector = jest.fn().mockReturnValue(false);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (defaultProps.checkoutState as any).data.isInstrumentCardNumberRequired =
+            isInstrumentCardNumberRequiredSelector;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (defaultProps.checkoutState as any).data.isInstrumentCardCodeRequired =
+            isInstrumentCardCodeRequiredSelector;
+
+        render(<PaymentMethodTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        if (call.paypalcommercecreditcards?.form) {
+            const options = await call.paypalcommercecreditcards.form(selectedInstrument);
+
+            expect(options.fields.cardCodeVerification).toBeUndefined();
+            expect(options.fields.cardNumberVerification).toBeUndefined();
+            expect(options.fields.cardExpiryVerification).toBeUndefined();
+        }
+    });
+
+    it('getHostedFormOptions returns correct fields when not using instrument', async () => {
+        render(<PaymentMethodTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        if (call.paypalcommercecreditcards?.form) {
+            const options = await call.paypalcommercecreditcards.form();
+
+            expect(options.fields.cardCode).toEqual(
+                expect.objectContaining({
+                    accessibilityLabel: expect.any(String),
+                    containerId: expect.any(String),
+                }),
+            );
+            expect(options.fields.cardExpiry).toEqual(
+                expect.objectContaining({
+                    accessibilityLabel: expect.any(String),
+                    containerId: expect.any(String),
+                    placeholder: expect.any(String),
+                }),
+            );
+            expect(options.fields.cardName).toEqual(
+                expect.objectContaining({
+                    accessibilityLabel: expect.any(String),
+                    containerId: expect.any(String),
+                }),
+            );
+            expect(options.fields.cardNumber).toEqual(
+                expect.objectContaining({
+                    accessibilityLabel: expect.any(String),
+                    containerId: expect.any(String),
+                }),
+            );
+        }
+    });
+
+    it('getHostedFormOptions returns empty styles object if styleContainerId is undefined', async () => {
+        // Simulate selectedInstrument with isInstrumentCardCodeRequired returning false
+        const selectedInstrument = {
+            bigpayToken: 'test-token',
+        };
+
+        const isInstrumentCardNumberRequiredSelector = jest.fn().mockReturnValue(false);
+        const isInstrumentCardCodeRequiredSelector = jest.fn().mockReturnValue(false);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (defaultProps.checkoutState as any).data.isInstrumentCardNumberRequired =
+            isInstrumentCardNumberRequiredSelector;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (defaultProps.checkoutState as any).data.isInstrumentCardCodeRequired =
+            isInstrumentCardCodeRequiredSelector;
+
+        render(<PaymentMethodTest {...defaultProps} />);
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        if (call.paypalcommercecreditcards?.form) {
+            const options = await call.paypalcommercecreditcards.form(selectedInstrument);
+
+            expect(options.styles).toEqual({});
+        }
+    });
+
+    it('renders fallback form when isHostedFormEnabled is false', () => {
+        defaultProps.method.config.isHostedFormEnabled = false;
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(document.querySelector('.paymentMethod--creditCard')).toBeInTheDocument();
+    });
+
+    it('renders with required customer code and cardholder name fields', () => {
+        defaultProps.method.config.requireCustomerCode = true;
+        defaultProps.method.config.showCardHolderName = true;
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(screen.getByText('Customer Code')).toBeInTheDocument();
+        expect(screen.getByLabelText(/Name on Card/i)).toBeInTheDocument();
+    });
+
+    it('renders card code field if cardCode is true', () => {
+        defaultProps.method.config.cardCode = true;
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(screen.getByLabelText(/CVV|Security Code|Card Code/i)).toBeInTheDocument();
+    });
+
+    it('calls onUnhandledError if error occurs during initializePayment', async () => {
+        (checkoutService.initializePayment as jest.Mock).mockRejectedValueOnce(
+            new Error('init error'),
+        );
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+    });
+
+    it('sets validation schema if payment is required', () => {
+        jest.spyOn(checkoutState.data, 'isPaymentDataRequired').mockReturnValue(true);
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(paymentForm.setValidationSchema).toHaveBeenCalled();
+    });
+
+    it('deinitializes payment method when component unmounts', () => {
+        const { unmount } = render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(checkoutService.deinitializePayment).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(checkoutService.deinitializePayment).toHaveBeenCalled();
+    });
+
+    it('renders loading overlay while waiting for method to initialize', () => {
+        jest.spyOn(checkoutState.statuses, 'isLoadingInstruments').mockReturnValue(true);
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(document.getElementsByClassName('loadingOverlay')).toHaveLength(1);
+    });
+
+    it('renders customer code field if requireCustomerCode is true', () => {
+        defaultProps.method.config.requireCustomerCode = true;
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(screen.getByText('Customer Code')).toBeInTheDocument();
+    });
+
+    it('renders save card checkbox if vaulting is enabled', () => {
+        defaultProps.method.config.isVaultingEnabled = true;
+
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
+        jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+    });
+
+    it('uses PaymentMethod to retrieve instruments', () => {
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(checkoutState.data.getInstruments).toHaveBeenCalledWith(defaultProps.method);
+    });
+
+    it('renders with save card checkbox if vaulting is enabled and no instruments', () => {
+        defaultProps.method.config.isVaultingEnabled = true;
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
+        jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+    });
+
+    it('does not render save card checkbox if vaulting is disabled', () => {
+        defaultProps.method.config.isVaultingEnabled = false;
+        jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(
+            screen.queryByText('Save this card for future transactions'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('does not show instruments fieldset when there are no stored instruments', () => {
+        defaultProps.method.config.isVaultingEnabled = false;
+
+        jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        expect(screen.queryByTestId('account-instrument-fieldset')).not.toBeInTheDocument();
+    });
+});

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.tsx
@@ -1,0 +1,300 @@
+import { CardInstrument, LegacyHostedFormOptions } from '@bigcommerce/checkout-sdk';
+import { compact, forIn } from 'lodash';
+import React, { FunctionComponent, ReactNode, useCallback, useState } from 'react';
+
+import {
+    CreditCardPaymentMethodComponent,
+    CreditCardPaymentMethodProps,
+} from '@bigcommerce/checkout/credit-card-integration';
+import {
+    getHostedCreditCardValidationSchema,
+    getHostedInstrumentValidationSchema,
+    HostedCreditCardFieldset,
+    HostedCreditCardValidation,
+} from '@bigcommerce/checkout/hosted-credit-card-integration';
+import {
+    CreditCardCustomerCodeField,
+    CreditCardInputStylesType,
+    getCreditCardInputStyles,
+    isInstrumentCardCodeRequiredSelector,
+    isInstrumentCardNumberRequiredSelector,
+} from '@bigcommerce/checkout/instrument-utils';
+import {
+    PaymentMethodProps,
+    PaymentMethodResolveId,
+    toResolvableComponent,
+} from '@bigcommerce/checkout/payment-integration-api';
+
+const PayPalCommerceCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {
+    const { checkoutService, checkoutState, paymentForm, language, method } = props;
+
+    const { cardCode, showCardHolderName, isHostedFormEnabled, requireCustomerCode } =
+        method.config;
+
+    const [focusedFieldType, setFocusedFieldType] = useState<string>();
+
+    const { setFieldTouched, setFieldValue, setSubmitted, submitForm } = paymentForm;
+    const isInstrumentCardCodeRequiredProp = isInstrumentCardCodeRequiredSelector(checkoutState);
+    const isInstrumentCardNumberRequiredProp =
+        isInstrumentCardNumberRequiredSelector(checkoutState);
+
+    // TODO: update checkout-sdk cardCode inteface with null value or check if it is possible to get cardCode as null at all
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const isCardCodeRequired = cardCode || cardCode === null;
+    const isCardHolderNameRequired = showCardHolderName ?? true;
+
+    const getHostedFieldId: (name: string) => string = useCallback(
+        (name) => {
+            return `${compact([method.gateway, method.id]).join('-')}-${name}`;
+        },
+        [method],
+    );
+
+    const getHostedFormOptions: (
+        selectedInstrument?: CardInstrument,
+    ) => Promise<LegacyHostedFormOptions> = useCallback(
+        async (selectedInstrument) => {
+            const styleProps = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
+
+            const isInstrumentCardNumberRequired = selectedInstrument
+                ? isInstrumentCardNumberRequiredProp(selectedInstrument, method)
+                : false;
+            const isInstrumentCardCodeRequired = selectedInstrument
+                ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
+                : false;
+
+            // Info: to generate valid nonce for vaulted instrument with untrusted shipping address, all hosted fields must be rendered
+            const shouldRenderHostedFields =
+                isInstrumentCardNumberRequired || isInstrumentCardCodeRequired;
+
+            let styleContainerId;
+
+            if (selectedInstrument && shouldRenderHostedFields) {
+                styleContainerId = getHostedFieldId('ccCvv');
+            }
+
+            if (!selectedInstrument) {
+                styleContainerId = getHostedFieldId('ccNumber');
+            }
+
+            return {
+                fields: selectedInstrument
+                    ? {
+                          cardCodeVerification: shouldRenderHostedFields
+                              ? {
+                                    accessibilityLabel: language.translate(
+                                        'payment.credit_card_cvv_label',
+                                    ),
+                                    containerId: getHostedFieldId('ccCvv'),
+                                    instrumentId: selectedInstrument.bigpayToken,
+                                }
+                              : undefined,
+                          cardNumberVerification: shouldRenderHostedFields
+                              ? {
+                                    accessibilityLabel: language.translate(
+                                        'payment.credit_card_number_label',
+                                    ),
+                                    containerId: getHostedFieldId('ccNumber'),
+                                    instrumentId: selectedInstrument.bigpayToken,
+                                }
+                              : undefined,
+                          cardExpiryVerification: shouldRenderHostedFields
+                              ? {
+                                    accessibilityLabel: language.translate(
+                                        'payment.credit_card_expiry_label',
+                                    ),
+                                    containerId: getHostedFieldId('ccExpiry'),
+                                    instrumentId: selectedInstrument.bigpayToken,
+                                }
+                              : undefined,
+                      }
+                    : {
+                          cardCode: isCardCodeRequired
+                              ? {
+                                    accessibilityLabel: language.translate(
+                                        'payment.credit_card_cvv_label',
+                                    ),
+                                    containerId: getHostedFieldId('ccCvv'),
+                                }
+                              : undefined,
+                          cardExpiry: {
+                              accessibilityLabel: language.translate(
+                                  'payment.credit_card_expiration_label',
+                              ),
+                              containerId: getHostedFieldId('ccExpiry'),
+                              placeholder: language.translate(
+                                  'payment.credit_card_expiration_placeholder_text',
+                              ),
+                          },
+                          cardName: {
+                              accessibilityLabel: language.translate(
+                                  'payment.credit_card_name_label',
+                              ),
+                              containerId: getHostedFieldId('ccName'),
+                          },
+                          cardNumber: {
+                              accessibilityLabel: language.translate(
+                                  'payment.credit_card_number_label',
+                              ),
+                              containerId: getHostedFieldId('ccNumber'),
+                          },
+                      },
+                styles: styleContainerId
+                    ? {
+                          default: await getCreditCardInputStyles(styleContainerId, styleProps),
+                          error: await getCreditCardInputStyles(
+                              styleContainerId,
+                              styleProps,
+                              CreditCardInputStylesType.Error,
+                          ),
+                          focus: await getCreditCardInputStyles(
+                              styleContainerId,
+                              styleProps,
+                              CreditCardInputStylesType.Focus,
+                          ),
+                      }
+                    : {},
+                onBlur: ({ fieldType }) => {
+                    if (focusedFieldType === fieldType) {
+                        setFocusedFieldType(undefined);
+                    }
+                },
+                onCardTypeChange: ({ cardType }) => {
+                    setFieldValue('hostedForm.cardType', cardType);
+                },
+                onEnter: () => {
+                    setSubmitted(true);
+                    submitForm();
+                },
+                onFocus: ({ fieldType }) => {
+                    setFocusedFieldType(fieldType);
+                },
+                onValidate: ({ errors = {} }) => {
+                    forIn(errors, (fieldErrors, fieldType) => {
+                        const errorKey = `hostedForm.errors.${fieldType}`;
+
+                        setFieldValue(
+                            errorKey,
+                            fieldErrors && fieldErrors[0].type ? fieldErrors[0].type : '',
+                        );
+
+                        if (fieldErrors && fieldErrors[0]) {
+                            setFieldTouched(errorKey);
+                        }
+                    });
+                },
+            };
+        },
+        [
+            focusedFieldType,
+            getHostedFieldId,
+            isCardCodeRequired,
+            isCardHolderNameRequired,
+            isInstrumentCardCodeRequiredProp,
+            isInstrumentCardNumberRequiredProp,
+            language,
+            method,
+            setFieldValue,
+            setFieldTouched,
+            setFocusedFieldType,
+            setSubmitted,
+            submitForm,
+        ],
+    );
+
+    const getHostedStoredCardValidationFieldset: (
+        selectedInstrument?: CardInstrument,
+    ) => ReactNode = useCallback(
+        (selectedInstrument) => {
+            const isInstrumentCardNumberRequired = selectedInstrument
+                ? isInstrumentCardNumberRequiredProp(selectedInstrument, method)
+                : false;
+            const isInstrumentCardCodeRequired = selectedInstrument
+                ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
+                : false;
+
+            // Info: to generate valid nonce for vaulted instrument with untrusted shipping address, all hosted fields must be rendered
+            const shouldRenderHostedFields =
+                isInstrumentCardNumberRequired || isInstrumentCardCodeRequired;
+
+            return (
+                <HostedCreditCardValidation
+                    cardCodeId={
+                        isInstrumentCardCodeRequired ? getHostedFieldId('ccCvv') : undefined
+                    }
+                    cardExpiryId={
+                        shouldRenderHostedFields ? getHostedFieldId('ccExpiry') : undefined
+                    }
+                    cardNumberId={
+                        isInstrumentCardNumberRequired ? getHostedFieldId('ccNumber') : undefined
+                    }
+                    focusedFieldType={focusedFieldType}
+                />
+            );
+        },
+        [
+            focusedFieldType,
+            getHostedFieldId,
+            isInstrumentCardCodeRequiredProp,
+            isInstrumentCardNumberRequiredProp,
+            method,
+        ],
+    );
+
+    const initializePayment = checkoutService.initializePayment;
+
+    const initializePayPalCommerceCreditCardPayment: CreditCardPaymentMethodProps['initializePayment'] =
+        useCallback(
+            async (options, selectedInstrument) => {
+                return initializePayment({
+                    ...options,
+                    paypalcommercecreditcards: {
+                        form: isHostedFormEnabled
+                            ? await getHostedFormOptions(selectedInstrument)
+                            : undefined,
+                    },
+                });
+            },
+            [getHostedFormOptions, initializePayment],
+        );
+
+    // Info: isHostedFormEnabled is an option in store config which responsible for switching PayPal Commerce Credit Card form
+    // rendering between Hosted Form and default BC fields (non-hosted)
+    return isHostedFormEnabled ? (
+        <CreditCardPaymentMethodComponent
+            {...props}
+            cardFieldset={
+                <HostedCreditCardFieldset
+                    additionalFields={
+                        requireCustomerCode && <CreditCardCustomerCodeField name="ccCustomerCode" />
+                    }
+                    cardCodeId={isCardCodeRequired ? getHostedFieldId('ccCvv') : undefined}
+                    cardExpiryId={getHostedFieldId('ccExpiry')}
+                    cardNameId={getHostedFieldId('ccName')}
+                    cardNumberId={getHostedFieldId('ccNumber')}
+                    focusedFieldType={focusedFieldType}
+                />
+            }
+            cardValidationSchema={getHostedCreditCardValidationSchema({ language })}
+            deinitializePayment={checkoutService.deinitializePayment}
+            getHostedFormOptions={getHostedFormOptions}
+            getStoredCardValidationFieldset={getHostedStoredCardValidationFieldset}
+            initializePayment={initializePayPalCommerceCreditCardPayment}
+            storedCardValidationSchema={getHostedInstrumentValidationSchema({
+                language,
+                isCardExpiryRequired: true,
+            })}
+        />
+    ) : (
+        <CreditCardPaymentMethodComponent
+            {...props}
+            deinitializePayment={checkoutService.deinitializePayment}
+            initializePayment={initializePayPalCommerceCreditCardPayment}
+        />
+    );
+};
+
+export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
+    PayPalCommerceCreditCardPaymentMethod,
+    [{ id: 'paypalcommercecreditcards' }],
+);

--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -15,6 +15,13 @@ export { default as PayPalCommerceCreditPaymentMethod } from './PayPalCommerceCr
 
 /**
  *
+ * PayPal Commerce Credit Cards
+ *
+ * */
+export { default as PayPalCommerceCreditCardsPaymentMethod } from './PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod';
+
+/**
+ *
  * PayPal Commerce Fastlane
  *
  * */


### PR DESCRIPTION
## What?
Created PayPalCommerceCreditCardsPaymentMethod in paypal-commerce-integration package

## Why?
To remove the same component from core in the future

## Testing / Proof
Unit tests
Manual tests
CI

Place order with credit card:

https://github.com/user-attachments/assets/a2e11db7-528b-44aa-992b-ea86df9ce27d

Place order with vaulted instrument:

https://github.com/user-attachments/assets/3557c495-ad1b-4780-a8ea-a14c6cb4df94

Place order with new card and coupon code:

https://github.com/user-attachments/assets/377dd617-a8de-4442-8354-7ce481dbc283




