### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.898.2",
+        "@bigcommerce/checkout-sdk": "^1.898.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.898.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.898.2.tgz",
-      "integrity": "sha512-OKMW9a1iDuI7y5POZke2G2XMQW0ETW/y+GalcNFqC8OICaQyP8T5s7qliC1zynPkhDk1K8x2AGGIrJDYa92j/g==",
+      "version": "1.898.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.898.3.tgz",
+      "integrity": "sha512-Y+omGscm6X4tinJ7ieWlUcO0O1C4Nh+yEr62LHehs2KItb9mqtrMTl0bh9buMW7eoQoB39AmmUDKd8RugHHlBg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.898.2",
+    "@bigcommerce/checkout-sdk": "^1.898.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-js version
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/3207](https://github.com/bigcommerce/checkout-sdk-js/pull/3207)

## Rollout/Rollback
Rollback this PR

## Testing
In checkout-sdk PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a core checkout/payment dependency, which can change runtime checkout behavior despite being a small diff. Risk depends on upstream SDK changes and compatibility with existing integrations.
> 
> **Overview**
> Bumps `@bigcommerce/checkout-sdk` from `^1.898.2` to `^1.898.3` in `package.json` and updates `package-lock.json` to pull in the new SDK tarball/integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccf7d217234b0a141d2d3c036f8c07e85a0492bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->