### PR TITLE
refactor(checkout): CHECKOUT-9375 Convert DropdownTrigger

### DIFF
--- a/packages/core/src/app/ui/dropdown/DropdownTrigger.tsx
+++ b/packages/core/src/app/ui/dropdown/DropdownTrigger.tsx
@@ -1,5 +1,5 @@
 import { Placement } from '@popperjs/core';
-import React, { Component, MouseEventHandler, ReactNode } from 'react';
+import React, { MouseEventHandler, ReactElement, ReactNode, useCallback, useEffect, useState } from 'react';
 import { Manager, Popper, Reference } from 'react-popper';
 
 import {
@@ -13,103 +13,94 @@ export interface DropdownTriggerProps {
     children?: ReactNode;
 }
 
-export interface DropdownTriggerState {
-    shouldShow: boolean;
-}
+const DropdownTrigger = ({
+    placement = 'bottom-start',
+    dropdown,
+    children
+}: DropdownTriggerProps): ReactElement => {
+    const [shouldShow, setShouldShow] = useState(false);
 
-export default class DropdownTrigger extends Component<DropdownTriggerProps, DropdownTriggerState> {
-    static defaultProps = {
-        placement: 'bottom-start',
-    };
-
-    state: Readonly<DropdownTriggerState> = {
-        shouldShow: false,
-    };
-
-    componentWillUnmount(): void {
-        document.removeEventListener('click', this.handleClose);
-    }
-
-    render() {
-        const { children, placement, dropdown } = this.props;
-        const { shouldShow } = this.state;
-
-        return (
-            <Manager>
-                <Reference>
-                    {({ ref }) => (
-                        <div className="dropdownTrigger" onClick={this.handleClick} ref={ref}>
-                            {children}
-                        </div>
-                    )}
-                </Reference>
-
-                <Popper
-                    modifiers={[
-                        { name: 'hide', enabled: false },
-                        { name: 'flip', enabled: false },
-                        { name: 'preventOverflow', enabled: false },
-                    ]}
-                    placement={placement}
-                >
-                    {({ ref, style }) =>
-                        !shouldShow ? null : (
-                            <div
-                                className="dropdownMenu"
-                                ref={ref}
-                                style={{
-                                    ...style,
-                                    width: '100%',
-                                    zIndex: 1,
-                                }}
-                            >
-                                {dropdown}
-                            </div>
-                        )
-                    }
-                </Popper>
-            </Manager>
-        );
-    }
-
-    private handleClick: MouseEventHandler<HTMLElement> = (event) => {
-        const { shouldShow } = this.state;
-
-        if (shouldShow) {
-            this.handleClose(event.nativeEvent);
-        } else {
-            this.handleOpen(event.nativeEvent);
-        }
-    };
-
-    private handleOpen: (event: MouseEvent) => void = () => {
-        const { shouldShow } = this.state;
-
-        if (shouldShow) {
-            return;
-        }
-
-        this.setState({ shouldShow: true }, () => {
-            this.getRootElement()?.addEventListener('click', this.handleClose);
-        });
-    };
-
-    private handleClose: (event: MouseEvent) => void = () => {
-        const { shouldShow } = this.state;
-
-        if (!shouldShow) {
-            return;
-        }
-
-        this.setState({ shouldShow: false }, () => {
-            this.getRootElement()?.removeEventListener('click', this.handleClose);
-        });
-    };
-
-    private getRootElement() {
+    const getRootElement = useCallback(() => {
         return (
             document.getElementById(CHECKOUT_ROOT_NODE_ID) ||
             document.getElementById(MICRO_APP_NG_CHECKOUT_ROOT_NODE_ID)
         );
-    }
-}
+    }, []);
+
+    const handleClose = useCallback(() => {
+        if (!shouldShow) {
+            return;
+        }
+
+        setShouldShow(false);
+    }, [shouldShow]);
+
+    const handleOpen = useCallback(() => {
+        if (shouldShow) {
+            return;
+        }
+
+        setShouldShow(true);
+    }, [shouldShow]);
+
+    const handleClick: MouseEventHandler<HTMLElement> = useCallback(() => {
+        if (shouldShow) {
+            handleClose();
+        } else {
+            handleOpen();
+        }
+    }, [shouldShow, handleClose, handleOpen]);
+
+    useEffect(() => {
+        const rootElement = getRootElement();
+
+        if (shouldShow) {
+            rootElement?.addEventListener('click', handleClose);
+        } else {
+            rootElement?.removeEventListener('click', handleClose);
+        }
+
+        return () => {
+            rootElement?.removeEventListener('click', handleClose);
+        };
+    }, [shouldShow, handleClose, getRootElement]);
+
+    return (
+        <Manager>
+            <Reference>
+                {({ ref }) => (
+                    <div className="dropdownTrigger" onClick={handleClick} ref={ref}>
+                        {children}
+                    </div>
+                )}
+            </Reference>
+
+            <Popper
+                modifiers={[
+                    { name: 'hide', enabled: false },
+                    { name: 'flip', enabled: false },
+                    { name: 'preventOverflow', enabled: false },
+                ]}
+                placement={placement}
+            >
+                {({ ref, style }) =>
+                    !shouldShow ? null : (
+                        <div
+                            className="dropdownMenu"
+                            ref={ref}
+                            style={{
+                                ...style,
+                                width: '100%',
+                                zIndex: 1,
+                            }}
+                        >
+                            {dropdown}
+                        </div>
+                    )
+                }
+            </Popper>
+        </Manager>
+    );
+};
+
+export default DropdownTrigger;


### PR DESCRIPTION
## What?
Convert class component `DropdownTrigger` into function component.

## Why?
Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Testing / Proof
CI.
