### PR TITLE
chore(payment): PI-5187 remove LayBuy payment method

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -52,7 +52,6 @@ const PaymentMethodComponent: FunctionComponent<
 
     if (
         method.id === PaymentMethodId.Humm ||
-        method.id === PaymentMethodId.Laybuy ||
         method.type === PaymentMethodProviderType.Hosted
     ) {
         return (

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -164,10 +164,6 @@ export function getPaymentMethodTitle(
                         : cdnPath('/img/payment-providers/klarna-header.png'),
                 titleText: methodDisplayName,
             },
-            [PaymentMethodId.Laybuy]: {
-                logoUrl: cdnPath('/img/payment-providers/laybuy-checkout-header.png'),
-                titleText: '',
-            },
             [PaymentMethodType.Paypal]: {
                 // TODO: method.id === PaymentMethodId.BraintreeVenmo should be removed after the PAYPAL-1380.checkout_button_strategies_update experiment removal
                 logoUrl:

--- a/packages/payment-integration-api/src/PaymentMethodId.ts
+++ b/packages/payment-integration-api/src/PaymentMethodId.ts
@@ -36,7 +36,6 @@ enum PaymentMethodId {
     Humm = 'humm',
     Ideal = 'ideal',
     Klarna = 'klarna',
-    Laybuy = 'laybuy',
     Mollie = 'mollie',
     Moneris = 'moneris',
     OrbitalGooglePay = 'googlepayorbital',


### PR DESCRIPTION
## What/Why?

Remove all LayBuy (BNPL) payment method code from checkout-js as part of Phase 4 deprecation ([PI-5187](https://bigcommercecloud.atlassian.net/browse/PI-5187)).

Changes:
- Removed `Laybuy` entry from `PaymentMethodId` enum
- Removed `method.id === PaymentMethodId.Laybuy` routing check in `PaymentMethod.tsx`
- Removed LayBuy custom logo/title configuration from `PaymentMethodTitle.tsx`

LayBuy had no dedicated package, components, tests, feature flags, or experiments — it used the generic `HostedPaymentMethod` path.

## Rollout/Rollback

No experiment or feature flag involved. LayBuy transactions were already stopped in Phase 3 ([PI-4533](https://bigcommercecloud.atlassian.net/browse/PI-4533)). Rollback is a simple code revert if needed.

## Testing

- Lint passes (payment-integration-api, core)
- Unit tests pass (payment-integration-api, core payment method tests)
- Confirmed no remaining `laybuy` references in source `.ts`/`.tsx` files
- HAR fixtures still contain `laybuy` in recorded API responses — will be cleaned up naturally on next `npm run regenerate-har`

[PI-5187]: https://bigcommercecloud.atlassian.net/browse/PI-5187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-4533]: https://bigcommercecloud.atlassian.net/browse/PI-4533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical removal of a deprecated payment method; main risk is any remaining upstream data still returning `laybuy` causing missing title/behavior rather than broader checkout impact.
> 
> **Overview**
> Removes Laybuy support by deleting the `Laybuy` entry from the shared `PaymentMethodId` enum and stripping Laybuy-specific UI handling.
> 
> Checkout no longer routes `laybuy` through the hosted payment method path in `PaymentMethod.tsx`, and `PaymentMethodTitle.tsx` drops the Laybuy logo/title override so it will no longer appear with custom branding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bf9040beff04388d25e81de8089bf7ea9ce311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->