### PR TITLE
fix(shipping): CHECKOUT-9630 Update empty countries error logic to account for logged in shopper

### DIFF
--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -73,16 +73,15 @@ const ShippingForm = ({
         }
     }, [shippingFormRenderTimestamp]);
 
-    // Handle error when no countries are available - use useEffect to avoid setState during render
     useEffect(() => {
-        if (countries.length === 0 && isNoCountriesErrorOnCheckoutEnabled) {
+        if (isInitialValueLoaded && countries.length === 0 && isNoCountriesErrorOnCheckoutEnabled) {
             onUnhandledError(new CustomError({
                 name: 'no_countries_available',
                 message: getLanguageService().translate('shipping.no_countries_available_message'),
                 title: getLanguageService().translate('shipping.no_countries_available_heading'),
             }));
         }
-    }, [countries.length]);
+    }, [isInitialValueLoaded, countries.length]);
 
     const getMultiShippingForm = () => {
         return <MultiShippingForm
@@ -95,7 +94,7 @@ const ShippingForm = ({
         />;
     };
 
-    if (countries.length === 0 && isNoCountriesErrorOnCheckoutEnabled) {
+    if (isInitialValueLoaded && countries.length === 0 && isNoCountriesErrorOnCheckoutEnabled) {
         return null;
     }
 


### PR DESCRIPTION
## What/Why?
Update empty countries error logic to account for logged in shopper. Since right now for logged in shopper customer step is skipped and hence shipping step is loaded straight away. Initially all loading flags are false, and that causes the error to be thrown on first rerender.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- screencast

### logged in shopper, no countries configured

https://github.com/user-attachments/assets/2648d124-933f-43c0-85ad-48bb20458b71

### logged in shopper, country configured

https://github.com/user-attachments/assets/c8d68925-6d1a-4917-8a2b-80a552677bbb

### guest shopper, no countries configured

https://github.com/user-attachments/assets/23086582-7ebc-401c-863b-659eccf3701f

### guest shopper, country configured


https://github.com/user-attachments/assets/3cd19c98-b649-47e9-8a29-8738f27c8a3a


