### PR TITLE
feat(checkout): CHECKOUT-9813 invoice-to-checkout flow redirection

### DIFF
--- a/packages/contexts/src/capabilities/CapabilitiesProvider.tsx
+++ b/packages/contexts/src/capabilities/CapabilitiesProvider.tsx
@@ -1,8 +1,9 @@
 import { type CheckoutSelectors } from '@bigcommerce/checkout-sdk';
-import React, { type ReactElement, type ReactNode } from 'react';
+import React, { type ReactElement, type ReactNode, useMemo } from 'react';
 
-import { defaultCapabilities } from './Capability';
 import CapabilitiesContext from './CapabilitiesContext';
+import { applyCapabilitiesOverride } from './capabilitiesOverride';
+import { defaultCapabilities } from './Capability';
 
 interface CapabilitiesProviderProps {
     checkoutState: CheckoutSelectors;
@@ -16,8 +17,16 @@ const CapabilitiesProvider = ({
     const capabilities =
         checkoutState.data.getConfig()?.checkoutSettings.capabilities ?? defaultCapabilities;
 
+    // TODO: CHECKOUT-9979: Remove the override logic
+    const overriddenCapabilities = useMemo(
+        () => applyCapabilitiesOverride(capabilities),
+        [capabilities],
+    );
+
     return (
-        <CapabilitiesContext.Provider value={capabilities}>{children}</CapabilitiesContext.Provider>
+        <CapabilitiesContext.Provider value={overriddenCapabilities}>
+            {children}
+        </CapabilitiesContext.Provider>
     );
 };
 

--- a/packages/contexts/src/capabilities/capabilitiesOverride.ts
+++ b/packages/contexts/src/capabilities/capabilitiesOverride.ts
@@ -1,0 +1,58 @@
+// TEMP (CHECKOUT-9979): Client-side override for capability flags while the API is pending.
+// Remove this file and its usage in CapabilitiesProvider.tsx on project delivery.
+//
+// Usage: append `?capabilitiesOverride=<url-encoded-json>` to the checkout URL, e.g.
+//   ?capabilitiesOverride=%7B%22orderConfirmation%22%3A%7B%22invoiceRedirect%22%3Atrue%7D%7D
+// Only the keys present in the JSON are overridden; all other values come from the API.
+
+import { type Capabilities } from '@bigcommerce/checkout-sdk/essential';
+
+const OVERRIDE_QUERY_PARAM = 'capabilitiesOverride';
+
+type CapabilitiesOverride = {
+    [K in keyof Capabilities]?: Partial<Capabilities[K]>;
+};
+
+function parseOverride(): CapabilitiesOverride | undefined {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+
+    const raw = new URLSearchParams(window.location.search).get(OVERRIDE_QUERY_PARAM);
+
+    if (!raw) {
+        return undefined;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as CapabilitiesOverride;
+        }
+    } catch {
+        // Malformed override — fall back to API-provided capabilities.
+    }
+
+    return undefined;
+}
+
+const capabilitiesOverride = parseOverride();
+
+export function applyCapabilitiesOverride(capabilities: Capabilities): Capabilities {
+    if (!capabilitiesOverride) {
+        return capabilities;
+    }
+
+    return {
+        userJourney: { ...capabilities.userJourney, ...capabilitiesOverride.userJourney },
+        customer: { ...capabilities.customer, ...capabilitiesOverride.customer },
+        shipping: { ...capabilities.shipping, ...capabilitiesOverride.shipping },
+        billing: { ...capabilities.billing, ...capabilitiesOverride.billing },
+        payment: { ...capabilities.payment, ...capabilitiesOverride.payment },
+        orderConfirmation: {
+            ...capabilities.orderConfirmation,
+            ...capabilitiesOverride.orderConfirmation,
+        },
+    };
+}

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -13,7 +13,9 @@ import {
     type AnalyticsContextProps,
     type AnalyticsEvents,
     AnalyticsProviderMock,
+    CapabilitiesContext,
     CheckoutProvider,
+    defaultCapabilities,
     ExtensionProvider,
     type ExtensionServiceInterface,
     LocaleProvider,
@@ -580,6 +582,72 @@ describe('Checkout', () => {
             await waitFor(() => {
                 expect(defaultProps.errorLogger.log).toHaveBeenCalledWith(error);
             });
+        });
+
+        it('redirects to B2B buyer portal after payment when invoiceRedirect capability is enabled', async () => {
+            const originalLocation = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...window.location,
+                    replace: jest.fn(),
+                },
+                configurable: true,
+                writable: true,
+            });
+
+            try {
+                checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+                jest.spyOn(checkoutService, 'submitOrder').mockResolvedValue({
+                    data: {
+                        getOrder: () => ({ orderId: 123 } as any),
+                    },
+                } as any);
+
+                const invoiceRedirectCapabilities = {
+                    ...defaultCapabilities,
+                    orderConfirmation: {
+                        ...defaultCapabilities.orderConfirmation,
+                        invoiceRedirect: true,
+                    },
+                };
+
+                const CheckoutWithInvoiceRedirect: FunctionComponent<CheckoutProps> = (props) => (
+                    <CheckoutProvider checkoutService={checkoutService}>
+                        <LocaleProvider checkoutService={checkoutService} languageService={getLanguageService()}>
+                            <AnalyticsProviderMock>
+                                <ExtensionProvider extensionService={extensionService}>
+                                    <ThemeProvider>
+                                        <CapabilitiesContext.Provider value={invoiceRedirectCapabilities}>
+                                            <Checkout {...props} />
+                                        </CapabilitiesContext.Provider>
+                                    </ThemeProvider>
+                                </ExtensionProvider>
+                            </AnalyticsProviderMock>
+                        </LocaleProvider>
+                    </CheckoutProvider>
+                );
+
+                render(<CheckoutWithInvoiceRedirect {...defaultProps} />);
+
+                await checkout.waitForPaymentStep();
+
+                await userEvent.click(screen.getByText(/place order/i));
+
+                await waitFor(() => {
+                    expect(window.location.replace).toHaveBeenCalledWith(
+                        'https://store.url/#/invoice?receiptId=',
+                    );
+                });
+            } finally {
+                Object.defineProperty(window, 'location', {
+                    value: originalLocation,
+                    configurable: true,
+                    writable: true,
+                });
+            }
         });
     });
 });

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -23,7 +23,7 @@ import React, {
   useState,
 } from 'react';
 
-import { type AnalyticsContextProps, type ExtensionContextProps, withExtension } from '@bigcommerce/checkout/contexts';
+import { type AnalyticsContextProps, type ExtensionContextProps, useCapabilities, withExtension } from '@bigcommerce/checkout/contexts';
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { OrderConfirmationPageSkeleton } from '@bigcommerce/checkout/ui';
@@ -156,6 +156,8 @@ const Checkout = ({
         hasSelectedShippingOptions: state.hasSelectedShippingOptions,
     });
 
+    const { orderConfirmation: { invoiceRedirect } } = useCapabilities();
+
     const navigateToStep = useCallback((type: CheckoutStepType, options?: { isDefault?: boolean }):void => {
         const step = find(stepsRef.current, { type });
 
@@ -218,6 +220,15 @@ const Checkout = ({
         SubscribeSessionStorage.removeSubscribeStatus();
 
         setState(prevState => ({ ...prevState, isRedirecting: true }));
+
+        if (invoiceRedirect && orderId !== undefined) {
+            const { links: { siteLink = '' } = {} } = data.getConfig() || {};
+
+            // TODO: CHECKOUT-9813 Get receiptId via B2B v1 API, more details in CHECKOUT-9813
+            window.location.replace(`${siteLink}/#/invoice?receiptId=`);
+
+            return;
+        }
 
         void navigateToOrderConfirmationUtility(orderId);
     }, []);


### PR DESCRIPTION
## What/Why?

Redirect to the buyer portal after invoice-to-checkout. 

This ticket is partially done and depends on the receipt ID. We can complete it once we build the mechanism to call B2B endpoints.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-purchase redirect flow to conditionally send shoppers to an external buyer-portal URL, which can impact order completion UX if misconfigured. Also introduces a temporary query-param-based capability override that could unintentionally toggle flags in shared/test links.
> 
> **Overview**
> Adds an *invoice-to-buyer-portal* redirect path after successful order submission when the `orderConfirmation.invoiceRedirect` capability is enabled, using `siteLink/#/invoice?receiptId=` (receipt ID still TODO).
> 
> Introduces a temporary client-side `capabilitiesOverride` query param that merges URL-provided capability JSON over the API capabilities in `CapabilitiesProvider`, and adds a unit test ensuring `window.location.replace` is invoked when `invoiceRedirect` is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7a092e5a19282e2c1ae458f85997b7043948953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->