### PR TITLE
feat(checkout): CHECKOUT-9817 Add excludePPSDKFilter

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -136,7 +136,11 @@ const Checkout = ({
                       subscribeToConsignments,
                       themeV2
                   }: CheckoutPageProps):ReactElement => {
-    const { userJourney: { requiresB2BToken } } = useCapabilities();
+    const capabilities = useCapabilities();
+    const {
+        userJourney: { requiresB2BToken },
+        orderConfirmation: { invoiceRedirect },
+    } = capabilities;
     const { fetchB2BToken } = useB2BToken();
 
     const [state, setState] = useState<CheckoutState>({
@@ -159,8 +163,6 @@ const Checkout = ({
     }>({
         hasSelectedShippingOptions: state.hasSelectedShippingOptions,
     });
-
-    const { orderConfirmation: { invoiceRedirect } } = useCapabilities();
 
     const navigateToStep = useCallback((type: CheckoutStepType, options?: { isDefault?: boolean }):void => {
         const step = find(stepsRef.current, { type });
@@ -460,6 +462,7 @@ const Checkout = ({
 
             case CheckoutStepType.Payment:
                 return <PaymentStep
+                    capabilities={capabilities}
                     cart={cart}
                     checkEmbeddedSupport={checkEmbeddedSupport}
                     consignments={consignments}

--- a/packages/core/src/app/checkout/components/PaymentStep.tsx
+++ b/packages/core/src/app/checkout/components/PaymentStep.tsx
@@ -35,6 +35,7 @@ export interface PaymentStepProps extends PaymentProps {
 const PaymentStep = ({
     step,
     cart,
+    capabilities,
     consignments,
     errorLogger,
     onEdit,
@@ -56,6 +57,7 @@ const PaymentStep = ({
     >
         <LazyContainer loadingSkeleton={<ChecklistSkeleton />}>
             <Payment
+                capabilities={capabilities}
                 checkEmbeddedSupport={checkEmbeddedSupport}
                 errorLogger={errorLogger}
                 isEmbedded={isEmbedded()}

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -1,4 +1,5 @@
 import {
+    type Capabilities,
     type Cart,
     type CartStockPositionsChangedError,
     type CheckoutSelectors,
@@ -59,6 +60,7 @@ import {
 import { getFilteredPaymentMethodsWithDefault } from './paymentMethodFilters';
 
 export interface PaymentProps {
+    capabilities: Capabilities;
     errorLogger: ErrorLogger;
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
@@ -486,6 +488,7 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
                       getPaymentMethod: updatedState.data.getPaymentMethod,
                       methods,
                       paymentProviderCustomer: updatedState.data.getPaymentProviderCustomer(),
+                      capabilities: props.capabilities,
                   }).defaultMethod
                 : undefined;
             const selectedMethod = state.selectedMethod || defaultMethod;
@@ -644,10 +647,10 @@ const Payment= (props: PaymentProps & WithCheckoutPaymentProps & WithLanguagePro
     );
 }
 
-export function mapToPaymentProps({
-        checkoutService,
-        checkoutState,
-}: CheckoutContextProps): WithCheckoutPaymentProps | null {
+export function mapToPaymentProps(
+    { checkoutService, checkoutState }: CheckoutContextProps,
+    { capabilities } : PaymentProps,
+): WithCheckoutPaymentProps | null {
     const {
         data: {
             getCart,
@@ -694,6 +697,7 @@ export function mapToPaymentProps({
         getPaymentMethod,
         methods,
         paymentProviderCustomer,
+        capabilities,
     });
 
     return {

--- a/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.test.ts
@@ -1,5 +1,7 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+
 import { getCheckout, getCheckoutPayment } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getConsignment } from '../../shipping/consignment.mock';
@@ -33,6 +35,7 @@ describe('applyPaymentMethodFilters', () => {
     const authorizenet: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
 
     const baseContext = (): PaymentMethodFilterContext => ({
+        capabilities: defaultCapabilities,
         checkout: getCheckout(),
         checkoutSettings: getStoreConfig().checkoutSettings,
         getPaymentMethod: jest.fn(),

--- a/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
@@ -1,6 +1,7 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
 import { boltAndBraintreeFilter } from './boltAndBraintreeFilter';
+import { excludePPSDKFilter } from './excludePPSDKFilter';
 import { multiShippingFilter } from './multiShippingFilter';
 import { selectedHostedPaymentFilter } from './selectedHostedPaymentFilter';
 import { stripeLinkAuthFilter } from './stripeLinkAuthFilter';
@@ -12,6 +13,7 @@ const FILTERS: PaymentMethodFilter[] = [
     stripeLinkAuthFilter,
     boltAndBraintreeFilter,
     multiShippingFilter,
+    excludePPSDKFilter,
     selectedHostedPaymentFilter,
 ];
 

--- a/packages/core/src/app/payment/paymentMethodFilters/boltAndBraintreeFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/boltAndBraintreeFilter.test.ts
@@ -1,5 +1,7 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+
 import { getCheckout } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getPaymentMethod } from '../payment-methods.mock';
@@ -13,6 +15,7 @@ describe('boltAndBraintreeFilter', () => {
 
     beforeEach(() => {
         context = {
+            capabilities: defaultCapabilities,
             checkout: getCheckout(),
             checkoutSettings: getStoreConfig().checkoutSettings,
             getPaymentMethod: jest.fn(),

--- a/packages/core/src/app/payment/paymentMethodFilters/excludePPSDKFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/excludePPSDKFilter.test.ts
@@ -1,0 +1,47 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getPaymentMethod } from '../payment-methods.mock';
+import { PaymentMethodProviderType } from '../paymentMethod';
+
+import { excludePPSDKFilter } from './excludePPSDKFilter';
+import { type PaymentMethodFilterContext } from './types';
+
+describe('excludePPSDKFilter', () => {
+    const ppsdkMethod: PaymentMethod = {
+        ...getPaymentMethod(),
+        id: 'ppsdk-provider',
+        type: PaymentMethodProviderType.PPSDK,
+    };
+    const apiMethod: PaymentMethod = {
+        ...getPaymentMethod(),
+        id: 'authorizenet',
+        type: PaymentMethodProviderType.Api,
+    };
+
+    const buildContext = (excludePPSDK: boolean): PaymentMethodFilterContext => ({
+        capabilities: {
+            ...defaultCapabilities,
+            payment: { ...defaultCapabilities.payment, excludePPSDK },
+        },
+        checkout: getCheckout(),
+        checkoutSettings: getStoreConfig().checkoutSettings,
+        getPaymentMethod: jest.fn(),
+        paymentProviderCustomer: undefined,
+    });
+
+    it('returns the original methods when capabilities.payment.excludePPSDK is false', () => {
+        const methods = [ppsdkMethod, apiMethod];
+
+        expect(excludePPSDKFilter.apply(methods, buildContext(false))).toEqual(methods);
+    });
+
+    it('removes PPSDK methods when capabilities.payment.excludePPSDK is true', () => {
+        const methods = [ppsdkMethod, apiMethod];
+
+        expect(excludePPSDKFilter.apply(methods, buildContext(true))).toEqual([apiMethod]);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/excludePPSDKFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/excludePPSDKFilter.ts
@@ -1,0 +1,14 @@
+import { PaymentMethodProviderType } from '../paymentMethod';
+
+import { type PaymentMethodFilter } from './types';
+
+export const excludePPSDKFilter: PaymentMethodFilter = {
+    name: 'excludePPSDK',
+    apply(methods, { capabilities }) {
+        if (!capabilities.payment.excludePPSDK) {
+            return methods;
+        }
+
+        return methods.filter((method) => method.type !== PaymentMethodProviderType.PPSDK);
+    },
+};

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.test.ts
@@ -1,9 +1,11 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+
 import { getCheckout, getCheckoutPayment } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getPaymentMethod } from '../payment-methods.mock';
-import { PaymentMethodId } from '../paymentMethod';
+import { PaymentMethodId, PaymentMethodProviderType } from '../paymentMethod';
 
 import { getFilteredPaymentMethodsWithDefault } from './getFilteredPaymentMethodsWithDefault';
 
@@ -20,6 +22,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         const authorizenet = buildMethod({ id: 'authorizenet' });
 
         const { filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
             checkout: getCheckout(),
             checkoutSettings,
             getPaymentMethod: jest.fn(),
@@ -34,6 +37,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         const second = buildMethod({ id: 'paypalexpress' });
 
         const { defaultMethod } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
             checkout: getCheckout(),
             checkoutSettings,
             getPaymentMethod: jest.fn(),
@@ -51,6 +55,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         });
 
         const { defaultMethod } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
             checkout: getCheckout(),
             checkoutSettings,
             getPaymentMethod: jest.fn(),
@@ -68,6 +73,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         };
 
         const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
             checkout,
             checkoutSettings,
             getPaymentMethod: jest.fn().mockReturnValue(amazon),
@@ -90,6 +96,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         };
 
         const { defaultMethod } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
             checkout,
             checkoutSettings,
             getPaymentMethod: jest.fn().mockReturnValue(amazon),
@@ -107,6 +114,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         const other = buildMethod({ id: 'authorizenet' });
 
         const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
             checkout: getCheckout(),
             checkoutSettings,
             getPaymentMethod: jest.fn(),
@@ -122,6 +130,7 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
         const braintreeLocal = buildMethod({ id: PaymentMethodId.BraintreeLocalPaymentMethod });
 
         const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            capabilities: defaultCapabilities,
             checkout: getCheckout(),
             checkoutSettings,
             getPaymentMethod: jest.fn(),
@@ -130,5 +139,27 @@ describe('getFilteredPaymentMethodsWithDefault', () => {
 
         expect(filteredMethods).toEqual([]);
         expect(defaultMethod).toBeUndefined();
+    });
+
+    it('excludes PPSDK methods when capabilities.payment.excludePPSDK is true', () => {
+        const ppsdk = buildMethod({
+            id: 'ppsdk-provider',
+            type: PaymentMethodProviderType.PPSDK,
+        });
+        const authorizenet = buildMethod({ id: 'authorizenet' });
+
+        const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
+            capabilities: {
+                ...defaultCapabilities,
+                payment: { ...defaultCapabilities.payment, excludePPSDK: true },
+            },
+            checkout: getCheckout(),
+            checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            methods: [ppsdk, authorizenet],
+        });
+
+        expect(filteredMethods).toEqual([authorizenet]);
+        expect(defaultMethod).toEqual(authorizenet);
     });
 });

--- a/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/getFilteredPaymentMethodsWithDefault.ts
@@ -1,4 +1,5 @@
 import {
+    type Capabilities,
     type Checkout,
     type CheckoutSettings,
     type PaymentMethod,
@@ -11,6 +12,7 @@ import { PaymentMethodProviderType } from '../paymentMethod';
 import { applyPaymentMethodFilters } from './applyPaymentMethodFilters';
 
 export interface PaymentMethodSelectionProps {
+    capabilities: Capabilities;
     checkout: Checkout;
     checkoutSettings: CheckoutSettings; // this is for passing experiment flags, we don't have any experiment in filters currently.
     methods: PaymentMethod[];
@@ -48,12 +50,14 @@ export const getFilteredPaymentMethodsWithDefault = ({
     getPaymentMethod,
     methods,
     paymentProviderCustomer,
+    capabilities,
 }: PaymentMethodSelectionProps): DefaultPaymentMethodResult => {
     const filteredMethods = applyPaymentMethodFilters(methods, {
         checkout,
         checkoutSettings,
         getPaymentMethod,
         paymentProviderCustomer,
+        capabilities,
     });
 
     return {

--- a/packages/core/src/app/payment/paymentMethodFilters/multiShippingFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/multiShippingFilter.test.ts
@@ -1,5 +1,7 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+
 import { getCheckout } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getConsignment } from '../../shipping/consignment.mock';
@@ -14,6 +16,7 @@ describe('multiShippingFilter', () => {
     const otherMethod: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
 
     const buildContext = (consignmentCount: number): PaymentMethodFilterContext => ({
+        capabilities: defaultCapabilities,
         checkout: {
             ...getCheckout(),
             consignments: Array.from({ length: consignmentCount }, () => getConsignment()),
@@ -43,6 +46,7 @@ describe('multiShippingFilter', () => {
 
     it('returns the original methods when checkout.consignments is undefined', () => {
         const context: PaymentMethodFilterContext = {
+            capabilities: defaultCapabilities,
             checkout: { ...getCheckout(), consignments: undefined as never },
             checkoutSettings: getStoreConfig().checkoutSettings,
             getPaymentMethod: jest.fn(),

--- a/packages/core/src/app/payment/paymentMethodFilters/selectedHostedPaymentFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/selectedHostedPaymentFilter.test.ts
@@ -1,5 +1,7 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+
 import { getCheckout, getCheckoutPayment } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getPaymentMethod } from '../payment-methods.mock';
@@ -14,6 +16,7 @@ describe('selectedHostedPaymentFilter', () => {
 
     it('returns the original methods when no payments are present on the checkout', () => {
         const context: PaymentMethodFilterContext = {
+            capabilities: defaultCapabilities,
             checkout: { ...getCheckout(), payments: undefined },
             checkoutSettings: getStoreConfig().checkoutSettings,
             getPaymentMethod: jest.fn(),
@@ -26,6 +29,7 @@ describe('selectedHostedPaymentFilter', () => {
 
     it('returns the original methods when only non-hosted payments are on the checkout', () => {
         const context: PaymentMethodFilterContext = {
+            capabilities: defaultCapabilities,
             checkout: {
                 ...getCheckout(),
                 payments: [
@@ -47,6 +51,7 @@ describe('selectedHostedPaymentFilter', () => {
     it('returns only the selected hosted method when it is resolvable from the registry', () => {
         const getPaymentMethodMock = jest.fn().mockReturnValue(amazon);
         const context: PaymentMethodFilterContext = {
+            capabilities: defaultCapabilities,
             checkout: {
                 ...getCheckout(),
                 payments: [getCheckoutPayment('amazonpay')],
@@ -62,6 +67,7 @@ describe('selectedHostedPaymentFilter', () => {
 
     it('returns the original methods when the selected hosted method cannot be resolved', () => {
         const context: PaymentMethodFilterContext = {
+            capabilities: defaultCapabilities,
             checkout: {
                 ...getCheckout(),
                 payments: [getCheckoutPayment('amazonpay')],

--- a/packages/core/src/app/payment/paymentMethodFilters/stripeLinkAuthFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/stripeLinkAuthFilter.test.ts
@@ -1,5 +1,7 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
 
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+
 import { getCheckout } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getPaymentMethod } from '../payment-methods.mock';
@@ -25,6 +27,7 @@ describe('stripeLinkAuthFilter', () => {
         };
 
         context = {
+            capabilities: defaultCapabilities,
             checkout: getCheckout(),
             checkoutSettings: getStoreConfig().checkoutSettings,
             getPaymentMethod: jest.fn(),

--- a/packages/core/src/app/payment/paymentMethodFilters/types.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/types.ts
@@ -1,4 +1,5 @@
 import {
+    type Capabilities,
     type Checkout,
     type CheckoutSettings,
     type PaymentMethod,
@@ -6,6 +7,7 @@ import {
 } from '@bigcommerce/checkout-sdk';
 
 export interface PaymentMethodFilterContext {
+    capabilities: Capabilities;
     checkout: Checkout;
     checkoutSettings: CheckoutSettings;
     getPaymentMethod: (methodId: string, gatewayId?: string) => PaymentMethod | undefined;


### PR DESCRIPTION
## What/Why?

Add excludePPSDKFilter to the payment method filters list.

It hides PPSDK payment methods when the flag `capabilities.payment.excludePPSDK` is `true`.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the payment method filtering pipeline and selection logic, which can alter which payment options appear or default during checkout. Risk is moderated by being gated behind `capabilities.payment.excludePPSDK` and covered with unit tests, but it still affects a critical checkout step.
> 
> **Overview**
> Adds a new `excludePPSDKFilter` to the payment method filter pipeline to remove methods with provider type `PPSDK` when `capabilities.payment.excludePPSDK` is enabled.
> 
> Threads `capabilities` from `CheckoutPage` through `PaymentStep` into `Payment`, updates the filter context/types to require `capabilities`, and ensures default payment method selection uses the capability-aware filtered list; updates and adds unit tests to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d40c64ba2cca3fc6277c736c5f6391585b727b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->