### PR TITLE
chore(payment): PAYPAL-5758 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.812.0",
+        "@bigcommerce/checkout-sdk": "^1.813.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.812.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.812.0.tgz",
-      "integrity": "sha512-G9U0STYTk/+QuOAW0PUI+SLWHNYYcRpHzCP37S9l5GwflnypGLnqwVdLkejV0xDzndv3Utmu4KdMP7jKex8F8w==",
+      "version": "1.813.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.813.0.tgz",
+      "integrity": "sha512-VEs+9TiYUBliWkFffo/lpdHNZVvJJHXeV+51clgKZoI9ZW0m42/z2LhUFwbTIn+Y1aFrvibOu/92989UYN++gA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.812.0",
+    "@bigcommerce/checkout-sdk": "^1.813.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk version

To deliver: https://github.com/bigcommerce/checkout-sdk-js/pull/3032

## Rollout/Rollback

Revert

## Testing

All tests passed
