### PR TITLE
feat(payment): PI-4748 Migrate CBA MPGS to Resolver Configuration

### DIFF
--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -38,5 +38,6 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
         { id: 'credit_card', gateway: 'checkoutcom' },
 
         { id: 'tdonlinemart' },
+        { id: 'cba_mpgs' },
     ],
 );


### PR DESCRIPTION
## What/Why?
As part of this project https://bigcommercecloud.atlassian.net/browse/PROJECT-7822
cba_mpgs id added to toResolvableComponent

Here is original PR which was previously blocked by issue with hosted fields focus https://github.com/bigcommerce/checkout-js/pull/2745 

## Rollout/Rollback

Revert this PR.

## Testing

Tested manually:
**CC flow**

https://github.com/user-attachments/assets/649b474e-68f0-46cf-a506-cb7612b67321

**Vaulted CC flow**

https://github.com/user-attachments/assets/e20506d0-f4bb-4cd0-a273-f662c021f0e8

We don't have functional tests for CBA MPGS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code churn, but it changes payment-method resolution for `cba_mpgs`, which could route that gateway through the hosted credit card integration and impact checkout payment flows if misconfigured.
> 
> **Overview**
> Routes the `cba_mpgs` payment method through the hosted credit card integration by adding it to the `toResolvableComponent` configuration in `HostedCreditCardPaymentMethod.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a57d8872d88006d3fba468a33575e01183b812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->