### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.793.0",
+        "@bigcommerce/checkout-sdk": "^1.793.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.793.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.793.0.tgz",
-      "integrity": "sha512-wYE7Hlf7eu04Be66VzJ8M6bImM64zlCj/f4WZUnRw2Qw1oXpnuwlLM1I9fKIIbkS46x6xuxNYAQD6SH6i3ZWRw==",
+      "version": "1.793.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.793.1.tgz",
+      "integrity": "sha512-WfP/dn4nwwc7nHU6Fwb9y8lpzFB5UOKxpHhIjmKjLyEZfVR9cashLiBxuHZ3B0eLhBxIhXaxA19CxLCK2IKIow==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.793.0",
+    "@bigcommerce/checkout-sdk": "^1.793.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdj-js version
to deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/2991](https://github.com/bigcommerce/checkout-sdk-js/pull/2991)

## Rollout/Rollback
Rollback this PR and all related

## Testing
Manually tested and unit tests
