### PR TITLE
feat(checkout): CHECKOUT-9900 [Accessibility] Resolve broken ARIA reference for address fields on the checkout

### DIFF
--- a/packages/braintree-integration/src/BraintreeAch/components/__snapshots__/BraintreeAchFormFields.test.tsx.snap
+++ b/packages/braintree-integration/src/BraintreeAch/components/__snapshots__/BraintreeAchFormFields.test.tsx.snap
@@ -54,6 +54,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
               Checking
             </option>
           </select>
+          <ul
+            class="form-field-errors"
+            data-test="account-type-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="accountType-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -80,6 +94,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
             type="text"
             value=""
           />
+          <ul
+            class="form-field-errors"
+            data-test="account-number-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="accountNumber-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -104,6 +132,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
             type="text"
             value=""
           />
+          <ul
+            class="form-field-errors"
+            data-test="routing-number-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="routingNumber-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -155,6 +197,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
               Business
             </option>
           </select>
+          <ul
+            class="form-field-errors"
+            data-test="ownership-type-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="ownershipType-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -179,6 +235,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
             type="text"
             value=""
           />
+          <ul
+            class="form-field-errors"
+            data-test="business-name-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="businessName-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -233,6 +303,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
             Checking
           </option>
         </select>
+        <ul
+          class="form-field-errors"
+          data-test="account-type-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="accountType-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -259,6 +343,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
           type="text"
           value=""
         />
+        <ul
+          class="form-field-errors"
+          data-test="account-number-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="accountNumber-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -283,6 +381,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
           type="text"
           value=""
         />
+        <ul
+          class="form-field-errors"
+          data-test="routing-number-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="routingNumber-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -334,6 +446,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
             Business
           </option>
         </select>
+        <ul
+          class="form-field-errors"
+          data-test="ownership-type-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="ownershipType-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -358,6 +484,20 @@ exports[`BraintreeAchFormFields Component should render form with business field
           type="text"
           value=""
         />
+        <ul
+          class="form-field-errors"
+          data-test="business-name-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="businessName-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
   </div>,
@@ -469,6 +609,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
               Checking
             </option>
           </select>
+          <ul
+            class="form-field-errors"
+            data-test="account-type-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="accountType-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -495,6 +649,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
             type="text"
             value=""
           />
+          <ul
+            class="form-field-errors"
+            data-test="account-number-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="accountNumber-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -519,6 +687,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
             type="text"
             value=""
           />
+          <ul
+            class="form-field-errors"
+            data-test="routing-number-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="routingNumber-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -570,6 +752,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
               Business
             </option>
           </select>
+          <ul
+            class="form-field-errors"
+            data-test="ownership-type-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="ownershipType-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -594,6 +790,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
             type="text"
             value=""
           />
+          <ul
+            class="form-field-errors"
+            data-test="first-name-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="firstName-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
       <div
@@ -618,6 +828,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
             type="text"
             value=""
           />
+          <ul
+            class="form-field-errors"
+            data-test="last-name-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="lastName-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -672,6 +896,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
             Checking
           </option>
         </select>
+        <ul
+          class="form-field-errors"
+          data-test="account-type-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="accountType-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -698,6 +936,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
           type="text"
           value=""
         />
+        <ul
+          class="form-field-errors"
+          data-test="account-number-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="accountNumber-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -722,6 +974,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
           type="text"
           value=""
         />
+        <ul
+          class="form-field-errors"
+          data-test="routing-number-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="routingNumber-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -773,6 +1039,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
             Business
           </option>
         </select>
+        <ul
+          class="form-field-errors"
+          data-test="ownership-type-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="ownershipType-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -797,6 +1077,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
           type="text"
           value=""
         />
+        <ul
+          class="form-field-errors"
+          data-test="first-name-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="firstName-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
     <div
@@ -821,6 +1115,20 @@ exports[`BraintreeAchFormFields Component should render form with personal field
           type="text"
           value=""
         />
+        <ul
+          class="form-field-errors"
+          data-test="last-name-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="lastName-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
   </div>,

--- a/packages/braintree-integration/src/BraintreeAch/components/__snapshots__/BraintreeAchMandateText.test.tsx.snap
+++ b/packages/braintree-integration/src/BraintreeAch/components/__snapshots__/BraintreeAchMandateText.test.tsx.snap
@@ -25,6 +25,20 @@ exports[`BraintreeAchMandateText renders mandate text checkbox with business dat
           >
             By clicking Place Order, I authorize Braintree, a service of PayPal, on behalf of s1504098821 to verify my bank account information using bank information and consumer reports and I authorize s1504098821 to initiate an ACH/electronic debit to my savings account, Depository Name: BigcommerceStore, Routing Number: 010000015 and Account Number: 100000000, in the amount of $190 on 01.01.2023. I agree the ACH transactions I authorize comply with all applicable laws.
           </label>
+          <ul
+            class="form-field-errors"
+            data-test="order-consent-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="orderConsent-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -50,6 +64,20 @@ exports[`BraintreeAchMandateText renders mandate text checkbox with business dat
         >
           By clicking Place Order, I authorize Braintree, a service of PayPal, on behalf of s1504098821 to verify my bank account information using bank information and consumer reports and I authorize s1504098821 to initiate an ACH/electronic debit to my savings account, Depository Name: BigcommerceStore, Routing Number: 010000015 and Account Number: 100000000, in the amount of $190 on 01.01.2023. I agree the ACH transactions I authorize comply with all applicable laws.
         </label>
+        <ul
+          class="form-field-errors"
+          data-test="order-consent-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="orderConsent-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
   </div>,
@@ -132,6 +160,20 @@ exports[`BraintreeAchMandateText renders mandate text checkbox with personal dat
           >
             By clicking Place Order, I authorize Braintree, a service of PayPal, on behalf of s1504098821 to verify my bank account information using bank information and consumer reports and I authorize s1504098821 to initiate an ACH/electronic debit to my savings account, Depository Name: Name Surname, Routing Number: 010000015 and Account Number: 100000000, in the amount of $190 on 01.01.2023. I agree the ACH transactions I authorize comply with all applicable laws.
           </label>
+          <ul
+            class="form-field-errors"
+            data-test="order-consent-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="orderConsent-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -157,6 +199,20 @@ exports[`BraintreeAchMandateText renders mandate text checkbox with personal dat
         >
           By clicking Place Order, I authorize Braintree, a service of PayPal, on behalf of s1504098821 to verify my bank account information using bank information and consumer reports and I authorize s1504098821 to initiate an ACH/electronic debit to my savings account, Depository Name: Name Surname, Routing Number: 010000015 and Account Number: 100000000, in the amount of $190 on 01.01.2023. I agree the ACH transactions I authorize comply with all applicable laws.
         </label>
+        <ul
+          class="form-field-errors"
+          data-test="order-consent-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="orderConsent-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
   </div>,
@@ -239,6 +295,20 @@ exports[`BraintreeAchMandateText renders mandate text checkbox with text for vau
           >
             By clicking Place Order, I authorize Braintree, a service of PayPal, on behalf of s1504098821 to verify my bank account information using bank information and consumer reports and I authorize s1504098821 to initiate an ACH/electronic debit to my savings account, Depository Name: Name Surname, Routing Number: 010000015 and Account Number: 100000000, in the amount of $190 on 01.01.2023. I agree the ACH transactions I authorize comply with all applicable laws.
           </label>
+          <ul
+            class="form-field-errors"
+            data-test="order-consent-field-error-message"
+          >
+            <li
+              class="form-field-error"
+            >
+              <span
+                aria-hidden="true"
+                class="is-srOnly"
+                id="orderConsent-field-error-message"
+              />
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -264,6 +334,20 @@ exports[`BraintreeAchMandateText renders mandate text checkbox with text for vau
         >
           By clicking Place Order, I authorize Braintree, a service of PayPal, on behalf of s1504098821 to verify my bank account information using bank information and consumer reports and I authorize s1504098821 to initiate an ACH/electronic debit to my savings account, Depository Name: Name Surname, Routing Number: 010000015 and Account Number: 100000000, in the amount of $190 on 01.01.2023. I agree the ACH transactions I authorize comply with all applicable laws.
         </label>
+        <ul
+          class="form-field-errors"
+          data-test="order-consent-field-error-message"
+        >
+          <li
+            class="form-field-error"
+          >
+            <span
+              aria-hidden="true"
+              class="is-srOnly"
+              id="orderConsent-field-error-message"
+            />
+          </li>
+        </ul>
       </div>
     </div>
   </div>,

--- a/packages/ui/src/form/FormFieldError/FormFieldError.test.tsx
+++ b/packages/ui/src/form/FormFieldError/FormFieldError.test.tsx
@@ -1,55 +1,111 @@
-import userEvent from '@testing-library/user-event';
-import { Formik } from 'formik';
+import { ErrorMessage, useFormikContext } from 'formik';
 import React from 'react';
 
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
-import { BasicFormField } from '../BasicFormField';
 import { FormContext } from '../contexts';
 
 import FormFieldError, { type FormFieldErrorProps } from './FormFieldError';
 
-describe('FormFieldError', () => {
-    let defaultProps: FormFieldErrorProps;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('formik', () => ({
+    ...jest.requireActual('formik'),
+    useFormikContext: jest.fn(),
+    ErrorMessage: jest.fn(({ render: renderFn }: { render: (msg: string) => string }) =>
+        renderFn('Test error message'),
+    ),
+}));
 
-    beforeEach(() => {
-        defaultProps = {
-            name: 'foobar',
-            errorId: '',
-        };
+describe('FormFieldError', () => {
+    const defaultProps: FormFieldErrorProps = {
+        name: 'testField',
+        testId: 'test-field-error',
+        errorId: 'test-error-id',
+    };
+
+    const mockFormikContext = (errors = {}, touched = {}) => {
+        (useFormikContext as jest.Mock).mockReturnValue({
+            errors,
+            touched,
+        });
+    };
+
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 
-    it('renders formfielderror component with message', async () => {
-        const { container } = render(
+    it('renders error message when there is an error and form is submitted', () => {
+        mockFormikContext({ testField: 'Error message' }, { testField: true });
+
+        render(
             <FormContext.Provider value={{ isSubmitted: true, setSubmitted: jest.fn() }}>
-                <Formik
-                    initialValues={{ foobar: '' }}
-                    onSubmit={jest.fn()}
-                    render={() => (
-                        <>
-                            <BasicFormField
-                                name="foobar"
-                                testId="input"
-                                validate={() => 'Invalid'}
-                            />
-                            <FormFieldError {...defaultProps} />
-                        </>
-                    )}
-                />
+                <FormFieldError {...defaultProps} />
             </FormContext.Provider>,
         );
 
-        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-        const inputElement = container.querySelector('input[name="foobar"]');
+        expect(screen.getByRole('alert')).toHaveTextContent('Test error message');
+    });
 
-        expect(inputElement).toBeInTheDocument();
+    it('does not render error message when field is not touched', () => {
+        mockFormikContext({ testField: 'Error message' }, { testField: false });
 
-        if (inputElement) {
-            await userEvent.type(inputElement, 'test');
-        }
+        render(
+            <FormContext.Provider value={{ isSubmitted: true, setSubmitted: jest.fn() }}>
+                <FormFieldError {...defaultProps} />
+            </FormContext.Provider>,
+        );
 
-        await userEvent.tab();
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
 
-        expect(screen.getByText('Invalid')).toBeInTheDocument();
+    it('renders hidden span with errorId when there is no error', () => {
+        mockFormikContext({}, {});
+
+        const { container } = render(
+            <FormContext.Provider value={{ isSubmitted: false, setSubmitted: jest.fn() }}>
+                <FormFieldError {...defaultProps} />
+            </FormContext.Provider>,
+        );
+
+        // eslint-disable-next-line testing-library/no-container
+        const hiddenSpan = container.querySelector(`#${defaultProps.errorId}`);
+
+        expect(hiddenSpan).toBeInTheDocument();
+        expect(hiddenSpan).toHaveAttribute('aria-hidden', 'true');
+        expect(hiddenSpan).toHaveClass('is-srOnly');
+    });
+
+    it('passes correct props to ErrorMessage component', () => {
+        mockFormikContext({ testField: 'Error message' }, { testField: true });
+
+        render(
+            <FormContext.Provider value={{ isSubmitted: true, setSubmitted: jest.fn() }}>
+                <FormFieldError {...defaultProps} />
+            </FormContext.Provider>,
+        );
+
+        expect(ErrorMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                name: defaultProps.name,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                render: expect.any(Function),
+            }),
+            {},
+        );
+    });
+
+    it('renders with proper accessibility attributes on error', () => {
+        mockFormikContext({ testField: 'Error message' }, { testField: true });
+
+        render(
+            <FormContext.Provider value={{ isSubmitted: true, setSubmitted: jest.fn() }}>
+                <FormFieldError {...defaultProps} />
+            </FormContext.Provider>,
+        );
+
+        const alertLabel = screen.getByRole('alert');
+
+        expect(alertLabel).toHaveAttribute('aria-live', 'polite');
+        expect(alertLabel).toHaveAttribute('id', defaultProps.errorId);
     });
 });

--- a/packages/ui/src/form/FormFieldError/FormFieldError.tsx
+++ b/packages/ui/src/form/FormFieldError/FormFieldError.tsx
@@ -1,4 +1,4 @@
-import { ErrorMessage } from 'formik';
+import { ErrorMessage, getIn, useFormikContext } from 'formik';
 import React, { type FunctionComponent, memo, useCallback } from 'react';
 
 import { FormContext } from '../contexts';
@@ -10,30 +10,40 @@ export interface FormFieldErrorProps {
 }
 
 const FormFieldError: FunctionComponent<FormFieldErrorProps> = ({ name, testId, errorId }) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const formikContext = useFormikContext<Record<string, any>>();
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const hasError = getIn(formikContext.errors, name) && getIn(formikContext.touched, name);
+
     const renderMessage = useCallback(
         (message: string) => (
-            <ul className="form-field-errors" data-test={testId}>
-                <li className="form-field-error">
-                    <label
-                        aria-live="polite"
-                        className="form-inlineMessage"
-                        htmlFor={name}
-                        id={errorId}
-                        role="alert"
-                    >
-                        {message}
-                    </label>
-                </li>
-            </ul>
+            <label
+                aria-live="polite"
+                className="form-inlineMessage"
+                htmlFor={name}
+                id={errorId}
+                role="alert"
+            >
+                {message}
+            </label>
         ),
-        [errorId, name, testId],
+        [errorId, name],
     );
 
     return (
         <FormContext.Consumer>
-            {({ isSubmitted }) =>
-                isSubmitted && <ErrorMessage name={name} render={renderMessage} />
-            }
+            {({ isSubmitted }) => (
+                <ul className="form-field-errors" data-test={testId}>
+                    <li className="form-field-error">
+                        {hasError && isSubmitted ? (
+                            <ErrorMessage name={name} render={renderMessage} />
+                        ) : (
+                            <span aria-hidden="true" className="is-srOnly" id={errorId} />
+                        )}
+                    </li>
+                </ul>
+            )}
         </FormContext.Consumer>
     );
 };


### PR DESCRIPTION
## What/Why?

### What?
Ensure `aria-labelledby` reference always resolves to a DOM element in the checkout's address step.

### Why?
[WAVE](https://wave.webaim.org/) accessibility evaluation tool (via Chrome extension) reported broken ARIA reference on the address fields. This PR resolves the issue in order to adhere to WCAG compliance standards.

## Rollout/Rollback

Revert the PR

## Testing

- [x] Unit tests pass (5 new/updated tests)
- [x] Run WAVE browser extension and confirm the 'Broken ARIA reference' error is gone
- [x] Verify error messages still display correctly after form submission with invalid input

### Before:
<img width="1385" height="713" alt="Before" src="https://github.com/user-attachments/assets/f608f413-465f-4563-969e-ab39da5c33a1" />

<img width="1002" height="596" alt="Screenshot 2026-03-26 at 10 45 22 am" src="https://github.com/user-attachments/assets/44c0d960-7bd4-4352-876b-e37ea54bf059" />

### After:
<img width="1395" height="712" alt="After" src="https://github.com/user-attachments/assets/46c52381-ba75-42fe-82be-44c9b2b21f31" />

<img width="932" height="704" alt="Screenshot 2026-03-26 at 12 19 03 pm" src="https://github.com/user-attachments/assets/7788a2fd-78e1-49ec-8f71-3aaa9164f90b" />

<img width="933" height="589" alt="Screenshot 2026-03-26 at 12 19 45 pm" src="https://github.com/user-attachments/assets/feb2215e-fff6-49ac-94c0-a513231bb913" />





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/accessibility change that adjusts error rendering markup and test coverage; main risk is minor regression in when/where validation messages appear.
> 
> **Overview**
> Fixes broken `aria-labelledby` references by ensuring every field’s `*-field-error-message` id is always present in the DOM via `FormFieldError` rendering a screen-reader-only `<span>` when no error is shown.
> 
> Updates `FormFieldError` to only render the visible alert after submit *and* when the field has both `touched` and an error, and revises unit tests plus Braintree ACH snapshots to match the new error-container markup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa72ab6d8a67619d7995f2e6f4012f4419b71f84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->