### PR TITLE
refactor(test): CHECKOUT-9429 Refactor analyticsTracker in tests

### DIFF
--- a/packages/core/src/app/billing/Billing.test.tsx
+++ b/packages/core/src/app/billing/Billing.test.tsx
@@ -11,8 +11,6 @@ import React, { type FunctionComponent } from 'react';
 
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
 import {
-    type AnalyticsContextProps,
-    type AnalyticsEvents,
     AnalyticsProviderMock,
  ThemeProvider } from '@bigcommerce/checkout/contexts';
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
@@ -51,9 +49,8 @@ describe('Billing step', () => {
     let checkout: CheckoutPageNodeObject;
     let CheckoutTest: FunctionComponent<CheckoutIntermediateProps>;
     let checkoutService: CheckoutService;
-    let defaultProps: CheckoutIntermediateProps & AnalyticsContextProps;
+    let defaultProps: CheckoutIntermediateProps;
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
-    let analyticsTracker: Partial<AnalyticsEvents>;
 
     const checkoutWithCustomer = {
         ...checkoutWithShipping,
@@ -81,12 +78,6 @@ describe('Billing step', () => {
         embeddedMessengerMock = createEmbeddedCheckoutMessenger({
             parentOrigin: 'https://store.url',
         });
-        analyticsTracker = {
-            checkoutBegin: jest.fn(),
-            trackStepViewed: jest.fn(),
-            trackStepCompleted: jest.fn(),
-            exitCheckout: jest.fn(),
-        };
         defaultProps = {
             checkoutId: 'x',
             containerId: CHECKOUT_ROOT_NODE_ID,
@@ -94,7 +85,6 @@ describe('Billing step', () => {
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
             embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
             errorLogger: createErrorLogger(),
-            analyticsTracker,
         };
 
         jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
@@ -102,7 +92,7 @@ describe('Billing step', () => {
 
         jest.mock('lodash', () => ({
             ...jest.requireActual('lodash'),
-            debounce: (fn) => {
+            debounce: (fn: any) => {
                 fn.cancel = jest.fn();
 
                 return fn;

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -10,11 +10,7 @@ import { rest } from 'msw';
 import React, { act, type FunctionComponent } from 'react';
 
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
-import {
-    type AnalyticsContextProps,
-    type AnalyticsEvents,
-    AnalyticsProviderMock,
- ThemeProvider } from '@bigcommerce/checkout/contexts';
+import { AnalyticsProviderMock, ThemeProvider } from '@bigcommerce/checkout/contexts';
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
     CHECKOUT_ROOT_NODE_ID,
@@ -40,9 +36,8 @@ describe('Payment step', () => {
     let checkout: CheckoutPageNodeObject;
     let CheckoutTest: FunctionComponent<CheckoutProps>;
     let checkoutService: CheckoutService;
-    let defaultProps: CheckoutProps & AnalyticsContextProps;
+    let defaultProps: CheckoutProps;
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
-    let analyticsTracker: Partial<AnalyticsEvents>;
 
     beforeAll(() => {
         checkout = new CheckoutPageNodeObject();
@@ -64,12 +59,6 @@ describe('Payment step', () => {
         embeddedMessengerMock = createEmbeddedCheckoutMessenger({
             parentOrigin: 'https://store.url',
         });
-        analyticsTracker = {
-            checkoutBegin: jest.fn(),
-            trackStepViewed: jest.fn(),
-            trackStepCompleted: jest.fn(),
-            exitCheckout: jest.fn(),
-        };
         defaultProps = {
             checkoutId: checkoutWithBillingEmail.id,
             containerId: CHECKOUT_ROOT_NODE_ID,
@@ -77,7 +66,6 @@ describe('Payment step', () => {
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
             embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
             errorLogger: createErrorLogger(),
-            analyticsTracker,
         };
 
         jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -7,15 +7,10 @@ import {
 import { faker } from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
-import { rest } from 'msw';
 import React, { type FunctionComponent } from 'react';
 
 import { ExtensionProvider } from '@bigcommerce/checkout/checkout-extension';
-import {
-    type AnalyticsContextProps,
-    type AnalyticsEvents,
-    AnalyticsProviderMock,
- ThemeProvider } from '@bigcommerce/checkout/contexts';
+import { AnalyticsProviderMock, ThemeProvider } from '@bigcommerce/checkout/contexts';
 import { getLanguageService, LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
     CHECKOUT_ROOT_NODE_ID,
@@ -48,9 +43,8 @@ describe('Shipping step', () => {
     let checkout: CheckoutPageNodeObject;
     let CheckoutTest: FunctionComponent<CheckoutProps>;
     let checkoutService: CheckoutService;
-    let defaultProps: CheckoutProps & AnalyticsContextProps;
+    let defaultProps: CheckoutProps;
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
-    let analyticsTracker: Partial<AnalyticsEvents>;
 
     beforeAll(() => {
         checkout = new CheckoutPageNodeObject();
@@ -73,12 +67,6 @@ describe('Shipping step', () => {
         embeddedMessengerMock = createEmbeddedCheckoutMessenger({
             parentOrigin: 'https://store.url',
         });
-        analyticsTracker = {
-            checkoutBegin: jest.fn(),
-            trackStepViewed: jest.fn(),
-            trackStepCompleted: jest.fn(),
-            exitCheckout: jest.fn(),
-        };
         defaultProps = {
             checkoutId: 'x',
             containerId: CHECKOUT_ROOT_NODE_ID,
@@ -86,7 +74,6 @@ describe('Shipping step', () => {
             embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
             embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
             errorLogger: createErrorLogger(),
-            analyticsTracker,
         };
 
         jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
@@ -95,7 +82,7 @@ describe('Shipping step', () => {
 
         jest.mock('lodash', () => ({
             ...jest.requireActual('lodash'),
-            debounce: (fn) => {
+            debounce: (fn:any) => {
                 fn.cancel = jest.fn();
 
                 return fn;
@@ -436,7 +423,7 @@ describe('Shipping step', () => {
             );
             // eslint-disable-next-line jest-dom/prefer-to-have-attribute
             expect(
-                screen.queryByLabelText('My billing address is the same as my shipping address.').hasAttribute('checked'),
+                screen.queryByLabelText('My billing address is the same as my shipping address.')?.hasAttribute('checked'),
             ).toBeFalsy();
 
             await userEvent.click(screen.getByLabelText('My billing address is the same as my shipping address.'));
@@ -604,7 +591,7 @@ describe('Shipping step', () => {
         });
     });
 
-    it.only('renders and validates shipping form built-in and customfields', async () => {
+    it('renders and validates shipping form built-in and customfields', async () => {
         checkoutService = checkout.use(CheckoutPreset.CheckoutWithBillingEmailAndCustomFormFields);
 
         jest.spyOn(checkoutService, 'updateShippingAddress');
@@ -704,7 +691,7 @@ describe('Shipping step', () => {
         it('sees the quote failed message when no shipping option available', async () => {
             jest.mock('lodash', () => ({
                 ...jest.requireActual('lodash'),
-                debounce: (fn) => {
+                debounce: (fn:any) => {
                     fn.cancel = jest.fn();
 
                     return fn;

--- a/packages/core/src/app/shipping/stripeUPE/StripeShipping.test.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShipping.test.tsx
@@ -16,7 +16,6 @@ import CheckoutStepType from '../../checkout/CheckoutStepType';
 import ConsoleErrorLogger from '../../common/error/ConsoleErrorLogger';
 import { getStoreConfig } from '../../config/config.mock';
 import { getCustomer } from '../../customer/customers.mock';
-import { getShippingAddress } from '../shipping-addresses.mock';
 
 import StripeShipping, { type StripeShippingProps } from './StripeShipping';
 
@@ -30,6 +29,7 @@ describe('Stripe Shipping Component', () => {
    checkoutService.initializeShipping = initialize;
 
   const defaultProps: StripeShippingProps = {
+        isInitializing: false,
         step: {
             isActive: true,
             isBusy: false,


### PR DESCRIPTION
## What/Why?

Refactor the `analyticsTracker` object in tests.

## Rollout/Rollback

Revert.

## Testing

CI.
