### PR TITLE
feat(checkout): CHECKOUT-8973 Display "show password" toggle in the desktop view on the checkout page

### DIFF
--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -229,12 +229,6 @@
         font-weight: $legend-font-weight;
     }
 
-    .form-toggle-password {
-        @include breakpoint("large") {
-            display: none;
-        }
-    }
-
     .form-field-password {
         position: relative;
     }


### PR DESCRIPTION
## What/Why?

**What?** Display "show password" toggle in the desktop view on the checkout page.
**Why?** We currently display the “show password” toggle in password field in the mobile view. But we don’t display it in the “desktop view”

## Rollout/Rollback
Revert this PR.

## Testing

- Manual testing

**BEFORE**
<img width="1698" height="892" alt="Screenshot 2025-09-08 at 4 11 05 pm" src="https://github.com/user-attachments/assets/1d962126-dd99-4d5d-8d85-5342837d778a" />


**AFTER**
<img width="1712" height="891" alt="Screenshot 2025-09-08 at 4 09 39 pm" src="https://github.com/user-attachments/assets/9704bbcc-34be-4544-8097-f882afc6e57a" />
