### PR TITLE
chore(others): CHECKOUT-9450 Remove rollOutLazyPaymentStrategies flag check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.909.0",
+        "@bigcommerce/checkout-sdk": "^1.909.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.909.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.909.0.tgz",
-      "integrity": "sha512-N8PesTC78Ijh3j2uOqJPcAi/sV+NPJ5N1dBzyelJ6Twe7lxehHxs2VLYbROaDBWNF6nktpDlx3XCev5zKgnk0A==",
+      "version": "1.909.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.909.1.tgz",
+      "integrity": "sha512-fkUbKLibW9LjgtGnh2x9+ipK9MHX2o4Iemvg/WAqa2SKFKELzfSVmZVY2SQqwZIa46pHXywaJc+FhM8HOzEFnA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.909.0",
+    "@bigcommerce/checkout-sdk": "^1.909.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/auto-loader.ts
+++ b/packages/core/src/app/auto-loader.ts
@@ -2,6 +2,12 @@ import type { BrowserOptions } from '@sentry/browser';
 
 import { loadFiles } from './loader';
 
+enum OrderPermalinkStatus {
+    Valid = 'valid',
+    Expired = 'expired',
+    RateLimited = 'rate_limited',
+}
+
 export interface CustomCheckoutWindow extends Window {
     checkoutConfig: {
         containerId: string;
@@ -9,8 +15,7 @@ export interface CustomCheckoutWindow extends Window {
         checkoutId?: string;
         publicPath?: string;
         sentryConfig?: BrowserOptions;
-        permalinkStatus?: 'valid' | 'expired' | 'rate_limited' | null;
-        rollOutLazyPaymentStrategies?: boolean;
+        permalinkStatus?: OrderPermalinkStatus | null;
     };
 }
 

--- a/packages/core/src/app/checkout/CheckoutApp.tsx
+++ b/packages/core/src/app/checkout/CheckoutApp.tsx
@@ -25,7 +25,6 @@ export interface CheckoutAppProps {
     publicPath?: string;
     sentryConfig?: BrowserOptions;
     sentrySampleRate?: number;
-    rollOutLazyPaymentStrategies?: boolean;
 }
 
 const CheckoutApp = (props: CheckoutAppProps): ReactElement => {
@@ -51,7 +50,6 @@ const CheckoutApp = (props: CheckoutAppProps): ReactElement => {
         locale: languageService.getLocale(),
         shouldWarnMutation: process.env.NODE_ENV === 'development',
         errorLogger,
-        rollOutLazyPaymentStrategies: props.rollOutLazyPaymentStrategies,
     }), []);
     const extensionService = useMemo(() => new ExtensionService(checkoutService, errorLogger), []);
     const embeddedStylesheet = useMemo(() => createEmbeddedCheckoutStylesheet(), []);


### PR DESCRIPTION
## What/Why?
Remove rollOutLazyPaymentStrategies flag since the experiment has been rolled out successfully.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to removing an initialization flag that could change checkout service behavior in environments still expecting it, plus a minor `@bigcommerce/checkout-sdk` version bump.
> 
> **Overview**
> Removes the `rollOutLazyPaymentStrategies` experiment flag from the app surface area by dropping it from `CheckoutAppProps` and no longer passing it into `createCheckoutService`.
> 
> Updates `CustomCheckoutWindow.checkoutConfig.permalinkStatus` to use a dedicated `OrderPermalinkStatus` enum instead of a string-literal union.
> 
> Bumps `@bigcommerce/checkout-sdk` from `1.909.0` to `1.909.1` (and updates `package-lock.json` accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49d2b44accef4877027e1d40e5006c9dee6511e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->