### PR TITLE
fix(payment): Stripe OCS fix accordion item toggle

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -233,6 +233,28 @@ describe('when using Stripe OCS payment', () => {
         );
     });
 
+    it('should show submit button', () => {
+        const hidePaymentSubmitButtonMock = jest.fn();
+        const props = {
+            ...defaultProps,
+            paymentForm: {
+                ...defaultProps.paymentForm,
+                hidePaymentSubmitButton: hidePaymentSubmitButtonMock,
+            },
+        };
+
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
+            (options: WithStripeOCSPaymentInitializeOptions) => {
+                options.stripeocs?.render();
+
+                return Promise.resolve(checkoutState);
+            },
+        );
+        render(<PaymentMethodTest {...props} method={method} />);
+
+        expect(hidePaymentSubmitButtonMock).toHaveBeenCalledWith(method, false);
+    });
+
     describe('# Stripe OCS accordion layout', () => {
         it('accordion collapsed when selected different payment method', () => {
             accordionContextValues.selectedItemId = 'nonStripeItem';

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -33,18 +33,31 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 }) => {
     const collapseStripeElement = useRef<() => void>();
     const { onToggle, selectedItemId } = useContext(AccordionContext);
+    const [selectedPaymentMethodId, setSelectedPaymentMethodId] = useState<string | undefined>(
+        selectedItemId,
+    );
     const [isOCSLoading, setIsOCSLoading] = useState(false);
     const methodSelector = `${method.gateway}-${method.id}`;
     const containerId = `${methodSelector}-component-field`;
     const paymentContext = paymentForm;
 
     useEffect(() => {
-        if (selectedItemId?.includes(`${method.gateway}-`)) {
+        if (selectedItemId === methodSelector) {
             return;
         }
 
+        setSelectedPaymentMethodId(selectedItemId);
         collapseStripeElement.current?.();
-    }, [selectedItemId, method.gateway]);
+    }, [selectedItemId, methodSelector]);
+
+    useEffect(() => {
+        if (selectedPaymentMethodId !== methodSelector) {
+            return;
+        }
+
+        onToggle(selectedPaymentMethodId);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedPaymentMethodId, methodSelector]);
 
     const renderSubmitButton = useCallback(() => {
         paymentContext.hidePaymentSubmitButton(method, false);
@@ -85,7 +98,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     fonts: getFonts(),
                     onError: onUnhandledError,
                     render: renderSubmitButton,
-                    paymentMethodSelect: onToggle,
+                    paymentMethodSelect: setSelectedPaymentMethodId,
                     handleClosePaymentMethod: (collapseElement: () => void) => {
                         collapseStripeElement.current = collapseElement;
                     },
@@ -100,7 +113,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             checkoutService,
             onUnhandledError,
             renderSubmitButton,
-            onToggle,
+            setSelectedPaymentMethodId,
             setIsOCSLoading,
         ],
     );


### PR DESCRIPTION
## What/Why?
• Fix Stripe accordion toggle action, for show correct selected payment method method.
• Increase unit test coverage

## Rollout/Rollback
Rollback this PR

## Testing
Before:

https://github.com/user-attachments/assets/1cf709fa-9604-4275-9346-1a0b2d2239f8


After:

https://github.com/user-attachments/assets/b49539c0-4629-4eb9-b96d-725c8a0eee7f


https://github.com/user-attachments/assets/fc3b7b61-328c-438c-b8e9-69b42cb2bdb5


Unit test coverage:
<img width="728" height="86" alt="Screenshot 2025-09-08 at 14 18 25" src="https://github.com/user-attachments/assets/e277d5b7-3b46-4c53-866f-f009e99c8218" />

