### PR TITLE
feat(checkout): CHECKOUT-9454 Convert GoogleAutocomplete

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { noop } from 'lodash';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { Autocomplete, type AutocompleteItem } from '../../ui/autocomplete';
 
@@ -49,10 +49,9 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     const [autoComplete, setAutoComplete] = useState<string>('off');
     const googleAutocompleteServiceRef = useRef<GoogleAutocompleteService>();
 
-    // Initialize the service
-    useEffect(() => {
+    if (!googleAutocompleteServiceRef.current) {
         googleAutocompleteServiceRef.current = new GoogleAutocompleteService(apiKey);
-    }, [apiKey]);
+    }
 
     const onSelectHandler = (item: AutocompleteItem) => {
         const service = googleAutocompleteServiceRef.current;


### PR DESCRIPTION
## What/Why?

Convert class component `GoogleAutocomplete` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
