### PR TITLE
feat(checkout): CHECKOUT-9817 Introduce paymentMethodFilters

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -1,7 +1,6 @@
 import {
     type Cart,
     type CartStockPositionsChangedError,
-    type Checkout,
     type CheckoutSelectors,
     type CheckoutService,
     type CheckoutSettings,
@@ -9,7 +8,6 @@ import {
     type OrderFinalizeOptions,
     type OrderRequestBody,
     type PaymentMethod,
-    type PaymentProviderCustomer,
 } from '@bigcommerce/checkout-sdk';
 import { createAfterpayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/afterpay';
 import { createBlueSnapV2PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
@@ -20,7 +18,7 @@ import { createOffsitePaymentStrategy } from '@bigcommerce/checkout-sdk/integrat
 import { createPaypalExpressPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/paypal-express';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import { memoizeOne } from '@bigcommerce/memoize';
-import { compact, find, isEmpty, noop } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 import React, {
   type ReactElement,
   type ReactNode,
@@ -56,76 +54,9 @@ import PaymentContext from './PaymentContext';
 import PaymentForm from './PaymentForm';
 import {
     getUniquePaymentMethodId,
-    PaymentMethodId,
     PaymentMethodProviderType,
 } from './paymentMethod';
-
-interface PaymentMethodSelectionParams {
-    checkout: Checkout;
-    methods: PaymentMethod[];
-    consignments?: Consignment[];
-    getPaymentMethod: (methodId: string, gatewayId?: string) => PaymentMethod | undefined;
-    paymentProviderCustomer?: PaymentProviderCustomer;
-}
-
-const getDefaultPaymentMethod = ({
-    checkout,
-    consignments,
-    getPaymentMethod,
-    methods,
-    paymentProviderCustomer,
-}: PaymentMethodSelectionParams): { filteredMethods: PaymentMethod[]; defaultMethod?: PaymentMethod } => {
-    let filteredMethods = methods;
-
-    // TODO: In accordance with the checkout team, this functionality is temporary and will be implemented in the backend instead.
-    if (paymentProviderCustomer?.stripeLinkAuthenticationState) {
-        const stripeUpePaymentMethod = filteredMethods.filter(
-            (method) => method.id === 'card' && method.gateway === PaymentMethodId.StripeUPE,
-        );
-
-        filteredMethods = stripeUpePaymentMethod.length ? stripeUpePaymentMethod : filteredMethods;
-    }
-
-    filteredMethods = filteredMethods.filter((method: PaymentMethod) => {
-        if (method.id === PaymentMethodId.Bolt && method.initializationData) {
-            return Boolean(method.initializationData.showInCheckout);
-        }
-
-        return method.id !== PaymentMethodId.BraintreeLocalPaymentMethod;
-    });
-
-    if (consignments && consignments.length > 1) {
-        const multiShippingIncompatibleMethodIds: string[] = [
-            PaymentMethodId.AmazonPay,
-        ];
-
-        filteredMethods = filteredMethods.filter(
-            (method: PaymentMethod) => !multiShippingIncompatibleMethodIds.includes(method.id),
-        );
-    }
-
-    const selectedPayment = checkout.payments
-        ? find(checkout.payments, { providerType: PaymentMethodProviderType.Hosted })
-        : undefined;
-    let selectedPaymentMethod;
-
-    if (selectedPayment) {
-        selectedPaymentMethod = getPaymentMethod(
-            selectedPayment.providerId,
-            selectedPayment.gatewayId,
-        );
-        filteredMethods = selectedPaymentMethod ? compact([selectedPaymentMethod]) : filteredMethods;
-    } else {
-        selectedPaymentMethod = find(filteredMethods, {
-            config: { hasDefaultStoredInstrument: true },
-        });
-    }
-
-    return {
-        defaultMethod: selectedPaymentMethod || filteredMethods[0],
-        filteredMethods,
-    };
-};
+import { getFilteredPaymentMethodsWithDefault } from './paymentMethodFilters';
 
 export interface PaymentProps {
     errorLogger: ErrorLogger;
@@ -545,12 +476,13 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
         try {
             const updatedState = await loadPaymentMethods();
             const checkout = updatedState.data.getCheckout();
+            const config = updatedState.data.getConfig();
             const methods = updatedState.data.getPaymentMethods() || EMPTY_ARRAY;
 
-            const defaultMethod = checkout
-                ? getDefaultPaymentMethod({
+            const defaultMethod = (checkout && config)
+                ? getFilteredPaymentMethodsWithDefault({
                       checkout,
-                      consignments: updatedState.data.getConsignments(),
+                      checkoutSettings: config.checkoutSettings,
                       getPaymentMethod: updatedState.data.getPaymentMethod,
                       methods,
                       paymentProviderCustomer: updatedState.data.getPaymentProviderCustomer(),
@@ -756,9 +688,9 @@ export function mapToPaymentProps({
 
     const isTermsConditionsRequired = isTermsConditionsEnabled;
     const { isStoreCreditApplied } = checkout;
-    const { defaultMethod, filteredMethods } = getDefaultPaymentMethod({
+    const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
         checkout,
-        consignments,
+        checkoutSettings: config.checkoutSettings,
         getPaymentMethod,
         methods,
         paymentProviderCustomer,

--- a/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.test.ts
@@ -1,0 +1,107 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout, getCheckoutPayment } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getConsignment } from '../../shipping/consignment.mock';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { PaymentMethodId } from '../paymentMethod';
+
+import { applyPaymentMethodFilters } from './applyPaymentMethodFilters';
+import { type PaymentMethodFilterContext } from './types';
+
+describe('applyPaymentMethodFilters', () => {
+    const amazon: PaymentMethod = { ...getPaymentMethod(), id: PaymentMethodId.AmazonPay };
+    const boltVisible: PaymentMethod = {
+        ...getPaymentMethod(),
+        id: PaymentMethodId.Bolt,
+        initializationData: { showInCheckout: true },
+    };
+    const boltHidden: PaymentMethod = {
+        ...getPaymentMethod(),
+        id: PaymentMethodId.Bolt,
+        initializationData: { showInCheckout: false },
+    };
+    const braintreeLocal: PaymentMethod = {
+        ...getPaymentMethod(),
+        id: PaymentMethodId.BraintreeLocalPaymentMethod,
+    };
+    const stripeUpeCard: PaymentMethod = {
+        ...getPaymentMethod(),
+        id: 'card',
+        gateway: PaymentMethodId.StripeUPE,
+    };
+    const authorizenet: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
+
+    const baseContext = (): PaymentMethodFilterContext => ({
+        checkout: getCheckout(),
+        checkoutSettings: getStoreConfig().checkoutSettings,
+        getPaymentMethod: jest.fn(),
+        paymentProviderCustomer: undefined,
+    });
+
+    it('removes Braintree local methods and hidden Bolt by default', () => {
+        const result = applyPaymentMethodFilters(
+            [boltHidden, braintreeLocal, authorizenet],
+            baseContext(),
+        );
+
+        expect(result).toEqual([authorizenet]);
+    });
+
+    it('keeps a visible Bolt and unrelated methods', () => {
+        const result = applyPaymentMethodFilters([boltVisible, authorizenet], baseContext());
+
+        expect(result).toEqual([boltVisible, authorizenet]);
+    });
+
+    it('runs the multi-shipping filter when there is more than one consignment', () => {
+        const context: PaymentMethodFilterContext = {
+            ...baseContext(),
+            checkout: {
+                ...getCheckout(),
+                consignments: [getConsignment(), getConsignment()],
+            },
+        };
+
+        const result = applyPaymentMethodFilters([amazon, authorizenet], context);
+
+        expect(result).toEqual([authorizenet]);
+    });
+
+    it('runs the stripe link auth filter when authenticated', () => {
+        const context: PaymentMethodFilterContext = {
+            ...baseContext(),
+            paymentProviderCustomer: { stripeLinkAuthenticationState: true },
+        };
+
+        const result = applyPaymentMethodFilters([stripeUpeCard, authorizenet], context);
+
+        expect(result).toEqual([stripeUpeCard]);
+    });
+
+    it('returns only the selected hosted method when one is already on the checkout', () => {
+        const context: PaymentMethodFilterContext = {
+            ...baseContext(),
+            checkout: {
+                ...getCheckout(),
+                payments: [getCheckoutPayment('amazonpay')],
+            },
+            getPaymentMethod: jest.fn().mockReturnValue(amazon),
+        };
+
+        const result = applyPaymentMethodFilters([amazon, authorizenet], context);
+
+        expect(result).toEqual([amazon]);
+        expect(context.getPaymentMethod).toHaveBeenCalledWith('amazonpay', undefined);
+    });
+
+    it('returns the input untouched when no filter conditions apply', () => {
+        const result = applyPaymentMethodFilters([authorizenet], baseContext());
+
+        expect(result).toEqual([authorizenet]);
+    });
+
+    it('returns an empty list when given an empty list', () => {
+        expect(applyPaymentMethodFilters([], baseContext())).toEqual([]);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
@@ -1,0 +1,23 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { boltAndBraintreeFilter } from './boltAndBraintreeFilter';
+import { multiShippingFilter } from './multiShippingFilter';
+import { selectedHostedPaymentFilter } from './selectedHostedPaymentFilter';
+import { stripeLinkAuthFilter } from './stripeLinkAuthFilter';
+import { type PaymentMethodFilter, type PaymentMethodFilterContext } from './types';
+
+// Order matters. selectedHostedPaymentFilter must run last because it can
+// collapse the list to a single method when a hosted payment is already in flight.
+const FILTERS: PaymentMethodFilter[] = [
+    stripeLinkAuthFilter,
+    boltAndBraintreeFilter,
+    multiShippingFilter,
+    selectedHostedPaymentFilter,
+];
+
+export function applyPaymentMethodFilters(
+    methods: PaymentMethod[],
+    context: PaymentMethodFilterContext,
+): PaymentMethod[] {
+    return FILTERS.reduce((acc, filter) => filter.apply(acc, context), methods);
+}

--- a/packages/core/src/app/payment/paymentMethodFilters/boltAndBraintreeFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/boltAndBraintreeFilter.test.ts
@@ -1,0 +1,94 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { PaymentMethodId } from '../paymentMethod';
+
+import { boltAndBraintreeFilter } from './boltAndBraintreeFilter';
+import { type PaymentMethodFilterContext } from './types';
+
+describe('boltAndBraintreeFilter', () => {
+    let context: PaymentMethodFilterContext;
+
+    beforeEach(() => {
+        context = {
+            checkout: getCheckout(),
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            paymentProviderCustomer: undefined,
+        };
+    });
+
+    it('keeps Bolt when initializationData.showInCheckout is true', () => {
+        const boltVisible: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.Bolt,
+            initializationData: { showInCheckout: true },
+        };
+
+        expect(boltAndBraintreeFilter.apply([boltVisible], context)).toEqual([boltVisible]);
+    });
+
+    it('removes Bolt when initializationData.showInCheckout is false', () => {
+        const boltHidden: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.Bolt,
+            initializationData: { showInCheckout: false },
+        };
+
+        expect(boltAndBraintreeFilter.apply([boltHidden], context)).toEqual([]);
+    });
+
+    it('keeps Bolt when no initializationData is present', () => {
+        const boltWithoutInitData: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.Bolt,
+            initializationData: undefined,
+        };
+
+        expect(boltAndBraintreeFilter.apply([boltWithoutInitData], context)).toEqual([
+            boltWithoutInitData,
+        ]);
+    });
+
+    it('removes Braintree local payment methods', () => {
+        const braintreeLocal: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.BraintreeLocalPaymentMethod,
+        };
+
+        expect(boltAndBraintreeFilter.apply([braintreeLocal], context)).toEqual([]);
+    });
+
+    it('keeps unrelated payment methods untouched', () => {
+        const other: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
+
+        expect(boltAndBraintreeFilter.apply([other], context)).toEqual([other]);
+    });
+
+    it('filters a mixed list correctly', () => {
+        const boltVisible: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.Bolt,
+            initializationData: { showInCheckout: true },
+        };
+        const boltHidden: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.Bolt,
+            initializationData: { showInCheckout: false },
+        };
+        const braintreeLocal: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.BraintreeLocalPaymentMethod,
+        };
+        const other: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
+
+        expect(
+            boltAndBraintreeFilter.apply(
+                [boltVisible, boltHidden, braintreeLocal, other],
+                context,
+            ),
+        ).toEqual([boltVisible, other]);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/boltAndBraintreeFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/boltAndBraintreeFilter.ts
@@ -1,0 +1,16 @@
+import { PaymentMethodId } from '../paymentMethod';
+
+import { type PaymentMethodFilter } from './types';
+
+export const boltAndBraintreeFilter: PaymentMethodFilter = {
+    name: 'boltAndBraintree',
+    apply(methods) {
+        return methods.filter((method) => {
+            if (method.id === PaymentMethodId.Bolt && method.initializationData) {
+                return Boolean(method.initializationData.showInCheckout);
+            }
+
+            return method.id !== PaymentMethodId.BraintreeLocalPaymentMethod;
+        });
+    },
+};

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
@@ -1,0 +1,134 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout, getCheckoutPayment } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { PaymentMethodId } from '../paymentMethod';
+
+import { getFilteredPaymentMethodsWithDefault } from './getFilteredPaymentMethodsWithDefault';
+
+describe('getFilteredPaymentMethodsWithDefault', () => {
+    const checkoutSettings = getStoreConfig().checkoutSettings;
+
+    const buildMethod = (overrides: Partial<PaymentMethod>): PaymentMethod => ({
+        ...getPaymentMethod(),
+        ...overrides,
+    });
+
+    it('applies the filter pipeline and returns the filtered list', () => {
+        const braintreeLocal = buildMethod({ id: PaymentMethodId.BraintreeLocalPaymentMethod });
+        const authorizenet = buildMethod({ id: 'authorizenet' });
+
+        const { filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            checkout: getCheckout(),
+            checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            methods: [braintreeLocal, authorizenet],
+        });
+
+        expect(filteredMethods).toEqual([authorizenet]);
+    });
+
+    it('selects the first filtered method as default when nothing else qualifies', () => {
+        const first = buildMethod({ id: 'authorizenet' });
+        const second = buildMethod({ id: 'paypalexpress' });
+
+        const { defaultMethod } = getFilteredPaymentMethodsWithDefault({
+            checkout: getCheckout(),
+            checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            methods: [first, second],
+        });
+
+        expect(defaultMethod).toEqual(first);
+    });
+
+    it('selects the method with a default stored instrument as default', () => {
+        const plain = buildMethod({ id: 'authorizenet' });
+        const withDefault = buildMethod({
+            id: 'paypalexpress',
+            config: { ...getPaymentMethod().config, hasDefaultStoredInstrument: true },
+        });
+
+        const { defaultMethod } = getFilteredPaymentMethodsWithDefault({
+            checkout: getCheckout(),
+            checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            methods: [plain, withDefault],
+        });
+
+        expect(defaultMethod).toEqual(withDefault);
+    });
+
+    it('returns the selected hosted method as both the only option and the default', () => {
+        const amazon = buildMethod({ id: 'amazonpay' });
+        const checkout = {
+            ...getCheckout(),
+            payments: [getCheckoutPayment('amazonpay')],
+        };
+
+        const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            checkout,
+            checkoutSettings,
+            getPaymentMethod: jest.fn().mockReturnValue(amazon),
+            methods: [amazon, buildMethod({ id: 'authorizenet' })],
+        });
+
+        expect(filteredMethods).toEqual([amazon]);
+        expect(defaultMethod).toEqual(amazon);
+    });
+
+    it('prefers the selected hosted method over a method with hasDefaultStoredInstrument', () => {
+        const amazon = buildMethod({ id: 'amazonpay' });
+        const cardWithDefault = buildMethod({
+            id: 'authorizenet',
+            config: { ...getPaymentMethod().config, hasDefaultStoredInstrument: true },
+        });
+        const checkout = {
+            ...getCheckout(),
+            payments: [getCheckoutPayment('amazonpay')],
+        };
+
+        const { defaultMethod } = getFilteredPaymentMethodsWithDefault({
+            checkout,
+            checkoutSettings,
+            getPaymentMethod: jest.fn().mockReturnValue(amazon),
+            methods: [amazon, cardWithDefault],
+        });
+
+        expect(defaultMethod).toEqual(amazon);
+    });
+
+    it('honours stripe link authentication by collapsing to Stripe UPE card method', () => {
+        const stripeUpeCard = buildMethod({
+            id: 'card',
+            gateway: PaymentMethodId.StripeUPE,
+        });
+        const other = buildMethod({ id: 'authorizenet' });
+
+        const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            checkout: getCheckout(),
+            checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            methods: [stripeUpeCard, other],
+            paymentProviderCustomer: { stripeLinkAuthenticationState: true },
+        });
+
+        expect(filteredMethods).toEqual([stripeUpeCard]);
+        expect(defaultMethod).toEqual(stripeUpeCard);
+    });
+
+    it('returns an undefined defaultMethod when filtering produces no methods', () => {
+        const braintreeLocal = buildMethod({ id: PaymentMethodId.BraintreeLocalPaymentMethod });
+
+        const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            checkout: getCheckout(),
+            checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            methods: [braintreeLocal],
+        });
+
+        expect(filteredMethods).toEqual([]);
+        expect(defaultMethod).toBeUndefined();
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
@@ -1,0 +1,63 @@
+import {
+    type Checkout,
+    type CheckoutSettings,
+    type PaymentMethod,
+    type PaymentProviderCustomer,
+} from '@bigcommerce/checkout-sdk';
+import { find } from 'lodash';
+
+import { PaymentMethodProviderType } from '../paymentMethod';
+
+import { applyPaymentMethodFilters } from './applyPaymentMethodFilters';
+
+export interface PaymentMethodSelectionProps {
+    checkout: Checkout;
+    checkoutSettings: CheckoutSettings; // this is for passing experiment flags, we don't have any experiment in filters currently.
+    methods: PaymentMethod[];
+    getPaymentMethod: (methodId: string, gatewayId?: string) => PaymentMethod | undefined;
+    paymentProviderCustomer?: PaymentProviderCustomer;
+}
+
+export interface DefaultPaymentMethodResult {
+    filteredMethods: PaymentMethod[];
+    defaultMethod?: PaymentMethod;
+}
+
+const selectDefaultMethod = (
+    filteredMethods: PaymentMethod[],
+    checkout: Checkout,
+): PaymentMethod | undefined => {
+    const hasSelectedHostedPayment = checkout.payments
+        ? Boolean(find(checkout.payments, { providerType: PaymentMethodProviderType.Hosted }))
+        : false;
+
+    if (hasSelectedHostedPayment) {
+        return filteredMethods[0];
+    }
+
+    const methodWithDefaultStoredInstrument = find(filteredMethods, {
+        config: { hasDefaultStoredInstrument: true },
+    });
+
+    return methodWithDefaultStoredInstrument || filteredMethods[0];
+};
+
+export const getFilteredPaymentMethodsWithDefault = ({
+    checkout,
+    checkoutSettings,
+    getPaymentMethod,
+    methods,
+    paymentProviderCustomer,
+}: PaymentMethodSelectionProps): DefaultPaymentMethodResult => {
+    const filteredMethods = applyPaymentMethodFilters(methods, {
+        checkout,
+        checkoutSettings,
+        getPaymentMethod,
+        paymentProviderCustomer,
+    });
+
+    return {
+        defaultMethod: selectDefaultMethod(filteredMethods, checkout),
+        filteredMethods,
+    };
+};

--- a/packages/core/src/app/payment/paymentMethodFilters/index.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/index.ts
@@ -1,0 +1,1 @@
+export { getFilteredPaymentMethodsWithDefault } from './getFilteredPaymentMethodsWithDefault';

--- a/packages/core/src/app/payment/paymentMethodFilters/multiShippingFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/multiShippingFilter.test.ts
@@ -1,0 +1,55 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getConsignment } from '../../shipping/consignment.mock';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { PaymentMethodId } from '../paymentMethod';
+
+import { multiShippingFilter } from './multiShippingFilter';
+import { type PaymentMethodFilterContext } from './types';
+
+describe('multiShippingFilter', () => {
+    const amazonPay: PaymentMethod = { ...getPaymentMethod(), id: PaymentMethodId.AmazonPay };
+    const otherMethod: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
+
+    const buildContext = (consignmentCount: number): PaymentMethodFilterContext => ({
+        checkout: {
+            ...getCheckout(),
+            consignments: Array.from({ length: consignmentCount }, () => getConsignment()),
+        },
+        checkoutSettings: getStoreConfig().checkoutSettings,
+        getPaymentMethod: jest.fn(),
+        paymentProviderCustomer: undefined,
+    });
+
+    it('returns the original methods when there are no consignments', () => {
+        const methods = [amazonPay, otherMethod];
+
+        expect(multiShippingFilter.apply(methods, buildContext(0))).toEqual(methods);
+    });
+
+    it('returns the original methods when there is exactly one consignment', () => {
+        const methods = [amazonPay, otherMethod];
+
+        expect(multiShippingFilter.apply(methods, buildContext(1))).toEqual(methods);
+    });
+
+    it('removes incompatible methods (e.g. Amazon Pay) when there are multiple consignments', () => {
+        const methods = [amazonPay, otherMethod];
+
+        expect(multiShippingFilter.apply(methods, buildContext(2))).toEqual([otherMethod]);
+    });
+
+    it('returns the original methods when checkout.consignments is undefined', () => {
+        const context: PaymentMethodFilterContext = {
+            checkout: { ...getCheckout(), consignments: undefined as never },
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            paymentProviderCustomer: undefined,
+        };
+        const methods = [amazonPay, otherMethod];
+
+        expect(multiShippingFilter.apply(methods, context)).toEqual(methods);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/multiShippingFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/multiShippingFilter.ts
@@ -1,0 +1,18 @@
+import { PaymentMethodId } from '../paymentMethod';
+
+import { type PaymentMethodFilter } from './types';
+
+const MULTI_SHIPPING_INCOMPATIBLE_METHOD_IDS: string[] = [PaymentMethodId.AmazonPay];
+
+export const multiShippingFilter: PaymentMethodFilter = {
+    name: 'multiShipping',
+    apply(methods, { checkout }) {
+        if (!checkout.consignments || checkout.consignments.length <= 1) {
+            return methods;
+        }
+
+        return methods.filter(
+            (method) => !MULTI_SHIPPING_INCOMPATIBLE_METHOD_IDS.includes(method.id),
+        );
+    },
+};

--- a/packages/core/src/app/payment/paymentMethodFilters/selectedHostedPaymentFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/selectedHostedPaymentFilter.test.ts
@@ -1,0 +1,77 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout, getCheckoutPayment } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { PaymentMethodProviderType } from '../paymentMethod';
+
+import { selectedHostedPaymentFilter } from './selectedHostedPaymentFilter';
+import { type PaymentMethodFilterContext } from './types';
+
+describe('selectedHostedPaymentFilter', () => {
+    const amazon: PaymentMethod = { ...getPaymentMethod(), id: 'amazonpay' };
+    const other: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
+
+    it('returns the original methods when no payments are present on the checkout', () => {
+        const context: PaymentMethodFilterContext = {
+            checkout: { ...getCheckout(), payments: undefined },
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            paymentProviderCustomer: undefined,
+        };
+        const methods = [amazon, other];
+
+        expect(selectedHostedPaymentFilter.apply(methods, context)).toEqual(methods);
+    });
+
+    it('returns the original methods when only non-hosted payments are on the checkout', () => {
+        const context: PaymentMethodFilterContext = {
+            checkout: {
+                ...getCheckout(),
+                payments: [
+                    {
+                        ...getCheckoutPayment(),
+                        providerType: PaymentMethodProviderType.Api,
+                    },
+                ],
+            },
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            paymentProviderCustomer: undefined,
+        };
+        const methods = [amazon, other];
+
+        expect(selectedHostedPaymentFilter.apply(methods, context)).toEqual(methods);
+    });
+
+    it('returns only the selected hosted method when it is resolvable from the registry', () => {
+        const getPaymentMethodMock = jest.fn().mockReturnValue(amazon);
+        const context: PaymentMethodFilterContext = {
+            checkout: {
+                ...getCheckout(),
+                payments: [getCheckoutPayment('amazonpay')],
+            },
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: getPaymentMethodMock,
+            paymentProviderCustomer: undefined,
+        };
+
+        expect(selectedHostedPaymentFilter.apply([amazon, other], context)).toEqual([amazon]);
+        expect(getPaymentMethodMock).toHaveBeenCalledWith('amazonpay', undefined);
+    });
+
+    it('returns the original methods when the selected hosted method cannot be resolved', () => {
+        const context: PaymentMethodFilterContext = {
+            checkout: {
+                ...getCheckout(),
+                payments: [getCheckoutPayment('amazonpay')],
+            },
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn().mockReturnValue(undefined),
+            paymentProviderCustomer: undefined,
+        };
+        const methods = [amazon, other];
+
+        expect(selectedHostedPaymentFilter.apply(methods, context)).toEqual(methods);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/selectedHostedPaymentFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/selectedHostedPaymentFilter.ts
@@ -1,0 +1,25 @@
+import { compact, find } from 'lodash';
+
+import { PaymentMethodProviderType } from '../paymentMethod';
+
+import { type PaymentMethodFilter } from './types';
+
+export const selectedHostedPaymentFilter: PaymentMethodFilter = {
+    name: 'selectedHostedPayment',
+    apply(methods, { checkout, getPaymentMethod }) {
+        const selectedPayment = checkout.payments
+            ? find(checkout.payments, { providerType: PaymentMethodProviderType.Hosted })
+            : undefined;
+
+        if (!selectedPayment) {
+            return methods;
+        }
+
+        const selectedPaymentMethod = getPaymentMethod(
+            selectedPayment.providerId,
+            selectedPayment.gatewayId,
+        );
+
+        return selectedPaymentMethod ? compact([selectedPaymentMethod]) : methods;
+    },
+};

--- a/packages/core/src/app/payment/paymentMethodFilters/stripeLinkAuthFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/stripeLinkAuthFilter.test.ts
@@ -1,0 +1,89 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { PaymentMethodId } from '../paymentMethod';
+
+import { stripeLinkAuthFilter } from './stripeLinkAuthFilter';
+import { type PaymentMethodFilterContext } from './types';
+
+describe('stripeLinkAuthFilter', () => {
+    let context: PaymentMethodFilterContext;
+    let stripeUpeCard: PaymentMethod;
+    let otherMethod: PaymentMethod;
+
+    beforeEach(() => {
+        stripeUpeCard = {
+            ...getPaymentMethod(),
+            id: 'card',
+            gateway: PaymentMethodId.StripeUPE,
+        };
+        otherMethod = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.Bolt,
+        };
+
+        context = {
+            checkout: getCheckout(),
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            paymentProviderCustomer: undefined,
+        };
+    });
+
+    it('returns the original methods when no payment provider customer is set', () => {
+        const methods = [stripeUpeCard, otherMethod];
+
+        expect(stripeLinkAuthFilter.apply(methods, context)).toEqual(methods);
+    });
+
+    it('returns the original methods when stripeLinkAuthenticationState is false', () => {
+        const methods = [stripeUpeCard, otherMethod];
+
+        expect(
+            stripeLinkAuthFilter.apply(methods, {
+                ...context,
+                paymentProviderCustomer: { stripeLinkAuthenticationState: false },
+            }),
+        ).toEqual(methods);
+    });
+
+    it('keeps only Stripe UPE card method when authenticated and a Stripe UPE card method exists', () => {
+        const methods = [stripeUpeCard, otherMethod];
+
+        expect(
+            stripeLinkAuthFilter.apply(methods, {
+                ...context,
+                paymentProviderCustomer: { stripeLinkAuthenticationState: true },
+            }),
+        ).toEqual([stripeUpeCard]);
+    });
+
+    it('falls back to the original methods when authenticated but no Stripe UPE card is available', () => {
+        const methods = [otherMethod];
+
+        expect(
+            stripeLinkAuthFilter.apply(methods, {
+                ...context,
+                paymentProviderCustomer: { stripeLinkAuthenticationState: true },
+            }),
+        ).toEqual(methods);
+    });
+
+    it('does not match a Stripe UPE method whose id is not "card"', () => {
+        const stripeUpeNonCard = {
+            ...getPaymentMethod(),
+            id: 'ideal',
+            gateway: PaymentMethodId.StripeUPE,
+        };
+        const methods = [stripeUpeNonCard, otherMethod];
+
+        expect(
+            stripeLinkAuthFilter.apply(methods, {
+                ...context,
+                paymentProviderCustomer: { stripeLinkAuthenticationState: true },
+            }),
+        ).toEqual(methods);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/stripeLinkAuthFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/stripeLinkAuthFilter.ts
@@ -1,0 +1,19 @@
+import { PaymentMethodId } from '../paymentMethod';
+
+import { type PaymentMethodFilter } from './types';
+
+// TODO: In accordance with the checkout team, this functionality is temporary and will be implemented in the backend instead.
+export const stripeLinkAuthFilter: PaymentMethodFilter = {
+    name: 'stripeLinkAuth',
+    apply(methods, { paymentProviderCustomer }) {
+        if (!paymentProviderCustomer?.stripeLinkAuthenticationState) {
+            return methods;
+        }
+
+        const stripeUpeMethods = methods.filter(
+            (method) => method.id === 'card' && method.gateway === PaymentMethodId.StripeUPE,
+        );
+
+        return stripeUpeMethods.length ? stripeUpeMethods : methods;
+    },
+};

--- a/packages/core/src/app/payment/paymentMethodFilters/types.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/types.ts
@@ -1,0 +1,18 @@
+import {
+    type Checkout,
+    type CheckoutSettings,
+    type PaymentMethod,
+    type PaymentProviderCustomer,
+} from '@bigcommerce/checkout-sdk';
+
+export interface PaymentMethodFilterContext {
+    checkout: Checkout;
+    checkoutSettings: CheckoutSettings;
+    getPaymentMethod: (methodId: string, gatewayId?: string) => PaymentMethod | undefined;
+    paymentProviderCustomer?: PaymentProviderCustomer;
+}
+
+export interface PaymentMethodFilter {
+    name: string;
+    apply(methods: PaymentMethod[], context: PaymentMethodFilterContext): PaymentMethod[];
+}


### PR DESCRIPTION
## What/Why?

Refactors payment method filtering in [Payment.tsx](packages/core/src/app/payment/Payment.tsx) by extracting the inline filter logic into a dedicated `paymentMethodFilters/` module with a pluggable `PaymentMethodFilter` interface.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the logic that determines which payment methods are shown and which is selected by default, which can affect checkout completion if filtering/selection differs from prior behavior. Mitigated by comprehensive new unit tests, but still touches critical payment-flow UX.
> 
> **Overview**
> Refactors checkout payment method selection by moving the inline filtering/default-method logic out of `Payment.tsx` into a new `paymentMethodFilters/` module and switching `Payment.tsx` to call `getFilteredPaymentMethodsWithDefault` (now requiring `checkoutSettings` from config).
> 
> Introduces a small filter pipeline (`applyPaymentMethodFilters`) with pluggable `PaymentMethodFilter` implementations for **Stripe Link-auth narrowing**, **Bolt visibility + Braintree local removal**, **multi-shipping incompatibilities (e.g. Amazon Pay)**, and **locking to an in-flight hosted payment method**, plus unit tests covering the combined behavior and default-method selection rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7693cefeccba013d53085fcd1c3cfe8fe2bebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->