### PR TITLE
CHECKOUT-9450: Fix e2e tests not running against current build

### DIFF
--- a/packages/test-framework/src/fixture/pageObject/playwright/PlaywrightHelper.ts
+++ b/packages/test-framework/src/fixture/pageObject/playwright/PlaywrightHelper.ts
@@ -4,6 +4,7 @@ import { includes } from 'lodash';
 import { getStoreUrl } from '../../';
 import { type CheckoutPagePreset } from '../../../';
 
+import { getAppVersion } from './getAppVersion';
 import { PollyObject } from './PollyObject';
 import { ServerSideRender } from './ServerSideRender';
 
@@ -145,11 +146,13 @@ export class PlaywrightHelper {
             const localhostUrl = `http://localhost:${process.env.PORT || ''}`;
             const storeUrl = this.isReplay ? localhostUrl : this.storeUrl;
             const checkoutUrl = this.isReplay ? `${localhostUrl}/checkout` : `${storeUrl}/checkout`;
+            const appVersion = getAppVersion();
             const htmlStr = await this.server.renderFile(filePath, {
                 ...data,
                 localhostUrl,
                 storeUrl,
                 checkoutUrl,
+                appVersion,
             });
 
             await this.page.route(url, (route) => {

--- a/packages/test-framework/src/fixture/pageObject/playwright/getAppVersion.ts
+++ b/packages/test-framework/src/fixture/pageObject/playwright/getAppVersion.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+let appVersion = '';
+
+export function getAppVersion(): string {
+    if (appVersion) {
+        return appVersion;
+    }
+
+    const manifestPath = resolve(__dirname, '../../../../../../dist/manifest.json');
+    const manifestContent = readFileSync(manifestPath, 'utf-8');
+    const manifest: unknown = JSON.parse(manifestContent);
+
+    if (hasAppVersion(manifest)) {
+        appVersion = String(manifest.appVersion);
+
+        return appVersion;
+    }
+
+    return '';
+}
+
+function hasAppVersion(manifest: unknown): manifest is { appVersion: string } {
+    return (
+        typeof manifest === 'object' &&
+        manifest !== null &&
+        'appVersion' in manifest &&
+        typeof manifest.appVersion === 'string'
+    );
+}

--- a/packages/test-framework/src/support/checkout.ejs
+++ b/packages/test-framework/src/support/checkout.ejs
@@ -26,7 +26,7 @@
             containerId: 'micro-app-ng-checkout',
         };
     </script>
-    <script src="<%= localhostUrl %>/auto-loader.js" type="text/javascript"></script>
+    <script src="<%= localhostUrl %>/auto-loader-<%= appVersion %>.js" type="text/javascript"></script>
     <script type="text/javascript">
         (function() {
             window.checkout.renderCheckout({

--- a/packages/test-framework/src/support/orderConfirmation.ejs
+++ b/packages/test-framework/src/support/orderConfirmation.ejs
@@ -26,7 +26,7 @@
             containerId: 'micro-app-ng-checkout',
         };
     </script>
-    <script src="<%= localhostUrl %>/auto-loader.js" type="text/javascript"></script>
+    <script src="<%= localhostUrl %>/auto-loader-<%= appVersion %>.js" type="text/javascript"></script>
     <script type="text/javascript">
         (function () {
             window.checkout.renderOrderConfirmation({


### PR DESCRIPTION
## What/Why?

This PR fixes an issue where e2e tests were not running against the current build. The problem was caused by the `autoload.js` file not being generated during pull request builds. To resolve this, we need to specify the exact version from `manifest.json`, e.g.: `autoload-v1.2.3-prerelease.js`.

## Rollout/Rollback

Revert

## Testing

CircleCI