### PR TITLE
chore(payment): PI-4360 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.809.0",
+        "@bigcommerce/checkout-sdk": "^1.809.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.809.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.809.0.tgz",
-      "integrity": "sha512-wpj/ZsduJBz5JYwOjwu5shMV3jKDkdCauXvlf/Nz3FBODJa+nI3kB/sy74+zGHJy6/mMxQ84vv4hMRalm68sEw==",
+      "version": "1.809.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.809.2.tgz",
+      "integrity": "sha512-wga+CEUxpPz3r5DHAzxEbgCk3T9mc7tYO6GI4eBXV8hAaa3xnYPZWJ6VASojiWi7vbov+o5qUvZvUPwio7Dp2Q==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.809.0",
+    "@bigcommerce/checkout-sdk": "^1.809.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version to release https://github.com/bigcommerce/checkout-sdk-js/pull/3027
Additionaly https://github.com/bigcommerce/checkout-sdk-js/pull/3028

## Rollout/Rollback
Revert this PR

## Testing
https://github.com/bigcommerce/checkout-sdk-js/pull/3027 testing section here
