### PR TITLE
CHECKOUT-9450: Pass strategies as part of order finalisation

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -3,9 +3,16 @@ import {
     type CheckoutSelectors,
     type CheckoutService,
     type CheckoutSettings,
+    type OrderFinalizeOptions,
     type OrderRequestBody,
     type PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
+import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
+import { createCheckoutComAPMPaymentStrategy, createCheckoutComCreditCardPaymentStrategy, createCheckoutComFawryPaymentStrategy, createCheckoutComIdealPaymentStrategy, createCheckoutComSepaPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
+import { createClearpayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/clearpay';
+import { createOffsitePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/offsite';
+import { createPaypalExpressPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/paypal-express';
+import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import { memoizeOne } from '@bigcommerce/memoize';
 import { compact, find, isEmpty, noop } from 'lodash';
 import React, {
@@ -77,7 +84,7 @@ interface WithCheckoutPaymentProps {
     usableStoreCredit: number;
     applyStoreCredit(useStoreCredit: boolean): Promise<CheckoutSelectors>;
     clearError(error: Error): void;
-    finalizeOrderIfNeeded(): Promise<CheckoutSelectors>;
+    finalizeOrderIfNeeded(options: OrderFinalizeOptions): Promise<CheckoutSelectors>;
     isPaymentDataRequired(): boolean;
     loadCheckout(): Promise<CheckoutSelectors>;
     loadPaymentMethods(): Promise<CheckoutSelectors>;
@@ -448,7 +455,20 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
             await loadPaymentMethodsOrThrow();
 
             try {
-                const state = await finalizeOrderIfNeeded();
+                const state = await finalizeOrderIfNeeded({
+                    integrations: [
+                        createCBAMPGSPaymentStrategy,
+                        createCheckoutComAPMPaymentStrategy,
+                        createCheckoutComCreditCardPaymentStrategy,
+                        createCheckoutComFawryPaymentStrategy,
+                        createCheckoutComIdealPaymentStrategy,
+                        createCheckoutComSepaPaymentStrategy,
+                        createClearpayPaymentStrategy,
+                        createOffsitePaymentStrategy,
+                        createPaypalExpressPaymentStrategy,
+                        createSagePayPaymentStrategy,
+                    ],
+                });
                 const order = state.data.getOrder();
 
                 onFinalize(order?.orderId);


### PR DESCRIPTION
## What/Why?

Pass strategies that require client-side orchestration into the `finalizeOrder` method; otherwise, they won’t be executed once the fallback is removed.

## Rollout/Rollback
Revert or turn off `CHECKOUT-9450.lazy_load_payment_strategies`

## Testing

See https://github.com/bigcommerce/checkout-sdk-js/pull/3080
