### PR TITLE
Fix billing same as shipping checkbox to honour checkout settings

### DIFF
--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -147,7 +147,6 @@ export interface WithCheckoutProps {
     isPriceHiddenFromGuests: boolean;
     isShowingWalletButtonsOnTop: boolean;
     isShippingDiscountDisplayEnabled: boolean;
-    isInitialLoadFinished: boolean;
     loginUrl: string;
     cartUrl: string;
     createAccountUrl: string;
@@ -192,12 +191,6 @@ class Checkout extends Component<
     }
 
     componentDidUpdate(prevProps: WithCheckoutProps): void {
-        const { isInitialLoad } = this.state;
-
-        if (this.props.isInitialLoadFinished && isInitialLoad) {
-            this.setState({ isInitialLoad: false });
-        }
-        
         if (prevProps.steps.length === 0 && this.props.steps && this.props.steps.length > 0) {
             this.handleReady();
         }
@@ -292,6 +285,10 @@ class Checkout extends Component<
                 isSubscribed: defaultNewsletterSignupOption,
             });
 
+            if (this.state.isInitialLoad) {
+                this.setState({ isInitialLoad: false });
+            }
+
             if (isMultiShippingMode) {
                 this.setState({ isMultiShippingMode });
             }
@@ -350,7 +347,7 @@ class Checkout extends Component<
         const loadingSkeleton = isMobileView() ? null : pageLoadingSkeleton;
 
         return (
-            <LoadingOverlay hideContentWhenLoading isLoading={isInitialLoad || isRedirecting} loadingSkeleton={loadingSkeleton}>
+            <LoadingOverlay unmountContentWhenLoading isLoading={isInitialLoad || isRedirecting} loadingSkeleton={loadingSkeleton}>
                 <div className="layout-main">
                     <LoadingNotification isLoading={extensionState.isShowingLoadingIndicator} />
 

--- a/packages/core/src/app/checkout/Checkout.tsx
+++ b/packages/core/src/app/checkout/Checkout.tsx
@@ -285,12 +285,12 @@ class Checkout extends Component<
                 isSubscribed: defaultNewsletterSignupOption,
             });
 
-            if (this.state.isInitialLoad) {
-                this.setState({ isInitialLoad: false });
-            }
-
             if (isMultiShippingMode) {
                 this.setState({ isMultiShippingMode });
+            }
+
+            if (this.state.isInitialLoad) {
+                this.setState({ isInitialLoad: false });
             }
 
             window.addEventListener('beforeunload', this.handleBeforeExit);
@@ -347,7 +347,7 @@ class Checkout extends Component<
         const loadingSkeleton = isMobileView() ? null : pageLoadingSkeleton;
 
         return (
-            <LoadingOverlay unmountContentWhenLoading isLoading={isInitialLoad || isRedirecting} loadingSkeleton={loadingSkeleton}>
+            <LoadingOverlay isLoading={isInitialLoad || isRedirecting} loadingSkeleton={loadingSkeleton} unmountContentWhenLoading>
                 <div className="layout-main">
                     <LoadingNotification isLoading={extensionState.isShowingLoadingIndicator} />
 

--- a/packages/core/src/app/checkout/mapToCheckoutProps.ts
+++ b/packages/core/src/app/checkout/mapToCheckoutProps.ts
@@ -43,10 +43,8 @@ export default function mapToCheckoutProps({
         data.getConfig()?.checkoutSettings,
         'PROJECT-6643.enable_shipping_discounts_in_orders',
     );
-    const isInitialLoadFinished = Boolean(data.getCart() && data.getConfig());
 
     return {
-        isInitialLoadFinished,
         billingAddress: data.getBillingAddress(),
         cart: data.getCart(),
         clearError: checkoutService.clearError,

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -427,7 +427,7 @@ describe('Shipping step', () => {
             );
             // eslint-disable-next-line jest-dom/prefer-to-have-attribute
             expect(
-                screen.getByLabelText('My billing address is the same as my shipping address.').hasAttribute('checked'),
+                screen.queryByLabelText('My billing address is the same as my shipping address.').hasAttribute('checked'),
             ).toBeFalsy();
 
             await userEvent.click(screen.getByLabelText('My billing address is the same as my shipping address.'));

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -411,6 +411,6 @@ export default withLanguage(
                           }),
                       ),
                   }),
-        enableReinitialize: false,
+        enableReinitialize: false, // This is false due to the concern that a shopper may lose typed details if somehow checkout state changes in the middle.
     })(SingleShippingForm),
 );


### PR DESCRIPTION
## What?
Render checkout steps only after checkout, checkout-settings and extensions have been loaded to avoid conflict in the formik state.

## Why?
To fix issue where "My Billing address is the same as my Shipping address" remains checked disregarding Checkout settings

## Testing / Proof

- CI checks
- Manual testing


**BEFORE**

https://github.com/user-attachments/assets/c01c21a6-a898-41e9-86ef-0be81408d184



**AFTER**

https://github.com/user-attachments/assets/0b747746-90cf-4751-9ddb-afe88e0567f1

