### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.764.0",
+        "@bigcommerce/checkout-sdk": "^1.766.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.764.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.764.0.tgz",
-      "integrity": "sha512-r48GweM3oFY2WiJ0wgqysy1seU4jSDNOL1IBMMxd9KNVi13cqkZmYtRk9qUotvDBu5BARCTXKcwA7Fk2blEu0g==",
+      "version": "1.766.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.766.0.tgz",
+      "integrity": "sha512-5Q1bwo5JYDLblwUyxCRaRxB3uWGNeoXcICMn9BuDki1IfGn9OYnUZa7U3TfvlKPKZhn4yjr32ofABgWRJSiIEw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.764.0",
+    "@bigcommerce/checkout-sdk": "^1.766.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump Checkout-sdk-js verison

## Why?
To deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/2927](https://github.com/bigcommerce/checkout-sdk-js/pull/2927)
[https://github.com/bigcommerce/checkout-sdk-js/pull/2924](https://github.com/bigcommerce/checkout-sdk-js/pull/2924)

## Testing / Proof
In checkout-sdk PRs
