### PR TITLE
refactor(checkout): CHECKOUT-9384 Convert Toggle

### DIFF
--- a/packages/core/src/app/ui/toggle/Toggle.tsx
+++ b/packages/core/src/app/ui/toggle/Toggle.tsx
@@ -1,36 +1,19 @@
-import { Component, ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 export interface ToggleProps {
     openByDefault?: boolean;
     children: (props: { toggle: any; isOpen: boolean }) => ReactNode;
 }
 
-export interface ToggleState {
-    isOpen: boolean;
-}
+const Toggle = ({ openByDefault, children }: ToggleProps): ReactNode => {
+    const [isOpen, setIsOpen] = useState(Boolean(openByDefault));
 
-export default class Toggle extends Component<ToggleProps, ToggleState> {
-    constructor(props: ToggleProps) {
-        super(props);
-
-        this.state = { isOpen: !!props.openByDefault };
-    }
-
-    render(): ReactNode {
-        const { children } = this.props;
-        const { isOpen } = this.state;
-
-        return children({
-            isOpen,
-            toggle: this.toggle,
-        });
-    }
-
-    private toggle: (event: Event) => void = (event) => {
-        const { isOpen } = this.state;
-
+    const toggle = (event: Event) => {
         event.preventDefault();
-
-        this.setState({ isOpen: !isOpen });
+        setIsOpen(!isOpen);
     };
-}
+
+    return children({ isOpen, toggle });
+};
+
+export default Toggle;


### PR DESCRIPTION
## What/Why?

Convert class component `CheckoutStep` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert.

## Testing
CI.
