### PR TITLE
feat(payment): PI-5112 bump checkout-sdk to 1.899.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.898.6",
+        "@bigcommerce/checkout-sdk": "^1.899.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.898.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.898.6.tgz",
-      "integrity": "sha512-tmrr9g1VBtqDn3N6QA6hhnlkp23D2P+/tyDsJ93YLTtNA8bcTkk9C7lS3tN8r1Sf1Ef4zWo3/4H95YS1A0eQRQ==",
+      "version": "1.899.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.899.0.tgz",
+      "integrity": "sha512-0kVxCO42ZuLR2nam8uTtIrd6e4D7q3OgjlYWaKSQcZfxQ7/4HuZ0JHhyVlebF1wRAOzbntyj0miruXyNDJ7eTg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.898.6",
+    "@bigcommerce/checkout-sdk": "^1.899.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk to 1.899.0
To deliver https://github.com/bigcommerce/checkout-sdk-js/pull/3206

## Rollout/Rollback
Disable experiment:
`PI-5111.google_pay_direct_pay_on_click`

Or revert.

## Testing
Manual testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade in the checkout/payment SDK may change runtime payment behavior despite minimal code changes. Risk is limited to integration compatibility and should be covered by checkout/payment regression testing.
> 
> **Overview**
> Updates `@bigcommerce/checkout-sdk` from `^1.898.6` to `^1.899.0` in `package.json` and refreshes `package-lock.json` to pull the new SDK tarball/integrity.
> 
> No application code changes; the functional impact comes from the new SDK version (per the referenced upstream change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880c76565036c362dc59203a4c4ba88651d9542b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->