### PR TITLE
feat(checkout): CHECKOUT-9826 shipping and billing step warning message when no addresses

### DIFF
--- a/packages/core/src/app/address/mapAddressFromFormValues.ts
+++ b/packages/core/src/app/address/mapAddressFromFormValues.ts
@@ -9,7 +9,12 @@ export default function mapAddressFromFormValues(formValues: AddressFormValues, 
     const { customFields, extraFields, shouldSaveAddress, ...address } = formValues;
 
     if (storageKey && extraFields && Object.keys(extraFields).length > 0) {
-        B2BExtraFieldsSessionStorage.setFields(storageKey, extraFields as Record<string, unknown>);
+        const fieldsToStore = {
+            ...extraFields,
+            shouldSaveAddress,
+        }
+
+        B2BExtraFieldsSessionStorage.setFields(storageKey, fieldsToStore as Record<string, unknown>);
     }
 
     return {

--- a/packages/core/src/app/billing/Billing.test.tsx
+++ b/packages/core/src/app/billing/Billing.test.tsx
@@ -12,6 +12,7 @@ import React, { type FunctionComponent } from 'react';
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
 import {
     AnalyticsProviderMock,
+    CapabilitiesContext,
     CheckoutProvider,
     defaultCapabilities,
     ExtensionProvider,
@@ -34,13 +35,14 @@ import {
     checkoutWithShippingAndBilling,
     consignment,
     customer,
+    customerWithoutSavedAddresses,
     formFields,
     payments,
     shippingAddress,
     shippingAddress2,
     shippingAddress3,
 } from '@bigcommerce/checkout/test-framework';
-import { act, renderWithoutWrapper as render, screen } from '@bigcommerce/checkout/test-utils';
+import { act, renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 
 import Checkout from '../checkout/Checkout';
 import { type CheckoutInitializerProps } from '../checkout/CheckoutInitializer';
@@ -480,6 +482,59 @@ describe('Billing step', () => {
 
             expect(checkoutService.updateBillingAddress).toHaveBeenCalled();
             expect(screen.getByRole('radio', { name: payments[0].config.displayName })).toBeInTheDocument();
+        });
+    });
+
+    describe('restrictManualAddressEntry warning', () => {
+        const checkoutWithShippingAndNoAddresses = {
+            ...checkoutWithShipping,
+            customer: customerWithoutSavedAddresses,
+        };
+
+        it('shows a warning when restrictManualAddressEntry is true and the customer has no saved addresses', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
+                checkout: checkoutWithShippingAndNoAddresses,
+            });
+
+            const restrictManualAddressCapabilities = {
+                ...defaultCapabilities,
+                billing: {
+                    ...defaultCapabilities.billing,
+                    restrictManualAddressEntry: true,
+                },
+            };
+
+            const CheckoutWithRestrictedAddressEntry: FunctionComponent<CheckoutInitializerProps> = (props) => (
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <LocaleProvider checkoutService={checkoutService} languageService={getLanguageService()}>
+                        <AnalyticsProviderMock>
+                            <ExtensionProvider extensionService={extensionService}>
+                                <ThemeProvider>
+                                    <CapabilitiesContext.Provider value={restrictManualAddressCapabilities}>
+                                        <Checkout {...props} />
+                                    </CapabilitiesContext.Provider>
+                                </ThemeProvider>
+                            </ExtensionProvider>
+                        </AnalyticsProviderMock>
+                    </LocaleProvider>
+                </CheckoutProvider>
+            );
+
+            render(<CheckoutWithRestrictedAddressEntry {...defaultProps} />);
+
+            expect(await screen.findByText(/no billing address to choose from/i)).toBeInTheDocument();
+        });
+
+        it('does not show the warning when restrictManualAddressEntry is false', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
+                checkout: checkoutWithShippingAndNoAddresses,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForBillingStep();
+
+            expect(screen.queryByText(/no billing address to choose from/i)).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -31,7 +31,7 @@ const getFieldsWithExtraFields = (getBillingAddressFields: (countryCode: string)
 
 const Billing = ({ navigateNextStep, onReady, onUnhandledError }:BillingProps): ReactElement => {
     const { checkoutService, checkoutState } = useCheckout();
-    const { userJourney: { hasAddressExtraFields } } = useCapabilities();
+    const { userJourney: { hasAddressExtraFields }, billing: { restrictManualAddressEntry } } = useCapabilities();
 
     const {
         data: {
@@ -104,18 +104,17 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }:BillingProps): 
         void init();
     }, []);
 
-    // TODO: Show warning message when restrictManualAddressEntry is true and no addresses are available
-    // Yet to decide where we get the addresses from in b2b flow??
-    // const hasAddresses = customer?.addresses && customer.addresses.length > 0;
-    // const showWarningMessage = restrictManualAddressEntry && !hasAddresses;
+    // Show warning message when restrictManualAddressEntry is true and no addresses are available
+    const hasAddresses = customer?.addresses && customer.addresses.length > 0;
+    const showWarningMessage = restrictManualAddressEntry && !hasAddresses;
 
-    // if (showWarningMessage) {
-    //     return (
-    //         <div className="no-addresses-warning body-regular">
-    //             <TranslatedString id="billing.no_billing_addresses_warning" />
-    //         </div>
-    //     );
-    // }
+    if (showWarningMessage) {
+        return (
+            <div className="no-addresses-warning body-regular">
+                <TranslatedString id="billing.no_billing_addresses_warning" />
+            </div>
+        );
+    }
 
     return (
         <AddressFormSkeleton isLoading={isInitializing}>

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -11,7 +11,9 @@ import React, { type FunctionComponent } from 'react';
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
 import {
     AnalyticsProviderMock,
+    CapabilitiesContext,
     CheckoutProvider,
+    defaultCapabilities,
     ExtensionProvider,
     type ExtensionServiceInterface,
     LocaleProvider,
@@ -27,6 +29,7 @@ import {
     checkoutSettings,
     checkoutWithBillingEmail,
     checkoutWithCustomerHavingInvalidAddress,
+    checkoutWithLoggedInCustomer,
     checkoutWithMultiShippingCart,
     checkoutWithShipping,
     checkoutWithShippingAndBilling,
@@ -949,6 +952,54 @@ describe('Shipping step', () => {
                     type: 'custom',
                 })
             );
+        });
+    });
+
+    describe('restrictManualAddressEntry warning', () => {
+        it('shows a warning when restrictManualAddressEntry is true and the customer has no saved addresses', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithLoggedInCustomer, {
+                checkout: checkoutWithLoggedInCustomer,
+            });
+
+            const restrictManualAddressCapabilities = {
+                ...defaultCapabilities,
+                shipping: {
+                    ...defaultCapabilities.shipping,
+                    restrictManualAddressEntry: true,
+                },
+            };
+
+            const CheckoutWithRestrictedAddressEntry: FunctionComponent<CheckoutProps> = (props) => (
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <LocaleProvider checkoutService={checkoutService} languageService={getLanguageService()}>
+                        <AnalyticsProviderMock>
+                            <ExtensionProvider extensionService={extensionService}>
+                                <ThemeProvider>
+                                    <CapabilitiesContext.Provider value={restrictManualAddressCapabilities}>
+                                        <Checkout {...props} />
+                                    </CapabilitiesContext.Provider>
+                                </ThemeProvider>
+                            </ExtensionProvider>
+                        </AnalyticsProviderMock>
+                    </LocaleProvider>
+                </CheckoutProvider>
+            );
+
+            render(<CheckoutWithRestrictedAddressEntry {...defaultProps} />);
+
+            expect(await screen.findByText(/no shipping address to choose from/i)).toBeInTheDocument();
+        });
+
+        it('does not show the warning when restrictManualAddressEntry is false', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithLoggedInCustomer, {
+                checkout: checkoutWithLoggedInCustomer,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            expect(screen.queryByText(/no shipping address to choose from/i)).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -2,6 +2,7 @@ import { type CheckoutSelectors } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 
+import { useCapabilities } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, ConfirmationModal } from '@bigcommerce/checkout/ui';
 
@@ -64,6 +65,7 @@ function Shipping({
         updateShippingAddress,
         updateBillingAddress,
     } = useShipping();
+    const { shipping: { restrictManualAddressEntry } } = useCapabilities();
 
     useEffect(() => {
         const initializeShipping = async () => {
@@ -182,18 +184,17 @@ function Shipping({
         />;
     }
 
-    // TODO: Show warning message when restrictManualAddressEntry is true and no addresses are available
-    // Yet to decide where we get the addresses from in b2b flow??
-    // const hasAddresses = customer?.addresses && customer?.addresses.length > 0;
-    // const showWarningMessage = restrictManualAddressEntry && !hasAddresses;
+    // Show warning message when restrictManualAddressEntry is true and no addresses are available
+    const hasAddresses = customer?.addresses && customer?.addresses.length > 0;
+    const showWarningMessage = restrictManualAddressEntry && !hasAddresses;
 
-    // if (showWarningMessage) {
-    //     return (
-    //         <div className="no-addresses-warning body-regular">
-    //             <TranslatedString id="shipping.no_shipping_addresses_warning" />
-    //         </div>
-    //     );
-    // }
+    if (showWarningMessage) {
+        return (
+            <div className="no-addresses-warning body-regular">
+                <TranslatedString id="shipping.no_shipping_addresses_warning" />
+            </div>
+        );
+    }
 
     return (
         <AddressFormSkeleton isLoading={isInitializing} renderWhileLoading={true}>

--- a/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
+++ b/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
@@ -18,5 +18,5 @@
 }
 
 .no-addresses-warning {
-    padding: spacing("base") 0 spacing("double") 0;
+    padding: spacing("single") 0 (spacing("single") + spacing("third")) 0;
 }


### PR DESCRIPTION
## What/Why?
- Add `shouldSaveAddress` to session storage along with extra fields.
- Show warning message when `restrictManualAddressEntry` capability is true and no addresses are available to select.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<img width="1565" height="851" alt="Screenshot 2026-04-29 at 2 19 25 pm" src="https://github.com/user-attachments/assets/55728730-aed3-4c83-baa2-5688a3c3f7e0" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9d91fb5fb8e834db562aec4b9e15a4852c768050. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->