### PR TITLE
fix(payment): Hide buttons that was cashed by checkout-settings 'remoteCheckoutProviders'

### DIFF
--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -123,14 +123,14 @@ function mapToCheckoutButtonContainerProps({
     checkoutService,
 }: CheckoutContextProps): WithCheckoutCheckoutButtonContainerProps | null {
     const {
-        data: { getConfig, getCustomer, isPaymentDataRequired },
+        data: { getConfig, getCustomer, isPaymentDataRequired, getPaymentMethods },
         statuses: { isInitializedCustomer },
         errors: { getInitializeCustomerError },
     } = checkoutState;
     const config = getConfig();
     const providers = config?.checkoutSettings.remoteCheckoutProviders ?? [];
-
-    const availableMethodIds = getSupportedMethodIds(providers);
+    const paymentMethods = getPaymentMethods();
+    const availableMethodIds = getSupportedMethodIds(providers, paymentMethods);
     const customer = getCustomer();
 
     if (!isPaymentDataRequired()) {

--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -51,7 +51,8 @@ const CheckoutButtonList: FunctionComponent<
     onError,
 }) => {
     const { language } = useLocale();
-    const supportedMethodIds = getSupportedMethodIds(methodIds);
+    const paymentMethods = checkoutState.data.getPaymentMethods();
+    const supportedMethodIds = getSupportedMethodIds(methodIds, paymentMethods);
 
     if (supportedMethodIds.length === 0) {
         return null;

--- a/packages/core/src/app/customer/getSupportedMethods.test.ts
+++ b/packages/core/src/app/customer/getSupportedMethods.test.ts
@@ -1,4 +1,13 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
 import { getSupportedMethodIds } from './getSupportedMethods';
+import { getPaymentMethod } from '@bigcommerce/checkout/test-mocks';
+
+const buildPaymentMethod = (id: string, isHidden?: boolean): PaymentMethod => ({
+    ...getPaymentMethod(),
+    id,
+    initializationData: isHidden === undefined ? undefined : { isHidden },
+});
 
 describe('getSupportedMethods', () => {
     it('filters out unsupported methods', () => {
@@ -7,5 +16,61 @@ describe('getSupportedMethods', () => {
         const filteredMethods = getSupportedMethodIds(methods);
 
         expect(filteredMethods).toEqual(['amazonpay']);
+    });
+
+    it('filters out supported methods flagged as hidden via initializationData.isHidden', () => {
+        const methods = ['amazonpay', 'applepay', 'paypalcommerce'];
+        const loadedPaymentMethods = [
+            buildPaymentMethod('applepay', true),
+            buildPaymentMethod('paypalcommerce', false),
+        ];
+
+        const filteredMethods = getSupportedMethodIds(methods, loadedPaymentMethods);
+
+        expect(filteredMethods).toEqual(['amazonpay', 'paypalcommerce']);
+    });
+
+    it('keeps supported methods when initializationData is missing', () => {
+        const methods = ['amazonpay', 'applepay'];
+        const loadedPaymentMethods = [
+            buildPaymentMethod('amazonpay'),
+            buildPaymentMethod('applepay'),
+        ];
+
+        const filteredMethods = getSupportedMethodIds(methods, loadedPaymentMethods);
+
+        expect(filteredMethods).toEqual(['amazonpay', 'applepay']);
+    });
+
+    it('ignores hidden methods that are not in the supported list', () => {
+        const methods = ['amazonpay'];
+        const loadedPaymentMethods = [
+            buildPaymentMethod('authorizenet', true),
+            buildPaymentMethod('amazonpay', false),
+        ];
+
+        const filteredMethods = getSupportedMethodIds(methods, loadedPaymentMethods);
+
+        expect(filteredMethods).toEqual(['amazonpay']);
+    });
+
+    it('returns an empty array when every supported method is hidden', () => {
+        const methods = ['applepay', 'googlepaybraintree'];
+        const loadedPaymentMethods = [
+            buildPaymentMethod('applepay', true),
+            buildPaymentMethod('googlepaybraintree', true),
+        ];
+
+        const filteredMethods = getSupportedMethodIds(methods, loadedPaymentMethods);
+
+        expect(filteredMethods).toEqual([]);
+    });
+
+    it('treats an empty loadedPaymentMethods list as no methods hidden', () => {
+        const methods = ['amazonpay', 'applepay'];
+
+        const filteredMethods = getSupportedMethodIds(methods, []);
+
+        expect(filteredMethods).toEqual(['amazonpay', 'applepay']);
     });
 });

--- a/packages/core/src/app/customer/getSupportedMethods.ts
+++ b/packages/core/src/app/customer/getSupportedMethods.ts
@@ -1,3 +1,5 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
 const APPLE_PAY = 'applepay';
 
 // TODO: The API should tell UI which payment method offers its own checkout button
@@ -32,6 +34,15 @@ export const SUPPORTED_METHODS: string[] = [
     'googlepay_bigcommerce_payments',
 ];
 
-export const getSupportedMethodIds = (methodIds: string[]): string[] => {
-    return methodIds.filter((methodId) => SUPPORTED_METHODS.includes(methodId));
+export const getSupportedMethodIds = (
+    requestedMethodIds: string[],
+    loadedPaymentMethods: PaymentMethod[] = [],
+): string[] => {
+    const hiddenMethodIds = loadedPaymentMethods
+        .filter((method) => method.initializationData?.isHidden)
+        .map((method) => method.id);
+
+    return requestedMethodIds.filter(
+        (methodId) => SUPPORTED_METHODS.includes(methodId) && !hiddenMethodIds.includes(methodId),
+    );
 };


### PR DESCRIPTION
## What/Why?
Add logic to hide payment methods that can not be processed but cashed for some time and returns in `checkoutSettings.remoteCheckoutProviders` array.

## Rollout/Rollback
Rollback this PR.

## Testing
Before:

https://github.com/user-attachments/assets/95e5e778-3fd6-4f8f-bd58-ed3f0b136ae9

After:


https://github.com/user-attachments/assets/ceed81be-2afd-4a91-a963-193f250eb08d


https://github.com/user-attachments/assets/1cdac521-55db-49f6-a859-cdb6705d8fd6

<img width="607" height="84" alt="Screenshot 2026-05-27 at 19 24 38" src="https://github.com/user-attachments/assets/41c28939-e0e2-4312-bfbe-894ecbfef187" />





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout UI filtering only; backward-compatible optional parameter with tests and no auth or payment processing changes.
> 
> **Overview**
> Remote/wallet checkout buttons no longer appear for payment methods that are still listed in cached **`remoteCheckoutProviders`** but are marked unavailable via **`initializationData.isHidden`** on loaded payment methods.
> 
> **`getSupportedMethodIds`** now takes an optional second argument (`loadedPaymentMethods`) and excludes hidden method IDs in addition to the existing supported-method allowlist. **`CheckoutButtonContainer`** and **`CheckoutButtonList`** pass **`getPaymentMethods()`** into that helper so the UI matches live payment-method state. Unit tests cover hidden flags, missing initialization data, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf60e03a7530fb3951667f3fbcbcc4b7b8848db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->