### PR TITLE
chore(payment): bump checkout-sdk version (1.755.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.755.1",
+        "@bigcommerce/checkout-sdk": "^1.755.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.755.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.755.1.tgz",
-      "integrity": "sha512-mVALPG1WtzQ4aWFM50Dcqk/QqF+C9Dv4T9T7EDbaAGgdjdccosecLGrpS2ZlHVXtY5u65jLFCVxitTzD7Kqb5Q==",
+      "version": "1.755.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.755.2.tgz",
+      "integrity": "sha512-2m4oRt+FOgpuXTKl9AMUAJ4AzA+uMfkCZPY0y0eXckMAcdyrsoRAK/wFLCJpaqH8Pw15g1NpNKlCND+ujRUZtg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.755.1",
+    "@bigcommerce/checkout-sdk": "^1.755.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump checkout-sdk version to 1.755.2

## Why?
to release https://github.com/bigcommerce/checkout-sdk-js/pull/2905

## Testing / Proof
all tests passed
