### PR TITLE
fix(checkout): CHECKOUT-9941 Fix BlueSnap Loading Issue

### DIFF
--- a/packages/bluesnap-direct-integration/src/BlueSnapDirectPayByBankPaymentMethod.tsx
+++ b/packages/bluesnap-direct-integration/src/BlueSnapDirectPayByBankPaymentMethod.tsx
@@ -1,5 +1,5 @@
 import { createBlueSnapDirectAPMPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
-import React, { type FunctionComponent, useCallback, useEffect } from 'react';
+import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
 import {
     type PaymentMethodProps,
@@ -22,15 +22,19 @@ const BlueSnapDirectPayByBankPaymentMethod: FunctionComponent<PaymentMethodProps
         throw new Error('Unable to get initialization data');
     }
 
+    const setValidationSchemaRef = useRef(setValidationSchema);
+
+    setValidationSchemaRef.current = setValidationSchema;
+
     const initializePayByBank = useCallback(async () => {
-        setValidationSchema(method, getPayByBankValidationSchema(language));
+        setValidationSchemaRef.current(method, getPayByBankValidationSchema(language));
 
         await initializePayment({
             gatewayId: method.gateway,
             methodId: method.id,
             integrations: [createBlueSnapDirectAPMPaymentStrategy],
         });
-    }, [initializePayment, language, method, setValidationSchema]);
+    }, [initializePayment, language, method]);
 
     const deinitializePayByBank = useCallback(async () => {
         await deinitializePayment({

--- a/packages/bluesnap-direct-integration/src/BlueSnapDirectPayByBankPaymentMethod.tsx
+++ b/packages/bluesnap-direct-integration/src/BlueSnapDirectPayByBankPaymentMethod.tsx
@@ -1,5 +1,5 @@
 import { createBlueSnapDirectAPMPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
-import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
+import React, { type FunctionComponent, useCallback, useEffect } from 'react';
 
 import {
     type PaymentMethodProps,
@@ -22,19 +22,15 @@ const BlueSnapDirectPayByBankPaymentMethod: FunctionComponent<PaymentMethodProps
         throw new Error('Unable to get initialization data');
     }
 
-    const setValidationSchemaRef = useRef(setValidationSchema);
-
-    setValidationSchemaRef.current = setValidationSchema;
-
     const initializePayByBank = useCallback(async () => {
-        setValidationSchemaRef.current(method, getPayByBankValidationSchema(language));
+        setValidationSchema(method, getPayByBankValidationSchema(language));
 
         await initializePayment({
             gatewayId: method.gateway,
             methodId: method.id,
             integrations: [createBlueSnapDirectAPMPaymentStrategy],
         });
-    }, [initializePayment, language, method]);
+    }, [initializePayment, language, method, setValidationSchema]);
 
     const deinitializePayByBank = useCallback(async () => {
         await deinitializePayment({

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -523,7 +523,7 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
         }));
     };
 
-    const setValidationSchema = (
+    const setValidationSchema = useCallback((
         method: PaymentMethod,
         schema: ObjectSchema<Partial<PaymentFormValues>> | null,
     ): void => {
@@ -534,7 +534,7 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
         }
 
         validationSchemasRef.current[uniqueId] = schema;
-    };
+    }, []);
 
     const loadPaymentMethodsOrThrow = async (): Promise<void> => {
         const {


### PR DESCRIPTION
## What/Why?

- Fix infinite re-render loop when selecting BlueSnap Direct "Pay by Bank" payment method (EUR, EU billing/shipping)
- Root cause:
        `setValidationSchema` in Payment.tsx is not memoized, so it gets a new reference on every render. This cascades through `PaymentMethodV2.tsx` → `createPaymentFormService()` → `BlueSnapDirectPayByBankPaymentMethod`, where it's listed as a `useCallback` dependency, causing the initialization effect to loop infinitely.

## Notes
5 other payment methods have `setValidationSchema` in effect/callback dependency arrays:

- BlueSnapDirectIdealPaymentMethod (line 40)
- BlueSnapDirectSepaPaymentMethod (line 85)
- BlueSnapDirectEcpPaymentMethod (line 117)
- BigCommercePaymentsRatePayPaymentMethod (line 199)
- PaypalCommerceRatePayPaymentMethod (line 210)

They're all susceptible to the same class of bug. However, it will only be an issue if they trigger `Payment.tsx` to re-render. For now, we focus on fixing the reported issue.

## Rollout/Rollback

CI.

## Testing

### Manual Testing
https://pre-provisioned-sc92bwmkgz.my-integration.zone/checkout

https://github.com/user-attachments/assets/c363c775-ce96-44ff-8077-d41b369d498f




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized React hook change that only stabilizes a callback reference; minimal behavioral risk outside of reducing unnecessary re-initialization.
> 
> **Overview**
> Fixes an infinite re-render/initialization loop for some payment methods (notably BlueSnap Direct Pay by Bank) by memoizing `setValidationSchema` in `Payment.tsx` with `useCallback` so its function reference remains stable across renders.
> 
> This ensures downstream hooks/effects that depend on `setValidationSchema` don’t repeatedly re-run just because `Payment` re-rendered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2e9be6ec789311887a2788ea874d74b023de93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->