### PR TITLE
refactor(checkout): CHECKOUT-9476 Improve Saving validationSchemas

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -92,7 +92,10 @@ interface PaymentState {
     shouldDisableSubmit: { [key: string]: boolean };
     shouldHidePaymentSubmitButton: { [key: string]: boolean };
     submitFunctions: { [key: string]: ((values: PaymentFormValues) => void) | null };
-    validationSchemas: { [key: string]: ObjectSchema<Partial<PaymentFormValues>> | null };
+}
+
+interface validationSchemas {
+    [key: string]: ObjectSchema<Partial<PaymentFormValues>> | null;
 }
 
 const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguageProps & AnalyticsContextProps): ReactElement  => {
@@ -101,12 +104,12 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
         isReady: false,
         shouldDisableSubmit: {},
         shouldHidePaymentSubmitButton: {},
-        validationSchemas: {},
         submitFunctions: {},
     });
 
     const isReadyRef = useRef(state.isReady);
     const grandTotalChangeUnsubscribe = useRef<() => void>();
+    const validationSchemasRef = useRef<validationSchemas>({});
 
     const renderOrderErrorModal = (): ReactNode => {
             const { finalizeOrderError, language, shouldLocaliseErrorMessages, submitOrderError } =
@@ -373,18 +376,12 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
         schema: ObjectSchema<Partial<PaymentFormValues>> | null,
     ): void => {
         const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
-        const { validationSchemas } = state;
 
-        if (validationSchemas[uniqueId] === schema) {
+        if (validationSchemasRef.current[uniqueId] === schema) {
             return;
         }
 
-        setState(prevState => ({ ...prevState,
-            validationSchemas: {
-                ...validationSchemas,
-                [uniqueId]: schema,
-            },
-        }));
+        validationSchemasRef.current[uniqueId] = schema;
     };
 
     const loadPaymentMethodsOrThrow = async (): Promise<void> => {
@@ -525,7 +522,7 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
                         termsConditionsText={props.termsConditionsText}
                         termsConditionsUrl={props.termsConditionsUrl}
                         usableStoreCredit={props.usableStoreCredit}
-                        validationSchema={(uniqueSelectedMethodId && state.validationSchemas[uniqueSelectedMethodId]) || undefined}
+                        validationSchema={(uniqueSelectedMethodId && validationSchemasRef.current[uniqueSelectedMethodId]) || undefined}
                     />
                 )}
             </ChecklistSkeleton>


### PR DESCRIPTION
## What/Why?

Fix infinite render loop in Braintree ACH payment method.

The Braintree ACH method was causing the UI to freeze due to an infinite render loop in the Payment component.

The loop occurred because `BraintreeAchPaymentForm` repeatedly updated the `validationSchemas` state in `Payment`, which re-triggered its own `useEffect` ([code](https://github.com/bigcommerce/checkout-js/blob/dff12645a25483f9ba12089fcb03a9745224b059/packages/braintree-integration/src/BraintreeAch/components/BraintreeAchPaymentForm.tsx#L95)).

This PR resolves the issue by moving `validationSchemas` from state to a `useRef`, preventing unnecessary re-renders while preserving existing BraintreeACH implementation.

## Rollout/Rollback

Revert.

## Testing
Pending confirmation from the integration team on the fix.
