### PR TITLE
CHECKOUT-9432: Fix inconsistent component names to allow lazy loading

### DIFF
--- a/packages/apple-pay-integration/src/ApplePayPaymentMethod.tsx
+++ b/packages/apple-pay-integration/src/ApplePayPaymentMethod.tsx
@@ -6,7 +6,7 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
-const ApplePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
+const ApplePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     method,
     checkoutService,
     language,
@@ -55,6 +55,6 @@ const ApplePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 };
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
-    ApplePaymentMethod,
+    ApplePayPaymentMethod,
     [{ id: 'applepay' }],
 );

--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentCreditCards/BigCommercePaymentsCreditCardsPaymentMethod.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentCreditCards/BigCommercePaymentsCreditCardsPaymentMethod.tsx
@@ -25,7 +25,7 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
-const BigCommercePaymentsCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = (
+const BigCommercePaymentsCreditCardsPaymentMethod: FunctionComponent<PaymentMethodProps> = (
     props,
 ) => {
     const { checkoutService, checkoutState, paymentForm, language, method } = props;
@@ -297,6 +297,6 @@ const BigCommercePaymentsCreditCardPaymentMethod: FunctionComponent<PaymentMetho
 };
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
-    BigCommercePaymentsCreditCardPaymentMethod,
+    BigCommercePaymentsCreditCardsPaymentMethod,
     [{ id: 'bigcommerce_payments_creditcards' }],
 );

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.test.tsx
@@ -33,7 +33,7 @@ import {
 } from '@bigcommerce/checkout/test-mocks';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
-import PayPalCommerceCreditCardPaymentMethod from './PayPalCommerceCreditCardsPaymentMethod';
+import PayPalCommerceCreditCardsPaymentMethod from './PayPalCommerceCreditCardsPaymentMethod';
 
 describe('PayPalCommerceCreditCardPaymentMethod', () => {
     let initialValues: CreditCardPaymentMethodValues;
@@ -86,7 +86,7 @@ describe('PayPalCommerceCreditCardPaymentMethod', () => {
                 <PaymentFormContext.Provider value={{ paymentForm }}>
                     <LocaleContext.Provider value={localeContext}>
                         <Formik initialValues={initialValues} onSubmit={noop}>
-                            <PayPalCommerceCreditCardPaymentMethod {...props} />
+                            <PayPalCommerceCreditCardsPaymentMethod {...props} />
                         </Formik>
                     </LocaleContext.Provider>
                 </PaymentFormContext.Provider>

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.tsx
@@ -25,7 +25,7 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
-const PayPalCommerceCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {
+const PayPalCommerceCreditCardsPaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {
     const { checkoutService, checkoutState, paymentForm, language, method } = props;
 
     const { cardCode, showCardHolderName, isHostedFormEnabled, requireCustomerCode } =
@@ -295,6 +295,6 @@ const PayPalCommerceCreditCardPaymentMethod: FunctionComponent<PaymentMethodProp
 };
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
-    PayPalCommerceCreditCardPaymentMethod,
+    PayPalCommerceCreditCardsPaymentMethod,
     [{ id: 'paypalcommercecreditcards' }],
 );


### PR DESCRIPTION
## What/Why?

Some payment method components couldn’t be lazy loaded because their names didn’t match the re-exported names at the root package level (e.g.: `PayPalCommerceCreditCardPaymentMethod` vs `PayPalCommerceCreditCardsPaymentMethods). I’ve renamed them for consistency and added a validation step in the auto-export build script to ensure the build fails if inconsistent naming occurs in the future.

## Rollout/Rollback

Revert

## Testing

### Before

The screenshot shows that `PayPalCommerceCreditCardsPaymentMethod` could not be resolved. As a result, the fallback component `HostedCreditCardPaymentMethod` was used, which led to an error due to missing required options.

<img width="1304" height="775" alt="Screenshot 2025-08-25 at 3 05 05 pm" src="https://github.com/user-attachments/assets/830c1cd2-da4d-4e3c-b58f-f015053fff95" />

### After

The screenshot shows `PayPalCommerceCreditCardsPaymentMethod` could now be resolved after renaming.

<img width="1305" height="779" alt="Screenshot 2025-08-25 at 3 19 56 pm" src="https://github.com/user-attachments/assets/b06d5a5f-18e9-4814-86b0-a13f09f9927a" />