### PR TITLE
feat(order): BACK-392 Update order confirmation page to support BO

### DIFF
--- a/packages/core/src/app/order/getBackorderCount.ts
+++ b/packages/core/src/app/order/getBackorderCount.ts
@@ -5,7 +5,7 @@ export default function getBackorderCount({
     digitalItems,
 }: LineItemMap): number {
     return [...physicalItems, ...digitalItems].reduce(
-        (total, item) => total + (item.stockPosition?.quantityBackordered ?? 0),
+        (total, item) => total + Number(item.stockPosition?.quantityBackordered ?? item.quantityBackordered ?? 0),
         0,
     );
 }

--- a/packages/core/src/app/order/mapBackorderDetails.ts
+++ b/packages/core/src/app/order/mapBackorderDetails.ts
@@ -1,0 +1,15 @@
+import { type DigitalItem, type PhysicalItem } from '@bigcommerce/checkout-sdk';
+
+import { type OrderItemType } from './OrderSummaryItem';
+
+export const mapBackorderDetails = (item: DigitalItem | PhysicalItem): Pick<OrderItemType, 'quantityBackordered' | 'quantityOnHand' | 'backorderMessage'> => {
+    const quantityBackordered = item.stockPosition?.quantityBackordered ?? item.quantityBackordered;
+    const quantityOnHand = item.stockPosition?.quantityOnHand ?? ((quantityBackordered != null ? (item.quantity - quantityBackordered) : undefined));
+    const backorderMessage = item.stockPosition?.backorderMessage || item.backorderMessage || undefined;
+
+    return {
+        quantityBackordered,
+        quantityOnHand,
+        backorderMessage,
+    };
+}

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -7,6 +7,10 @@ import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { type OrderItemType, type OrderSummaryItemOption } from './OrderSummaryItem';
 
 function mapFromDigital(item: DigitalItem): OrderItemType {
+    const quantityBackordered = item.stockPosition?.quantityBackordered ?? item.quantityBackordered;
+    const quantityOnHand = item.stockPosition?.quantityOnHand ?? ((quantityBackordered != null ? (item.quantity - quantityBackordered) : undefined));
+    const backorderMessage = item.stockPosition?.backorderMessage || item.backorderMessage || undefined;
+
     return {
         id: item.id,
         quantity: item.quantity,
@@ -21,9 +25,9 @@ function mapFromDigital(item: DigitalItem): OrderItemType {
             })),
             getDigitalItemDescription(item),
         ],
-        quantityBackordered: item.stockPosition?.quantityBackordered,
-        quantityOnHand: item.stockPosition?.quantityOnHand,
-        backorderMessage: item.stockPosition?.backorderMessage || undefined,
+        quantityBackordered,
+        quantityOnHand,
+        backorderMessage,
     };
 }
 

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -4,13 +4,10 @@ import React from 'react';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
 import getOrderSummaryItemImage from './getOrderSummaryItemImage';
+import { mapBackorderDetails } from './mapBackorderDetails';
 import { type OrderItemType, type OrderSummaryItemOption } from './OrderSummaryItem';
 
 function mapFromDigital(item: DigitalItem): OrderItemType {
-    const quantityBackordered = item.stockPosition?.quantityBackordered ?? item.quantityBackordered;
-    const quantityOnHand = item.stockPosition?.quantityOnHand ?? ((quantityBackordered != null ? (item.quantity - quantityBackordered) : undefined));
-    const backorderMessage = item.stockPosition?.backorderMessage || item.backorderMessage || undefined;
-
     return {
         id: item.id,
         quantity: item.quantity,
@@ -25,9 +22,7 @@ function mapFromDigital(item: DigitalItem): OrderItemType {
             })),
             getDigitalItemDescription(item),
         ],
-        quantityBackordered,
-        quantityOnHand,
-        backorderMessage,
+        ...mapBackorderDetails(item),
     };
 }
 

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -4,6 +4,10 @@ import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { type OrderItemType } from './OrderSummaryItem';
 
 function mapFromPhysical(item: PhysicalItem): OrderItemType {
+    const quantityBackordered = item.stockPosition?.quantityBackordered ?? item.quantityBackordered;
+    const quantityOnHand = item.stockPosition?.quantityOnHand ?? ((quantityBackordered != null ? (item.quantity - quantityBackordered) : undefined));
+    const backorderMessage = item.stockPosition?.backorderMessage || item.backorderMessage || undefined;
+
     return {
         id: item.id,
         quantity: item.quantity,
@@ -16,9 +20,9 @@ function mapFromPhysical(item: PhysicalItem): OrderItemType {
             testId: 'cart-item-product-option',
             content: `${option.name} ${option.value}`,
         })),
-        quantityBackordered: item.stockPosition?.quantityBackordered,
-        quantityOnHand: item.stockPosition?.quantityOnHand,
-        backorderMessage: item.stockPosition?.backorderMessage || undefined,
+        quantityBackordered,
+        quantityOnHand,
+        backorderMessage,
     };
 }
 

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -1,13 +1,10 @@
 import { type PhysicalItem } from '@bigcommerce/checkout-sdk';
 
 import getOrderSummaryItemImage from './getOrderSummaryItemImage';
+import { mapBackorderDetails } from './mapBackorderDetails';
 import { type OrderItemType } from './OrderSummaryItem';
 
 function mapFromPhysical(item: PhysicalItem): OrderItemType {
-    const quantityBackordered = item.stockPosition?.quantityBackordered ?? item.quantityBackordered;
-    const quantityOnHand = item.stockPosition?.quantityOnHand ?? ((quantityBackordered != null ? (item.quantity - quantityBackordered) : undefined));
-    const backorderMessage = item.stockPosition?.backorderMessage || item.backorderMessage || undefined;
-
     return {
         id: item.id,
         quantity: item.quantity,
@@ -20,9 +17,7 @@ function mapFromPhysical(item: PhysicalItem): OrderItemType {
             testId: 'cart-item-product-option',
             content: `${option.name} ${option.value}`,
         })),
-        quantityBackordered,
-        quantityOnHand,
-        backorderMessage,
+        ...mapBackorderDetails(item),
     };
 }
 


### PR DESCRIPTION
## What/Why?
Display backorder details for the order summary line items on order confirmation page.

## Rollout/Rollback
Revert

## Testing
Screen record
https://github.com/user-attachments/assets/4045e506-60ab-4d4e-92ae-a0389a41ede7


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/data-mapping change that only affects how backorder quantities/messages are derived and displayed on the order summary; main risk is incorrect counts/messages if upstream fields vary in type/availability.
> 
> **Overview**
> Updates order summary item mapping to **consistently populate backorder details** (`quantityBackordered`, `quantityOnHand`, `backorderMessage`) for both physical and digital items via a new `mapBackorderDetails` helper, including fallbacks when `stockPosition` is absent.
> 
> Adjusts `getBackorderCount` to **count backordered quantity from either `stockPosition.quantityBackordered` or legacy `quantityBackordered`**, coercing values to numbers to avoid type mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0e2ed6b80726dcd9593c3e58694da7f53aabde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->