### PR TITLE
feat(payment): remove experiment google pay billing address editing

### DIFF
--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.test.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.test.ts
@@ -281,37 +281,10 @@ describe('getCheckoutStepStatuses()', () => {
             it('should be editable if experiment is on', () => {
                 jest.spyOn(state.data, 'getCheckout').mockReturnValue(getCheckoutWithPayments('googlepaystripe'));
                 jest.spyOn(state.data, 'getBillingAddress').mockReturnValue(getBillingAddress());
-                jest.spyOn(state.data, 'getConfig').mockReturnValue({
-                    ...getStoreConfig(),
-                    checkoutSettings: {
-                        ...getStoreConfig().checkoutSettings,
-                        features: {
-                            'STRIPE-546.allow_billing_address_editing_for_all_Google_Pay_providers': true,
-                        }
-                    }
-                });
 
                 const steps = getCheckoutStepStatuses(state);
 
                 expect(find(steps, { type: CheckoutStepType.Billing })!.isEditable).toBe(true);
-            });
-
-            it('should NOT be editable if experiment is off', () => {
-                jest.spyOn(state.data, 'getCheckout').mockReturnValue(getCheckoutWithPayments('googlepaystripe'));
-                jest.spyOn(state.data, 'getBillingAddress').mockReturnValue(getBillingAddress());
-                jest.spyOn(state.data, 'getConfig').mockReturnValue({
-                    ...getStoreConfig(),
-                    checkoutSettings: {
-                        ...getStoreConfig().checkoutSettings,
-                        features: {
-                            'STRIPE-546.allow_billing_address_editing_for_all_Google_Pay_providers': false,
-                        }
-                    }
-                });
-
-                const steps = getCheckoutStepStatuses(state);
-
-                expect(find(steps, { type: CheckoutStepType.Billing })!.isEditable).toBe(false);
             });
         })
     });

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -90,7 +90,7 @@ const getBillingStepStatus = createSelector(
             : EMPTY_ARRAY;
     },
     ({ data }: CheckoutSelectors) => data.getConfig(),
-    (checkout, billingAddress, billingAddressFields, config) => {
+    (checkout, billingAddress, billingAddressFields) => {
         const hasAddress = billingAddress
             ? isValidAddress(billingAddress, billingAddressFields)
             : false;
@@ -125,12 +125,7 @@ const getBillingStepStatus = createSelector(
             };
         }
 
-        const isGooglePayBillingAddressEditingEnabled = isExperimentEnabled(
-            config?.checkoutSettings,
-            'STRIPE-546.allow_billing_address_editing_for_all_Google_Pay_providers',
-        );
-        const isUsingGooglePay =
-            isGooglePayBillingAddressEditingEnabled && (checkout && checkout.payments
+        const isUsingGooglePay = (checkout && checkout.payments
                 ? checkout.payments.some((payment) => (payment?.providerId || '').startsWith('googlepay'))
                 : false);
 


### PR DESCRIPTION
## What/Why?
Remove `STRIPE-546.allow_billing_address_editing_for_all_Google_Pay_providers` experiment

## Rollout/Rollback
Revert this PR.

## Testing
Manual
