### PR TITLE
feat(checkout): CHECKOUT-9428 Remove Scroll Bars from Error Modal

### DIFF
--- a/packages/core/src/scss/components/foundation/modal/_modal.scss
+++ b/packages/core/src/scss/components/foundation/modal/_modal.scss
@@ -174,7 +174,7 @@
 // Specific styles for displaying cart summary on mobile
 body.has-activeModal {
     .modal-body {
-        overflow: scroll;
+        overflow: auto;
         padding-bottom: 20%; // This is to fill the space occupied by Safari and Chrome's navigation bar on mobile
 
         @include breakpoint("small") {


### PR DESCRIPTION
## What/Why?

Remove unnecessary scroll bars from the checkout page's generic error modal.

Please note: in MacOS, scroll bars only always show up when "Show scroll bars" is set to "Always".

<img width="300" height="558" alt="image" src="https://github.com/user-attachments/assets/d2ca605b-5d45-414a-9bf0-5f0997930425" />


## Rollout/Rollback

CI.

## Testing
### Manual testing
#### Before
<img width="3014" height="1642" alt="Screenshot 2025-09-17 at 14 48 32" src="https://github.com/user-attachments/assets/a2594ef3-5275-4087-bd76-811f17fc6677" />

#### After
<img width="3014" height="1642" alt="Screenshot 2025-09-17 at 14 48 08" src="https://github.com/user-attachments/assets/1e6ec6f7-706f-4b47-a2a4-482b047add96" />