### PR TITLE
feat(payment): PAYPAL-6267 replaced paypal logo cdn url

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -169,7 +169,7 @@ export function getPaymentMethodTitle(
                 logoUrl:
                     method.id === PaymentMethodId.BraintreeVenmo && method.logoUrl
                         ? method.logoUrl
-                        : cdnPath('/img/payment-providers/paypalpaymentsprouk.png'),
+                        : cdnPath('/img/payment-providers/paypal.svg'),
                 titleText: '',
                 subtitle: (props: PaymentMethodSubtitleProps): ReactNode => {
                     if (method.id === PaymentMethodId.BraintreePaypalCredit || method.id === PaymentMethodId.BraintreePaypal) {


### PR DESCRIPTION
## What/Why?
Replaced paypal logo cdn url

## Rollout/Rollback
Revert this PR

## Testing
Not needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single UI asset URL change for the PayPal payment method with no impact to payment logic or data handling.
> 
> **Overview**
> Updates `PaymentMethodTitle` so the PayPal payment method header uses the new CDN logo asset `'/img/payment-providers/paypal.svg'` (while still honoring the Venmo override), replacing the previous `paypalpaymentsprouk.png` image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9155b7dce0eaae9a5858ceff31c88c738ba726b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->