### PR TITLE
CHECKOUT-9450: Fix incorrect strategy for Barclaycard

### DIFF
--- a/packages/barclay-integration/src/BarclaycardPaymentMethod.test.tsx
+++ b/packages/barclay-integration/src/BarclaycardPaymentMethod.test.tsx
@@ -27,6 +27,7 @@ import {
 } from '@bigcommerce/checkout/test-mocks';
 
 import BarclaycardPaymentMethod from './BarclaycardPaymentMethod';
+import { createOffsitePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/offsite';
 
 describe('When using Barclaycard Payment Method', () => {
     let checkoutService: CheckoutService;
@@ -44,6 +45,7 @@ describe('When using Barclaycard Payment Method', () => {
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
         jest.spyOn(checkoutState.data, 'getCart').mockReturnValue(getCart());
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
+        jest.spyOn(checkoutService, 'initializePayment').mockResolvedValue(checkoutState);
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
 
         localeContext = createLocaleContext(getStoreConfig());
@@ -83,5 +85,15 @@ describe('When using Barclaycard Payment Method', () => {
         const view = render(<PaymentMethodTest />);
 
         expect(view).toMatchSnapshot();
+    });
+
+    it('should initialize Barclaycard PaymentMethod', () => {
+        render(<PaymentMethodTest />);
+
+        expect(checkoutService.initializePayment).toHaveBeenCalledWith({
+            gatewayId: '',
+            methodId: 'barclaycard',
+            integrations: [createOffsitePaymentStrategy],
+        });
     });
 });

--- a/packages/barclay-integration/src/BarclaycardPaymentMethod.tsx
+++ b/packages/barclay-integration/src/BarclaycardPaymentMethod.tsx
@@ -1,5 +1,5 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
+import { createOffsitePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/offsite';
 import React, { type FunctionComponent, useCallback } from 'react';
 
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
@@ -20,7 +20,7 @@ const BarclaycardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         (options: PaymentInitializeOptions) => {
             return checkoutService.initializePayment({
                 ...options,
-                integrations: [createCreditCardPaymentStrategy],
+                integrations: [createOffsitePaymentStrategy],
             });
         },
         [checkoutService],


### PR DESCRIPTION
## What/Why?

Barclaycard should use `OffsitePaymentStrategy` instead of `CreditCardPaymentStrategy` as it is an offsite payment method.

## Rollout/Rollback

Revert or turn off `CHECKOUT-9450.lazy_load_payment_strategies`

## Testing

https://github.com/user-attachments/assets/a3d9d7aa-2ef4-4347-9dd0-5c5779faf861


