### PR TITLE
feat(checkout): CHECKOUT-9385 Convert ui package class components

### DIFF
--- a/packages/core/src/app/ui/tooltip/TooltipTrigger.tsx
+++ b/packages/core/src/app/ui/tooltip/TooltipTrigger.tsx
@@ -1,6 +1,5 @@
-
 import { Placement } from '@popperjs/core';
-import React, { Component, ReactEventHandler, ReactNode } from 'react';
+import React, { ReactEventHandler, ReactNode, useState } from 'react';
 import { Manager, Popper, Reference } from 'react-popper';
 
 export interface TooltipTriggerProps {
@@ -9,64 +8,55 @@ export interface TooltipTriggerProps {
     children: ReactNode;
 }
 
-export interface TooltipTriggerState {
-    shouldShow: boolean;
-}
+const TooltipTrigger: React.FC<TooltipTriggerProps> = ({
+    placement = 'bottom',
+    tooltip,
+    children,
+}) => {
+    const [shouldShow, setShouldShow] = useState(false);
 
-export default class TooltipTrigger extends Component<TooltipTriggerProps, TooltipTriggerState> {
-    static defaultProps = {
-        placement: 'bottom',
+    const handleShow: ReactEventHandler<HTMLElement> = () => {
+        setShouldShow(true);
     };
 
-    state: Readonly<TooltipTriggerState> = {
-        shouldShow: false,
+    const handleHide: ReactEventHandler<HTMLElement> = () => {
+        setShouldShow(false);
     };
 
-    render() {
-        const { children, placement, tooltip } = this.props;
-        const { shouldShow } = this.state;
+    return (
+        <Manager>
+            <Reference>
+                {({ ref }) => (
+                    <span
+                        onBlur={handleHide}
+                        onFocus={handleShow}
+                        onMouseEnter={handleShow}
+                        onMouseLeave={handleHide}
+                        ref={ref}
+                    >
+                        {children}
+                    </span>
+                )}
+            </Reference>
 
-        return (
-            <Manager>
-                <Reference>
-                    {({ ref }) => (
-                        <span
-                            onBlur={this.handleHide}
-                            onFocus={this.handleShow}
-                            onMouseEnter={this.handleShow}
-                            onMouseLeave={this.handleHide}
-                            ref={ref}
-                        >
-                            {children}
-                        </span>
-                    )}
-                </Reference>
+            <Popper
+                modifiers={[
+                    { name: 'hide', enabled: false },
+                    { name: 'flip', enabled: false },
+                    { name: 'preventOverflow', enabled: false },
+                ]}
+                placement={placement}
+            >
+                {({ ref, style }) =>
+                    shouldShow && (
+                        <div ref={ref} style={style}>
+                            {tooltip}
+                        </div>
+                    )
+                }
+            </Popper>
+        </Manager>
+    );
+};
 
-                <Popper
-                    modifiers={[
-                        { name: 'hide', enabled: false },
-                        { name: 'flip', enabled: false },
-                        { name: 'preventOverflow', enabled: false },
-                    ]}
-                    placement={placement}
-                >
-                    {({ ref, style }) =>
-                        shouldShow && (
-                            <div ref={ref} style={style}>
-                                {tooltip}
-                            </div>
-                        )
-                    }
-                </Popper>
-            </Manager>
-        );
-    }
-
-    private handleShow: ReactEventHandler<HTMLElement> = () => {
-        this.setState({ shouldShow: true });
-    };
-
-    private handleHide: ReactEventHandler<HTMLElement> = () => {
-        this.setState({ shouldShow: false });
-    };
-}
+export default TooltipTrigger;

--- a/packages/ui/src/form/BasicFormField/BasicFormField.tsx
+++ b/packages/ui/src/form/BasicFormField/BasicFormField.tsx
@@ -1,12 +1,13 @@
 import { Field, FieldConfig, FieldProps, getIn } from 'formik';
 import { isDate, noop } from 'lodash';
 import React, {
-    Component,
     createElement,
     FunctionComponent,
     memo,
     useCallback,
+    useEffect,
     useMemo,
+    useRef,
 } from 'react';
 import shallowEqual from 'shallowequal';
 
@@ -26,41 +27,40 @@ type InnerFieldInputProps = FieldProps &
 
 type InnerFieldProps = Omit<BasicFormFieldProps, keyof FieldConfig> & InnerFieldInputProps;
 
-class InnerFieldInput extends Component<InnerFieldInputProps> {
-    componentDidUpdate({ field: prevField }: InnerFieldInputProps) {
-        const {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            field: { value },
-            onChange = noop,
-        } = this.props;
+const InnerFieldInput: FunctionComponent<InnerFieldInputProps> = ({
+    field,
+    onChange = noop,
+    component = 'input',
+    render,
+    ...props
+}) => {
+    const prevValueRef = useRef<unknown>(field.value);
 
+    useEffect(() => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const comparableValue = isDate(value) ? value.getTime() : value;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const comparablePrevValue = isDate(prevField.value)
-            ? prevField.value.getTime()
-            : prevField.value;
+        const comparableValue = isDate(field.value) ? field.value.getTime() : field.value;
+        const comparablePrevValue = isDate(prevValueRef.current)
+            ? prevValueRef.current.getTime()
+            : prevValueRef.current;
 
         if (comparableValue !== comparablePrevValue) {
-            onChange(value);
+            onChange(field.value);
         }
+
+        prevValueRef.current = field.value;
+    }, [field.value, onChange]);
+
+    if (render) {
+        return render({ field, ...props });
     }
 
-    render() {
-        const { component = 'input', field, render } = this.props;
-
-        if (render) {
-            return render(this.props);
-        }
-
-        if (typeof component === 'string') {
-            return createElement(component, field);
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-        return createElement(component as any, this.props);
+    if (typeof component === 'string') {
+        return createElement(component, field);
     }
-}
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return createElement(component as any, { field, ...props });
+};
 
 const InnerField: FunctionComponent<InnerFieldProps> = memo(
     ({ additionalClassName, component, field, form, onChange, render, testId }) => {


### PR DESCRIPTION
## What/Why?

Convert class components `TooltipTrigger, ModalTrigger, DropdownTrigger, BasicFormField`  into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
