### PR TITLE
fix(payment): added data-test attribute

### DIFF
--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -219,7 +219,10 @@ class CreditCardPaymentMethodComponent extends Component<
         return (
             <LocaleContext.Provider value={createLocaleContext(storeConfig)}>
                 <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                    <div className="paymentMethod paymentMethod--creditCard">
+                    <div
+                        className="paymentMethod paymentMethod--creditCard"
+                        data-test="credit-cart-payment-method"
+                    >
                         {shouldShowInstrumentFieldset && (
                             <CardInstrumentFieldset
                                 instruments={instruments}


### PR DESCRIPTION
## What/Why?
- Added data-test attribute to fix form visibility issue

We have https://www.zagg.com/ store have custom script that relies on checkout html markup `data-test="credit-cart-payment-method"`. The issue could be reproduced only for logged in customers and caused because custom script didn't find data-test mentioned before.

<img width="1440" height="366" alt="Screenshot 2025-09-29 at 19 26 00" src="https://github.com/user-attachments/assets/476ca851-6eba-4790-ac1e-9372696e299b" />

<img width="1910" height="1510" alt="image" src="https://github.com/user-attachments/assets/e7db731c-8a5f-4bd6-9efb-303d0749df0e" />

<img width="1459" height="778" alt="Screenshot 2025-09-29 at 20 07 01" src="https://github.com/user-attachments/assets/203573fb-811d-4d46-ba05-4d49dc9887aa" />

## Rollout/Rollback
Revert

## Testing
Unit
