### PR TITLE
feat(checkout): CHECKOUT-9468 remove guest message from multi shipping header

### DIFF
--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -186,7 +186,6 @@ class Shipping extends Component<ShippingProps & WithCheckoutShippingProps & Ext
                     />
                     <ShippingHeader
                         cartHasPromotionalItems={cartHasPromotionalItems}
-                        isGuest={isGuest}
                         isMultiShippingMode={isMultiShippingMode}
                         onMultiShippingChange={this.handleMultiShippingModeSwitch}
                         shouldShowMultiShipping={shouldShowMultiShipping}

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -13,7 +13,6 @@ import './ShippingHeader.scss';
 
 interface ShippingHeaderProps {
     isMultiShippingMode: boolean;
-    isGuest: boolean;
     shouldShowMultiShipping: boolean;
     onMultiShippingChange(): void;
     cartHasPromotionalItems?: boolean;
@@ -21,7 +20,6 @@ interface ShippingHeaderProps {
 
 const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
     isMultiShippingMode,
-    isGuest,
     onMultiShippingChange,
     shouldShowMultiShipping,
     cartHasPromotionalItems,
@@ -47,9 +45,7 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
                     <TranslatedString
                         id={
                             isMultiShippingMode
-                                ? isGuest
-                                    ? 'shipping.multishipping_address_heading_guest'
-                                    : 'shipping.multishipping_address_heading'
+                                ? 'shipping.multishipping_address_heading'
                                 : 'shipping.shipping_address_heading'
                         }
                     />

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.tsx
@@ -52,12 +52,10 @@ const StripeShipping = ({
   const {
     data: {
       getCheckout,
-      getCustomer,
       getShippingAddressFields,
     },
   } = checkoutState;
   const checkout = getCheckout();
-  const customer = getCustomer();
   const getFields = getShippingAddressFields;
 
   const [isStripeLoading, setIsStripeLoading] = useState(true);
@@ -71,12 +69,11 @@ const StripeShipping = ({
     setIsStripeAutoStep(true);
   };
 
-  if (!checkout || !customer) {
+  if (!checkout) {
     return null;
   }
 
   const customerMessage = checkout.customerMessage;
-  const isGuest = customer.isGuest;
 
   return (
     <>
@@ -86,7 +83,6 @@ const StripeShipping = ({
         style={{ display: isStripeAutoStep || isStripeLoading ? 'none' : undefined }}
       >
         <ShippingHeader
-          isGuest={isGuest}
           isMultiShippingMode={isMultiShippingMode}
           onMultiShippingChange={onMultiShippingChange}
           shouldShowMultiShipping={shouldShowMultiShipping}


### PR DESCRIPTION
## What/Why?

Remove guest message from multi shipping header, since we have enabled multi shipping for guest customer and they don't need to sign in.

## Rollout/Rollback

Revert this PR

## Testing

- CI checks
- Manual testing
**BEFORE**

<img width="1401" height="816" alt="Screenshot 2025-09-18 at 11 02 01 am" src="https://github.com/user-attachments/assets/537dc02d-f656-4c8c-92d7-f619aeac5959" />


**AFTER**
<img width="1421" height="816" alt="Screenshot 2025-09-18 at 12 21 18 pm" src="https://github.com/user-attachments/assets/42feb16c-9c22-41d0-b293-c42f3c00e32d" />
