### PR TITLE
chore(payment): PAYPAL-5984 bump checkout-sdk v1.815.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.814.0",
+        "@bigcommerce/checkout-sdk": "^1.815.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.814.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.814.0.tgz",
-      "integrity": "sha512-q+QVD0sYq2zKfQdOjp4NOGeyZtOys7DoNIzRMiP/RQ4ZxHeKNjeVL5mRZcypq/PZtC6d04liAi09XtG0SX1gQg==",
+      "version": "1.815.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.815.0.tgz",
+      "integrity": "sha512-igQVHERVGTsKS3SHTXs8ubfc2rJCLmmE2Mi7djTaMDg47R/uI/D00ysCb1WgsEkpMfqT4K9umwkpIJcvkVmTHA==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.814.0",
+    "@bigcommerce/checkout-sdk": "^1.815.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk v1.815.0 as part of checkout-sdk release.

The release contains:
https://github.com/bigcommerce/checkout-sdk-js/pull/3031

## Rollout/Rollback
Merge / revert

## Testing
Unit tests
Manual tests
CI
