### PR TITLE
feat(customer): CHECKOUT-9390 Redirect to storefront for auth when setting is on

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:server": "http-server dist",
     "typecheck": "tsc --noEmit -p ./tsconfig.base.json",
     "dev": "npm-run-all nx:dev",
-    "dev:vm": "WEBPACK_DONE='rsync -rvc --progress --delete --compress-level=9 build store.bcdev:/opt/bigcommerce_app/vagrant_code/vendor/bower_components/checkout/' npm run dev",
+    "dev:vm": "WEBPACK_DONE='rsync -rvc --progress --delete --compress-level=9 build store.bcdev:/opt/bigcommerce_app/vagrant_code/vendor/bower_components/checkout-js/' npm run dev",
     "dev:server": "http-server build --cors",
     "e2e": "npm run build && npx playwright install && PORT=5005 MODE=REPLAY npx playwright test",
     "release": "echo 'Please do not release locally, use CircleCi'",

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -86,6 +86,7 @@ export interface WithCheckoutCustomerProps {
     signInError?: Error;
     isFloatingLabelEnabled?: boolean;
     isExpressPrivacyPolicy: boolean;
+    shouldRedirectToStorefrontForAuth: boolean;
     clearError(error: Error): Promise<CheckoutSelectors>;
     continueAsGuest(credentials: GuestCredentials): Promise<CheckoutSelectors>;
     deinitializeCustomer(options: CustomerRequestOptions): Promise<CheckoutSelectors>;
@@ -321,6 +322,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
             signInError,
             isFloatingLabelEnabled,
             viewType,
+            shouldRedirectToStorefrontForAuth,
         } = this.props;
 
         return (
@@ -340,6 +342,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 onCreateAccount={this.showCreateAccount}
                 onSendLoginEmail={this.handleEmailLoginClicked}
                 onSignIn={this.handleSignIn}
+                shouldRedirectToStorefrontForAuth={shouldRedirectToStorefrontForAuth}
                 shouldShowCreateAccountLink={isAccountCreationEnabled}
                 signInError={signInError}
                 viewType={viewType}
@@ -585,6 +588,7 @@ export function mapToWithCheckoutCustomerProps({
             isAccountCreationEnabled,
             isExpressPrivacyPolicy,
             features,
+            shouldRedirectToStorefrontForAuth
         },
     } = config as StoreConfig & { checkoutSettings: { isAccountCreationEnabled: boolean } };
 
@@ -632,6 +636,7 @@ export function mapToWithCheckoutCustomerProps({
         isExpressPrivacyPolicy,
         isPaymentDataRequired: isPaymentDataRequired(),
         shouldRenderStripeForm: providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart),
+        shouldRedirectToStorefrontForAuth,
     };
 }
 

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -23,6 +23,7 @@ import EmailField from './EmailField';
 import getEmailValidationSchema from './getEmailValidationSchema';
 import mapErrorMessage from './mapErrorMessage';
 import PasswordField from './PasswordField';
+import { RedirectToStorefrontLogin } from './RedirectToStorefrontLogin';
 
 export interface LoginFormProps {
     canCancel?: boolean;
@@ -39,6 +40,7 @@ export interface LoginFormProps {
     passwordlessLogin?: boolean;
     shouldShowCreateAccountLink?: boolean;
     isFloatingLabelEnabled?: boolean;
+    shouldRedirectToStorefrontForAuth: boolean;
     onCancel?(): void;
     onCreateAccount?(): void;
     onChangeEmail?(email: string): void;
@@ -71,6 +73,7 @@ const LoginForm: FunctionComponent<
     signInError,
     shouldShowCreateAccountLink,
     isFloatingLabelEnabled,
+    shouldRedirectToStorefrontForAuth,
     viewType = CustomerViewType.Login,
 }) => {
     const { themeV2 } = useThemeContext();
@@ -137,7 +140,7 @@ const LoginForm: FunctionComponent<
                     <EmailField isFloatingLabelEnabled={isFloatingLabelEnabled} onChange={onChangeEmail} />
                 )}
 
-                <PasswordField isFloatingLabelEnabled={isFloatingLabelEnabled} />
+                {!shouldRedirectToStorefrontForAuth && <PasswordField isFloatingLabelEnabled={isFloatingLabelEnabled} />}
 
                 <p className={classNames('form-legend-container', { 'body-cta': themeV2 })}>
                     <span>
@@ -148,7 +151,7 @@ const LoginForm: FunctionComponent<
                                 testId="customer-signin-link"
                             />
                         }
-                        { !isSignInEmailEnabled &&
+                        { !isSignInEmailEnabled && !shouldRedirectToStorefrontForAuth &&
                             <a
                                 data-test="forgot-password-link"
                                 href={ forgotPasswordUrl }
@@ -170,17 +173,23 @@ const LoginForm: FunctionComponent<
                 </p>
 
                 <div className="form-actions">
-                    <Button
-                        className={themeV2 ? 'body-bold' : ''}
-                        disabled={isSigningIn || isExecutingPaymentMethodCheckout}
-                        id="checkout-customer-continue"
-                        isLoading={isSigningIn || isExecutingPaymentMethodCheckout}
-                        testId="customer-continue-button"
-                        type="submit"
-                        variant={ButtonVariant.Primary}
+                    {shouldRedirectToStorefrontForAuth ?
+                        <RedirectToStorefrontLogin
+                            isDisabled={Boolean(isSigningIn || isExecutingPaymentMethodCheckout)}
+                            isLoading={Boolean(isSigningIn || isExecutingPaymentMethodCheckout)}
+                        />
+                        :
+                        <Button
+                            className={themeV2 ? 'body-bold' : ''}
+                            disabled={isSigningIn || isExecutingPaymentMethodCheckout}
+                            id="checkout-customer-continue"
+                            isLoading={isSigningIn || isExecutingPaymentMethodCheckout}
+                            testId="customer-continue-button"
+                            type="submit"
+                            variant={ButtonVariant.Primary}
                     >
                         <TranslatedString id="customer.sign_in_action" />
-                    </Button>
+                    </Button>}
 
                     {viewType === CustomerViewType.SuggestedLogin && (
                         <a

--- a/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
+++ b/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
@@ -1,0 +1,42 @@
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
+import { Button, ButtonVariant, useThemeContext } from '@bigcommerce/checkout/ui';
+import React from 'react';
+
+interface RedirectToStorefrontLoginProps {
+    isDisabled: boolean;
+    isLoading: boolean;
+}
+
+export const RedirectToStorefrontLogin: React.FC<RedirectToStorefrontLoginProps> = ({
+    isDisabled,
+    isLoading,
+}) => {
+    const { themeV2 } = useThemeContext();
+    const { checkoutState: { data: { getConfig } } } = useCheckout();
+
+    const config = getConfig();
+    if (!config) {
+        return null;
+    }
+
+    const { checkoutLink, loginLink } = config.links;
+
+    const handleRedirect = () => {
+        return window.location.assign(`${loginLink}?redirectTo=${checkoutLink}`);
+    }
+
+    return (
+        <Button
+            className={themeV2 ? 'body-bold' : ''}
+            disabled={isDisabled}
+            id="checkout-customer-continue"
+            isLoading={isLoading}
+            onClick={handleRedirect}
+            testId="customer-continue-button"
+            variant={ButtonVariant.Primary}
+        >
+            <TranslatedString id="customer.sign_in_action" />
+        </Button>
+    );
+};

--- a/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
+++ b/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
@@ -16,6 +16,7 @@ export const RedirectToStorefrontLogin: React.FC<RedirectToStorefrontLoginProps>
     const { checkoutState: { data: { getConfig } } } = useCheckout();
 
     const config = getConfig();
+
     if (!config) {
         return null;
     }


### PR DESCRIPTION
## What/Why?
Redirect to storefront for auth when setting is on for doing auth in storefront login/logout. This is especially for catalyst stores.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast


https://github.com/user-attachments/assets/e175ba8e-d67e-4a0e-9a2a-644a8b1c88c5


