### PR TITLE
chore(payment): bump checkout sdk to v1.778.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.778.2",
+        "@bigcommerce/checkout-sdk": "^1.778.5",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.778.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.778.2.tgz",
-      "integrity": "sha512-A88iUNY2IrcSXM/ifMhnX4Tjr2ESlEroCj94Mu8jCNPOQ8fubuRXJOGIu2N5cy3abmX2jU20Fn9W9ccxY1r1OA==",
+      "version": "1.778.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.778.5.tgz",
+      "integrity": "sha512-nQzf1FDwXF1NA2MMdzmO5dmsHGWYX45I0Nf5ZKGql++vPaNpgXgg6CUu2yuMt+uIoP47ZZH85ePEkGop90HFuw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.778.2",
+    "@bigcommerce/checkout-sdk": "^1.778.5",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump checkout sdk to v1.778.5

## Why?
As part of release:
https://github.com/bigcommerce/checkout-sdk-js/pull/2953
https://github.com/bigcommerce/checkout-sdk-js/pull/2952
https://github.com/bigcommerce/checkout-sdk-js/pull/2951

## Testing / Proof
Unit tests
Manual tests
CI
