### PR TITLE
fix(checkout): CHECKOUT-9707 Gate SingleShippingForm functional component behind an experiment

### DIFF
--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { useExtensions } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useExtensions } from '@bigcommerce/checkout/contexts';
 import { getLanguageService } from '@bigcommerce/checkout/locale';
 
 import { CustomError } from '../common/error';
@@ -9,6 +9,7 @@ import { useShipping } from './hooks/useShipping';
 import isUsingMultiShipping from './isUsingMultiShipping';
 import MultiShippingForm, { type MultiShippingFormValues } from './MultiShippingForm';
 import SingleShippingForm, { type SingleShippingFormValues } from './SingleShippingForm';
+import SingleShippingFormClassComponent from './SingleShippingFormClass';
 
 export interface ShippingFormProps {
     cartHasChanged: boolean;
@@ -51,8 +52,10 @@ const ShippingForm = ({
         shouldShowOrderComments,
         shippingAddress,
         validateMaxLength,
-        updateShippingAddress: updateAddress
+        updateShippingAddress: updateAddress,
+        useSingleShippingFormFunctionComponent,
     } = useShipping();
+    const { shipping: { hideBillingSameAsShippingCheck } } = useCapabilities();
     const { extensionState: { shippingFormRenderTimestamp } } = useExtensions();
 
     useEffect(() => {
@@ -88,6 +91,41 @@ const ShippingForm = ({
         />;
     };
 
+    const getSingleShippingForm = () => {
+        const singleShippingFormProps = {
+            cartHasChanged,
+            consignments,
+            customerMessage,
+            defaultShippingExpectationMessage,
+            deinitialize,
+            deleteConsignments,
+            getFields,
+            initialize,
+            isBillingSameAsShipping,
+            isInitialValueLoaded,
+            isLoading,
+            isShippingStepPending,
+            methodId,
+            onSubmit: onSingleShippingSubmit,
+            onUnhandledError,
+            shippingAddress,
+            shippingFormRenderTimestamp,
+            shouldShowOrderComments,
+            updateAddress,
+            validateMaxLength,
+        };
+
+        if (useSingleShippingFormFunctionComponent) {
+            return <SingleShippingForm {...singleShippingFormProps} />;
+        }
+
+        return <SingleShippingFormClassComponent
+            {...singleShippingFormProps}
+            hideBillingSameAsShippingCheck={hideBillingSameAsShippingCheck}
+            isMultiShippingMode={isMultiShippingMode}
+        />;
+    }
+
     if (isInitialValueLoaded && countries.length === 0 && isNoCountriesErrorOnCheckoutEnabled) {
         return null;
     }
@@ -95,28 +133,7 @@ const ShippingForm = ({
     return isMultiShippingMode ? (
         getMultiShippingForm()
     ) : (
-        <SingleShippingForm
-            cartHasChanged={cartHasChanged}
-            consignments={consignments}
-            customerMessage={customerMessage}
-            defaultShippingExpectationMessage={defaultShippingExpectationMessage}
-            deinitialize={deinitialize}
-            deleteConsignments={deleteConsignments}
-            getFields={getFields}
-            initialize={initialize}
-            isBillingSameAsShipping={isBillingSameAsShipping}
-            isInitialValueLoaded={isInitialValueLoaded}
-            isLoading={isLoading}
-            isShippingStepPending={isShippingStepPending}
-            methodId={methodId}
-            onSubmit={onSingleShippingSubmit}
-            onUnhandledError={onUnhandledError}
-            shippingAddress={shippingAddress}
-            shippingFormRenderTimestamp={shippingFormRenderTimestamp}
-            shouldShowOrderComments={shouldShowOrderComments}
-            updateAddress={updateAddress}
-            validateMaxLength={validateMaxLength}
-        />
+        getSingleShippingForm()
     );
 };
 

--- a/packages/core/src/app/shipping/SingleShippingFormClass.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingFormClass.test.tsx
@@ -1,0 +1,411 @@
+import { createCheckoutService } from '@bigcommerce/checkout-sdk';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
+import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
+import { createLocaleContext } from '@bigcommerce/checkout/locale';
+import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import { getAddressFormFields } from '../address/formField.mock';
+import { createErrorLogger } from '../common/error';
+import { getStoreConfig } from '../config/config.mock';
+
+import { getShippingAddress } from './shipping-addresses.mock';
+import SingleShippingForm, { type SingleShippingFormProps } from './SingleShippingFormClass';
+
+describe('SingleShippingForm', () => {
+    const checkoutService = createCheckoutService();
+    const extensionService = new ExtensionService(checkoutService, createErrorLogger());
+    const addressFormFields = getAddressFormFields().filter(({ custom }) => !custom);
+
+    const defaultProps: SingleShippingFormProps = {
+        isMultiShippingMode: false,
+        shippingAddress: getShippingAddress(),
+        customerMessage: '',
+        shouldShowOrderComments: true,
+        consignments: [],
+        cartHasChanged: false,
+        isBillingSameAsShipping: false,
+        isInitialValueLoaded: true,
+        isLoading: false,
+        isShippingStepPending: false,
+        shippingFormRenderTimestamp: undefined,
+        onSubmit: jest.fn(),
+        getFields: jest.fn(() => addressFormFields),
+        onUnhandledError: jest.fn(),
+        deinitialize: jest.fn(),
+        signOut: jest.fn(),
+        initialize: jest.fn(),
+        updateAddress: jest.fn(),
+        deleteConsignments: jest.fn(),
+        validateMaxLength: false,
+    };
+
+    const shippingAutosaveDelay = 500;
+    const waitingDelay = shippingAutosaveDelay + 200;
+
+    const createSingleShippingFormComponent = (props?: Partial<SingleShippingFormProps>) => {
+        const localeContext = createLocaleContext(getStoreConfig());
+
+        return (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleContext.Provider value={localeContext}>
+                    <ExtensionProvider extensionService={extensionService}>
+                        <SingleShippingForm
+                            {...defaultProps}
+                            {...props}
+                            shippingAutosaveDelay={shippingAutosaveDelay}
+                        />
+                    </ExtensionProvider>
+                </LocaleContext.Provider>
+            </CheckoutProvider>
+        );
+    };
+
+    const renderSingleShippingFormComponent = (props?: Partial<SingleShippingFormProps>) => {
+        return render(createSingleShippingFormComponent(props));
+    };
+
+    it('calls updateAddress with last event during a given timeframe', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({ updateAddress });
+
+        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
+        await userEvent.keyboard('foo 1');
+
+        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
+        await userEvent.keyboard('foo 2');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalledTimes(1);
+        expect(updateAddress).toHaveBeenCalledWith(
+            {
+                ...getShippingAddress(),
+                address1: 'foo 2',
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': true,
+                    },
+                },
+            },
+        );
+    });
+
+    it('calls updateAddress if modified field does not affect shipping but makes form valid', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({
+            updateAddress,
+            getFields: () => [
+                ...addressFormFields.map((field) => ({ ...field, required: true })),
+            ],
+        });
+
+        await userEvent.clear(screen.getByTestId('addressLine2Input-text'));
+        await userEvent.keyboard('foo 1');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalledTimes(1);
+        expect(updateAddress).toHaveBeenCalledWith(
+            {
+                ...getShippingAddress(),
+                address2: 'foo 1',
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': true,
+                    },
+                },
+            },
+        );
+    });
+
+    it('calls updateAddress including shipping options if modified field does not affect shipping but has never requested shipping options', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({ updateAddress });
+
+        await userEvent.clear(screen.getByTestId('addressLine2Input-text'));
+        await userEvent.keyboard('foo 1');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalledTimes(1);
+        expect(updateAddress).toHaveBeenCalledWith(
+            {
+                ...getShippingAddress(),
+                address2: 'foo 1',
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': true,
+                    },
+                },
+            },
+        );
+    });
+
+    it('calls updateAddress including shipping options if custom form fields are updated', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({
+            updateAddress,
+            getFields: () => [
+                ...addressFormFields,
+                {
+                    custom: true,
+                    default: '',
+                    fieldType: 'text',
+                    id: 'field_25',
+                    label: 'Custom message',
+                    name: 'field_25',
+                    required: true,
+                    type: 'string',
+                },
+            ],
+        });
+
+        await userEvent.clear(screen.getByTestId('field_25Input-text'));
+        await userEvent.keyboard('foo');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalledTimes(1);
+        expect(updateAddress).toHaveBeenCalledWith(
+            {
+                ...getShippingAddress(),
+                customFields: [
+                    {
+                        fieldId: 'field_25',
+                        fieldValue: 'foo',
+                    },
+                ],
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': true,
+                    },
+                },
+            },
+        );
+    });
+
+    it('calls updateAddress without shipping options if modified field does not affect shipping and shipping options have already been requested', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({ updateAddress });
+
+        await userEvent.clear(screen.getByTestId('addressLine2Input-text'));
+        await userEvent.keyboard('foo1');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        await userEvent.clear(screen.getByTestId('addressLine2Input-text'));
+        await userEvent.keyboard('foo2');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalledWith(
+            {
+                ...getShippingAddress(),
+                address2: 'foo2',
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': false,
+                    },
+                },
+            },
+        );
+    });
+
+    it('does not call updateAddress if modified field produces invalid address', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({ updateAddress });
+
+        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).not.toHaveBeenCalled();
+    });
+
+    it('does not call updateAddress if same address', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({ updateAddress });
+
+        const shippingCountry = defaultProps.shippingAddress?.country || '';
+        const countryLastChar = shippingCountry.charAt(shippingCountry.length - 1);
+
+        await userEvent.click(screen.getByTestId('countryInput-text'));
+        await userEvent.keyboard(`{backspace}${countryLastChar}`);
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).not.toHaveBeenCalled();
+    });
+
+    it('calls update address for amazon pay if required custom fields are filled out', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({
+            methodId: 'amazonpay',
+            updateAddress,
+            getFields: () => [
+                ...addressFormFields,
+                {
+                    custom: true,
+                    default: '',
+                    fieldType: 'text',
+                    id: 'field_25',
+                    label: 'Custom message',
+                    name: 'field_25',
+                    required: true,
+                    type: 'string',
+                },
+            ],
+        });
+
+        await userEvent.clear(screen.getByTestId('field_25-text'));
+        await userEvent.keyboard('foo');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalledTimes(1);
+        expect(updateAddress).toHaveBeenCalledWith(
+            {
+                ...getShippingAddress(),
+                customFields: [
+                    {
+                        fieldId: 'field_25',
+                        fieldValue: 'foo',
+                    },
+                ],
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': true,
+                    },
+                },
+            },
+        );
+    });
+
+    it('does not update address for amazon pay if required custom fields is left empty', async () => {
+        const updateAddress = jest.fn();
+
+        renderSingleShippingFormComponent({
+            methodId: 'amazonpay',
+            updateAddress,
+            getFields: () => [
+                ...addressFormFields,
+                {
+                    custom: true,
+                    default: '',
+                    fieldType: 'text',
+                    id: 'field_25',
+                    label: 'Custom message',
+                    name: 'field_25',
+                    required: true,
+                    type: 'string',
+                },
+            ],
+        });
+
+        await userEvent.clear(screen.getByTestId('field_25-text'));
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).not.toHaveBeenCalled();
+    });
+
+    it('does not render billing same as shipping checkbox for amazon pay', async () => {
+        renderSingleShippingFormComponent({ methodId: 'amazonpay' });
+
+        expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
+    });
+
+    it('re-renders itself when shippingFormRenderTimestamp is changed', async () => {
+        const customField = {
+            custom: true,
+            default: 'BigCommerce',
+            id: 'custom',
+            label: 'Custom',
+            name: 'custom',
+            required: false,
+        };
+
+        const { rerender } = renderSingleShippingFormComponent({
+            getFields: () => [...addressFormFields, customField],
+            shippingFormRenderTimestamp: 1,
+        });
+
+        expect(screen.getByTestId('customInput-text')).toHaveValue('BigCommerce');
+
+        rerender(
+            createSingleShippingFormComponent({
+                getFields: () => [
+                    ...addressFormFields,
+                    {
+                        ...customField,
+                        default: 'BigCommerce Sydney',
+                    },
+                ],
+                shippingFormRenderTimestamp: 1,
+            }),
+        );
+
+        expect(screen.getByTestId('customInput-text')).toHaveValue('BigCommerce');
+
+        rerender(
+            createSingleShippingFormComponent({
+                getFields: () => [
+                    ...addressFormFields,
+                    {
+                        ...customField,
+                        default: 'BigCommerce Sydney',
+                    },
+                ],
+                shippingFormRenderTimestamp: 2,
+            }),
+        );
+
+        expect(screen.getByTestId('customInput-text')).toHaveValue('BigCommerce Sydney');
+    });
+
+    it('calls onUnhandledError when empty cart error is thrown', async () => {
+        const onUnhandledError = jest.fn();
+        const emptyCartError = {
+            type: 'empty_cart',
+            message: 'Cart is empty',
+        } as any;
+
+        const updateAddress = jest.fn().mockRejectedValue(emptyCartError);
+
+        renderSingleShippingFormComponent({
+            updateAddress,
+            onUnhandledError,
+        });
+
+        await userEvent.clear(screen.getByTestId('addressLine1Input-text'));
+        await userEvent.keyboard('foo 1');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateAddress).toHaveBeenCalled();
+        expect(onUnhandledError).toHaveBeenCalledWith(emptyCartError);
+    });
+});

--- a/packages/core/src/app/shipping/SingleShippingFormClass.tsx
+++ b/packages/core/src/app/shipping/SingleShippingFormClass.tsx
@@ -1,0 +1,410 @@
+import {
+    type Address,
+    type CheckoutParams,
+    type CheckoutSelectors,
+    type Consignment,
+    type FormField,
+    type RequestOptions,
+    type ShippingInitializeOptions,
+    type ShippingRequestOptions,
+} from '@bigcommerce/checkout-sdk';
+import { type FormikProps } from 'formik';
+import { debounce, isEqual, noop } from 'lodash';
+import React, { PureComponent, type ReactNode } from 'react';
+import { lazy, object } from 'yup';
+
+import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
+import { FormContext } from '@bigcommerce/checkout/ui';
+
+import {
+    type AddressFormValues,
+    getAddressFormFieldsValidationSchema,
+    getTranslateAddressError,
+    isEqualAddress,
+    mapAddressFromFormValues,
+    mapAddressToFormValues,
+} from '../address';
+import { isErrorWithType } from '../common/error';
+import { withFormikExtended } from '../common/form';
+import { getCustomFormFieldsValidationSchema } from '../formFields';
+import { PaymentMethodId } from '../payment/paymentMethod';
+import { Fieldset, Form } from '../ui/form';
+
+import BillingSameAsShippingField from './BillingSameAsShippingField';
+import hasSelectedShippingOptions from './hasSelectedShippingOptions';
+import isSelectedShippingOptionValid from './isSelectedShippingOptionValid';
+import ShippingAddress from './ShippingAddress';
+import { SHIPPING_ADDRESS_FIELDS } from './ShippingAddressFields';
+import ShippingFormFooter from './ShippingFormFooter';
+
+export interface SingleShippingFormProps {
+    hideBillingSameAsShippingCheck: boolean;
+    isBillingSameAsShipping: boolean;
+    cartHasChanged: boolean;
+    consignments: Consignment[];
+    customerMessage: string;
+    defaultShippingExpectationMessage?: string;
+    isLoading: boolean;
+    isShippingStepPending: boolean;
+    isMultiShippingMode: boolean;
+    methodId?: string;
+    shippingAddress?: Address;
+    shippingAutosaveDelay?: number;
+    shouldShowOrderComments: boolean;
+    isInitialValueLoaded: boolean;
+    shippingFormRenderTimestamp?: number;
+    validateMaxLength: boolean;
+    deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
+    deleteConsignments(): Promise<Address | undefined>;
+    getFields(countryCode?: string): FormField[];
+    initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
+    onSubmit(values: SingleShippingFormValues): void;
+    onUnhandledError?(error: Error): void;
+    updateAddress(
+        address: Partial<Address>,
+        options?: RequestOptions<CheckoutParams>,
+    ): Promise<CheckoutSelectors>;
+}
+
+export interface SingleShippingFormValues {
+    billingSameAsShipping: boolean;
+    shippingAddress?: AddressFormValues;
+    orderComment: string;
+}
+
+interface SingleShippingFormState {
+    isResettingAddress: boolean;
+    isUpdatingShippingData: boolean;
+    hasRequestedShippingOptions: boolean;
+}
+
+function shouldHaveCustomValidation(methodId?: string): boolean {
+    const methodIdsWithoutCustomValidation: string[] = [
+        PaymentMethodId.BraintreeAcceleratedCheckout,
+        PaymentMethodId.PayPalCommerceAcceleratedCheckout,
+    ];
+
+    return Boolean(methodId && !methodIdsWithoutCustomValidation.includes(methodId));
+}
+
+export const SHIPPING_AUTOSAVE_DELAY = 1700;
+
+class SingleShippingForm extends PureComponent<
+    SingleShippingFormProps & WithLanguageProps & FormikProps<SingleShippingFormValues>
+> {
+    static contextType = FormContext;
+
+    state: SingleShippingFormState = {
+        isResettingAddress: false,
+        isUpdatingShippingData: false,
+        hasRequestedShippingOptions: false,
+    };
+
+    private debouncedUpdateAddress: any;
+
+    constructor(
+        props: SingleShippingFormProps & WithLanguageProps & FormikProps<SingleShippingFormValues>,
+    ) {
+        super(props);
+
+        const { updateAddress, onUnhandledError = noop } = this.props;
+
+        this.debouncedUpdateAddress = debounce(
+            async (address: Address, includeShippingOptions: boolean) => {
+                try {
+                    await updateAddress(address, {
+                        params: {
+                            include: {
+                                'consignments.availableShippingOptions': includeShippingOptions,
+                            },
+                        },
+                    });
+
+                    if (includeShippingOptions) {
+                        this.setState({ hasRequestedShippingOptions: true });
+                    }
+                } catch (error) {
+                    if (isErrorWithType(error) && error.type === 'empty_cart') {
+                        return onUnhandledError(error);
+                    }
+                } finally {
+                    this.setState({ isUpdatingShippingData: false });
+                }
+            },
+            props.shippingAutosaveDelay ?? SHIPPING_AUTOSAVE_DELAY,
+        );
+    }
+
+    componentDidUpdate({ shippingFormRenderTimestamp }: SingleShippingFormProps) {
+        const {
+            shippingFormRenderTimestamp: newShippingFormRenderTimestamp,
+            setValues,
+            getFields,
+            shippingAddress,
+            isBillingSameAsShipping,
+            customerMessage,
+            values,
+            setFieldValue,
+        } = this.props;
+
+        const stateOrProvinceCodeFormField = getFields(values && values.shippingAddress?.countryCode).find(
+            ({ name }) => name === 'stateOrProvinceCode',
+        );
+
+        // Workaround for a bug found during manual testing:
+        // When the shipping step first loads, the `stateOrProvinceCode` field may not be there.
+        // It later appears with an empty value if the selected country has states/provinces.
+        // To address this, we manually set `stateOrProvinceCode` in Formik.
+        if (
+            stateOrProvinceCodeFormField &&
+            shippingAddress?.stateOrProvinceCode &&
+            !values.shippingAddress?.stateOrProvinceCode
+        ) {
+            setFieldValue('shippingAddress.stateOrProvinceCode', shippingAddress.stateOrProvinceCode);
+        }
+
+        // This is for executing extension command, `ReRenderShippingForm`.
+        if (newShippingFormRenderTimestamp !== shippingFormRenderTimestamp) {
+            setValues({
+                billingSameAsShipping: isBillingSameAsShipping,
+                orderComment: customerMessage,
+                shippingAddress: mapAddressToFormValues(
+                    getFields(shippingAddress && shippingAddress.countryCode),
+                    shippingAddress,
+                ),
+            });
+        }
+    }
+
+    render(): ReactNode {
+        const {
+            hideBillingSameAsShippingCheck,
+            cartHasChanged,
+            isInitialValueLoaded,
+            isLoading,
+            onUnhandledError,
+            methodId,
+            shippingAddress,
+            consignments,
+            shouldShowOrderComments,
+            initialize,
+            isValid,
+            deinitialize,
+            values: { shippingAddress: addressForm },
+            isShippingStepPending,
+            shippingFormRenderTimestamp,
+            validateMaxLength,
+            defaultShippingExpectationMessage,
+        } = this.props;
+
+        const { isResettingAddress, isUpdatingShippingData, hasRequestedShippingOptions } =
+            this.state;
+
+        const PAYMENT_METHOD_VALID = ['amazonpay'];
+        const shouldShowBillingSameAsShipping =
+            !hideBillingSameAsShippingCheck &&
+            !PAYMENT_METHOD_VALID.some((method) => method === methodId);
+
+        return (
+            <Form autoComplete="on">
+                <Fieldset>
+                    <ShippingAddress
+                        consignments={consignments}
+                        deinitialize={deinitialize}
+                        formFields={this.getFields(addressForm && addressForm.countryCode)}
+                        hasRequestedShippingOptions={hasRequestedShippingOptions}
+                        initialize={initialize}
+                        isLoading={isResettingAddress}
+                        isShippingStepPending={isShippingStepPending}
+                        methodId={methodId}
+                        onAddressSelect={this.handleAddressSelect}
+                        onFieldChange={this.handleFieldChange}
+                        onUnhandledError={onUnhandledError}
+                        onUseNewAddress={this.onUseNewAddress}
+                        shippingAddress={shippingAddress}
+                        validateMaxLength={validateMaxLength}
+                    />
+                    {shouldShowBillingSameAsShipping && (
+                        <div className="form-body">
+                            <BillingSameAsShippingField />
+                        </div>
+                    )}
+                </Fieldset>
+
+                <ShippingFormFooter
+                    cartHasChanged={cartHasChanged}
+                    defaultShippingExpectationMessage={defaultShippingExpectationMessage}
+                    isInitialValueLoaded={isInitialValueLoaded}
+                    isLoading={isLoading || isUpdatingShippingData}
+                    isMultiShippingMode={false}
+                    shippingFormRenderTimestamp={shippingFormRenderTimestamp}
+                    shouldDisableSubmit={this.shouldDisableSubmit()}
+                    shouldShowOrderComments={shouldShowOrderComments}
+                    shouldShowShippingOptions={isValid}
+                />
+            </Form>
+        );
+    }
+
+    private shouldDisableSubmit: () => boolean = () => {
+        const { isLoading, consignments, isValid } = this.props;
+
+        const { isUpdatingShippingData } = this.state;
+
+        if (!isValid) {
+            return false;
+        }
+
+        return isLoading || isUpdatingShippingData || !hasSelectedShippingOptions(consignments) || !isSelectedShippingOptionValid(consignments);
+    };
+
+    private handleFieldChange: (name: string) => void = async (name) => {
+        const { setFieldValue } = this.props;
+
+        if (name === 'countryCode') {
+            setFieldValue('shippingAddress.stateOrProvince', '');
+            setFieldValue('shippingAddress.stateOrProvinceCode', '');
+        }
+
+        // Enqueue the following code to run after Formik has run validation
+        await new Promise((resolve) => setTimeout(resolve));
+
+        const isShippingField = SHIPPING_ADDRESS_FIELDS.includes(name);
+
+        const { hasRequestedShippingOptions } = this.state;
+
+        const { isValid } = this.props;
+
+        if (!isValid) {
+            return;
+        }
+
+        this.updateAddressWithFormData(isShippingField || !hasRequestedShippingOptions);
+    };
+
+    private updateAddressWithFormData(includeShippingOptions: boolean) {
+        const {
+            shippingAddress,
+            values: { shippingAddress: addressForm },
+        } = this.props;
+
+        const updatedShippingAddress = addressForm && mapAddressFromFormValues(addressForm);
+
+        if (Array.isArray(shippingAddress?.customFields)) {
+            includeShippingOptions = !isEqual(
+                shippingAddress?.customFields,
+                updatedShippingAddress?.customFields
+            ) || includeShippingOptions;
+        }
+
+        if (!updatedShippingAddress || isEqualAddress(updatedShippingAddress, shippingAddress)) {
+            return;
+        }
+
+        this.setState({ isUpdatingShippingData: true });
+        this.debouncedUpdateAddress(updatedShippingAddress, includeShippingOptions);
+    }
+
+    private handleAddressSelect: (address: Address) => void = async (address) => {
+        const { updateAddress, onUnhandledError = noop, values, setValues } = this.props;
+
+        this.setState({ isResettingAddress: true });
+
+        try {
+            await updateAddress(address);
+
+            setValues({
+                ...values,
+                shippingAddress: mapAddressToFormValues(
+                    this.getFields(address.countryCode),
+                    address,
+                ),
+            });
+        } catch (error) {
+            onUnhandledError(error);
+        } finally {
+            this.setState({ isResettingAddress: false });
+        }
+    };
+
+    private onUseNewAddress: () => void = async () => {
+        const { deleteConsignments, onUnhandledError = noop, setValues, values } = this.props;
+
+        this.setState({ isResettingAddress: true });
+
+        try {
+            const address = await deleteConsignments();
+
+            setValues({
+                ...values,
+                shippingAddress: mapAddressToFormValues(
+                    this.getFields(address && address.countryCode),
+                    address,
+                ),
+            });
+        } catch (e) {
+            onUnhandledError(e);
+        } finally {
+            this.setState({ isResettingAddress: false });
+        }
+    };
+
+    private getFields(countryCode: string | undefined): FormField[] {
+        const { getFields } = this.props;
+
+        return getFields(countryCode);
+    }
+}
+
+export default withLanguage(
+    withFormikExtended<SingleShippingFormProps & WithLanguageProps, SingleShippingFormValues>({
+        handleSubmit: (values, { props: { onSubmit } }) => {
+            onSubmit(values);
+        },
+        mapPropsToValues: ({
+            getFields,
+            shippingAddress,
+            isBillingSameAsShipping,
+            customerMessage,
+        }) => ({
+            billingSameAsShipping: isBillingSameAsShipping,
+            orderComment: customerMessage,
+            shippingAddress: mapAddressToFormValues(
+                getFields(shippingAddress && shippingAddress.countryCode),
+                shippingAddress,
+            ),
+        }),
+        isInitialValid: ({ shippingAddress, getFields, language, validateMaxLength }) =>
+            !!shippingAddress &&
+            getAddressFormFieldsValidationSchema({
+                language,
+                formFields: getFields(shippingAddress.countryCode),
+                validateMaxLength,
+            }).isValidSync(shippingAddress),
+        validationSchema: ({
+            language,
+            getFields,
+            methodId,
+            validateMaxLength,
+        }: SingleShippingFormProps & WithLanguageProps) =>
+            shouldHaveCustomValidation(methodId)
+                ? object({
+                      shippingAddress: lazy<Partial<AddressFormValues>>((formValues) =>
+                          getCustomFormFieldsValidationSchema({
+                              translate: getTranslateAddressError(getFields(formValues && formValues.countryCode), language),
+                              formFields: getFields(formValues && formValues.countryCode),
+                          }),
+                      ),
+                  })
+                : object({
+                      shippingAddress: lazy<Partial<AddressFormValues>>((formValues) =>
+                          getAddressFormFieldsValidationSchema({
+                              language,
+                              formFields: getFields(formValues && formValues.countryCode),
+                              validateMaxLength,
+                          }),
+                      ),
+                  }),
+        enableReinitialize: false, // This is false due to the concern that a shopper may lose typed details if somehow checkout state changes in the middle.
+    })(SingleShippingForm),
+);

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -152,5 +152,6 @@ export const useShipping = () => {
         updateShippingAddress: checkoutService.updateShippingAddress,
         shouldRenderStripeForm: providerWithCustomCheckout === PaymentMethodId.StripeUPE && shouldUseStripeLinkByMinimumAmount(cart),
         validateMaxLength: isExperimentEnabled(config.checkoutSettings, 'CHECKOUT-9768.form_fields_max_length_validation', false),
+        useSingleShippingFormFunctionComponent: isExperimentEnabled(config.checkoutSettings, 'CHECKOUT-9707.use_single_shipping_form_function_component', false),
     };
 }


### PR DESCRIPTION
## What/Why?
Recently we are noticing the drop in checkout conversion rate from March 30th 2026, which is also inline with the release of SingleShippingForm class to functional component conversion. So we are gating SingleShippingForm functional component behind an experiment to confirm whether this conversion is the reason behind the dropping conversion rate.

**Depends on:** https://github.com/bigcommerce/bigcommerce/pull/67729

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shipping-step UI path selection and introduces a new class-based `SingleShippingForm` implementation; issues here can directly impact address updates and shipping option loading. Risk is mitigated by gating the functional component behind an experiment flag and adding targeted tests for autosave/update behavior.
> 
> **Overview**
> **Single-shipping rendering is now experiment-gated.** `ShippingForm` chooses between the existing functional `SingleShippingForm` and a new class-based `SingleShippingFormClass` based on `CHECKOUT-9707.use_single_shipping_form_function_component` (wired via `useShipping`).
> 
> **Adds a class-based fallback form and coverage.** Introduces `SingleShippingFormClass.tsx` (including debounced autosave `updateAddress` behavior, conditional inclusion of shipping options, and `ReRenderShippingForm` timestamp handling) and a comprehensive `SingleShippingFormClass.test.tsx` suite validating debouncing, include/exclude of shipping options, custom-field behavior, Amazon Pay nuances, and empty-cart error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50a7ab2698826d204cfee00d96e6f46d00c9f1b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->