### PR TITLE
fix(payment): Stripe OCS layout type based on isCustomChecklistItem

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -78,7 +78,14 @@ describe('when using Stripe OCS payment', () => {
         checkoutService = createCheckoutService();
         checkoutState = checkoutService.getState();
         localeContext = createLocaleContext(getStoreConfig());
-        method = { ...getPaymentMethod(), id: methodId, gateway: gatewayId };
+        method = {
+            ...getPaymentMethod(),
+            id: methodId,
+            gateway: gatewayId,
+            initializationData: {
+                isCustomChecklistItem: true,
+            },
+        };
         initializePayment = jest
             .spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
@@ -256,6 +263,74 @@ describe('when using Stripe OCS payment', () => {
     });
 
     describe('# Stripe OCS accordion layout', () => {
+        it('should initialize with auto layout when isCustomChecklistItem is false', () => {
+            method = {
+                ...method,
+                initializationData: {
+                    isCustomChecklistItem: false,
+                },
+            };
+
+            render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+                    gatewayId: method.gateway,
+                    [gatewayId]: {
+                        containerId: expectedContainerId,
+                        layout: {
+                            ...defaultAccordionLayout,
+                            type: 'auto',
+                        },
+                        appearance: {
+                            variables: { color: '#cccccc' },
+                        },
+                        fonts: [{ cssSrc: 'fontSrc' }],
+                        onError: expect.any(Function),
+                        render: expect.any(Function),
+                        paymentMethodSelect: expect.any(Function),
+                        handleClosePaymentMethod: expect.any(Function),
+                        togglePreloader: expect.any(Function),
+                    },
+                }),
+            );
+        });
+
+        it('should initialize with accordion layout when isCustomChecklistItem is true', () => {
+            method = {
+                ...method,
+                initializationData: {
+                    isCustomChecklistItem: true,
+                },
+            };
+
+            render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+                    gatewayId: method.gateway,
+                    [gatewayId]: {
+                        containerId: expectedContainerId,
+                        layout: {
+                            ...defaultAccordionLayout,
+                            type: 'accordion',
+                        },
+                        appearance: {
+                            variables: { color: '#cccccc' },
+                        },
+                        fonts: [{ cssSrc: 'fontSrc' }],
+                        onError: expect.any(Function),
+                        render: expect.any(Function),
+                        paymentMethodSelect: expect.any(Function),
+                        handleClosePaymentMethod: expect.any(Function),
+                        togglePreloader: expect.any(Function),
+                    },
+                }),
+            );
+        });
+
         it('accordion collapsed when selected different payment method', () => {
             accordionContextValues.selectedItemId = 'nonStripeItem';
 

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -97,6 +97,9 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         statuses: { isLoadingInstruments },
     } = checkoutState;
     const checkout = getCheckout();
+    const {
+        initializationData: { isCustomChecklistItem },
+    } = method;
 
     const initializeStripePayment = useCallback(
         async (options: PaymentInitializeOptions) => {
@@ -107,7 +110,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                 stripeocs: {
                     containerId,
                     layout: {
-                        type: 'accordion',
+                        type: isCustomChecklistItem ? 'accordion' : 'auto',
                         defaultCollapsed: selectedItemId !== methodSelector,
                         radios: true,
                         linkInAccordion: true,
@@ -130,6 +133,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             containerId,
             selectedItemId,
             methodSelector,
+            isCustomChecklistItem,
             checkoutService,
             onUnhandledError,
             renderSubmitButton,


### PR DESCRIPTION
## What/Why?
Change Stripe OCS layout type to math widget view to place where it will be rendered

## Rollout/Rollback
Rollback this PR

## Testing
Before:
<img width="634" height="504" alt="Screenshot 2025-10-01 at 12 57 26" src="https://github.com/user-attachments/assets/3818f079-0a0c-4708-bba6-eeeff4d1ab8f" />

After:
<img width="628" height="441" alt="Screenshot 2025-10-01 at 12 59 37" src="https://github.com/user-attachments/assets/c4643753-d8e2-422a-aadd-a084c0a24626" />
<img width="632" height="866" alt="Screenshot 2025-10-01 at 14 19 26" src="https://github.com/user-attachments/assets/2856e975-8679-4d0e-acef-0450e4446091" />

