### PR TITLE
feat(checkout): CHECKOUT-9468 convert ShippingOptionsForm

### DIFF
--- a/packages/core/src/app/shipping/ShippingComponent.test.tsx
+++ b/packages/core/src/app/shipping/ShippingComponent.test.tsx
@@ -8,6 +8,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import React, { type FunctionComponent } from 'react';
 
+import { AnalyticsProviderMock } from '@bigcommerce/checkout/analytics';
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import {
@@ -121,9 +122,11 @@ describe('Shipping component', () => {
         ComponentTest = (props) => (
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
-                    <ExtensionProvider checkoutService={checkoutService} errorLogger={errorLogger} >
-                        <Shipping {...props} />
-                    </ExtensionProvider>
+                    <AnalyticsProviderMock>
+                        <ExtensionProvider checkoutService={checkoutService} errorLogger={errorLogger} >
+                            <Shipping {...props} />
+                        </ExtensionProvider>
+                    </AnalyticsProviderMock>
                 </LocaleContext.Provider>
             </CheckoutProvider>
         );


### PR DESCRIPTION
## What/Why?

Convert class component `ShippingOptionsForm` into function component.

Replacing class components with function components eliminates the need for traditional lifecycle methods and enables full adoption of React 18 features like hooks and concurrent rendering.

This modernization aligns with React’s roadmap and ensures greater compatibility with future updates.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

https://github.com/user-attachments/assets/12d5d5d4-aa6c-464d-8cc9-3df315ad8fc0


