### PR TITLE
fix(payment): PI-4517 bump checkout-sdk version due to the WP Access …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.829.1",
+        "@bigcommerce/checkout-sdk": "^1.829.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.829.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.829.1.tgz",
-      "integrity": "sha512-bfcvRQt+dszg4gP5vMtBhLiQVZZSkE8HuN9yNrwiS/YrtP+MXTWw0WjMzsho4uFd69SdygMfiSjLfJseMmwR5Q==",
+      "version": "1.829.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.829.2.tgz",
+      "integrity": "sha512-bWZ458c6TsSKLJHV2dpqYbxfGLDQuKOGP/PBF4Hg5V11n1636xHzxr/sa81Loizlv3JhNbgiConbUgkBDNo6hg==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.829.1",
+    "@bigcommerce/checkout-sdk": "^1.829.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
…fix release

## What/Why?
PI-4517 bump checkout-sdk version due to the WP Access fix release
https://github.com/bigcommerce/checkout-sdk-js/pull/3067

## Rollout/Rollback

Revert this PR

## Testing
Non 3ds

https://github.com/user-attachments/assets/67b71784-a395-40f3-890e-85add1f5a6ac

3ds frictionless

https://github.com/user-attachments/assets/fe954737-97e0-4722-9a37-45d666df8f3a

3ds challenged

https://github.com/user-attachments/assets/f7e1008c-38cd-47ea-a118-02a1b744924e
