### PR TITLE
CHECKOUT-9423: Prefer ESM entry points over CJS for external packages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,11 +56,7 @@ function appConfig(options, argv) {
             resolve: {
                 alias,
                 extensions: ['.ts', '.tsx', '.js'],
-                // It seems some packages, i.e.: Formik, have incorrect
-                // source maps for their ESM bundle. Therefore, until that
-                // issue is fixed, we prefer to resolve packages using the
-                // `main` field rather `module` field.
-                mainFields: ['browser', 'main', 'module'],
+                mainFields: ['browser', 'module', 'main'],
             },
             optimization: {
                 runtimeChunk: 'single',


### PR DESCRIPTION
## What/Why?

Prefer ESM entry points over CommonJS (CJS) when resolving external packages. ESM supports tree-shaking, reducing bundle size by removing unused code, whereas CJS does not. The previous preference for CJS was a workaround for a Formik bug, which has been resolved with the recent [Formik upgrade](https://github.com/bigcommerce/checkout-js/pull/2286), making it safe to revert.

## Rollout/Rollback

Revert

## Testing

### Before
<img width="1559" height="814" alt="Screenshot 2025-08-11 at 1 52 54 pm" src="https://github.com/user-attachments/assets/1f8d30ac-a0b6-4d30-8f3f-45dd120b1fd5" />

### After
<img width="1558" height="806" alt="Screenshot 2025-08-11 at 1 48 07 pm" src="https://github.com/user-attachments/assets/6ef642da-a0f7-4d08-9b57-d4d80a520350" />

