### PR TITLE
feat(payment): checkout-sdk bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.802.0",
+        "@bigcommerce/checkout-sdk": "^1.803.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.802.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.802.0.tgz",
-      "integrity": "sha512-4xva0lPBlmREkqVzmCSgVLYDO1lUzzyosLiexeL+WelPqBaeQskHxIXb3tpxA2Lx26m4VmV8K8YhI22rmW8YMA==",
+      "version": "1.803.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.803.0.tgz",
+      "integrity": "sha512-YKA4mN3MT6R9CkDBKQX00arGteepqGagLTv2dv/AvvYYfnl+grb+LTOP9QKcdAemVI789ibDJ6y+3rPsd2U0qg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.802.0",
+    "@bigcommerce/checkout-sdk": "^1.803.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version. To release: https://github.com/bigcommerce/checkout-sdk-js/pull/3014

## Rollout/Rollback
Revert this PR

## Testing
Manual testing
