### PR TITLE
feat(payment): checkout-sdk version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.790.0",
+        "@bigcommerce/checkout-sdk": "^1.792.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.790.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.790.0.tgz",
-      "integrity": "sha512-/YWKTuwRqxChOVZaQ6YwrtOho6XxaH2gHQe6FujMl+fE2VuwTu9McAIZVa2EglV6Q8IsMQRCYCwzy979ynxj0A==",
+      "version": "1.792.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.792.0.tgz",
+      "integrity": "sha512-NEcxOqZIMMb15sAf8iC/VBo84Mu1O5DDxgfIqB2fEg+mDu4ydSeo6+s8+d4RdKsbuf2ZOq524ljq8P8GkO8ZdQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.790.0",
+    "@bigcommerce/checkout-sdk": "^1.792.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version.
To deliver:
https://github.com/bigcommerce/checkout-sdk-js/pull/2986
https://github.com/bigcommerce/checkout-sdk-js/pull/2987

Related PR:
https://github.com/bigcommerce/bigcommerce/pull/64783

## Rollout/Rollback
Revert this PR

## Testing
Manual testing
