### PR TITLE
refactor(checkout): CHECKOUT-9386 Convert ManageInstrumentsModal

### DIFF
--- a/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.test.tsx
+++ b/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.test.tsx
@@ -55,16 +55,6 @@ describe('ManageInstrumentsModal', () => {
         );
     });
 
-    it('throws an error if not wrapped in checkout context', () => {
-        expect(() =>
-            render(
-                <LocaleContext.Provider value={localeContext}>
-                    <ManageInstrumentsModal {...defaultProps} />
-                </LocaleContext.Provider>,
-            ),
-        ).toThrow('Need to wrap in checkout context');
-    });
-
     it('renders list of card instruments in table format', () => {
         render(
             <ManageInstrumentsModalTest

--- a/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.tsx
+++ b/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.tsx
@@ -1,6 +1,6 @@
 import { type PaymentInstrument } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
-import React, { type ReactElement, useCallback, useState } from 'react';
+import React, { type ReactElement, useState } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
@@ -78,10 +78,10 @@ const ManageInstrumentsModal = ({
         }
     };
 
-    const handleDeleteInstrument = useCallback((id: string): void => {
+    const handleDeleteInstrument = (id: string): void => {
         setIsConfirmingDelete(true);
         setSelectedInstrumentId(id);
-    }, []);
+    };
 
     const ModalContent = () => {
         if (isConfirmingDelete) {

--- a/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.tsx
+++ b/packages/instrument-utils/src/storedInstrument/ManageInstrumentsModal/ManageInstrumentsModal.tsx
@@ -1,9 +1,9 @@
 import { type PaymentInstrument } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
-import React, { Component, type ReactNode } from 'react';
+import React, { type ReactElement, useCallback, useState } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
-import { CheckoutContext } from '@bigcommerce/checkout/payment-integration-api';
+import { useCheckout } from '@bigcommerce/checkout/payment-integration-api';
 import { Button, ButtonSize, ButtonVariant, Modal, ModalHeader } from '@bigcommerce/checkout/ui';
 
 import {
@@ -26,71 +26,64 @@ export interface ManageInstrumentsModalProps {
     onRequestClose?(): void;
 }
 
-export interface ManageInstrumentsModalState {
-    isConfirmingDelete: boolean;
-    selectedInstrumentId?: string;
-}
+const ManageInstrumentsModal = ({
+    isOpen,
+    instruments,
+    onAfterOpen,
+    onDeleteInstrument = noop,
+    onDeleteInstrumentError = noop,
+    onRequestClose,
+}: ManageInstrumentsModalProps): ReactElement => {
+    const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+    const [selectedInstrumentId, setSelectedInstrumentId] = useState<string | undefined>();
 
-class ManageInstrumentsModal extends Component<
-    ManageInstrumentsModalProps,
-    ManageInstrumentsModalState
-> {
-    static contextType = CheckoutContext;
-    declare context: React.ContextType<typeof CheckoutContext>;
+    const {
+        checkoutState: {
+            errors: { getDeleteInstrumentError },
+            statuses: { isDeletingInstrument, isLoadingInstruments },
+        },
+        checkoutService: { deleteInstrument, clearError },
+    } = useCheckout();
 
-    state: ManageInstrumentsModalState = {
-        isConfirmingDelete: false,
+    const deleteInstrumentError = getDeleteInstrumentError();
+
+    const handleAfterOpen = (): void => {
+        setIsConfirmingDelete(false);
+        onAfterOpen?.();
     };
 
-    render(): ReactNode {
-        if (!this.context) {
-            throw Error('Need to wrap in checkout context');
+    const handleCancel = (): void => {
+        const existingError = getDeleteInstrumentError();
+
+        if (existingError) {
+            void clearError(existingError);
         }
 
-        const {
-            checkoutState: {
-                errors: { getDeleteInstrumentError },
-            },
-        } = this.context;
+        setIsConfirmingDelete(false);
+    };
 
-        const deleteInstrumentError = getDeleteInstrumentError();
-
-        const { isOpen, onRequestClose } = this.props;
-
-        return (
-            <Modal
-                closeButtonLabel={<TranslatedString id="common.close_action" />}
-                footer={this.renderFooter()}
-                header={
-                    <ModalHeader>
-                        <TranslatedString id="payment.instrument_manage_modal_title_text" />
-                    </ModalHeader>
-                }
-                isOpen={isOpen}
-                onAfterOpen={this.handleAfterOpen}
-                onRequestClose={onRequestClose}
-            >
-                {deleteInstrumentError && <ManageInstrumentsAlert error={deleteInstrumentError} />}
-
-                {this.renderContent()}
-            </Modal>
-        );
-    }
-
-    private renderContent(): ReactNode {
-        if (!this.context) {
-            throw Error('Need to wrap in checkout context');
+    const handleConfirmDelete = async (): Promise<void> => {
+        if (!selectedInstrumentId) {
+            return;
         }
 
-        const {
-            checkoutState: {
-                statuses: { isDeletingInstrument },
-            },
-        } = this.context;
-        const { instruments } = this.props;
+        try {
+            await deleteInstrument(selectedInstrumentId);
+            onDeleteInstrument(selectedInstrumentId);
+            onRequestClose?.();
+        } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error));
 
-        const { isConfirmingDelete } = this.state;
+            onDeleteInstrumentError(err);
+        }
+    };
 
+    const handleDeleteInstrument = useCallback((id: string): void => {
+        setIsConfirmingDelete(true);
+        setSelectedInstrumentId(id);
+    }, []);
+
+    const ModalContent = () => {
         if (isConfirmingDelete) {
             return (
                 <p>
@@ -109,7 +102,7 @@ class ManageInstrumentsModal extends Component<
                 <ManageAchInstrumentsTable
                     instruments={achInstrument}
                     isDeletingInstrument={isDeletingInstrument()}
-                    onDeleteInstrument={this.handleDeleteInstrument}
+                    onDeleteInstrument={handleDeleteInstrument}
                 />
             );
         }
@@ -121,7 +114,7 @@ class ManageInstrumentsModal extends Component<
                 <ManageAccountInstrumentsTable
                     instruments={bankAndAccountInstruments}
                     isDeletingInstrument={isDeletingInstrument()}
-                    onDeleteInstrument={this.handleDeleteInstrument}
+                    onDeleteInstrument={handleDeleteInstrument}
                 />
             );
         }
@@ -130,129 +123,60 @@ class ManageInstrumentsModal extends Component<
             <ManageCardInstrumentsTable
                 instruments={cardInstruments}
                 isDeletingInstrument={isDeletingInstrument()}
-                onDeleteInstrument={this.handleDeleteInstrument}
+                onDeleteInstrument={handleDeleteInstrument}
             />
         );
-    }
+    };
 
-    private renderFooter(): ReactNode {
-        if (!this.context) {
-            throw Error('Need to wrap in checkout context');
-        }
-
-        const {
-            checkoutState: {
-                statuses: { isDeletingInstrument, isLoadingInstruments },
-            },
-        } = this.context;
-
-        const { onRequestClose } = this.props;
-        const { isConfirmingDelete } = this.state;
-
-        if (isConfirmingDelete) {
-            return (
-                <>
-                    <Button
-                        onClick={this.handleCancel}
-                        size={ButtonSize.Small}
-                        testId="manage-instrument-cancel-button"
-                    >
-                        <TranslatedString id="common.cancel_action" />
-                    </Button>
-
-                    <Button
-                        disabled={isDeletingInstrument() || isLoadingInstruments()}
-                        onClick={this.handleConfirmDelete}
-                        size={ButtonSize.Small}
-                        testId="manage-instrument-confirm-button"
-                        variant={ButtonVariant.Primary}
-                    >
-                        <TranslatedString id="payment.instrument_manage_modal_confirmation_action" />
-                    </Button>
-                </>
-            );
-        }
-
-        return (
+    const ConfirmDelete = () => (
+        <>
             <Button
-                onClick={onRequestClose}
+                onClick={handleCancel}
                 size={ButtonSize.Small}
-                testId="manage-instrument-close-button"
+                testId="manage-instrument-cancel-button"
             >
-                <TranslatedString id="common.close_action" />
+                <TranslatedString id="common.cancel_action" />
             </Button>
-        );
-    }
 
-    private handleAfterOpen: () => void = () => {
-        const { onAfterOpen } = this.props;
+            <Button
+                disabled={isDeletingInstrument() || isLoadingInstruments()}
+                onClick={handleConfirmDelete}
+                size={ButtonSize.Small}
+                testId="manage-instrument-confirm-button"
+                variant={ButtonVariant.Primary}
+            >
+                <TranslatedString id="payment.instrument_manage_modal_confirmation_action" />
+            </Button>
+        </>
+    );
+    const CloseButton = () => (
+        <Button
+            onClick={onRequestClose}
+            size={ButtonSize.Small}
+            testId="manage-instrument-close-button"
+        >
+            <TranslatedString id="common.close_action" />
+        </Button>
+    );
 
-        this.setState(
-            {
-                isConfirmingDelete: false,
-            },
-            onAfterOpen,
-        );
-    };
+    return (
+        <Modal
+            closeButtonLabel={<TranslatedString id="common.close_action" />}
+            footer={isConfirmingDelete ? <ConfirmDelete /> : <CloseButton />}
+            header={
+                <ModalHeader>
+                    <TranslatedString id="payment.instrument_manage_modal_title_text" />
+                </ModalHeader>
+            }
+            isOpen={isOpen}
+            onAfterOpen={handleAfterOpen}
+            onRequestClose={onRequestClose}
+        >
+            {deleteInstrumentError && <ManageInstrumentsAlert error={deleteInstrumentError} />}
 
-    private handleCancel: () => void = () => {
-        if (!this.context) {
-            throw Error('Need to wrap in checkout context');
-        }
-
-        const {
-            checkoutState: {
-                errors: { getDeleteInstrumentError },
-            },
-            checkoutService: { clearError },
-        } = this.context;
-
-        const deleteInstrumentError = getDeleteInstrumentError();
-
-        if (deleteInstrumentError) {
-            void clearError(deleteInstrumentError);
-        }
-
-        this.setState({
-            isConfirmingDelete: false,
-        });
-    };
-
-    private handleConfirmDelete: () => void = async () => {
-        if (!this.context) {
-            throw Error('Need to wrap in checkout context');
-        }
-
-        const {
-            checkoutService: { deleteInstrument },
-        } = this.context;
-
-        const {
-            onDeleteInstrument = noop,
-            onDeleteInstrumentError = noop,
-            onRequestClose = noop,
-        } = this.props;
-        const { selectedInstrumentId } = this.state;
-
-        if (!selectedInstrumentId) {
-            return;
-        }
-
-        try {
-            await deleteInstrument(selectedInstrumentId);
-            onDeleteInstrument(selectedInstrumentId);
-            onRequestClose();
-        } catch (error) {
-            onDeleteInstrumentError(error);
-        }
-    };
-
-    private handleDeleteInstrument: (id: string) => void = (id) => {
-        this.setState({
-            isConfirmingDelete: true,
-            selectedInstrumentId: id,
-        });
-    };
-}
+            <ModalContent />
+        </Modal>
+    );
+};
 
 export default ManageInstrumentsModal;


### PR DESCRIPTION
## What/Why?

Convert class component `ManageInstrumentsModal` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert.

## Testing
### Manual Testing
#### Delete flow

https://github.com/user-attachments/assets/6715b9a6-ed05-4046-96fd-5ce1b7964ae1

#### Cancel flow

https://github.com/user-attachments/assets/429bc8d5-1feb-497a-a626-258f347cccd4