### PR TITLE
feat(payment): Stripe OCS radio button for Link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.767.2",
+        "@bigcommerce/checkout-sdk": "^1.768.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.767.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.767.2.tgz",
-      "integrity": "sha512-11R6DtpFdEx/7hQHRDh3sjYDLSHam5W95K7sxQIYZf8T5ZHyXF7lhrgDDpXh1Vkxiz1SgZyUAklGZ30I84p0lg==",
+      "version": "1.768.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.768.0.tgz",
+      "integrity": "sha512-RHhygQa/5reNlmKcf/ZdWsmuUBfyxZkMNTUqBXWgHxUOM5CEfeOzzgpdO2GSLTilyJ7OnKIWZEpp+NEsyC3WFA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.767.2",
+    "@bigcommerce/checkout-sdk": "^1.768.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -55,6 +55,7 @@ describe('when using Stripe OCS payment', () => {
         spacedAccordionItems: false,
         type: 'accordion',
         visibleAccordionItemsCount: 0,
+        linkInAccordion: true,
     };
     let method: PaymentMethod;
     let checkoutService: CheckoutService;

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -67,6 +67,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                         type: 'accordion',
                         defaultCollapsed: selectedItemId !== methodSelector,
                         radios: true,
+                        linkInAccordion: true,
                         spacedAccordionItems: false,
                         visibleAccordionItemsCount: 0,
                     },


### PR DESCRIPTION
## What?
Add `linkInAccordion` option to Stripe OCS accordion config

## Why?
This feature will be added by stripe team to manage STRIPE OCS Link logic as accordion section with additional radio button
PR with related changes: [https://github.com/bigcommerce/checkout-sdk-js/pull/2935](https://github.com/bigcommerce/checkout-sdk-js/pull/2935)

## Testing / Proof
In related PR
