### PR TITLE
feat(payment): PI-5142 [Oney] Add Oney payment method

### DIFF
--- a/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.test.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import { createAdyenV3PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/adyen';
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React, { type FunctionComponent } from 'react';
@@ -231,6 +232,202 @@ describe('when using AdyenV3 payment', () => {
             );
             expect(cancelAdditionalActionModalFlow).toHaveBeenCalledTimes(1);
             expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('when method has grouped FacilyPay variants', () => {
+        it('renders a variant select and initializes payment for the default variant', () => {
+            const variantLow: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_3',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 3',
+                },
+            };
+            const variantHigh: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_12',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 12',
+                },
+            };
+            const groupedRepresentative: PaymentMethod = {
+                ...variantLow,
+                initializationData: {
+                    groupedMethods: [variantLow, variantHigh],
+                },
+            };
+
+            const defaultAdyenProps: PaymentMethodProps = {
+                method: groupedRepresentative,
+                onUnhandledError: jest.fn(),
+                checkoutService,
+                checkoutState,
+                paymentForm,
+                language: createLanguageService(),
+            };
+
+            render(<PaymentMethodTest {...defaultAdyenProps} />);
+
+            expect(screen.getByRole('combobox')).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'Option 3' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'Option 12' })).toBeInTheDocument();
+
+            expect(initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: 'facilypay_3',
+                }),
+            );
+        });
+
+        it('sets methodIdOverride when the shopper selects another variant', async () => {
+            const variantLow: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_3',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 3',
+                },
+            };
+            const variantHigh: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_12',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 12',
+                },
+            };
+            const groupedRepresentative: PaymentMethod = {
+                ...variantLow,
+                initializationData: {
+                    groupedMethods: [variantLow, variantHigh],
+                },
+            };
+
+            const defaultAdyenProps: PaymentMethodProps = {
+                method: groupedRepresentative,
+                onUnhandledError: jest.fn(),
+                checkoutService,
+                checkoutState,
+                paymentForm,
+                language: createLanguageService(),
+            };
+
+            render(<PaymentMethodTest {...defaultAdyenProps} />);
+
+            await userEvent.selectOptions(screen.getByRole('combobox'), 'facilypay_12');
+
+            expect(paymentForm.setFieldValue).toHaveBeenCalledWith(
+                'methodIdOverride',
+                'facilypay_12',
+            );
+        });
+
+        it('clears methodIdOverride on unmount while grouped', () => {
+            const variantLow: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_3',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 3',
+                },
+            };
+            const variantHigh: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_12',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 12',
+                },
+            };
+            const groupedRepresentative: PaymentMethod = {
+                ...variantLow,
+                initializationData: {
+                    groupedMethods: [variantLow, variantHigh],
+                },
+            };
+
+            const defaultAdyenProps: PaymentMethodProps = {
+                method: groupedRepresentative,
+                onUnhandledError: jest.fn(),
+                checkoutService,
+                checkoutState,
+                paymentForm,
+                language: createLanguageService(),
+            };
+
+            jest.clearAllMocks();
+
+            const { unmount } = render(<PaymentMethodTest {...defaultAdyenProps} />);
+
+            unmount();
+
+            expect(paymentForm.setFieldValue).toHaveBeenCalledWith('methodIdOverride', undefined);
+        });
+
+        it('does not clear methodIdOverride during grouped rerender', async () => {
+            const variantLow: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_3',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 3',
+                },
+            };
+            const variantHigh: PaymentMethod = {
+                ...getPaymentMethod(),
+                id: 'facilypay_12',
+                gateway: 'adyenv3',
+                method: 'scheme',
+                config: {
+                    ...getPaymentMethod().config,
+                    displayName: 'Option 12',
+                },
+            };
+            const groupedRepresentative: PaymentMethod = {
+                ...variantLow,
+                initializationData: {
+                    groupedMethods: [variantLow, variantHigh],
+                },
+            };
+
+            const defaultAdyenProps: PaymentMethodProps = {
+                method: groupedRepresentative,
+                onUnhandledError: jest.fn(),
+                checkoutService,
+                checkoutState,
+                paymentForm,
+                language: createLanguageService(),
+            };
+
+            const { rerender } = render(<PaymentMethodTest {...defaultAdyenProps} />);
+
+            await userEvent.selectOptions(screen.getByRole('combobox'), 'facilypay_12');
+
+            jest.clearAllMocks();
+
+            rerender(<PaymentMethodTest {...defaultAdyenProps} />);
+
+            expect(paymentForm.setFieldValue).not.toHaveBeenCalledWith(
+                'methodIdOverride',
+                undefined,
+            );
         });
     });
 });

--- a/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
@@ -3,9 +3,10 @@ import {
     type AdyenValidationState,
     type CardInstrument,
     type PaymentInitializeOptions,
+    type PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
 import { createAdyenV3PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/adyen';
-import React, { type FunctionComponent, useCallback, useRef, useState } from 'react';
+import React, { type FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { type HostedWidgetComponentProps } from '@bigcommerce/checkout/hosted-widget-integration';
 import {
@@ -13,7 +14,7 @@ import {
     type PaymentMethodResolveId,
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
-import { FormContext, LoadingOverlay } from '@bigcommerce/checkout/ui';
+import { FormContext, LoadingOverlay, Modal } from '@bigcommerce/checkout/ui';
 
 import AdyenV3CardValidation from './AdyenV3CardValidation';
 import AdyenV3Form from './AdyenV3Form';
@@ -48,16 +49,49 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         shouldShowModal: true,
     });
 
+    const groupedMethods = // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        (method.initializationData as { groupedMethods?: PaymentMethod[] } | null)?.groupedMethods;
+    const isGrouped = Boolean(groupedMethods?.length);
+    const [selectedVariantMethod, setSelectedVariantMethod] = useState<PaymentMethod>(method);
+
     const [shouldRenderAdditionalActionContentModal, setShouldRenderAdditionalActionContentModal] =
         useState<boolean>(false);
     const [isAdditionalActionContentModalVisible, setIsAdditionalActionContentModalVisible] =
         useState<boolean>(false);
     const [cardValidationState, setCardValidationState] = useState<AdyenValidationState>();
-    const containerId = `adyen-${method.id}-component-field`;
-    const additionalActionContainerId = `adyen-${method.id}-additional-action-component-field`;
-    const cardVerificationContainerId = `adyen-${method.id}-tsv-component-field`;
-    const component = method.id;
+    const setFieldValueRef = useRef(paymentForm.setFieldValue);
+    const containerId = `adyen-${selectedVariantMethod.id}-component-field`;
+    const additionalActionContainerId = `adyen-${selectedVariantMethod.id}-additional-action-component-field`;
+    const cardVerificationContainerId = `adyen-${selectedVariantMethod.id}-tsv-component-field`;
+    const component = selectedVariantMethod.id;
     const shouldHideInstrumentExpiryDate = component === AdyenV3PaymentMethodType.bcmc;
+
+    const handleVariantChange = useCallback(
+        (variantId: string) => {
+            const variant = groupedMethods?.find((m) => m.id === variantId);
+
+            if (variant && variant.id !== selectedVariantMethod.id) {
+                setSelectedVariantMethod(variant);
+
+                paymentForm.setFieldValue('methodIdOverride', variant.id);
+            }
+        },
+        [groupedMethods, paymentForm, selectedVariantMethod.id],
+    );
+
+    useEffect(() => {
+        setFieldValueRef.current = paymentForm.setFieldValue;
+    }, [paymentForm]);
+
+    useEffect(() => {
+        if (!isGrouped) {
+            return;
+        }
+
+        return () => {
+            setFieldValueRef.current('methodIdOverride', undefined);
+        };
+    }, [isGrouped]);
 
     const onBeforeLoad = useCallback((shopperInteraction: boolean) => {
         ref.current.shouldShowModal = shopperInteraction;
@@ -91,18 +125,18 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     }, []);
 
     const initializeAdyenPayment: HostedWidgetComponentProps['initializePayment'] = useCallback(
-        async (options: PaymentInitializeOptions, selectedInstrument: CardInstrument) => {
+        async (options: PaymentInitializeOptions, selectedInstrument?: CardInstrument) => {
             const adyenOptions: AdyenOptions = {
                 [AdyenV3PaymentMethodType.scheme]: {
                     hasHolderName: true,
                     holderNameRequired: true,
                 },
             };
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             const selectedInstrumentId = selectedInstrument?.bigpayToken;
 
             return checkoutService.initializePayment({
                 ...options,
+                methodId: component,
                 integrations: [createAdyenV3PaymentStrategy],
                 adyenv3: {
                     cardVerificationContainerId:
@@ -137,6 +171,37 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             checkoutService,
         ],
     );
+
+    useEffect(() => {
+        if (!isGrouped) {
+            return;
+        }
+
+        paymentForm.setValidationSchema(method, null);
+        paymentForm.setSubmit(method, null);
+
+        void initializeAdyenPayment({
+            methodId: component,
+            gatewayId: method.gateway,
+        }).catch((error: unknown) => {
+            if (error instanceof Error) {
+                onUnhandledError(error);
+            }
+        });
+
+        return () => {
+            paymentForm.setValidationSchema(method, null);
+            paymentForm.setSubmit(method, null);
+
+            void checkoutService.deinitializePayment({
+                gatewayId: method.gateway,
+                methodId: component,
+            });
+        };
+        // Re-run only when `initializeAdyenPayment` changes (it already lists `component`, container ids, and `checkoutService`).
+        // Adding `method`, `paymentForm`, or `checkoutService` causes an infinite loop
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [initializeAdyenPayment]);
 
     const validateInstrument = (
         shouldShowNumberField: boolean,
@@ -179,29 +244,58 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     return (
         <FormContext.Provider value={formContextProps}>
-            <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
-                <AdyenV3Form
-                    {...rest}
-                    additionalActionContainerId={additionalActionContainerId}
-                    cancelAdditionalActionModalFlow={cancelAdditionalActionModalFlow}
-                    checkoutService={checkoutService}
-                    checkoutState={checkoutState}
-                    containerId={containerId}
-                    hideContentWhenSignedOut
-                    initializePayment={initializeAdyenPayment}
-                    isAccountInstrument={isAccountInstrument()}
-                    isModalVisible={isAdditionalActionContentModalVisible}
-                    language={language}
-                    method={method}
-                    onUnhandledError={onUnhandledError}
-                    paymentForm={paymentForm}
-                    shouldHideInstrumentExpiryDate={shouldHideInstrumentExpiryDate}
-                    shouldRenderAdditionalActionContentModal={
-                        shouldRenderAdditionalActionContentModal
-                    }
-                    validateInstrument={validateInstrument}
-                />
-            </LoadingOverlay>
+            {isGrouped ? (
+                <>
+                    <select
+                        className="form-select optimizedCheckout-form-select"
+                        onChange={(e) => handleVariantChange(e.target.value)}
+                        value={selectedVariantMethod.id}
+                    >
+                        {groupedMethods!.map((m) => (
+                            <option key={m.id} value={m.id}>
+                                {m.config.displayName}
+                            </option>
+                        ))}
+                    </select>
+                    <div id={containerId} />
+                    <Modal
+                        additionalBodyClassName="modal-body--center"
+                        closeButtonLabel={language.translate('common.close_action')}
+                        isOpen={shouldRenderAdditionalActionContentModal}
+                        onRequestClose={cancelAdditionalActionModalFlow}
+                        shouldShowCloseButton={true}
+                    >
+                        <div id={additionalActionContainerId} style={{ width: '100%' }} />
+                    </Modal>
+                    {!shouldRenderAdditionalActionContentModal && (
+                        <div id={additionalActionContainerId} />
+                    )}
+                </>
+            ) : (
+                <LoadingOverlay hideContentWhenLoading isLoading={isLoading}>
+                    <AdyenV3Form
+                        {...rest}
+                        additionalActionContainerId={additionalActionContainerId}
+                        cancelAdditionalActionModalFlow={cancelAdditionalActionModalFlow}
+                        checkoutService={checkoutService}
+                        checkoutState={checkoutState}
+                        containerId={containerId}
+                        hideContentWhenSignedOut
+                        initializePayment={initializeAdyenPayment}
+                        isAccountInstrument={isAccountInstrument()}
+                        isModalVisible={isAdditionalActionContentModalVisible}
+                        language={language}
+                        method={method}
+                        onUnhandledError={onUnhandledError}
+                        paymentForm={paymentForm}
+                        shouldHideInstrumentExpiryDate={shouldHideInstrumentExpiryDate}
+                        shouldRenderAdditionalActionContentModal={
+                            shouldRenderAdditionalActionContentModal
+                        }
+                        validateInstrument={validateInstrument}
+                    />
+                </LoadingOverlay>
+            )}
         </FormContext.Provider>
     );
 };

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -26,6 +26,7 @@ import {
 import {
     CheckoutPageNodeObject,
     CheckoutPreset,
+    checkoutSettings,
     checkoutWithBillingEmail, checkoutWithShippingAndBilling, customer,
     orderResponse,
     payments,
@@ -286,6 +287,151 @@ describe('Payment step', () => {
 
         expect(screen.getByRole('radio')).toBeInTheDocument();
         expect(screen.queryByText(/BrainTree/)).not.toBeInTheDocument();
+    });
+
+    it('groups payment methods that match configured prefix when PAYMENTS-5142 experiment is enabled', async () => {
+        const facilypay3 = {
+            ...payments[0],
+            id: 'facilypay_3',
+            config: {
+                ...payments[0].config,
+                displayName: '3x Oney',
+            },
+        };
+        const facilypay6 = {
+            ...payments[0],
+            id: 'facilypay_6',
+            config: {
+                ...payments[0].config,
+                displayName: '6x Oney',
+            },
+        };
+        const card = {
+            ...payments[0],
+            id: 'card',
+            config: {
+                ...payments[0].config,
+                displayName: 'Card',
+            },
+        };
+
+        const configWithGroupingExperiment = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    features: {
+                        ...checkoutSettings.storeConfig.checkoutSettings.features,
+                        'PAYMENTS-5142.payment_method_grouping': true,
+                    },
+                },
+            },
+        };
+
+        checkout.setRequestHandler(rest.get(
+            '/api/storefront/payments',
+            (_, res, ctx) => res(
+                ctx.json([card, facilypay6, facilypay3]),
+            )));
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: configWithGroupingExperiment,
+        });
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio', { name: 'Oney' })).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: '3x Oney' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: '6x Oney' })).not.toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'Card' })).toBeInTheDocument();
+    });
+
+    it('does not group prefixed payment methods when PAYMENTS-5142 experiment is disabled', async () => {
+        const facilypay3 = {
+            ...payments[0],
+            id: 'facilypay_3',
+            config: {
+                ...payments[0].config,
+                displayName: '3x Oney',
+            },
+        };
+        const facilypay6 = {
+            ...payments[0],
+            id: 'facilypay_6',
+            config: {
+                ...payments[0].config,
+                displayName: '6x Oney',
+            },
+        };
+
+        const configWithoutGroupingExperiment = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    features: {
+                        ...checkoutSettings.storeConfig.checkoutSettings.features,
+                        'PAYMENTS-5142.payment_method_grouping': false,
+                    },
+                },
+            },
+        };
+
+        checkout.setRequestHandler(rest.get(
+            '/api/storefront/payments',
+            (_, res, ctx) => res(
+                ctx.json([facilypay6, facilypay3]),
+            )));
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: configWithoutGroupingExperiment,
+        });
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio', { name: '3x Oney' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: '6x Oney' })).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'Oney' })).not.toBeInTheDocument();
+    });
+
+    it('does not group payment methods when no configured prefix matches', async () => {
+        const installments3 = {
+            ...payments[0],
+            id: 'installments_3',
+            config: {
+                ...payments[0].config,
+                displayName: '3x Installments',
+            },
+        };
+        const installments6 = {
+            ...payments[0],
+            id: 'installments_6',
+            config: {
+                ...payments[0].config,
+                displayName: '6x Installments',
+            },
+        };
+
+        checkout.setRequestHandler(rest.get(
+            '/api/storefront/payments',
+            (_, res, ctx) => res(
+                ctx.json([installments3, installments6]),
+            )));
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio', { name: '3x Installments' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: '6x Installments' })).toBeInTheDocument();
     });
 
     it('does not render payment form if there are no methods', async () => {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -4,7 +4,6 @@ import {
     type CartStockPositionsChangedError,
     type CheckoutSelectors,
     type CheckoutService,
-    type CheckoutSettings,
     type Consignment,
     type OrderFinalizeOptions,
     type OrderRequestBody,
@@ -77,7 +76,6 @@ export interface PaymentProps {
 interface WithCheckoutPaymentProps {
     availableStoreCredit: number;
     cart?: Cart;
-    checkoutSettings: CheckoutSettings;
     consignments?: Consignment[];
     cartUrl: string;
     defaultMethod?: PaymentMethod;
@@ -681,10 +679,7 @@ export function mapToPaymentProps(
         return null;
     }
 
-    const checkoutSettings = config.checkoutSettings & {
-        orderTermsAndConditionsLocation: string,
-    };
-
+    const checkoutSettings = config.checkoutSettings;
     const {
         enableTermsAndConditions: isTermsConditionsEnabled,
         features,
@@ -708,7 +703,6 @@ export function mapToPaymentProps(
         applyStoreCredit: checkoutService.applyStoreCredit,
         availableStoreCredit: customer.storeCredit,
         cart: getCart(),
-        checkoutSettings,
         consignments,
         cartUrl: config.links.cartLink,
         clearError: checkoutService.clearError,

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -681,7 +681,7 @@ export function mapToPaymentProps(
         return null;
     }
 
-    const checkoutSettings = config.checkoutSettings as CheckoutSettings & {
+    const checkoutSettings = config.checkoutSettings & {
         orderTermsAndConditionsLocation: string;
     };
 

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -77,6 +77,7 @@ export interface PaymentProps {
 interface WithCheckoutPaymentProps {
     availableStoreCredit: number;
     cart?: Cart;
+    checkoutSettings: CheckoutSettings;
     consignments?: Consignment[];
     cartUrl: string;
     defaultMethod?: PaymentMethod;
@@ -480,7 +481,6 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
             const checkout = updatedState.data.getCheckout();
             const config = updatedState.data.getConfig();
             const methods = updatedState.data.getPaymentMethods() || EMPTY_ARRAY;
-
             const defaultMethod = (checkout && config)
                 ? getFilteredPaymentMethodsWithDefault({
                       checkout,
@@ -681,13 +681,17 @@ export function mapToPaymentProps(
         return null;
     }
 
+    const checkoutSettings = config.checkoutSettings as CheckoutSettings & {
+        orderTermsAndConditionsLocation: string;
+    };
+
     const {
         enableTermsAndConditions: isTermsConditionsEnabled,
         features,
         orderTermsAndConditionsType: termsConditionsType,
         orderTermsAndConditions: termsCondtitionsText,
         orderTermsAndConditionsLink: termsCondtitionsUrl,
-    } = config.checkoutSettings as CheckoutSettings & { orderTermsAndConditionsLocation: string };
+    } = checkoutSettings;
 
     const isTermsConditionsRequired = isTermsConditionsEnabled;
     const { isStoreCreditApplied } = checkout;
@@ -704,6 +708,7 @@ export function mapToPaymentProps(
         applyStoreCredit: checkoutService.applyStoreCredit,
         availableStoreCredit: customer.storeCredit,
         cart: getCart(),
+        checkoutSettings,
         consignments,
         cartUrl: config.links.cartLink,
         clearError: checkoutService.clearError,
@@ -721,7 +726,7 @@ export function mapToPaymentProps(
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,
         shouldLocaliseErrorMessages:
             features['PAYMENTS-6799.localise_checkout_payment_error_messages'],
-        shouldShowSubmitPaymentButton: isExperimentEnabled(config.checkoutSettings, 'CHECKOUT-9729.show_submit_button_when_payment_not_required', false),
+        shouldShowSubmitPaymentButton: isExperimentEnabled(checkoutSettings, 'CHECKOUT-9729.show_submit_button_when_payment_not_required', false),
         submitOrder: checkoutService.submitOrder,
         submitOrderError: getSubmitOrderError(),
         checkoutServiceSubscribe: checkoutService.subscribe,

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -682,7 +682,7 @@ export function mapToPaymentProps(
     }
 
     const checkoutSettings = config.checkoutSettings & {
-        orderTermsAndConditionsLocation: string;
+        orderTermsAndConditionsLocation: string,
     };
 
     const {

--- a/packages/core/src/app/payment/groupPaymentMethodsByPrefix.test.ts
+++ b/packages/core/src/app/payment/groupPaymentMethodsByPrefix.test.ts
@@ -1,0 +1,61 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getPaymentMethod } from '@bigcommerce/checkout/test-mocks';
+
+import { groupMethodsByPrefix } from './groupPaymentMethodsByPrefix';
+
+describe('groupMethodsByPrefix', () => {
+    const facilypayMethod = (id: string, displayName: string): PaymentMethod => ({
+        ...getPaymentMethod(),
+        id,
+        gateway: 'adyenv3',
+        method: 'scheme',
+        type: 'PAYMENT_TYPE_API',
+        config: {
+            ...getPaymentMethod().config,
+            displayName,
+        },
+    });
+
+    it('returns the same list when no methods match the prefix', () => {
+        const methods: PaymentMethod[] = [facilypayMethod('scheme', 'Card')];
+        const result = groupMethodsByPrefix(methods, 'facilypay_');
+
+        expect(result).toEqual(methods);
+    });
+
+    it('returns the same list when only one method matches the prefix', () => {
+        const methods: PaymentMethod[] = [facilypayMethod('facilypay_6', '6x Oney')];
+        const result = groupMethodsByPrefix(methods, 'facilypay_');
+
+        expect(result).toEqual(methods);
+    });
+
+    it('merges multiple prefixed methods into one representative ordered by numeric suffix', () => {
+        const three = facilypayMethod('facilypay_3', '3x Oney');
+        const twelve = facilypayMethod('facilypay_12', '12x Oney');
+        const other = facilypayMethod('scheme', 'Card');
+
+        const result = groupMethodsByPrefix([twelve, three, other], 'facilypay_');
+
+        expect(result.map((m) => m.id)).toEqual(['facilypay_3', 'scheme']);
+
+        const representative = result.find((m) => m.id === 'facilypay_3');
+
+        expect(representative?.initializationData).toEqual(
+            expect.objectContaining({
+                groupedMethods: [three, twelve],
+            }),
+        );
+    });
+
+    it('strips a leading Nx multiplier from the representative display name', () => {
+        const three = facilypayMethod('facilypay_3', '3x Oney label');
+        const four = facilypayMethod('facilypay_4', '4x Oney other');
+
+        const result = groupMethodsByPrefix([four, three], 'facilypay_');
+        const representative = result.find((m) => m.id === 'facilypay_3');
+
+        expect(representative?.config.displayName).toBe('Oney label');
+    });
+});

--- a/packages/core/src/app/payment/groupPaymentMethodsByPrefix.test.ts
+++ b/packages/core/src/app/payment/groupPaymentMethodsByPrefix.test.ts
@@ -2,7 +2,7 @@ import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
 import { getPaymentMethod } from '@bigcommerce/checkout/test-mocks';
 
-import { groupMethodsByPrefix } from './groupPaymentMethodsByPrefix';
+import { groupPaymentMethodsByPrefix } from './groupPaymentMethodsByPrefix';
 
 describe('groupMethodsByPrefix', () => {
     const facilypayMethod = (id: string, displayName: string): PaymentMethod => ({
@@ -19,14 +19,14 @@ describe('groupMethodsByPrefix', () => {
 
     it('returns the same list when no methods match the prefix', () => {
         const methods: PaymentMethod[] = [facilypayMethod('scheme', 'Card')];
-        const result = groupMethodsByPrefix(methods, 'facilypay_');
+        const result = groupPaymentMethodsByPrefix(methods, 'facilypay_');
 
         expect(result).toEqual(methods);
     });
 
     it('returns the same list when only one method matches the prefix', () => {
         const methods: PaymentMethod[] = [facilypayMethod('facilypay_6', '6x Oney')];
-        const result = groupMethodsByPrefix(methods, 'facilypay_');
+        const result = groupPaymentMethodsByPrefix(methods, 'facilypay_');
 
         expect(result).toEqual(methods);
     });
@@ -36,7 +36,7 @@ describe('groupMethodsByPrefix', () => {
         const twelve = facilypayMethod('facilypay_12', '12x Oney');
         const other = facilypayMethod('scheme', 'Card');
 
-        const result = groupMethodsByPrefix([twelve, three, other], 'facilypay_');
+        const result = groupPaymentMethodsByPrefix([twelve, three, other], 'facilypay_');
 
         expect(result.map((m) => m.id)).toEqual(['facilypay_3', 'scheme']);
 
@@ -53,7 +53,7 @@ describe('groupMethodsByPrefix', () => {
         const three = facilypayMethod('facilypay_3', '3x Oney label');
         const four = facilypayMethod('facilypay_4', '4x Oney other');
 
-        const result = groupMethodsByPrefix([four, three], 'facilypay_');
+        const result = groupPaymentMethodsByPrefix([four, three], 'facilypay_');
         const representative = result.find((m) => m.id === 'facilypay_3');
 
         expect(representative?.config.displayName).toBe('Oney label');

--- a/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
+++ b/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
@@ -66,7 +66,7 @@ export const groupPaymentMethodsByPrefix = (methods: PaymentMethod[], prefix: st
     return flatMapGroupedPaymentMethodRepresentativeIntoList(
         methods,
         prefix,
-        sortedGroup[0].id,
+        representative.id,
         representative,
     );
 };

--- a/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
+++ b/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
@@ -27,7 +27,7 @@ const buildGroupedPaymentMethodRepresentative = (sortedGroup: PaymentMethod[]): 
         ...first,
         config: {
             ...first.config,
-            displayName: first.config.displayName?.replace(/^\d+x\s+/i, '') ?? first.config.displayName,
+            displayName: first.config.displayName?.replace(/^\d+x\s+/i, ''),
         },
         initializationData: {
             ...first.initializationData,

--- a/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
+++ b/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
@@ -1,0 +1,72 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+/** Payment method ids with any of these prefixes may be merged when grouping is enabled. */
+export const GROUPED_METHOD_ID_PREFIXES = ['facilypay_'] as const;
+
+const selectAndSortPaymentMethodsByPrefix = (
+    methods: PaymentMethod[],
+    prefix: string,
+): PaymentMethod[] | undefined => {
+    const group = methods.filter((m) => m.id.startsWith(prefix));
+
+    if (group.length <= 1) {
+        return undefined;
+    }
+
+    return [...group].sort((a, b) => {
+        const toNum = (id: string) => parseInt(id.slice(prefix.length), 10) || 0;
+
+        return toNum(a.id) - toNum(b.id);
+    });
+};
+
+const buildGroupedPaymentMethodRepresentative = (sortedGroup: PaymentMethod[]): PaymentMethod => {
+    const [first] = sortedGroup;
+
+    return {
+        ...first,
+        config: {
+            ...first.config,
+            displayName: first.config.displayName?.replace(/^\d+x\s+/i, '') ?? first.config.displayName,
+        },
+        initializationData: {
+            ...(first.initializationData as Record<string, unknown>),
+            groupedMethods: sortedGroup,
+        },
+    };
+};
+
+const spliceGroupedPaymentMethodRepresentativeIntoList = (
+    methods: PaymentMethod[],
+    prefix: string,
+    representativeSourceId: string,
+    representative: PaymentMethod,
+): PaymentMethod[] =>
+    methods.flatMap((m) => {
+        if (!m.id.startsWith(prefix)) {
+            return [m];
+        }
+
+        if (m.id === representativeSourceId) {
+            return [representative];
+        }
+
+        return [];
+    });
+
+export const groupMethodsByPrefix = (methods: PaymentMethod[], prefix: string): PaymentMethod[] => {
+    const sortedGroup = selectAndSortPaymentMethodsByPrefix(methods, prefix);
+
+    if (!sortedGroup) {
+        return methods;
+    }
+
+    const representative = buildGroupedPaymentMethodRepresentative(sortedGroup);
+
+    return spliceGroupedPaymentMethodRepresentativeIntoList(
+        methods,
+        prefix,
+        sortedGroup[0].id,
+        representative,
+    );
+};

--- a/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
+++ b/packages/core/src/app/payment/groupPaymentMethodsByPrefix.ts
@@ -1,6 +1,6 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
-/** Payment method ids with any of these prefixes may be merged when grouping is enabled. */
+// Payment method ids with any of these prefixes may be merged when grouping is enabled
 export const GROUPED_METHOD_ID_PREFIXES = ['facilypay_'] as const;
 
 const selectAndSortPaymentMethodsByPrefix = (
@@ -30,13 +30,13 @@ const buildGroupedPaymentMethodRepresentative = (sortedGroup: PaymentMethod[]): 
             displayName: first.config.displayName?.replace(/^\d+x\s+/i, '') ?? first.config.displayName,
         },
         initializationData: {
-            ...(first.initializationData as Record<string, unknown>),
+            ...first.initializationData,
             groupedMethods: sortedGroup,
         },
     };
 };
 
-const spliceGroupedPaymentMethodRepresentativeIntoList = (
+const flatMapGroupedPaymentMethodRepresentativeIntoList = (
     methods: PaymentMethod[],
     prefix: string,
     representativeSourceId: string,
@@ -54,7 +54,7 @@ const spliceGroupedPaymentMethodRepresentativeIntoList = (
         return [];
     });
 
-export const groupMethodsByPrefix = (methods: PaymentMethod[], prefix: string): PaymentMethod[] => {
+export const groupPaymentMethodsByPrefix = (methods: PaymentMethod[], prefix: string): PaymentMethod[] => {
     const sortedGroup = selectAndSortPaymentMethodsByPrefix(methods, prefix);
 
     if (!sortedGroup) {
@@ -63,7 +63,7 @@ export const groupMethodsByPrefix = (methods: PaymentMethod[], prefix: string): 
 
     const representative = buildGroupedPaymentMethodRepresentative(sortedGroup);
 
-    return spliceGroupedPaymentMethodRepresentativeIntoList(
+    return flatMapGroupedPaymentMethodRepresentativeIntoList(
         methods,
         prefix,
         sortedGroup[0].id,

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
@@ -192,7 +192,8 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
             methods: [card, facilypay6, facilypay3],
         });
 
-        expect(filteredMethods.map((m) => m.id)).toEqual(['facilypay_3', 'card']);
+        expect(filteredMethods.map((m) => m.id)).toEqual(['card', 'facilypay_3']);
+
         const grouped = filteredMethods.find((m) => m.id === 'facilypay_3');
 
         expect(grouped?.initializationData).toEqual(
@@ -200,7 +201,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
                 groupedMethods: [facilypay3, facilypay6],
             }),
         );
-        expect(defaultMethod).toEqual(grouped);
+        expect(defaultMethod).toEqual(card);
     });
 
     it('does not group facilypay_* methods when PAYMENTS-5142.payment_method_grouping is disabled', () => {

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
@@ -162,4 +162,72 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         expect(filteredMethods).toEqual([authorizenet]);
         expect(defaultMethod).toEqual(authorizenet);
     });
+
+    it('groups facilypay_* methods when PAYMENTS-5142.payment_method_grouping is enabled', () => {
+        const facilypay3 = buildMethod({
+            id: 'facilypay_3',
+            config: { ...getPaymentMethod().config, displayName: '3x Oney' },
+        });
+        const facilypay6 = buildMethod({
+            id: 'facilypay_6',
+            config: { ...getPaymentMethod().config, displayName: '6x Oney' },
+        });
+        const card = buildMethod({
+            id: 'card',
+            config: { ...getPaymentMethod().config, displayName: 'Card' },
+        });
+        const checkoutSettingsWithGrouping = {
+            ...checkoutSettings,
+            features: {
+                ...checkoutSettings.features,
+                'PAYMENTS-5142.payment_method_grouping': true,
+            },
+        };
+
+        const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
+            checkout: getCheckout(),
+            checkoutSettings: checkoutSettingsWithGrouping,
+            getPaymentMethod: jest.fn(),
+            methods: [card, facilypay6, facilypay3],
+        });
+
+        expect(filteredMethods.map((m) => m.id)).toEqual(['facilypay_3', 'card']);
+        const grouped = filteredMethods.find((m) => m.id === 'facilypay_3');
+
+        expect(grouped?.initializationData).toEqual(
+            expect.objectContaining({
+                groupedMethods: [facilypay3, facilypay6],
+            }),
+        );
+        expect(defaultMethod).toEqual(grouped);
+    });
+
+    it('does not group facilypay_* methods when PAYMENTS-5142.payment_method_grouping is disabled', () => {
+        const facilypay3 = buildMethod({
+            id: 'facilypay_3',
+            config: { ...getPaymentMethod().config, displayName: '3x Oney' },
+        });
+        const facilypay6 = buildMethod({
+            id: 'facilypay_6',
+            config: { ...getPaymentMethod().config, displayName: '6x Oney' },
+        });
+        const checkoutSettingsWithoutGrouping = {
+            ...checkoutSettings,
+            features: {
+                ...checkoutSettings.features,
+                'PAYMENTS-5142.payment_method_grouping': false,
+            },
+        };
+
+        const { filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
+            checkout: getCheckout(),
+            checkoutSettings: checkoutSettingsWithoutGrouping,
+            getPaymentMethod: jest.fn(),
+            methods: [facilypay6, facilypay3],
+        });
+
+        expect(filteredMethods).toEqual([facilypay6, facilypay3]);
+    });
 });

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
@@ -8,7 +8,7 @@ import {
 import { find } from 'lodash';
 
 import { isExperimentEnabled } from '../../common/utility';
-import { GROUPED_METHOD_ID_PREFIXES, groupMethodsByPrefix } from '../groupPaymentMethodsByPrefix';
+import { GROUPED_METHOD_ID_PREFIXES, groupPaymentMethodsByPrefix } from '../groupPaymentMethodsByPrefix';
 import { PaymentMethodProviderType } from '../paymentMethod';
 
 import { applyPaymentMethodFilters } from './applyPaymentMethodFilters';
@@ -71,7 +71,7 @@ export const getFilteredPaymentMethodsWithDefault = ({
         isExperimentEnabled(checkoutSettings, 'PAYMENTS-5142.payment_method_grouping', false)
     ) {
         filteredMethods = GROUPED_METHOD_ID_PREFIXES.reduce(
-            (acc, prefix) => groupMethodsByPrefix(acc, prefix),
+            (acc, prefix) => groupPaymentMethodsByPrefix(acc, prefix),
             filteredMethods,
         );
     }

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
@@ -7,6 +7,8 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import { find } from 'lodash';
 
+import { isExperimentEnabled } from '../../common/utility';
+import { GROUPED_METHOD_ID_PREFIXES, groupMethodsByPrefix } from '../groupPaymentMethodsByPrefix';
 import { PaymentMethodProviderType } from '../paymentMethod';
 
 import { applyPaymentMethodFilters } from './applyPaymentMethodFilters';
@@ -52,13 +54,27 @@ export const getFilteredPaymentMethodsWithDefault = ({
     paymentProviderCustomer,
     capabilities,
 }: PaymentMethodSelectionProps): DefaultPaymentMethodResult => {
-    const filteredMethods = applyPaymentMethodFilters(methods, {
+    let filteredMethods = applyPaymentMethodFilters(methods, {
         checkout,
         checkoutSettings,
         getPaymentMethod,
         paymentProviderCustomer,
         capabilities,
     });
+
+    const shouldGroupPaymentMethodsByPrefix = filteredMethods.some((method) =>
+        GROUPED_METHOD_ID_PREFIXES.some((prefix) => method.id.startsWith(prefix)),
+    );
+
+    if (
+        shouldGroupPaymentMethodsByPrefix &&
+        isExperimentEnabled(checkoutSettings, 'PAYMENTS-5142.payment_method_grouping', false)
+    ) {
+        filteredMethods = GROUPED_METHOD_ID_PREFIXES.reduce(
+            (acc, prefix) => groupMethodsByPrefix(acc, prefix),
+            filteredMethods,
+        );
+    }
 
     return {
         defaultMethod: selectDefaultMethod(filteredMethods, checkout),


### PR DESCRIPTION
## What/Why?

**Add select and render grouped Oney payment method variant options**

When groupedMethods is detected in initializationData, the component takes a lightweight path: renders only the select variant selector, a hidden SDK mount point, and the additional-action Modal (for BNPL redirect/3DS). The Adyen strategy is initialized and deinitialized directly via useEffect — no HostedWidgetPaymentComponent, no hosted card fields. On variant change the strategy is reinitialized and methodIdOverride is updated. MethodIdOverride is cleared on unmount. The non-grouped path (credit card, BCMC, etc.) is completely unchanged.

Introduced a generic prefix-based grouping mechanism via a standalone groupMethodsByPrefix function, applied in getDefaultPaymentMethod through GROUPED_METHOD_ID_PREFIXES.reduce(groupMethodsByPrefix, filteredMethods). Methods sharing a common ID prefix (facilypay_) are sorted numerically and collapsed into a single representative — the numerically first variant at its original position in the list. Non-representative variants are removed from filteredMethods entirely. The representative carries all variants in initializationData.groupedMethods and has its numeric prefix stripped from displayName (e.g. "3x Oney by bank card" → "Oney by bank card"). 
Adding support for a new group in the future requires only adding a prefix to GROUPED_METHOD_ID_PREFIXES.

## Rollout/Rollback

Revert PR or disable experiment PAYMENTS-5142.payment_method_grouping

## Testing 

https://github.com/user-attachments/assets/bf62fcef-4145-4bc7-9afc-83e7b0aad6bf



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how payment methods are filtered/rendered and how Adyen V3 initializes/deinitializes payment for grouped variants, which can affect checkout payment selection and submission behavior when the experiment is enabled.
> 
> **Overview**
> Adds **experiment-gated payment method grouping** (`PAYMENTS-5142.payment_method_grouping`) that collapses multiple `facilypay_*` methods into a single representative method with `initializationData.groupedMethods`, including numeric-suffix sorting and display-name cleanup.
> 
> Updates `AdyenV3PaymentMethod` to detect grouped methods and render a lightweight variant selector + Adyen mount points, managing `initializePayment`/`deinitializePayment` directly and using `paymentForm`’s `methodIdOverride` to switch variants (cleared on unmount).
> 
> Expands unit/integration coverage to verify grouping behavior in filtering/UI and the grouped Adyen variant flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4e1a91b7127364fc60612c61ab1b74e4883a1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->