### PR TITLE
refactor(payment): PI-4277 create generic hosted payment method functional component

### DIFF
--- a/packages/bluesnap-direct-integration/src/BlueSnapV2PaymentMethod.tsx
+++ b/packages/bluesnap-direct-integration/src/BlueSnapV2PaymentMethod.tsx
@@ -10,7 +10,7 @@ import React, {
 
 import {
     HostedPaymentComponent,
-    HostedPaymentMethodProps,
+    type HostedPaymentComponentProps,
 } from '@bigcommerce/checkout/hosted-payment-integration';
 import {
     PaymentMethodProps,
@@ -19,7 +19,7 @@ import {
 } from '@bigcommerce/checkout/payment-integration-api';
 import { LoadingOverlay, Modal } from '@bigcommerce/checkout/ui';
 
-export type BlueSnapV2PaymentMethodProps = HostedPaymentMethodProps;
+export type BlueSnapV2PaymentMethodProps = HostedPaymentComponentProps;
 
 interface BlueSnapV2PaymentMethodRef {
     paymentPageContentRef: RefObject<HTMLDivElement>;

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -76,7 +76,6 @@ const PaymentMethodComponent: FunctionComponent<
         method.id === PaymentMethodId.BraintreeVenmo ||
         method.id === PaymentMethodId.Humm ||
         method.id === PaymentMethodId.Laybuy ||
-        method.id === PaymentMethodId.Quadpay ||
         method.id === PaymentMethodId.Sezzle ||
         method.id === PaymentMethodId.Zip ||
         method.method === PaymentMethodType.Paypal ||

--- a/packages/hosted-payment-integration/project.json
+++ b/packages/hosted-payment-integration/project.json
@@ -16,5 +16,5 @@
       }
     }
   },
-  "tags": ["scope:shared"]
+  "tags": ["scope:integration", "scope:shared"]
 }

--- a/packages/hosted-payment-integration/src/HostedPaymentMethod.test.tsx
+++ b/packages/hosted-payment-integration/src/HostedPaymentMethod.test.tsx
@@ -1,0 +1,65 @@
+import {
+    CheckoutSelectors,
+    CheckoutService,
+    createCheckoutService,
+    createLanguageService,
+} from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import {
+    PaymentFormService,
+    PaymentMethodProps,
+} from '@bigcommerce/checkout/payment-integration-api';
+import {
+    getCart,
+    getCustomer,
+    getPaymentFormServiceMock,
+    getStoreConfig,
+} from '@bigcommerce/checkout/test-mocks';
+import { render } from '@bigcommerce/checkout/test-utils';
+
+import HostedPaymentMethod from './HostedPaymentMethod';
+
+describe('When using Hosted payment method', () => {
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let defaultProps: PaymentMethodProps;
+    let paymentForm: PaymentFormService;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        paymentForm = getPaymentFormServiceMock();
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+        jest.spyOn(checkoutState.data, 'getCart').mockReturnValue(getCart());
+        jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
+        jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
+
+        defaultProps = {
+            method: {
+                id: 'quadpay',
+                method: 'credit-card',
+                supportedCards: [],
+                config: {},
+                type: 'PAYMENT_TYPE_API',
+                skipRedirectConfirmationAlert: true,
+            },
+            checkoutService,
+            checkoutState,
+            paymentForm,
+            language: createLanguageService(),
+            onUnhandledError: jest.fn(),
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('user does not see a description or instrument fields for Zip/Quadpay', () => {
+        const { container } = render(<HostedPaymentMethod {...defaultProps} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/packages/hosted-payment-integration/src/HostedPaymentMethod.tsx
+++ b/packages/hosted-payment-integration/src/HostedPaymentMethod.tsx
@@ -1,0 +1,36 @@
+import React, { type FunctionComponent } from 'react';
+
+import {
+    type PaymentMethodProps,
+    type PaymentMethodResolveId,
+    toResolvableComponent,
+} from '@bigcommerce/checkout/payment-integration-api';
+
+import { HostedPaymentComponent } from './components';
+
+const HostedPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
+    checkoutService,
+    checkoutState,
+    method,
+    onUnhandledError,
+    language,
+    paymentForm,
+}) => {
+    return (
+        <HostedPaymentComponent
+            checkoutService={checkoutService}
+            checkoutState={checkoutState}
+            deinitializePayment={checkoutService.deinitializePayment}
+            initializePayment={checkoutService.initializePayment}
+            language={language}
+            method={method}
+            onUnhandledError={onUnhandledError}
+            paymentForm={paymentForm}
+        />
+    );
+};
+
+export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
+    HostedPaymentMethod,
+    [{ id: 'quadpay' }],
+);

--- a/packages/hosted-payment-integration/src/components/HostedPaymentComponent.test.tsx
+++ b/packages/hosted-payment-integration/src/components/HostedPaymentComponent.test.tsx
@@ -29,13 +29,13 @@ import {
 } from '@bigcommerce/checkout/test-mocks';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
-import HostedPaymentMethod, { HostedPaymentMethodProps } from './HostedPaymentComponent';
+import HostedPaymentMethod, { HostedPaymentComponentProps } from './HostedPaymentComponent';
 
 describe('HostedPaymentMethod', () => {
     let checkoutService: CheckoutService;
     let checkoutState: CheckoutSelectors;
-    let defaultProps: HostedPaymentMethodProps;
-    let HostedPaymentMethodTest: FunctionComponent<HostedPaymentMethodProps>;
+    let defaultProps: HostedPaymentComponentProps;
+    let HostedPaymentMethodTest: FunctionComponent<HostedPaymentComponentProps>;
     let localeContext: LocaleContextType;
     let paymentForm: PaymentFormService;
 

--- a/packages/hosted-payment-integration/src/components/HostedPaymentComponent.tsx
+++ b/packages/hosted-payment-integration/src/components/HostedPaymentComponent.tsx
@@ -21,7 +21,7 @@ import {
 import { PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 
-export interface HostedPaymentMethodProps {
+export interface HostedPaymentComponentProps {
     checkoutService: CheckoutService;
     checkoutState: CheckoutSelectors;
     description?: ReactNode;
@@ -35,12 +35,12 @@ export interface HostedPaymentMethodProps {
     onUnhandledError?(error: Error): void;
 }
 
-interface HostedPaymentMethodState {
+interface HostedPaymentComponentState {
     isAddingNewInstrument: boolean;
     selectedInstrument?: AccountInstrument;
 }
 
-interface HostedPaymentMethodDerivedProps {
+interface HostedPaymentComponentDerivedProps {
     instruments: AccountInstrument[];
     isInstrumentFeatureAvailable: boolean;
     isLoadingInstruments: boolean;
@@ -50,8 +50,8 @@ interface HostedPaymentMethodDerivedProps {
 }
 
 function getHostedPaymentMethodDerivedProps(
-    props: HostedPaymentMethodProps,
-): HostedPaymentMethodDerivedProps {
+    props: HostedPaymentComponentProps,
+): HostedPaymentComponentDerivedProps {
     const filterAccountInstruments = memoizeOne((instruments: PaymentInstrument[] = []) =>
         instruments.filter(isAccountInstrument),
     );
@@ -101,10 +101,10 @@ function getHostedPaymentMethodDerivedProps(
 }
 
 class HostedPaymentMethodComponent extends Component<
-    HostedPaymentMethodProps,
-    HostedPaymentMethodState
+    HostedPaymentComponentProps,
+    HostedPaymentComponentState
 > {
-    state: HostedPaymentMethodState = {
+    state: HostedPaymentComponentState = {
         isAddingNewInstrument: false,
     };
 

--- a/packages/hosted-payment-integration/src/components/index.ts
+++ b/packages/hosted-payment-integration/src/components/index.ts
@@ -1,0 +1,4 @@
+export {
+    default as HostedPaymentComponent,
+    type HostedPaymentComponentProps,
+} from './HostedPaymentComponent';

--- a/packages/hosted-payment-integration/src/index.ts
+++ b/packages/hosted-payment-integration/src/index.ts
@@ -1,4 +1,2 @@
-export {
-    default as HostedPaymentComponent,
-    HostedPaymentMethodProps,
-} from './HostedPaymentComponent';
+export { default as HostedPaymentMethod } from './HostedPaymentMethod';
+export { HostedPaymentComponent, type HostedPaymentComponentProps } from './components';


### PR DESCRIPTION
## What/Why?
As we're preparing for moving several payment providers out of the `core` directory:
- created generic functional component for Hosted Payment Method
- renamed Hosted Payment Component's interfaces to avoid confusion

## Rollout/Rollback
Revert

## Testing
Unit + manual testing
