### PR TITLE
refactor(checkout): CHECKOUT-9938 Refactor extra fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.899.2",
+        "@bigcommerce/checkout-sdk": "^1.899.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,10 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.899.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.899.2.tgz",
-      "integrity": "sha512-ys73N9KEaXBmRFk8yM097++DzB+a4pAKas6bTqMiSRVF2U3mOErn3Bu4+esTOY3l+wJ0GasjjZ/jMoCdovHdnw==",
-      "license": "MIT",
+      "version": "1.899.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.899.4.tgz",
+      "integrity": "sha512-F5Jdgaxs5TXXSpAJoN7lfbcHZ9BC3zXzACWpNc4v/R1bisffLsDBcWbb2Kldm0Vmwgdl2QFUD2ydCBn78pvfMA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.899.2",
+    "@bigcommerce/checkout-sdk": "^1.899.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -5,6 +5,7 @@ export const defaultCapabilities: Capabilities = {
         disableEditCart: false,
         hasCompanyAddressBook: false,
         hasAddressExtraFields: false,
+        requiresB2BToken: false,
     },
     customer: {
         superAdminCompanySelector: false,

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -4,7 +4,7 @@ export const defaultCapabilities: Capabilities = {
     userJourney: {
         disableEditCart: false,
         hasCompanyAddressBook: false,
-        hasExtraAddressFields: false,
+        hasAddressExtraFields: false,
     },
     customer: {
         superAdminCompanySelector: false,

--- a/packages/core/src/app/address/AddressForm.tsx
+++ b/packages/core/src/app/address/AddressForm.tsx
@@ -1,4 +1,4 @@
-import { type FormField, isExtraFormField } from '@bigcommerce/checkout-sdk/essential';
+import { type FormField, isExtraField } from '@bigcommerce/checkout-sdk/essential';
 import { forIn, noop } from 'lodash';
 import React, { useCallback, useEffect, useRef } from 'react';
 
@@ -126,7 +126,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
                                 return fieldName ? `${fieldName}.customFields` : 'customFields';
                             }
 
-                            if (isExtraFormField(field)) {
+                            if (isExtraField(field)) {
                                 return fieldName ? `${fieldName}.extraFields` : 'extraFields';
                             }
 
@@ -168,7 +168,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
                                 isFloatingLabelEnabled={isFloatingLabelEnabledValue}
                                 key={`${field.id}-${field.name}`}
                                 label={
-                                    (field.custom || isExtraFormField(field)) ? (
+                                    (field.custom || isExtraField(field)) ? (
                                         field.label
                                     ) : (
                                         <TranslatedString id={LABEL[field.name]} />

--- a/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
+++ b/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
@@ -1,6 +1,6 @@
-import { B2BExtraAddressFieldsSessionStorage } from './B2BExtraAddressFieldsSessionStorage';
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 
-describe('B2BExtraAddressFieldsSessionStorage', () => {
+describe('B2BExtraFieldsSessionStorage', () => {
     beforeEach(() => {
         sessionStorage.clear();
     });
@@ -9,31 +9,31 @@ describe('B2BExtraAddressFieldsSessionStorage', () => {
         it('moves fields from temp key to the real consignment key', () => {
             const fields = { b2bExtraField_100: 'Acme Corp' };
 
-            B2BExtraAddressFieldsSessionStorage.setFields(
-                B2BExtraAddressFieldsSessionStorage.getConsignmentKey(''),
+            B2BExtraFieldsSessionStorage.setFields(
+                B2BExtraFieldsSessionStorage.getConsignmentKey(''),
                 fields,
             );
 
-            B2BExtraAddressFieldsSessionStorage.reassignConsignmentKey('consignment-123');
+            B2BExtraFieldsSessionStorage.reassignConsignmentKey('consignment-123');
 
             expect(
-                B2BExtraAddressFieldsSessionStorage.getFields(
-                    B2BExtraAddressFieldsSessionStorage.getConsignmentKey('consignment-123'),
+                B2BExtraFieldsSessionStorage.getFields(
+                    B2BExtraFieldsSessionStorage.getConsignmentKey('consignment-123'),
                 ),
             ).toEqual(fields);
             expect(
-                B2BExtraAddressFieldsSessionStorage.getFields(
-                    B2BExtraAddressFieldsSessionStorage.getConsignmentKey(''),
+                B2BExtraFieldsSessionStorage.getFields(
+                    B2BExtraFieldsSessionStorage.getConsignmentKey(''),
                 ),
             ).toBeUndefined();
         });
 
         it('does nothing when temp key has no data', () => {
-            B2BExtraAddressFieldsSessionStorage.reassignConsignmentKey('consignment-123');
+            B2BExtraFieldsSessionStorage.reassignConsignmentKey('consignment-123');
 
             expect(
-                B2BExtraAddressFieldsSessionStorage.getFields(
-                    B2BExtraAddressFieldsSessionStorage.getConsignmentKey('consignment-123'),
+                B2BExtraFieldsSessionStorage.getFields(
+                    B2BExtraFieldsSessionStorage.getConsignmentKey('consignment-123'),
                 ),
             ).toBeUndefined();
         });

--- a/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
+++ b/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
@@ -1,7 +1,7 @@
-export class B2BExtraAddressFieldsSessionStorage {
-    static readonly BILLING_KEY = 'b2bExtraAddressFields_billing';
-    static readonly SHIPPING_KEY = 'b2bExtraAddressFields_shipping';
-    static readonly CONSIGNMENT_KEY_PREFIX = 'b2bExtraAddressFields_consignment_';
+export class B2BExtraFieldsSessionStorage {
+    static readonly BILLING_KEY = 'b2bAddressExtraFields_billing';
+    static readonly SHIPPING_KEY = 'b2bAddressExtraFields_shipping';
+    static readonly CONSIGNMENT_KEY_PREFIX = 'b2bAddressExtraFields_consignment_';
 
     static getConsignmentKey(consignmentId: string): string {
         return `${this.CONSIGNMENT_KEY_PREFIX}${consignmentId}`;

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -1,4 +1,4 @@
-export { B2BExtraAddressFieldsSessionStorage } from './B2BExtraAddressFieldsSessionStorage';
+export { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 export { default as mapAddressToFormValues, AddressFormValues } from './mapAddressToFormValues';
 export { default as mapAddressFromFormValues } from './mapAddressFromFormValues';
 export { default as stripExtraFieldsFromAddress } from './stripExtraFieldsFromAddress';

--- a/packages/core/src/app/address/mapAddressFromFormValues.ts
+++ b/packages/core/src/app/address/mapAddressFromFormValues.ts
@@ -2,14 +2,14 @@ import { type Address, type AddressKey } from '@bigcommerce/checkout-sdk';
 
 import { mapCustomFormFieldsFromFormValues } from '../formFields';
 
-import { B2BExtraAddressFieldsSessionStorage } from './B2BExtraAddressFieldsSessionStorage';
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import { type AddressFormValues } from './mapAddressToFormValues';
 
 export default function mapAddressFromFormValues(formValues: AddressFormValues, storageKey?: string): Pick<Address, Exclude<AddressKey, 'extraFields'>> {
     const { customFields, extraFields, shouldSaveAddress, ...address } = formValues;
 
     if (storageKey && extraFields && Object.keys(extraFields).length > 0) {
-        B2BExtraAddressFieldsSessionStorage.setFields(storageKey, extraFields as Record<string, unknown>);
+        B2BExtraFieldsSessionStorage.setFields(storageKey, extraFields as Record<string, unknown>);
     }
 
     return {

--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -2,12 +2,12 @@ import {
     type Address,
     type AddressKey,
     type FormField,
-    isExtraFormField,
+    isExtraField,
 } from '@bigcommerce/checkout-sdk/essential';
 
 import { DynamicFormFieldType } from '@bigcommerce/checkout/ui';
 
-import { B2BExtraAddressFieldsSessionStorage } from './B2BExtraAddressFieldsSessionStorage';
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 
 export type AddressFormValues = Pick<Address, Exclude<AddressKey, 'customFields' | 'extraFields'>> & {
     customFields: { [id: string]: any };
@@ -24,7 +24,7 @@ export default function mapAddressToFormValues(
             (addressFormValues, field) => {
                 const { name, custom, fieldType, default: defaultValue } = field;
 
-                if (isExtraFormField(field)) {
+                if (isExtraField(field)) {
                     if (!addressFormValues.extraFields) {
                         addressFormValues.extraFields = {};
                     }
@@ -91,7 +91,7 @@ export default function mapAddressToFormValues(
     const extraFields = values.extraFields;
 
     if (storageKey && extraFields) {
-        const storedExtraFields = B2BExtraAddressFieldsSessionStorage.getFields(storageKey);
+        const storedExtraFields = B2BExtraFieldsSessionStorage.getFields(storageKey);
 
         if (storedExtraFields) {
             Object.keys(extraFields).forEach(key => {

--- a/packages/core/src/app/address/searchingAddresses.test.ts
+++ b/packages/core/src/app/address/searchingAddresses.test.ts
@@ -1,0 +1,92 @@
+import { type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import { searchingAddresses } from './searchingAddresses';
+
+const baseAddress: CustomerAddress = {
+    id: 1,
+    type: 'residential',
+    firstName: 'Test',
+    lastName: 'Tester',
+    company: 'Bigcommerce',
+    address1: '12345 Testing Way',
+    address2: '',
+    city: 'Some City',
+    stateOrProvince: 'California',
+    stateOrProvinceCode: 'CA',
+    country: 'United States',
+    countryCode: 'US',
+    postalCode: '95555',
+    phone: '555-555-5555',
+    customFields: [],
+};
+
+describe('searchingAddresses', () => {
+    it('returns all addresses when query is empty', () => {
+        expect(searchingAddresses([baseAddress], '')).toEqual([baseAddress]);
+        expect(searchingAddresses([baseAddress], '   ')).toEqual([baseAddress]);
+    });
+
+    it('matches on standard address fields', () => {
+        expect(searchingAddresses([baseAddress], 'Test')).toEqual([baseAddress]);
+        expect(searchingAddresses([baseAddress], 'some city')).toEqual([baseAddress]);
+        expect(searchingAddresses([baseAddress], '95555')).toEqual([baseAddress]);
+    });
+
+    it('returns empty array when no address matches', () => {
+        expect(searchingAddresses([baseAddress], 'zzz')).toEqual([]);
+    });
+
+    it('matches on customFields string value', () => {
+        const address: CustomerAddress = {
+            ...baseAddress,
+            customFields: [{ fieldId: 'field_1', fieldValue: 'custom-value' }],
+        };
+
+        expect(searchingAddresses([address], 'custom-value')).toEqual([address]);
+        expect(searchingAddresses([address], 'no-match')).toEqual([]);
+    });
+
+    it('matches on customFields numeric value', () => {
+        const address: CustomerAddress = {
+            ...baseAddress,
+            customFields: [{ fieldId: 'field_2', fieldValue: 42 }],
+        };
+
+        expect(searchingAddresses([address], '42')).toEqual([address]);
+    });
+
+    it('matches on customFields array value', () => {
+        const address: CustomerAddress = {
+            ...baseAddress,
+            customFields: [{ fieldId: 'field_3', fieldValue: ['foo', 'bar'] }],
+        };
+
+        expect(searchingAddresses([address], 'foo')).toEqual([address]);
+        expect(searchingAddresses([address], 'bar')).toEqual([address]);
+    });
+
+    it('matches on extraFields string value', () => {
+        const address: CustomerAddress = {
+            ...baseAddress,
+            extraFields: [{ fieldId: 'ef_1', fieldValue: 'extra-value' }],
+        };
+
+        expect(searchingAddresses([address], 'extra-value')).toEqual([address]);
+        expect(searchingAddresses([address], 'no-match')).toEqual([]);
+    });
+
+    it('matches on extraFields numeric value', () => {
+        const address: CustomerAddress = {
+            ...baseAddress,
+            extraFields: [{ fieldId: 'ef_2', fieldValue: 99 }],
+        };
+
+        expect(searchingAddresses([address], '99')).toEqual([address]);
+    });
+
+    it('handles missing extraFields gracefully', () => {
+        const address: CustomerAddress = { ...baseAddress };
+
+        expect(searchingAddresses([address], 'Test')).toEqual([address]);
+    });
+});

--- a/packages/core/src/app/address/searchingAddresses.ts
+++ b/packages/core/src/app/address/searchingAddresses.ts
@@ -19,6 +19,10 @@ export function searchingAddresses(addresses: CustomerAddress[], query: string):
             address.postalCode,
             address.country,
             address.countryCode,
+            ...(address.customFields ?? []).map(({ fieldValue }) =>
+                Array.isArray(fieldValue) ? fieldValue.join(' ') : String(fieldValue),
+            ),
+            ...(address.extraFields ?? []).map(({ fieldValue }) => String(fieldValue)),
         ]
             .filter(Boolean)
             .join(' ')

--- a/packages/core/src/app/billing/Billing.test.tsx
+++ b/packages/core/src/app/billing/Billing.test.tsx
@@ -24,6 +24,7 @@ import {
     CHECKOUT_ROOT_NODE_ID,
 } from '@bigcommerce/checkout/payment-integration-api';
 import {
+    addressExtraFields,
     CheckoutPageNodeObject,
     CheckoutPreset,
     checkoutSettings,
@@ -33,7 +34,6 @@ import {
     checkoutWithShippingAndBilling,
     consignment,
     customer,
-    extraAddressFormFields,
     formFields,
     payments,
     shippingAddress,
@@ -136,7 +136,7 @@ describe('Billing step', () => {
 
         await checkout.waitForBillingStep();
 
-        expect(screen.queryByText(extraAddressFormFields[0].labelName)).not.toBeInTheDocument();
+        expect(screen.queryByText(addressExtraFields[0].name)).not.toBeInTheDocument();
 
         await checkout.fillAddressForm();
 
@@ -297,7 +297,7 @@ describe('Billing step', () => {
         expect(screen.getByText('Custom Dropdown is required')).toBeInTheDocument();
     });
 
-    it('renders extra address fields when hasExtraAddressFields is enabled', async () => {
+    it('renders extra address fields when hasAddressExtraFields is enabled', async () => {
         const configOverrides = {
             ...checkoutSettings,
             storeConfig: {
@@ -308,20 +308,20 @@ describe('Billing step', () => {
                         ...defaultCapabilities,
                         userJourney: {
                             ...defaultCapabilities.userJourney,
-                            hasExtraAddressFields: true,
+                            hasAddressExtraFields: true,
                         },
                     },
                 },
             },
         };
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndExtraAddressFields, { config: configOverrides });
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndAddressExtraFields, { config: configOverrides });
 
         render(<CheckoutTest {...defaultProps} />);
 
         await checkout.waitForBillingStep();
 
-        expect(screen.getByText(extraAddressFormFields[0].labelName)).toBeInTheDocument();
+        expect(screen.getByText(addressExtraFields[0].name)).toBeInTheDocument();
     });
 
     describe('registered customer', () => {

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -5,7 +5,7 @@ import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton } from '@bigcommerce/checkout/ui';
 
-import { B2BExtraAddressFieldsSessionStorage, isEqualAddress, mapAddressFromFormValues } from '../address';
+import { B2BExtraFieldsSessionStorage, isEqualAddress, mapAddressFromFormValues } from '../address';
 import { Legend } from '../ui/form';
 
 import BillingForm, { type BillingFormValues } from './BillingForm';
@@ -17,21 +17,21 @@ export interface BillingProps {
     onUnhandledError(error: Error): void;
 }
 
-const getFieldsWithExtraFields = (getBillingAddressFields: (countryCode: string) => FormField[], hasExtraAddressFields: boolean, getAddressExtraFormFields: () => FormField[], countryCode?: string) => {
+const getFieldsWithExtraFields = (getBillingAddressFields: (countryCode: string) => FormField[], hasAddressExtraFields: boolean, getAddressExtraFields: () => FormField[], countryCode?: string) => {
     const addressFields = getBillingAddressFields(countryCode || '');
 
-    if (!hasExtraAddressFields) {
+    if (!hasAddressExtraFields) {
         return addressFields;
     }
 
-    const extraAddressFields = getAddressExtraFormFields();
+    const addressExtraFields = getAddressExtraFields();
 
-    return [...addressFields, ...extraAddressFields];
+    return [...addressFields, ...addressExtraFields];
 };
 
 const Billing = ({ navigateNextStep, onReady, onUnhandledError }:BillingProps): ReactElement => {
     const { checkoutService, checkoutState } = useCheckout();
-    const { userJourney: { hasExtraAddressFields } } = useCapabilities();
+    const { userJourney: { hasAddressExtraFields } } = useCapabilities();
 
     const {
         data: {
@@ -41,7 +41,7 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }:BillingProps): 
             getCustomer,
             getBillingAddress,
             getBillingAddressFields,
-            getAddressExtraFormFields,
+            getAddressExtraFields,
         },
         statuses: { isLoadingBillingCountries },
     } = checkoutState;
@@ -68,7 +68,7 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }:BillingProps): 
         const updateCheckout  = checkoutService.updateCheckout;
         const billingAddress  = getBillingAddress();
         const promises: Array<Promise<CheckoutSelectors>> = [];
-        const address = mapAddressFromFormValues(addressValues, B2BExtraAddressFieldsSessionStorage.BILLING_KEY);
+        const address = mapAddressFromFormValues(addressValues, B2BExtraFieldsSessionStorage.BILLING_KEY);
 
         if (address && !isEqualAddress(address, billingAddress)) {
             promises.push(updateAddress(address));
@@ -128,7 +128,7 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }:BillingProps): 
                 <BillingForm
                     billingAddress={billingAddress}
                     customerMessage={customerMessage}
-                    getFields={(countryCode?: string) => getFieldsWithExtraFields(getBillingAddressFields, hasExtraAddressFields, getAddressExtraFormFields, countryCode)}
+                    getFields={(countryCode?: string) => getFieldsWithExtraFields(getBillingAddressFields, hasAddressExtraFields, getAddressExtraFields, countryCode)}
                     methodId={methodId}
                     navigateNextStep={navigateNextStep}
                     onSubmit={handleSubmit}

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -1,7 +1,7 @@
 import {
     type Address,
     type FormField,
-    isExtraFormField,
+    isExtraField,
 } from '@bigcommerce/checkout-sdk/essential';
 import { type FormikProps, withFormik } from 'formik';
 import React, { type RefObject, useRef, useState } from 'react';
@@ -17,13 +17,13 @@ import {
   type AddressFormValues,
   AddressSelect,
   AddressType,
-  B2BExtraAddressFieldsSessionStorage,
+  B2BExtraFieldsSessionStorage,
   getAddressFormFieldsValidationSchema,
   getTranslateAddressError,
   isValidCustomerAddress,
   mapAddressToFormValues,
 } from '../address';
-import { getCustomFormFieldsValidationSchema, getExtraFormFieldsValidationSchema } from '../formFields';
+import { getAddressExtraFieldsValidationSchema, getCustomFormFieldsValidationSchema } from '../formFields';
 import { OrderComments } from '../orderComments';
 import { getShippableItemsCount } from '../shipping';
 import { Button, ButtonVariant } from '../ui/button';
@@ -74,10 +74,10 @@ const BillingForm = ({
     const addresses = customer.addresses;
     const shouldRenderStaticAddress = methodId === 'amazonpay';
     const allFormFields = getFields(values.countryCode);
-    const customOrExtraFormFields = allFormFields.filter((field) => field.custom || isExtraFormField(field));
-    const hasCustomOrExtraFormFields = customOrExtraFormFields.length > 0;
+    const customOrExtraFields = allFormFields.filter((field) => field.custom || isExtraField(field));
+    const hasCustomOrExtraFields = customOrExtraFields.length > 0;
     const editableFormFields =
-        shouldRenderStaticAddress && hasCustomOrExtraFormFields ? customOrExtraFormFields : allFormFields;
+        shouldRenderStaticAddress && hasCustomOrExtraFields ? customOrExtraFields : allFormFields;
     const billingAddresses = isGuest && isPayPalFastlaneEnabled ? paypalFastlaneAddresses : addresses;
     const hasAddresses = billingAddresses?.length > 0;
     const hasValidCustomerAddress =
@@ -175,7 +175,7 @@ export default withLanguage(
             ...mapAddressToFormValues(
                 getFields(billingAddress && billingAddress.countryCode),
                 billingAddress,
-                B2BExtraAddressFieldsSessionStorage.BILLING_KEY,
+                B2BExtraFieldsSessionStorage.BILLING_KEY,
             ),
             orderComment: customerMessage,
         }),
@@ -186,7 +186,7 @@ export default withLanguage(
             const formValues = mapAddressToFormValues(
                 fields,
                 billingAddress,
-                B2BExtraAddressFieldsSessionStorage.BILLING_KEY,
+                B2BExtraFieldsSessionStorage.BILLING_KEY,
             );
 
             return getAddressFormFieldsValidationSchema({
@@ -198,7 +198,7 @@ export default withLanguage(
             language,
             getFields,
             methodId,
-        }: BillingFormProps & WithLanguageProps) => 
+        }: BillingFormProps & WithLanguageProps) =>
             methodId === 'amazonpay'
                 ? lazy<Partial<AddressFormValues>>((values) => {
                     const translate = getTranslateAddressError(getFields(values && values.countryCode), language);
@@ -207,7 +207,7 @@ export default withLanguage(
                           translate,
                           formFields: getFields(values && values.countryCode),
                       }).concat(
-                        getExtraFormFieldsValidationSchema({
+                        getAddressExtraFieldsValidationSchema({
                             translate,
                             formFields: getFields(values && values.countryCode),
                         })

--- a/packages/core/src/app/formFields/getAddressExtraFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getAddressExtraFieldsValidationSchema.ts
@@ -1,22 +1,22 @@
-import { type FormField, isExtraFormField } from '@bigcommerce/checkout-sdk/essential';
+import { type FormField, isExtraField } from '@bigcommerce/checkout-sdk/essential';
 import { memoize } from '@bigcommerce/memoize';
 import { number, object, type ObjectSchema, type Schema, string } from 'yup';
 
 import { type TranslateValidationErrorFunction } from './getCustomFormFieldsValidationSchema';
 
-export interface ExtraFormFieldsValidationSchemaOptions {
+export interface AddressExtraFieldsValidationSchemaOptions {
     formFields: FormField[];
     translate?: TranslateValidationErrorFunction;
 }
 
-export default memoize(function getExtraFormFieldsValidationSchema({
+export default memoize(function getAddressExtraFieldsValidationSchema({
     formFields,
     translate = () => undefined,
-}: ExtraFormFieldsValidationSchemaOptions): ObjectSchema<Record<string, any>> {
+}: AddressExtraFieldsValidationSchemaOptions): ObjectSchema<Record<string, any>> {
     return object({
         extraFields: object(
             formFields
-                .filter((field) => isExtraFormField(field))
+                .filter((field) => isExtraField(field))
                 .reduce<Record<string, Schema<unknown>>>((schema, { name, label, required, type, maxLength, max }) => {
                     if (type === 'integer') {
                         let fieldSchema = number()

--- a/packages/core/src/app/formFields/getExtraFormFieldsValidationSchema.test.ts
+++ b/packages/core/src/app/formFields/getExtraFormFieldsValidationSchema.test.ts
@@ -1,9 +1,9 @@
 import { type FormField } from '@bigcommerce/checkout-sdk';
 
 import { type TranslateValidationErrorFunction } from './getCustomFormFieldsValidationSchema';
-import getExtraFormFieldsValidationSchema from './getExtraFormFieldsValidationSchema';
+import getAddressExtraFieldsValidationSchema from './getAddressExtraFieldsValidationSchema';
 
-describe('getExtraFormFieldsValidationSchema', () => {
+describe('getAddressExtraFieldsValidationSchema', () => {
     let translate: TranslateValidationErrorFunction;
 
     beforeEach(() => {
@@ -24,7 +24,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
         ];
 
         it('validates required string field', async () => {
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const error = await schema
                 .validate({ extraFields: { b2bExtraField_100: '' } })
                 .catch((e) => e.message);
@@ -37,7 +37,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
         });
 
         it('validates maxLength for string field', async () => {
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const error = await schema
                 .validate({ extraFields: { b2bExtraField_100: 'this string is too long' } })
                 .catch((e) => e.message);
@@ -51,7 +51,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
         });
 
         it('passes for a valid string value', async () => {
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const spy = jest.fn();
 
             await schema.validate({ extraFields: { b2bExtraField_100: 'valid' } }).then(spy);
@@ -75,7 +75,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
         ];
 
         it('validates required integer field', async () => {
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const error = await schema
                 .validate({ extraFields: { b2bExtraField_200: undefined } })
                 .catch((e) => e.message);
@@ -88,7 +88,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
         });
 
         it('validates max for integer field', async () => {
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const error = await schema
                 .validate({ extraFields: { b2bExtraField_200: 101 } })
                 .catch((e) => e.message);
@@ -102,7 +102,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
         });
 
         it('passes for a valid integer value', async () => {
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const spy = jest.fn();
 
             await schema.validate({ extraFields: { b2bExtraField_200: 50 } }).then(spy);
@@ -124,7 +124,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
                 },
             ];
 
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const spy = jest.fn();
 
             await schema.validate({ extraFields: { b2bExtraField_300: '' } }).then(spy);
@@ -145,7 +145,7 @@ describe('getExtraFormFieldsValidationSchema', () => {
                 } as FormField,
             ];
 
-            const schema = getExtraFormFieldsValidationSchema({ formFields, translate });
+            const schema = getAddressExtraFieldsValidationSchema({ formFields, translate });
             const spy = jest.fn();
 
             await schema.validate({ extraFields: { b2bExtraField_400: undefined } }).then(spy);

--- a/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
+++ b/packages/core/src/app/formFields/getFormFieldsValidationSchema.ts
@@ -1,11 +1,11 @@
-import { isExtraFormField } from '@bigcommerce/checkout-sdk/essential';
+import { isExtraField } from '@bigcommerce/checkout-sdk/essential';
 import { memoize } from '@bigcommerce/memoize';
 import { object, type ObjectSchema, string, type StringSchema } from 'yup';
 
 import getCustomFormFieldsValidationSchema, {
     type FormFieldsValidationSchemaOptions,
 } from './getCustomFormFieldsValidationSchema';
-import getExtraFormFieldsValidationSchema from './getExtraFormFieldsValidationSchema';
+import getAddressExtraFieldsValidationSchema from './getAddressExtraFieldsValidationSchema';
 
 export const WHITELIST_REGEXP = /^[^<>]*$/;
 
@@ -20,7 +20,7 @@ export default memoize(function getFormFieldsValidationSchema({
 }: FormFieldsValidationSchemaOptions): ObjectSchema<FormFieldValues> {
     return object({
         ...formFields
-            .filter((field) => !field.custom && !isExtraFormField(field))
+            .filter((field) => !field.custom && !isExtraField(field))
             .reduce((schema, { name, required, label, maxLength }) => {
                 schema[name] = string();
 
@@ -49,6 +49,6 @@ export default memoize(function getFormFieldsValidationSchema({
     }).concat(
         getCustomFormFieldsValidationSchema({ formFields, translate }),
     ).concat(
-        getExtraFormFieldsValidationSchema({ formFields, translate }),
+        getAddressExtraFieldsValidationSchema({ formFields, translate }),
     ) as ObjectSchema<FormFieldValues>;
 });

--- a/packages/core/src/app/formFields/index.ts
+++ b/packages/core/src/app/formFields/index.ts
@@ -8,6 +8,6 @@ export {
     TranslateValidationErrorFunction,
     CustomFormFieldValues,
 } from './getCustomFormFieldsValidationSchema';
-export { default as getExtraFormFieldsValidationSchema } from './getExtraFormFieldsValidationSchema';
+export { default as getAddressExtraFieldsValidationSchema } from './getAddressExtraFieldsValidationSchema';
 export { default as mapCustomFormFieldsFromFormValues } from './mapCustomFormFieldsFromFormValues';
-export { default as mapExtraFormFieldsFromFormValues } from './mapExtraFormFieldsFromFormValues';
+export { default as mapAddressExtraFieldsFromFormValues } from './mapAddressExtraFieldsFromFormValues';

--- a/packages/core/src/app/formFields/mapAddressExtraFieldsFromFormValues.test.ts
+++ b/packages/core/src/app/formFields/mapAddressExtraFieldsFromFormValues.test.ts
@@ -1,6 +1,6 @@
-import mapExtraFormFieldsFromFormValues from './mapExtraFormFieldsFromFormValues';
+import mapAddressExtraFieldsFromFormValues from './mapAddressExtraFieldsFromFormValues';
 
-describe('mapExtraFormFieldsFromFormValues', () => {
+describe('mapAddressExtraFieldsFromFormValues', () => {
     it('converts extra fields object to array of fieldId/fieldValue pairs', () => {
         const extraFields = {
             b2bExtraField_100: 'Acme Corp',
@@ -8,7 +8,7 @@ describe('mapExtraFormFieldsFromFormValues', () => {
             b2bExtraField_300: 42,
         };
 
-        const result = mapExtraFormFieldsFromFormValues(extraFields);
+        const result = mapAddressExtraFieldsFromFormValues(extraFields);
 
         expect(result).toEqual([
             { fieldId: 'b2bExtraField_100', fieldValue: 'Acme Corp' },
@@ -18,10 +18,10 @@ describe('mapExtraFormFieldsFromFormValues', () => {
     });
 
     it('returns undefined when extraFields is undefined', () => {
-        expect(mapExtraFormFieldsFromFormValues(undefined)).toBeUndefined();
+        expect(mapAddressExtraFieldsFromFormValues(undefined)).toBeUndefined();
     });
 
     it('returns empty array when extraFields is empty', () => {
-        expect(mapExtraFormFieldsFromFormValues({})).toEqual([]);
+        expect(mapAddressExtraFieldsFromFormValues({})).toEqual([]);
     });
 });

--- a/packages/core/src/app/formFields/mapAddressExtraFieldsFromFormValues.ts
+++ b/packages/core/src/app/formFields/mapAddressExtraFieldsFromFormValues.ts
@@ -1,4 +1,4 @@
-export default function mapExtraFormFieldsFromFormValues(
+export default function mapAddressExtraFieldsFromFormValues(
     extraFields?: { [id: string]: any },
 ): Array<{ fieldId: string; fieldValue: string | number }> | undefined {
     if (!extraFields) {

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -9,14 +9,14 @@ import {
     type AddressFormValues,
     AddressSelect,
     AddressType,
-    B2BExtraAddressFieldsSessionStorage,
+    B2BExtraFieldsSessionStorage,
     isValidAddress,
     mapAddressFromFormValues,
     stripExtraFieldsFromAddress,
 } from '../address';
 import { ErrorModal } from "../common/error";
 import { EMPTY_ARRAY, isExperimentEnabled } from "../common/utility";
-import { mapExtraFormFieldsFromFormValues } from '../formFields';
+import { mapAddressExtraFieldsFromFormValues } from '../formFields';
 
 import { AssignItemFailedError, AssignItemInvalidAddressError } from "./errors";
 import GuestCustomerAddressSelector from "./GuestCustomerAddressSelector";
@@ -68,7 +68,7 @@ const ConsignmentAddressSelector = ({
         return null;
     }
 
-    const storageKey = B2BExtraAddressFieldsSessionStorage.getConsignmentKey(consignment?.id ?? '');
+    const storageKey = B2BExtraFieldsSessionStorage.getConsignmentKey(consignment?.id ?? '');
 
     // TODO: add filter for addresses
     const addresses = customer.addresses || EMPTY_ARRAY;
@@ -138,7 +138,7 @@ const ConsignmentAddressSelector = ({
 
         await handleSelectAddress({
             ...address,
-            extraFields: mapExtraFormFieldsFromFormValues(addressFormValues.extraFields),
+            extraFields: mapAddressExtraFieldsFromFormValues(addressFormValues.extraFields),
         });
 
         if (!isGuest) {

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -6,7 +6,7 @@ import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from "@bigcommerce/checkout/dom-utils";
 import { TranslatedString } from "@bigcommerce/checkout/locale";
 
-import { B2BExtraAddressFieldsSessionStorage } from '../address';
+import { B2BExtraFieldsSessionStorage } from '../address';
 import { EMPTY_ARRAY } from "../common/utility";
 
 import AllocateItemsModal from "./AllocateItemsModal";
@@ -87,7 +87,7 @@ const NewConsignment = ({
             );
 
             if (newConsignment) {
-                B2BExtraAddressFieldsSessionStorage.reassignConsignmentKey(newConsignment.id);
+                B2BExtraFieldsSessionStorage.reassignConsignmentKey(newConsignment.id);
             }
         } catch (error) {
             if (error instanceof AssignItemFailedError) {

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, ConfirmationModal } from '@bigcommerce/checkout/ui';
 
-import { B2BExtraAddressFieldsSessionStorage, isEqualAddress, mapAddressFromFormValues } from '../address';
+import { B2BExtraFieldsSessionStorage, isEqualAddress, mapAddressFromFormValues } from '../address';
 import type CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 
 import { useShipping } from './hooks/useShipping';
@@ -45,7 +45,7 @@ function Shipping({
     const [isInitializing, setIsInitializing] = useState(true);
     const [isMultiShippingUnavailableModalOpen, setIsMultiShippingUnavailableModalOpen] = useState(false);
 
-    const { 
+    const {
         billingAddress,
         customerMessage,
         cartHasPromotionalItems,
@@ -113,7 +113,7 @@ function Shipping({
     }, []);
 
     const handleSingleShippingSubmit = async (values: SingleShippingFormValues) => {
-        const updatedShippingAddress = values.shippingAddress && mapAddressFromFormValues(values.shippingAddress, B2BExtraAddressFieldsSessionStorage.SHIPPING_KEY);
+        const updatedShippingAddress = values.shippingAddress && mapAddressFromFormValues(values.shippingAddress, B2BExtraFieldsSessionStorage.SHIPPING_KEY);
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const hasRemoteBilling = hasRemoteBillingFn(methodId);
 
@@ -122,10 +122,10 @@ function Shipping({
         }
 
         if (values.billingSameAsShipping && updatedShippingAddress && !hasRemoteBilling) {
-            const shippingExtraFields = B2BExtraAddressFieldsSessionStorage.getFields(B2BExtraAddressFieldsSessionStorage.SHIPPING_KEY);
+            const shippingExtraFields = B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY);
 
             if (shippingExtraFields) {
-                B2BExtraAddressFieldsSessionStorage.setFields(B2BExtraAddressFieldsSessionStorage.BILLING_KEY, shippingExtraFields);
+                B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, shippingExtraFields);
             }
 
             if (!isEqualAddress(updatedShippingAddress, billingAddress)) {

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -18,7 +18,7 @@ import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/loca
 
 import {
     type AddressFormValues,
-    B2BExtraAddressFieldsSessionStorage,
+    B2BExtraFieldsSessionStorage,
     getAddressFormFieldsValidationSchema,
     getTranslateAddressError,
     isEqualAddress,
@@ -27,7 +27,7 @@ import {
 } from '../address';
 import { isErrorWithType } from '../common/error';
 import { withFormikExtended } from '../common/form';
-import { getCustomFormFieldsValidationSchema, getExtraFormFieldsValidationSchema } from '../formFields';
+import { getAddressExtraFieldsValidationSchema, getCustomFormFieldsValidationSchema } from '../formFields';
 import { PaymentMethodId } from '../payment/paymentMethod';
 import { Fieldset, Form } from '../ui/form';
 
@@ -192,7 +192,7 @@ const SingleShippingForm: React.FC<
                 shippingAddress: mapAddressToFormValues(
                     getFields(shippingAddress?.countryCode),
                     shippingAddress,
-                    B2BExtraAddressFieldsSessionStorage.SHIPPING_KEY,
+                    B2BExtraFieldsSessionStorage.SHIPPING_KEY,
                 ),
             });
         }
@@ -236,7 +236,7 @@ const SingleShippingForm: React.FC<
         }
 
         const errors = await validateForm(updatedValues);
-        
+
         const addressErrors = errors.shippingAddress;
 
         // Only update address if there are no address errors
@@ -357,7 +357,7 @@ export default withLanguage(
             shippingAddress: mapAddressToFormValues(
                 getFields(shippingAddress?.countryCode),
                 shippingAddress,
-                B2BExtraAddressFieldsSessionStorage.SHIPPING_KEY,
+                B2BExtraFieldsSessionStorage.SHIPPING_KEY,
             ),
         }),
         isInitialValid: ({ shippingAddress, getFields, language, validateMaxLength }) => {
@@ -367,7 +367,7 @@ export default withLanguage(
             const formValues = mapAddressToFormValues(
                 fields,
                 shippingAddress,
-                B2BExtraAddressFieldsSessionStorage.SHIPPING_KEY,
+                B2BExtraFieldsSessionStorage.SHIPPING_KEY,
             );
 
             return getAddressFormFieldsValidationSchema({
@@ -392,7 +392,7 @@ export default withLanguage(
                               translate,
                               formFields: fields,
                           }).concat(
-                              getExtraFormFieldsValidationSchema({
+                              getAddressExtraFieldsValidationSchema({
                                   translate,
                                   formFields: fields,
                               }),

--- a/packages/core/src/app/shipping/hooks/useShipping.test.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.test.ts
@@ -45,7 +45,7 @@ describe('useShipping', () => {
             getBillingAddress,
             getShippingAddressFields: getAddressFormFields,
             getShippingCountries: getCountries,
-            getAddressExtraFormFields: jest.fn().mockReturnValue([]),
+            getAddressExtraFields: jest.fn().mockReturnValue([]),
         },
         statuses: {
             isShippingStepPending: () => false,
@@ -207,12 +207,12 @@ describe('useShipping', () => {
             },
         ];
 
-        it('returns system fields combined with extra fields when hasExtraAddressFields is true', () => {
+        it('returns system fields combined with extra fields when hasAddressExtraFields is true', () => {
             jest.spyOn(contexts, 'useCapabilities').mockReturnValue({
                 ...defaultCapabilities,
-                userJourney: { ...defaultCapabilities.userJourney, hasExtraAddressFields: true },
+                userJourney: { ...defaultCapabilities.userJourney, hasAddressExtraFields: true },
             });
-            checkoutState.data.getAddressExtraFormFields.mockReturnValue(extraFields);
+            checkoutState.data.getAddressExtraFields.mockReturnValue(extraFields);
 
             const { result } = renderHook(() => useShipping());
             const fields = result.current.getFields('US');
@@ -223,12 +223,12 @@ describe('useShipping', () => {
             expect(fields[fields.length - 1].name).toBe('b2bExtraField_100');
         });
 
-        it('returns only system fields when hasExtraAddressFields is false even if extra fields exist', () => {
+        it('returns only system fields when hasAddressExtraFields is false even if extra fields exist', () => {
             jest.spyOn(contexts, 'useCapabilities').mockReturnValue({
                 ...defaultCapabilities,
-                userJourney: { ...defaultCapabilities.userJourney, hasExtraAddressFields: false },
+                userJourney: { ...defaultCapabilities.userJourney, hasAddressExtraFields: false },
             });
-            checkoutState.data.getAddressExtraFormFields.mockReturnValue(extraFields);
+            checkoutState.data.getAddressExtraFields.mockReturnValue(extraFields);
 
             const { result } = renderHook(() => useShipping());
             const fields = result.current.getFields('US');
@@ -239,9 +239,9 @@ describe('useShipping', () => {
         it('returns only system fields when no extra fields exist', () => {
             jest.spyOn(contexts, 'useCapabilities').mockReturnValue({
                 ...defaultCapabilities,
-                userJourney: { ...defaultCapabilities.userJourney, hasExtraAddressFields: true },
+                userJourney: { ...defaultCapabilities.userJourney, hasAddressExtraFields: true },
             });
-            checkoutState.data.getAddressExtraFormFields.mockReturnValue([]);
+            checkoutState.data.getAddressExtraFields.mockReturnValue([]);
 
             const { result } = renderHook(() => useShipping());
             const fields = result.current.getFields('US');

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -28,7 +28,7 @@ const deleteConsignmentsSelector = createSelector(
 
 export const useShipping = () => {
     const { checkoutState, checkoutService } = useCheckout();
-    const { userJourney: { hasExtraAddressFields } } = useCapabilities();
+    const { userJourney: { hasAddressExtraFields } } = useCapabilities();
 
     const {
         data: {
@@ -41,7 +41,7 @@ export const useShipping = () => {
             getBillingAddress,
             getShippingAddressFields,
             getShippingCountries,
-            getAddressExtraFormFields,
+            getAddressExtraFields,
         },
         statuses: {
             isShippingStepPending,
@@ -104,14 +104,14 @@ export const useShipping = () => {
     const getFieldsWithExtraFields = useCallback((countryCode?: string) => {
         const addressFields = getShippingAddressFields(countryCode || '');
 
-        if (!hasExtraAddressFields) {
+        if (!hasAddressExtraFields) {
             return addressFields;
         }
 
-        const extraAddressFields = getAddressExtraFormFields();
+        const addressExtraFields = getAddressExtraFields();
 
-        return [...addressFields, ...extraAddressFields];
-    }, [getShippingAddressFields, getAddressExtraFormFields, hasExtraAddressFields]);
+        return [...addressFields, ...addressExtraFields];
+    }, [getShippingAddressFields, getAddressExtraFields, hasAddressExtraFields]);
 
     return {
         assignItem: checkoutService.assignItemsToAddress,

--- a/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
+++ b/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
@@ -14,6 +14,7 @@ import { type SetupServer, setupServer } from 'msw/node';
 import { act } from 'react';
 
 import {
+    addressExtraFields,
     applepayMethod,
     checkout,
     CheckoutPreset,
@@ -37,7 +38,6 @@ import {
     countries,
     customer,
     customFormFields,
-    extraAddressFormFields,
     formFields,
     payments,
     shippingAddress,
@@ -295,7 +295,7 @@ export class CheckoutPageNodeObject {
                 });
                 break;
 
-            case CheckoutPreset.CheckoutWithShippingAndExtraAddressFields:
+            case CheckoutPreset.CheckoutWithShippingAndAddressExtraFields:
                 this.server.use(
                     rest.get('/api/storefront/checkout/*', (_, res, ctx) =>
                         res(ctx.json(checkoutWithShipping)),
@@ -305,7 +305,7 @@ export class CheckoutPageNodeObject {
                 void checkoutService.hydrateInitialState({
                     ...initialState,
                     checkout: { ...checkoutWithShipping, ...overrides?.checkout },
-                    extraFields: extraAddressFormFields,
+                    extraFields: { address: addressExtraFields, order: [] },
                 });
                 break;
 

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
@@ -481,7 +481,7 @@ enum CheckoutPreset {
     CheckoutWithPromotions = 'CheckoutWithPromotions',
     CheckoutWithShipping = 'CheckoutWithShipping',
     CheckoutWithShippingAndBilling = 'CheckoutWithShippingAndBilling',
-    CheckoutWithShippingAndExtraAddressFields = 'CheckoutWithShippingAndExtraAddressFields',
+    CheckoutWithShippingAndAddressExtraFields = 'CheckoutWithShippingAndAddressExtraFields',
     CustomErrorFlashMessage = 'CustomErrorFlashMessage',
     ErrorFlashMessage = 'ErrorFlashMessage',
     UnsupportedProvider = 'UnsupportedProvider',

--- a/packages/test-framework/src/react-testing-library-support/mocks/form-fields.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/form-fields.ts
@@ -471,16 +471,17 @@ const customFormFields: FormField[] = [
     },
 ];
 
-const extraAddressFormFields: ExtraField[] = [
+const addressExtraFields: ExtraField[] = [
     {
-        id: 1,
-        fieldName: 'b2bExtraField',
-        fieldType: 0,
+        id: '1',
+        name: 'B2B Billing Extra',
+        visibleToStorefront: true,
         isRequired: false,
-        visibleToEnduser: true,
-        defaultValue: '',
-        labelName: 'B2B Billing Extra',
+        type: 'text',
+        config: {
+            defaultValue: '',
+        },
     },
 ];
 
-export { extraAddressFormFields, formFields, customFormFields };
+export { addressExtraFields, formFields, customFormFields };

--- a/packages/test-framework/src/react-testing-library-support/mocks/index.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/index.ts
@@ -2,7 +2,7 @@ export * from './checkout.mock';
 export * from './checkout-settings.mock';
 export { applepayMethod } from './payment-method.mock';
 export { countries } from './countries';
-export { extraAddressFormFields, formFields, customFormFields } from './form-fields';
+export { addressExtraFields, formFields, customFormFields } from './form-fields';
 export { payments } from './payments';
 export { orderResponse } from './order';
 export { initialState } from './initial-state';


### PR DESCRIPTION
## What/Why?
We have updated extra field naming across all checkout code. 

From now on, we only use the wording `extraField` and `addressExtraField`. We are going to introduce `orderExtraField` soon.

As a result, this PR include the following updates:
- Renamed `B2BExtraAddressFieldsSessionStorage` → `B2BExtraFieldsSessionStorage` and updated its session storage key prefix from `b2bExtraAddressFields_*` to `b2bAddressExtraFields_*`
- Renamed `getExtraFormFieldsValidationSchema` → `getAddressExtraFieldsValidationSchema` and `mapExtraFormFieldsFromFormValues` → `mapAddressExtraFieldsFromFormValues` to align with consistent naming convention
- Updated all usages of `isExtraFormField` → `isExtraField` and `getAddressExtraFormFields` → `getAddressExtraFields` 
- Renamed capability flag `hasExtraAddressFields` → `hasAddressExtraFields`; added `requiresB2BToken` to default capabilities

Add:
- Extended `searchingAddresses` to include `customFields` and `extraFields` values in address search text, with tests covering string, number, and array field values

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core billing/shipping address form field wiring, validation, and sessionStorage keys; regressions could hide/lose extra-field values or break B2B persistence. Changes are mostly mechanical renames but span many call sites and depend on the updated SDK API.
> 
> **Overview**
> Standardizes *extra field* naming across checkout by renaming capability flags, SDK selectors/helpers, and internal utilities (e.g., `hasExtraAddressFields`  `hasAddressExtraFields`, `isExtraFormField`  `isExtraField`, `getAddressExtraFormFields`  `getAddressExtraFields`). This includes renaming validation/mapping helpers to `getAddressExtraFieldsValidationSchema` and `mapAddressExtraFieldsFromFormValues`, and updating billing/shipping flows and tests to use the new APIs.
> 
> Updates B2B extra-field session storage by renaming `B2BExtraAddressFieldsSessionStorage` to `B2BExtraFieldsSessionStorage` and changing the persisted key prefixes (to `b2bAddressExtraFields_*`). Adds `requiresB2BToken` to `defaultCapabilities`.
> 
> Enhances `searchingAddresses` so address filtering also matches `customFields` (including array values) and `extraFields`, with a new dedicated test suite. Also bumps `@bigcommerce/checkout-sdk` from `1.899.2` to `1.899.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1548b755e8074e84acb4aabe7ad9144da0d2e8bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->