### PR TITLE
feat(checkout): CHECKOUT-9376 Update Autocomplete for Australian Addresses

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
@@ -5,12 +5,12 @@ describe('AddressSelectorAU', () => {
     it('should return correct street address', () => {
         const selector = new AddressSelectorAU(getGoogleAutocompletePlaceMock());
 
-        expect(selector.getStreet()).toBe('1-3 (l) Smail Street');
+        expect(selector.getStreet()).toBe('unit 6 1-3 (l) Smail Street');
     });
 
     it('should return correct street2 address value', () => {
         const selector = new AddressSelectorAU(getGoogleAutocompletePlaceMock());
 
-        expect(selector.getStreet2()).toBe('unit 6');
+        expect(selector.getStreet2()).toBe('');
     });
 });

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.ts
@@ -2,10 +2,10 @@ import AddressSelector from './AddressSelector';
 
 export default class AddressSelectorAU extends AddressSelector {
     getStreet(): string {
-        return `${this._get('street_number', 'long_name')} ${this._get('route', 'long_name')}`;
+        return `${this._get('subpremise', 'long_name')} ${this._get('street_number', 'long_name')} ${this._get('route', 'long_name')}`;
     }
 
     getStreet2(): string {
-        return this._get('subpremise', 'long_name');
+        return '';
     }
 }


### PR DESCRIPTION
## What?
This PR updates the autocomplete rules for Australian addresses. 

When a user selects an address that includes a unit number (e.g., "4/28 Beach St"), the unit number should appear in  Address Line 1 only.

## Why?
Improve Austrlian shopper experience.

## Testing / Proof
### Manual Testing

https://github.com/user-attachments/assets/133a543c-cea5-4863-9c57-4fadfa5443f8


