### PR TITLE
feat(checkout): CHECKOUT-9389 Add Mobile Loading Skeletons

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -536,7 +536,7 @@ class Checkout extends Component<
                 {(matched) => {
                     if (matched) {
                         return (
-                            <LazyContainer>
+                            <LazyContainer loadingSkeleton={<></>}>
                                 <Extension region={ExtensionRegion.SummaryAfter} />
                                 <CartSummaryDrawer isMultiShippingMode={isMultiShippingMode} />
                             </LazyContainer>

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -24,6 +24,7 @@ import { ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { TranslatedString, withLanguage, WithLanguageProps } from '@bigcommerce/checkout/locale';
 import {
     AddressFormSkeleton,
+    CartSummarySkeleton,
     ChecklistSkeleton,
     LazyContainer,
     LoadingNotification,
@@ -543,12 +544,12 @@ class Checkout extends Component<
                     }
 
                     return (
-                        <aside className="layout-cart">
-                            <LazyContainer>
-                                <CartSummary isMultiShippingMode={isMultiShippingMode} />
-                                <Extension region={ExtensionRegion.SummaryAfter} />
-                            </LazyContainer>
-                        </aside>
+                        <LazyContainer loadingSkeleton={<CartSummarySkeleton />}>
+                            <aside className="layout-cart">
+                                    <CartSummary isMultiShippingMode={isMultiShippingMode} />
+                                    <Extension region={ExtensionRegion.SummaryAfter} />
+                            </aside>
+                        </LazyContainer>
                     );
                 }}
             </MobileView>
@@ -571,6 +572,8 @@ class Checkout extends Component<
         if (options && options.isDefault) {
             this.setState({ defaultStepType: step.type });
         } else {
+            // TODO: setting activeStepType here is causing significant delay in rendering guest shopper form
+            // When converting functional component, we should set activeStepType before rendering <CheckoutPage />
             this.setState({ activeStepType: step.type });
         }
 

--- a/packages/core/src/app/order/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation.tsx
@@ -231,7 +231,7 @@ class OrderConfirmation extends Component<
                 {(matched) => {
                     if (matched) {
                         return (
-                            <LazyContainer>
+                            <LazyContainer loadingSkeleton={<></>}>
                                 <OrderSummaryDrawer
                                     {...mapToOrderSummarySubtotalsProps(order, isShippingDiscountDisplayEnabled)}
                                     headerLink={

--- a/packages/core/src/app/order/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation.tsx
@@ -14,7 +14,7 @@ import { AnalyticsContextProps } from '@bigcommerce/checkout/analytics';
 import { ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CheckoutContextProps } from '@bigcommerce/checkout/payment-integration-api';
-import {LazyContainer, OrderConfirmationPageSkeleton} from '@bigcommerce/checkout/ui';
+import { CartSummarySkeleton, LazyContainer, OrderConfirmationPageSkeleton } from '@bigcommerce/checkout/ui';
 
 import { withAnalytics } from '../analytics';
 import { withCheckout } from '../checkout';
@@ -247,8 +247,8 @@ class OrderConfirmation extends Component<
                     }
 
                     return (
-                        <aside className="layout-cart">
-                            <LazyContainer>
+                        <LazyContainer loadingSkeleton={<CartSummarySkeleton />}>
+                            <aside className="layout-cart">
                                 <OrderSummary
                                     headerLink={<PrintLink />}
                                     {...mapToOrderSummarySubtotalsProps(order, isShippingDiscountDisplayEnabled)}
@@ -257,8 +257,8 @@ class OrderConfirmation extends Component<
                                     storeCurrency={currency}
                                     total={order.orderAmount}
                                 />
-                            </LazyContainer>
-                        </aside>
+                            </aside>
+                        </LazyContainer>
                     );
                 }}
             </MobileView>

--- a/packages/core/src/scss/components/checkout/loadingSkeleton/_loadingSkeleton.scss
+++ b/packages/core/src/scss/components/checkout/loadingSkeleton/_loadingSkeleton.scss
@@ -1,3 +1,14 @@
+// The variables below are used across desktop and mobile views
+$textHeight: $floating-label-font-size--default * 1.2;
+$smallTextHeight: $floating-label-font-size--default * 0.8;
+$labelHeight: $floating-label-font-size--default * 0.9;
+$secondaryTitleHeight: $floating-label-input-height * 0.66;
+
+%no-skeleton {
+    background: none;
+    animation: none;
+}
+
 @keyframes lightColorTransition {
     0%, 100% {
         background-color: $loading-skeleton-grey-box-color;
@@ -7,6 +18,7 @@
     }
 }
 
+.animated-grey-box,
 .checkout-page-skeleton div,
 .address-form-skeleton div,
 .checklist-skeleton div,
@@ -31,32 +43,67 @@
         margin-top: spacing("double");
         width: 38.2%;
     }
-  
+
     .line-1,.line-2 {
         width: 100%;
-        height: $floating-label-font-size--default * 0.8;
+        height: $smallTextHeight;
         margin-bottom: spacing("half");
     }
-  
+
     .line-2 {
         width: 22%;
         margin-bottom: spacing("double");
     }
-  
+
     .continue {
         width: 120px;
+    }
+
+    .text {
+        @extend %no-skeleton;
+
+        height: auto;
+
+        div {
+            height: $floating-label-input-height * 0.33;
+            margin-bottom: spacing("quarter");
+        }
+
+        .t1 { width: 20%; }
+        .t2 { width: 8%; }
+        .t3 { width: 15%; }
+        .t4 { width: 25%; }
+
+        .first-line {
+            margin-bottom: spacing("half");
+        }
+
+        .line {
+            @extend %no-skeleton;
+
+            display: flex;
+            gap: spacing("quarter");
+        }
+
+        .line:first-child {
+            margin-bottom: spacing("single");
+        }
+
+        .line:last-child {
+            margin-bottom: spacing("double") + spacing("single");
+        }
     }
 }
 
 .checkout-page-skeleton {
-    .title--first {
+    .title--first, .mobile-title--first {
         margin-top: spacing("double");
         width: 120px;
     }
 
     .title {
         width: 100px;
-        height: $floating-label-input-height * 0.66;
+        height: $secondaryTitleHeight;
         margin: spacing("double") 0 spacing("double") + spacing("half");
     }
 
@@ -67,15 +114,15 @@
     .subscription,
     .terms--1,
     .terms--2 {
-        height: $floating-label-font-size--default * 0.8;
+        height: $smallTextHeight;
         margin-bottom: spacing("half");
     }
 
     .subscription {
+        @extend %no-skeleton;
+
         width: 33%;
         display: flex;
-        background: none;
-        animation: none;
         gap: $floating-label-input-height * 0.2;
 
         div {
@@ -100,6 +147,54 @@
         width: 44%;
         margin-bottom: spacing("double") + spacing("half") + spacing("quarter");
     }
+
+    .walletbutton--tagline {
+        margin: spacing("double") 0 spacing("half");
+        height: $smallTextHeight;
+        width: 45%;
+    }
+
+    .walletbutton {
+        height: $floating-label-input-height * 0.9;
+    }
+
+    .walletbutton--divider {
+        height: $floating-label-input-height * 0.4;
+        width: 5%;
+        margin: auto;
+    }
+
+    .mobile-title--first,
+    .mobile-title--2,
+    .mobile-title--3,
+    .mobile-title--4{
+        margin-top: spacing("single") + spacing("half");
+        margin-bottom: spacing("half");
+        height: $secondaryTitleHeight;
+    }
+
+    .mobile-title--2 {
+        width: 100px;
+    }
+
+    .mobile-title--3 {
+        width: 80px;
+    }
+
+    .mobile-title--4 {
+        width: 105px;
+    }
+
+    .divider {
+        border-bottom: $input-border-width $input-border-style $loading-skeleton-grey-box-color;
+        background: none;
+        border-radius: 0;
+        height: 0;
+    }
+
+    .divider:last-child {
+        margin-top: spacing("double");
+    }
 }
 
 .checkout-page-skeleton--cart {
@@ -113,16 +208,16 @@
     .item--coupon,
     .item--total,
     .item--tax {
+        @extend %no-skeleton;
+
         display: flex;
         justify-content: space-between;
-        background: none;
-        animation: none;
         height: auto;
         margin-bottom: spacing("single");
 
         div {
             width: 18%;
-            height: $floating-label-font-size--default * 0.9;
+            height: $labelHeight;
             margin-bottom: 0;
         }
     }
@@ -132,7 +227,7 @@
 
         div {
             width: 32%;
-            height: $floating-label-font-size--default * 1.2;
+            height: $textHeight;
         }
     }
 
@@ -177,6 +272,53 @@
     }
 }
 
+.checkout-page-skeleton--cartdrawer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: $cartDrawer-figure-size;
+    width: 100%;
+
+    .animated-grey-box {
+        margin-bottom: 0;
+    }
+
+    .product {
+        display: flex;
+        align-items: center;
+        gap: spacing("half");
+        width: 50%;
+
+        .figure {
+            width: $cartDrawer-figure-size;
+            height: $cartDrawer-figure-size;
+        }
+
+        .details {
+            display: flex;
+            flex-direction: column;
+            width: 50%;
+
+            .name {
+                width: 50%;
+                height: $floating-label-input-height * 0.3;
+                margin-bottom: spacing("quarter");
+            }
+
+            .description{
+                width: 100%;
+                height: $floating-label-input-height * 0.2;
+            }
+        }
+    }
+
+    .more {
+        width: $floating-label-input-height * 1.2;
+        height: $floating-label-input-height * 0.45;
+    }
+
+}
+
 .address-form-skeleton {
     display: flex;
     justify-content: space-between;
@@ -184,12 +326,12 @@
 
     div {
         margin-bottom: spacing('half');
-        height: $floating-label-input-height * 0.66;
+        height: $secondaryTitleHeight;
     }
 
     .label {
         width: 140px;
-        height: $floating-label-font-size--default * 0.9;
+        height: $labelHeight;
     }
 
     .name {
@@ -206,7 +348,7 @@
     div {
         width: 100%;
         margin-bottom: spacing('half');
-        height: $floating-label-input-height * 0.66;
+        height: $secondaryTitleHeight;
     }
 }
 

--- a/packages/ui/src/form/LoadingSkeleton/CheckoutPageSkeleton.test.tsx
+++ b/packages/ui/src/form/LoadingSkeleton/CheckoutPageSkeleton.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('../../utils', () => ({
+    isMobileView: jest.fn(),
+}));
+
+import { isMobileView } from '../../utils';
+
+import CheckoutPageSkeleton from './CheckoutPageSkeleton';
+
+describe('CheckoutPageSkeleton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders desktop skeleton when not mobile', () => {
+        (isMobileView as jest.Mock).mockReturnValue(false);
+
+        render(<CheckoutPageSkeleton />);
+
+        expect(screen.getByTestId('checkout-page-skeleton')).toBeInTheDocument();
+        expect(screen.queryByTestId('checkout-page-skeleton-mobile')).not.toBeInTheDocument();
+    });
+
+    it('renders mobile skeleton when isMobileView is true', () => {
+        (isMobileView as jest.Mock).mockReturnValue(true);
+
+        render(<CheckoutPageSkeleton />);
+
+        expect(screen.getByTestId('checkout-page-skeleton-mobile')).toBeInTheDocument();
+        expect(screen.queryByTestId('checkout-page-skeleton')).not.toBeInTheDocument();
+    });
+});

--- a/packages/ui/src/form/LoadingSkeleton/CheckoutPageSkeleton.tsx
+++ b/packages/ui/src/form/LoadingSkeleton/CheckoutPageSkeleton.tsx
@@ -1,39 +1,65 @@
-import classNames from 'classnames';
 import React, { FunctionComponent } from 'react';
 
-import { LoadingSpinner } from '../../loading';
-import { isEmbedded, isMobileView } from '../../utils';
+import { isMobileView } from '../../utils';
 
 import { CartSummarySkeleton } from './CartSummarySkeleton';
 
 const CheckoutPageSkeletonDesktop: FunctionComponent = () => (
-    <div
-        className={classNames('remove-checkout-step-numbers', { 'is-embedded': isEmbedded() })}
-        data-test="checkout-page-container"
-        id="checkout-page-container"
-    >
-        <div className="layout optimizedCheckout-contentPrimary">
-            <div className="layout-main" data-test="checkout-page-skeleton">
-                <div className="checkout-steps checkout-page-skeleton">
-                    <div className="title--first" />
-                    <div className="textbox" />
-                    <div className="subscription">
-                        <div className="checkbox" />
-                        <div className="description" />
-                    </div>
-                    <div className="terms--1" />
-                    <div className="terms--2" />
-                    <div className="title" />
-                    <div className="title" />
-                    <div className="title" />
+    <div className="layout optimizedCheckout-contentPrimary" data-test="checkout-page-skeleton">
+        <div className="layout-main">
+            <div className="checkout-steps checkout-page-skeleton">
+                <div className="title--first" />
+                <div className="textbox" />
+                <div className="subscription">
+                    <div className="checkbox" />
+                    <div className="description" />
                 </div>
+                <div className="terms--1" />
+                <div className="terms--2" />
+                <div className="title" />
+                <div className="title" />
+                <div className="title" />
             </div>
-            <CartSummarySkeleton />
         </div>
+        <CartSummarySkeleton />
     </div>
 );
 
-const CheckoutPageSkeletonMobile: FunctionComponent = () => <LoadingSpinner isLoading={true} />;
+const CheckoutPageSkeletonMobile: FunctionComponent = () => (
+    <div
+        className="layout optimizedCheckout-contentPrimary"
+        data-test="checkout-page-skeleton-mobile"
+    >
+        <div className="layout-main ">
+            <div className="checkout-page-skeleton">
+                <div className="walletbutton--tagline" />
+                <div className="walletbutton" />
+                <div className="walletbutton--divider" />
+                <div className="mobile-title--first" />
+                <div className="textbox" />
+                <div className="textbox" />
+                <div className="terms--1" />
+                <div className="mobile-title--2" />
+                <div className="divider" />
+                <div className="mobile-title--3" />
+                <div className="divider" />
+                <div className="mobile-title--4" />
+                <div className="divider" />
+                <div className="divider" />
+            </div>
+            <div className="checkout-page-skeleton--cartdrawer">
+                <div className="product">
+                    <div className="animated-grey-box figure" />
+                    <div className="details">
+                        <div className="animated-grey-box name" />
+                        <div className="animated-grey-box description" />
+                    </div>
+                </div>
+                <div className="animated-grey-box more" />
+            </div>
+        </div>
+    </div>
+);
 
 const CheckoutPageSkeleton: FunctionComponent = () => {
     return isMobileView() ? <CheckoutPageSkeletonMobile /> : <CheckoutPageSkeletonDesktop />;

--- a/packages/ui/src/form/LoadingSkeleton/OrderConfirmationPageSkeleton.test.tsx
+++ b/packages/ui/src/form/LoadingSkeleton/OrderConfirmationPageSkeleton.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('../../utils', () => ({
+    isMobileView: jest.fn(),
+}));
+
+import { isMobileView } from '../../utils';
+
+import OrderConfirmationPageSkeleton from './OrderConfirmationPageSkeleton';
+
+describe('OrderConfirmationPageSkeleton', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders desktop skeleton when not mobile', () => {
+        (isMobileView as jest.Mock).mockReturnValue(false);
+
+        render(<OrderConfirmationPageSkeleton />);
+
+        expect(screen.getByTestId('order-confirmation-page-skeleton')).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('order-confirmation-page-skeleton-mobile'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders mobile skeleton when isMobileView is true', () => {
+        (isMobileView as jest.Mock).mockReturnValue(true);
+
+        render(<OrderConfirmationPageSkeleton />);
+
+        expect(screen.getByTestId('order-confirmation-page-skeleton-mobile')).toBeInTheDocument();
+        expect(screen.queryByTestId('order-confirmation-page-skeleton')).not.toBeInTheDocument();
+    });
+});

--- a/packages/ui/src/form/LoadingSkeleton/OrderConfirmationPageSkeleton.tsx
+++ b/packages/ui/src/form/LoadingSkeleton/OrderConfirmationPageSkeleton.tsx
@@ -1,17 +1,11 @@
-import classNames from 'classnames';
 import React, { FunctionComponent } from 'react';
 
-import { LoadingSpinner } from '../../loading';
-import { isEmbedded, isMobileView } from '../../utils';
+import { isMobileView } from '../../utils';
 
 import { CartSummarySkeleton } from './CartSummarySkeleton';
 
 const OrderConfirmationPageSkeletonDesktop: FunctionComponent = () => (
-    <div
-        className={classNames('layout optimizedCheckout-contentPrimary', {
-            'is-embedded': isEmbedded(),
-        })}
-    >
+    <div className="layout optimizedCheckout-contentPrimary">
         <div className="layout-main" data-test="order-confirmation-page-skeleton">
             <div className="order-confirmation-page-skeleton">
                 <div className="thankyou" />
@@ -25,7 +19,38 @@ const OrderConfirmationPageSkeletonDesktop: FunctionComponent = () => (
 );
 
 const OrderConfirmationPageSkeletonMobile: FunctionComponent = () => (
-    <LoadingSpinner isLoading={true} />
+    <div className="layout optimizedCheckout-contentPrimary">
+        <div className="layout-main" data-test="order-confirmation-page-skeleton-mobile">
+            <div className="order-confirmation-page-skeleton">
+                <div className="thankyou" />
+                <div className="text">
+                    <div className="line">
+                        <div className="animated-grey-box t1" />
+                        <div className="animated-grey-box t2" />
+                    </div>
+                    <div className="animated-grey-box first-line" />
+                    <div className="animated-grey-box" />
+                    <div className="line">
+                        <div className="animated-grey-box t3" />
+                        <div className="animated-grey-box t4" />
+                    </div>
+                </div>
+                <div className="continue" />
+            </div>
+        </div>
+        <div className="cartDrawer optimizedCheckout-orderSummary">
+            <div className="checkout-page-skeleton--cartdrawer">
+                <div className="product">
+                    <div className="animated-grey-box figure" />
+                    <div className="details">
+                        <div className="animated-grey-box name" />
+                        <div className="animated-grey-box description" />
+                    </div>
+                </div>
+                <div className="animated-grey-box more" />
+            </div>
+        </div>
+    </div>
 );
 
 const OrderConfirmationPageSkeleton: FunctionComponent = () => {

--- a/packages/ui/src/form/LoadingSkeleton/index.ts
+++ b/packages/ui/src/form/LoadingSkeleton/index.ts
@@ -3,3 +3,4 @@ export { default as ChecklistSkeleton } from './ChecklistSkeleton';
 export { default as CheckoutPageSkeleton } from './CheckoutPageSkeleton';
 export { default as OrderConfirmationPageSkeleton } from './OrderConfirmationPageSkeleton';
 export { default as WalletButtonsContainerSkeleton } from './WalletButtonContainerSkeleton';
+export { CartSummarySkeleton } from './CartSummarySkeleton';

--- a/packages/ui/src/form/index.ts
+++ b/packages/ui/src/form/index.ts
@@ -12,6 +12,7 @@ export { TextInputIframeContainer } from './TextInputIframeContainer';
 export { FormContext, FormContextType, FormProvider } from './contexts';
 export {
     AddressFormSkeleton,
+    CartSummarySkeleton,
     CheckoutPageSkeleton,
     ChecklistSkeleton,
     OrderConfirmationPageSkeleton,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,7 @@ export { DropdownTrigger } from './dropdown';
 export {
     AddressFormSkeleton,
     BasicFormField,
+    CartSummarySkeleton,
     CheckoutPageSkeleton,
     DynamicFormField,
     DynamicFormFieldType,


### PR DESCRIPTION
## What/Why?

Add loading skeletons for the mobile version of checkout and order confirmation pages.

## Rollout/Rollback

Revert.

## Testing
### Checkout

https://github.com/user-attachments/assets/6a0b133a-1412-4763-b18b-7029a2baed40

### Order Confirmation

https://github.com/user-attachments/assets/88a059c0-baac-46fd-b15a-1962aedd1788


