### PR TITLE
fix(checkout): CHECKOUT-9506 Catch empty cart error message

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -312,10 +312,11 @@ class Checkout extends Component<
                     />
                 );
             } else {
+                const { message, action } = mapCheckoutComponentErrorMessage(error, language.translate.bind(language));
                 errorModal = <ErrorModal
                         error={error}
-                        message={mapCheckoutComponentErrorMessage(error, language.translate.bind(language))}
-                        onClose={this.handleCloseErrorModal}
+                        message={message}
+                        onClose={action === 'reload' ? this.reloadWindow : this.handleCloseErrorModal}
                     />;
             }
         }
@@ -470,7 +471,6 @@ class Checkout extends Component<
                         isBillingSameAsShipping={isBillingSameAsShipping}
                         isMultiShippingMode={isMultiShippingMode}
                         navigateNextStep={this.handleShippingNextStep}
-                        onContinueError={this.handleError}
                         onCreateAccount={this.handleShippingCreateAccount}
                         onReady={this.handleReady}
                         onSignIn={this.handleShippingSignIn}
@@ -797,6 +797,11 @@ class Checkout extends Component<
         const { analyticsTracker } = this.props;
 
         analyticsTracker.walletButtonClick(methodName);
+    }
+
+    private reloadWindow: () => void = () => {
+        this.setState({ error: undefined });
+        window.location.reload();
     }
 }
 

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -36,7 +36,7 @@ import { withAnalytics } from '../analytics';
 import { StaticBillingAddress } from '../billing';
 import { EmptyCartMessage } from '../cart';
 import { withCheckout } from '../checkout';
-import { CustomError, ErrorModal, isCustomError } from '../common/error';
+import { CustomError, ErrorModal, isCustomError, isErrorWithType } from '../common/error';
 import { retry } from '../common/utility';
 import {
     CheckoutButtonContainer,
@@ -58,6 +58,7 @@ import CheckoutStep from './CheckoutStep';
 import type CheckoutStepStatus from './CheckoutStepStatus';
 import CheckoutStepType from './CheckoutStepType';
 import type CheckoutSupport from './CheckoutSupport';
+import { mapCheckoutComponentErrorMessage } from './mapErrorMessage';
 import mapToCheckoutProps from './mapToCheckoutProps';
 
 const Billing = lazy(() =>
@@ -293,7 +294,7 @@ class Checkout extends Component<
 
     render(): ReactNode {
         const { error, isRedirecting } = this.state;
-        const { themeV2 } = this.props;
+        const { themeV2, language } = this.props;
 
         if(isRedirecting){
             return <OrderConfirmationPageSkeleton />;
@@ -311,7 +312,11 @@ class Checkout extends Component<
                     />
                 );
             } else {
-                errorModal = <ErrorModal error={error} onClose={this.handleCloseErrorModal} />;
+                errorModal = <ErrorModal
+                        error={error}
+                        message={mapCheckoutComponentErrorMessage(error, language.translate.bind(language))}
+                        onClose={this.handleCloseErrorModal}
+                    />;
             }
         }
 
@@ -465,6 +470,7 @@ class Checkout extends Component<
                         isBillingSameAsShipping={isBillingSameAsShipping}
                         isMultiShippingMode={isMultiShippingMode}
                         navigateNextStep={this.handleShippingNextStep}
+                        onContinueError={this.handleError}
                         onCreateAccount={this.handleShippingCreateAccount}
                         onReady={this.handleReady}
                         onSignIn={this.handleShippingSignIn}
@@ -691,6 +697,11 @@ class Checkout extends Component<
 
     private handleError: (error: Error) => void = (error) => {
         const { errorLogger } = this.props;
+
+        if (isErrorWithType(error) && error.type === 'empty_cart') {
+            this.setState({ error });
+            return;
+        }
 
         errorLogger.log(error);
 

--- a/packages/core/src/app/checkout/mapErrorMessage.test.ts
+++ b/packages/core/src/app/checkout/mapErrorMessage.test.ts
@@ -1,0 +1,13 @@
+import { getLanguageService } from '@bigcommerce/checkout/locale';
+
+import { mapCheckoutComponentErrorMessage } from './mapErrorMessage';
+
+const translate = getLanguageService().translate;
+
+describe('mapErrorMessage()', () => {
+    it('returns correct message when shopping cart is removed', () => {
+        const message = mapCheckoutComponentErrorMessage({ type: 'empty_cart' }, translate);
+
+        expect(message).toBe(translate('cart.empty_cart_error_message'));
+    });
+});

--- a/packages/core/src/app/checkout/mapErrorMessage.test.ts
+++ b/packages/core/src/app/checkout/mapErrorMessage.test.ts
@@ -6,8 +6,9 @@ const translate = getLanguageService().translate;
 
 describe('mapErrorMessage()', () => {
     it('returns correct message when shopping cart is removed', () => {
-        const message = mapCheckoutComponentErrorMessage({ type: 'empty_cart' }, translate);
+        const { message, action } = mapCheckoutComponentErrorMessage({ type: 'empty_cart' }, translate);
 
         expect(message).toBe(translate('cart.empty_cart_error_message'));
+        expect(action).toBe('reload');
     });
 });

--- a/packages/core/src/app/checkout/mapErrorMessage.ts
+++ b/packages/core/src/app/checkout/mapErrorMessage.ts
@@ -1,0 +1,14 @@
+import { type TranslationData } from '@bigcommerce/checkout-sdk';
+
+export function mapCheckoutComponentErrorMessage(
+    error: any,
+    translate: (key: string, data?: TranslationData) => string,
+): string {
+    switch (error.type) {
+        case 'empty_cart':
+            return translate('cart.empty_cart_error_message');
+
+        default:
+            return error.message;
+    }
+}

--- a/packages/core/src/app/checkout/mapErrorMessage.ts
+++ b/packages/core/src/app/checkout/mapErrorMessage.ts
@@ -3,12 +3,18 @@ import { type TranslationData } from '@bigcommerce/checkout-sdk';
 export function mapCheckoutComponentErrorMessage(
     error: any,
     translate: (key: string, data?: TranslationData) => string,
-): string {
+): { message: string, action: string } {
     switch (error.type) {
         case 'empty_cart':
-            return translate('cart.empty_cart_error_message');
+            return {
+                message: translate('cart.empty_cart_error_message'),
+                action: 'reload'
+            };
 
         default:
-            return error.message;
+            return {
+                message: error.message,
+                action: 'default'
+            };
     }
 }

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -436,6 +436,10 @@ class Customer extends Component<CustomerProps & WithCheckoutCustomerProps & Ana
                 onContinueAsGuest();
             }
 
+            if (isErrorWithType(error) && error.type === 'empty_cart') {
+                return onContinueAsGuestError(error);
+            }
+
             if (isErrorWithType(error) && error.status === 429) {
                 return onChangeViewType(CustomerViewType.EnforcedLogin);
             }

--- a/packages/core/src/app/customer/mapErrorMessage.ts
+++ b/packages/core/src/app/customer/mapErrorMessage.ts
@@ -11,6 +11,9 @@ export default function mapErrorMessage(
         case 'reset_password_before_login':
             return translate('customer.reset_password_before_login_error');
 
+        case 'empty_cart':
+            return translate('cart.empty_cart_error_message');
+
         default:
             return translate('customer.sign_in_error');
     }

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
@@ -33,6 +33,12 @@ describe('mapSubmitOrderErrorMessage()', () => {
         expect(message).toEqual(translate('shipping.cart_change_error'));
     });
 
+    it('returns correct message when shopping cart is removed', () => {
+        const message = mapSubmitOrderErrorMessage({ type: 'empty_cart' }, translate, false);
+
+        expect(message).toEqual(translate('cart.empty_cart_error_message'));
+    });
+
     it('returns correct message when payment error order_could_not_be_finalized_error', () => {
         const message = mapSubmitOrderErrorMessage(
             {

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -27,6 +27,9 @@ export default function mapSubmitOrderErrorMessage(
 
         case 'cart_consistency':
             return translate('cart.consistency_error');
+        
+        case 'empty_cart':
+            return translate('cart.empty_cart_error_message');
 
         default:
             if (

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -51,6 +51,7 @@ export interface ShippingProps {
     onSignIn(): void;
     navigateNextStep(isBillingSameAsShipping: boolean): void;
     setIsMultishippingMode(isMultiShippingMode: boolean): void;
+    onContinueError?(error: Error): void;
 }
 
 export interface WithCheckoutShippingProps {

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -51,7 +51,6 @@ export interface ShippingProps {
     onSignIn(): void;
     navigateNextStep(isBillingSameAsShipping: boolean): void;
     setIsMultishippingMode(isMultiShippingMode: boolean): void;
-    onContinueError?(error: Error): void;
 }
 
 export interface WithCheckoutShippingProps {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -79,7 +79,8 @@
             "taxes_text": "Taxes",
             "total_text": "Total",
             "empty_cart_message": "Your cart is empty, you are being redirected. Please <a href=\"{url}\" target=\"_top\">click here</a> if your browser does not redirect you.",
-            "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again."
+            "consistency_error": "Your checkout could not be processed because some details have changed. Please review your order and try again.",
+            "empty_cart_error_message": "Your cart contains items that aren't available for purchase or have exceeded the purchase limit. To place your order, please create a new cart with the quantities to the allowed limit or with different items."
         },
         "common": {
             "back_action": "Back",


### PR DESCRIPTION
## What/Why?
Catch empty cart error message and display a valid modal. 

At times if the cart only has one product and that product is made purchasable throughout checkout journey. The cart is removed on server side, we need to catch the error returned from server and display the message to shopper.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

### Place order

https://github.com/user-attachments/assets/95a433f2-9347-4321-83f2-34527c4e536a


### Continue as guest

https://github.com/user-attachments/assets/c39ced65-d665-4244-9024-12c6c6f0ab88


### Continue from shipping

https://github.com/user-attachments/assets/a3fc2b21-2b3d-4b08-91ba-37227776d56b

