### PR TITLE
feat(payment): enable Stripe Adaptive Pricing element

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -45,9 +45,10 @@ describe('when using Stripe OCS payment', () => {
     const gatewayId = 'stripeocs';
     const methodSelectorPrefix = `${gatewayId}-${methodId}`;
     const expectedContainerId = `${methodSelectorPrefix}-component-field`;
+    const expectedCurrencySelectorContainerId = `${methodSelectorPrefix}-provider-section-on-top-of-payments-list`;
     const defaultAccordionLayout = {
         defaultCollapsed: false,
-        radios: true,
+        radios: 'always',
         spacedAccordionItems: false,
         type: 'accordion',
         visibleAccordionItemsCount: 0,
@@ -163,6 +164,7 @@ describe('when using Stripe OCS payment', () => {
             integrations: [createStripeOCSPaymentStrategy, createStripeCSPaymentStrategy],
             [gatewayId]: {
                 containerId: expectedContainerId,
+                currencySelectorContainerId: expectedCurrencySelectorContainerId,
                 layout: defaultAccordionLayout,
                 appearance: {
                     variables: { color: '#cccccc' },
@@ -194,6 +196,7 @@ describe('when using Stripe OCS payment', () => {
             integrations: [createStripeOCSPaymentStrategy, createStripeCSPaymentStrategy],
             [gatewayId]: {
                 containerId: expectedContainerId,
+                currencySelectorContainerId: expectedCurrencySelectorContainerId,
                 layout: defaultAccordionLayout,
                 appearance: {
                     variables: { color: '#cccccc' },
@@ -217,6 +220,7 @@ describe('when using Stripe OCS payment', () => {
                 gatewayId: method.gateway,
                 [gatewayId]: {
                     containerId: expectedContainerId,
+                    currencySelectorContainerId: expectedCurrencySelectorContainerId,
                     layout: defaultAccordionLayout,
                     appearance: {
                         variables: { color: '#cccccc' },
@@ -246,6 +250,7 @@ describe('when using Stripe OCS payment', () => {
                 gatewayId: method.gateway,
                 [gatewayId]: {
                     containerId: expectedContainerId,
+                    currencySelectorContainerId: expectedCurrencySelectorContainerId,
                     layout: defaultAccordionLayout,
                     appearance: {
                         variables: { color: '#cccccc' },
@@ -309,6 +314,7 @@ describe('when using Stripe OCS payment', () => {
                     gatewayId: method.gateway,
                     [gatewayId]: {
                         containerId: expectedContainerId,
+                        currencySelectorContainerId: expectedCurrencySelectorContainerId,
                         layout: {
                             ...defaultAccordionLayout,
                             type: 'auto',
@@ -343,6 +349,7 @@ describe('when using Stripe OCS payment', () => {
                     gatewayId: method.gateway,
                     [gatewayId]: {
                         containerId: expectedContainerId,
+                        currencySelectorContainerId: expectedCurrencySelectorContainerId,
                         layout: {
                             ...defaultAccordionLayout,
                             type: 'accordion',
@@ -376,6 +383,7 @@ describe('when using Stripe OCS payment', () => {
                     gatewayId: method.gateway,
                     [gatewayId]: {
                         containerId: expectedContainerId,
+                        currencySelectorContainerId: expectedCurrencySelectorContainerId,
                         layout: {
                             ...defaultAccordionLayout,
                             defaultCollapsed: true,
@@ -403,6 +411,7 @@ describe('when using Stripe OCS payment', () => {
                     gatewayId: method.gateway,
                     [gatewayId]: {
                         containerId: expectedContainerId,
+                        currencySelectorContainerId: expectedCurrencySelectorContainerId,
                         layout: defaultAccordionLayout,
                         appearance: {
                             variables: { color: '#cccccc' },
@@ -431,6 +440,7 @@ describe('when using Stripe OCS payment', () => {
                     gatewayId: method.gateway,
                     [gatewayId]: {
                         containerId: expectedContainerId,
+                        currencySelectorContainerId: expectedCurrencySelectorContainerId,
                         layout: {
                             ...defaultAccordionLayout,
                             type: 'accordion',
@@ -527,6 +537,48 @@ describe('when using Stripe OCS payment', () => {
             rerender(<PaymentMethodTest {...defaultProps} method={method} />);
 
             expect(collapseElementMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('# Currency selector', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    options.stripeocs?.togglePreloader?.(false);
+
+                    return Promise.resolve(checkoutState);
+                },
+            );
+        });
+
+        it('should render currency selector styles for non-themeV2', () => {
+            themeContextValueMock = { themeV2: false };
+
+            render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(screen.queryByTestId('stripe-accordion-skeleton')).not.toBeInTheDocument();
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    [gatewayId]: expect.objectContaining({
+                        currencySelectorContainerId: expectedCurrencySelectorContainerId,
+                    }),
+                }),
+            );
+        });
+
+        it('should render currency selector styles for themeV2', () => {
+            themeContextValueMock = { themeV2: true };
+
+            render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(screen.queryByTestId('stripe-accordion-skeleton')).not.toBeInTheDocument();
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    [gatewayId]: expect.objectContaining({
+                        currencySelectorContainerId: expectedCurrencySelectorContainerId,
+                    }),
+                }),
+            );
         });
     });
 });

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -50,6 +50,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const { themeV2 } = useThemeContext();
     const methodSelector = `${method.gateway}-${method.id}`;
     const containerId = `${methodSelector}-component-field`;
+    const currencySelectorContainerId = `${methodSelector}-provider-section-on-top-of-payments-list`;
     const paymentContext = paymentForm;
 
     useEffect(() => {
@@ -121,10 +122,11 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                 integrations: [createStripeOCSPaymentStrategy, createStripeCSPaymentStrategy],
                 stripeocs: {
                     containerId,
+                    currencySelectorContainerId,
                     layout: {
                         type: isCustomChecklistItem ? 'accordion' : 'auto',
                         defaultCollapsed: selectedItemId !== methodSelector,
-                        radios: true,
+                        radios: 'always',
                         linkInAccordion: true,
                         spacedAccordionItems: !!themeV2,
                         visibleAccordionItemsCount: 0,
@@ -143,6 +145,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         },
         [
             containerId,
+            currencySelectorContainerId,
             selectedItemId,
             methodSelector,
             isCustomChecklistItem,
@@ -170,6 +173,12 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     }
 
     const renderCustomOCSSectionStyles = () => {
+        const currencySelectorStyles = `
+            #${currencySelectorContainerId} {
+                margin-bottom: 20px;
+            }
+        `;
+
         return themeV2 ? (
             <style>
                 {`
@@ -177,6 +186,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                         border: none;
                     }
                 `}
+                {currencySelectorStyles}
             </style>
         ) : (
             <style>
@@ -188,6 +198,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                         margin-bottom: -1px;
                     }
                 `}
+                {currencySelectorStyles}
             </style>
         );
     };


### PR DESCRIPTION
## What/Why?
Add Stripe Adaptive Pricing element to Stripe component

Related PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3218](https://github.com/bigcommerce/checkout-sdk-js/pull/3218)

[https://github.com/bigcommerce/checkout-js/pull/2944](https://github.com/bigcommerce/checkout-js/pull/2944)

[https://github.com/bigcommerce/checkout-js/pull/2948](https://github.com/bigcommerce/checkout-js/pull/2948)

## Rollout/Rollback
Rollback this PR

## Testing
<img width="2159" height="548" alt="Screenshot 2026-04-15 at 18 27 45" src="https://github.com/user-attachments/assets/eb38df03-ec9d-431a-ad3e-9a1c947e608a" />

https://github.com/user-attachments/assets/8a41ef4d-725e-4ace-8d03-a1900c5771ef

### NOTE:
Build failed because of dependency to interface update from checkout-sdk PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/3218](https://github.com/bigcommerce/checkout-sdk-js/pull/3218)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment-method initialization/config passed into the Stripe OCS strategy and adds new DOM/CSS assumptions for a new container, which could affect checkout rendering if the SDK/element behavior differs.
> 
> **Overview**
> Extends `StripeOCSPaymentMethod` initialization to pass a new `currencySelectorContainerId` into `stripeocs` options (to support Stripe’s currency selector/adaptive pricing element) and injects minimal CSS to space that container consistently across *themeV2* and legacy themes.
> 
> Also updates the Stripe accordion layout config to use `radios: 'always'` (instead of a boolean) and adjusts/adds unit tests to assert the new init option and cover both theme variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0a2a6eae300ef63b79c00b347aabc234c108b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->