### PR TITLE
feat(checkout): CHECKOUT-9949 Make coupon code entry easier to find o…

### DIFF
--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -111,7 +111,6 @@ const PaymentForm: FunctionComponent<
 
     const { checkoutState } = useCheckout();
     const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
-    const isMultiCouponEnabled = isExperimentEnabled(checkoutSettings, 'CHECKOUT-9674.multi_coupon_cart_checkout', false);
     const shouldShowSubmitButtonWhenPaymentNotRequired = isExperimentEnabled(checkoutSettings, 'CHECKOUT-9729.show_submit_button_when_payment_not_required', false);
     const hideSubmitPaymentButton = shouldHidePaymentSubmitButton || (shouldShowSubmitButtonWhenPaymentNotRequired && isPaymentDataRequired() && isEmpty(methods));
     
@@ -156,7 +155,7 @@ const PaymentForm: FunctionComponent<
                 />
             }
 
-            {!isMultiCouponEnabled && <PaymentRedeemables />}
+            <PaymentRedeemables />
 
             {isTermsConditionsRequired && (
                 <TermsConditions

--- a/packages/core/src/app/payment/PaymentRedeemables.tsx
+++ b/packages/core/src/app/payment/PaymentRedeemables.tsx
@@ -1,22 +1,30 @@
 import React, { type FunctionComponent, memo } from 'react';
 
+import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
 import { mapToRedeemableProps, Redeemable, type RedeemableProps } from '../cart';
 import { withCheckout } from '../checkout';
+import { isExperimentEnabled } from '../common/utility';
 import { Fieldset, Legend } from '../ui/form';
 
-const PaymentRedeemables: FunctionComponent<RedeemableProps> = (redeemableProps) => (
-    <Fieldset 
-        additionalClassName="redeemable-payments"
-        legend={
-            <Legend hidden>
-                <TranslatedString id="payment.redeemable_payments_text" />
-            </Legend>
-        }
-    >
-        <Redeemable {...redeemableProps} showAppliedRedeemables={true} />
-    </Fieldset>
-);
+const PaymentRedeemables: FunctionComponent<RedeemableProps> = (redeemableProps) => {
+    const { checkoutState } = useCheckout();
+    const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
+    const isMultiCouponEnabled = isExperimentEnabled(checkoutSettings, 'CHECKOUT-9674.multi_coupon_cart_checkout', false);
+
+    return (
+        <Fieldset 
+            additionalClassName="redeemable-payments"
+            legend={
+                <Legend hidden>
+                    <TranslatedString id="payment.redeemable_payments_text" />
+                </Legend>
+            }
+        >
+            <Redeemable {...redeemableProps} showAppliedRedeemables={!isMultiCouponEnabled} />
+        </Fieldset>
+    );
+};
 
 export default withCheckout(mapToRedeemableProps)(memo(PaymentRedeemables));


### PR DESCRIPTION
## What/Why?

### What
On mobile checkout, add a prominent field in the payment step making it easy for shoppers to locate and apply a coupon code.

### Why?
Merchants have reported that customers struggle to find the coupon code field during mobile checkout. The field exists but is hidden behind the "Show Details" toggle, which many shoppers overlook.

For example, merchants running discount coupon campaigns are seeing customer confusion and drop-off because the coupon entry point isn't visible by default. This added friction is likely contributing to checkout abandonment and reducing conversion rates.

## Rollout/Rollback

Revert the PR.

## Testing

- [x] Verified coupon input appears in the Payment step on mobile
- [x] Verify applied coupons displayed in the order summary

**Before**
On mobile, the coupon code field is difficult to find as it's hidden behind the "Show Details" order summary toggle, making it easy for shoppers to overlook.

https://github.com/user-attachments/assets/b25f394c-0a48-49ce-9e0b-b96b57e59ae8


**After**
On mobile, a coupon code field is now clearly visible at checkout. Applied coupons are also reflected in the order summary when the shopper expands "Show Details."

https://github.com/user-attachments/assets/9d75d612-358f-48b4-a0c3-c105edf043cb



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change limited to the payment step’s redeemables display logic; no changes to payment processing, auth, or data persistence.
> 
> **Overview**
> Makes `PaymentRedeemables` always render in `PaymentForm` (removing the previous experiment gate), ensuring the coupon/redeemables entry point is consistently visible in the payment step.
> 
> Moves the `CHECKOUT-9674.multi_coupon_cart_checkout` experiment check into `PaymentRedeemables` and uses it only to control whether already-applied redeemables are shown (`showAppliedRedeemables`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664b2537c8a8ffbb0a07e3292a796eb65fd2ecc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->