### PR TITLE
refactor(checkout): CHECKOUT-9386 Convert CreditCardPaymentMethodComponent

### DIFF
--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentCreditCards/BigCommercePaymentsCreditCardsPaymentMethod.test.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentCreditCards/BigCommercePaymentsCreditCardsPaymentMethod.test.tsx
@@ -31,7 +31,7 @@ import {
     getPaymentMethod,
     getStoreConfig,
 } from '@bigcommerce/checkout/test-mocks';
-import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 
 import BigCommercePaymentsCreditCardsPaymentMethod from './BigCommercePaymentsCreditCardsPaymentMethod';
 
@@ -404,7 +404,7 @@ describe('BigCommercePaymentsCreditCardPaymentMethod', () => {
         expect(screen.getByText('Customer Code')).toBeInTheDocument();
     });
 
-    it('renders save card checkbox if vaulting is enabled', () => {
+    it('renders save card checkbox if vaulting is enabled', async () => {
         defaultProps.method.config.isVaultingEnabled = true;
 
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
@@ -412,7 +412,9 @@ describe('BigCommercePaymentsCreditCardPaymentMethod', () => {
 
         render(<PaymentMethodTest {...defaultProps} />);
 
-        expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        });
     });
 
     it('uses PaymentMethod to retrieve instruments', () => {
@@ -421,14 +423,16 @@ describe('BigCommercePaymentsCreditCardPaymentMethod', () => {
         expect(checkoutState.data.getInstruments).toHaveBeenCalledWith(defaultProps.method);
     });
 
-    it('renders with save card checkbox if vaulting is enabled and no instruments', () => {
+    it('renders with save card checkbox if vaulting is enabled and no instruments', async () => {
         defaultProps.method.config.isVaultingEnabled = true;
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
         jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
 
         render(<PaymentMethodTest {...defaultProps} />);
 
-        expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        });
     });
 
     it('does not render save card checkbox if vaulting is disabled', () => {

--- a/packages/credit-card-integration/.eslintrc.json
+++ b/packages/credit-card-integration/.eslintrc.json
@@ -11,6 +11,7 @@
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unnecessary-condition": "off",
     "@typescript-eslint/consistent-type-assertions": "off",
-    "@typescript-eslint/naming-convention": "off"
+    "@typescript-eslint/naming-convention": "off",
+    "react-hooks/exhaustive-deps": "off"
   }
 }

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.test.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.test.tsx
@@ -35,12 +35,13 @@ import {
     getPaymentMethod,
     getStoreConfig,
 } from '@bigcommerce/checkout/test-mocks';
-import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 
-import CreditCardPaymentMethodComponent, {
+import {
     type CreditCardPaymentMethodProps,
     type CreditCardPaymentMethodValues,
 } from './CreditCardPaymentMethodComponent';
+import CreditCardPaymentMethodComponent from './CreditCardPaymentMethodContainer';
 
 describe('CreditCardPaymentMethod', () => {
     let checkoutService: CheckoutService;
@@ -236,7 +237,7 @@ describe('CreditCardPaymentMethod', () => {
             };
         });
 
-        it('initializes payment method with stored card validation fieldset', () => {
+        it('initializes payment method with stored card validation fieldset', async () => {
             const getStoredCardValidationFieldset = jest.fn();
 
             render(
@@ -248,10 +249,13 @@ describe('CreditCardPaymentMethod', () => {
             );
 
             expect(checkoutService.loadInstruments).toHaveBeenCalledWith();
-            expect(getStoredCardValidationFieldset).toHaveBeenCalled();
+
+            await waitFor(() => {
+                expect(getStoredCardValidationFieldset).toHaveBeenCalled();
+            });
         });
 
-        it('sets validation schema for stored instruments when component mounts', () => {
+        it('sets validation schema for stored instruments when component mounts', async () => {
             jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([
                 {
                     ...getCardInstrument(),
@@ -261,7 +265,9 @@ describe('CreditCardPaymentMethod', () => {
 
             render(<CreditCardPaymentMethodTest {...defaultProps} method={vaultedMethod} />);
 
-            expect(paymentForm.setValidationSchema).toHaveBeenCalled();
+            await waitFor(() => {
+                expect(paymentForm.setValidationSchema).toHaveBeenCalled();
+            });
 
             const schema: Schema<any> = (paymentForm.setValidationSchema as jest.Mock).mock
                 .calls[0][1];
@@ -285,13 +291,13 @@ describe('CreditCardPaymentMethod', () => {
             expect(screen.queryByText('payment.instrument_text')).not.toBeInTheDocument();
         });
 
-        it('shows save credit card form when there are no stored instruments', () => {
+        it('shows save credit card form when there are no stored instruments', async () => {
             jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
 
             render(<CreditCardPaymentMethodTest {...defaultProps} method={vaultedMethod} />);
 
             expect(
-                screen.getByText(
+                await screen.findByText(
                     localeContext.language.translate(
                         'payment.instrument_save_payment_method_label',
                     ),
@@ -305,7 +311,7 @@ describe('CreditCardPaymentMethod', () => {
             expect(checkoutState.data.getInstruments).toHaveBeenCalledWith(defaultProps.method);
         });
 
-        it('switches to "use new card" view if all instruments are deleted', () => {
+        it('switches to "use new card" view if all instruments are deleted', async () => {
             const { rerender } = render(
                 <CreditCardPaymentMethodTest {...defaultProps} method={vaultedMethod} />,
             );
@@ -325,7 +331,7 @@ describe('CreditCardPaymentMethod', () => {
             rerender(<CreditCardPaymentMethodTest {...defaultProps} method={vaultedMethod} />);
 
             expect(
-                screen.getByText(
+                await screen.findByText(
                     localeContext.language.translate(
                         'payment.instrument_save_payment_method_label',
                     ),

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodContainer.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodContainer.tsx
@@ -1,0 +1,55 @@
+import React, { type ReactNode, useEffect, useState } from 'react';
+
+import { isInstrumentFeatureAvailable } from '@bigcommerce/checkout/instrument-utils';
+import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
+
+import {
+    CreditCardPaymentMethodComponent,
+    type CreditCardPaymentMethodProps,
+} from './CreditCardPaymentMethodComponent';
+
+export const CreditCardPaymentMethodComponentContainer = (
+    props: CreditCardPaymentMethodProps & PaymentMethodProps,
+): ReactNode => {
+    const [componentDidMount, setComponentDidMount] = useState(false);
+
+    useEffect(() => {
+        const init = async () => {
+            const { checkoutService, checkoutState, isUsingMultiShipping = false, method } = props;
+
+            const {
+                data: { getConfig, getCustomer },
+            } = checkoutState;
+
+            const config = getConfig();
+            const customer = getCustomer();
+
+            if (!config || !customer || !method) {
+                throw new Error('Unable to get checkout');
+            }
+
+            const isInstrumentFeatureAvailableFlag = isInstrumentFeatureAvailable({
+                config,
+                customer,
+                isUsingMultiShipping,
+                paymentMethod: method,
+            });
+
+            if (isInstrumentFeatureAvailableFlag) {
+                await checkoutService.loadInstruments();
+            }
+
+            setComponentDidMount(true);
+        };
+
+        void init();
+    }, []);
+
+    if (!componentDidMount) {
+        return null;
+    }
+
+    return <CreditCardPaymentMethodComponent {...props} />;
+};
+
+export default CreditCardPaymentMethodComponentContainer;

--- a/packages/credit-card-integration/src/index.ts
+++ b/packages/credit-card-integration/src/index.ts
@@ -1,5 +1,5 @@
 export {
-    default as CreditCardPaymentMethodComponent,
     CreditCardPaymentMethodProps,
     CreditCardPaymentMethodValues,
 } from './CreditCardPaymentMethodComponent';
+export { default as CreditCardPaymentMethodComponent } from './CreditCardPaymentMethodContainer';

--- a/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceCreditCards/PayPalCommerceCreditCardsPaymentMethod.test.tsx
@@ -32,7 +32,7 @@ import {
     getPaymentMethod,
     getStoreConfig,
 } from '@bigcommerce/checkout/test-mocks';
-import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 
 import PayPalCommerceCreditCardsPaymentMethod from './PayPalCommerceCreditCardsPaymentMethod';
 
@@ -405,7 +405,7 @@ describe('PayPalCommerceCreditCardPaymentMethod', () => {
         expect(screen.getByText('Customer Code')).toBeInTheDocument();
     });
 
-    it('renders save card checkbox if vaulting is enabled', () => {
+    it('renders save card checkbox if vaulting is enabled', async () => {
         defaultProps.method.config.isVaultingEnabled = true;
 
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
@@ -413,7 +413,9 @@ describe('PayPalCommerceCreditCardPaymentMethod', () => {
 
         render(<PaymentMethodTest {...defaultProps} />);
 
-        expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        });
     });
 
     it('uses PaymentMethod to retrieve instruments', () => {
@@ -422,14 +424,16 @@ describe('PayPalCommerceCreditCardPaymentMethod', () => {
         expect(checkoutState.data.getInstruments).toHaveBeenCalledWith(defaultProps.method);
     });
 
-    it('renders with save card checkbox if vaulting is enabled and no instruments', () => {
+    it('renders with save card checkbox if vaulting is enabled and no instruments', async () => {
         defaultProps.method.config.isVaultingEnabled = true;
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
         jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
 
         render(<PaymentMethodTest {...defaultProps} />);
 
-        expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+        });
     });
 
     it('does not render save card checkbox if vaulting is disabled', () => {

--- a/packages/worldpay-access-integration/src/WorldPayCreditCardPaymentMethod.test.tsx
+++ b/packages/worldpay-access-integration/src/WorldPayCreditCardPaymentMethod.test.tsx
@@ -35,7 +35,7 @@ import {
     getPaymentMethod,
     getStoreConfig,
 } from '@bigcommerce/checkout/test-mocks';
-import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
+import { fireEvent, render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 
 import WorldpayCreditCardPaymentMethod from './WorldpayCreditCardPaymentMethod';
 
@@ -287,17 +287,23 @@ describe('WorldpayCreditCardPaymentMethod', () => {
             expect(screen.queryByTestId('account-instrument-fieldset')).not.toBeInTheDocument();
         });
 
-        it('shows save credit card form when there are no stored instruments', () => {
+        it('shows save credit card form when there are no stored instruments', async () => {
             jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
 
             render(<PaymentMethodTest {...defaultProps} />);
-            expect(screen.getByText('Save this card for future transactions')).toBeInTheDocument();
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Save this card for future transactions'),
+                ).toBeInTheDocument();
+            });
         });
 
-        it('uses PaymentMethod to retrieve instruments', () => {
+        it('uses PaymentMethod to retrieve instruments', async () => {
             render(<PaymentMethodTest {...defaultProps} />);
 
-            expect(checkoutState.data.getInstruments).toHaveBeenCalledWith(defaultProps.method);
+            await waitFor(() => {
+                expect(checkoutState.data.getInstruments).toHaveBeenCalledWith(defaultProps.method);
+            });
         });
     });
 });


### PR DESCRIPTION
## What/Why?

The bare minimum to convert `CreditCardPaymentMethodComponent` from class component to function component.
- Use `useEffect`.
- Convert private methods into arrow functions.
- Separate the functionality for loading instruments to prevent javascript closure issues.

## Rollout/Rollback

Revert.

## Testing
### Manual testing
Manually tested using Bluesnap and checkout.com to place orders.
- Use a new card.
- Add and use another card.
- Use a stored card.

All above will be checked again during checkout-js pipeline e2e tests.