### PR TITLE
CHECKOUT-9307: Always collect test results even if there are test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,9 @@ jobs:
               --command="xargs npm run test:others -- --ci --files" \
               --verbose \
               --split-by=timings
-      - run: node scripts/nx/collect-test-results.js
+      - run:
+          command: node scripts/nx/collect-test-results.js
+          when: always
       - store_test_results:
           path: test-results
 
@@ -56,7 +58,9 @@ jobs:
               --command="xargs npm run test:extension -- --ci --files" \
               --verbose \
               --split-by=timings
-      - run: node scripts/nx/collect-test-results.js
+      - run:
+          command: node scripts/nx/collect-test-results.js
+          when: always
       - store_test_results:
           path: test-results
 
@@ -75,7 +79,9 @@ jobs:
               --command="xargs npm run test:core -- --ci --files" \
               --verbose \
               --split-by=timings
-      - run: node scripts/nx/collect-test-results.js
+      - run:
+          command: node scripts/nx/collect-test-results.js
+          when: always
       - store_test_results:
           path: test-results
 


### PR DESCRIPTION
## What/Why?
Before this change, `collect-test-results.js` wouldn't run if the preceding step failed. As a result, CircleCI could not upload the test results, and was unable to re-run failed tests. Adding `when: always` ensures that this step is always executed regardless of the outcome of previous steps.

## Testing / Proof

This screenshot shows the test results were collected even though the preceding step failed.

<img width="1156" alt="Screenshot 2025-06-25 at 11 58 27 am" src="https://github.com/user-attachments/assets/10a87825-7f76-42b9-8ca0-238ef8ce7d72" />

These screenshots show that the failed test can be re-run independently.

<img width="998" alt="Screenshot 2025-06-25 at 12 03 12 pm" src="https://github.com/user-attachments/assets/ce28fd9c-9572-4c8f-950c-fab58b2a4dd1" />

<img width="835" alt="Screenshot 2025-06-25 at 12 02 16 pm" src="https://github.com/user-attachments/assets/17e25e09-0d5d-4af3-8ddc-731f855b505b" />
