### PR TITLE
chore(other): CHECKOUT-9448 Update sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.788.0",
+        "@bigcommerce/checkout-sdk": "^1.788.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.788.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.788.0.tgz",
-      "integrity": "sha512-sWhgOx4tfc59DgDZJurwXrd5i3nYlmnZRjpssBQ3iGzLkqRFEQJz/U3ui995loSAYNW3agdf8Zjo7vKjXjnGiw==",
+      "version": "1.788.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.788.1.tgz",
+      "integrity": "sha512-EOUSzFdQwisoDe7mvnzNm0Ke+yFGCiSu0PeDAfs51fT6iKkQN9IhsDz3ihfB34PVptOPplQCEOx5vlJizVBhZg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.788.0",
+    "@bigcommerce/checkout-sdk": "^1.788.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Update checkout SDK to release https://github.com/bigcommerce/checkout-sdk-js/commit/bcca91005ffb3daefb44ed829ec7f953c9875d2c

## Rollout/Rollback
revert this PR

## Testing
- CI 