### PR TITLE
chore(checkout): bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.909.2",
+        "@bigcommerce/checkout-sdk": "^1.909.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.909.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.909.2.tgz",
-      "integrity": "sha512-4et5ad/At1GQkZmrfJ4KSdf6vQHjDpcjoEaY/qVyJn66DFWyRu5sHYAbTh/sp1X4DM/3zSc+EUP55wbAOenwIg==",
+      "version": "1.909.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.909.3.tgz",
+      "integrity": "sha512-GPkfps7ObN67Nms9sv6ICtnY8+NxB3xzMtuB5jIQarlqCvqbVZzMwMJo6jIP43Q9xUvdKP6tCaC7wALNA/ftvw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.909.2",
+    "@bigcommerce/checkout-sdk": "^1.909.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/shipping/utils/setRecommendedOrMissingShippingOption.ts
+++ b/packages/core/src/app/shipping/utils/setRecommendedOrMissingShippingOption.ts
@@ -12,7 +12,7 @@ export const setRecommendedOrMissingShippingOption = async (
     selectConsignmentShippingOption: (
         consignmentId: string,
         shippingOptionId: string,
-        options?: ShippingRequestOptions<object>,
+        options?: ShippingRequestOptions,
     ) => Promise<CheckoutSelectors>,
 ): Promise<void> => {
     const previousShippingOptions = createShippingOptionsMap(previousConsignment);


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk version to release https://github.com/bigcommerce/checkout-sdk-js/pull/3240

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades a core external dependency (`@bigcommerce/checkout-sdk`), which can subtly affect checkout/shipping behavior even though the local code change is type-only.
> 
> **Overview**
> Upgrades `@bigcommerce/checkout-sdk` from `^1.909.2` to `^1.909.3` (including lockfile updates).
> 
> Adjusts `setRecommendedOrMissingShippingOption`’s `selectConsignmentShippingOption` signature to use the new `ShippingRequestOptions` type (dropping the previous generic), to stay compatible with the SDK update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae5b58a96b9d9c888946315aac4dfa368b4b66e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->