### PR TITLE
fix(checkout): wrap showDefaultShippingExpectationPrompt with feature/experiment flag

### DIFF
--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -98,7 +98,10 @@ export const useShipping = () => {
         config.checkoutSettings.providerWithCustomCheckout,
     );
 
-    const showDefaultShippingExpectationPrompt = getBackorderCount(cart.lineItems) > 0 && config.inventorySettings?.showDefaultShippingExpectationPrompt;
+    const showDefaultShippingExpectationPrompt =
+      config.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
+      config.inventorySettings?.showDefaultShippingExpectationPrompt &&
+      getBackorderCount(cart.lineItems) > 0;
     const defaultShippingExpectationPrompt = config.inventorySettings?.defaultShippingExpectationPrompt ?? undefined;
 
     const getFieldsWithExtraFields = useCallback((countryCode?: string) => {


### PR DESCRIPTION
## What/Why?

similar to order summary backorder info display:
<img width="2340" height="1650" alt="image" src="https://github.com/user-attachments/assets/0d89df0a-75d8-4925-83b8-723c3851f843" />

shipping expectation message should be wrapped with backorder 1.1 experiment

## Rollout/Rollback

revert the changes

## Testing

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens the condition for showing a UI message and does not alter checkout state mutations or API calls.
> 
> **Overview**
> Updates `useShipping` so the default shipping expectation/backorder prompt is only surfaced when `inventorySettings.shouldDisplayBackorderMessagesOnStorefront` is enabled, in addition to the existing `showDefaultShippingExpectationPrompt` flag and having backordered items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdb738673986ef35756baa633db25b578ea83bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->