### PR TITLE
feat(checkout): CHECKOUT-9301 Update Form Field Background Color

### DIFF
--- a/packages/core/src/scss/components/bigcommerce/forms/_forms.scss
+++ b/packages/core/src/scss/components/bigcommerce/forms/_forms.scss
@@ -33,3 +33,22 @@
 .formField--helpText {
     color: color("greys");
 }
+
+.form-field--error .form-select.floating-select,
+.form-field--error .form-select.floating-select:hover,
+.form-field--error .form-select.floating-select:focus,
+.form-field--error .form-input.floating-input,
+.form-field--error .form-input.floating-input:hover,
+.form-field--error .form-input.floating-input:focus,
+.form-select.floating-select,
+.form-select.floating-select:focus,
+.form-select.floating-select:hover,
+.form-input.floating-input,
+.form-input.floating-input:focus,
+.form-input.floating-input:hover,
+.form-input.optimizedCheckout-form-input,
+.form-input.optimizedCheckout-form-input:focus,
+.form-input.optimizedCheckout-form-input:hover {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+}

--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -64,12 +64,6 @@
             }
         }
 
-        .floating-input:not(:focus),
-        .floating-select:not(:focus),
-        .floating-textarea {
-            border-color: $floating-label-border-color;
-        }
-
         .floating-textarea {
             background-color: $floating-label-bg-color;
             padding-top: $input-verticalPadding * 2.5;
@@ -140,6 +134,14 @@
                     font-size: $fontSize-tiny;
                 }
             }
+        }
+    }
+
+    .form-field:not(.form-field--error) {
+        .floating-input:not(:focus),
+        .floating-select:not(:focus),
+        .floating-textarea {
+            border-color: $floating-label-border-color;
         }
     }
 

--- a/packages/core/src/scss/settings/foundation/forms/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/forms/_settings.scss
@@ -60,8 +60,8 @@ $input-disabled-bg:                  color("greys", "lighter");
 $input-disabled-borderColor:         container("borderColor", "dark");
 $input-disabled-color:               color("greys", "darker");
 $input-disabled-cursor:              not-allowed;
-$input-box-shadow:                   inset 0 1px 1px color("greys", "light");
-$input-box-shadow-error:             0 0 3px rgba($color-error, 0.6);
+$input-box-shadow:                   none;
+$input-box-shadow-error:             none;
 $input-include-glowing-effect:       true;
 
 // We use these to style the fieldset border and spacing.
@@ -153,7 +153,7 @@ $input-readonly-borderColor:         $input-disabled-borderColor;
 $input-readonly-color:               $input-disabled-color;
 $input-readonly-cursor:              text;
 
-$input-focus-boxShadow:              0 0 3px rgba(color("highlight"), 0.4);
+$input-focus-boxShadow:              none;
 $input-formIcon-width:               remCalc(18px);
 
 $select-boxShadow:                   $input-boxShadow;

--- a/packages/core/src/scss/settings/foundation/forms/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/forms/_settings.scss
@@ -35,7 +35,7 @@ $form-label-bottom-margin:           ($form-spacing / 4);
 $floating-chevron-top:               $fontSize-root * 1.15;
 $floating-form-field-spacing:        8px;
 $floating-label-border-color:        color("greys", "light");
-$floating-label-bg-color:            color("greys", "lightest");
+$floating-label-bg-color:            color("whites", "bright");
 $floating-label-color:               color("greys", "dark");
 $floating-label-error-padding-top:   spacing("half");
 $floating-label-font-size--default:  1.077rem; // 14px

--- a/packages/core/src/scss/settings/foundation/global/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/global/_settings.scss
@@ -66,11 +66,6 @@ $opposite-direction:          right;
 // We use these to make sure border radius matches unless we want it different.
 $global-radius:               4px;
 
-// We use these to control inset shadow shiny edges and depressions.
-$shiny-edge-size:             0 1px 0;
-$shiny-edge-color:            rgba(color("whites", "bright"), 0.5);
-$shiny-edge-active-color:     rgba(color("blacks"), 0.2);
-
 // We use this to control whether or not CSS classes come through in the gem files.
 $include-html-classes:        false;
 $include-print-styles:        false;


### PR DESCRIPTION
## What?
Update all form fields's color from `#fcfcfc` to `white`.

## Why?
Continue to evolve Optimized One Page Checkout to keep the design modern, light and fresh.

## Testing / Proof
### Before
<img width="651" height="1025" alt="image" src="https://github.com/user-attachments/assets/a67422e3-77cd-49af-ab54-ec6e94120229" />

### After
<img width="651" height="1025" alt="image" src="https://github.com/user-attachments/assets/24216719-94f6-475a-aab2-8f1d29540aca" />

