### PR TITLE
feat(payment): Add provider section container on top of payment methods list

### DIFF
--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -23,6 +23,12 @@ import PaymentForm, { type PaymentFormProps } from './PaymentForm';
 
 jest.useFakeTimers({ legacyFakeTimers: true });
 
+jest.mock('./ProvidersSectionOnTopOfPaymentsList', () => ({
+    ProvidersSectionOnTopOfPaymentsList: jest.fn(() =>
+        <div data-test="providers-section-on-top-of-payments-list" />
+    ),
+}));
+
 describe('PaymentForm', () => {
     let checkoutService: CheckoutService;
     let extensionService: ExtensionServiceInterface;
@@ -81,6 +87,7 @@ describe('PaymentForm', () => {
         expect(screen.getAllByRole('radio')).toHaveLength(2);
         expect(screen.getAllByText('Authorizenet')).toHaveLength(3);  // 2 radio buttons + 1 title for a11y (hidden)
         expect(screen.getByText(localeContext.language.translate('payment.place_order_action'))).toBeInTheDocument();
+        expect(screen.getByTestId('providers-section-on-top-of-payments-list')).toBeInTheDocument();
     });
 
     it('renders terms and conditions field if copy is provided', () => {

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -26,6 +26,7 @@ import PaymentRedeemables from './PaymentRedeemables';
 import PaymentSubmitButton from './PaymentSubmitButton';
 import SpamProtectionField from './SpamProtectionField';
 import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
+import { ProvidersSectionOnTopOfPaymentsList } from './ProvidersSectionOnTopOfPaymentsList';
 
 export interface PaymentFormProps {
     availableStoreCredit?: number;
@@ -254,6 +255,8 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
             {!isPaymentDataRequired() && <StoreCreditOverlay />}
 
             <Extension region={ExtensionRegion.PaymentPaymentMethodListBefore}/>
+
+            <ProvidersSectionOnTopOfPaymentsList methods={methods} />
 
             <PaymentMethodList
                 isEmbedded={isEmbedded}

--- a/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.test.tsx
+++ b/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.test.tsx
@@ -1,0 +1,140 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+import React from 'react';
+
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import { getPaymentMethod } from '../payment-methods.mock';
+
+import { ProvidersSectionOnTopOfPaymentsList } from './ProvidersSectionOnTopOfPaymentsList';
+
+describe('ProvidersSectionOnTopOfPaymentsList', () => {
+    it('renders wrapper div with correct class name', () => {
+        render(
+            <ProvidersSectionOnTopOfPaymentsList methods={[]} />,
+        );
+
+        expect(
+            screen.getByTestId('providers-section-on-top-of-payments-list'),
+        ).toBeInTheDocument();
+    });
+
+    it('does not render container for methods without hasSectionOnTopOfPaymentsList', () => {
+        const method: PaymentMethod = {
+            ...getPaymentMethod(),
+            initializationData: {},
+        };
+
+        render(
+            <ProvidersSectionOnTopOfPaymentsList methods={[method]} />,
+        );
+
+        expect(
+            screen.queryByTestId(`${method.id}-provider-section-on-top-of-payments-list`),
+        ).not.toBeInTheDocument();
+    });
+
+    it('does not render container when initializationData is undefined', () => {
+        const method: PaymentMethod = {
+            ...getPaymentMethod(),
+            initializationData: undefined,
+        };
+
+        render(
+            <ProvidersSectionOnTopOfPaymentsList methods={[method]} />,
+        );
+
+        expect(
+            screen.queryByTestId(`${method.id}-provider-section-on-top-of-payments-list`),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders container div for method with hasSectionOnTopOfPaymentsList', () => {
+        const method: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'stripe',
+            gateway: undefined,
+            initializationData: { hasSectionOnTopOfPaymentsList: true },
+        };
+
+        render(
+            <ProvidersSectionOnTopOfPaymentsList methods={[method]} />,
+        );
+
+        expect(
+            screen.getByTestId('stripe-provider-section-on-top-of-payments-list'),
+        ).toBeInTheDocument();
+    });
+
+    it('renders container id with gateway prefix when gateway is set', () => {
+        const method: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'card',
+            gateway: 'stripeupe',
+            initializationData: { hasSectionOnTopOfPaymentsList: true },
+        };
+
+        render(
+            <ProvidersSectionOnTopOfPaymentsList methods={[method]} />,
+        );
+
+        expect(
+            screen.getByTestId('stripeupe-card-provider-section-on-top-of-payments-list'),
+        ).toBeInTheDocument();
+    });
+
+    it('renders containers only for eligible methods', () => {
+        const eligibleMethod: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'stripe',
+            gateway: undefined,
+            initializationData: { hasSectionOnTopOfPaymentsList: true },
+        };
+
+        const ineligibleMethod: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'authorizenet',
+            gateway: undefined,
+            initializationData: {},
+        };
+
+        render(
+            <ProvidersSectionOnTopOfPaymentsList
+                methods={[eligibleMethod, ineligibleMethod]}
+            />,
+        );
+
+        expect(
+            screen.getByTestId('stripe-provider-section-on-top-of-payments-list'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByTestId('authorizenet-provider-section-on-top-of-payments-list'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('renders multiple containers for multiple eligible methods', () => {
+        const method1: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'card',
+            gateway: 'stripeupe',
+            initializationData: { hasSectionOnTopOfPaymentsList: true },
+        };
+
+        const method2: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'card',
+            gateway: 'stripeocs',
+            initializationData: { hasSectionOnTopOfPaymentsList: true },
+        };
+
+        render(
+            <ProvidersSectionOnTopOfPaymentsList methods={[method1, method2]} />,
+        );
+
+        expect(
+            screen.getByTestId('stripeupe-card-provider-section-on-top-of-payments-list'),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByTestId('stripeocs-card-provider-section-on-top-of-payments-list'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.test.tsx
+++ b/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.test.tsx
@@ -8,44 +8,38 @@ import { getPaymentMethod } from '../payment-methods.mock';
 import { ProvidersSectionOnTopOfPaymentsList } from './ProvidersSectionOnTopOfPaymentsList';
 
 describe('ProvidersSectionOnTopOfPaymentsList', () => {
-    it('renders wrapper div with correct class name', () => {
-        render(
+    it('returns null when methods array is empty', () => {
+        const { container } = render(
             <ProvidersSectionOnTopOfPaymentsList methods={[]} />,
         );
 
-        expect(
-            screen.getByTestId('providers-section-on-top-of-payments-list'),
-        ).toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 
-    it('does not render container for methods without hasSectionOnTopOfPaymentsList', () => {
+    it('returns null when no methods have hasSectionOnTopOfPaymentsList', () => {
         const method: PaymentMethod = {
             ...getPaymentMethod(),
             initializationData: {},
         };
 
-        render(
+        const { container } = render(
             <ProvidersSectionOnTopOfPaymentsList methods={[method]} />,
         );
 
-        expect(
-            screen.queryByTestId(`${method.id}-provider-section-on-top-of-payments-list`),
-        ).not.toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 
-    it('does not render container when initializationData is undefined', () => {
+    it('returns null when initializationData is undefined', () => {
         const method: PaymentMethod = {
             ...getPaymentMethod(),
             initializationData: undefined,
         };
 
-        render(
+        const { container } = render(
             <ProvidersSectionOnTopOfPaymentsList methods={[method]} />,
         );
 
-        expect(
-            screen.queryByTestId(`${method.id}-provider-section-on-top-of-payments-list`),
-        ).not.toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 
     it('renders container div for method with hasSectionOnTopOfPaymentsList', () => {

--- a/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.tsx
+++ b/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.tsx
@@ -8,7 +8,11 @@ export interface ProvidersSectionOnTopOfPaymentsListProps {
 
 export const ProvidersSectionOnTopOfPaymentsList = ({ methods }: ProvidersSectionOnTopOfPaymentsListProps) => {
     const methodsWithTopSection = methods.filter((method) => method.initializationData?.hasSectionOnTopOfPaymentsList);
-    
+
+    if (!methodsWithTopSection.length) {
+        return null;
+    }
+
     return (
         <div className="providers-section-on-top-of-payments-list" data-test="providers-section-on-top-of-payments-list">
             {methodsWithTopSection.map((method) => {

--- a/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.tsx
+++ b/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/ProvidersSectionOnTopOfPaymentsList.tsx
@@ -1,0 +1,24 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+import React from 'react';
+import { getUniquePaymentMethodId } from '../paymentMethod';
+
+export interface ProvidersSectionOnTopOfPaymentsListProps {
+    methods: PaymentMethod[];
+}
+
+export const ProvidersSectionOnTopOfPaymentsList = ({ methods }: ProvidersSectionOnTopOfPaymentsListProps) => {
+    const methodsWithTopSection = methods.filter((method) => method.initializationData?.hasSectionOnTopOfPaymentsList);
+    
+    return (
+        <div className="providers-section-on-top-of-payments-list" data-test="providers-section-on-top-of-payments-list">
+            {methodsWithTopSection.map((method) => {
+                const prefix = getUniquePaymentMethodId(method.id, method.gateway);
+                const containerId = `${prefix}-provider-section-on-top-of-payments-list`;
+
+                return (
+                    <div data-test={containerId} id={containerId} key={prefix} />
+                );
+            })}
+        </div>
+    );
+};

--- a/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/index.ts
+++ b/packages/core/src/app/payment/ProvidersSectionOnTopOfPaymentsList/index.ts
@@ -1,0 +1,1 @@
+export { ProvidersSectionOnTopOfPaymentsList } from './ProvidersSectionOnTopOfPaymentsList';


### PR DESCRIPTION
## What/Why?
- Adds a new `ProvidersSectionOnTopOfPaymentsList` component that renders container above the payment method list for providers that opt in via `initializationData.hasSectionOnTopOfPaymentsList`
- Each eligible payment method gets a uniquely identified container ({gateway}-{id}-provider-section-on-top-of-payments-list) that the payment SDK can mount custom UI into

Related PRs:

[https://github.com/bigcommerce/checkout-sdk-js/pull/3218](https://github.com/bigcommerce/checkout-sdk-js/pull/3218)

[https://github.com/bigcommerce/checkout-js/pull/2948](https://github.com/bigcommerce/checkout-js/pull/2948)

[https://github.com/bigcommerce/checkout-js/pull/2949](https://github.com/bigcommerce/checkout-js/pull/2949)

## Rollout/Rollback
Rollback this PR

## Testing
<img width="2159" height="548" alt="Screenshot 2026-04-15 at 18 27 45" src="https://github.com/user-attachments/assets/e8faea10-10e6-4a87-91fc-b8d92883ac9a" />

https://github.com/user-attachments/assets/a1f4e4b1-76cc-4b6c-96e5-fbaef4953c9d

<img width="611" height="76" alt="Screenshot 2026-04-15 at 19 02 08" src="https://github.com/user-attachments/assets/0f8bd38b-0ee6-40e8-ab6c-d846bca17339" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that adds extra DOM containers gated by a provider opt-in flag; main risk is unintended layout/CSS impact or provider-specific mounting assumptions.
> 
> **Overview**
> Adds a new `ProvidersSectionOnTopOfPaymentsList` rendered in `PaymentForm` above `PaymentMethodList` to expose per-provider mount points.
> 
> The component filters payment methods by `initializationData.hasSectionOnTopOfPaymentsList` and renders stable container divs with ids/data-test like `{gateway-}methodId-provider-section-on-top-of-payments-list`, with unit tests covering null/eligible cases and `PaymentForm` tests updated to assert the section is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51e7476af06fa96f321f414a332cea01e786170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->