### PR TITLE
chore(payment): bump checkout-sdk-js - 1.767.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.767.0",
+        "@bigcommerce/checkout-sdk": "^1.767.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.767.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.767.0.tgz",
-      "integrity": "sha512-faoLfjYcabhx4WLIUQ1+U9Nq2GhLBvjBnOMcSqDM3q77KuKCnh/LKe1PsFAt6QJQcby1vYCvfBk8634Tbs9sSQ==",
+      "version": "1.767.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.767.1.tgz",
+      "integrity": "sha512-GO9o6aHn+CElwVr193bUM+AgclP0YObdHivEWdTJG1V808FMHq1c7tM0790lSpAGVPP40zHG9S1nEleZO93C2w==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.767.0",
+    "@bigcommerce/checkout-sdk": "^1.767.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js - 1.767.1

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2930

## Testing / Proof
CI