### PR TITLE
chore(payment): bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.777.1",
+        "@bigcommerce/checkout-sdk": "^1.778.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.777.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.777.1.tgz",
-      "integrity": "sha512-4So4SNsG2Dvbalj+3SkluWvh7Tu0+nlEA92DKkIY63pdcPVjAINXjPrxdy/JS5YehRV7LNPOIpHBUG4xgO02JA==",
+      "version": "1.778.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.778.0.tgz",
+      "integrity": "sha512-9eySeGMKN9kS1PtPqjyL23C+MQcI20kvF1Gk1yX2VdPLT3L0HMf7lxWQ9cdcnCkEK8ksV3/bhMjwPTmaLljbLw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.777.1",
+    "@bigcommerce/checkout-sdk": "^1.778.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump checkout-sdk version

## Why?

To deliver: https://github.com/bigcommerce/checkout-sdk-js/pull/2943

## Testing / Proof

All tests passed
