### PR TITLE
chore(other): CHECKOUT-9902 update sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.898.3",
+        "@bigcommerce/checkout-sdk": "^1.898.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.898.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.898.3.tgz",
-      "integrity": "sha512-Y+omGscm6X4tinJ7ieWlUcO0O1C4Nh+yEr62LHehs2KItb9mqtrMTl0bh9buMW7eoQoB39AmmUDKd8RugHHlBg==",
+      "version": "1.898.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.898.4.tgz",
+      "integrity": "sha512-Sh00gDknOzU9Oa/352MBjq/9SVUnJf9pH40y1Ai1Cp7p25hIo/b3hA5cyddqjf4WKHx952Qplu3Hu5WbrOJrkA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.898.3",
+    "@bigcommerce/checkout-sdk": "^1.898.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -4,7 +4,6 @@ import {
     createEmbeddedCheckoutMessenger,
     type EmbeddedCheckoutMessenger,
 } from '@bigcommerce/checkout-sdk';
-import { faker } from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
 import React, { type FunctionComponent } from 'react';
@@ -549,15 +548,15 @@ describe('Shipping step', () => {
 
             await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
 
-            const randomAddress1 = JSON.parse(JSON.stringify({
-                firstName: faker.name.firstName(),
-                lastName: faker.name.lastName(),
-                address1: faker.address.streetAddress(),
-                city: faker.address.city(),
+            const randomAddress1 = {
+                firstName: 'John',
+                lastName: 'Smith',
+                address1: '123 Test Street',
+                city: 'Test City',
                 countryCode: 'CC',
                 stateOrProvince: 'dummy state',
-                postalCode: faker.address.zipCode(),
-            }));
+                postalCode: '12345',
+            };
 
             await checkout.fillAddressForm(randomAddress1);
             await userEvent.selectOptions(
@@ -572,15 +571,15 @@ describe('Shipping step', () => {
                 }),
             );
 
-            const randomAddress2 = JSON.parse(JSON.stringify({
-                firstName: faker.name.firstName(),
-                lastName: faker.name.lastName(),
-                address1: faker.address.streetAddress(),
-                city: faker.address.city(),
+            const randomAddress2 = {
+                firstName: 'Jane',
+                lastName: 'Doe',
+                address1: '456 Sample Avenue',
+                city: 'Melbourne',
                 countryCode: 'AU',
-                stateOrProvinceCode: faker.helpers.arrayElement(['NSW', 'VIC', 'QLD', 'TAS']),
-                postalCode: faker.address.zipCode(),
-            }));
+                stateOrProvinceCode: 'VIC',
+                postalCode: '3000',
+            };
 
             await checkout.fillAddressForm(randomAddress2);
             await userEvent.selectOptions(


### PR DESCRIPTION
## What/Why?
update checkout sdk to release https://github.com/bigcommerce/checkout-sdk-js/pull/3212

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a core dependency (`@bigcommerce/checkout-sdk`), which can change checkout behavior at runtime despite the small version bump. Test changes are low risk but won’t catch all SDK-driven regressions.
> 
> **Overview**
> Updates `@bigcommerce/checkout-sdk` from `^1.898.3` to `^1.898.4` (including `package-lock.json`).
> 
> Removes `@faker-js/faker` usage from `Shipping.test.tsx`, replacing randomized addresses with fixed test data to reduce flaky assertions when editing/updating shipping addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a9667a54348c7cf9777e6cc2912866e365b3fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->