### PR TITLE
chore(payment): PI-4355 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.816.0",
+        "@bigcommerce/checkout-sdk": "^1.816.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.816.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.816.0.tgz",
-      "integrity": "sha512-VTPbF4xWodrzH9hVitIa0tYoaPX4bfWw1IdKUSazMOdBHFplu75BkjhWxLsWVC8pNNRKFkYdCcNLU6zx9t3p4g==",
+      "version": "1.816.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.816.1.tgz",
+      "integrity": "sha512-NJf5D2jrYmCQWKUwMOoSjsFRDYbeIUUxamQoMDmU0l/HdCRSI/OC9tFO1cd3siSECl7d4fK9F8s42uhqCb2wDw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.816.0",
+    "@bigcommerce/checkout-sdk": "^1.816.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version due to the release of https://github.com/bigcommerce/checkout-sdk-js/pull/3041

## Rollout/Rollback

Revert this PR

## Testing

[Testing section here](https://github.com/bigcommerce/checkout-sdk-js/pull/3041)
