### PR TITLE
chore(checkout): CHECKOUT-9950 update checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.899.0",
+        "@bigcommerce/checkout-sdk": "^1.899.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.899.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.899.0.tgz",
-      "integrity": "sha512-0kVxCO42ZuLR2nam8uTtIrd6e4D7q3OgjlYWaKSQcZfxQ7/4HuZ0JHhyVlebF1wRAOzbntyj0miruXyNDJ7eTg==",
+      "version": "1.899.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.899.2.tgz",
+      "integrity": "sha512-ys73N9KEaXBmRFk8yM097++DzB+a4pAKas6bTqMiSRVF2U3mOErn3Bu4+esTOY3l+wJ0GasjjZ/jMoCdovHdnw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.899.0",
+    "@bigcommerce/checkout-sdk": "^1.899.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
update checkout sdk to releas
- https://github.com/bigcommerce/checkout-sdk-js/pull/3220
- https://github.com/bigcommerce/checkout-sdk-js/pull/3217

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk patch dependency bump; primary risk is unintended behavior changes coming from the updated `@bigcommerce/checkout-sdk` transitive code.
> 
> **Overview**
> Updates the `@bigcommerce/checkout-sdk` dependency from `^1.899.0` to `^1.899.2`, and refreshes `package-lock.json` to pin the new resolved tarball/integrity for that version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d153a6bcee1c201ba3294af5a621f5de5bcb60a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->