### PR TITLE
refactor(checkout): CHECKOUT-9386 Improve e2e CI Job Performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ orbs:
 executors:
   playwright_executor:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.55.0-noble
+      - image: mcr.microsoft.com/playwright:v1.52.0-noble
 
 jobs:
   test-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ orbs:
   security: bigcommerce/internal-security@volatile
   microapp: bigcommerce/internal-microapp@volatile
 
+executors:
+  playwright_executor:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.55.0-noble
+
 jobs:
   test-packages:
     <<: *node_executor
@@ -125,18 +130,14 @@ jobs:
             - dist
 
   e2e:
-    <<: *node_executor
+    executor: playwright_executor
     parallelism: 2
     resource_class: medium+
     steps:
       - ci/pre-setup
       - node/npm-install
-      - run:
-          name: "Build checkout-js"
-          command: npm run build
-      - run:
-          name: "Install playwright"
-          command: npx playwright install --with-deps
+      - attach_workspace:
+          at: .
       - run:
           name: "Run e2e tests"
           command: |
@@ -240,6 +241,8 @@ workflows:
       - e2e:
           filters:
             <<: *pull_request_filter
+          requires:
+            - build-prerelease
       - sdk-on-cdn:
           filters:
             <<: *pull_request_filter
@@ -288,6 +291,8 @@ workflows:
       - e2e:
           filters:
             <<: *release_filter
+          requires:
+            - build
       - security/scan:
           name: "Gitleaks secrets scan"
           filters:


### PR DESCRIPTION
## What/Why?

- Using an existing docker image with playwright to skip installing playwright on every run.
- Reuse the `/dist` artifacts from the `build` job, therefore, only build once, `e2e` job will start following a successful `build` run.

## Rollout/Rollback

Revert.

## Testing
Running time before
<img width="939" height="32" alt="image" src="https://github.com/user-attachments/assets/3d98a7ba-7e9f-42bd-9a92-8e13dae168e7" />

Running time after
<img width="939" height="32" alt="image" src="https://github.com/user-attachments/assets/550bfddf-eff4-4095-b746-1d69e862f638" />


