### PR TITLE
feat(payment): New logic for PayPal BNPL banner on checkout page

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -33,6 +33,13 @@ interface WithPaymentTitleProps {
     cdnBasePath: string;
 }
 
+interface PaymentMethodSubtitleProps {
+    onUnhandledError?(error: Error): void;
+    methodId: string;
+}
+
+type SubtitleType = ReactNode | ((subtitleProps?: PaymentMethodSubtitleProps) => ReactNode);
+
 export function getPaymentMethodTitle(
     language: LanguageService,
     basePath: string,
@@ -41,7 +48,7 @@ export function getPaymentMethodTitle(
 ): (method: PaymentMethod) => {
     logoUrl: string;
     titleText: string,
-    subtitle?: ReactNode | ((subtitleProps?: { onUnhandledError?(error: Error): void; methodId: string }) => ReactNode)
+    subtitle?: SubtitleType
 } {
     const cdnPath = (path: string) => `${basePath}${path}`;
 
@@ -82,12 +89,12 @@ export function getPaymentMethodTitle(
             [PaymentMethodId.PaypalCommerce]: {
                 logoUrl: cdnPath('/img/payment-providers/paypal_commerce_logo.svg'),
                 titleText: '',
-                subtitle: (props: { onUnhandledError?(error: Error): void; methodId: string }) => <PaypalCommerceCreditBanner containerId='paypal-commerce-banner-container' {...props} />
+                subtitle: (props: PaymentMethodSubtitleProps) => <PaypalCommerceCreditBanner containerId='paypal-commerce-banner-container' {...props} />
             },
             [PaymentMethodId.PaypalCommerceCredit]: {
                 logoUrl: cdnPath('/img/payment-providers/paypal_commerce_logo_letter.svg'),
                 titleText: methodDisplayName,
-                subtitle: (props: { onUnhandledError?(error: Error): void; methodId: string }) => <PaypalCommerceCreditBanner containerId='paypal-commerce-credit-banner-container' {...props} />
+                subtitle: (props: PaymentMethodSubtitleProps) => <PaypalCommerceCreditBanner containerId='paypal-commerce-credit-banner-container' {...props} />
             },
             [PaymentMethodId.PaypalCommerceAlternativeMethod]: {
                 logoUrl: method.logoUrl || '',

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -41,7 +41,7 @@ export function getPaymentMethodTitle(
 ): (method: PaymentMethod) => {
     logoUrl: string;
     titleText: string,
-    subtitle?: ReactNode | ((subtitleProps?: { onUnhandledError?(error: Error): void }) => ReactNode)
+    subtitle?: ReactNode | ((subtitleProps?: { onUnhandledError?(error: Error): void; methodId: string }) => ReactNode)
 } {
     const cdnPath = (path: string) => `${basePath}${path}`;
 
@@ -82,11 +82,12 @@ export function getPaymentMethodTitle(
             [PaymentMethodId.PaypalCommerce]: {
                 logoUrl: cdnPath('/img/payment-providers/paypal_commerce_logo.svg'),
                 titleText: '',
+                subtitle: (props: { onUnhandledError?(error: Error): void; methodId: string }) => <PaypalCommerceCreditBanner containerId='paypal-commerce-banner-container' {...props} />
             },
             [PaymentMethodId.PaypalCommerceCredit]: {
                 logoUrl: cdnPath('/img/payment-providers/paypal_commerce_logo_letter.svg'),
                 titleText: methodDisplayName,
-                subtitle: (props: { onUnhandledError?(error: Error): void }) => <PaypalCommerceCreditBanner {...props} />
+                subtitle: (props: { onUnhandledError?(error: Error): void; methodId: string }) => <PaypalCommerceCreditBanner containerId='paypal-commerce-credit-banner-container' {...props} />
             },
             [PaymentMethodId.PaypalCommerceAlternativeMethod]: {
                 logoUrl: method.logoUrl || '',
@@ -308,7 +309,7 @@ const PaymentMethodTitle: FunctionComponent<
     };
 
     const getSubtitle = () => {
-        const node = subtitle instanceof Function ? subtitle({ onUnhandledError }) : subtitle;
+        const node = subtitle instanceof Function ? subtitle({ onUnhandledError, methodId: method.id }) : subtitle;
 
         return node ? <div className="paymentProviderHeader-subtitleContainer">
             {node}

--- a/packages/paypal-utils/src/PaypalCommerceCreditBanner.test.tsx
+++ b/packages/paypal-utils/src/PaypalCommerceCreditBanner.test.tsx
@@ -20,6 +20,8 @@ describe('PaypalCommerceCreditBanner', () => {
     const checkoutState = checkoutService.getState();
     const defaultProps = {
         onUnhandledError: jest.fn(),
+        containerId: 'paypal-commerce-credit-banner-container',
+        methodId: 'paypalcommercecredit'
     };
 
     beforeEach(() => {
@@ -49,7 +51,7 @@ describe('PaypalCommerceCreditBanner', () => {
         expect(checkoutService.initializePayment).toHaveBeenCalledWith({
             methodId: PaymentMethodId.PaypalCommerceCredit,
             paypalcommercecredit: {
-                bannerContainerId: 'paypal-commerce-banner-container',
+                bannerContainerId: 'paypal-commerce-credit-banner-container',
             },
         });
 
@@ -68,7 +70,7 @@ describe('PaypalCommerceCreditBanner', () => {
         expect(checkoutService.initializePayment).toHaveBeenCalledWith({
             methodId: PaymentMethodId.PaypalCommerceCredit,
             paypalcommercecredit: {
-                bannerContainerId: 'paypal-commerce-banner-container',
+                bannerContainerId: 'paypal-commerce-credit-banner-container',
             },
         });
 

--- a/packages/paypal-utils/src/PaypalCommerceCreditBanner.test.tsx
+++ b/packages/paypal-utils/src/PaypalCommerceCreditBanner.test.tsx
@@ -21,7 +21,7 @@ describe('PaypalCommerceCreditBanner', () => {
     const defaultProps = {
         onUnhandledError: jest.fn(),
         containerId: 'paypal-commerce-credit-banner-container',
-        methodId: 'paypalcommercecredit'
+        methodId: 'paypalcommercecredit',
     };
 
     beforeEach(() => {

--- a/packages/paypal-utils/src/PaypalCommerceCreditBanner.test.tsx
+++ b/packages/paypal-utils/src/PaypalCommerceCreditBanner.test.tsx
@@ -18,9 +18,11 @@ describe('PaypalCommerceCreditBanner', () => {
 
     const checkoutService = createCheckoutService();
     const checkoutState = checkoutService.getState();
+    const bannerContainerId = 'paypal-commerce-credit-banner-container';
+
     const defaultProps = {
         onUnhandledError: jest.fn(),
-        containerId: 'paypal-commerce-credit-banner-container',
+        containerId: bannerContainerId,
         methodId: 'paypalcommercecredit',
     };
 
@@ -51,7 +53,7 @@ describe('PaypalCommerceCreditBanner', () => {
         expect(checkoutService.initializePayment).toHaveBeenCalledWith({
             methodId: PaymentMethodId.PaypalCommerceCredit,
             paypalcommercecredit: {
-                bannerContainerId: 'paypal-commerce-credit-banner-container',
+                bannerContainerId,
             },
         });
 
@@ -70,7 +72,7 @@ describe('PaypalCommerceCreditBanner', () => {
         expect(checkoutService.initializePayment).toHaveBeenCalledWith({
             methodId: PaymentMethodId.PaypalCommerceCredit,
             paypalcommercecredit: {
-                bannerContainerId: 'paypal-commerce-credit-banner-container',
+                bannerContainerId,
             },
         });
 

--- a/packages/paypal-utils/src/PaypalCommerceCreditBanner.tsx
+++ b/packages/paypal-utils/src/PaypalCommerceCreditBanner.tsx
@@ -4,13 +4,9 @@ import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 
 const PaypalCommerceCreditBanner: FunctionComponent<{
     methodId: string;
-    containerId: string
+    containerId: string;
     onUnhandledError?(error: Error): void;
-}> = ({
-    methodId,
-    containerId,
-    onUnhandledError,
-}) => {
+}> = ({ methodId, containerId, onUnhandledError }) => {
     const { checkoutService } = useCheckout();
 
     useEffect(() => {
@@ -33,9 +29,7 @@ const PaypalCommerceCreditBanner: FunctionComponent<{
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    return (
-        <div data-test={containerId} id={containerId} />
-    );
+    return <div data-test={containerId} id={containerId} />;
 };
 
 export default PaypalCommerceCreditBanner;

--- a/packages/paypal-utils/src/PaypalCommerceCreditBanner.tsx
+++ b/packages/paypal-utils/src/PaypalCommerceCreditBanner.tsx
@@ -1,8 +1,14 @@
 import React, { FunctionComponent, useEffect } from 'react';
 
-import { PaymentMethodId, useCheckout } from '@bigcommerce/checkout/payment-integration-api';
+import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 
-const PaypalCommerceCreditBanner: FunctionComponent<{ onUnhandledError?(error: Error): void }> = ({
+const PaypalCommerceCreditBanner: FunctionComponent<{
+    methodId: string;
+    containerId: string
+    onUnhandledError?(error: Error): void;
+}> = ({
+    methodId,
+    containerId,
     onUnhandledError,
 }) => {
     const { checkoutService } = useCheckout();
@@ -10,14 +16,14 @@ const PaypalCommerceCreditBanner: FunctionComponent<{ onUnhandledError?(error: E
     useEffect(() => {
         try {
             void checkoutService.initializePayment({
-                methodId: PaymentMethodId.PaypalCommerceCredit,
-                paypalcommercecredit: {
-                    bannerContainerId: 'paypal-commerce-banner-container',
+                methodId,
+                [methodId]: {
+                    bannerContainerId: containerId,
                 },
             });
 
             void checkoutService.deinitializePayment({
-                methodId: PaymentMethodId.PaypalCommerceCredit,
+                methodId,
             });
         } catch (error) {
             if (error instanceof Error) {
@@ -28,7 +34,7 @@ const PaypalCommerceCreditBanner: FunctionComponent<{ onUnhandledError?(error: E
     }, []);
 
     return (
-        <div data-test="paypal-commerce-banner-container" id="paypal-commerce-banner-container" />
+        <div data-test={containerId} id={containerId} />
     );
 };
 


### PR DESCRIPTION
## What?

Updated `PaymentMethodTitle` with providing banner initialization to PayPal Payment Section

Depends on: https://github.com/bigcommerce/checkout-sdk-js/pull/2919

## Why?

To be able render BNPL banner component

## Testing / Proof

**With Fastlane disabled**

Pay Later is disabled

<img width="822" alt="Screenshot 2025-07-04 at 15 08 10" src="https://github.com/user-attachments/assets/68b6b2cc-b639-4fe3-b8c7-61eac72260c8" />

Pay Later is enabled

<img width="722" alt="Screenshot 2025-07-04 at 15 10 37" src="https://github.com/user-attachments/assets/96d6401d-2bca-4430-9166-cc3503cacc42" />

**With Fastlane enabled**

Pay Later is disabled

<img width="699" alt="Screenshot 2025-07-04 at 15 11 40" src="https://github.com/user-attachments/assets/566293e1-fa58-4d1d-8abd-92f3cdd55cb0" />

Pay Later is enabled

<img width="638" alt="Screenshot 2025-07-04 at 15 12 51" src="https://github.com/user-attachments/assets/7434f4f5-b10f-48cb-9d75-626a875a044f" />
