### PR TITLE
feat(payment): Billie logo is not displayed at payment step

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -156,7 +156,9 @@ export function getPaymentMethodTitle(
                 titleText: '',
             },
             [PaymentMethodId.Klarna]: {
-                logoUrl: cdnPath('/img/payment-providers/klarna-header.png'),
+                logoUrl: method.initializationData?.enableBillie
+                        ? cdnPath('/img/payment-providers/klarna-billie-header.png')
+                        : cdnPath('/img/payment-providers/klarna-header.png'),
                 titleText: methodDisplayName,
             },
             [PaymentMethodId.Laybuy]: {


### PR DESCRIPTION
## What?
Displaying new logo for Billie Klarna in payment step.
Related PR - https://github.com/bigcommerce/bigcommerce/pull/64483

## Why?
We need different logo for Billie Klarna in payment step. For other Klarna payment method all stays the same.
<img width="917" height="903" alt="Zrzut ekranu 2025-07-30 o 14 20 07" src="https://github.com/user-attachments/assets/8eafbf93-7296-4d3f-80cd-d36fc099ae3f" />

## Testing / Proof
It will be tested manually. In order to make it work we need BE changes.
