### PR TITLE
refactor(checkout): CHECKOUT-9429 Clean up code style

### DIFF
--- a/packages/core/src/app/address/AddressForm.test.tsx
+++ b/packages/core/src/app/address/AddressForm.test.tsx
@@ -5,7 +5,7 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
 
-import { CheckoutProvider, LocaleContext , type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/address/AddressFormModal.test.tsx
+++ b/packages/core/src/app/address/AddressFormModal.test.tsx
@@ -4,7 +4,7 @@ import { faker } from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { CheckoutProvider, LocaleContext , type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/address/AddressSelect.test.tsx
+++ b/packages/core/src/app/address/AddressSelect.test.tsx
@@ -3,7 +3,7 @@ import { type CheckoutService, createCheckoutService } from '@bigcommerce/checko
 import { noop } from 'lodash';
 import React from 'react';
 
-import { CheckoutProvider, LocaleContext , type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/cart/CartSummary.test.tsx
+++ b/packages/core/src/app/cart/CartSummary.test.tsx
@@ -2,7 +2,7 @@ import { type CheckoutService, createCheckoutService } from '@bigcommerce/checko
 import React from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider, type ExtensionServiceInterface , LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, ExtensionProvider, type ExtensionServiceInterface, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/cart/CartSummaryAndDrawer.test.tsx
+++ b/packages/core/src/app/cart/CartSummaryAndDrawer.test.tsx
@@ -7,7 +7,7 @@ import {
 import React from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider ,type ExtensionServiceInterface , LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, ExtensionProvider ,type ExtensionServiceInterface, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/checkout/CheckoutApp.tsx
+++ b/packages/core/src/app/checkout/CheckoutApp.tsx
@@ -4,7 +4,7 @@ import React, { type ReactElement, useEffect, useMemo } from 'react';
 import ReactModal from 'react-modal';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { AnalyticsProvider , CheckoutProvider, ExtensionProvider, LocaleProvider, ThemeProvider } from '@bigcommerce/checkout/contexts';
+import { AnalyticsProvider, CheckoutProvider, ExtensionProvider, LocaleProvider, ThemeProvider } from '@bigcommerce/checkout/contexts';
 import { ErrorBoundary } from '@bigcommerce/checkout/error-handling-utils';
 import { getLanguageService } from '@bigcommerce/checkout/locale';
 

--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -7,7 +7,7 @@ import {
 import { noop } from 'lodash';
 import React, { type FunctionComponent, lazy, memo } from 'react';
 
-import { type CheckoutContextProps , useLocale } from '@bigcommerce/checkout/contexts';
+import { type CheckoutContextProps, useLocale } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { LazyContainer } from '@bigcommerce/checkout/ui';
 

--- a/packages/core/src/app/customer/CustomerGuest.test.tsx
+++ b/packages/core/src/app/customer/CustomerGuest.test.tsx
@@ -12,7 +12,7 @@ import { faker } from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 import React, { type FunctionComponent } from 'react';
 
-import { AnalyticsProviderMock, CheckoutProvider, LocaleContext , type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { AnalyticsProviderMock, CheckoutProvider, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { getGuestCustomer } from '@bigcommerce/checkout/test-mocks';
 import { render, screen } from '@bigcommerce/checkout/test-utils';

--- a/packages/core/src/app/customer/CustomerInfo.test.tsx
+++ b/packages/core/src/app/customer/CustomerInfo.test.tsx
@@ -6,7 +6,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import React, { type FunctionComponent } from 'react';
 
-import { CheckoutProvider , LocaleProvider } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, LocaleProvider } from '@bigcommerce/checkout/contexts';
 import { getLanguageService } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/customer/CustomerInfo.tsx
+++ b/packages/core/src/app/customer/CustomerInfo.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { noop } from 'lodash';
 import React, { type FunctionComponent } from 'react';
 
-import { type CheckoutContextProps , useThemeContext } from '@bigcommerce/checkout/contexts';
+import { type CheckoutContextProps, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
 import { withCheckout } from '../checkout';

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -4,7 +4,7 @@ import { noop } from 'lodash';
 import React, { type FunctionComponent, memo, useCallback } from 'react';
 import { object, string } from 'yup';
 
-import { useCheckout , useThemeContext } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import {
     TranslatedHtml,

--- a/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
+++ b/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useCheckout , useThemeContext } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { Button, ButtonVariant } from '@bigcommerce/checkout/ui';
 

--- a/packages/core/src/app/customer/RegisteredCustomer.test.tsx
+++ b/packages/core/src/app/customer/RegisteredCustomer.test.tsx
@@ -12,7 +12,7 @@ import { faker } from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 import React, { type FunctionComponent } from 'react';
 
-import { AnalyticsProviderMock , CheckoutProvider, LocaleContext , type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { AnalyticsProviderMock, CheckoutProvider, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { getCart, getCheckout, getStoreConfig } from '@bigcommerce/checkout/test-mocks';
 import { render, screen, within } from '@bigcommerce/checkout/test-utils';

--- a/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
+++ b/packages/core/src/app/customer/checkoutSuggestion/CheckoutSuggestion.tsx
@@ -6,7 +6,7 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import React, { type FunctionComponent, memo } from 'react';
 
-import { type CheckoutContextProps , useAnalytics } from '@bigcommerce/checkout/contexts';
+import { type CheckoutContextProps, useAnalytics } from '@bigcommerce/checkout/contexts';
 
 import { withCheckout } from '../../checkout';
 import { PaymentMethodId } from '../../payment/paymentMethod';

--- a/packages/core/src/app/order/OrderConfirmationApp.tsx
+++ b/packages/core/src/app/order/OrderConfirmationApp.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import ReactModal from 'react-modal';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { AnalyticsProvider , CheckoutProvider, ExtensionProvider, LocaleProvider, ThemeProvider } from '@bigcommerce/checkout/contexts';
+import { AnalyticsProvider, CheckoutProvider, ExtensionProvider, LocaleProvider, ThemeProvider } from '@bigcommerce/checkout/contexts';
 import { ErrorBoundary } from '@bigcommerce/checkout/error-handling-utils';
 import { getLanguageService } from '@bigcommerce/checkout/locale';
 

--- a/packages/core/src/app/order/OrderSummary.test.tsx
+++ b/packages/core/src/app/order/OrderSummary.test.tsx
@@ -2,7 +2,7 @@ import { createCheckoutService, type Order } from '@bigcommerce/checkout-sdk';
 import React, { type FunctionComponent } from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider , LocaleProvider } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, ExtensionProvider, LocaleProvider } from '@bigcommerce/checkout/contexts';
 import { getLanguageService } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/order/OrderSummaryDrawer.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.test.tsx
@@ -2,7 +2,7 @@ import { createCheckoutService, type CurrencyService, type Order } from '@bigcom
 import userEvent from '@testing-library/user-event';
 import React, { type FunctionComponent } from 'react';
 
-import { CheckoutProvider, LocaleContext , type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/order/OrderSummaryPrice.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, { type FC, type ReactNode, useCallback, useEffect, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
-import { useCheckout , useThemeContext } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 
 import { ShopperCurrency } from '../currency';

--- a/packages/core/src/app/order/OrderSummaryTotal.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryTotal.test.tsx
@@ -1,7 +1,7 @@
 import { createCheckoutService, type CurrencyService } from '@bigcommerce/checkout-sdk';
 import React from 'react';
 
-import { CheckoutProvider, LocaleContext , type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -8,7 +8,7 @@ import { noop } from 'lodash';
 import React, { type FunctionComponent } from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider ,type ExtensionServiceInterface , LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, ExtensionProvider ,type ExtensionServiceInterface, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -2,7 +2,7 @@ import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 import { find, get, noop } from 'lodash';
 import React, { type FunctionComponent, memo, useCallback, useMemo } from 'react';
 
-import { useCheckout , useLocale } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 
 import { connectFormik, type ConnectFormikProps } from '../../common/form';
 import { isMobile } from '../../common/utility';

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -5,7 +5,7 @@ import { compact } from 'lodash';
 import React, { type FunctionComponent, memo, type ReactNode } from 'react';
 
 import { BigCommercePaymentsPayLaterBanner } from '@bigcommerce/checkout/bigcommerce-payments-utils'
-import { type CheckoutContextProps , useThemeContext } from '@bigcommerce/checkout/contexts';
+import { type CheckoutContextProps, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
 import { BraintreePaypalCreditBanner, PaypalCommerceCreditBanner } from '@bigcommerce/checkout/paypal-utils';

--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -2,7 +2,7 @@ import { type ConsignmentLineItem } from "@bigcommerce/checkout-sdk";
 import classNames from "classnames";
 import React, { type FunctionComponent, useState } from "react";
 
-import { useCheckout , useThemeContext } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from "@bigcommerce/checkout/dom-utils";
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 

--- a/packages/core/src/app/shipping/MultiShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/MultiShippingForm.test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider ,type ExtensionServiceInterface , LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, ExtensionProvider ,type ExtensionServiceInterface, LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen, waitFor, within } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.test.tsx
+++ b/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.test.tsx
@@ -4,7 +4,7 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
 
-import { CheckoutContext, LocaleContext , type LocaleContextType, ThemeProvider } from '@bigcommerce/checkout/contexts';
+import { CheckoutContext, LocaleContext, type LocaleContextType, ThemeProvider } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { usePayPalFastlaneAddress } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import { getAddress, getCustomer } from '@bigcommerce/checkout/test-mocks';

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider , LocaleContext } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/core/src/app/shipping/shippingOption/MultiShippingOptions.tsx
+++ b/packages/core/src/app/shipping/shippingOption/MultiShippingOptions.tsx
@@ -2,7 +2,7 @@ import { type Consignment } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import React from 'react';
 
-import { useCheckout , useThemeContext } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { Alert, AlertType } from '@bigcommerce/checkout/ui';
 

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingAddress.tsx
@@ -110,7 +110,7 @@ const StripeShippingAddress: FunctionComponent<StripeShippingAddressProps> = (pr
 
     const handleStripeShippingAddress = useCallback(async (shipping: StripeShippingEvent) => {
         const { complete, phoneFieldRequired, value: { address = { country: '', state: '', line1: '', line2: '', city: '', postal_code: '' }
-            , name = '', firstName = '', lastName = '', phone = '' } } = shipping;
+           , name = '', firstName = '', lastName = '', phone = '' } } = shipping;
 
         if (complete) {
             if (shouldShowContent(shipping?.isNewAddress, phoneFieldRequired, phone)) {

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import React, { act } from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider , LocaleContext } from '@bigcommerce/checkout/contexts';
+import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -4,6 +4,7 @@ import {
     type LegacyHostedFormOptions,
 } from '@bigcommerce/checkout-sdk';
 import { createBlueSnapDirectCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
+import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
 import { compact, forIn } from 'lodash';
@@ -26,7 +27,6 @@ import { getHostedCreditCardValidationSchema } from './getHostedCreditCardValida
 import { getHostedInstrumentValidationSchema } from './getHostedInstrumentValidationSchema';
 import { HostedCreditCardFieldset } from './HostedCreditCardFieldset';
 import { HostedCreditCardValidation } from './HostedCreditCardValidation';
-import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 
 export interface HostedCreditCardComponentProps extends PaymentMethodProps {
     initializePayment?: CheckoutService['initializePayment'];

--- a/packages/hosted-payment-integration/src/HostedPaymentMethod.tsx
+++ b/packages/hosted-payment-integration/src/HostedPaymentMethod.tsx
@@ -1,5 +1,4 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-
 import { createAfterpayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/afterpay';
 import { createSezzlePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sezzle';
 import { createZipPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/zip';


### PR DESCRIPTION
## What/Why?

- Remove extra space in the import paths across the codebase.
- Apply `lint -- --fix`.

## Rollout/Rollback

Revert.

## Testing
CI.
