### PR TITLE
feat(checkout): adjust styling for Apple Pay and Google Pay icons

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -316,7 +316,12 @@ const PaymentMethodTitle: FunctionComponent<
     }
 
     return (
-        <div className="paymentProviderHeader-container">
+        <div className={
+            classNames(
+                'paymentProviderHeader-container',
+                method.id.includes('googlepay') ? 'paymentProviderHeader-container-googlePay' : null,
+            )
+        }>
             <div
                 className="paymentProviderHeader-nameContainer"
                 data-test={`payment-method-${method.id}`}
@@ -324,7 +329,11 @@ const PaymentMethodTitle: FunctionComponent<
                 {logoUrl && (
                     <img
                         alt={methodName}
-                        className="paymentProviderHeader-img"
+                        className={classNames(
+                            'paymentProviderHeader-img',
+                            method.id.includes('applepay') ? 'paymentProviderHeader-img-applePay' : null,
+                            method.id.includes('googlepay') ? 'paymentProviderHeader-img-googlePay' : null,
+                        )}
                         data-test="payment-method-logo"
                         src={logoUrl}
                     />

--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -7,6 +7,10 @@
     justify-content: space-between;
 }
 
+.paymentProviderHeader-container-googlePay {
+    align-items: center;
+}
+
 .paymentProviderHeader-subtitleContainer {
     flex-basis: 100%;
 }
@@ -27,6 +31,16 @@
         margin-left: spacing("half");
         white-space: nowrap;
     }
+}
+
+.paymentProviderHeader-img-applePay {
+    height: fontSize("larger");
+    margin-top: spacing("eighth");
+    margin-left: spacing("quarter");
+}
+
+.paymentProviderHeader-img-googlePay {
+    height: fontSize("larger");
 }
 
 .googlePay-logo {


### PR DESCRIPTION
## What?
Adjusted styling for Apple Pay and Google Pay icons
- centered vertically
- size increased

## Why?
For better user experience

## Testing / Proof
Before:
<img width="555" alt="Screenshot 2025-06-27 at 00 08 26" src="https://github.com/user-attachments/assets/6166d33e-ab3f-422b-80bb-ccc5609f3935" />

After:
<img width="562" alt="Screenshot 2025-06-27 at 00 06 10" src="https://github.com/user-attachments/assets/e4d15b63-da75-419a-aae4-c34a98c58182" />