### PR TITLE
refactor(checkout): CHECKOUT-9479 Update Test Mocks

### DIFF
--- a/packages/core/src/app/payment/creditCard/getCreditCardValidationSchema.test.ts
+++ b/packages/core/src/app/payment/creditCard/getCreditCardValidationSchema.test.ts
@@ -1,6 +1,7 @@
 import { createLanguageService, type LanguageService } from '@bigcommerce/checkout-sdk';
 
 import { type CreditCardFieldsetValues } from '@bigcommerce/checkout/payment-integration-api';
+import { getYear } from '@bigcommerce/checkout/test-mocks';
 
 import getCreditCardValidationSchema from './getCreditCardValidationSchema';
 
@@ -16,7 +17,7 @@ describe('getCreditCardValidationSchema()', () => {
         validData = {
             ccCustomerCode: '123',
             ccCvv: '123',
-            ccExpiry: '10 / 25',
+            ccExpiry: `10 / ${getYear(1)}`,
             ccName: 'BC',
             ccNumber: '4111 1111 1111 1111',
         };

--- a/packages/instrument-utils/src/creditCard/getCreditCardValidationSchema/getCreditCardValidationSchema.test.ts
+++ b/packages/instrument-utils/src/creditCard/getCreditCardValidationSchema/getCreditCardValidationSchema.test.ts
@@ -1,6 +1,7 @@
 import { createLanguageService, type LanguageService } from '@bigcommerce/checkout-sdk';
 
 import { type CreditCardFieldsetValues } from '@bigcommerce/checkout/payment-integration-api';
+import { getYear } from '@bigcommerce/checkout/test-mocks';
 
 import { getCreditCardValidationSchema } from '.';
 
@@ -16,7 +17,7 @@ describe('getCreditCardValidationSchema()', () => {
         validData = {
             ccCustomerCode: '123',
             ccCvv: '123',
-            ccExpiry: '10 / 25',
+            ccExpiry: `10 / ${getYear(1)}`,
             ccName: 'BC',
             ccNumber: '4111 1111 1111 1111',
         };


### PR DESCRIPTION
## What/Why?

Test date mocks have expired. 

Update them to use dynamic values so they won’t expire again in the future.

## Rollout/Rollback

Revert.

## Testing

CI.
