### PR TITLE
chore(payment): bump checkout-sdk-js version - 1.767.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.767.1",
+        "@bigcommerce/checkout-sdk": "^1.767.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.767.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.767.1.tgz",
-      "integrity": "sha512-GO9o6aHn+CElwVr193bUM+AgclP0YObdHivEWdTJG1V808FMHq1c7tM0790lSpAGVPP40zHG9S1nEleZO93C2w==",
+      "version": "1.767.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.767.2.tgz",
+      "integrity": "sha512-11R6DtpFdEx/7hQHRDh3sjYDLSHam5W95K7sxQIYZf8T5ZHyXF7lhrgDDpXh1Vkxiz1SgZyUAklGZ30I84p0lg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.767.1",
+    "@bigcommerce/checkout-sdk": "^1.767.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version - 1.767.2

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2931

## Testing / Proof
Unit tests
Manual tests
CI
