### PR TITLE
feat(checkout): CHECKOUT-9385 Convert instrument utils package class components 

### DIFF
--- a/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/AccountInstrumentSelect/AccountInstrumentSelect.tsx
@@ -348,6 +348,12 @@ const AccountInstrumentSelect: FunctionComponent<AccountInstrumentSelectProps> =
         //        This ensures that update Field value is called after formik has mounted.
         // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
         setTimeout(() => updateFieldValue(selectedInstrumentId));
+
+        return () => {
+            if (field.value === '' && selectedInstrumentId !== undefined) {
+                updateFieldValue();
+            }
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -361,14 +367,6 @@ const AccountInstrumentSelect: FunctionComponent<AccountInstrumentSelectProps> =
 
         prevSelectedInstrumentIdRef.current = selectedInstrumentId;
     }, [selectedInstrumentId, updateFieldValue]);
-
-    useEffect(() => {
-        return () => {
-            if (field.value === '' && selectedInstrumentId !== undefined) {
-                updateFieldValue();
-            }
-        };
-    }, [field.value, selectedInstrumentId, updateFieldValue]);
 
     const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
     const { value, ...otherFieldProps } = field;

--- a/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import creditCardType from 'credit-card-type';
 import { FieldProps } from 'formik';
 import { find, noop } from 'lodash';
-import React, { FunctionComponent, PureComponent, ReactNode, useCallback } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CreditCardIcon, DropdownTrigger } from '@bigcommerce/checkout/ui';
@@ -228,75 +228,73 @@ const InstrumentSelectButton: FunctionComponent<InstrumentSelectButtonProps> = (
     );
 };
 
-class InstrumentSelect extends PureComponent<InstrumentSelectProps> {
-    componentDidMount() {
-        const { selectedInstrumentId } = this.props;
+const InstrumentSelect: FunctionComponent<InstrumentSelectProps> = ({
+    field,
+    form,
+    instruments,
+    onSelectInstrument,
+    onUseNewInstrument,
+    selectedInstrumentId,
+    shouldHideExpiryDate = false,
+}) => {
+    const prevSelectedInstrumentIdRef = useRef(selectedInstrumentId);
 
+    const updateFieldValue = useCallback(
+        (instrumentId = '') => {
+            void form.setFieldValue(field.name, instrumentId);
+        },
+        [form, field.name],
+    );
+
+    useEffect(() => {
         // FIXME: Used setTimeout here because setFieldValue call doesnot set value if called before formik is properly mounted.
         //        This ensures that update Field value is called after formik has mounted.
         // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
-        setTimeout(() => this.updateFieldValue(selectedInstrumentId));
-    }
+        setTimeout(() => updateFieldValue(selectedInstrumentId));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
-    componentDidUpdate(prevProps: Readonly<InstrumentSelectProps>) {
-        const { selectedInstrumentId: prevSelectedInstrumentId } = prevProps;
-        const { selectedInstrumentId } = this.props;
-
-        if (prevSelectedInstrumentId !== selectedInstrumentId) {
-            this.updateFieldValue(selectedInstrumentId);
+    useEffect(() => {
+        if (prevSelectedInstrumentIdRef.current !== selectedInstrumentId) {
+            updateFieldValue(selectedInstrumentId);
         }
-    }
 
-    componentWillUnmount() {
-        const { selectedInstrumentId, field } = this.props;
+        prevSelectedInstrumentIdRef.current = selectedInstrumentId;
+    }, [selectedInstrumentId, updateFieldValue]);
 
-        if (field.value === '' && selectedInstrumentId !== undefined) {
-            this.updateFieldValue();
-        }
-    }
+    useEffect(() => {
+        return () => {
+            if (field.value === '' && selectedInstrumentId !== undefined) {
+                updateFieldValue();
+            }
+        };
+    }, [field.value, selectedInstrumentId, updateFieldValue]);
 
-    render(): ReactNode {
-        const {
-            field,
-            instruments,
-            onSelectInstrument,
-            onUseNewInstrument,
-            selectedInstrumentId,
-            shouldHideExpiryDate = false,
-        } = this.props;
+    const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
 
-        const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
-
-        return (
-            <div className="instrumentSelect">
-                <DropdownTrigger
-                    dropdown={
-                        <InstrumentMenu
-                            instruments={instruments}
-                            onSelectInstrument={onSelectInstrument}
-                            onUseNewInstrument={onUseNewInstrument}
-                            selectedInstrumentId={selectedInstrumentId}
-                            shouldHideExpiryDate={shouldHideExpiryDate}
-                        />
-                    }
-                >
-                    <InstrumentSelectButton
-                        instrument={selectedInstrument}
+    return (
+        <div className="instrumentSelect">
+            <DropdownTrigger
+                dropdown={
+                    <InstrumentMenu
+                        instruments={instruments}
+                        onSelectInstrument={onSelectInstrument}
+                        onUseNewInstrument={onUseNewInstrument}
+                        selectedInstrumentId={selectedInstrumentId}
                         shouldHideExpiryDate={shouldHideExpiryDate}
-                        testId="instrument-select"
                     />
+                }
+            >
+                <InstrumentSelectButton
+                    instrument={selectedInstrument}
+                    shouldHideExpiryDate={shouldHideExpiryDate}
+                    testId="instrument-select"
+                />
 
-                    <input type="hidden" {...field} />
-                </DropdownTrigger>
-            </div>
-        );
-    }
-
-    private updateFieldValue(instrumentId = ''): void {
-        const { form, field } = this.props;
-
-        void form.setFieldValue(field.name, instrumentId);
-    }
-}
+                <input type="hidden" {...field} />
+            </DropdownTrigger>
+        </div>
+    );
+};
 
 export default InstrumentSelect;

--- a/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
+++ b/packages/instrument-utils/src/storedInstrument/InstrumentSelect/InstrumentSelect.tsx
@@ -251,6 +251,12 @@ const InstrumentSelect: FunctionComponent<InstrumentSelectProps> = ({
         //        This ensures that update Field value is called after formik has mounted.
         // See GitHub issue: https://github.com/jaredpalmer/formik/issues/930
         setTimeout(() => updateFieldValue(selectedInstrumentId));
+
+        return () => {
+            if (field.value === '' && selectedInstrumentId !== undefined) {
+                updateFieldValue();
+            }
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -261,14 +267,6 @@ const InstrumentSelect: FunctionComponent<InstrumentSelectProps> = ({
 
         prevSelectedInstrumentIdRef.current = selectedInstrumentId;
     }, [selectedInstrumentId, updateFieldValue]);
-
-    useEffect(() => {
-        return () => {
-            if (field.value === '' && selectedInstrumentId !== undefined) {
-                updateFieldValue();
-            }
-        };
-    }, [field.value, selectedInstrumentId, updateFieldValue]);
 
     const selectedInstrument = find(instruments, { bigpayToken: selectedInstrumentId });
 


### PR DESCRIPTION
## What/Why?

Convert class components `AccountInstrumentSelect, InstrumentSelect`  into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
