### PR TITLE
fix(checkout): CHECKOUT-9933 Fix: Shipping options not loading when required custom checkbox field is present

### DIFF
--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -99,7 +99,6 @@ const SingleShippingForm: React.FC<
         isLoading,
         isShippingStepPending,
         isValid,
-        validateForm,
         methodId,
         onUnhandledError = noop,
         setFieldValue,
@@ -115,12 +114,12 @@ const SingleShippingForm: React.FC<
     }) => {
     const { shipping: { hideBillingSameAsShippingCheck } } = useCapabilities();
 
-    const propsRef = useRef({ values, shippingAddress });
+    const propsRef = useRef({ values, shippingAddress, isValid });
     const debouncedUpdateAddressRef = useRef<
         DebouncedFunc<(address: Address, includeShippingOptions: boolean) => Promise<void>> | undefined
     >(undefined);
 
-    propsRef.current = { values, shippingAddress };
+    propsRef.current = { values, shippingAddress, isValid };
 
     const [isResettingAddress, setIsResettingAddress] = useState(false);
     const [isUpdatingShippingData, setIsUpdatingShippingData] = useState(false);
@@ -221,26 +220,15 @@ const SingleShippingForm: React.FC<
     };
 
     const handleFieldChange = async (name: string) => {
-        let updatedValues = propsRef.current.values;
-
-        if (name === 'countryCode' && propsRef.current.values.shippingAddress) {
-            updatedValues = {
-                ...propsRef.current.values,
-                shippingAddress: {
-                    ...propsRef.current.values.shippingAddress,
-                    stateOrProvince: '',
-                    stateOrProvinceCode: '',
-                },
-            };
-            setValues(updatedValues);
+        if (name === 'countryCode') {
+            setFieldValue('shippingAddress.stateOrProvince', '');
+            setFieldValue('shippingAddress.stateOrProvinceCode', '');
         }
 
-        const errors = await validateForm(updatedValues);
+        // Enqueue the following code to run after Formik has run validation
+        await new Promise((resolve) => setTimeout(resolve));
 
-        const addressErrors = errors.shippingAddress;
-
-        // Only update address if there are no address errors
-        if (addressErrors && Object.keys(addressErrors).length > 0) {
+        if (!propsRef.current.isValid) {
             return;
         }
 


### PR DESCRIPTION
## What/Why?

**Problem**
When the shipping step includes a required custom checkbox field, selecting a value would not trigger the address update or load shipping options, leaving the shopper unable to proceed past the shipping step.

**Root cause**

**SingleShippingForm** was converted from a class component to a functional component in CHECKOUT-9707. The original class component's [handleFieldChange](https://github.com/bigcommerce/checkout-js/pull/2893#discussion_r2986082155) had this pattern:

```
// Enqueue the following code to run after Formik has run validation
await new Promise((resolve) => setTimeout(resolve));

if (!this.props.isValid) {
    return;
}
```

The `setTimeout` yields to the macrotask queue, allowing React to flush any pending state updates — including `FieldArray`'s async `push` dispatch that checkbox selections go through. Only after that flush does it check `isValid`.

During the functional component conversion, `this.props.isValid` (always live in a class component) was replaced with `await validateForm()` — since `isValid` from a closure would be stale. The `setTimeout` was then considered redundant and removed. This broke checkboxes: without the yield, `validateForm()` runs before React flushes the `FieldArray` dispatch, so the checkbox value isn't in Formik state yet, validation fails, and the address update is skipped.

**Fix**

Restore the original pattern faithfully in the functional component. `propsRef` is already updated synchronously on every render, so adding `isValid` to it gives us the equivalent of `this.props.isValid` — fresh after the `setTimeout` yield:

```
propsRef.current = { values, shippingAddress, isValid };

// ...

const handleFieldChange = async (name: string) => {
    if (name === 'countryCode') {
        setFieldValue('shippingAddress.stateOrProvince', '');
        setFieldValue('shippingAddress.stateOrProvinceCode', '');
    }

    // Enqueue the following code to run after Formik has run validation
    await new Promise((resolve) => setTimeout(resolve));

    if (!propsRef.current.isValid) {
        return;
    }

    // ...
};
```


## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing (TBA)

**BEFORE**

https://github.com/user-attachments/assets/57bc3b8b-5e38-4333-ac6f-d53c46974cf7



**AFTER**

https://github.com/user-attachments/assets/e096715d-8b4b-440b-886f-441156159643


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shipping form field-change timing and validation gating for address updates, which can affect when/if shipping options are requested. Risk is moderate due to reliance on async Formik validation/state flush behavior in a core checkout step.
> 
> **Overview**
> Restores the shipping address autosave/update flow in `SingleShippingForm` to wait for Formik’s async updates/validation before deciding whether to call `updateAddress`.
> 
> `handleFieldChange` now clears province fields via `setFieldValue`, yields to the macrotask queue (`setTimeout`) to let Formik flush updates, and gates address updates on the latest `isValid` stored in `propsRef` (removing the prior `validateForm`-based check).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 267f5c4494366835550ae31b9ae52db383107e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->