### PR TITLE
CHECKOUT-9450: Fix cba-mpgs missing strategy

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -1,3 +1,4 @@
+import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import { createCyberSourcePaymentStrategy, createCyberSourceV2PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
@@ -40,6 +41,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                         createCyberSourcePaymentStrategy,
                         createCyberSourceV2PaymentStrategy,
                         createSagePayPaymentStrategy,
+                        createCBAMPGSPaymentStrategy,
                     ],
                     creditCard: getHostedFormOptions && {
                         form: await getHostedFormOptions(selectedInstrument),


### PR DESCRIPTION
## What/Why?

Fix missing `cba-mpgs` strategy as reported in [Sentry](https://bigcommerce.sentry.io/issues/6919327713/events/2b0dcef376644ba88737a1b9b8c67cd7/?environment=production&project=1542560&query=is%3Aunresolved%20different%20strategy%20release.version%3A%3E%3D1.699.1&referrer=previous-event).

## Rollout/Rollback

Revert or turn off `CHECKOUT-9450.lazy_load_payment_strategies`

## Testing

<img width="1092" height="894" alt="Screenshot 2025-11-07 at 12 33 39 am" src="https://github.com/user-attachments/assets/706fb3c9-e638-43b2-b2b7-9362473c7ecb" />

