### PR TITLE
CHECKOUT-9450: Revert SDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.829.2",
+        "@bigcommerce/checkout-sdk": "^1.829.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,10 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.829.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.829.2.tgz",
-      "integrity": "sha512-bWZ458c6TsSKLJHV2dpqYbxfGLDQuKOGP/PBF4Hg5V11n1636xHzxr/sa81Loizlv3JhNbgiConbUgkBDNo6hg==",
-      "license": "MIT",
+      "version": "1.829.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.829.3.tgz",
+      "integrity": "sha512-+9UzsrnLyLfT0fgQtJZomK6wwcXx7banfGRWkACZ7FeAIE364z8+R/VJXoy68nX64VU9Bn9Gz1ELerBiNgTh3Q==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.829.2",
+    "@bigcommerce/checkout-sdk": "^1.829.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Some E2E tests are failing in the master branch due to the recent SDK upgrade.

## Rollout/Rollback

Revert

## Testing

CircleCI
