### PR TITLE
refactor(payment): PAYPAL-5710 Removed init braintree venmo from core

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -68,7 +68,6 @@ const PaymentMethodComponent: FunctionComponent<
     }
 
     if (
-        method.id === PaymentMethodId.BraintreeVenmo ||
         method.id === PaymentMethodId.Humm ||
         method.id === PaymentMethodId.Laybuy ||
         method.id === PaymentMethodId.Sezzle ||


### PR DESCRIPTION
## What/Why?
Removed BT venmo initialization from core

## Rollout/Rollback
Revert PR

## Testing


https://github.com/user-attachments/assets/ae6d6fe1-625a-42b8-9e7a-5bbeda7723a5

