### PR TITLE
CHECKOUT-9416: Fix the failed tests for `renderCheckout` and `renderOrderConfirmation`

### DIFF
--- a/packages/core/src/app/checkout/renderCheckout.test.tsx
+++ b/packages/core/src/app/checkout/renderCheckout.test.tsx
@@ -1,16 +1,17 @@
 import React, { FunctionComponent } from 'react';
 
+import { configurePublicPath } from '../common/bundler';
+
 import { CheckoutAppProps } from './CheckoutApp';
 import renderCheckout, { RenderCheckoutOptions } from './renderCheckout';
 
 let CheckoutApp: FunctionComponent<CheckoutAppProps>;
-let configurePublicPath: (path: string) => void;
 let publicPath: string;
 
 jest.mock('@welldone-software/why-did-you-render', () => jest.fn());
 
 jest.mock('../common/bundler', () => {
-    configurePublicPath = jest.fn((path) => {
+    const configurePublicPath = jest.fn((path) => {
         publicPath = path;
 
         return publicPath;

--- a/packages/core/src/app/order/renderOrderConfirmation.test.tsx
+++ b/packages/core/src/app/order/renderOrderConfirmation.test.tsx
@@ -1,16 +1,17 @@
 import React, { FunctionComponent } from 'react';
 
+import { configurePublicPath } from '../common/bundler';
+
 import { OrderConfirmationAppProps } from './OrderConfirmationApp';
 import renderOrderConfirmation, { RenderOrderConfirmationOptions } from './renderOrderConfirmation';
 
 let OrderConfirmationApp: FunctionComponent<OrderConfirmationAppProps>;
-let configurePublicPath: (path: string) => void;
 let publicPath: string;
 
 jest.mock('@welldone-software/why-did-you-render', () => jest.fn());
 
 jest.mock('../common/bundler', () => {
-    configurePublicPath = jest.fn((path) => {
+    const configurePublicPath = jest.fn((path) => {
         publicPath = path;
 
         return publicPath;


### PR DESCRIPTION
## What/Why?

For some reason, some of the tests for `renderCheckout` and `renderOrderConfirmation` (https://app.circleci.com/pipelines/github/bigcommerce/checkout-js/13802/workflows/1cfe030f-392e-47b8-bb03-5d11644f9f98/jobs/68536) started failing consistently after merging #2493 and #2489 due to the way the `configurePublicPath` mock was set up. This PR updates the mock setup to resolve the issue.

## Rollout/Rollback

Revert

## Testing

CircleCI
