### PR TITLE
feat(checkout): CHECKOUT-9635 [UX] Make the checkbox colour consistent with radio buttons for theme v2

### DIFF
--- a/packages/core/src/scss/themeV2/form/_form.scss
+++ b/packages/core/src/scss/themeV2/form/_form.scss
@@ -28,7 +28,13 @@
 
     .form-checklist-checkbox:checked~.form-label {
         &::before {
-            background-color: $color-highlight;
+            background-color: $color-black;
+            border-color: $color-black;
         }
+    }
+
+    .form-checkbox:checked + .form-label::before {
+        background-color: $color-black;
+        border-color: $color-black;
     }
 }


### PR DESCRIPTION
## What/Why?

**What?**
Updates checkbox styling in theme V2 to use black background and border colours instead of blue when checked. Gated behind the CHECKOUT-7962 experiment (themeV2), so it only applies when themeV2 is enabled.

**Why?**
Aligns checkbox checked state colours with design requirements to match with radio buttons. Previously, checked checkboxes used $color-highlight (#4496f6). This change switches to black for both background and border.

## Rollout/Rollback
Revert the PR

## Testing

1. Enable CHECKOUT-7962 experiment (themeV2)
2. Verify checked checkboxes show black background and border
3. Test checkbox types (screenshots below):

**_Newsletter subscription_**
<img width="562" height="198" alt="Screenshot 2025-12-01 at 10 58 06 am" src="https://github.com/user-attachments/assets/83065987-0723-45d1-b330-4842234f10f9" />

**_Privacy policy consent_**
<img width="546" height="197" alt="Screenshot 2025-12-01 at 12 02 04 pm" src="https://github.com/user-attachments/assets/a8a5bce0-dd95-4beb-8b12-5cbf0032b669" />

**_Billing same shipping and save address_**
<img width="945" height="580" alt="Screenshot 2025-12-01 at 10 13 59 am" src="https://github.com/user-attachments/assets/a1fbef08-fe42-4f60-a82e-8ae25c331e6a" />

_**Apply store credit**_
<img width="580" height="450" alt="Screenshot 2025-12-01 at 10 14 18 am" src="https://github.com/user-attachments/assets/80cbe712-4e1f-4209-8f9c-25cf349e0195" />

_**Accept terms**_
<img width="551" height="516" alt="Screenshot 2025-12-01 at 10 59 42 am" src="https://github.com/user-attachments/assets/4d1707d9-1df2-4ca8-99bc-16a9a72a3117" />

4. Verify unchecked state remains unchanged
<img width="530" height="176" alt="Screenshot 2025-12-01 at 12 06 33 pm" src="https://github.com/user-attachments/assets/d343b1d3-cdeb-407d-81e9-1e3057b9c920" />










