### PR TITLE
feat(checkout): CHECKOUT-9376 Update Autocomplete for AU Address II

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
@@ -2,14 +2,25 @@ import AddressSelectorAU from "./AddressSelectorAU";
 import { getGoogleAutocompletePlaceMock } from "./googleAutocompleteResult.mock";
 
 describe('AddressSelectorAU', () => {
-    it('should return correct street address', () => {
-        const selector = new AddressSelectorAU(getGoogleAutocompletePlaceMock());
+    const googleAutocompletePlaceMock = getGoogleAutocompletePlaceMock();
+
+    it('should return correct street address with subpremise', () => {
+        const selector = new AddressSelectorAU(googleAutocompletePlaceMock);
 
         expect(selector.getStreet()).toBe('unit 6/1-3 (l) Smail Street');
     });
 
+    it('should return correct street address without subpremise', () => {
+        const selector = new AddressSelectorAU({
+            ...googleAutocompletePlaceMock,
+            address_components: googleAutocompletePlaceMock.address_components?.slice(1),
+        });
+
+        expect(selector.getStreet()).toBe('1-3 (l) Smail Street');
+    });
+
     it('should return correct street2 address value', () => {
-        const selector = new AddressSelectorAU(getGoogleAutocompletePlaceMock());
+        const selector = new AddressSelectorAU(googleAutocompletePlaceMock);
 
         expect(selector.getStreet2()).toBe('');
     });

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
@@ -5,7 +5,7 @@ describe('AddressSelectorAU', () => {
     it('should return correct street address', () => {
         const selector = new AddressSelectorAU(getGoogleAutocompletePlaceMock());
 
-        expect(selector.getStreet()).toBe('unit 6 1-3 (l) Smail Street');
+        expect(selector.getStreet()).toBe('unit 6/1-3 (l) Smail Street');
     });
 
     it('should return correct street2 address value', () => {

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.ts
@@ -2,7 +2,10 @@ import AddressSelector from './AddressSelector';
 
 export default class AddressSelectorAU extends AddressSelector {
     getStreet(): string {
-        return `${this._get('subpremise', 'long_name')} ${this._get('street_number', 'long_name')} ${this._get('route', 'long_name')}`;
+        const subpremise = this._get('subpremise', 'short_name');
+        const subpremisePart = subpremise ? `${subpremise}/` : '';
+
+        return `${subpremisePart}${this._get('street_number', 'long_name')} ${this._get('route', 'long_name')}`;
     }
 
     getStreet2(): string {


### PR DESCRIPTION
## What?
Add `/` to an AU address when subprimise is applicable.

## Why?
Improve checkout experience.

## Testing / Proof

https://github.com/user-attachments/assets/32f3e446-00c0-48a1-8dd2-4cc388e942bd

