### PR TITLE
chore(payment): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.771.0",
+        "@bigcommerce/checkout-sdk": "^1.774.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.771.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.771.0.tgz",
-      "integrity": "sha512-+D3OKb0oTajOWtiPpY1bfSitc0uH0/LPFeBumrtLpS6aYsCAnCDzkeD+DXJViDKJpek4fdfcnJk1J5BrKpGynQ==",
+      "version": "1.774.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.774.0.tgz",
+      "integrity": "sha512-/cb1FXWhCUbqjaF3CrKxS2bEn3WOO9YtWOC9cyQpUBnVhTE+7YA9mB5XKS8E676+a8tTzDpO/XE4+Nv/TKgCjg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.771.0",
+    "@bigcommerce/checkout-sdk": "^1.774.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver: https://github.com/bigcommerce/checkout-sdk-js/pull/2932

## Testing / Proof

All tests passed
