### PR TITLE
feat(checkout): CHECKOUT-9889 Enable Extra Fields in Multi-shipping

### DIFF
--- a/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
+++ b/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
@@ -1,0 +1,41 @@
+import { B2BExtraAddressFieldsSessionStorage } from './B2BExtraAddressFieldsSessionStorage';
+
+describe('B2BExtraAddressFieldsSessionStorage', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    describe('reassignConsignmentKey', () => {
+        it('moves fields from temp key to the real consignment key', () => {
+            const fields = { b2bExtraField_100: 'Acme Corp' };
+
+            B2BExtraAddressFieldsSessionStorage.setFields(
+                B2BExtraAddressFieldsSessionStorage.getConsignmentKey(''),
+                fields,
+            );
+
+            B2BExtraAddressFieldsSessionStorage.reassignConsignmentKey('consignment-123');
+
+            expect(
+                B2BExtraAddressFieldsSessionStorage.getFields(
+                    B2BExtraAddressFieldsSessionStorage.getConsignmentKey('consignment-123'),
+                ),
+            ).toEqual(fields);
+            expect(
+                B2BExtraAddressFieldsSessionStorage.getFields(
+                    B2BExtraAddressFieldsSessionStorage.getConsignmentKey(''),
+                ),
+            ).toBeUndefined();
+        });
+
+        it('does nothing when temp key has no data', () => {
+            B2BExtraAddressFieldsSessionStorage.reassignConsignmentKey('consignment-123');
+
+            expect(
+                B2BExtraAddressFieldsSessionStorage.getFields(
+                    B2BExtraAddressFieldsSessionStorage.getConsignmentKey('consignment-123'),
+                ),
+            ).toBeUndefined();
+        });
+    });
+});

--- a/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.ts
+++ b/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.ts
@@ -28,4 +28,14 @@ export class B2BExtraAddressFieldsSessionStorage {
     static removeFields(key: string): void {
         sessionStorage.removeItem(key);
     }
+
+    static reassignConsignmentKey(consignmentId: string): void {
+        const tempKey = this.getConsignmentKey('');
+        const fields = this.getFields(tempKey);
+
+        if (fields) {
+            this.setFields(this.getConsignmentKey(consignmentId), fields);
+            this.removeFields(tempKey);
+        }
+    }
 }

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -1,6 +1,7 @@
 export { B2BExtraAddressFieldsSessionStorage } from './B2BExtraAddressFieldsSessionStorage';
 export { default as mapAddressToFormValues, AddressFormValues } from './mapAddressToFormValues';
 export { default as mapAddressFromFormValues } from './mapAddressFromFormValues';
+export { default as stripExtraFieldsFromAddress } from './stripExtraFieldsFromAddress';
 export { default as AddressForm } from './AddressForm';
 export { default as AddressFormModal } from './AddressFormModal';
 export { default as AddressSelect } from './AddressSelect';

--- a/packages/core/src/app/address/mapAddressFromFormValues.test.ts
+++ b/packages/core/src/app/address/mapAddressFromFormValues.test.ts
@@ -27,20 +27,6 @@ describe('mapAddressFromFormValues', () => {
 
         const result = mapAddressFromFormValues(formValues);
 
-        expect(result).not.toHaveProperty('extraFields');
-    });
-
-    it('preserves non-extra fields when stripping extraFields', () => {
-        const formValues: AddressFormValues = {
-            ...omit(getShippingAddress(), 'customFields'),
-            customFields: {},
-            extraFields: {
-                b2bExtraField_100: 'Acme Corp',
-            },
-        };
-
-        const result = mapAddressFromFormValues(formValues);
-
         expect(result.firstName).toBe(getShippingAddress().firstName);
         expect(result.lastName).toBe(getShippingAddress().lastName);
         expect(result).not.toHaveProperty('extraFields');

--- a/packages/core/src/app/address/mapAddressToFormValues.test.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.test.ts
@@ -47,6 +47,54 @@ describe('mapAddressToFormValues', () => {
         expect(result.extraFields?.b2bExtraField_200).toBe('Engineering');
     });
 
+    it('uses extra field value from address over default', () => {
+        const fields: FormField[] = [
+            ...getFormFields(),
+            {
+                custom: false,
+                default: 'Default Corp',
+                id: 'b2bExtraField_100',
+                label: 'Company Name',
+                name: 'b2bExtraField_100',
+                required: false,
+            },
+        ];
+
+        const address = {
+            firstName: 'John',
+            extraFields: [
+                { fieldId: 'b2bExtraField_100', fieldValue: 'Actual Corp' },
+            ],
+        } as Address;
+
+        const result = mapAddressToFormValues(fields, address);
+
+        expect(result.extraFields?.b2bExtraField_100).toBe('Actual Corp');
+    });
+
+    it('falls back to default when address has no matching extra field', () => {
+        const fields: FormField[] = [
+            ...getFormFields(),
+            {
+                custom: false,
+                default: 'Default Corp',
+                id: 'b2bExtraField_100',
+                label: 'Company Name',
+                name: 'b2bExtraField_100',
+                required: false,
+            },
+        ];
+
+        const address = {
+            firstName: 'John',
+            extraFields: [],
+        } as Address;
+
+        const result = mapAddressToFormValues(fields, address);
+
+        expect(result.extraFields?.b2bExtraField_100).toBe('Default Corp');
+    });
+
     it('uses empty string when extra field has no default', () => {
         const fields: FormField[] = [
             ...getFormFields(),

--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -29,8 +29,12 @@ export default function mapAddressToFormValues(
                         addressFormValues.extraFields = {};
                     }
 
-                    // Populate from field.default; sessionStorage-based values can be layered on top externally
-                    addressFormValues.extraFields[name] = defaultValue || '';
+                    // sessionStorage-based values will override API side extra field values later
+                    const extraFieldValue = address?.extraFields?.find(
+                        ({ fieldId }) => fieldId === name,
+                    )?.fieldValue;
+
+                    addressFormValues.extraFields[name] = extraFieldValue ?? defaultValue ?? '';
 
                     return addressFormValues;
                 }

--- a/packages/core/src/app/address/stripExtraFieldsFromAddress.test.ts
+++ b/packages/core/src/app/address/stripExtraFieldsFromAddress.test.ts
@@ -1,0 +1,24 @@
+import { type Address } from '@bigcommerce/checkout-sdk';
+
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+
+import stripExtraFieldsFromAddress from './stripExtraFieldsFromAddress';
+
+describe('stripExtraFieldsFromAddress', () => {
+    it('removes extraFields from address', () => {
+        const address: Address = {
+            ...getShippingAddress(),
+            extraFields: [
+                { fieldId: 'b2bExtraField_100', fieldValue: 'Acme Corp' },
+            ],
+        };
+
+        const result = stripExtraFieldsFromAddress(address);
+
+        expect(result).not.toHaveProperty('extraFields');
+        expect(result.firstName).toBe(address.firstName);
+        expect(result.lastName).toBe(address.lastName);
+        expect(result.address1).toBe(address.address1);
+        expect(result.customFields).toBe(address.customFields);
+    });
+});

--- a/packages/core/src/app/address/stripExtraFieldsFromAddress.ts
+++ b/packages/core/src/app/address/stripExtraFieldsFromAddress.ts
@@ -1,0 +1,7 @@
+import { type Address } from '@bigcommerce/checkout-sdk';
+
+export default function stripExtraFieldsFromAddress(address: Address): Omit<Address, 'extraFields'> {
+    const { extraFields: _extraFields, ...rest } = address;
+
+    return rest;
+}

--- a/packages/core/src/app/formFields/index.ts
+++ b/packages/core/src/app/formFields/index.ts
@@ -10,3 +10,4 @@ export {
 } from './getCustomFormFieldsValidationSchema';
 export { default as getExtraFormFieldsValidationSchema } from './getExtraFormFieldsValidationSchema';
 export { default as mapCustomFormFieldsFromFormValues } from './mapCustomFormFieldsFromFormValues';
+export { default as mapExtraFormFieldsFromFormValues } from './mapExtraFormFieldsFromFormValues';

--- a/packages/core/src/app/formFields/mapExtraFormFieldsFromFormValues.test.ts
+++ b/packages/core/src/app/formFields/mapExtraFormFieldsFromFormValues.test.ts
@@ -1,0 +1,27 @@
+import mapExtraFormFieldsFromFormValues from './mapExtraFormFieldsFromFormValues';
+
+describe('mapExtraFormFieldsFromFormValues', () => {
+    it('converts extra fields object to array of fieldId/fieldValue pairs', () => {
+        const extraFields = {
+            b2bExtraField_100: 'Acme Corp',
+            b2bExtraField_200: 'Engineering',
+            b2bExtraField_300: 42,
+        };
+
+        const result = mapExtraFormFieldsFromFormValues(extraFields);
+
+        expect(result).toEqual([
+            { fieldId: 'b2bExtraField_100', fieldValue: 'Acme Corp' },
+            { fieldId: 'b2bExtraField_200', fieldValue: 'Engineering' },
+            { fieldId: 'b2bExtraField_300', fieldValue: 42 },
+        ]);
+    });
+
+    it('returns undefined when extraFields is undefined', () => {
+        expect(mapExtraFormFieldsFromFormValues(undefined)).toBeUndefined();
+    });
+
+    it('returns empty array when extraFields is empty', () => {
+        expect(mapExtraFormFieldsFromFormValues({})).toEqual([]);
+    });
+});

--- a/packages/core/src/app/formFields/mapExtraFormFieldsFromFormValues.ts
+++ b/packages/core/src/app/formFields/mapExtraFormFieldsFromFormValues.ts
@@ -1,0 +1,14 @@
+export default function mapExtraFormFieldsFromFormValues(
+    extraFields?: { [id: string]: any },
+): Array<{ fieldId: string; fieldValue: string | number }> | undefined {
+    if (!extraFields) {
+        return undefined;
+    }
+
+    return Object.entries(extraFields).map(([name, value]) => {
+        return {
+            fieldId: name,
+            fieldValue: value as string | number,
+        };
+    });
+}

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -4,9 +4,19 @@ import React, { useState } from "react";
 import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from "@bigcommerce/checkout/locale";
 
-import { AddressFormModal, type AddressFormValues, AddressSelect, AddressType, isValidAddress, mapAddressFromFormValues } from "../address";
+import {
+    AddressFormModal,
+    type AddressFormValues,
+    AddressSelect,
+    AddressType,
+    B2BExtraAddressFieldsSessionStorage,
+    isValidAddress,
+    mapAddressFromFormValues,
+    stripExtraFieldsFromAddress,
+} from '../address';
 import { ErrorModal } from "../common/error";
 import { EMPTY_ARRAY, isExperimentEnabled } from "../common/utility";
+import { mapExtraFormFieldsFromFormValues } from '../formFields';
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
 import GuestCustomerAddressSelector from "./GuestCustomerAddressSelector";
@@ -58,6 +68,8 @@ const ConsignmentAddressSelector = ({
         return null;
     }
 
+    const storageKey = B2BExtraAddressFieldsSessionStorage.getConsignmentKey(consignment?.id ?? '');
+
     // TODO: add filter for addresses
     const addresses = customer.addresses || EMPTY_ARRAY;
 
@@ -75,10 +87,12 @@ const ConsignmentAddressSelector = ({
             return onUnhandledError(new AssignItemInvalidAddressError());
         }
 
+        const addressWithoutExtraFields = stripExtraFieldsFromAddress(address);
+
         if (!consignment) {
             setConsignmentRequest?.({
-                address,
-                shippingAddress: address,
+                address: addressWithoutExtraFields,
+                shippingAddress: addressWithoutExtraFields,
                 lineItems: [],
             });
 
@@ -90,8 +104,8 @@ const ConsignmentAddressSelector = ({
                 data: { getConsignments },
             } = await updateConsignment({
                 id: consignment.id,
-                address,
-                shippingAddress: address,
+                address: addressWithoutExtraFields,
+                shippingAddress: addressWithoutExtraFields,
                 lineItems: consignment.lineItems.map(({ id, quantity }) => ({ itemId: id, quantity })),
             });
 
@@ -120,9 +134,12 @@ const ConsignmentAddressSelector = ({
     }
 
     const handleSaveAddress = async (addressFormValues: AddressFormValues) => {
-        const address = mapAddressFromFormValues(addressFormValues);
+        const address = mapAddressFromFormValues(addressFormValues, storageKey);
 
-        await handleSelectAddress(address);
+        await handleSelectAddress({
+            ...address,
+            extraFields: mapExtraFormFieldsFromFormValues(addressFormValues.extraFields),
+        });
 
         if (!isGuest) {
             try {
@@ -162,6 +179,7 @@ const ConsignmentAddressSelector = ({
                 onRequestClose={handleCloseAddAddressForm}
                 onSaveAddress={handleSaveAddress}
                 selectedAddress={isGuest ? selectedAddress : undefined}
+                storageKey={storageKey}
             />
             {isGuest
                 ? <GuestCustomerAddressSelector

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -6,6 +6,7 @@ import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from "@bigcommerce/checkout/dom-utils";
 import { TranslatedString } from "@bigcommerce/checkout/locale";
 
+import { B2BExtraAddressFieldsSessionStorage } from '../address';
 import { EMPTY_ARRAY } from "../common/utility";
 
 import AllocateItemsModal from "./AllocateItemsModal";
@@ -67,6 +68,10 @@ const NewConsignment = ({
             return;
         }
 
+        const previousConsignmentIds = new Set(
+            (getPreviousConsignments() ?? []).map((c) => c.id),
+        );
+
         try {
             const {
                 data: { getConsignments },
@@ -76,6 +81,14 @@ const NewConsignment = ({
             });
 
             currentConsignments = getConsignments();
+
+            const newConsignment = currentConsignments?.find(
+                (c) => !previousConsignmentIds.has(c.id),
+            );
+
+            if (newConsignment) {
+                B2BExtraAddressFieldsSessionStorage.reassignConsignmentKey(newConsignment.id);
+            }
         } catch (error) {
             if (error instanceof AssignItemFailedError) {
                 onUnhandledError(error);


### PR DESCRIPTION
## What/Why?
- Add support for B2B extra address fields in the multi-shipping flow.
     - Strip extra fields from addresses before all API calls (`updateConsignment`, `setConsignmentRequest`, `createCustomerAddress`) to keep them client-side only.
     - Persist extra fields to session storage via `mapAddressFromFormValues` with a consignment-scoped storage key, and pass the same key to `AddressFormModal` for read-back on form init.

- Add `reassignConsignmentKey` to `B2BExtraAddressFieldsSessionStorage`.
     - Call `reassignConsignmentKey` in `NewConsignment.handleAllocateItems` after `assignItem` succeeds, identifying the new consignment by diffing against a pre-call snapshot of consignment IDs.



## Rollout/Rollback

Revert.

## Testing

### Manual testing

https://github.com/user-attachments/assets/6d1c21f2-2156-4f6f-81c9-5eb5edf3c224


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-shipping address selection/save flow and alters payloads sent to consignment/address APIs by stripping `extraFields`, which could affect shipping/address persistence if assumptions differ. Session-storage key reassignment adds stateful behavior that may be sensitive to consignment creation edge cases.
> 
> **Overview**
> Adds client-side support for B2B `extraFields` in the multi-shipping flow by **persisting extra field values in sessionStorage per consignment** and wiring a `storageKey` through `ConsignmentAddressSelector`/`AddressFormModal`.
> 
> Ensures `extraFields` stay client-only by introducing `stripExtraFieldsFromAddress` and using it before `updateConsignment`/`setConsignmentRequest`, while separately mapping form `extraFields` to the SDK array format via `mapExtraFormFieldsFromFormValues`.
> 
> Adds `B2BExtraAddressFieldsSessionStorage.reassignConsignmentKey` (with tests) and calls it after item allocation in `NewConsignment` to move temp extra-field data onto the newly-created consignment id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25655cd42ebcaacb75d2dd74175a98329cbe42f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->