### PR TITLE
refactor(checkout): CHECKOUT-9384 Collect ErrorBoundary Usage Data

### DIFF
--- a/packages/error-handling-utils/src/ErrorBoundary.test.tsx
+++ b/packages/error-handling-utils/src/ErrorBoundary.test.tsx
@@ -31,7 +31,7 @@ describe('ErrorBoundary', () => {
             </ErrorBoundary>,
         );
 
-        expect(logger.log).toHaveBeenCalledWith(error);
+        expect(logger.log).toHaveBeenCalledWith(error, { errorCode: 'ErrorBoundary' });
     });
 
     it('does not log error if filter returns false', () => {

--- a/packages/error-handling-utils/src/ErrorBoundary.tsx
+++ b/packages/error-handling-utils/src/ErrorBoundary.tsx
@@ -28,8 +28,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
             throw error;
         }
 
+        // Adding errorCode with value `ErrorBoundary` to collect usage statistics of ErrorBoundary
         if (logger) {
-            logger.log(error);
+            logger.log(error, {
+                errorCode: 'ErrorBoundary',
+            });
         }
     }
 


### PR DESCRIPTION
## What/Why?
Add tags value to collect `ErrorBoundary` usage data.

We are collecting this to determine whether we can safely remove this class component, because we want to avoid handling an error at the top level with `ErrorBoundary`. 

## Rollout/Rollback
Revert.

## Testing
CI.