### PR TITLE
fix(payment): PI-4321 fixed Sezzle payment method title

### DIFF
--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -64,14 +64,6 @@
     flex-shrink: 1;
 }
 
-@media (max-width: $screen-xsmall) {
-    div[data-test="payment-method-sezzle"] {
-        .paymentProviderHeader-name {
-            visibility: hidden;
-        }
-    }
-}
-
 .paymentMethod--creditCard,
 .paymentMethod--hosted,
 .paymentMethod--walletButton {


### PR DESCRIPTION
## What/Why?

Removed code that hides Sezzle title, and make Sezzle styles generic with other payments gateways

## Rollout/Rollback

Revert PR

## Testing

<img width="358" height="187" alt="image" src="https://github.com/user-attachments/assets/44348850-51a9-4e69-9793-faac4e6c1f4c" />
