### PR TITLE
feat(customer): CHECKOUT-9403 Hide passwordless login option for buy now cart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.786.0",
+        "@bigcommerce/checkout-sdk": "^1.787.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.786.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.786.0.tgz",
-      "integrity": "sha512-Ep+kO5d2/IIX0ilC8HqXn8XDJEae7ty9bZXnKKaBC2Am8FM65dwxtooKKHue5PIv+7KwWYUlOdl4T6VwJcO5KQ==",
+      "version": "1.787.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.787.0.tgz",
+      "integrity": "sha512-LGOtS8AVlE3sjAPl425N3DWV5F0833YfqLbBMKxZX54ErtPdtuJCf3FUwfrsfbZ4ovYNRO4Un4q52nMJqrfxlg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.786.0",
+    "@bigcommerce/checkout-sdk": "^1.787.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/customer/Customer.test.tsx
+++ b/packages/core/src/app/customer/Customer.test.tsx
@@ -38,7 +38,7 @@ import {
     checkoutWithBillingEmail,
     checkoutWithMultiShippingCart,
 } from '@bigcommerce/checkout/test-framework';
-import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+import { renderWithoutWrapper as render, screen } from '@bigcommerce/checkout/test-utils';
 import { ThemeProvider } from '@bigcommerce/checkout/ui';
 
 import { getBillingAddress } from '../billing/billingAddresses.mock';

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -80,6 +80,7 @@ export interface WithCheckoutCustomerProps {
     requiresMarketingConsent: boolean;
     signInEmail?: SignInEmail;
     signInEmailError?: Error;
+    isBuyNowCart: boolean;
     isAccountCreationEnabled: boolean;
     isPaymentDataRequired: boolean;
     createAccountError?: Error;
@@ -310,6 +311,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
 
     private renderLoginForm(): ReactNode {
         const {
+            isBuyNowCart,
             isEmbedded,
             email,
             forgotPasswordUrl,
@@ -331,6 +333,7 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 continueAsGuestButtonLabelId="customer.continue_as_guest_action"
                 email={this.draftEmail || email}
                 forgotPasswordUrl={forgotPasswordUrl}
+                isBuyNowCart={isBuyNowCart}
                 isExecutingPaymentMethodCheckout={isExecutingPaymentMethodCheckout}
                 isFloatingLabelEnabled={isFloatingLabelEnabled}
                 isSendingSignInEmail={isSendingSignInEmail}
@@ -617,6 +620,7 @@ export function mapToWithCheckoutCustomerProps({
         isCreatingAccount: isCreatingCustomerAccount(),
         createAccountError: getCreateCustomerAccountError(),
         hasBillingId: !!billingAddress?.id,
+        isBuyNowCart: cart.source === 'BUY_NOW',
         isContinuingAsGuest: isContinuingAsGuest(),
         isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
         isInitializing: isInitializingCustomer(),

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -26,6 +26,7 @@ import PasswordField from './PasswordField';
 import { RedirectToStorefrontLogin } from './RedirectToStorefrontLogin';
 
 export interface LoginFormProps {
+    isBuyNowCart: boolean;
     canCancel?: boolean;
     continueAsGuestButtonLabelId: string;
     email?: string;
@@ -57,6 +58,7 @@ export interface LoginFormValues {
 const LoginForm: FunctionComponent<
     LoginFormProps & WithLanguageProps & FormikProps<LoginFormValues>
 > = ({
+    isBuyNowCart,
     canCancel,
     continueAsGuestButtonLabelId,
     forgotPasswordUrl,
@@ -144,7 +146,7 @@ const LoginForm: FunctionComponent<
 
                 <p className={classNames('form-legend-container', { 'body-cta': themeV2 })}>
                     <span>
-                        { isSignInEmailEnabled &&
+                        { isSignInEmailEnabled && !isBuyNowCart &&
                             <TranslatedLink
                                 id="login_email.link"
                                 onClick={ onSendLoginEmail }

--- a/packages/core/src/app/customer/RegisteredCustomer.test.tsx
+++ b/packages/core/src/app/customer/RegisteredCustomer.test.tsx
@@ -419,4 +419,27 @@ describe('Registered Customer', () => {
 
         expect(screen.queryByTestId('customer-signin-link')).not.toBeInTheDocument();
     });
+
+    it('changes from guest to login view and no passwordless login is displayed for buy now cart', async () => {
+        const buyNowCheckout = {
+            ...getCheckout(),
+            cart: {
+                ...getCheckout().cart,
+                source: 'BUY_NOW',
+            }
+        };
+
+        // checkoutPageObject.setRequestHandler(
+        //     rest.get(
+        //         '/api/storefront/checkouts/*',
+        //         (_, res, ctx) => res(ctx.json(buyNowCheckout))
+        //     )
+        // );
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(buyNowCheckout);
+
+        render(<CustomerTest viewType={CustomerViewType.Login} {...defaultProps} />);    
+
+        expect(screen.queryByText(localeContext.language.translate('login_email.link'))).not.toBeInTheDocument();
+    });
 });

--- a/packages/core/src/app/customer/RegisteredCustomer.test.tsx
+++ b/packages/core/src/app/customer/RegisteredCustomer.test.tsx
@@ -429,13 +429,6 @@ describe('Registered Customer', () => {
             }
         };
 
-        // checkoutPageObject.setRequestHandler(
-        //     rest.get(
-        //         '/api/storefront/checkouts/*',
-        //         (_, res, ctx) => res(ctx.json(buyNowCheckout))
-        //     )
-        // );
-
         jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(buyNowCheckout);
 
         render(<CustomerTest viewType={CustomerViewType.Login} {...defaultProps} />);    

--- a/packages/locale/src/getDefaultTranslations.test.ts
+++ b/packages/locale/src/getDefaultTranslations.test.ts
@@ -55,6 +55,10 @@ describe('getDefaultTranslations', () => {
         expect(await getDefaultTranslations('es-PE')).toEqual(require('./translations/es-PE.json'));
     });
 
+    it('returns Japanese translations when ja locale is specified', async () => {
+        expect(await getDefaultTranslations('ja')).toEqual(require('./translations/ja.json'));
+    });
+
     it('returns Norwegian translations when no locale is specified', async () => {
         expect(await getDefaultTranslations('no')).toEqual(require('./translations/no.json'));
     });

--- a/packages/locale/src/getDefaultTranslations.ts
+++ b/packages/locale/src/getDefaultTranslations.ts
@@ -88,6 +88,11 @@ const AVAILABLE_TRANSLATIONS: Record<string, () => Promise<{ default: unknown }>
             /* webpackChunkName: "translations-sv" */
             './translations/pl.json'
         ),
+    ja: () =>
+        import(
+            /* webpackChunkName: "translations-ja" */
+            './translations/ja.json'
+        ),
     en: () => Promise.resolve({ default: FALLBACK_TRANSLATIONS }),
 };
 


### PR DESCRIPTION
## What/Why?
Remove option for passwordless login for buy now carts

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

https://github.com/user-attachments/assets/c8aaf257-7517-4dfb-81fa-fd15c5640c43


