### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.902.0",
+        "@bigcommerce/checkout-sdk": "^1.903.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.902.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.902.0.tgz",
-      "integrity": "sha512-HVu9lhU/hLPvkV/TnUl7+NdDi/oInLo/bOTIBn9CzPyp/8rLld4FOBDP1JbhSMCSfFGuvmeSahGZXWI4McyI+w==",
+      "version": "1.903.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.903.1.tgz",
+      "integrity": "sha512-f8uaUSBnJ4qtnmfP1uJnOUW8GkiScFxixmqga79jcgjgXQ8POY8M56sFOmjK8bRFRbOuMvl7mEY63ZEuVYbNnQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.902.0",
+    "@bigcommerce/checkout-sdk": "^1.903.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump Checkout-sdk-js version
To deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3218](https://github.com/bigcommerce/checkout-sdk-js/pull/3218)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3216](https://github.com/bigcommerce/checkout-sdk-js/pull/3216)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3225](https://github.com/bigcommerce/checkout-sdk-js/pull/3225)

## Rollout/Rollback
Rollback PR

## Testing
In checkout-sdk-js PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the `@bigcommerce/checkout-sdk` dependency/lockfile; behavior changes, if any, come solely from the upstream SDK release.
> 
> **Overview**
> Updates `@bigcommerce/checkout-sdk` from `^1.902.0` to `^1.903.1` in `package.json` and aligns `package-lock.json` to the new resolved tarball/integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad7c15d458ef40380054a552c2afad25da3b082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->