### PR TITLE
feat(payment): Add Knet to new NAS Checkout.com and make it possible to transact via other APMs

### DIFF
--- a/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
+++ b/packages/checkoutcom-integration/src/CheckoutcomCustomPaymentMethod.tsx
@@ -71,13 +71,5 @@ const CheckoutcomCustomPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     CheckoutcomCustomPaymentMethod,
-    [
-        { gateway: 'checkoutcom', id: 'ideal' },
-        { gateway: 'checkoutcom', id: 'fawry' },
-        { gateway: 'checkoutcom', id: 'oxxo' },
-        { gateway: 'checkoutcom', id: 'boleto' },
-        { gateway: 'checkoutcom', id: 'sepa' },
-        { gateway: 'checkoutcom', id: 'qpay' },
-        { gateway: 'checkoutcom', id: 'p24' },
-    ],
+    [{ gateway: 'checkoutcom' }],
 );

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -290,6 +290,8 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
             id: 'hosted-credit-card',
         },
         { id: 'credit_card', gateway: 'bluesnapdirect' },
+        { id: 'credit_card', gateway: 'checkoutcom' },
+
         { id: 'tdonlinemart' },
     ],
 );


### PR DESCRIPTION
## What/Why?

to make it possible to use KNET and all the checkoutcom APMs, without using their id directly
For now the Knet redirect link is not working, we're in touch with their support to find the solution

## Rollout/Rollback
Revert this PR

## Testing

Before:
it was displayed as a credit card instead of redirecting to the redirect url
<img width="1722" height="1174" alt="image" src="https://github.com/user-attachments/assets/3c900bec-65d2-4920-9df2-4261aeaefb09" />

After:
<img width="1441" height="795" alt="Screenshot 2025-09-01 at 14 19 02" src="https://github.com/user-attachments/assets/20223085-a019-46bc-99b9-2940bcabda7c" />
<img width="796" height="385" alt="Screenshot 2025-09-01 at 14 23 16" src="https://github.com/user-attachments/assets/6c53321b-ca42-481c-a5b6-e51b604fbaf5" />

to make sure credit card is still working:

https://github.com/user-attachments/assets/24c5dbc9-de7e-4cfa-92f4-53bc9bab03f5

