### PR TITLE
refactor(checkout): CHECKOUT-9375 Convert ModalTrigger

### DIFF
--- a/packages/core/src/app/ui/modal/ModalTrigger.tsx
+++ b/packages/core/src/app/ui/modal/ModalTrigger.tsx
@@ -1,9 +1,12 @@
 import React, {
-    Component,
     KeyboardEvent,
     KeyboardEventHandler,
     MouseEventHandler,
+    ReactElement,
     ReactNode,
+    useEffect,
+    useRef,
+    useState,
 } from 'react';
 
 export interface ModalTriggerProps {
@@ -16,69 +19,53 @@ export interface ModalTriggerModalProps {
     onRequestClose(): void;
 }
 
-export interface ModalTriggerState {
-    isOpen: boolean;
-}
+const ModalTrigger = ({ children, modal }: ModalTriggerProps): ReactElement => {
+    const [isOpen, setIsOpen] = useState(false);
+    const canHandleEventRef = useRef(false);
 
-export default class ModalTrigger extends Component<ModalTriggerProps, ModalTriggerState> {
-    state = {
-        isOpen: false,
-    };
+    useEffect(() => {
+        canHandleEventRef.current = true;
 
-    private canHandleEvent = false;
+        return () => {
+            canHandleEventRef.current = false;
+        };
+    }, []);
 
-    componentDidMount(): void {
-        this.canHandleEvent = true;
-    }
-
-    componentWillUnmount(): void {
-        this.canHandleEvent = false;
-    }
-
-    render() {
-        const { children, modal } = this.props;
-        const { isOpen } = this.state;
-
-        return (
-            <>
-                {children({
-                    onClick: this.handleOpen,
-                    onKeyPress: this.handleKeyOpen,
-                })}
-
-                {modal({
-                    isOpen,
-                    onRequestClose: this.handleClose,
-                })}
-            </>
-        );
-    }
-
-    private handleOpen: () => void = () => {
-        if (!this.canHandleEvent) {
+    const handleOpen = (): void => {
+        if (!canHandleEventRef.current) {
             return;
         }
 
-        this.setState({
-            isOpen: true,
-        });
+        setIsOpen(true);
     };
 
-    private handleClose: () => void = () => {
-        if (!this.canHandleEvent) {
+    const handleClose = (): void => {
+        if (!canHandleEventRef.current) {
             return;
         }
 
-        this.setState({
-            isOpen: false,
-        });
+        setIsOpen(false);
     };
 
-    private handleKeyOpen: (keyboardEvent: KeyboardEvent<HTMLElement>) => void = (
-        keyboardEvent,
-    ) => {
+    const handleKeyOpen = (keyboardEvent: KeyboardEvent<HTMLElement>): void => {
         if (keyboardEvent.key === 'Enter') {
-            this.handleOpen();
+            handleOpen();
         }
     };
-}
+
+    return (
+        <>
+            {children({
+                onClick: handleOpen,
+                onKeyPress: handleKeyOpen,
+            })}
+
+            {modal({
+                isOpen,
+                onRequestClose: handleClose,
+            })}
+        </>
+    );
+};
+
+export default ModalTrigger;


### PR DESCRIPTION
## What?
Convert class component `ModalTrigger` into function component.

## Why?
Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Testing / Proof
CI.
