### PR TITLE
CHECKOUT-9307: Run certain jobs for canonical PRs only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,12 @@ aliases:
         ignore:
           - master
 
+  - &canonical_pull_request_filter
+      branches:
+        ignore:
+          - master
+          - /pull\/[0-9]+/
+
 version: 2.1
 
 orbs:
@@ -240,12 +246,12 @@ workflows:
       - security/scan:
           name: "Gitleaks secrets scan"
           filters:
-            <<: *pull_request_filter
+            <<: *canonical_pull_request_filter
           context: org-global
           GITLEAKS_BLOCK: "false"
       - microapp/upload-artifact:
           filters:
-            <<: *pull_request_filter
+            <<: *canonical_pull_request_filter
           context: GCR + Artifact Bucket Access
           requires:
             - test-core
@@ -254,9 +260,10 @@ workflows:
             - lint
             - build-prerelease
             - e2e
+            - "Gitleaks secrets scan"
       - ci/notify-success:
           filters:
-            <<: *pull_request_filter
+            <<: *canonical_pull_request_filter
           context: GCR + Artifact Bucket Access
           requires:
             - microapp/upload-artifact
@@ -281,6 +288,12 @@ workflows:
       - e2e:
           filters:
             <<: *release_filter
+      - security/scan:
+          name: "Gitleaks secrets scan"
+          filters:
+            <<: *release_filter
+          context: org-global
+          GITLEAKS_BLOCK: "false"
       - release:
           filters:
             <<: *release_filter
@@ -291,6 +304,7 @@ workflows:
             - lint
             - build
             - e2e
+            - "Gitleaks secrets scan"
       - upload_to_sentry:
           filters:
             <<: *release_filter


### PR DESCRIPTION
## What/Why?
Only run certain jobs in the `pull_request` workflow (i.e.: `security/scan`, `microapp/upload-artifact`, `ci/notify-success`) for PRs originating from the canonical repo. These jobs won't run for PRs from forks by external contributors as they require credentials. They are intended to run only for PRs submitted by BC engineers.

## Testing / Proof

### Canonical PR

<img width="1156" alt="Screenshot 2025-06-25 at 12 33 10 pm" src="https://github.com/user-attachments/assets/4fa1f3e3-7d99-40da-8e67-996d4eec30e1" />

### Fork PR

<img width="1156" alt="Screenshot 2025-06-25 at 12 32 29 pm" src="https://github.com/user-attachments/assets/d4e4903d-9500-4f8f-8e3d-9f1f35a80277" />

