### PR TITLE
feat(checkout): CHECKOUT-9675 Add Multi Coupon UI

### DIFF
--- a/packages/core/src/app/coupon/MultiCoupon.tsx
+++ b/packages/core/src/app/coupon/MultiCoupon.tsx
@@ -1,0 +1,44 @@
+import React, { type FunctionComponent, useState } from 'react';
+
+import { preventDefault } from '@bigcommerce/checkout/dom-utils';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+
+import { CouponForm, Discounts } from './components';
+import { useMultiCoupon } from './useMultiCoupon';
+
+interface MultiCouponProps {
+    test?: string;
+}
+
+const MultiCoupon: FunctionComponent<MultiCouponProps> = () => {
+  const { isCouponCodeCollapsed } = useMultiCoupon();
+
+  const [isCouponFormVisible, setIsCouponFormVisible] = useState(isCouponCodeCollapsed);
+
+  const toggleCouponForm = () => {
+    setIsCouponFormVisible((prevState) => !prevState);
+  };
+
+  return (
+    <>
+      <section className="cart-section optimizedCheckout-orderSummary-cartSection">
+        <a
+          aria-controls="coupon-form-collapsable"
+          aria-expanded={isCouponFormVisible}
+          className="redeemable-label"
+          data-test="redeemable-label"
+          href="#"
+          onClick={preventDefault(toggleCouponForm)}
+        >
+          <TranslatedString id="redeemable.toggle_action" />
+        </a>
+        {isCouponFormVisible && <CouponForm />}
+      </section>
+      <section className="cart-section optimizedCheckout-orderSummary-cartSection">
+        <Discounts />
+      </section>
+    </>
+  );
+};
+
+export default MultiCoupon;

--- a/packages/core/src/app/coupon/components/CouponForm.tsx
+++ b/packages/core/src/app/coupon/components/CouponForm.tsx
@@ -1,0 +1,52 @@
+import classNames from 'classnames';
+import React, { type FunctionComponent, useState } from 'react';
+
+import { useLocale, useThemeContext } from '@bigcommerce/checkout/contexts';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { IconCoupon, IconError, IconRemoveCoupon, TextInput } from '@bigcommerce/checkout/ui';
+
+import { Button, ButtonVariant } from '../../ui/button';
+
+export const CouponForm: FunctionComponent = () => {
+    const [applyCouponError, setApplyCouponError] = useState<string | null>(null);
+    const { themeV2 } = useThemeContext();
+    const { language } = useLocale();
+
+    return (
+        <>
+            <div className="coupon-form" id="coupon-form-collapsable">
+                <TextInput
+                    additionalClassName="form-input optimizedCheckout-form-input coupon-input"
+                    aria-label={language.translate('redeemable.code_label')}
+                    placeholder={language.translate('redeemable.coupon_placeholder')}
+                    testId="redeemableEntry-input"
+                    themeV2={themeV2}
+                />
+                <Button
+                    className={classNames('coupon-button', {
+                        'body-bold': themeV2,
+                    })}
+                    id="applyRedeemableButton"
+                    testId="redeemableEntry-submit"
+                    variant={ButtonVariant.Secondary}
+                >
+                    <TranslatedString id="redeemable.apply_action" />
+                </Button>
+            </div>
+            <div className="applied-coupons-list">
+                {Boolean(applyCouponError) &&
+                    <ul className="applied-coupon-error-message" role="alert">
+                        <IconError />
+                        <span>{applyCouponError}</span>
+                        <span onClick={() => setApplyCouponError(null)}><IconRemoveCoupon /></span>
+                    </ul>
+                }
+                <ul><IconCoupon />Chicken mugs half price! (ABC11111)<IconRemoveCoupon /></ul>
+                <ul><IconCoupon />ABC22222<IconRemoveCoupon /></ul>
+                <ul><IconCoupon />New customer 10% off Loooooooooooooonnnnnnnnng(EXTRA12345)<IconRemoveCoupon /></ul>
+                <ul><IconCoupon />Free sample (FREE34567)<IconRemoveCoupon /></ul>
+            </div>
+        </>
+    );
+};
+

--- a/packages/core/src/app/coupon/components/Discounts.tsx
+++ b/packages/core/src/app/coupon/components/Discounts.tsx
@@ -1,0 +1,97 @@
+import React, { type FunctionComponent, useState } from 'react';
+
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { IconCoupon, IconDownArrow, IconUpArrow } from '@bigcommerce/checkout/ui';
+
+
+export const Discounts: FunctionComponent = () => {
+    const [isCouponDiscountsVisible, setIsCouponDiscountsVisible] = useState(true);
+    const [isShippingDiscountsVisible, setIsShippingDiscountsVisible] = useState(true);
+
+    return (
+        <>
+            <div aria-live="polite" className="cart-priceItem optimizedCheckout-contentPrimary">
+                <span className="cart-priceItem-label">
+                    <TranslatedString id="cart.subtotal_text" />
+                </span>
+                <span className="cart-priceItem-value">$40.00</span>
+            </div>
+            <div
+                aria-controls="applied-coupon-discounts-collapsable"
+                aria-expanded={isCouponDiscountsVisible}
+                aria-live="polite"
+                className="coupon-discount-toggle cart-priceItem optimizedCheckout-contentPrimary"
+                onClick={() => setIsCouponDiscountsVisible(!isCouponDiscountsVisible)}
+            >
+                <span className="cart-priceItem-label">
+                    <div className="toggle-button">
+                        <TranslatedString id="redeemable.discounts_text" />
+                        {isCouponDiscountsVisible ? <IconDownArrow /> : <IconUpArrow />}
+                    </div>
+                </span>
+                <span className="cart-priceItem-value">-$16.00</span>
+            </div>
+            {isCouponDiscountsVisible && (
+                <div className="applied-discounts-list" id="applied-coupon-discounts-collapsable">
+                    <div aria-live="polite" className="cart-priceItem optimizedCheckout-contentPrimary">
+                        <span className="cart-priceItem-label">
+                            <IconCoupon /> HAPPY NEW YEAR
+                        </span>
+                        <span className="cart-priceItem-value">-$4.00</span>
+                    </div>
+                    <div aria-live="polite" className="cart-priceItem optimizedCheckout-contentPrimary">
+                        <span className="cart-priceItem-label">
+                            <IconCoupon /> Long Long Long Long Long Long Long Long Long Long Long Long Long Automatic promotion
+                        </span>
+                        <span className="cart-priceItem-value">-$4.00</span>
+                    </div>
+                    <div aria-live="polite" className="cart-priceItem optimizedCheckout-contentPrimary">
+                        <span className="cart-priceItem-label">
+                            <IconCoupon /> New customer 10% off Loooooooooooooooooong(EXTRA12345)
+                        </span>
+                        <span className="cart-priceItem-value">-$4.00</span>
+                    </div>
+                    <div aria-live="polite" className="cart-priceItem optimizedCheckout-contentPrimary">
+                        <span className="cart-priceItem-label">
+                            <IconCoupon /> NEW10OFF
+                        </span>
+                        <span className="cart-priceItem-value">-$4.00</span>
+                    </div>
+                </div>
+            )}
+            <div
+                aria-controls="applied-shipping-discounts-collapsable"
+                aria-expanded={isShippingDiscountsVisible}
+                aria-live="polite"
+                className="shipping-discount-toggle cart-priceItem optimizedCheckout-contentPrimary"
+                onClick={() => setIsShippingDiscountsVisible(!isShippingDiscountsVisible)}
+            >
+                <span className="cart-priceItem-label">
+                    <div className="toggle-button">
+                        <TranslatedString id="shipping.shipping_heading" />
+                        {isShippingDiscountsVisible ? <IconDownArrow /> : <IconUpArrow />}
+                    </div>
+                </span>
+                <span className="cart-priceItem-value">
+                    <span className="shipping-cost-before-discount">$10.00</span> $6.00
+                </span>
+            </div>
+            {isShippingDiscountsVisible && (
+                <div className="applied-discounts-list" id="applied-shipping-discounts-collapsable">
+                    <div aria-live="polite" className="cart-priceItem optimizedCheckout-contentPrimary">
+                        <span className="cart-priceItem-label">
+                            <IconCoupon /> Save on shipping (SHIPPINGSAVE)
+                        </span>
+                        <span className="cart-priceItem-value">-$1.00</span>
+                    </div>
+                    <div aria-live="polite" className="cart-priceItem optimizedCheckout-contentPrimary">
+                        <span className="cart-priceItem-label">
+                            <IconCoupon /> Automatic promotion
+                        </span>
+                        <span className="cart-priceItem-value">-$3.00</span>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+};

--- a/packages/core/src/app/coupon/components/index.ts
+++ b/packages/core/src/app/coupon/components/index.ts
@@ -1,0 +1,2 @@
+export { CouponForm } from './CouponForm';
+export { Discounts } from './Discounts';

--- a/packages/core/src/app/coupon/index.ts
+++ b/packages/core/src/app/coupon/index.ts
@@ -1,1 +1,2 @@
 export { default as AppliedCoupon } from './AppliedCoupon';
+export { default as MultiCoupon } from './MultiCoupon';

--- a/packages/core/src/app/coupon/useMultiCoupon.ts
+++ b/packages/core/src/app/coupon/useMultiCoupon.ts
@@ -1,0 +1,20 @@
+import { useCheckout } from '@bigcommerce/checkout/contexts';
+
+interface UseMultiCouponValues {
+    isCouponCodeCollapsed: boolean;
+}
+
+export const useMultiCoupon = (): UseMultiCouponValues => {
+    const { checkoutState } = useCheckout();
+    const config = checkoutState.data.getConfig();
+
+    if(!config) {
+        throw new Error('Checkout configuration is not available');
+    }
+
+    const isCouponCodeCollapsed = config.checkoutSettings.isCouponCodeCollapsed;
+
+    return {
+        isCouponCodeCollapsed,
+    }
+}

--- a/packages/core/src/app/order/OrderSummary.test.tsx
+++ b/packages/core/src/app/order/OrderSummary.test.tsx
@@ -24,8 +24,11 @@ jest.mock('../currency', () => ({
 
 describe('OrderSummary', () => {
     const checkoutService = createCheckoutService();
+    const checkoutState = checkoutService.getState();
     const extensionService = new ExtensionService(checkoutService, createErrorLogger());
     const languageService = getLanguageService();
+
+    jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
 
     describe('when shopper has same currency as store', () => {
         beforeEach(() => {

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -5,10 +5,13 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import React, { cloneElement, type FunctionComponent, isValidElement, type ReactNode } from 'react';
 
+import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { Button, IconCloseWithBorder } from '@bigcommerce/checkout/ui';
 
+import { isExperimentEnabled } from '../common/utility';
+import { MultiCoupon } from '../coupon';
 import { ShopperCurrency } from '../currency';
 import { Modal, ModalHeader } from '../ui/modal';
 import { isSmallScreen } from '../ui/responsive';
@@ -37,7 +40,6 @@ const OrderSummaryModal: FunctionComponent<
     OrderSummaryDrawerProps & OrderSummarySubtotalsProps
 > = ({
     additionalLineItems,
-    children,
     isTaxIncluded,
     taxes,
     onRequestClose,
@@ -50,6 +52,10 @@ const OrderSummaryModal: FunctionComponent<
     total,
     ...orderSummarySubtotalsProps
 }) => {
+    const { checkoutState } = useCheckout();
+    const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
+    const isMultiCouponEnabled = isExperimentEnabled(checkoutSettings, 'PROJECT-7321-5991.multi-coupon-cart-checkout', false);
+
     const displayInclusiveTax = isTaxIncluded && taxes && taxes.length > 0;
 
     const subHeaderText = <OrderModalSummarySubheader
@@ -83,10 +89,13 @@ const OrderSummaryModal: FunctionComponent<
         <OrderSummarySection>
             <OrderSummaryItems displayLineItemsCount={false} items={items} />
         </OrderSummarySection>
-        <OrderSummarySection>
-            <OrderSummarySubtotals isTaxIncluded={isTaxIncluded} taxes={taxes} {...orderSummarySubtotalsProps} />
-            {additionalLineItems}
-        </OrderSummarySection>
+        {isMultiCouponEnabled
+            ? <MultiCoupon />
+            : <OrderSummarySection>
+                    <OrderSummarySubtotals isTaxIncluded={isTaxIncluded} taxes={taxes} {...orderSummarySubtotalsProps} />
+                    {additionalLineItems}
+            </OrderSummarySection>
+        }
         <OrderSummarySection>
             <OrderSummaryTotal
                 orderAmount={total}

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -5,10 +5,12 @@ import React, { type FunctionComponent, memo, useCallback, useContext, useMemo }
 import { type ObjectSchema } from 'yup';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
+import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString, withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
 import { FormContext } from '@bigcommerce/checkout/ui';
 
+import { isExperimentEnabled } from '../common/utility';
 import { TermsConditions } from '../termsConditions';
 import { Fieldset, Form, Legend } from '../ui/form';
 
@@ -106,6 +108,10 @@ const PaymentForm: FunctionComponent<
         );
     }, [selectedMethod]);
 
+    const { checkoutState } = useCheckout();
+    const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
+    const isMultiCouponEnabled = isExperimentEnabled(checkoutSettings, 'PROJECT-7321-5991.multi-coupon-cart-checkout', false);
+
     if (shouldExecuteSpamCheck) {
         return (
             <SpamProtectionField
@@ -139,7 +145,7 @@ const PaymentForm: FunctionComponent<
                 values={values}
             />
 
-            <PaymentRedeemables />
+            {!isMultiCouponEnabled && <PaymentRedeemables />}
 
             {isTermsConditionsRequired && (
                 <TermsConditions

--- a/packages/core/src/app/payment/PaymentRedeemables.test.tsx
+++ b/packages/core/src/app/payment/PaymentRedeemables.test.tsx
@@ -26,7 +26,7 @@ describe('PaymentRedeemables', () => {
             </CheckoutProvider>,
         );
 
-        const link = screen.getByRole('link', { name: 'Coupon/Gift Certificate' });
+        const link = screen.getByRole('link', { name: 'Coupon / gift certificate' });
 
         expect(screen.getByRole('group')).toBeInTheDocument();
         expect(screen.getByRole('group')).toHaveClass("form-fieldset redeemable-payments");

--- a/packages/core/src/app/shipping/MultiShippingForm.scss
+++ b/packages/core/src/app/shipping/MultiShippingForm.scss
@@ -90,7 +90,7 @@ $allocate-items-table-image-width-small-screen: 40%;
 }
 
 .modal.modal--afterOpen {
-    .button--tertiary {
+    .button--tertiary:not(.coupon-button) {
         border: none;
         background-color: transparent;
     }

--- a/packages/core/src/scss/components/_components.scss
+++ b/packages/core/src/scss/components/_components.scss
@@ -132,3 +132,6 @@
 
 // Checkout Skeleton
 @import "checkout/loadingSkeleton/component";
+
+// (multi) Coupon
+@import "checkout/coupon/component";

--- a/packages/core/src/scss/components/checkout/coupon/_component.scss
+++ b/packages/core/src/scss/components/checkout/coupon/_component.scss
@@ -1,0 +1,1 @@
+@import "coupon";

--- a/packages/core/src/scss/components/checkout/coupon/_coupon.scss
+++ b/packages/core/src/scss/components/checkout/coupon/_coupon.scss
@@ -1,0 +1,150 @@
+// Coupon form and applied coupons list styles
+.coupon-form {
+    display: flex;
+    align-items: stretch;
+    gap: spacing('half');
+    width: 100%;
+    margin: spacing('half') 0;
+
+    .coupon-input {
+        flex: 1;
+        min-width: 0;
+    }
+    .coupon-input::placeholder {
+        color: $color-secondaryDarkest;
+        opacity: 1;
+    }
+
+    .coupon-button {
+        border-color: $color-primaryDark;
+        color: $color-primaryDark;
+        flex-shrink: 0;
+        margin-bottom: 0;
+    }
+}
+
+.applied-coupons-list {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    ul {
+        background: $color-greyLightest;
+        color: $color-primary;
+        display: inline-block;
+        padding: spacing('quarter');
+        margin: 0 0 spacing('half');
+        font-weight: fontWeight("thin");
+        word-break: break-all;
+
+        .coupon-icon {
+            vertical-align: middle;
+            margin-right: spacing('quarter');
+        }
+
+        .remove-coupon-icon {
+            cursor: pointer;
+            vertical-align: middle;
+            margin-left: spacing('half');
+        }
+    }
+
+    ul:last-child {
+        margin-bottom: 0;
+    }
+
+    ul.applied-coupon-error-message{
+        align-items: center;
+        background: $color-errorLight;
+        color: $color-error;
+        display: flex;
+        justify-content: space-between;
+        padding: spacing('quarter');
+        width: 100%;
+        margin-bottom: spacing('half');
+        gap: spacing('half');
+        word-break: auto-phrase;
+
+        svg.icon-error {
+            width: 15px;
+            height: 15px;
+
+            path{
+                fill: $color-error;
+            }
+        }
+
+        .remove-coupon-icon {
+            float: right;
+        }
+    }
+
+    .icon-path {
+        transition: fill 200ms ease-in-out;
+    }
+}
+
+.applied-coupons-list ul:hover {
+    .icon-path {
+        fill: $color-primaryDark;
+    }
+}
+
+// Discounts section styles
+.coupon-discount-toggle,.shipping-discount-toggle {
+    cursor: pointer;
+
+    .toggle-button {
+        display: inline-block;
+    }
+
+    .arrow {
+        float: right;
+        margin-left: spacing('half');
+    }
+}
+
+.shipping-discount-toggle{
+    margin-top: spacing('half');
+
+    .shipping-cost-before-discount {
+        color: $color-secondaryDarkest;
+        text-decoration: line-through;
+        margin-right: spacing('quarter');
+    }
+}
+
+.applied-discounts-list {
+    span {
+        color: $color-secondaryDarkest;
+        font-family: $fontFamily-montserrat;
+        font-weight: fontWeight("thin");
+    }
+
+    span:last-child {
+        padding-left: spacing('half');
+    }
+
+    div {
+        margin-bottom: spacing('quarter') / 2;
+    }
+
+    .cart-priceItem-label {
+        word-break: break-all;
+    }
+
+    .coupon-icon {
+        vertical-align: middle;
+        margin-right: spacing('quarter');
+    }
+}
+
+// Total savings styles
+.total-savings {
+    color: $color-secondaryDarkest;
+    text-align: right;
+
+    .total-savings-highlight {
+        color: $color-totalSavingsHighlight;
+    }
+}

--- a/packages/core/src/scss/settings/global/color/_color.scss
+++ b/packages/core/src/scss/settings/global/color/_color.scss
@@ -83,3 +83,4 @@ $color-orderVerificationRequired:   #e89fae;
 // -----------------------------------------------------------------------------
 
 $color-errorLighter:                #fdf5f5;
+$color-totalSavingsHighlight:       #2AAB3F;

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -481,11 +481,14 @@
             "coupon_location_error": "Your shipping address doesn't meet the location requirements for the coupon code you entered.",
             "coupon_min_order_total": "Your order does not meet the minimum total for this coupon code to be applied.",
             "coupon_text": "Coupon",
+            "coupon_placeholder": "Enter your code here",
+            "discounts_text": "Discounts",
             "gift_certificate_remaining_text": "Remaining",
             "gift_certificate_text": "Gift Certificate",
             "remove_action": "Remove",
             "store_credit_available_text": "Your account currently has {storeCredit} total store credit available",
-            "toggle_action": "Coupon/Gift Certificate"
+            "toggle_action": "Coupon / gift certificate",
+            "total_savings_text": "You saved <span class=\"total-savings-highlight\">{totalSaving}</span> in total!"
         },
         "remote": {
             "browser_unsupported": "The selected payment method requires a different web browser. Please choose another payment method.",

--- a/packages/ui/src/icon/IconCoupon.tsx
+++ b/packages/ui/src/icon/IconCoupon.tsx
@@ -1,0 +1,35 @@
+import React, { type FunctionComponent } from 'react';
+
+const IconCoupon: FunctionComponent = () => {
+    return (
+        <svg
+            className="coupon-icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <mask
+                height="16"
+                id="mask0_4221_16176"
+                maskUnits="userSpaceOnUse"
+                style={{ maskType: 'alpha' }}
+                width="16"
+                x="0"
+                y="0"
+            >
+                <rect fill="#D9D9D9" height="16" width="16" />
+            </mask>
+            <g mask="url(#mask0_4221_16176)">
+                <path
+                    className="icon-path"
+                    d="M7.40595 14.6654L1.3252 8.5782L8.24186 1.66797H14.3226V7.74872L7.40595 14.6654ZM11.8379 4.87692C12.0397 4.87692 12.2128 4.80335 12.3572 4.6562C12.5017 4.50906 12.5739 4.33673 12.5739 4.13922C12.5739 3.93957 12.5019 3.76753 12.358 3.62309C12.214 3.47865 12.0412 3.40644 11.8394 3.40644C11.6376 3.40644 11.4645 3.4784 11.32 3.62234C11.1756 3.76628 11.1034 3.93807 11.1034 4.13772C11.1034 4.33736 11.1754 4.51047 11.3193 4.65705C11.4632 4.80363 11.6361 4.87692 11.8379 4.87692ZM7.39855 13.5782L13.5662 7.40874V2.42437H8.57401L2.41236 8.59487L7.39855 13.5782Z"
+                    fill="#979797"
+                />
+            </g>
+        </svg>
+    );
+};
+
+export default IconCoupon;

--- a/packages/ui/src/icon/IconDownArrow.tsx
+++ b/packages/ui/src/icon/IconDownArrow.tsx
@@ -1,0 +1,22 @@
+import React, { type FunctionComponent } from 'react';
+
+const IconDownArrow: FunctionComponent = () => {
+    return (
+        <svg
+            className="arrow"
+            fill="none"
+            height="20"
+            viewBox="0 0 20 20"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                className="icon-path"
+                d="M6.77083 7.50156L10.0042 10.7349L13.2375 7.50156C13.5625 7.17656 14.0875 7.17656 14.4125 7.50156C14.7375 7.82656 14.7375 8.35156 14.4125 8.67656L10.5875 12.5016C10.2625 12.8266 9.7375 12.8266 9.4125 12.5016L5.5875 8.67656C5.2625 8.35156 5.2625 7.82656 5.5875 7.50156C5.9125 7.1849 6.44583 7.17656 6.77083 7.50156Z"
+                fill="#979797"
+            />
+        </svg>
+    );
+};
+
+export default IconDownArrow;

--- a/packages/ui/src/icon/IconError.tsx
+++ b/packages/ui/src/icon/IconError.tsx
@@ -3,7 +3,13 @@ import React, { type FunctionComponent } from 'react';
 import withIconContainer from './withIconContainer';
 
 const IconError: FunctionComponent = () => (
-    <svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <svg
+        className="icon-error"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+    >
         <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
     </svg>
 );

--- a/packages/ui/src/icon/IconRemoveCoupon.tsx
+++ b/packages/ui/src/icon/IconRemoveCoupon.tsx
@@ -1,0 +1,29 @@
+import React, { type FunctionComponent } from 'react';
+
+const IconRemoveCoupon: FunctionComponent = () => {
+    return (
+        <svg
+            className="remove-coupon-icon"
+            fill="none"
+            height="20"
+            viewBox="0 0 20 20"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <g clipPath="url(#clip0_4221_14238)">
+                <path
+                    className="icon-path"
+                    d="M15.2496 4.7599C14.9246 4.4349 14.3996 4.4349 14.0746 4.7599L9.99961 8.82656L5.92461 4.75156C5.59961 4.42656 5.07461 4.42656 4.74961 4.75156C4.42461 5.07656 4.42461 5.60156 4.74961 5.92656L8.82461 10.0016L4.74961 14.0766C4.42461 14.4016 4.42461 14.9266 4.74961 15.2516C5.07461 15.5766 5.59961 15.5766 5.92461 15.2516L9.99961 11.1766L14.0746 15.2516C14.3996 15.5766 14.9246 15.5766 15.2496 15.2516C15.5746 14.9266 15.5746 14.4016 15.2496 14.0766L11.1746 10.0016L15.2496 5.92656C15.5663 5.6099 15.5663 5.07656 15.2496 4.7599Z"
+                    fill="#999999"
+                />
+            </g>
+            <defs>
+                <clipPath id="clip0_4221_14238">
+                    <rect fill="white" height="20" width="20" />
+                </clipPath>
+            </defs>
+        </svg>
+    );
+};
+
+export default IconRemoveCoupon;

--- a/packages/ui/src/icon/IconUpArrow.tsx
+++ b/packages/ui/src/icon/IconUpArrow.tsx
@@ -1,0 +1,22 @@
+import React, { type FunctionComponent } from 'react';
+
+const IconUpArrow: FunctionComponent = () => {
+    return (
+        <svg
+            className="arrow"
+            fill="none"
+            height="20"
+            viewBox="0 0 20 20"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                className="icon-path"
+                d="M6.77083 12.4984L10.0042 9.26506L13.2375 12.4984C13.5625 12.8234 14.0875 12.8234 14.4125 12.4984C14.7375 12.1734 14.7375 11.6484 14.4125 11.3234L10.5875 7.4984C10.2625 7.1734 9.7375 7.1734 9.4125 7.4984L5.5875 11.3234C5.2625 11.6484 5.2625 12.1734 5.5875 12.4984C5.9125 12.8151 6.44583 12.8234 6.77083 12.4984Z"
+                fill="#979797"
+            />
+        </svg>
+    );
+};
+
+export default IconUpArrow;

--- a/packages/ui/src/icon/index.ts
+++ b/packages/ui/src/icon/index.ts
@@ -55,3 +55,7 @@ export { default as IconPayPalFastlane } from './IconPayPalFastlane';
 export { default as IconNewAccount } from './IconNewAccount';
 export { default as IconUsdCoin } from './IconUsdCoin';
 export { default as IconAch } from './IconAch';
+export { default as IconRemoveCoupon } from './IconRemoveCoupon';
+export { default as IconCoupon } from './IconCoupon';
+export { default as IconDownArrow } from './IconDownArrow';
+export { default as IconUpArrow } from './IconUpArrow';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -80,6 +80,11 @@ export {
     IconSepa,
     IconUsdCoin,
     IconAch,
+    IconError,
+    IconCoupon,
+    IconRemoveCoupon,
+    IconDownArrow,
+    IconUpArrow,
 } from './icon';
 export { LazyContainer, LoadingNotification, LoadingOverlay, LoadingSpinner } from './loading';
 export {


### PR DESCRIPTION
## What/Why?

Add new multi coupon UI behind an experiment.

## Rollout/Rollback

Revert.

## Testing

When the experiment is `off`, UI stays the same.
<img width="500" height="899" alt="Screenshot 2025-12-01 at 11 53 12" src="https://github.com/user-attachments/assets/6f4e282e-b04f-464a-b423-3500d8b05c9e" />

When the experiment is `on`, new UI appears with hard-coded data.
<img width="500" height="896" alt="image" src="https://github.com/user-attachments/assets/b0ea119f-3a45-4d30-8b75-047a8f7ca339" />

Mobile View.
<img width="300" height="830" alt="image" src="https://github.com/user-attachments/assets/2a15a3df-db64-47be-b04b-a74dd340f02e" />


