### PR TITLE
chore(payment): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.754.0",
+        "@bigcommerce/checkout-sdk": "^1.755.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.754.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.754.0.tgz",
-      "integrity": "sha512-QNsquoVHXisUBNM+zqes4/v3aTuDJ25FzcEhdNsDHuefyrp2HqmMDLJu0Paf7c6Nl+3VXiJ7eQcTArOHHK1D9g==",
+      "version": "1.755.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.755.0.tgz",
+      "integrity": "sha512-zA5Ib0OejlgwzV8+PUNpdZfXQZw5yB1LgGRjUvVUB7V9E0V76DLGbvsna0FkeF4n14UQGWCdJWoC8pag6PWFfA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.754.0",
+    "@bigcommerce/checkout-sdk": "^1.755.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver: https://github.com/bigcommerce/checkout-sdk-js/pull/2906

## Testing / Proof

All tests passed
