### PR TITLE
feat(payment): customer step buttons height 40px

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.822.0",
+        "@bigcommerce/checkout-sdk": "^1.823.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.822.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.822.0.tgz",
-      "integrity": "sha512-wls/IW1omSs5xdAQdzuAQ5bVaLIaQYXzvPJtVs9h3Oah0q7j/DuL3Kf4bDROsYmDi+Ea+C0yq+A04MLb1GqOxQ==",
+      "version": "1.823.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.823.0.tgz",
+      "integrity": "sha512-2HetJyvA4DLpxGfObkLMuth041aG3KJK+NBeLiDTAbqlmyo2YFZaFekTF57uAARAmBEJDZRbTYu94YqK/MXcXQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.822.0",
+    "@bigcommerce/checkout-sdk": "^1.823.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/customer/CheckoutButton.tsx
+++ b/packages/core/src/app/customer/CheckoutButton.tsx
@@ -2,7 +2,7 @@ import { type CustomerInitializeOptions, type CustomerRequestOptions } from '@bi
 import { noop } from 'lodash';
 import React, { type ReactElement, useEffect } from 'react';
 
-const WALLET_BUTTON_HEIGHT = 36;
+const WALLET_BUTTON_HEIGHT = 40;
 
 export interface CheckoutButtonProps {
     containerId: string;

--- a/packages/core/src/scss/settings/foundation/buttons/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/buttons/_settings.scss
@@ -210,5 +210,5 @@ $button-radius:                         3px;
 
 // We use these to control the look of the wallet buttons on the top of the checkout
 $wallet-button-max-width:               320px;
-$wallet-button-height:                  36px;
+$wallet-button-height:                  40px;
 $wallet-button-track-size:              12;

--- a/packages/google-pay-integration/src/GooglePayButton.scss
+++ b/packages/google-pay-integration/src/GooglePayButton.scss
@@ -5,7 +5,7 @@
     }
 
     & .gpay-card-info-container {
-        height: 36px;
+        height: 40px;
         width: 100%;
         min-width: 100%;
         min-height: unset;


### PR DESCRIPTION
## What/Why?
Increased payment button height on customer step to 40px
Also includes PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/3046

## Rollout/Rollback
Revert this PR

## Testing
<img width="651" height="227" alt="Screenshot 2025-10-28 at 15 18 41" src="https://github.com/user-attachments/assets/d25498c5-6945-4285-becc-85e59707dc09" />

