### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.757.0",
+        "@bigcommerce/checkout-sdk": "^1.758.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.757.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.757.0.tgz",
-      "integrity": "sha512-Z49Nf3W0FBz6h3uFk/hPIk/ZhJWN+G9hWsu/lfLDt1lZ6hS/f9jqX/YaI7zDYHogeJeb3At89ByqOxpqaUrBnw==",
+      "version": "1.758.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.758.0.tgz",
+      "integrity": "sha512-sJarQe9+9C5oS05qJb+qSDBQKBY087Flsb9ZxRXyFIXXUoZfPXeGbop414LjbM/86M1I8yEYd//6DHznZk0/lw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.757.0",
+    "@bigcommerce/checkout-sdk": "^1.758.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version

## Why?
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2915](https://github.com/bigcommerce/checkout-sdk-js/pull/2915)

## Testing / ProofManually checked and unit tests
