### PR TITLE
refactor(checkout): CHECKOUT-9384 Convert ShippingAddressForm

### DIFF
--- a/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.test.tsx
+++ b/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.test.tsx
@@ -51,7 +51,6 @@ describe('PayPalFastlaneShippingAddress', () => {
             isShippingStepPending: false,
             hasRequestedShippingOptions: false,
             onUseNewAddress: jest.fn(),
-            addresses: getCustomer().addresses,
             shippingAddress: getCustomer().addresses[0],
             formFields: [
                 {
@@ -91,6 +90,8 @@ describe('PayPalFastlaneShippingAddress', () => {
                 }
             ],
         };
+
+        jest.spyOn(checkoutState.data,'getCustomer').mockReturnValue(getCustomer());
     })
 
     it('renders PayPalFastlaneShippingAddress edit button', async () => {

--- a/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.tsx
+++ b/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.tsx
@@ -47,7 +47,6 @@ export const PayPalFastlaneShippingAddress: FC<PayPalFastlaneShippingAddressProp
         initialize,
         deinitialize,
         shippingAddress,
-        addresses,
         handleFieldChange,
         isLoading
     } = props;
@@ -123,9 +122,7 @@ export const PayPalFastlaneShippingAddress: FC<PayPalFastlaneShippingAddressProp
             ) : (
                 <ShippingAddressForm
                     address={shippingAddress}
-                    addresses={addresses}
                     consignments={props.consignments}
-                    countries={countries}
                     countriesWithAutocomplete={props.countriesWithAutocomplete}
                     formFields={formFields}
                     googleMapsApiKey={props.googleMapsApiKey}
@@ -134,7 +131,6 @@ export const PayPalFastlaneShippingAddress: FC<PayPalFastlaneShippingAddressProp
                     onAddressSelect={onAddressSelect}
                     onFieldChange={handleFieldChange}
                     onUseNewAddress={props.onUseNewAddress}
-                    shouldShowSaveAddress={props.shouldShowSaveAddress}
                 />
             )}
         </LoadingOverlay>

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -204,7 +204,6 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps & Ext
                     />
                     <ShippingForm
                         {...shippingFormProps}
-                        addresses={customer.addresses}
                         deinitialize={deinitializeShippingMethod}
                         initialize={initializeShippingMethod}
                         isBillingSameAsShipping={isBillingSameAsShipping}
@@ -217,7 +216,6 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps & Ext
                         onSingleShippingSubmit={this.handleSingleShippingSubmit}
                         setIsMultishippingMode={setIsMultishippingMode}
                         shippingFormRenderTimestamp={shippingFormRenderTimestamp}
-                        shouldShowSaveAddress={!isGuest}
                         updateAddress={updateShippingAddress}
                     />
                 </div>

--- a/packages/core/src/app/shipping/ShippingAddress.tsx
+++ b/packages/core/src/app/shipping/ShippingAddress.tsx
@@ -2,8 +2,6 @@ import {
     type Address,
     type CheckoutSelectors,
     type Consignment,
-    type Country,
-    type CustomerAddress,
     type FormField,
     type ShippingInitializeOptions,
     type ShippingRequestOptions,
@@ -18,9 +16,7 @@ import { PayPalFastlaneShippingAddress } from './PayPalFastlaneShippingAddress';
 import ShippingAddressForm from './ShippingAddressForm';
 
 export interface ShippingAddressProps {
-    addresses: CustomerAddress[];
     consignments: Consignment[];
-    countries?: Country[];
     countriesWithAutocomplete: string[];
     formFields: FormField[];
     googleMapsApiKey?: string;
@@ -28,7 +24,6 @@ export interface ShippingAddressProps {
     isShippingStepPending: boolean;
     methodId?: string;
     shippingAddress?: Address;
-    shouldShowSaveAddress?: boolean;
     hasRequestedShippingOptions: boolean;
     isFloatingLabelEnabled?: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
@@ -43,7 +38,6 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
     const {
         methodId,
         formFields,
-        countries,
         countriesWithAutocomplete,
         consignments,
         googleMapsApiKey,
@@ -53,8 +47,6 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
         isLoading,
         shippingAddress,
         hasRequestedShippingOptions,
-        addresses,
-        shouldShowSaveAddress,
         isFloatingLabelEnabled,
     } = props;
 
@@ -91,9 +83,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
     return (
         <ShippingAddressForm
             address={shippingAddress}
-            addresses={addresses}
             consignments={consignments}
-            countries={countries}
             countriesWithAutocomplete={countriesWithAutocomplete}
             formFields={formFields}
             googleMapsApiKey={googleMapsApiKey}
@@ -102,7 +92,6 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
             onAddressSelect={onAddressSelect}
             onFieldChange={handleFieldChange}
             onUseNewAddress={onUseNewAddress}
-            shouldShowSaveAddress={shouldShowSaveAddress}
         />
     );
 };

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -4,8 +4,6 @@ import {
     type CheckoutParams,
     type CheckoutSelectors,
     type Consignment,
-    type Country,
-    type CustomerAddress,
     type CustomerRequestOptions,
     type FormField,
     type RequestOptions,
@@ -23,11 +21,9 @@ import MultiShippingGuestForm from './MultiShippingGuestForm';
 import SingleShippingForm, { type SingleShippingFormValues } from './SingleShippingForm';
 
 export interface ShippingFormProps {
-    addresses: CustomerAddress[];
     cart: Cart;
     cartHasChanged: boolean;
     consignments: Consignment[];
-    countries: Country[];
     countriesWithAutocomplete: string[];
     customerMessage: string;
     googleMapsApiKey?: string;
@@ -39,7 +35,6 @@ export interface ShippingFormProps {
     isGuestMultiShippingEnabled: boolean;
     methodId?: string;
     shippingAddress?: Address;
-    shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
     isInitialValueLoaded: boolean;
@@ -62,11 +57,9 @@ export interface ShippingFormProps {
 }
 
 const ShippingForm = ({
-    addresses,
     cart,
     cartHasChanged,
       consignments,
-      countries,
       countriesWithAutocomplete,
       onCreateAccount,
       customerMessage,
@@ -87,7 +80,6 @@ const ShippingForm = ({
     onUnhandledError,
       shippingAddress,
       shouldShowOrderComments,
-      shouldShowSaveAddress,
       signOut,
       updateAddress,
       isShippingStepPending,
@@ -138,10 +130,8 @@ const ShippingForm = ({
         getMultiShippingForm()
     ) : (
         <SingleShippingForm
-            addresses={addresses}
             cartHasChanged={cartHasChanged}
             consignments={consignments}
-            countries={countries}
             countriesWithAutocomplete={countriesWithAutocomplete}
             customerMessage={customerMessage}
             deinitialize={deinitialize}
@@ -161,7 +151,6 @@ const ShippingForm = ({
             shippingAddress={shippingAddress}
             shippingFormRenderTimestamp={shippingFormRenderTimestamp}
             shouldShowOrderComments={shouldShowOrderComments}
-            shouldShowSaveAddress={shouldShowSaveAddress}
             signOut={signOut}
             updateAddress={updateAddress}
         />

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -3,8 +3,6 @@ import {
     type CheckoutParams,
     type CheckoutSelectors,
     type Consignment,
-    type Country,
-    type CustomerAddress,
     type CustomerRequestOptions,
     type FormField,
     type RequestOptions,
@@ -40,11 +38,9 @@ import { SHIPPING_ADDRESS_FIELDS } from './ShippingAddressFields';
 import ShippingFormFooter from './ShippingFormFooter';
 
 export interface SingleShippingFormProps {
-    addresses: CustomerAddress[];
     isBillingSameAsShipping: boolean;
     cartHasChanged: boolean;
     consignments: Consignment[];
-    countries: Country[];
     countriesWithAutocomplete: string[];
     customerMessage: string;
     googleMapsApiKey?: string;
@@ -54,7 +50,6 @@ export interface SingleShippingFormProps {
     methodId?: string;
     shippingAddress?: Address;
     shippingAutosaveDelay?: number;
-    shouldShowSaveAddress?: boolean;
     shouldShowOrderComments: boolean;
     isFloatingLabelEnabled?: boolean;
     isInitialValueLoaded: boolean;
@@ -180,14 +175,11 @@ class SingleShippingForm extends PureComponent<
 
     render(): ReactNode {
         const {
-            addresses,
             cartHasChanged,
             isInitialValueLoaded,
             isLoading,
             onUnhandledError,
             methodId,
-            shouldShowSaveAddress,
-            countries,
             countriesWithAutocomplete,
             googleMapsApiKey,
             shippingAddress,
@@ -214,9 +206,7 @@ class SingleShippingForm extends PureComponent<
             <Form autoComplete="on">
                 <Fieldset>
                     <ShippingAddress
-                        addresses={addresses}
                         consignments={consignments}
-                        countries={countries}
                         countriesWithAutocomplete={countriesWithAutocomplete}
                         deinitialize={deinitialize}
                         formFields={this.getFields(addressForm && addressForm.countryCode)}
@@ -232,7 +222,6 @@ class SingleShippingForm extends PureComponent<
                         onUnhandledError={onUnhandledError}
                         onUseNewAddress={this.onUseNewAddress}
                         shippingAddress={shippingAddress}
-                        shouldShowSaveAddress={shouldShowSaveAddress}
                     />
                     {shouldShowBillingSameAsShipping && (
                         <div className="form-body">


### PR DESCRIPTION
## What/Why?

Convert class component `ShippingAddressForm` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert.

## Testing
CI.
