### PR TITLE
feat(payment): PI-4748 Migrate CBA MPGS to Resolver Configuration

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -96,7 +96,6 @@ const PaymentMethodComponent: FunctionComponent<
         const knownMethods = [
             { id: 'authorizenet', gateway: null, method: PaymentMethodType.CreditCard, type: PaymentMethodProviderType.Api },
             { id: 'clover', gateway: null, method: PaymentMethodType.CreditCard, type: PaymentMethodProviderType.Api },
-            { id: 'cba_mpgs', gateway: null, method: PaymentMethodType.CreditCard, type: PaymentMethodProviderType.Api },
             { id: 'cybersourcev2', gateway: null, method: PaymentMethodType.CreditCard, type: PaymentMethodProviderType.Api },
             { id: 'ewayrapid', gateway: null, method: PaymentMethodType.CreditCard, type: PaymentMethodProviderType.Api },
             { id: 'hps', gateway: null, method: PaymentMethodType.CreditCard, type: PaymentMethodProviderType.Api },

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -38,5 +38,6 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
         { id: 'credit_card', gateway: 'checkoutcom' },
 
         { id: 'tdonlinemart' },
+        { id: 'cba_mpgs' },
     ],
 );


### PR DESCRIPTION
## What/Why?
**cba_mpgs** id added to **toResolvableComponent**

## Rollout/Rollback
Revert this PR


## Testing
Tested manually:
CC flow + Vaulted CC flow

We don't have functional tests for CBA MPGS

https://github.com/user-attachments/assets/dbe5ef7d-2de7-4847-a0d3-4e24e289aabb

