### PR TITLE
chore(checkout): CHECKOUT-9493 Update windcave hosted form to work with buy now cart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.794.0",
+        "@bigcommerce/checkout-sdk": "^1.794.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.794.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.794.0.tgz",
-      "integrity": "sha512-9ZrDMxY9UkPi0ZxKyXEDbr0U/I5k6Ul+nIS3L7iPqg6pabJIgQ2Xzc0Wl77bUgvTjVtFezU0gIuUIZWpFb/v9w==",
+      "version": "1.794.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.794.3.tgz",
+      "integrity": "sha512-2yYM08SiY8s3tbDc9RmugQtuzlPOs/KP99UjLuozPyJVFkOevgLZDC/UQpWp0Yv6a6aw7GoZHJBywZ+06hnr0Q==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.794.0",
+    "@bigcommerce/checkout-sdk": "^1.794.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump SDK to release https://github.com/bigcommerce/checkout-sdk-js/pull/2998
This update in SDK applies the change to hosted forms for windcave to work for buy now carts.

## Rollout/Rollback
- revert

## Testing
- CI
- Screencast

#### buy now cart
https://github.com/user-attachments/assets/353dd419-5329-454e-9770-31d7b31db61d

#### primary cart


https://github.com/user-attachments/assets/12819b1a-8cae-4488-9bee-ddd352064382


