### PR TITLE
fix(payment): PAYPAL-6050 add header Wallet buttons on top of checkout page

### DIFF
--- a/packages/core/src/app/customer/getSupportedMethods.ts
+++ b/packages/core/src/app/customer/getSupportedMethods.ts
@@ -5,6 +5,9 @@ export const SUPPORTED_METHODS: string[] = [
     'amazonpay',
     APPLE_PAY,
     'chasepay',
+    'bigcommerce_payments',
+    'bigcommerce_payments_paylater',
+    'bigcommerce_payments_venmo',
     'braintreevisacheckout',
     'braintreepaypal',
     'braintreepaypalcredit',
@@ -27,6 +30,7 @@ export const SUPPORTED_METHODS: string[] = [
     'googlepaytdonlinemart',
     'stripeocs',
     'googlepaystripeocs',
+    'googlepay_bigcommerce_payments',
 ];
 
 export const getSupportedMethodIds = (methodIds: string[]): string[] => {


### PR DESCRIPTION


## What/Why?
Show header Wallet buttons on top of checkout page
add bcp to support methods 
- bigcommerce_payments
- bigcommerce_payments_paylater
- bigcommerce_payments_venmo
- googlepay_bigcommerce_payments

## Rollout/Rollback
Rollout

## Testing
<img width="2950" height="2012" alt="Screenshot 2025-11-11 at 16 47 15" src="https://github.com/user-attachments/assets/ebc94023-69bc-4624-86f8-8f74b4d733e2" />

