### PR TITLE
fix(payment): fixed the issue with infinite loading of vaulted instruments during HostedPaymentMethodComponent rendering process

### DIFF
--- a/packages/hosted-payment-integration/src/components/HostedPaymentComponent.tsx
+++ b/packages/hosted-payment-integration/src/components/HostedPaymentComponent.tsx
@@ -114,6 +114,7 @@ const HostedPaymentMethodComponent: React.FC<HostedPaymentComponentProps> = (pro
         instruments,
         isNewAddress,
         isInstrumentFeatureAvailable: isInstrumentFeatureAvailableProp,
+        loadInstruments,
     } = derivedProps;
 
     const getDefaultInstrument = useCallback((): AccountInstrument | undefined => {
@@ -146,7 +147,7 @@ const HostedPaymentMethodComponent: React.FC<HostedPaymentComponentProps> = (pro
                 });
 
                 if (isInstrumentFeatureAvailableProp) {
-                    await derivedProps.loadInstruments();
+                    await loadInstruments();
                 }
             } catch (error) {
                 onUnhandledError(error);
@@ -154,16 +155,7 @@ const HostedPaymentMethodComponent: React.FC<HostedPaymentComponentProps> = (pro
         };
 
         void initializePaymentAsync();
-    }, [
-        initializePayment,
-        method.gateway,
-        method.id,
-        isInstrumentFeatureAvailableProp,
-        derivedProps,
-        onUnhandledError,
-    ]);
 
-    useEffect(() => {
         return () => {
             const deinitializePaymentAsync = async () => {
                 try {
@@ -178,7 +170,8 @@ const HostedPaymentMethodComponent: React.FC<HostedPaymentComponentProps> = (pro
 
             void deinitializePaymentAsync();
         };
-    }, [deinitializePayment, method.gateway, method.id, onUnhandledError]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const currentSelectedInstrument = selectedInstrument || getDefaultInstrument();
     const isLoading = isInitializing || isLoadingInstruments;


### PR DESCRIPTION
## What/Why?
Fixed the issue with infinite loading of vaulted instruments during HostedPaymentMethodComponent rendering process, to be able to use PayPal Vaulted instruments and make payments

## Rollout/Rollback
Merge / revert

## Testing
Unit tests
Manual tests

Before:

https://github.com/user-attachments/assets/aaca28d1-8b94-4f11-8eb5-6cf2a22c9936

After: 

https://github.com/user-attachments/assets/b9ee078b-8458-4067-b42b-3b2c670faf97


