### PR TITLE
feat(checkout): CHECKOUT-9454 Convert Autocomplete component

### DIFF
--- a/packages/core/src/app/ui/autocomplete/AutocompleteContent.tsx
+++ b/packages/core/src/app/ui/autocomplete/AutocompleteContent.tsx
@@ -1,0 +1,73 @@
+import { includes, isNumber } from 'lodash';
+import React, { type ReactNode } from 'react';
+
+import { useThemeContext } from '@bigcommerce/checkout/ui';
+
+import { Label } from '../form';
+import { Popover, PopoverList } from '../popover';
+
+import type AutocompleteItem from './autocomplete-item';
+import { toPopoverItem } from './utils';
+
+export interface AutocompleteContentProps {
+    isOpen: boolean;
+    getInputProps: (options?: any) => any;
+    getMenuProps: () => any;
+    getItemProps: (options: any) => any;
+    highlightedIndex: number | null;
+    initialValue?: string;
+    inputProps?: any;
+    items: AutocompleteItem[];
+    listTestId?: string;
+    children?: ReactNode;
+}
+
+const AutocompleteContent: React.FC<AutocompleteContentProps> = ({
+    isOpen,
+    getInputProps,
+    getMenuProps,
+    getItemProps,
+    highlightedIndex,
+    initialValue,
+    inputProps,
+    items,
+    listTestId,
+    children,
+}) => {
+    const { themeV2 } = useThemeContext();
+    const validInputProps = { ...getInputProps({ value: initialValue }), ...inputProps };
+
+    delete validInputProps.labelText;
+
+    return (
+        <>
+            <input {...validInputProps} />
+            {inputProps && includes(inputProps.className, 'floating') && (
+                <Label
+                    additionalClassName={themeV2 ? 'floating-form-field-label' : ''}
+                    htmlFor={inputProps.id}
+                    id={inputProps['aria-labelledby']}
+                    isFloatingLabelEnabled={true}
+                >
+                    {inputProps.labelText}
+                </Label>
+            )}
+            {isOpen && !!items.length && (
+                <Popover>
+                    <PopoverList
+                        getItemProps={getItemProps}
+                        highlightedIndex={
+                            isNumber(highlightedIndex) ? highlightedIndex : -1
+                        }
+                        items={items.map((item) => toPopoverItem(item))}
+                        menuProps={getMenuProps()}
+                        testId={listTestId}
+                    />
+                    {children}
+                </Popover>
+            )}
+        </>
+    );
+};
+
+export default AutocompleteContent;

--- a/packages/core/src/app/ui/autocomplete/utils.tsx
+++ b/packages/core/src/app/ui/autocomplete/utils.tsx
@@ -1,0 +1,51 @@
+import React, { Fragment, type ReactChild } from 'react';
+
+import { type PopoverListItem } from '../popover';
+
+import type AutocompleteItem from './autocomplete-item';
+
+export const highlightItem = (item: AutocompleteItem): ReactChild[] | ReactChild => {
+    if (!item.highlightedSlices || !item.highlightedSlices.length) {
+        return item.label;
+    }
+
+    let lastIndex = 0;
+    let key = 0;
+
+    return item.highlightedSlices.reduce((node, slice, i) => {
+        const { label } = item;
+        const { offset, length } = slice;
+        const notHighlightedLength = offset - lastIndex;
+
+        if (notHighlightedLength) {
+            node.push(
+                <Fragment key={key}>{label.substr(lastIndex, notHighlightedLength)}</Fragment>,
+            );
+            key += 1;
+        }
+
+        lastIndex = offset + length;
+
+        node.push(<strong key={key}>{label.substr(offset, length)}</strong>);
+        key += 1;
+
+        if (i === (item.highlightedSlices || []).length - 1) {
+            node.push(<Fragment key={key}>{label.substr(lastIndex)}</Fragment>);
+            key += 1;
+        }
+
+        return node;
+        // eslint-disable-next-line @typescript-eslint/prefer-reduce-type-parameter
+    }, [] as ReactChild[]);
+};
+
+export const toPopoverItem = (item: AutocompleteItem): PopoverListItem => {
+    return {
+        ...item,
+        content: highlightItem(item),
+    };
+};
+
+export const itemToString = (item?: AutocompleteItem | null): string => {
+    return (item && item.value) || '';
+};


### PR DESCRIPTION
## What/Why?

Convert class component `Autocomplete` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
