### PR TITLE
feat(payment): checkout-sdk bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.838.1",
+        "@bigcommerce/checkout-sdk": "^1.839.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.838.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.838.1.tgz",
-      "integrity": "sha512-zWzOp25q+0WHgTuQdb6g6QvrhH+LuZnxqUzL23wMd8HwIRyygzAgekuFNFb8CUFCtWBqCzR0giikeoaqFtDCJQ==",
+      "version": "1.839.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.839.0.tgz",
+      "integrity": "sha512-goIyORrEIvomJc6dLq0zEYBK8rG1jVcwF/sw6kc/nnOSpkTkw4AGrqNWrHnDLsqcnpjp/Fvzd1RZOUzKHtR5uw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.838.1",
+    "@bigcommerce/checkout-sdk": "^1.839.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version.
To release this PR:
https://github.com/bigcommerce/checkout-sdk-js/pull/3090

## Rollout/Rollback
Revert this PR

## Testing
Manual test.
