### PR TITLE
feat(payment): checkout-sdk version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.778.5",
+        "@bigcommerce/checkout-sdk": "^1.778.6",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.778.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.778.5.tgz",
-      "integrity": "sha512-nQzf1FDwXF1NA2MMdzmO5dmsHGWYX45I0Nf5ZKGql++vPaNpgXgg6CUu2yuMt+uIoP47ZZH85ePEkGop90HFuw==",
+      "version": "1.778.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.778.6.tgz",
+      "integrity": "sha512-05tcpv6eCcrbFUJIuITA70R3QEvnjJMY2bg7HQEx7LUG0hIM2c+acFnVd+b9U5AyayA1l+GG5wB17dKH74m3kA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.778.5",
+    "@bigcommerce/checkout-sdk": "^1.778.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Checkout-sdk version bump

## Why?
To deliver:
https://github.com/bigcommerce/checkout-sdk-js/pull/2954

## Testing / Proof
Manual testing
