### PR TITLE
chore(payment): PAYPAL-6378 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.899.4",
+        "@bigcommerce/checkout-sdk": "^1.900.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.899.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.899.4.tgz",
-      "integrity": "sha512-F5Jdgaxs5TXXSpAJoN7lfbcHZ9BC3zXzACWpNc4v/R1bisffLsDBcWbb2Kldm0Vmwgdl2QFUD2ydCBn78pvfMA==",
+      "version": "1.900.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.900.0.tgz",
+      "integrity": "sha512-7ReF+i4GjB7HnA2JEMgbrcP6Zx4K5tlisfjbqc0uyefOIe6BCezC+A4U8kj1JJ6s5GCZjyM71V7BkH0anuKJOA==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.899.4",
+    "@bigcommerce/checkout-sdk": "^1.900.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk-js version

To release: https://github.com/bigcommerce/checkout-sdk-js/pull/3202

## Rollout/Rollback

Revert

## Testing

All tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it updates the checkout/payment SDK, which can change runtime behavior across payment flows even though this PR only adjusts dependency versions.
> 
> **Overview**
> Upgrades **`@bigcommerce/checkout-sdk`** from `^1.899.4` to `^1.900.0` in `package.json`.
> 
> Updates `package-lock.json` to lock the new `@bigcommerce/checkout-sdk@1.900.0` artifact (resolved URL/integrity metadata and package entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af815024a7bc1082573e73cb0899edba707f473. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->