### PR TITLE
fix(checkout): CHECKOUT-9959 Fix Google Pay Sign-out Issue

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -49,6 +49,7 @@ import type CheckoutSupport from './CheckoutSupport';
 import { BillingStep, CartSummary, CheckoutHeader, CustomerStep, PaymentStep, ShippingStep } from './components';
 import { mapCheckoutComponentErrorMessage } from './mapErrorMessage';
 import mapToCheckoutProps from './mapToCheckoutProps';
+import { shouldShowShippingOptionExpiredError } from './shouldShowShippingOptionExpiredError';
 import useB2BToken from './hooks/useB2BToken';
 
 export interface CheckoutProps {
@@ -260,7 +261,7 @@ const Checkout = ({
         navigateToStep(CheckoutStepType.Shipping);
     }, [navigateToStep]);
 
-    const handleConsignmentsUpdated = ({ data }: CheckoutSelectors):void => {
+    const handleConsignmentsUpdated = ({ data, statuses }: CheckoutSelectors):void => {
         const { hasSelectedShippingOptions: prevHasSelectedShippingOptions, activeStepType, defaultStepType } =
             stateRef.current;
 
@@ -277,11 +278,12 @@ const Checkout = ({
             findIndex(stepsRef.current, { type: CheckoutStepType.Shipping }) <
             findIndex(stepsRef.current, { type: activeStepType }) || isDefaultStepPaymentOrBilling;
 
-        if (
-            prevHasSelectedShippingOptions &&
-            !newHasSelectedShippingOptions &&
-            isShippingStepFinished
-        ) {
+        if (shouldShowShippingOptionExpiredError({
+            prevHasSelectedShippingOptions,
+            newHasSelectedShippingOptions,
+            isShippingStepFinished,
+            isSigningOut: statuses.isSigningOut(),
+        })) {
             navigateToStep(CheckoutStepType.Shipping);
             setState(prevState => ({ ...prevState, error: new ShippingOptionExpiredError() }));
         }

--- a/packages/core/src/app/checkout/shouldShowShippingOptionExpiredError.test.ts
+++ b/packages/core/src/app/checkout/shouldShowShippingOptionExpiredError.test.ts
@@ -1,0 +1,47 @@
+import { shouldShowShippingOptionExpiredError } from './shouldShowShippingOptionExpiredError';
+
+describe('shouldShowShippingOptionExpiredError', () => {
+    const conditions = {
+        prevHasSelectedShippingOptions: true,
+        newHasSelectedShippingOptions: false,
+        isShippingStepFinished: true,
+        isSigningOut: false,
+    };
+
+    it('returns true when shipping options were lost after the shipping step finished and no sign-out is in progress', () => {
+        expect(shouldShowShippingOptionExpiredError(conditions)).toBe(true);
+    });
+
+    it('returns false during a wallet sign-out even when shipping options were lost', () => {
+        expect(
+            shouldShowShippingOptionExpiredError({ ...conditions, isSigningOut: true }),
+        ).toBe(false);
+    });
+
+    it('returns false when shipping options are still present', () => {
+        expect(
+            shouldShowShippingOptionExpiredError({
+                ...conditions,
+                newHasSelectedShippingOptions: true,
+            }),
+        ).toBe(false);
+    });
+
+    it('returns false when no shipping option was selected before the update', () => {
+        expect(
+            shouldShowShippingOptionExpiredError({
+                ...conditions,
+                prevHasSelectedShippingOptions: false,
+            }),
+        ).toBe(false);
+    });
+
+    it('returns false when the shopper has not yet completed the shipping step', () => {
+        expect(
+            shouldShowShippingOptionExpiredError({
+                ...conditions,
+                isShippingStepFinished: false,
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/core/src/app/checkout/shouldShowShippingOptionExpiredError.ts
+++ b/packages/core/src/app/checkout/shouldShowShippingOptionExpiredError.ts
@@ -1,0 +1,23 @@
+interface ShippingOptionExpiredErrorConditions {
+    prevHasSelectedShippingOptions: boolean;
+    newHasSelectedShippingOptions: boolean;
+    isShippingStepFinished: boolean;
+    isSigningOut: boolean;
+}
+
+export function shouldShowShippingOptionExpiredError({
+    prevHasSelectedShippingOptions,
+    newHasSelectedShippingOptions,
+    isShippingStepFinished,
+    isSigningOut,
+}: ShippingOptionExpiredErrorConditions): boolean {
+    // A wallet sign-out (e.g. Google Pay) intentionally clears the
+    // wallet-provided shipping option server-side. Suppress the
+    // expired-quote modal so the sign-out flow can complete.
+    return (
+        prevHasSelectedShippingOptions &&
+        !newHasSelectedShippingOptions &&
+        isShippingStepFinished &&
+        !isSigningOut
+    );
+}


### PR DESCRIPTION
## What/Why?
### The Issue
Shopper is trapped in a loop of signing out of Google Pay on the payment step.
- SDK calls `loadCurrentCheckout` as part of the sign-out flow.
    - Server cleared the wallet-provided shipping option.
    - `CheckoutPage`'s consignment subscriber sees no selected shipping option.
    - Subscriber raises a `ShippingOptionExpiredError` modal.
- Modal interrupts the sign-out (and in some paths fails it outright).

```mermaid
sequenceDiagram
    autonumber
    actor Shopper
    participant WB as WalletButtonPayment<br/>MethodComponent
    participant SDK as checkout-sdk-js<br/>(GooglePay strategy)
    participant Server as BC backend<br/>/remote-checkout/.../signout
    participant Sub as CheckoutPage<br/>handleConsignments<br/>Updated subscriber
    participant UI as CheckoutPage UI
    Note over Shopper,UI: Pre-state: payment step, GooglePay signed in,<br/>consignment has selectedShippingOption from GooglePay
    Shopper->>WB: Click "Sign out"
    WB->>SDK: await signOutCustomer({ methodId })
    SDK->>Server: GET /remote-checkout/{providerId}/signout
    Server-->>SDK: 200 (clears GooglePay shipping data server-side)
    SDK->>Server: loadCurrentCheckout()
    Server-->>SDK: consignment with selectedShippingOption = null
    Note over SDK,Sub: State updates emit to subscribers
    SDK-->>Sub: consignments changed
    Sub->>Sub: prevHasSelectedShippingOptions = true<br/>newHasSelectedShippingOptions = false<br/>isShippingStepFinished = true (on payment step)
    rect rgb(255, 230, 230)
        Note over Sub,UI: BUG: heuristic can't tell "user signed out"<br/>from "quote went stale"
        Sub->>UI: navigateToStep(Shipping)
        Sub->>UI: setState({ error: ShippingOptionExpiredError })
        UI-->>Shopper: ⚠️ Modal: "shipping price no longer valid"
    end
    alt signOutCustomer resolves
        SDK-->>WB: resolved
        WB->>WB: window.location.reload()
        Note over Shopper,UI: Modal flashes, page reloads —<br/>but server state still inconsistent,<br/>error often re-triggers after reload
    else signOutCustomer rejects<br/>(e.g. loadCurrentCheckout fails on bad state)
        SDK-->>WB: throws
        WB->>WB: onSignOutError(err)  ← noop for GooglePay
        Note over Shopper,UI: ❌ No reload. User stuck on modal,<br/>still signed in to GooglePay → loop
    end
```

### The Fix
We extracted the modal-trigger condition into a named `shouldShowShippingOptionExpiredError` predicate and added a `!isSigningOut` guard.

## Rollout/Rollback
Revert.

## Testing

### Before

https://github.com/user-attachments/assets/e471bc90-90c9-406d-ab49-cbe78b064d5f



### After

https://github.com/user-attachments/assets/c0893899-950e-4cc2-aedd-fc7251ae07c7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout step/error navigation logic when consignments update, which can affect user flow around shipping/payment. Scope is small and covered by a new unit test, but regressions could impact checkout progression.
> 
> **Overview**
> Prevents wallet sign-out flows (e.g. Google Pay) from being interrupted by the *shipping option expired* modal when the server intentionally clears the wallet-selected shipping option.
> 
> `CheckoutPage` now gates the `ShippingOptionExpiredError` trigger behind a new `shouldShowShippingOptionExpiredError` predicate that also checks `statuses.isSigningOut()`, and adds unit tests covering the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1288bd1d890dd10ba1287151d229e3e5e27187d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->