### PR TITLE
fix(payment): Unable to place an order when PayLater is enabled

### DIFF
--- a/packages/bigcommerce-payments-utils/src/BigCommercePaymentsPayLaterBanner.tsx
+++ b/packages/bigcommerce-payments-utils/src/BigCommercePaymentsPayLaterBanner.tsx
@@ -3,35 +3,35 @@ import React, { FunctionComponent, useEffect } from 'react';
 import { PaymentMethodId, useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 
 const BigCommercePaymentsPayLaterBanner: FunctionComponent<{
-   onUnhandledError?(error: Error): void
+    onUnhandledError?(error: Error): void
 }> = ({ onUnhandledError }) => {
-   const { checkoutService } = useCheckout();
+    const { checkoutService } = useCheckout();
 
-   useEffect(() => {
+    useEffect(() => {
         try {
             void checkoutService.initializePayment({
-              methodId: PaymentMethodId.BigCommercePaymentsPayLater,
-              bigcommerce_payments_paylater: {
-                bannerContainerId: 'bigcommerce-payments-banner-container',
-              },
+                methodId: PaymentMethodId.BigCommercePaymentsPayLater,
+                bigcommerce_payments_paylater: {
+                    bannerContainerId: 'bigcommerce-payments-banner-container',
+                },
             });
 
             void checkoutService.deinitializePayment({
-              methodId: PaymentMethodId.BigCommercePaymentsPayLater,
+                methodId: PaymentMethodId.BigCommercePaymentsPayLater,
             });
-    } catch (error) {
+        } catch (error) {
             if (error instanceof Error) {
-              onUnhandledError?.(error);
+                onUnhandledError?.(error);
             }
         }
-  });
+    }, []);
 
-  return (
+    return (
         <div
-          data-test='bigcommerce-payments-banner-container'
-          id='bigcommerce-payments-banner-container'
+            data-test='bigcommerce-payments-banner-container'
+            id='bigcommerce-payments-banner-container'
         />
-  );
+    );
 };
 
 export default BigCommercePaymentsPayLaterBanner;


### PR DESCRIPTION
## What?

Fix of infinite BCP Pay Later Banner initialisation

## Why?

To fix an issue with placing an order via BCP

## Testing / Proof

Before

https://github.com/user-attachments/assets/cc8cf669-d00c-4ded-8307-014d099012e2

After

https://github.com/user-attachments/assets/9e550ac6-56e1-4a59-99c8-21d9ca384348
