### PR TITLE
Singleshipping form autocomplete fix

### DIFF
--- a/packages/core/src/app/address/AddressForm.tsx
+++ b/packages/core/src/app/address/AddressForm.tsx
@@ -93,13 +93,16 @@ const AddressForm: React.FC<AddressFormProps> = ({
             }
 
             setFieldValue(fieldName, value as string);
-            onChange(fieldName, value as string);
+            // onChange(fieldName, value as string);
         });
 
         const address1 = address.address1 ? address.address1 : autocompleteValue;
-
-        if (address1) {
-            syncNonFormikValue(AUTOCOMPLETE_FIELD_NAME, address1);
+        
+        // if (address1) {
+        //     syncNonFormikValue(AUTOCOMPLETE_FIELD_NAME, address1);
+        // }
+        if (address1 && fieldName === AUTOCOMPLETE_FIELD_NAME) {
+            setFieldValue(fieldName, address1);
         }
     }, [countries, setFieldValue, onChange, syncNonFormikValue]);
 

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -49,7 +49,6 @@ const ShippingForm = ({
         methodId,
         shouldShowOrderComments,
         shippingAddress,
-        signOut,
         updateShippingAddress: updateAddress
     } = useShipping();
     const { extensionState: { shippingFormRenderTimestamp } } = useExtensions();
@@ -94,7 +93,6 @@ const ShippingForm = ({
             isBillingSameAsShipping={isBillingSameAsShipping}
             isInitialValueLoaded={isInitialValueLoaded}
             isLoading={isLoading}
-            isMultiShippingMode={isMultiShippingMode}
             isShippingStepPending={isShippingStepPending}
             methodId={methodId}
             onSubmit={onSingleShippingSubmit}
@@ -102,7 +100,6 @@ const ShippingForm = ({
             shippingAddress={shippingAddress}
             shippingFormRenderTimestamp={shippingFormRenderTimestamp}
             shouldShowOrderComments={shouldShowOrderComments}
-            signOut={signOut}
             updateAddress={updateAddress}
         />
     );

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -3,7 +3,6 @@ import {
     type CheckoutParams,
     type CheckoutSelectors,
     type Consignment,
-    type CustomerRequestOptions,
     type FormField,
     type RequestOptions,
     type ShippingInitializeOptions,
@@ -11,11 +10,10 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import { type FormikProps } from 'formik';
 import { debounce, isEqual, noop } from 'lodash';
-import React, { PureComponent, type ReactNode } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { lazy, object } from 'yup';
 
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
-import { FormContext } from '@bigcommerce/checkout/ui';
 
 import {
     type AddressFormValues,
@@ -44,7 +42,6 @@ export interface SingleShippingFormProps {
     customerMessage: string;
     isLoading: boolean;
     isShippingStepPending: boolean;
-    isMultiShippingMode: boolean;
     methodId?: string;
     shippingAddress?: Address;
     shippingAutosaveDelay?: number;
@@ -57,7 +54,6 @@ export interface SingleShippingFormProps {
     initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
     onSubmit(values: SingleShippingFormValues): void;
     onUnhandledError?(error: Error): void;
-    signOut(options?: CustomerRequestOptions): void;
     updateAddress(
         address: Partial<Address>,
         options?: RequestOptions<CheckoutParams>,
@@ -68,12 +64,6 @@ export interface SingleShippingFormValues {
     billingSameAsShipping: boolean;
     shippingAddress?: AddressFormValues;
     orderComment: string;
-}
-
-interface SingleShippingFormState {
-    isResettingAddress: boolean;
-    isUpdatingShippingData: boolean;
-    hasRequestedShippingOptions: boolean;
 }
 
 function shouldHaveCustomValidation(methodId?: string): boolean {
@@ -87,27 +77,47 @@ function shouldHaveCustomValidation(methodId?: string): boolean {
 
 export const SHIPPING_AUTOSAVE_DELAY = 1700;
 
-class SingleShippingForm extends PureComponent<
+const SingleShippingForm: React.FC<
     SingleShippingFormProps & WithLanguageProps & FormikProps<SingleShippingFormValues>
-> {
-    static contextType = FormContext;
+> = ({
+        cartHasChanged,
+        consignments,
+        customerMessage,
+        deinitialize,
+        deleteConsignments,
+        getFields,
+        initialize,
+        isBillingSameAsShipping,
+        isInitialValueLoaded,
+        isLoading,
+        isShippingStepPending,
+        isValid,
+        validateForm,
+        methodId,
+        onUnhandledError = noop,
+        setFieldValue,
+        setValues,
+        shippingAddress,
+        shippingAutosaveDelay = SHIPPING_AUTOSAVE_DELAY,
+        shippingFormRenderTimestamp,
+        shouldShowOrderComments,
+        updateAddress,
+        values,
+    }) => {
+    const [isResettingAddress, setIsResettingAddress] = useState(false);
+    const [isUpdatingShippingData, setIsUpdatingShippingData] = useState(false);
+    const [hasRequestedShippingOptions, setHasRequestedShippingOptions] = useState(false);
 
-    state: SingleShippingFormState = {
-        isResettingAddress: false,
-        isUpdatingShippingData: false,
-        hasRequestedShippingOptions: false,
-    };
+    const stateOrProvinceCodeFormField = useMemo(() => {
+        return getFields(
+            values.shippingAddress?.countryCode,
+        ).find(({ name }) => name === 'stateOrProvinceCode');
+    }, [getFields, values.shippingAddress?.countryCode]);
 
-    private debouncedUpdateAddress: any;
+    const debouncedUpdateAddressRef = useRef<any>();
 
-    constructor(
-        props: SingleShippingFormProps & WithLanguageProps & FormikProps<SingleShippingFormValues>,
-    ) {
-        super(props);
-
-        const { updateAddress } = this.props;
-
-        this.debouncedUpdateAddress = debounce(
+    useEffect(() => {
+        debouncedUpdateAddressRef.current = debounce(
             async (address: Address, includeShippingOptions: boolean) => {
                 try {
                     await updateAddress(address, {
@@ -119,32 +129,21 @@ class SingleShippingForm extends PureComponent<
                     });
 
                     if (includeShippingOptions) {
-                        this.setState({ hasRequestedShippingOptions: true });
+                        setHasRequestedShippingOptions(true);
                     }
                 } finally {
-                    this.setState({ isUpdatingShippingData: false });
+                    setIsUpdatingShippingData(false);
                 }
             },
-            props.shippingAutosaveDelay ?? SHIPPING_AUTOSAVE_DELAY,
+            shippingAutosaveDelay,
         );
-    }
+        
+        return () => {
+            debouncedUpdateAddressRef.current?.cancel();
+        };
+    }, []);
 
-    componentDidUpdate({ shippingFormRenderTimestamp }: SingleShippingFormProps) {
-        const {
-            shippingFormRenderTimestamp: newShippingFormRenderTimestamp,
-            setValues,
-            getFields,
-            shippingAddress,
-            isBillingSameAsShipping,
-            customerMessage,
-            values,
-            setFieldValue,
-        } = this.props;
-
-        const stateOrProvinceCodeFormField = getFields(values && values.shippingAddress?.countryCode).find(
-            ({ name }) => name === 'stateOrProvinceCode',
-        );
-
+    useEffect(() => {
         // Workaround for a bug found during manual testing:
         // When the shipping step first loads, the `stateOrProvinceCode` field may not be there.
         // It later appears with an empty value if the selected country has states/provinces.
@@ -156,194 +155,157 @@ class SingleShippingForm extends PureComponent<
         ) {
             setFieldValue('shippingAddress.stateOrProvinceCode', shippingAddress.stateOrProvinceCode);
         }
+    }, [
+        stateOrProvinceCodeFormField,
+        shippingAddress?.stateOrProvinceCode,
+        values.shippingAddress?.stateOrProvinceCode,
+    ]);
 
-        // This is for executing extension command, `ReRenderShippingForm`.
-        if (newShippingFormRenderTimestamp !== shippingFormRenderTimestamp) {
+
+    useEffect(() => {
+        if (shippingFormRenderTimestamp) {
             setValues({
                 billingSameAsShipping: isBillingSameAsShipping,
                 orderComment: customerMessage,
                 shippingAddress: mapAddressToFormValues(
-                    getFields(shippingAddress && shippingAddress.countryCode),
+                    getFields(shippingAddress?.countryCode),
                     shippingAddress,
                 ),
             });
         }
-    }
+    }, [shippingFormRenderTimestamp]);
 
-    render(): ReactNode {
-        const {
-            cartHasChanged,
-            isInitialValueLoaded,
-            isLoading,
-            onUnhandledError,
-            methodId,
-            shippingAddress,
-            consignments,
-            shouldShowOrderComments,
-            initialize,
-            isValid,
-            deinitialize,
-            values: { shippingAddress: addressForm },
-            isShippingStepPending,
-            shippingFormRenderTimestamp,
-        } = this.props;
+    const updateAddressWithFormData = (includeShippingOptions: boolean) => {
+        const updatedShippingAddress =
+            values.shippingAddress && mapAddressFromFormValues(values.shippingAddress);
 
-        const { isResettingAddress, isUpdatingShippingData, hasRequestedShippingOptions } =
-            this.state;
-
-        const PAYMENT_METHOD_VALID = ['amazonpay'];
-        const shouldShowBillingSameAsShipping = !PAYMENT_METHOD_VALID.some(
-            (method) => method === methodId,
-        );
-
-        return (
-            <Form autoComplete="on">
-                <Fieldset>
-                    <ShippingAddress
-                        consignments={consignments}
-                        deinitialize={deinitialize}
-                        formFields={this.getFields(addressForm && addressForm.countryCode)}
-                        hasRequestedShippingOptions={hasRequestedShippingOptions}
-                        initialize={initialize}
-                        isLoading={isResettingAddress}
-                        isShippingStepPending={isShippingStepPending}
-                        methodId={methodId}
-                        onAddressSelect={this.handleAddressSelect}
-                        onFieldChange={this.handleFieldChange}
-                        onUnhandledError={onUnhandledError}
-                        onUseNewAddress={this.onUseNewAddress}
-                        shippingAddress={shippingAddress}
-                    />
-                    {shouldShowBillingSameAsShipping && (
-                        <div className="form-body">
-                            <BillingSameAsShippingField />
-                        </div>
-                    )}
-                </Fieldset>
-
-                <ShippingFormFooter
-                    cartHasChanged={cartHasChanged}
-                    isInitialValueLoaded={isInitialValueLoaded}
-                    isLoading={isLoading || isUpdatingShippingData}
-                    isMultiShippingMode={false}
-                    shippingFormRenderTimestamp={shippingFormRenderTimestamp}
-                    shouldDisableSubmit={this.shouldDisableSubmit()}
-                    shouldShowOrderComments={shouldShowOrderComments}
-                    shouldShowShippingOptions={isValid}
-                />
-            </Form>
-        );
-    }
-
-    private shouldDisableSubmit: () => boolean = () => {
-        const { isLoading, consignments, isValid } = this.props;
-
-        const { isUpdatingShippingData } = this.state;
-
-        if (!isValid) {
-            return false;
-        }
-
-        return isLoading || isUpdatingShippingData || !hasSelectedShippingOptions(consignments) || !isSelectedShippingOptionValid(consignments);
-    };
-
-    private handleFieldChange: (name: string) => void = async (name) => {
-        const { setFieldValue } = this.props;
-
-        if (name === 'countryCode') {
-            setFieldValue('shippingAddress.stateOrProvince', '');
-            setFieldValue('shippingAddress.stateOrProvinceCode', '');
-        }
-
-        // Enqueue the following code to run after Formik has run validation
-        await new Promise((resolve) => setTimeout(resolve));
-
-        const isShippingField = SHIPPING_ADDRESS_FIELDS.includes(name);
-
-        const { hasRequestedShippingOptions } = this.state;
-
-        const { isValid } = this.props;
-
-        if (!isValid) {
-            return;
-        }
-
-        this.updateAddressWithFormData(isShippingField || !hasRequestedShippingOptions);
-    };
-
-    private updateAddressWithFormData(includeShippingOptions: boolean) {
-        const {
-            shippingAddress,
-            values: { shippingAddress: addressForm },
-        } = this.props;
-
-        const updatedShippingAddress = addressForm && mapAddressFromFormValues(addressForm);
+        let newIncludeShippingOptions = includeShippingOptions;
 
         if (Array.isArray(shippingAddress?.customFields)) {
-            includeShippingOptions = !isEqual(
-                shippingAddress?.customFields,
-                updatedShippingAddress?.customFields
-            ) || includeShippingOptions;
+            newIncludeShippingOptions =
+                !isEqual(shippingAddress?.customFields, updatedShippingAddress?.customFields) ||
+                includeShippingOptions;
         }
 
         if (!updatedShippingAddress || isEqualAddress(updatedShippingAddress, shippingAddress)) {
             return;
         }
 
-        this.setState({ isUpdatingShippingData: true });
-        this.debouncedUpdateAddress(updatedShippingAddress, includeShippingOptions);
-    }
+        setIsUpdatingShippingData(true);
+        debouncedUpdateAddressRef.current?.(updatedShippingAddress, newIncludeShippingOptions);
+    };
 
-    private handleAddressSelect: (address: Address) => void = async (address) => {
-        const { updateAddress, onUnhandledError = noop, values, setValues } = this.props;
+    const handleFieldChange = async (name: string) => {
+        if (name === 'countryCode') {
+            setFieldValue('shippingAddress.stateOrProvince', '');
+            setFieldValue('shippingAddress.stateOrProvinceCode', '');
+        }
 
-        this.setState({ isResettingAddress: true });
+        await new Promise((resolve) => setTimeout(resolve));
+
+        const errors = await validateForm();
+        const addressErrors = errors.shippingAddress;
+
+        // Only update address if there are no address errors
+        if (addressErrors && Object.keys(addressErrors).length > 0) {
+            return;
+        }
+
+        const isShippingField = SHIPPING_ADDRESS_FIELDS.includes(name);
+
+        updateAddressWithFormData(isShippingField || !hasRequestedShippingOptions);
+    };
+
+    const handleAddressSelect = async (address: Address) => {
+        setIsResettingAddress(true);
 
         try {
             await updateAddress(address);
 
             setValues({
                 ...values,
-                shippingAddress: mapAddressToFormValues(
-                    this.getFields(address.countryCode),
-                    address,
-                ),
+                shippingAddress: mapAddressToFormValues(getFields(address.countryCode), address),
             });
         } catch (error) {
             onUnhandledError(error);
         } finally {
-            this.setState({ isResettingAddress: false });
+            setIsResettingAddress(false);
         }
-    };
+    }
 
-    private onUseNewAddress: () => void = async () => {
-        const { deleteConsignments, onUnhandledError = noop, setValues, values } = this.props;
-
-        this.setState({ isResettingAddress: true });
+    const handleUseNewAddress = async () => {
+        setIsResettingAddress(true);
 
         try {
             const address = await deleteConsignments();
 
             setValues({
                 ...values,
-                shippingAddress: mapAddressToFormValues(
-                    this.getFields(address && address.countryCode),
-                    address,
-                ),
+                shippingAddress: mapAddressToFormValues(getFields(address?.countryCode), address),
             });
-        } catch (e) {
-            onUnhandledError(e);
+        } catch (error) {
+            onUnhandledError(error);
         } finally {
-            this.setState({ isResettingAddress: false });
+            setIsResettingAddress(false);
         }
     };
 
-    private getFields(countryCode: string | undefined): FormField[] {
-        const { getFields } = this.props;
+    const shouldDisableSubmit = () => {
+        if (!isValid) {
+            return false;
+        }
 
-        return getFields(countryCode);
-    }
-}
+        return (
+            isLoading ||
+            isUpdatingShippingData ||
+            !hasSelectedShippingOptions(consignments) ||
+            !isSelectedShippingOptionValid(consignments)
+        );
+    };
+
+    const PAYMENT_METHOD_VALID = ['amazonpay'];
+    const shouldShowBillingSameAsShipping = !PAYMENT_METHOD_VALID.some(
+        (method) => method === methodId,
+    );
+
+    return (
+        <Form autoComplete="on">
+            <Fieldset>
+                <ShippingAddress
+                    consignments={consignments}
+                    deinitialize={deinitialize}
+                    formFields={getFields(values.shippingAddress?.countryCode)}
+                    hasRequestedShippingOptions={hasRequestedShippingOptions}
+                    initialize={initialize}
+                    isLoading={isResettingAddress}
+                    isShippingStepPending={isShippingStepPending}
+                    methodId={methodId}
+                    onAddressSelect={handleAddressSelect}
+                    onFieldChange={handleFieldChange}
+                    onUnhandledError={onUnhandledError}
+                    onUseNewAddress={handleUseNewAddress}
+                    shippingAddress={shippingAddress}
+                />
+                {shouldShowBillingSameAsShipping && (
+                    <div className="form-body">
+                        <BillingSameAsShippingField />
+                    </div>
+                )}
+            </Fieldset>
+
+            <ShippingFormFooter
+                cartHasChanged={cartHasChanged}
+                isInitialValueLoaded={isInitialValueLoaded}
+                isLoading={isLoading || isUpdatingShippingData}
+                isMultiShippingMode={false}
+                shippingFormRenderTimestamp={shippingFormRenderTimestamp}
+                shouldDisableSubmit={shouldDisableSubmit()}
+                shouldShowOrderComments={shouldShowOrderComments}
+                shouldShowShippingOptions={isValid}
+            />
+        </Form>
+    );
+};
 
 export default withLanguage(
     withFormikExtended<SingleShippingFormProps & WithLanguageProps, SingleShippingFormValues>({
@@ -359,7 +321,7 @@ export default withLanguage(
             billingSameAsShipping: isBillingSameAsShipping,
             orderComment: customerMessage,
             shippingAddress: mapAddressToFormValues(
-                getFields(shippingAddress && shippingAddress.countryCode),
+                getFields(shippingAddress?.countryCode),
                 shippingAddress,
             ),
         }),
@@ -379,7 +341,7 @@ export default withLanguage(
                       shippingAddress: lazy<Partial<AddressFormValues>>((formValues) =>
                           getCustomFormFieldsValidationSchema({
                               translate: getTranslateAddressError(language),
-                              formFields: getFields(formValues && formValues.countryCode),
+                              formFields: getFields(formValues?.countryCode),
                           }),
                       ),
                   })
@@ -387,7 +349,7 @@ export default withLanguage(
                       shippingAddress: lazy<Partial<AddressFormValues>>((formValues) =>
                           getAddressFormFieldsValidationSchema({
                               language,
-                              formFields: getFields(formValues && formValues.countryCode),
+                              formFields: getFields(formValues?.countryCode),
                           }),
                       ),
                   }),


### PR DESCRIPTION
## What/Why?

- Revert SingleShippingForm conversion. https://github.com/bigcommerce/checkout-js/pull/2599
- Solve the google autocomplete value not populating payload correctly issue.

## Rollout/Rollback

Revert this PR

## Testing

- CI checks
- Manual testing

**BEFORE**

https://github.com/user-attachments/assets/43db2083-d69a-4055-a8fe-f2e9aed82841



**AFTER**


https://github.com/user-attachments/assets/2bc8612c-c755-4902-9320-2988fd63538a

