### PR TITLE
CHECKOUT-9450: Fix `checkoutcom` missing strategy

### DIFF
--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -26,6 +26,7 @@ import { getHostedCreditCardValidationSchema } from './getHostedCreditCardValida
 import { getHostedInstrumentValidationSchema } from './getHostedInstrumentValidationSchema';
 import { HostedCreditCardFieldset } from './HostedCreditCardFieldset';
 import { HostedCreditCardValidation } from './HostedCreditCardValidation';
+import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 
 export interface HostedCreditCardComponentProps extends PaymentMethodProps {
     initializePayment?: CheckoutService['initializePayment'];
@@ -257,6 +258,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                         createCreditCardPaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
                         createTDOnlineMartPaymentStrategy,
+                        createCheckoutComCreditCardPaymentStrategy,
                     ],
                     creditCard: {
                         form: await getHostedFormOptions(selectedInstrument),


### PR DESCRIPTION
## What/Why?

We've noticed more [logs](https://bigcommerce.sentry.io/issues/6919533865/events/214388ed99924893acd88975cc49bfcd/?environment=production&project=1542560&query=is%3Aunresolved%20different%20strategy%20is%20registered%20release.version%3A%3E%3D1.698.3&referrer=previous-event) complaining about mismatched strategies after ramping up to T2. This time is related to Checkout.com.

## Rollout/Rollback

Revert

## Testing

### Before
<img width="1672" height="349" alt="Screenshot 2025-11-06 at 11 42 48 am" src="https://github.com/user-attachments/assets/4b910667-bab6-46cc-9d11-6370d1aa4fd4" />

### After
<img width="1673" height="800" alt="Screenshot 2025-11-06 at 11 48 34 am" src="https://github.com/user-attachments/assets/7bef90d4-cdf0-4ba9-8d9f-534ca33de7f4" />

