### PR TITLE
chore(shipping): CHECKOUT-9515 Reduce height of options message container

### DIFF
--- a/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.scss
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.scss
@@ -5,7 +5,7 @@
     border: container("border");
     border-radius: $global-radius;
     display: flex;
-    min-height: 9.383rem;
+    min-height: 5rem;
     text-align: center;
 }
 


### PR DESCRIPTION
## What/Why?
Reduce height of options message container, since the present implementation takes a bit too much space on the page.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screenshot
<img width="1677" height="794" alt="Screenshot 2025-09-29 at 10 54 08 pm" src="https://github.com/user-attachments/assets/c9db96e8-0902-4433-85ae-a1a930b2df45" />


