### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.784.0",
+        "@bigcommerce/checkout-sdk": "^1.785.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.784.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.784.0.tgz",
-      "integrity": "sha512-Buzgd+27hJ6XtqfBlUpCw/VvcuMT5YOZd2TCpHqow/CpB2eFY0gwZlzc3YI6aE+O8D/RVT32UIagPECREUHUzg==",
+      "version": "1.785.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.785.0.tgz",
+      "integrity": "sha512-n4Pek0tT40wvbyG/KLD7OL6YRa66B890ARwbLuvOm9vTmQ+4hcYJz/4PW26aNnqNtlzwae+pZvj6Z4jfMA2WIw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.784.0",
+    "@bigcommerce/checkout-sdk": "^1.785.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-version
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2969](https://github.com/bigcommerce/checkout-sdk-js/pull/2969)

## Rollout/Rollback
Rollback this PR

## Testing
In related PR
