### PR TITLE
refactor(checkout): CHECKOUT-9657 Create PaymentStep

### DIFF
--- a/packages/core/src/app/checkout/components/PaymentStep.tsx
+++ b/packages/core/src/app/checkout/components/PaymentStep.tsx
@@ -1,0 +1,73 @@
+import type { Cart, Consignment } from '@bigcommerce/checkout-sdk/essential';
+import React, { lazy ,type  ReactElement } from 'react';
+
+import type { ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { ChecklistSkeleton, LazyContainer } from '@bigcommerce/checkout/ui';
+
+import { isEmbedded } from '../../embeddedCheckout';
+import { type PaymentProps } from '../../payment';
+import { isUsingMultiShipping } from '../../shipping';
+import CheckoutStep from '../CheckoutStep';
+import type CheckoutStepStatus from '../CheckoutStepStatus';
+import type CheckoutStepType from '../CheckoutStepType';
+
+const Payment = lazy(() =>
+    import(
+        /* webpackChunkName: "payment" */
+        '../../payment/Payment'
+    ),
+);
+
+export interface PaymentStepProps extends PaymentProps {
+    step: CheckoutStepStatus;
+    cart?: Cart;
+    consignments?: Consignment[];
+    errorLogger: ErrorLogger;
+    onEdit(type: CheckoutStepType): void;
+    onExpanded(type: CheckoutStepType): void;
+}
+
+const PaymentStep = ({
+    step,
+    cart,
+    consignments,
+    errorLogger,
+    onEdit,
+    onExpanded,
+    checkEmbeddedSupport,
+    onCartChangedError,
+    onFinalize,
+    onReady,
+    onSubmit,
+    onSubmitError,
+    onUnhandledError,
+}: PaymentStepProps): ReactElement => (
+    <CheckoutStep
+        {...step}
+        heading={<TranslatedString id="payment.payment_heading" />}
+        key={step.type}
+        onEdit={onEdit}
+        onExpanded={onExpanded}
+    >
+        <LazyContainer loadingSkeleton={<ChecklistSkeleton />}>
+            <Payment
+                checkEmbeddedSupport={checkEmbeddedSupport}
+                errorLogger={errorLogger}
+                isEmbedded={isEmbedded()}
+                isUsingMultiShipping={
+                    cart && consignments ? isUsingMultiShipping(consignments, cart.lineItems) : false
+                }
+                onCartChangedError={onCartChangedError}
+                onFinalize={onFinalize}
+                onReady={onReady}
+                onSubmit={onSubmit}
+                onSubmitError={onSubmitError}
+                onUnhandledError={onUnhandledError}
+            />
+        </LazyContainer>
+    </CheckoutStep>
+);
+
+export default PaymentStep;
+

--- a/packages/core/src/app/checkout/components/index.ts
+++ b/packages/core/src/app/checkout/components/index.ts
@@ -1,3 +1,4 @@
 export { default as CartSummary } from './CartSummary';
 export { default as CheckoutHeader } from './CheckoutHeader';
 export { default as BillingStep } from './BillingStep';
+export { default as PaymentStep } from './PaymentStep';


### PR DESCRIPTION
## What/Why?

Replacing `renderPaymentStep` method with a component before converting checkout component into function component.

## Rollout/Rollback

Revert.

## Testing

CI.
