### PR TITLE
feat(checkout): CHECKOUT-9385 Convert WalletButtonPaymentMethodComponent

### DIFF
--- a/packages/wallet-button-integration/src/PaymentView.tsx
+++ b/packages/wallet-button-integration/src/PaymentView.tsx
@@ -1,0 +1,84 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+import React, { type ReactNode } from 'react';
+
+import { preventDefault } from '@bigcommerce/checkout/dom-utils';
+import { SignOutLink } from '@bigcommerce/checkout/instrument-utils';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+
+export interface PaymentViewProps {
+    accountMask?: string;
+    cardName?: string;
+    cardType?: string;
+    expiryMonth?: string;
+    expiryYear?: string;
+    shouldShowEditButton?: boolean;
+    editButtonClassName?: string;
+    editButtonLabel?: ReactNode;
+    buttonId: string;
+    method: PaymentMethod;
+    onSignOut: () => void;
+}
+
+const PaymentView: React.FC<PaymentViewProps> = ({
+    accountMask,
+    cardName,
+    cardType,
+    expiryMonth,
+    expiryYear,
+    shouldShowEditButton,
+    editButtonClassName,
+    editButtonLabel,
+    buttonId,
+    method,
+    onSignOut,
+}) => {
+    return (
+        <>
+            {!!cardName && (
+                <p data-test="payment-method-wallet-card-name">
+                    <strong>
+                        <TranslatedString id="payment.credit_card_name_label" />:
+                    </strong>{' '}
+                    {cardName}
+                </p>
+            )}
+
+            {!!accountMask && !!cardType && (
+                <p data-test="payment-method-wallet-card-type">
+                    <strong>{`${cardType}:`}</strong> {accountMask}
+                </p>
+            )}
+
+            {!!expiryMonth && !!expiryYear && (
+                <p data-test="payment-method-wallet-card-expiry">
+                    <strong>
+                        <TranslatedString id="payment.credit_card_expiration_date_label" />:
+                    </strong>{' '}
+                    {`${expiryMonth}/${expiryYear}`}
+                </p>
+            )}
+
+            {!!shouldShowEditButton && (
+                <p>
+                    {
+                        // eslint-disable-next-line jsx-a11y/anchor-is-valid
+                        <a
+                            className={editButtonClassName}
+                            href="#"
+                            id={buttonId}
+                            onClick={preventDefault()}
+                        >
+                            {editButtonLabel || (
+                                <TranslatedString id="remote.select_different_card_action" />
+                            )}
+                        </a>
+                    }
+                </p>
+            )}
+
+            <SignOutLink method={method} onSignOut={onSignOut} />
+        </>
+    );
+};
+
+export default PaymentView;

--- a/packages/wallet-button-integration/src/SignInView.tsx
+++ b/packages/wallet-button-integration/src/SignInView.tsx
@@ -1,0 +1,36 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+import React, { type ReactNode } from 'react';
+
+import { preventDefault } from '@bigcommerce/checkout/dom-utils';
+import { TranslatedString, useLocale } from '@bigcommerce/checkout/locale';
+import { getPaymentMethodName } from '@bigcommerce/checkout/payment-integration-api';
+
+export interface SignInViewProps {
+    buttonId: string;
+    method: PaymentMethod;
+    signInButtonClassName?: string;
+    signInButtonLabel?: ReactNode;
+}
+
+const SignInView: React.FC<SignInViewProps> = ({
+    buttonId,
+    method,
+    signInButtonClassName,
+    signInButtonLabel,
+}) => {
+    const { language } = useLocale();
+
+    return (
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
+        <a className={signInButtonClassName} href="#" id={buttonId} onClick={preventDefault()}>
+            {signInButtonLabel || (
+                <TranslatedString
+                    data={{ providerName: getPaymentMethodName(language)(method) }}
+                    id="remote.sign_in_action"
+                />
+            )}
+        </a>
+    );
+};
+
+export default SignInView;

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
@@ -53,8 +53,6 @@ describe('WalletButtonPaymentMethod', () => {
         };
         defaultProps = {
             signOutCustomer: checkoutService.signOutCustomer,
-            checkoutState,
-            language: localeContext.language,
             paymentForm,
             buttonId: 'button-container',
             deinitializePayment: jest.fn(),
@@ -143,8 +141,8 @@ describe('WalletButtonPaymentMethod', () => {
         render(<WalletButtonPaymentMethodTest {...defaultProps} />);
         expect(
             screen.getByText(
-                defaultProps.language.translate('remote.sign_in_action', {
-                    providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                localeContext.language.translate('remote.sign_in_action', {
+                    providerName: getPaymentMethodName(localeContext.language)(defaultProps.method),
                 }),
             ),
         ).toBeInTheDocument();
@@ -230,8 +228,8 @@ describe('WalletButtonPaymentMethod', () => {
         it('renders sign out link', () => {
             render(<WalletButtonPaymentMethodTest {...defaultProps} />);
 
-            const linkText = defaultProps.language.translate('remote.sign_out_action', {
-                providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+            const linkText = localeContext.language.translate('remote.sign_out_action', {
+                providerName: getPaymentMethodName(localeContext.language)(defaultProps.method),
             });
 
             expect(screen.getByText(linkText)).toBeInTheDocument();
@@ -313,7 +311,7 @@ describe('WalletButtonPaymentMethod', () => {
             );
             expect(
                 screen.queryByText(
-                    defaultProps.language.translate('remote.select_different_card_action'),
+                    localeContext.language.translate('remote.select_different_card_action'),
                 ),
             ).not.toBeInTheDocument();
             expect(screen.getByText(editButtonLabel)).toBeInTheDocument();
@@ -324,7 +322,7 @@ describe('WalletButtonPaymentMethod', () => {
 
             expect(
                 screen.queryByText(
-                    defaultProps.language.translate('remote.select_different_card_action'),
+                    localeContext.language.translate('remote.select_different_card_action'),
                 ),
             ).not.toBeInTheDocument();
         });
@@ -342,8 +340,8 @@ describe('WalletButtonPaymentMethod', () => {
             );
 
             const actionButton = screen.getByText(
-                defaultProps.language.translate('remote.sign_out_action', {
-                    providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                localeContext.language.translate('remote.sign_out_action', {
+                    providerName: getPaymentMethodName(localeContext.language)(defaultProps.method),
                 }),
             );
 
@@ -373,8 +371,8 @@ describe('WalletButtonPaymentMethod', () => {
             );
 
             const actionButton = screen.getByText(
-                defaultProps.language.translate('remote.sign_out_action', {
-                    providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                localeContext.language.translate('remote.sign_out_action', {
+                    providerName: getPaymentMethodName(localeContext.language)(defaultProps.method),
                 }),
             );
 

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
@@ -36,35 +36,23 @@ export interface WalletButtonPaymentMethodProps {
     onUnhandledError?(error: Error): void;
 }
 
-interface WalletButtonPaymentMethodDerivedProps {
-    accountMask?: string;
-    cardName?: string;
-    cardType?: string;
-    expiryMonth?: string;
-    expiryYear?: string;
-    isPaymentDataRequired: boolean;
-    isPaymentSelected: boolean;
-}
-
-const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProps> = (props) => {
-    const {
-        paymentForm,
-        buttonId,
-        editButtonClassName,
-        editButtonLabel,
-        isInitializing = false,
-        method,
-        shouldShowEditButton,
-        signInButtonClassName,
-        signInButtonLabel,
-        signOutCustomer,
-        deinitializePayment,
-        initializePayment,
-        onSignOut = noop,
-        onSignOutError = noop,
-        onUnhandledError = noop,
-    } = props;
-
+const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProps> = ({
+    paymentForm,
+    buttonId,
+    editButtonClassName,
+    editButtonLabel,
+    isInitializing = false,
+    method,
+    shouldShowEditButton,
+    signInButtonClassName,
+    signInButtonLabel,
+    signOutCustomer,
+    deinitializePayment,
+    initializePayment,
+    onSignOut = noop,
+    onSignOutError = noop,
+    onUnhandledError = noop,
+}) => {
     const {
         checkoutState: {
             data: { getBillingAddress, getCheckout, isPaymentDataRequired },
@@ -79,14 +67,10 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
     }
 
     const walletPaymentData = normalizeWalletPaymentData(method.initializationData);
-    const derivedProps: WalletButtonPaymentMethodDerivedProps = {
-        ...walletPaymentData,
-        // FIXME: I'm not sure how this would work for non-English names.
-        cardName:
-            walletPaymentData && [billingAddress.firstName, billingAddress.lastName].join(' '),
-        isPaymentDataRequired: isPaymentDataRequired(),
-        isPaymentSelected: some(checkout.payments, { providerId: method.id }),
-    };
+    const isPaymentSelected = some(checkout.payments, { providerId: method.id });
+    // FIXME: I'm not sure how this would work for non-English names.
+    const cardName =
+        walletPaymentData && [billingAddress.firstName, billingAddress.lastName].join(' ');
 
     const toggleSubmit = () => {
         const { disableSubmit } = paymentForm;
@@ -153,15 +137,14 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
         toggleSubmit();
     });
 
-    const { isPaymentSelected } = derivedProps;
-
     return (
         <LoadingOverlay hideContentWhenLoading isLoading={isInitializing}>
             <div className="paymentMethod paymentMethod--walletButton">
                 {isPaymentSelected ? (
                     <PaymentView
-                        {...derivedProps}
+                        {...walletPaymentData}
                         buttonId={buttonId}
+                        cardName={cardName}
                         editButtonClassName={editButtonClassName}
                         editButtonLabel={editButtonLabel}
                         method={method}


### PR DESCRIPTION
## What/Why?

Convert class component `WalletButtonPaymentMethodComponent` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
