### PR TITLE
feat(payment): checkout-sdk bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.827.0",
+        "@bigcommerce/checkout-sdk": "^1.828.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.827.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.827.0.tgz",
-      "integrity": "sha512-etEaT4Cdxr1vgsO+0jNgWaSaCD6/HKuMaJdMa57X5jWTlVQ+wX+zafBbfq60Hv3YP3lg6FXST4XCIULs+T9yAw==",
+      "version": "1.828.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.828.0.tgz",
+      "integrity": "sha512-vt03LBmhZonNQ9u5UevhvFk8suzkENXljUwU4TVtI18t3dmVxWxts+qQnJKrbpcS0Jsdvp5LqOOJC0dSlg4F2g==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.827.0",
+    "@bigcommerce/checkout-sdk": "^1.828.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version
To deliver:
https://github.com/bigcommerce/checkout-sdk-js/pull/3060

## Rollout/Rollback
Revert this PR

## Testing
Manual
