### PR TITLE
refactor(checkout): CHECKOUT-9479 Remove duplicated providers

### DIFF
--- a/packages/adyen-integration/src/adyenv2/AdyenV2PaymentMethod.tsx
+++ b/packages/adyen-integration/src/adyenv2/AdyenV2PaymentMethod.tsx
@@ -9,10 +9,7 @@ import { createAdyenV2PaymentStrategy } from '@bigcommerce/checkout-sdk/integrat
 import React, { type FunctionComponent, useCallback, useRef, useState } from 'react';
 
 import { type HostedWidgetComponentProps } from '@bigcommerce/checkout/hosted-widget-integration';
-import { LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
-    CheckoutContext,
-    PaymentFormContext,
     type PaymentMethodProps,
     type PaymentMethodResolveId,
     toResolvableComponent,
@@ -185,30 +182,24 @@ const AdyenV2PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     return (
         <FormContext.Provider value={formContextProps}>
-            <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
-                <LocaleProvider checkoutService={checkoutService}>
-                    <PaymentFormContext.Provider value={{ paymentForm }}>
-                        <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                            <AdyenV2Form
-                                {...rest}
-                                additionalActionContainerId={additionalActionContainerId}
-                                cancelAdditionalActionModalFlow={cancelAdditionalActionModalFlow}
-                                checkoutService={checkoutService}
-                                checkoutState={checkoutState}
-                                containerId={containerId}
-                                initializePayment={initializeAdyenPayment}
-                                isAccountInstrument={isAccountInstrument()}
-                                language={language}
-                                method={method}
-                                paymentForm={paymentForm}
-                                shouldHideInstrumentExpiryDate={shouldHideInstrumentExpiryDate}
-                                showAdditionalActionContent={showAdditionalActionContent}
-                                validateInstrument={validateInstrument}
-                            />
-                        </LoadingOverlay>
-                    </PaymentFormContext.Provider>
-                </LocaleProvider>
-            </CheckoutContext.Provider>
+            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                <AdyenV2Form
+                    {...rest}
+                    additionalActionContainerId={additionalActionContainerId}
+                    cancelAdditionalActionModalFlow={cancelAdditionalActionModalFlow}
+                    checkoutService={checkoutService}
+                    checkoutState={checkoutState}
+                    containerId={containerId}
+                    initializePayment={initializeAdyenPayment}
+                    isAccountInstrument={isAccountInstrument()}
+                    language={language}
+                    method={method}
+                    paymentForm={paymentForm}
+                    shouldHideInstrumentExpiryDate={shouldHideInstrumentExpiryDate}
+                    showAdditionalActionContent={showAdditionalActionContent}
+                    validateInstrument={validateInstrument}
+                />
+            </LoadingOverlay>
         </FormContext.Provider>
     );
 };

--- a/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.test.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.test.tsx
@@ -19,6 +19,7 @@ import {
 } from '@bigcommerce/checkout/locale';
 import {
     CheckoutProvider,
+    PaymentFormProvider,
     type PaymentFormService,
     type PaymentMethodProps,
 } from '@bigcommerce/checkout/payment-integration-api';
@@ -34,7 +35,6 @@ describe('when using AdyenV3 payment', () => {
     let method: PaymentMethod;
     let checkoutService: CheckoutService;
     let checkoutState: CheckoutSelectors;
-    let defaultProps: PaymentMethodProps;
     let localeContext: LocaleContextType;
     let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
     let paymentForm: PaymentFormService;
@@ -53,15 +53,6 @@ describe('when using AdyenV3 payment', () => {
             .spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
-        defaultProps = {
-            method: { ...getPaymentMethod(), id: 'scheme', gateway: 'adyenv3', method: 'scheme' },
-            checkoutService,
-            checkoutState,
-            paymentForm,
-            language: createLanguageService(),
-            onUnhandledError: jest.fn(),
-        };
-
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
 
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
@@ -71,11 +62,13 @@ describe('when using AdyenV3 payment', () => {
 
         PaymentMethodTest = (props) => (
             <CheckoutProvider checkoutService={checkoutService}>
-                <LocaleContext.Provider value={localeContext}>
-                    <Formik initialValues={{}} onSubmit={noop}>
-                        <AdyenV3PaymentMethod {...props} />
-                    </Formik>
-                </LocaleContext.Provider>
+                <PaymentFormProvider paymentForm={paymentForm}>
+                    <LocaleContext.Provider value={localeContext}>
+                        <Formik initialValues={{}} onSubmit={noop}>
+                            <AdyenV3PaymentMethod {...props} />
+                        </Formik>
+                    </LocaleContext.Provider>
+                </PaymentFormProvider>
             </CheckoutProvider>
         );
     });

--- a/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
@@ -8,10 +8,7 @@ import { createAdyenV3PaymentStrategy } from '@bigcommerce/checkout-sdk/integrat
 import React, { type FunctionComponent, useCallback, useRef, useState } from 'react';
 
 import { type HostedWidgetComponentProps } from '@bigcommerce/checkout/hosted-widget-integration';
-import { LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
-    CheckoutContext,
-    PaymentFormContext,
     type PaymentMethodProps,
     type PaymentMethodResolveId,
     toResolvableComponent,
@@ -182,35 +179,29 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     return (
         <FormContext.Provider value={formContextProps}>
-            <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
-                <LocaleProvider checkoutService={checkoutService}>
-                    <PaymentFormContext.Provider value={{ paymentForm }}>
-                        <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                            <AdyenV3Form
-                                {...rest}
-                                additionalActionContainerId={additionalActionContainerId}
-                                cancelAdditionalActionModalFlow={cancelAdditionalActionModalFlow}
-                                checkoutService={checkoutService}
-                                checkoutState={checkoutState}
-                                containerId={containerId}
-                                hideContentWhenSignedOut
-                                initializePayment={initializeAdyenPayment}
-                                isAccountInstrument={isAccountInstrument()}
-                                isModalVisible={isAdditionalActionContentModalVisible}
-                                language={language}
-                                method={method}
-                                onUnhandledError={onUnhandledError}
-                                paymentForm={paymentForm}
-                                shouldHideInstrumentExpiryDate={shouldHideInstrumentExpiryDate}
-                                shouldRenderAdditionalActionContentModal={
-                                    shouldRenderAdditionalActionContentModal
-                                }
-                                validateInstrument={validateInstrument}
-                            />
-                        </LoadingOverlay>
-                    </PaymentFormContext.Provider>
-                </LocaleProvider>
-            </CheckoutContext.Provider>
+            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                <AdyenV3Form
+                    {...rest}
+                    additionalActionContainerId={additionalActionContainerId}
+                    cancelAdditionalActionModalFlow={cancelAdditionalActionModalFlow}
+                    checkoutService={checkoutService}
+                    checkoutState={checkoutState}
+                    containerId={containerId}
+                    hideContentWhenSignedOut
+                    initializePayment={initializeAdyenPayment}
+                    isAccountInstrument={isAccountInstrument()}
+                    isModalVisible={isAdditionalActionContentModalVisible}
+                    language={language}
+                    method={method}
+                    onUnhandledError={onUnhandledError}
+                    paymentForm={paymentForm}
+                    shouldHideInstrumentExpiryDate={shouldHideInstrumentExpiryDate}
+                    shouldRenderAdditionalActionContentModal={
+                        shouldRenderAdditionalActionContentModal
+                    }
+                    validateInstrument={validateInstrument}
+                />
+            </LoadingOverlay>
         </FormContext.Provider>
     );
 };

--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentsFastlane/BigCommercePaymentsFastlanePaymentMethod.test.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentsFastlane/BigCommercePaymentsFastlanePaymentMethod.test.tsx
@@ -2,6 +2,7 @@ import { createCheckoutService, createLanguageService } from '@bigcommerce/check
 import { createBigCommercePaymentsFastlanePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bigcommerce-payments';
 import React from 'react';
 
+import { PaymentFormProvider } from '@bigcommerce/checkout/payment-integration-api';
 import { getPaymentFormServiceMock } from '@bigcommerce/checkout/test-mocks';
 import { render } from '@bigcommerce/checkout/test-utils';
 
@@ -10,6 +11,7 @@ import BigCommercePaymentsFastlanePaymentMethod from './BigCommercePaymentsFastl
 describe('BigCommercePaymentsFastlanePaymentMethod', () => {
     const checkoutService = createCheckoutService();
     const checkoutState = checkoutService.getState();
+    const paymentForm = getPaymentFormServiceMock();
 
     const method = {
         clientToken: 'token',
@@ -41,7 +43,11 @@ describe('BigCommercePaymentsFastlanePaymentMethod', () => {
             .spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
-        render(<BigCommercePaymentsFastlanePaymentMethod {...props} />);
+        render(
+            <PaymentFormProvider paymentForm={paymentForm}>
+                <BigCommercePaymentsFastlanePaymentMethod {...props} />
+            </PaymentFormProvider>,
+        );
 
         expect(initializePayment).toHaveBeenCalledWith({
             methodId: props.method.id,
@@ -59,7 +65,11 @@ describe('BigCommercePaymentsFastlanePaymentMethod', () => {
             .spyOn(checkoutService, 'deinitializePayment')
             .mockResolvedValue(checkoutState);
 
-        const view = render(<BigCommercePaymentsFastlanePaymentMethod {...props} />);
+        const view = render(
+            <PaymentFormProvider paymentForm={paymentForm}>
+                <BigCommercePaymentsFastlanePaymentMethod {...props} />
+            </PaymentFormProvider>,
+        );
 
         view.unmount();
 

--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentsFastlane/BigCommercePaymentsFastlanePaymentMethod.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentsFastlane/BigCommercePaymentsFastlanePaymentMethod.tsx
@@ -2,20 +2,17 @@ import { type CardInstrument } from '@bigcommerce/checkout-sdk';
 import { createBigCommercePaymentsFastlanePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bigcommerce-payments';
 import React, { type FunctionComponent, useEffect, useRef } from 'react';
 
-import { LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
-    CheckoutContext,
-    PaymentFormContext,
     type PaymentMethodProps,
     type PaymentMethodResolveId,
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 import { FormContext, LoadingOverlay } from '@bigcommerce/checkout/ui';
+import { isErrorWithTranslationKey } from '@bigcommerce/checkout/utility';
 
 import BigCommercePaymentsFastlaneForm from './components/BigCommercePaymentsFastlaneForm';
 
 import './BigCommercePaymentsFastlanePaymentMethod.scss';
-import { isErrorWithTranslationKey } from '@bigcommerce/checkout/utility';
 
 export interface BigCommercePaymentsFastlaneCardComponentRef {
     renderPayPalCardComponent?: (container: string) => void;
@@ -101,22 +98,14 @@ const BigCommercePaymentsFastlanePaymentMethod: FunctionComponent<PaymentMethodP
 
     return (
         <FormContext.Provider value={formContextProps}>
-            <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
-                <LocaleProvider checkoutService={checkoutService}>
-                    <PaymentFormContext.Provider value={{ paymentForm }}>
-                        <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                            <BigCommercePaymentsFastlaneForm
-                                renderPayPalCardComponent={
-                                    paypalCardComponentRef.current.renderPayPalCardComponent
-                                }
-                                showPayPalCardSelector={
-                                    paypalCardComponentRef.current.showPayPalCardSelector
-                                }
-                            />
-                        </LoadingOverlay>
-                    </PaymentFormContext.Provider>
-                </LocaleProvider>
-            </CheckoutContext.Provider>
+            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                <BigCommercePaymentsFastlaneForm
+                    renderPayPalCardComponent={
+                        paypalCardComponentRef.current.renderPayPalCardComponent
+                    }
+                    showPayPalCardSelector={paypalCardComponentRef.current.showPayPalCardSelector}
+                />
+            </LoadingOverlay>
         </FormContext.Provider>
     );
 };

--- a/packages/braintree-integration/src/BraintreeAch/BraintreeAchPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeAch/BraintreeAchPaymentMethod.tsx
@@ -1,10 +1,7 @@
 import { createBraintreeAchPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useEffect, useRef } from 'react';
 
-import { LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
-    CheckoutContext,
-    PaymentFormContext,
     type PaymentMethodProps,
     type PaymentMethodResolveId,
     toResolvableComponent,
@@ -94,18 +91,9 @@ const BraintreeAchPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     return (
         <FormContext.Provider value={formContextProps}>
-            <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
-                <LocaleProvider checkoutService={checkoutService}>
-                    <PaymentFormContext.Provider value={{ paymentForm }}>
-                        <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                            <BraintreeAchPaymentForm
-                                method={method}
-                                updateMandateText={updateMandateText}
-                            />
-                        </LoadingOverlay>
-                    </PaymentFormContext.Provider>
-                </LocaleProvider>
-            </CheckoutContext.Provider>
+            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                <BraintreeAchPaymentForm method={method} updateMandateText={updateMandateText} />
+            </LoadingOverlay>
         </FormContext.Provider>
     );
 };

--- a/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.test.tsx
@@ -2,6 +2,7 @@ import { createCheckoutService, createLanguageService } from '@bigcommerce/check
 import { createBraintreeFastlanePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React from 'react';
 
+import { PaymentFormProvider } from '@bigcommerce/checkout/payment-integration-api';
 import { getPaymentFormServiceMock } from '@bigcommerce/checkout/test-mocks';
 import { render } from '@bigcommerce/checkout/test-utils';
 
@@ -10,6 +11,7 @@ import BraintreeFastlanePaymentMethod from './BraintreeFastlanePaymentMethod';
 describe('BraintreeFastlanePaymentMethod', () => {
     const checkoutService = createCheckoutService();
     const checkoutState = checkoutService.getState();
+    const paymentForm = getPaymentFormServiceMock();
 
     const method = {
         clientToken: 'token',
@@ -41,7 +43,11 @@ describe('BraintreeFastlanePaymentMethod', () => {
             .spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
-        render(<BraintreeFastlanePaymentMethod {...props} />);
+        render(
+            <PaymentFormProvider paymentForm={paymentForm}>
+                <BraintreeFastlanePaymentMethod {...props} />
+            </PaymentFormProvider>,
+        );
 
         expect(initializePayment).toHaveBeenCalledWith({
             methodId: props.method.id,
@@ -59,7 +65,11 @@ describe('BraintreeFastlanePaymentMethod', () => {
             .spyOn(checkoutService, 'deinitializePayment')
             .mockResolvedValue(checkoutState);
 
-        const view = render(<BraintreeFastlanePaymentMethod {...props} />);
+        const view = render(
+            <PaymentFormProvider paymentForm={paymentForm}>
+                <BraintreeFastlanePaymentMethod {...props} />
+            </PaymentFormProvider>,
+        );
 
         view.unmount();
 

--- a/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.tsx
@@ -2,10 +2,7 @@ import { type CardInstrument } from '@bigcommerce/checkout-sdk';
 import { createBraintreeFastlanePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useEffect, useRef } from 'react';
 
-import { LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
-    CheckoutContext,
-    PaymentFormContext,
     type PaymentMethodProps,
     type PaymentMethodResolveId,
     toResolvableComponent,
@@ -87,22 +84,16 @@ const BraintreeFastlanePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     return (
         <FormContext.Provider value={formContextProps}>
-            <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
-                <LocaleProvider checkoutService={checkoutService}>
-                    <PaymentFormContext.Provider value={{ paymentForm }}>
-                        <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                            <BraintreeFastlaneForm
-                                renderPayPalCardComponent={
-                                    paypalFastlaneComponentRef?.current?.renderPayPalCardComponent
-                                }
-                                showPayPalCardSelector={
-                                    paypalFastlaneComponentRef.current?.showPayPalCardSelector
-                                }
-                            />
-                        </LoadingOverlay>
-                    </PaymentFormContext.Provider>
-                </LocaleProvider>
-            </CheckoutContext.Provider>
+            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                <BraintreeFastlaneForm
+                    renderPayPalCardComponent={
+                        paypalFastlaneComponentRef?.current?.renderPayPalCardComponent
+                    }
+                    showPayPalCardSelector={
+                        paypalFastlaneComponentRef.current?.showPayPalCardSelector
+                    }
+                />
+            </LoadingOverlay>
         </FormContext.Provider>
     );
 };

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -28,7 +28,6 @@ import {
     isInstrumentFeatureAvailable,
     StoreInstrumentFieldset,
 } from '@bigcommerce/checkout/instrument-utils';
-import { createLocaleContext, LocaleContext } from '@bigcommerce/checkout/locale';
 import {
     CaptureMessageComponent,
     type CardInstrumentFieldsetValues,
@@ -365,57 +364,52 @@ export const CreditCardPaymentMethodComponent = (
     }
 
     return (
-        <LocaleContext.Provider value={createLocaleContext(storeConfig)}>
-            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                <div
-                    className="paymentMethod paymentMethod--creditCard"
-                    data-test="credit-cart-payment-method"
-                >
-                    {shouldShowInstrumentFieldset && (
-                        <CardInstrumentFieldset
-                            instruments={outerInstruments}
-                            onDeleteInstrument={handleDeleteInstrument}
-                            onSelectInstrument={handleSelectInstrument}
-                            onUseNewInstrument={handleUseNewCard}
-                            selectedInstrumentId={
-                                selectedInstrument && selectedInstrument.bigpayToken
+        <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+            <div
+                className="paymentMethod paymentMethod--creditCard"
+                data-test="credit-cart-payment-method"
+            >
+                {shouldShowInstrumentFieldset && (
+                    <CardInstrumentFieldset
+                        instruments={outerInstruments}
+                        onDeleteInstrument={handleDeleteInstrument}
+                        onSelectInstrument={handleSelectInstrument}
+                        onUseNewInstrument={handleUseNewCard}
+                        selectedInstrumentId={selectedInstrument && selectedInstrument.bigpayToken}
+                        validateInstrument={
+                            getStoredCardValidationFieldset ? (
+                                getStoredCardValidationFieldset(selectedInstrument)
+                            ) : (
+                                <CreditCardValidation
+                                    shouldShowCardCodeField={shouldShowCardCodeField}
+                                    shouldShowNumberField={shouldShowNumberField}
+                                />
+                            )
+                        }
+                    />
+                )}
+
+                {shouldShowCreditCardFieldset && !cardFieldset && (
+                    <>
+                        <CaptureMessageComponent message={SentryMessage} />
+                        <CreditCardFieldset
+                            shouldShowCardCodeField={
+                                methodProp.config.cardCode || methodProp.config.cardCode === null
                             }
-                            validateInstrument={
-                                getStoredCardValidationFieldset ? (
-                                    getStoredCardValidationFieldset(selectedInstrument)
-                                ) : (
-                                    <CreditCardValidation
-                                        shouldShowCardCodeField={shouldShowCardCodeField}
-                                        shouldShowNumberField={shouldShowNumberField}
-                                    />
-                                )
-                            }
+                            shouldShowCustomerCodeField={methodProp.config.requireCustomerCode}
                         />
-                    )}
+                    </>
+                )}
 
-                    {shouldShowCreditCardFieldset && !cardFieldset && (
-                        <>
-                            <CaptureMessageComponent message={SentryMessage} />
-                            <CreditCardFieldset
-                                shouldShowCardCodeField={
-                                    methodProp.config.cardCode ||
-                                    methodProp.config.cardCode === null
-                                }
-                                shouldShowCustomerCodeField={methodProp.config.requireCustomerCode}
-                            />
-                        </>
-                    )}
+                {shouldShowCreditCardFieldset && cardFieldset}
 
-                    {shouldShowCreditCardFieldset && cardFieldset}
-
-                    {isInstrumentFeatureAvailableProp && (
-                        <StoreInstrumentFieldset
-                            instrumentId={selectedInstrument && selectedInstrument.bigpayToken}
-                            instruments={outerInstruments}
-                        />
-                    )}
-                </div>
-            </LoadingOverlay>
-        </LocaleContext.Provider>
+                {isInstrumentFeatureAvailableProp && (
+                    <StoreInstrumentFieldset
+                        instrumentId={selectedInstrument && selectedInstrument.bigpayToken}
+                        instruments={outerInstruments}
+                    />
+                )}
+            </div>
+        </LoadingOverlay>
     );
 };

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.test.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.test.tsx
@@ -2,6 +2,7 @@ import { createCheckoutService, createLanguageService } from '@bigcommerce/check
 import { createPayPalCommerceFastlanePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/paypal-commerce';
 import React from 'react';
 
+import { PaymentFormProvider } from '@bigcommerce/checkout/payment-integration-api';
 import { getPaymentFormServiceMock } from '@bigcommerce/checkout/test-mocks';
 import { render } from '@bigcommerce/checkout/test-utils';
 
@@ -10,6 +11,7 @@ import PayPalCommerceFastlanePaymentMethod from './PayPalCommerceFastlanePayment
 describe('PayPalCommerceFastlanePaymentMethod', () => {
     const checkoutService = createCheckoutService();
     const checkoutState = checkoutService.getState();
+    const paymentForm = getPaymentFormServiceMock();
 
     const method = {
         clientToken: 'token',
@@ -31,7 +33,7 @@ describe('PayPalCommerceFastlanePaymentMethod', () => {
         method,
         checkoutService,
         checkoutState,
-        paymentForm: getPaymentFormServiceMock(),
+        paymentForm,
         language: createLanguageService(),
         onUnhandledError: jest.fn(),
     };
@@ -41,7 +43,11 @@ describe('PayPalCommerceFastlanePaymentMethod', () => {
             .spyOn(checkoutService, 'initializePayment')
             .mockResolvedValue(checkoutState);
 
-        render(<PayPalCommerceFastlanePaymentMethod {...props} />);
+        render(
+            <PaymentFormProvider paymentForm={paymentForm}>
+                <PayPalCommerceFastlanePaymentMethod {...props} />
+            </PaymentFormProvider>,
+        );
 
         expect(initializePayment).toHaveBeenCalledWith({
             methodId: props.method.id,
@@ -59,7 +65,11 @@ describe('PayPalCommerceFastlanePaymentMethod', () => {
             .spyOn(checkoutService, 'deinitializePayment')
             .mockResolvedValue(checkoutState);
 
-        const view = render(<PayPalCommerceFastlanePaymentMethod {...props} />);
+        const view = render(
+            <PaymentFormProvider paymentForm={paymentForm}>
+                <PayPalCommerceFastlanePaymentMethod {...props} />
+            </PaymentFormProvider>,
+        );
 
         view.unmount();
 

--- a/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.tsx
+++ b/packages/paypal-commerce-integration/src/PayPalCommerceFastlane/PayPalCommerceFastlanePaymentMethod.tsx
@@ -2,10 +2,7 @@ import { type CardInstrument } from '@bigcommerce/checkout-sdk';
 import { createPayPalCommerceFastlanePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/paypal-commerce';
 import React, { type FunctionComponent, useEffect, useRef } from 'react';
 
-import { LocaleProvider } from '@bigcommerce/checkout/locale';
 import {
-    CheckoutContext,
-    PaymentFormContext,
     type PaymentMethodProps,
     type PaymentMethodResolveId,
     toResolvableComponent,
@@ -13,7 +10,6 @@ import {
 import { FormContext, LoadingOverlay } from '@bigcommerce/checkout/ui';
 
 import PayPalCommerceFastlaneForm from './components/PayPalCommerceFastlaneForm';
-
 import './PayPalCommerceFastlanePaymentMethod.scss';
 import isErrorWithTranslationKey from './is-error-with-translation-key';
 
@@ -101,22 +97,14 @@ const PayPalCommerceFastlanePaymentMethod: FunctionComponent<PaymentMethodProps>
 
     return (
         <FormContext.Provider value={formContextProps}>
-            <CheckoutContext.Provider value={{ checkoutState, checkoutService }}>
-                <LocaleProvider checkoutService={checkoutService}>
-                    <PaymentFormContext.Provider value={{ paymentForm }}>
-                        <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                            <PayPalCommerceFastlaneForm
-                                renderPayPalCardComponent={
-                                    paypalCardComponentRef.current.renderPayPalCardComponent
-                                }
-                                showPayPalCardSelector={
-                                    paypalCardComponentRef.current.showPayPalCardSelector
-                                }
-                            />
-                        </LoadingOverlay>
-                    </PaymentFormContext.Provider>
-                </LocaleProvider>
-            </CheckoutContext.Provider>
+            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                <PayPalCommerceFastlaneForm
+                    renderPayPalCardComponent={
+                        paypalCardComponentRef.current.renderPayPalCardComponent
+                    }
+                    showPayPalCardSelector={paypalCardComponentRef.current.showPayPalCardSelector}
+                />
+            </LoadingOverlay>
         </FormContext.Provider>
     );
 };


### PR DESCRIPTION
## What/Why?

Remove duplicated providers from the production code.

After cleaning up,
- `PaymentFormProvider` is in only used in `packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx`.
- `LocaleProvider` and `CheckoutProvider` are only used in `packages/core/src/app/checkout/CheckoutApp.tsx` and `packages/core/src/app/order/OrderConfirmationApp.tsx`.

## Rollout/Rollback

Revert.

## Testing

CI.

### Manual testing
#### Braintree

https://github.com/user-attachments/assets/4ec97697-dd26-438d-8262-9c5c537fce14

#### Adyen

https://github.com/user-attachments/assets/54de0354-c92c-4cdf-b110-ae76ecbaabab