### PR TITLE
feat(payment): Stripe OCS preloader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.781.0",
+        "@bigcommerce/checkout-sdk": "^1.784.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2226,9 +2226,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.781.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.781.0.tgz",
-      "integrity": "sha512-eH/Jf5SDSnpG9YW3hF98uYkzEfPeW0LmNHjf+Kji40J0+oN0MP2UR1T8CTPZQDQZi5qDi1FGPHIZk+tjVkYiFw==",
+      "version": "1.784.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.784.0.tgz",
+      "integrity": "sha512-Buzgd+27hJ6XtqfBlUpCw/VvcuMT5YOZd2TCpHqow/CpB2eFY0gwZlzc3YI6aE+O8D/RVT32UIagPECREUHUzg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.781.0",
+    "@bigcommerce/checkout-sdk": "^1.784.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -29,6 +29,7 @@ import {
     getPaymentMethod,
     getStoreConfig,
 } from '@bigcommerce/checkout/test-mocks';
+import { screen } from '@bigcommerce/checkout/test-utils';
 import { AccordionContext, AccordionContextProps } from '@bigcommerce/checkout/ui';
 
 import StripeOCSPaymentMethod from './StripeOCSPaymentMethod';
@@ -144,6 +145,7 @@ describe('when using Stripe OCS payment', () => {
                 render: expect.any(Function),
                 paymentMethodSelect: expect.any(Function),
                 handleClosePaymentMethod: expect.any(Function),
+                togglePreloader: expect.any(Function),
             },
         });
     });
@@ -173,6 +175,7 @@ describe('when using Stripe OCS payment', () => {
                 render: expect.any(Function),
                 paymentMethodSelect: expect.any(Function),
                 handleClosePaymentMethod: expect.any(Function),
+                togglePreloader: expect.any(Function),
             },
         });
     });
@@ -195,6 +198,7 @@ describe('when using Stripe OCS payment', () => {
                     render: expect.any(Function),
                     paymentMethodSelect: expect.any(Function),
                     handleClosePaymentMethod: expect.any(Function),
+                    togglePreloader: expect.any(Function),
                 },
             }),
         );
@@ -223,38 +227,7 @@ describe('when using Stripe OCS payment', () => {
                     render: expect.any(Function),
                     paymentMethodSelect: expect.any(Function),
                     handleClosePaymentMethod: expect.any(Function),
-                },
-            }),
-        );
-    });
-
-    // TODO: remove after fix issue with module on BE side
-    it('initializes method without gateway id', () => {
-        const methodWithoutGatewayId = {
-            ...method,
-            gateway: undefined,
-        };
-
-        render(<PaymentMethodTest {...defaultProps} method={methodWithoutGatewayId} />);
-
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-            expect.objectContaining({
-                methodId: method.id,
-                gatewayId: undefined,
-                [methodId]: {
-                    containerId: `undefined-${methodId}-component-field`,
-                    layout: {
-                        ...defaultAccordionLayout,
-                        defaultCollapsed: true,
-                    },
-                    appearance: {
-                        variables: { color: '#cccccc' },
-                    },
-                    fonts: [{ cssSrc: 'fontSrc' }],
-                    onError: expect.any(Function),
-                    render: expect.any(Function),
-                    paymentMethodSelect: expect.any(Function),
-                    handleClosePaymentMethod: expect.any(Function),
+                    togglePreloader: expect.any(Function),
                 },
             }),
         );
@@ -284,6 +257,7 @@ describe('when using Stripe OCS payment', () => {
                         render: expect.any(Function),
                         paymentMethodSelect: expect.any(Function),
                         handleClosePaymentMethod: expect.any(Function),
+                        togglePreloader: expect.any(Function),
                     },
                 }),
             );
@@ -307,6 +281,7 @@ describe('when using Stripe OCS payment', () => {
                         render: expect.any(Function),
                         paymentMethodSelect: expect.any(Function),
                         handleClosePaymentMethod: expect.any(Function),
+                        togglePreloader: expect.any(Function),
                     },
                 }),
             );
@@ -314,6 +289,30 @@ describe('when using Stripe OCS payment', () => {
     });
 
     describe('# Stripe OCS accordion actions', () => {
+        it('toggle accordion preloader', () => {
+            let toggleAction: ((show: boolean) => void) | undefined;
+
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    toggleAction = options.stripeocs?.togglePreloader;
+
+                    return Promise.resolve(checkoutState);
+                },
+            );
+
+            const { rerender } = render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(screen.getByTestId('stripe-accordion-skeleton')).toBeInTheDocument();
+
+            if (typeof toggleAction === 'function') {
+                toggleAction(false);
+            }
+
+            rerender(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(screen.queryByTestId('stripe-accordion-skeleton')).not.toBeInTheDocument();
+        });
+
         it('should call collapse BC accordion when stripe accordion item is selected', () => {
             jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
                 (options: WithStripeOCSPaymentInitializeOptions) => {

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -153,7 +153,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     );
 
     const renderPreloader = () => (
-        <div style={{ padding: '10px 18px' }}>
+        <div data-test="stripe-accordion-skeleton" style={{ padding: '10px 18px' }}>
             <ChecklistSkeleton />
         </div>
     );
@@ -193,8 +193,5 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     StripeOCSPaymentMethod,
-    [
-        { gateway: 'stripeupe', id: 'stripe_ocs' },
-        { gateway: 'stripeocs', id: 'optimized_checkout' },
-    ],
+    [{ gateway: 'stripeocs', id: 'optimized_checkout' }],
 );


### PR DESCRIPTION
## What?
Add loading animation for Stripe OCS accordion
Related PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2959](https://github.com/bigcommerce/checkout-sdk-js/pull/2959)

## Why?
To show shopper that some payment methods are loading

## Testing / Proof
Before:

https://github.com/user-attachments/assets/bb3f6d81-f55f-4f94-a838-353905832f3d

After:

https://github.com/user-attachments/assets/4b84fabb-6bcc-4031-af19-6dbcdd6fac95

