### PR TITLE
chore(payment): bump checkout-sdk-js version - 1.768.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.768.0",
+        "@bigcommerce/checkout-sdk": "^1.768.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.768.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.768.0.tgz",
-      "integrity": "sha512-RHhygQa/5reNlmKcf/ZdWsmuUBfyxZkMNTUqBXWgHxUOM5CEfeOzzgpdO2GSLTilyJ7OnKIWZEpp+NEsyC3WFA==",
+      "version": "1.768.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.768.1.tgz",
+      "integrity": "sha512-CBLihABSiVN4Wcwl4eGwZ/ckJjbmglwq+bTKKBG4Ysv3BU3Z8lYT86OOnMaMgy1U3XpkCIDq0TV8VmbZnUMl+A==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.768.0",
+    "@bigcommerce/checkout-sdk": "^1.768.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout-sdk-js version - 1.768.1

## Why?
A part of release https://github.com/bigcommerce/checkout-sdk-js/pull/2933

## Testing / Proof
Unit tests
Manual tests
CI