### PR TITLE
refactor(checkout): CHECKOUT-9938 Restore B2B extra fields on address select

### DIFF
--- a/packages/core/src/app/address/AddressSelect.test.tsx
+++ b/packages/core/src/app/address/AddressSelect.test.tsx
@@ -19,6 +19,7 @@ import { getCustomer } from '../customer/customers.mock';
 import { getAddress } from './address.mock';
 import AddressSelect, { type AddressSelectProps } from './AddressSelect';
 import AddressType from './AddressType';
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import { getAddressContent } from './SingleLineStaticAddress';
 
 describe('AddressSelect component', () => {
@@ -158,6 +159,79 @@ describe('AddressSelect component', () => {
         expect(
             screen.getByRole('textbox', { name: 'Search addresses' }),
         ).toBeInTheDocument();
+    });
+
+    describe('storageKey / reading extra fields', () => {
+        const storageKey = 'test_storage_key';
+
+        afterEach(() => {
+            B2BExtraFieldsSessionStorage.removeFields(storageKey);
+        });
+
+        it('enriches address with extra fields from session storage when storageKey is provided', () => {
+            const onSelectAddress = jest.fn();
+
+            B2BExtraFieldsSessionStorage.setFields(storageKey, { 'b2bExtraField_foo': 'bar' });
+
+            renderAddressSelect({ onSelectAddress, storageKey });
+
+            fireEvent.click(screen.getByTestId('address-select-button'));
+            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
+
+            expect(onSelectAddress).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    extraFields: [{ fieldId: 'b2bExtraField_foo', fieldValue: 'bar' }],
+                }),
+            );
+        });
+
+        it('preserves numeric extra field values without string coercion', () => {
+            const onSelectAddress = jest.fn();
+
+            B2BExtraFieldsSessionStorage.setFields(storageKey, { 'b2bExtraField_num': 42 });
+
+            renderAddressSelect({ onSelectAddress, storageKey });
+
+            fireEvent.click(screen.getByTestId('address-select-button'));
+            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
+
+            expect(onSelectAddress).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    extraFields: [{ fieldId: 'b2bExtraField_num', fieldValue: 42 }],
+                }),
+            );
+        });
+
+        it('does not call onSelectAddress when re-selecting an address whose extra fields match session storage', () => {
+            const onSelectAddress = jest.fn();
+
+            B2BExtraFieldsSessionStorage.setFields(storageKey, { 'b2bExtraField_foo': 'bar' });
+
+            const selectedAddress = {
+                ...getCustomer().addresses[0],
+                extraFields: [{ fieldId: 'b2bExtraField_foo', fieldValue: 'bar' }],
+            };
+
+            renderAddressSelect({ onSelectAddress, selectedAddress, storageKey });
+
+            fireEvent.click(screen.getByTestId('address-select-button'));
+            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
+
+            expect(onSelectAddress).not.toHaveBeenCalled();
+        });
+
+        it('calls onSelectAddress without extra fields when no storageKey is provided', () => {
+            const onSelectAddress = jest.fn();
+
+            renderAddressSelect({ onSelectAddress });
+
+            fireEvent.click(screen.getByTestId('address-select-button'));
+            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
+
+            expect(onSelectAddress).toHaveBeenCalledWith(
+                expect.not.objectContaining({ extraFields: expect.anything() }),
+            );
+        });
     });
 
     it('shows Powered By PP Fastlane label', () => {

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -9,6 +9,7 @@ import { DropdownTrigger } from '../ui/dropdown';
 import AddressSelectButton from './AddressSelectButton';
 import { AddressSelectComponent } from './AddressSelectComponent';
 import type AddressType from './AddressType';
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import isEqualAddress from './isEqualAddress';
 import { SearchableAddressSelectComponent } from './SearchableAddressSelectComponent';
 
@@ -19,6 +20,7 @@ export interface AddressSelectProps {
     selectedAddress?: Address;
     type: AddressType;
     showSingleLineAddress?: boolean;
+    storageKey?: string;
     onSelectAddress(address: Address): void;
     onUseNewAddress(currentAddress?: Address): void;
     placeholderText?: ReactNode;
@@ -29,6 +31,7 @@ const AddressSelect = ({
     selectedAddress,
     type,
     showSingleLineAddress,
+    storageKey,
     onSelectAddress,
     onUseNewAddress,
     placeholderText,
@@ -37,8 +40,10 @@ const AddressSelect = ({
     const { shouldShowPayPalFastlaneLabel } = usePayPalFastlaneAddress();
 
     const handleSelectAddress = (newAddress: Address) => {
-        if (!isEqualAddress(selectedAddress, newAddress)) {
-            onSelectAddress(newAddress);
+        const addressWithExtraFields = getAddressWithExtraFields(newAddress, storageKey);
+
+        if (!isEqualAddress(selectedAddress, addressWithExtraFields)) {
+            onSelectAddress(addressWithExtraFields);
         }
     };
 
@@ -80,6 +85,22 @@ const AddressSelect = ({
             {shouldShowPayPalFastlaneLabel && <PoweredByPayPalFastlaneLabel />}
         </div>
     );
+}
+
+function getAddressWithExtraFields(address: Address, storageKey?: string): Address {
+    if (!storageKey) return address;
+
+    const storedExtraFields = B2BExtraFieldsSessionStorage.getFields(storageKey);
+
+    if (!storedExtraFields) return address;
+
+    return {
+        ...address,
+        extraFields: Object.entries(storedExtraFields).map(([fieldId, fieldValue]) => ({
+            fieldId,
+            fieldValue: String(fieldValue),
+        })),
+    };
 }
 
 export default memo(AddressSelect);

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -98,7 +98,7 @@ function getAddressWithExtraFields(address: Address, storageKey?: string): Addre
         ...address,
         extraFields: Object.entries(storedExtraFields).map(([fieldId, fieldValue]) => ({
             fieldId,
-            fieldValue: String(fieldValue),
+            fieldValue: typeof fieldValue === 'number' ? fieldValue : String(fieldValue),
         })),
     };
 }

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -129,6 +129,7 @@ const BillingForm = ({
                                 selectedAddress={
                                     hasValidCustomerAddress ? billingAddress : undefined
                                 }
+                                storageKey={B2BExtraFieldsSessionStorage.BILLING_KEY}
                                 type={AddressType.Billing}
                             />
                         </LoadingOverlay>

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -193,6 +193,7 @@ const ConsignmentAddressSelector = ({
                     placeholderText={<TranslatedString id="shipping.choose_shipping_address" />}
                     selectedAddress={selectedAddress}
                     showSingleLineAddress
+                    storageKey={storageKey}
                     type={AddressType.Shipping}
                 />
             }

--- a/packages/core/src/app/shipping/ShippingAddressForm.tsx
+++ b/packages/core/src/app/shipping/ShippingAddressForm.tsx
@@ -8,7 +8,14 @@ import React, { type ReactElement } from 'react';
 import { useCapabilities, useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 
-import { AddressForm, AddressSelect, AddressType, isValidCustomerAddress, reorderAddressFormFields } from '../address';
+import {
+    AddressForm,
+    AddressSelect,
+    AddressType,
+    B2BExtraFieldsSessionStorage,
+    isValidCustomerAddress,
+    reorderAddressFormFields
+} from '../address';
 import { connectFormik, type ConnectFormikProps } from '../common/form';
 import { Fieldset } from '../ui/form';
 
@@ -106,6 +113,7 @@ const ShippingAddressForm = (
                             selectedAddress={
                                 hasValidCustomerAddress ? shippingAddress : undefined
                             }
+                            storageKey={B2BExtraFieldsSessionStorage.SHIPPING_KEY}
                             type={AddressType.Shipping}
                         />
                     </LoadingOverlay>

--- a/packages/core/src/app/shipping/SingleShippingFormClass.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingFormClass.test.tsx
@@ -7,6 +7,7 @@ import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
+import { B2BExtraFieldsSessionStorage } from '../address';
 import { getAddressFormFields } from '../address/formField.mock';
 import { createErrorLogger } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
@@ -384,6 +385,33 @@ describe('SingleShippingForm', () => {
         );
 
         expect(screen.getByTestId('customInput-text')).toHaveValue('BigCommerce Sydney');
+    });
+
+    it('initializes extra field form values from session storage on mount', async () => {
+        B2BExtraFieldsSessionStorage.setFields(
+            B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+            { 'b2bExtraField_test': 'stored_value' },
+        );
+
+        renderSingleShippingFormComponent({
+            getFields: () => [
+                ...addressFormFields,
+                {
+                    custom: false,
+                    default: '',
+                    fieldType: 'text' as const,
+                    id: 'b2bExtraField_test',
+                    label: 'Extra field',
+                    name: 'b2bExtraField_test',
+                    required: false,
+                    type: 'string',
+                },
+            ],
+        });
+
+        expect(screen.getByTestId('b2bExtraField_testInput-text')).toHaveValue('stored_value');
+
+        B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY);
     });
 
     it('calls onUnhandledError when empty cart error is thrown', async () => {

--- a/packages/core/src/app/shipping/SingleShippingFormClass.tsx
+++ b/packages/core/src/app/shipping/SingleShippingFormClass.tsx
@@ -18,6 +18,7 @@ import { FormContext } from '@bigcommerce/checkout/ui';
 
 import {
     type AddressFormValues,
+    B2BExtraFieldsSessionStorage,
     getAddressFormFieldsValidationSchema,
     getTranslateAddressError,
     isEqualAddress,
@@ -372,15 +373,25 @@ export default withLanguage(
             shippingAddress: mapAddressToFormValues(
                 getFields(shippingAddress && shippingAddress.countryCode),
                 shippingAddress,
+                B2BExtraFieldsSessionStorage.SHIPPING_KEY,
             ),
         }),
-        isInitialValid: ({ shippingAddress, getFields, language, validateMaxLength }) =>
-            !!shippingAddress &&
-            getAddressFormFieldsValidationSchema({
+        isInitialValid: ({ shippingAddress, getFields, language, validateMaxLength }) => {
+            if (!shippingAddress) return false;
+
+            const fields = getFields(shippingAddress.countryCode);
+            const formValues = mapAddressToFormValues(
+                fields,
+                shippingAddress,
+                B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+            );
+
+            return getAddressFormFieldsValidationSchema({
                 language,
-                formFields: getFields(shippingAddress.countryCode),
+                formFields: fields,
                 validateMaxLength,
-            }).isValidSync(shippingAddress),
+            }).isValidSync(formValues);
+        },
         validationSchema: ({
             language,
             getFields,


### PR DESCRIPTION
## What/Why?

Fix the issues where B2B extra fields are not restored.
- `SingleShippingFormClass` — `mapPropsToValues` and `isInitialValid` did not pass
  `SHIPPING_KEY` to `mapAddressToFormValues`, so session-stored extra field values
  were never loaded into the form
- `AddressSelect` — re-selecting the same address cleared extra fields because
  `isEqualAddress` compared `selectedAddress` (with extra fields) against the raw
  address book entry (without), always finding them unequal

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core shipping/billing address selection and initial form validation, so regressions could impact address submission or autosave behavior. Logic is scoped to optional `storageKey` handling and covered by added unit tests.
> 
> **Overview**
> Restores B2B `extraFields` behavior by threading a `storageKey` through `AddressSelect` and the shipping/billing forms so session-stored values are reapplied instead of being dropped.
> 
> `AddressSelect` now merges session-stored extra fields into the selected address before equality checks/callbacks (preserving numeric values), preventing re-selecting the same address from clearing fields. `SingleShippingFormClass` now passes `SHIPPING_KEY` into `mapAddressToFormValues` for both `mapPropsToValues` and `isInitialValid`, and new tests cover the session-storage restore path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ba96be1c80fffc4c680d402a79042357777847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->