### PR TITLE
refactor(payment): reverted back changes related to continue button text in suggest login form

### DIFF
--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -321,7 +321,6 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             isSigningIn,
             isExecutingPaymentMethodCheckout,
             isAccountCreationEnabled,
-            providerWithCustomCheckout,
             signInError,
             isFloatingLabelEnabled,
             viewType,
@@ -330,11 +329,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
         return (
             <LoginForm
                 canCancel={isGuestEnabled}
-                continueAsGuestButtonLabelId={
-                    providerWithCustomCheckout
-                        ? 'customer.continue'
-                        : 'customer.continue_as_guest_action'
-                }
+                continueAsGuestButtonLabelId="customer.continue_as_guest_action"
                 email={this.draftEmail || email}
                 forgotPasswordUrl={forgotPasswordUrl}
                 isExecutingPaymentMethodCheckout={isExecutingPaymentMethodCheckout}


### PR DESCRIPTION
## What?
Reverted back changes related to continue button text in suggest login form

## Why?
"Continue as guest" button text is better for understanding then "Continue", so the customers would not be confused what to do next when the "suggest to login" form shows up on the screen.

## Testing / Proof
This behaviour could be reproduced with Braintree Fastlane or PPCP Fastlane providers enabled.

Manual tests
CI

Before:
<img width="757" height="356" alt="Screenshot 2025-07-16 at 15 45 31" src="https://github.com/user-attachments/assets/de4003be-ff1e-4fb6-967e-7e77e0e114ae" />

After:
<img width="769" height="361" alt="Screenshot 2025-07-16 at 15 42 48" src="https://github.com/user-attachments/assets/f6631b96-570f-4423-a59a-498ee7ce5fb1" />

