### PR TITLE
refactor(checkout): CHECKOUT-9386 Convert CreditCardPaymentMethodComponent

### DIFF
--- a/packages/credit-card-integration/.eslintrc.json
+++ b/packages/credit-card-integration/.eslintrc.json
@@ -11,6 +11,7 @@
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unnecessary-condition": "off",
     "@typescript-eslint/consistent-type-assertions": "off",
-    "@typescript-eslint/naming-convention": "off"
+    "@typescript-eslint/naming-convention": "off",
+    "react-hooks/exhaustive-deps": "off"
   }
 }

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.test.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.test.tsx
@@ -35,12 +35,13 @@ import {
     getPaymentMethod,
     getStoreConfig,
 } from '@bigcommerce/checkout/test-mocks';
-import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { renderWithoutWrapper as render, screen } from '@bigcommerce/checkout/test-utils';
 
-import CreditCardPaymentMethodComponent, {
+import { CreditCardPaymentMethodComponent } from './CreditCardPaymentMethodComponent';
+import {
     type CreditCardPaymentMethodProps,
     type CreditCardPaymentMethodValues,
-} from './CreditCardPaymentMethodComponent';
+} from './CreditCardPaymentMethodType';
 
 describe('CreditCardPaymentMethod', () => {
     let checkoutService: CheckoutService;

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -221,7 +221,10 @@ export const CreditCardPaymentMethodComponent = ({
     return (
         <LocaleContext.Provider value={createLocaleContext(config)}>
             <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                <div className="paymentMethod paymentMethod--creditCard">
+                <div
+                    className="paymentMethod paymentMethod--creditCard"
+                    data-test="credit-cart-payment-method"
+                >
                     {shouldShowInstrumentFieldset && (
                         <CardInstrumentFieldset
                             instruments={instruments}

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -1,321 +1,102 @@
-import {
-    type CardInstrument,
-    type CheckoutSelectors,
-    type HostedFieldType,
-    type Instrument,
-    type LegacyHostedFormOptions,
-    type PaymentInitializeOptions,
-    type PaymentInstrument,
-    type PaymentMethod,
-    type PaymentRequestOptions,
-} from '@bigcommerce/checkout-sdk';
-import { memoizeOne } from '@bigcommerce/memoize';
 import { find } from 'lodash';
-import React, { Component, type ReactNode } from 'react';
+import React, { type ReactElement, useEffect, useRef, useState } from 'react';
 import { type ObjectSchema } from 'yup';
 
 import {
     CardInstrumentFieldset,
     configureCardValidator,
     CreditCardFieldset,
-    type CreditCardFieldsetValues,
     CreditCardValidation,
     getCreditCardValidationSchema,
     getInstrumentValidationSchema,
+    isInstrumentFeatureAvailable as getIsInstrumentFeatureAvailable,
     isCardInstrument,
     isInstrumentCardCodeRequiredSelector,
     isInstrumentCardNumberRequiredSelector,
-    isInstrumentFeatureAvailable,
     StoreInstrumentFieldset,
 } from '@bigcommerce/checkout/instrument-utils';
 import { createLocaleContext, LocaleContext } from '@bigcommerce/checkout/locale';
-import {
-    type CardInstrumentFieldsetValues,
-    type PaymentMethodProps,
-} from '@bigcommerce/checkout/payment-integration-api';
+import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
 import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 
-export interface CreditCardPaymentMethodProps {
-    cardFieldset?: ReactNode;
-    cardValidationSchema?: ObjectSchema;
-    isInitializing?: boolean;
-    isUsingMultiShipping?: boolean;
-    storedCardValidationSchema?: ObjectSchema;
-    initializePayment(
-        options: PaymentInitializeOptions,
-        selectedInstrument?: CardInstrument,
-    ): Promise<CheckoutSelectors>;
-    deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
-    getHostedFormOptions?(selectedInstrument?: CardInstrument): Promise<LegacyHostedFormOptions>;
-    getStoredCardValidationFieldset?(selectedInstrument?: CardInstrument): ReactNode;
-}
+import { type CreditCardPaymentMethodProps } from './CreditCardPaymentMethodType';
 
-interface CreditCardPaymentMethodDerivedProps {
-    instruments: CardInstrument[];
-    isCardCodeRequired: boolean;
-    isCustomerCodeRequired: boolean;
-    isInstrumentFeatureAvailable: boolean;
-    isLoadingInstruments: boolean;
-    isPaymentDataRequired: boolean;
-    shouldShowInstrumentFieldset: boolean;
-    isInstrumentCardCodeRequired(instrument: Instrument, method: PaymentMethod): boolean;
-    isInstrumentCardNumberRequired(instrument: Instrument, method: PaymentMethod): boolean;
-    loadInstruments(): Promise<CheckoutSelectors>;
-}
+export const CreditCardPaymentMethodComponent = ({
+    cardFieldset,
+    cardValidationSchema,
+    checkoutService,
+    checkoutState,
+    deinitializePayment,
+    getStoredCardValidationFieldset,
+    initializePayment,
+    isInitializing,
+    isUsingMultiShipping = false,
+    language,
+    method,
+    onUnhandledError,
+    paymentForm: { setFieldValue, setValidationSchema },
+    storedCardValidationSchema,
+}: CreditCardPaymentMethodProps & PaymentMethodProps): ReactElement => {
+    const [isAddingNewCard, setIsAddingNewCard] = useState<boolean>(false);
+    const [selectedInstrumentId, setSelectedInstrumentId] = useState<string>();
 
-interface CreditCardPaymentMethodState {
-    focusedHostedFieldType?: HostedFieldType;
-    isAddingNewCard: boolean;
-    selectedInstrumentId?: string;
-}
+    const {
+        data: { getConfig, getCustomer, getInstruments, isPaymentDataRequired },
+        statuses: { isLoadingInstruments },
+    } = checkoutState;
+    const config = getConfig();
+    const customer = getCustomer();
 
-export type CreditCardPaymentMethodValues = CreditCardFieldsetValues | CardInstrumentFieldsetValues;
-
-class CreditCardPaymentMethodComponent extends Component<
-    CreditCardPaymentMethodProps & PaymentMethodProps
-> {
-    state: CreditCardPaymentMethodState = {
-        isAddingNewCard: false,
-    };
-
-    private filterInstruments = memoizeOne(
-        (instruments: PaymentInstrument[] = []): CardInstrument[] =>
-            instruments.filter(isCardInstrument),
-    );
-
-    async componentDidMount(): Promise<void> {
-        const {
-            initializePayment,
-            method,
-            onUnhandledError,
-            paymentForm: { setValidationSchema },
-        } = this.props;
-        const { isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp, loadInstruments } =
-            this.getCreditCardPaymentMethodDerivedProps();
-
-        setValidationSchema(method, this.getValidationSchema());
-        configureCardValidator();
-
-        try {
-            if (isInstrumentFeatureAvailableProp) {
-                await loadInstruments();
-            }
-
-            await initializePayment(
-                {
-                    gatewayId: method.gateway,
-                    methodId: method.id,
-                },
-                this.getSelectedInstrument(),
-            );
-        } catch (error) {
-            if (error instanceof Error) {
-                onUnhandledError(error);
-            }
-        }
+    if (!config || !customer || !method) {
+        throw new Error('Unable to get checkout');
     }
 
-    async componentWillUnmount(): Promise<void> {
-        const {
-            deinitializePayment,
-            method,
-            onUnhandledError,
-            paymentForm: { setValidationSchema },
-        } = this.props;
-
-        setValidationSchema(method, null);
-
-        try {
-            await deinitializePayment({
-                gatewayId: method.gateway,
-                methodId: method.id,
-            });
-        } catch (error) {
-            if (error instanceof Error) {
-                onUnhandledError(error);
-            }
-        }
-    }
-
-    async componentDidUpdate(
-        _prevProps: Readonly<CreditCardPaymentMethodProps>,
-        prevState: Readonly<CreditCardPaymentMethodState>,
-    ): Promise<void> {
-        const {
-            deinitializePayment,
-            initializePayment,
-            method,
-            onUnhandledError,
-            paymentForm: { setValidationSchema },
-        } = this.props;
-
-        const { isAddingNewCard, selectedInstrumentId } = this.state;
-
-        setValidationSchema(method, this.getValidationSchema());
-
-        if (
-            selectedInstrumentId !== prevState.selectedInstrumentId ||
-            isAddingNewCard !== prevState.isAddingNewCard
-        ) {
-            try {
-                await deinitializePayment({
-                    gatewayId: method.gateway,
-                    methodId: method.id,
-                });
-
-                await initializePayment(
-                    {
-                        gatewayId: method.gateway,
-                        methodId: method.id,
-                    },
-                    this.getSelectedInstrument(),
-                );
-            } catch (error) {
-                if (error instanceof Error) {
-                    onUnhandledError(error);
-                }
-            }
-        }
-    }
-
-    render(): ReactNode {
-        const {
-            checkoutState,
-            cardFieldset,
-            getStoredCardValidationFieldset,
-            isInitializing,
-            method,
-        } = this.props;
-        const {
-            instruments,
-            isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
-            isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
-            isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
-            isLoadingInstruments,
-            shouldShowInstrumentFieldset,
-        } = this.getCreditCardPaymentMethodDerivedProps();
-        const {
-            data: { getConfig },
-        } = checkoutState;
-
-        const { isAddingNewCard } = this.state;
-
-        const selectedInstrument = this.getSelectedInstrument();
-        const shouldShowCreditCardFieldset = !shouldShowInstrumentFieldset || isAddingNewCard;
-        const isLoading = isInitializing || isLoadingInstruments;
-        const shouldShowNumberField = selectedInstrument
-            ? isInstrumentCardNumberRequiredProp(selectedInstrument, method)
-            : false;
-        const shouldShowCardCodeField = selectedInstrument
-            ? isInstrumentCardCodeRequiredProp(selectedInstrument, method)
-            : false;
-
-        const storeConfig = getConfig();
-
-        if (!storeConfig) {
-            throw Error('Unable to get config or customer');
-        }
-
-        return (
-            <LocaleContext.Provider value={createLocaleContext(storeConfig)}>
-                <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                    <div
-                        className="paymentMethod paymentMethod--creditCard"
-                        data-test="credit-cart-payment-method"
-                    >
-                        {shouldShowInstrumentFieldset && (
-                            <CardInstrumentFieldset
-                                instruments={instruments}
-                                onDeleteInstrument={this.handleDeleteInstrument}
-                                onSelectInstrument={this.handleSelectInstrument}
-                                onUseNewInstrument={this.handleUseNewCard}
-                                selectedInstrumentId={
-                                    selectedInstrument && selectedInstrument.bigpayToken
-                                }
-                                validateInstrument={
-                                    getStoredCardValidationFieldset ? (
-                                        getStoredCardValidationFieldset(selectedInstrument)
-                                    ) : (
-                                        <CreditCardValidation
-                                            shouldShowCardCodeField={shouldShowCardCodeField}
-                                            shouldShowNumberField={shouldShowNumberField}
-                                        />
-                                    )
-                                }
-                            />
-                        )}
-
-                        {shouldShowCreditCardFieldset && !cardFieldset && (
-                            <CreditCardFieldset
-                                shouldShowCardCodeField={
-                                    method.config.cardCode || method.config.cardCode === null
-                                }
-                                shouldShowCustomerCodeField={method.config.requireCustomerCode}
-                            />
-                        )}
-
-                        {shouldShowCreditCardFieldset && cardFieldset}
-
-                        {isInstrumentFeatureAvailableProp && (
-                            <StoreInstrumentFieldset
-                                instrumentId={selectedInstrument && selectedInstrument.bigpayToken}
-                                instruments={instruments}
-                            />
-                        )}
-                    </div>
-                </LoadingOverlay>
-            </LocaleContext.Provider>
-        );
-    }
-
-    private getSelectedInstrument(): CardInstrument | undefined {
-        const { instruments } = this.getCreditCardPaymentMethodDerivedProps();
-        const { selectedInstrumentId = this.getDefaultInstrumentId() } = this.state;
-
-        return find(instruments, { bigpayToken: selectedInstrumentId });
-    }
-
-    private getDefaultInstrumentId(): string | undefined {
-        const { isAddingNewCard } = this.state;
-
+    const instruments = getInstruments(method)?.filter(isCardInstrument) ?? [];
+    const isInstrumentFeatureAvailable = getIsInstrumentFeatureAvailable({
+        config,
+        customer,
+        isUsingMultiShipping,
+        paymentMethod: method,
+    });
+    const isInstrumentCardCodeRequired = isInstrumentCardCodeRequiredSelector(checkoutState);
+    const isInstrumentCardNumberRequired = isInstrumentCardNumberRequiredSelector(checkoutState);
+    const loadInstruments = checkoutService.loadInstruments;
+    const shouldShowInstrumentFieldset = isInstrumentFeatureAvailable && instruments.length > 0;
+    const shouldShowCreditCardFieldset = !shouldShowInstrumentFieldset || isAddingNewCard;
+    const isLoading = isInitializing || isLoadingInstruments();
+    const getDefaultInstrumentId = (): string | undefined => {
         if (isAddingNewCard) {
             return;
         }
-
-        const { instruments } = this.getCreditCardPaymentMethodDerivedProps();
 
         const defaultInstrument =
             instruments.find((instrument) => instrument.defaultInstrument) || instruments[0];
 
         return defaultInstrument && defaultInstrument.bigpayToken;
-    }
+    };
+    const selectedInstrument = find(instruments, {
+        bigpayToken: selectedInstrumentId || getDefaultInstrumentId(),
+    });
+    const shouldShowNumberField = selectedInstrument
+        ? isInstrumentCardNumberRequired(selectedInstrument, method)
+        : false;
+    const shouldShowCardCodeField = selectedInstrument
+        ? isInstrumentCardCodeRequired(selectedInstrument, method)
+        : false;
 
-    private getValidationSchema(): ObjectSchema | null {
-        const { cardValidationSchema, language, method, storedCardValidationSchema } = this.props;
-        const {
-            isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredProp,
-            isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredProp,
-            isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
-            isPaymentDataRequired,
-        } = this.getCreditCardPaymentMethodDerivedProps();
-
-        if (!isPaymentDataRequired) {
+    const getValidationSchema = (): ObjectSchema | null => {
+        if (!isPaymentDataRequired()) {
             return null;
         }
 
-        const selectedInstrument = this.getSelectedInstrument();
-
-        if (isInstrumentFeatureAvailableProp && selectedInstrument) {
+        if (isInstrumentFeatureAvailable && selectedInstrument) {
             return (
                 storedCardValidationSchema ||
                 getInstrumentValidationSchema({
                     instrumentBrand: selectedInstrument.brand,
                     instrumentLast4: selectedInstrument.last4,
-                    isCardCodeRequired: isInstrumentCardCodeRequiredProp(
-                        selectedInstrument,
-                        method,
-                    ),
-                    isCardNumberRequired: isInstrumentCardNumberRequiredProp(
+                    isCardCodeRequired: isInstrumentCardCodeRequired(selectedInstrument, method),
+                    isCardNumberRequired: isInstrumentCardNumberRequired(
                         selectedInstrument,
                         method,
                     ),
@@ -331,82 +112,157 @@ class CreditCardPaymentMethodComponent extends Component<
                 language,
             })
         );
-    }
-
-    private handleUseNewCard: () => void = () => {
-        this.setState({
-            isAddingNewCard: true,
-            selectedInstrumentId: undefined,
-        });
     };
 
-    private handleSelectInstrument: (id: string) => void = (id) => {
-        this.setState({
-            isAddingNewCard: false,
-            selectedInstrumentId: id,
-        });
+    const handleUseNewCard = (): void => {
+        setIsAddingNewCard(true);
+        setSelectedInstrumentId(undefined);
     };
 
-    private handleDeleteInstrument: (id: string) => void = (id) => {
-        const {
-            paymentForm: { setFieldValue },
-        } = this.props;
-        const { instruments } = this.getCreditCardPaymentMethodDerivedProps();
-        const { selectedInstrumentId } = this.state;
+    const handleSelectInstrument = (id: string): void => {
+        setIsAddingNewCard(false);
+        setSelectedInstrumentId(id);
+    };
 
+    const handleDeleteInstrument = (id: string): void => {
         if (instruments.length === 0) {
-            this.setState({
-                isAddingNewCard: true,
-                selectedInstrumentId: undefined,
-            });
-
+            setIsAddingNewCard(true);
+            setSelectedInstrumentId(undefined);
             setFieldValue('instrumentId', '');
         } else if (selectedInstrumentId === id) {
-            this.setState({
-                selectedInstrumentId: this.getDefaultInstrumentId(),
-            });
+            const defaultInstrumentId = getDefaultInstrumentId();
 
-            setFieldValue('instrumentId', this.getDefaultInstrumentId());
+            setSelectedInstrumentId(defaultInstrumentId);
+            setFieldValue('instrumentId', defaultInstrumentId);
         }
     };
 
-    private getCreditCardPaymentMethodDerivedProps(): CreditCardPaymentMethodDerivedProps {
-        const { checkoutService, checkoutState, isUsingMultiShipping = false, method } = this.props;
+    useEffect(() => {
+        const init = async () => {
+            setValidationSchema(method, getValidationSchema());
+            configureCardValidator();
 
-        const {
-            data: { getConfig, getCustomer, getInstruments, isPaymentDataRequired },
-            statuses: { isLoadingInstruments },
-        } = checkoutState;
+            try {
+                if (isInstrumentFeatureAvailable) {
+                    await loadInstruments();
+                }
 
-        const config = getConfig();
-        const customer = getCustomer();
+                await initializePayment(
+                    {
+                        gatewayId: method.gateway,
+                        methodId: method.id,
+                    },
+                    selectedInstrument,
+                );
+            } catch (error) {
+                if (error instanceof Error) {
+                    onUnhandledError(error);
+                }
+            }
+        };
 
-        if (!config || !customer || !method) {
-            throw new Error('Unable to get checkout');
+        void init();
+
+        return () => {
+            const deInit = async () => {
+                try {
+                    setValidationSchema(method, null);
+
+                    await deinitializePayment({
+                        gatewayId: method.gateway,
+                        methodId: method.id,
+                    });
+                } catch (error) {
+                    if (error instanceof Error) {
+                        onUnhandledError(error);
+                    }
+                }
+            };
+
+            void deInit();
+        };
+    }, []);
+
+    const isInitialRenderRef = useRef(true);
+
+    useEffect(() => {
+        if (isInitialRenderRef.current) {
+            isInitialRenderRef.current = false;
+
+            return;
         }
 
-        const instruments = this.filterInstruments(getInstruments(method));
-        const isInstrumentFeatureAvailableProp = isInstrumentFeatureAvailable({
-            config,
-            customer,
-            isUsingMultiShipping,
-            paymentMethod: method,
-        });
+        const reInit = async () => {
+            try {
+                setValidationSchema(method, getValidationSchema());
 
-        return {
-            instruments,
-            isCardCodeRequired: method.config.cardCode || method.config.cardCode === null,
-            isCustomerCodeRequired: !!method.config.requireCustomerCode,
-            isInstrumentCardCodeRequired: isInstrumentCardCodeRequiredSelector(checkoutState),
-            isInstrumentCardNumberRequired: isInstrumentCardNumberRequiredSelector(checkoutState),
-            isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
-            isLoadingInstruments: isLoadingInstruments(),
-            isPaymentDataRequired: isPaymentDataRequired(),
-            loadInstruments: checkoutService.loadInstruments,
-            shouldShowInstrumentFieldset:
-                isInstrumentFeatureAvailableProp && instruments.length > 0,
+                await deinitializePayment({
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                });
+
+                await initializePayment(
+                    {
+                        gatewayId: method.gateway,
+                        methodId: method.id,
+                    },
+                    selectedInstrument,
+                );
+            } catch (error: unknown) {
+                if (error instanceof Error) {
+                    onUnhandledError(error);
+                }
+            }
         };
-    }
-}
 
-export default CreditCardPaymentMethodComponent;
+        void reInit();
+    }, [selectedInstrumentId, isAddingNewCard]);
+
+    return (
+        <LocaleContext.Provider value={createLocaleContext(config)}>
+            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                <div className="paymentMethod paymentMethod--creditCard">
+                    {shouldShowInstrumentFieldset && (
+                        <CardInstrumentFieldset
+                            instruments={instruments}
+                            onDeleteInstrument={handleDeleteInstrument}
+                            onSelectInstrument={handleSelectInstrument}
+                            onUseNewInstrument={handleUseNewCard}
+                            selectedInstrumentId={
+                                selectedInstrument && selectedInstrument.bigpayToken
+                            }
+                            validateInstrument={
+                                getStoredCardValidationFieldset ? (
+                                    getStoredCardValidationFieldset(selectedInstrument)
+                                ) : (
+                                    <CreditCardValidation
+                                        shouldShowCardCodeField={shouldShowCardCodeField}
+                                        shouldShowNumberField={shouldShowNumberField}
+                                    />
+                                )
+                            }
+                        />
+                    )}
+
+                    {shouldShowCreditCardFieldset && !cardFieldset && (
+                        <CreditCardFieldset
+                            shouldShowCardCodeField={
+                                method.config.cardCode || method.config.cardCode === null
+                            }
+                            shouldShowCustomerCodeField={method.config.requireCustomerCode}
+                        />
+                    )}
+
+                    {shouldShowCreditCardFieldset && cardFieldset}
+
+                    {isInstrumentFeatureAvailable && (
+                        <StoreInstrumentFieldset
+                            instrumentId={selectedInstrument && selectedInstrument.bigpayToken}
+                            instruments={instruments}
+                        />
+                    )}
+                </div>
+            </LoadingOverlay>
+        </LocaleContext.Provider>
+    );
+};

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodType.ts
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodType.ts
@@ -1,0 +1,33 @@
+import {
+    type CardInstrument,
+    type CheckoutSelectors,
+    type LegacyHostedFormOptions,
+    type PaymentInitializeOptions,
+    type PaymentRequestOptions,
+} from '@bigcommerce/checkout-sdk';
+import { type ReactNode } from 'react';
+import { type ObjectSchema } from 'yup';
+
+import { type CreditCardFieldsetValues } from '@bigcommerce/checkout/instrument-utils';
+import { type CardInstrumentFieldsetValues } from '@bigcommerce/checkout/payment-integration-api';
+
+export interface CreditCardPaymentMethodProps {
+    cardFieldset?: ReactNode;
+    cardValidationSchema?: ObjectSchema;
+    isInitializing?: boolean;
+    isUsingMultiShipping?: boolean;
+    storedCardValidationSchema?: ObjectSchema;
+
+    initializePayment(
+        options: PaymentInitializeOptions,
+        selectedInstrument?: CardInstrument,
+    ): Promise<CheckoutSelectors>;
+
+    deinitializePayment(options: PaymentRequestOptions): Promise<CheckoutSelectors>;
+
+    getHostedFormOptions?(selectedInstrument?: CardInstrument): Promise<LegacyHostedFormOptions>;
+
+    getStoredCardValidationFieldset?(selectedInstrument?: CardInstrument): ReactNode;
+}
+
+export type CreditCardPaymentMethodValues = CreditCardFieldsetValues | CardInstrumentFieldsetValues;

--- a/packages/credit-card-integration/src/index.ts
+++ b/packages/credit-card-integration/src/index.ts
@@ -1,5 +1,5 @@
+export { CreditCardPaymentMethodComponent } from './CreditCardPaymentMethodComponent';
 export {
-    default as CreditCardPaymentMethodComponent,
     CreditCardPaymentMethodProps,
     CreditCardPaymentMethodValues,
-} from './CreditCardPaymentMethodComponent';
+} from './CreditCardPaymentMethodType';


### PR DESCRIPTION
## What/Why?

Re-release https://github.com/bigcommerce/checkout-js/pull/2530 with updated dependencies due to an incident.

Convert class component `CreditCardPaymentMethodComponent` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert.

## Testing
### CI.
### Manual Testing
Bluesnap (The CC form fields freezing is a known issue)

https://github.com/user-attachments/assets/086eeaac-da33-42ae-bbcd-c8bb98df76ad

Access Worldpay

https://github.com/user-attachments/assets/5dd9e06a-8f5e-4637-9a63-58c23edfcc4c