### PR TITLE
refactor(payment): PI-4278 refactor Zip to use generic hosted payment component

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -78,7 +78,6 @@ const PaymentMethodComponent: FunctionComponent<
         method.id === PaymentMethodId.Humm ||
         method.id === PaymentMethodId.Laybuy ||
         method.id === PaymentMethodId.Sezzle ||
-        method.id === PaymentMethodId.Zip ||
         method.method === PaymentMethodType.Paypal ||
         method.method === PaymentMethodType.PaypalCredit ||
         method.type === PaymentMethodProviderType.Hosted

--- a/packages/hosted-payment-integration/src/HostedPaymentMethod.test.tsx
+++ b/packages/hosted-payment-integration/src/HostedPaymentMethod.test.tsx
@@ -23,8 +23,9 @@ import HostedPaymentMethod from './HostedPaymentMethod';
 describe('When using Hosted payment method', () => {
     let checkoutService: CheckoutService;
     let checkoutState: CheckoutSelectors;
-    let defaultProps: PaymentMethodProps;
+    let defaultProps: Omit<PaymentMethodProps, 'method'>;
     let paymentForm: PaymentFormService;
+    let paymentMethod: PaymentMethodProps['method'];
 
     beforeEach(() => {
         checkoutService = createCheckoutService();
@@ -37,14 +38,6 @@ describe('When using Hosted payment method', () => {
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
 
         defaultProps = {
-            method: {
-                id: 'quadpay',
-                method: 'credit-card',
-                supportedCards: [],
-                config: {},
-                type: 'PAYMENT_TYPE_API',
-                skipRedirectConfirmationAlert: true,
-            },
             checkoutService,
             checkoutState,
             paymentForm,
@@ -57,8 +50,36 @@ describe('When using Hosted payment method', () => {
         jest.clearAllMocks();
     });
 
-    test('user does not see a description or instrument fields for Zip/Quadpay', () => {
-        const { container } = render(<HostedPaymentMethod {...defaultProps} />);
+    test('user does not see a description or instrument fields for Quadpay (Zip US)', () => {
+        paymentMethod = {
+            id: 'quadpay',
+            method: 'credit-card',
+            supportedCards: [],
+            config: {},
+            type: 'PAYMENT_TYPE_API',
+            skipRedirectConfirmationAlert: true,
+        };
+
+        const { container } = render(
+            <HostedPaymentMethod method={paymentMethod} {...defaultProps} />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('user does not see a description or instrument fields for Zip', () => {
+        paymentMethod = {
+            id: 'zip',
+            method: 'credit-card',
+            supportedCards: [],
+            config: {},
+            type: 'PAYMENT_TYPE_API',
+            skipRedirectConfirmationAlert: true,
+        };
+
+        const { container } = render(
+            <HostedPaymentMethod method={paymentMethod} {...defaultProps} />,
+        );
 
         expect(container).toBeEmptyDOMElement();
     });

--- a/packages/hosted-payment-integration/src/HostedPaymentMethod.tsx
+++ b/packages/hosted-payment-integration/src/HostedPaymentMethod.tsx
@@ -32,5 +32,5 @@ const HostedPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     HostedPaymentMethod,
-    [{ id: 'quadpay' }],
+    [{ id: 'quadpay' }, { id: 'zip' }],
 );


### PR DESCRIPTION
## What/Why?
Refactored Zip to move it out of the `core` directory and use generic hosted payment component

## Rollout/Rollback
Revert

## Testing
Manual + unit testing

https://github.com/user-attachments/assets/160a471a-3644-4e4a-aa77-8c3308335286