### PR TITLE
chore(payment): PI-5250 bump checkout sdk version to 1.909.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.905.0",
+        "@bigcommerce/checkout-sdk": "^1.909.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.905.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.905.0.tgz",
-      "integrity": "sha512-q85axtwsc8o2i1Ur70VoHp0QiZi4IoDHlnnmAuS2sm3rQtf9iowut7G1FcysgFhG5QWKKIkxjJHUPWDVYKWBOg==",
+      "version": "1.909.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.909.0.tgz",
+      "integrity": "sha512-N8PesTC78Ijh3j2uOqJPcAi/sV+NPJ5N1dBzyelJ6Twe7lxehHxs2VLYbROaDBWNF6nktpDlx3XCev5zKgnk0A==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.905.0",
+    "@bigcommerce/checkout-sdk": "^1.909.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump checkout sdk version to 1.909.0 to release latest changes in sdk

## Rollout/Rollback

Revert

## Testing

CI/manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a dependency upgrade, but it updates the checkout SDK used for payment/checkout flows, so regressions may surface at runtime even though no app code changed.
> 
> **Overview**
> Upgrades `@bigcommerce/checkout-sdk` from `^1.905.0` to `^1.909.0` in `package.json` and updates `package-lock.json` to pull the new resolved package (tarball + integrity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb139bd90e57bab098660a5e68df0433e68e133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->