### PR TITLE
fix(payment): updated billing form to show fastlane addresses only for guest users

### DIFF
--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -77,7 +77,7 @@ const BillingForm = ({
     const hasCustomFormFields = customFormFields.length > 0;
     const editableFormFields =
         shouldRenderStaticAddress && hasCustomFormFields ? customFormFields : allFormFields;
-    const billingAddresses = isPayPalFastlaneEnabled ? paypalFastlaneAddresses : addresses;
+    const billingAddresses = isGuest && isPayPalFastlaneEnabled ? paypalFastlaneAddresses : addresses;
     const hasAddresses = billingAddresses?.length > 0;
     const hasValidCustomerAddress =
         billingAddress &&


### PR DESCRIPTION
## What?
Updated billing form to show fastlane addresses only for guest users

## Why?
Fastlane is not supported for BC logged in customers, so logged in customers should be able to use addresses from their address book in billing step

## Testing / Proof
Manual tests
CI

Before:
<img width="1022" height="825" alt="Screenshot 2025-07-16 at 17 32 15" src="https://github.com/user-attachments/assets/36661a4b-32b1-4d52-a1d6-c0dabfe1e18d" />

After:
<img width="1021" height="823" alt="Screenshot 2025-07-16 at 17 32 37" src="https://github.com/user-attachments/assets/292e9565-832a-4df6-8bea-512d63f314b4" />

