### PR TITLE
fix(payment): Make payment method title icon more readable for the sc…

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -336,7 +336,7 @@ const PaymentMethodTitle: FunctionComponent<
             >
                 {logoUrl && (
                     <img
-                        alt={methodName}
+                        alt={`${methodName} icon`}
                         className={classNames(
                             'paymentProviderHeader-img',
                             {'paymentProviderHeader-img-applePay': method.id === 'applepay'},


### PR DESCRIPTION
…reen readers

## What?
Make payment method title icon more readable for the screen readers

## Why?
All input fields under the payment section should only be announced once by screen reader.
However, they are announced twice for the Adyen. 
The reason of it is a icon alt attribute, that sets to the methodName. I've added icon word to the alt attribute for more understandable reading.
![image](https://github.com/user-attachments/assets/67b11786-6164-4900-85e5-8f3cd3d6d2e6)



## Testing / Proof
<img width="1105" alt="image" src="https://github.com/user-attachments/assets/1842f407-adfd-40c3-8e71-53560c874cc6" />

