### PR TITLE
chore(other): CHECKOUT-9902 update sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.898.4",
+        "@bigcommerce/checkout-sdk": "^1.898.6",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.898.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.898.4.tgz",
-      "integrity": "sha512-Sh00gDknOzU9Oa/352MBjq/9SVUnJf9pH40y1Ai1Cp7p25hIo/b3hA5cyddqjf4WKHx952Qplu3Hu5WbrOJrkA==",
+      "version": "1.898.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.898.6.tgz",
+      "integrity": "sha512-tmrr9g1VBtqDn3N6QA6hhnlkp23D2P+/tyDsJ93YLTtNA8bcTkk9C7lS3tN8r1Sf1Ef4zWo3/4H95YS1A0eQRQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.898.4",
+    "@bigcommerce/checkout-sdk": "^1.898.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Update sdk to release https://github.com/bigcommerce/checkout-sdk-js/pull/3214

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the core `@bigcommerce/checkout-sdk` dependency used by checkout flows; behavior changes come from the upstream SDK release and could affect payments/order submission despite the small diff.
> 
> **Overview**
> Updates the app to use `@bigcommerce/checkout-sdk` `^1.898.6` (from `^1.898.4`).
> 
> Regenerates `package-lock.json` entries for the new SDK tarball (version/resolved URL/integrity) with no other code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bdfbe761ddb233b01238ddf3a7b8a57c07ff6e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->