### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.837.2",
+        "@bigcommerce/checkout-sdk": "^1.838.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.837.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.837.2.tgz",
-      "integrity": "sha512-kvgcsJ3lY/28Xu0hC+WvwJ089TY8xJKoso8YfaD+JSPRe9xHKtKmRvflgGxeHkE4O/ZSxc814qBN+xLZtZ5yYw==",
+      "version": "1.838.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.838.0.tgz",
+      "integrity": "sha512-VerIT4Om32MH+TZlKcjk+UnGmoIXnNCM9c0BRg+xaFJbviB+ceO2b97PGH9EY9moY8Sozfu+K5ypa4S15Q/6DA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.837.2",
+    "@bigcommerce/checkout-sdk": "^1.838.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-js version to deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/3096](https://github.com/bigcommerce/checkout-sdk-js/pull/3096)

## Rollout/Rollback
Rollback this PR

## Testing
manually tested & functional tests
