### PR TITLE
CHECKOUT-9388: Disable auto public path resolution

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -302,6 +302,7 @@ function loaderConfig(options, argv) {
                 filename: `[name]-${appVersion}.js`,
                 library: LOADER_LIBRARY_NAME,
                 crossOriginLoading: 'anonymous',
+                publicPath: '/',
             },
             plugins: [
                 new SubresourceIntegrityPlugin({


### PR DESCRIPTION
## What/Why?
Disable automatic public path resolution in Webpack since the public path is already [provided](https://github.com/bigcommerce/checkout-js/blob/25e4638bc7fe95743d5ba051b321d1f55ac37f71/packages/core/src/app/loader.ts#L36). Without this change, the loader script cannot be inlined.

## Rollout/Rollback

Revert

## Testing

The page loads without automatic public path resolution in webpack.

<img width="1212" height="584" alt="Screenshot 2025-10-14 at 11 32 35 am" src="https://github.com/user-attachments/assets/4868abf4-c4c2-41df-b5d6-8956aa390a85" />


