### PR TITLE
PI-4734 [Adyen][FE] Oney - Hide Oney default inputs

### DIFF
--- a/packages/adyen-integration/src/adyenv3/AdyenV3Oney.scss
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3Oney.scss
@@ -1,0 +1,7 @@
+[id*="facilypay_"][id$="-component-field"] .adyen-checkout-form-instruction {
+    display: none;
+}
+
+.optimizedCheckout-form-select + [id*="facilypay_"][id$="-component-field"] {
+    margin-top: 1.5rem;
+}

--- a/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
@@ -18,6 +18,7 @@ import { FormContext, LoadingOverlay, Modal } from '@bigcommerce/checkout/ui';
 
 import AdyenV3CardValidation from './AdyenV3CardValidation';
 import AdyenV3Form from './AdyenV3Form';
+import './AdyenV3Oney.scss';
 
 export interface AdyenOptions {
     [key: string]: AdyenCreditCardComponentOptions;

--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -94,6 +94,10 @@ body.klarna-payments-fso-open {
     scroll-behavior: auto;
 }
 
+[id^="adyen-facilypay_"][id$="-component-field"] .adyen-checkout-form-instruction {
+    visibility: hidden;
+}
+
 .stripe-sepa-mandate-disclaimer {
     margin-bottom: 0;
     padding-bottom: remCalc(20px);

--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -94,10 +94,6 @@ body.klarna-payments-fso-open {
     scroll-behavior: auto;
 }
 
-[id^="adyen-facilypay_"][id$="-component-field"] .adyen-checkout-form-instruction {
-    visibility: hidden;
-}
-
 .stripe-sepa-mandate-disclaimer {
     margin-bottom: 0;
     padding-bottom: remCalc(20px);


### PR DESCRIPTION
## What/Why?
After hiding default inputs for Oney according to Oney documentation, still the instruction note to fill all the fields stays. Since it doesn't make sense to leave it there in this case, we need to hide it. 

## Rollout/Rollback
Revert this PR

## Testing
before:
<img width="2564" height="1476" alt="image" src="https://github.com/user-attachments/assets/fcdf6572-97c4-46f7-a112-0d6d08a6c035" />
after:

<img width="798" height="463" alt="Screenshot 2026-05-12 at 15 31 09" src="https://github.com/user-attachments/assets/548128b9-3f24-4a4d-beed-59805664584d" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely CSS/UI adjustments for the Adyen V3 Oney/FacilyPay hosted component with no changes to payment initialization or data handling.
> 
> **Overview**
> Applies Oney/FacilyPay-specific styling to the Adyen V3 payment method UI by hiding the `.adyen-checkout-form-instruction` message inside `facilypay_*` component containers.
> 
> Also tweaks layout by adding top margin to the hosted component when it follows the grouped-method `<select>`, and wires the new stylesheet into `AdyenV3PaymentMethod` via an import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5238270655fc13cda56eafebcc37c1050c6642ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->