### PR TITLE
feat(payment): Stripe adaptive pricing styling

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.test.tsx
@@ -11,7 +11,7 @@ import {
     createStripeCSPaymentStrategy,
     createStripeOCSPaymentStrategy,
 } from '@bigcommerce/checkout-sdk/integrations/stripe';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React, { type FunctionComponent } from 'react';
@@ -38,7 +38,14 @@ import { AccordionContext, type AccordionContextProps } from '@bigcommerce/check
 import * as getStripeOCSStyles from './getStripeOCSStyles';
 import StripeOCSPaymentMethod from './StripeOCSPaymentMethod';
 
-jest.mock('./getStripeOCSStyles');
+jest.mock('./getStripeOCSStyles', () => ({
+    ...jest.requireActual<typeof import('./getStripeOCSStyles')>('./getStripeOCSStyles'),
+    getAppearanceForOCSElement: jest.fn(),
+    getFonts: jest.fn(),
+}));
+
+const { CheckoutTheme } =
+    jest.requireActual<typeof import('./getStripeOCSStyles')>('./getStripeOCSStyles');
 
 describe('when using Stripe OCS payment', () => {
     const methodId = 'optimized_checkout';
@@ -368,7 +375,7 @@ describe('when using Stripe OCS payment', () => {
             );
             expect(getAppearanceForOCSElementMock).toHaveBeenCalledWith(
                 expectedContainerId,
-                undefined,
+                CheckoutTheme.DEFAULT,
             );
         });
 
@@ -460,7 +467,7 @@ describe('when using Stripe OCS payment', () => {
             );
             expect(getAppearanceForOCSElementMock).toHaveBeenCalledWith(
                 expectedContainerId,
-                'themeV2',
+                CheckoutTheme.THEME_V2,
             );
         });
     });
@@ -537,6 +544,154 @@ describe('when using Stripe OCS payment', () => {
             rerender(<PaymentMethodTest {...defaultProps} method={method} />);
 
             expect(collapseElementMock).not.toHaveBeenCalled();
+        });
+
+        it('forwards Stripe errors to onUnhandledError', () => {
+            const onUnhandledErrorMock = jest.fn();
+            const stripeError = new Error('Stripe initialization failed');
+
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    options.stripeocs?.onError?.(stripeError);
+
+                    return Promise.resolve(checkoutState);
+                },
+            );
+
+            render(
+                <PaymentMethodTest
+                    {...defaultProps}
+                    method={method}
+                    onUnhandledError={onUnhandledErrorMock}
+                />,
+            );
+
+            expect(onUnhandledErrorMock).toHaveBeenCalledWith(stripeError);
+        });
+    });
+
+    describe('# Delayed BC accordion toggle', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('schedules a delayed onToggle when the Stripe-selected method differs from the BC selectedItemId', () => {
+            accordionContextValues = {
+                onToggle: onToggleMock,
+                selectedItemId: 'nonStripeItem',
+            };
+
+            let paymentMethodSelectRef: ((id: string) => void) | undefined;
+
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    paymentMethodSelectRef = options.stripeocs?.paymentMethodSelect;
+
+                    return Promise.resolve(checkoutState);
+                },
+            );
+
+            const { rerender } = render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            act(() => {
+                paymentMethodSelectRef?.('selectedStripeMethodId');
+            });
+
+            const newOnToggleMock = jest.fn();
+
+            accordionContextValues = {
+                onToggle: newOnToggleMock,
+                selectedItemId: 'nonStripeItem',
+            };
+            rerender(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            act(() => {
+                jest.advanceTimersByTime(100);
+            });
+
+            expect(newOnToggleMock).toHaveBeenCalledWith('selectedStripeMethodId');
+        });
+
+        it('cancels a pending delayed onToggle when onToggle changes again before it fires', () => {
+            accordionContextValues = {
+                onToggle: onToggleMock,
+                selectedItemId: 'nonStripeItem',
+            };
+
+            let paymentMethodSelectRef: ((id: string) => void) | undefined;
+
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    paymentMethodSelectRef = options.stripeocs?.paymentMethodSelect;
+
+                    return Promise.resolve(checkoutState);
+                },
+            );
+
+            const { rerender } = render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            act(() => {
+                paymentMethodSelectRef?.('selectedStripeMethodId');
+            });
+
+            const firstOnToggleMock = jest.fn();
+
+            accordionContextValues = {
+                onToggle: firstOnToggleMock,
+                selectedItemId: 'nonStripeItem',
+            };
+            rerender(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            const secondOnToggleMock = jest.fn();
+
+            accordionContextValues = {
+                onToggle: secondOnToggleMock,
+                selectedItemId: 'nonStripeItem',
+            };
+            rerender(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            act(() => {
+                jest.advanceTimersByTime(100);
+            });
+
+            expect(firstOnToggleMock).not.toHaveBeenCalled();
+            expect(secondOnToggleMock).toHaveBeenCalledWith('selectedStripeMethodId');
+        });
+
+        it('does not schedule onToggle when selected payment method already matches selectedItemId', () => {
+            let paymentMethodSelectRef: ((id: string) => void) | undefined;
+
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(
+                (options: WithStripeOCSPaymentInitializeOptions) => {
+                    paymentMethodSelectRef = options.stripeocs?.paymentMethodSelect;
+
+                    return Promise.resolve(checkoutState);
+                },
+            );
+
+            const { rerender } = render(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            act(() => {
+                paymentMethodSelectRef?.(methodSelectorPrefix);
+            });
+
+            const newOnToggleMock = jest.fn();
+
+            accordionContextValues = {
+                onToggle: newOnToggleMock,
+                selectedItemId: methodSelectorPrefix,
+            };
+            rerender(<PaymentMethodTest {...defaultProps} method={method} />);
+
+            act(() => {
+                jest.advanceTimersByTime(100);
+            });
+
+            expect(newOnToggleMock).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeOCSPaymentMethod.tsx
@@ -30,7 +30,7 @@ import {
 } from '@bigcommerce/checkout/payment-integration-api';
 import { AccordionContext, ChecklistSkeleton } from '@bigcommerce/checkout/ui';
 
-import { getAppearanceForOCSElement, getFonts } from './getStripeOCSStyles';
+import { CheckoutTheme, getAppearanceForOCSElement, getFonts } from './getStripeOCSStyles';
 
 const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     paymentForm,
@@ -115,7 +115,7 @@ const StripeOCSPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         async (options: PaymentInitializeOptions) => {
             setIsOCSLoading(true);
 
-            const theme = themeV2 ? 'themeV2' : undefined;
+            const theme = themeV2 ? CheckoutTheme.THEME_V2 : CheckoutTheme.DEFAULT;
 
             return checkoutService.initializePayment({
                 ...options,

--- a/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.test.ts
+++ b/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.test.ts
@@ -1,6 +1,6 @@
 import * as domUtils from '@bigcommerce/checkout/dom-utils';
 
-import { getAppearanceForOCSElement, getFonts } from './getStripeOCSStyles';
+import { CheckoutTheme, getAppearanceForOCSElement, getFonts } from './getStripeOCSStyles';
 
 describe('getStripeOCSStyles', () => {
     afterEach(() => {
@@ -115,6 +115,7 @@ describe('getStripeOCSStyles', () => {
                     colorTextPlaceholder: 'black',
                     colorIcon: 'black',
                     fontFamily: 'Monaco, sans-serif',
+                    accordionItemSpacing: '16px',
                 },
                 rules: {
                     '.Input': {
@@ -129,8 +130,6 @@ describe('getStripeOCSStyles', () => {
                         borderBottom: '1px solid black',
                         borderLeft: '1px solid black',
                         borderColor: 'yellow',
-                        marginBottom: '8px',
-                        marginTop: '8px',
                         backgroundColor: '#fcfcfc',
                         boxShadow: 'none',
                         fontSize: '16px',
@@ -171,12 +170,27 @@ describe('getStripeOCSStyles', () => {
                         fill: '#4496f6',
                         stroke: '#4496f6',
                     },
+                    '.ToggleItem': {
+                        borderRadius: '4px',
+                        border: '1px solid black',
+                        backgroundColor: '#fcfcfc',
+                        boxShadow: 'none',
+                        outline: 'none',
+                    },
+                    '.ToggleItem--selected': {
+                        fontWeight: 'bold',
+                        color: 'green',
+                        backgroundColor: '#fcfcfc',
+                        borderColor: '#4496f6',
+                        outline: 'none',
+                        boxShadow: 'none',
+                    },
                 },
             });
         });
 
         it('returns the correct styles for the OCS element and themeV2', () => {
-            expect(getAppearanceForOCSElement(containerId, 'themeV2')).toEqual({
+            expect(getAppearanceForOCSElement(containerId, CheckoutTheme.THEME_V2)).toEqual({
                 variables: {
                     colorPrimary: '0 0 5px rgba(0, 0, 0, 0.5)',
                     colorBackground: 'white',
@@ -186,6 +200,7 @@ describe('getStripeOCSStyles', () => {
                     colorTextPlaceholder: 'black',
                     colorIcon: 'black',
                     fontFamily: 'Monaco, sans-serif',
+                    accordionItemSpacing: '16px',
                 },
                 rules: {
                     '.Input': {
@@ -200,8 +215,6 @@ describe('getStripeOCSStyles', () => {
                         borderBottom: '1px solid black',
                         borderLeft: '1px solid black',
                         borderColor: 'yellow',
-                        marginBottom: '8px',
-                        marginTop: '8px',
                         backgroundColor: '#fcfcfc',
                         boxShadow: 'none',
                         fontSize: '16px',
@@ -241,6 +254,21 @@ describe('getStripeOCSStyles', () => {
                     '.RadioIconOuter--checked': {
                         fill: '#4496f6',
                         stroke: '#4496f6',
+                    },
+                    '.ToggleItem': {
+                        borderRadius: '4px',
+                        border: '1px solid black',
+                        backgroundColor: '#fcfcfc',
+                        boxShadow: 'none',
+                        outline: 'none',
+                    },
+                    '.ToggleItem--selected': {
+                        fontWeight: 'bold',
+                        color: 'green',
+                        backgroundColor: '#fcfcfc',
+                        borderColor: '#4496f6',
+                        outline: 'none',
+                        boxShadow: 'none',
                     },
                 },
             });
@@ -285,8 +313,6 @@ describe('getStripeOCSStyles', () => {
                             borderBottom: '1px solid black',
                             borderLeft: '1px solid black',
                             borderColor: 'yellow',
-                            marginBottom: '8px',
-                            marginTop: '8px',
                             backgroundColor: '#fcfcfc',
                             boxShadow: 'none',
                             fontSize: '16px',
@@ -312,6 +338,7 @@ describe('getStripeOCSStyles', () => {
                     colorTextPlaceholder: undefined,
                     colorIcon: undefined,
                     fontFamily: undefined,
+                    accordionItemSpacing: '0px',
                 },
                 rules: {
                     '.Input': {
@@ -326,8 +353,6 @@ describe('getStripeOCSStyles', () => {
                         borderBottom: undefined,
                         borderLeft: undefined,
                         borderColor: undefined,
-                        marginBottom: undefined,
-                        marginTop: undefined,
                         backgroundColor: undefined,
                         boxShadow: 'none',
                         fontSize: undefined,
@@ -368,6 +393,20 @@ describe('getStripeOCSStyles', () => {
                         stroke: undefined,
                         fill: undefined,
                     },
+                    '.ToggleItem': {
+                        borderRadius: '4px',
+                        border: undefined,
+                        backgroundColor: undefined,
+                        boxShadow: 'none',
+                        outline: 'none',
+                    },
+                    '.ToggleItem--selected': {
+                        fontWeight: 'bold',
+                        color: undefined,
+                        backgroundColor: undefined,
+                        outline: 'none',
+                        boxShadow: 'none',
+                    },
                 },
             });
         });
@@ -402,7 +441,7 @@ describe('getStripeOCSStyles', () => {
                 },
             });
 
-            expect(getAppearanceForOCSElement(containerId, 'themeV2')).toEqual(
+            expect(getAppearanceForOCSElement(containerId, CheckoutTheme.THEME_V2)).toEqual(
                 expect.objectContaining({
                     rules: expect.objectContaining({
                         '.RadioIconInner': {
@@ -424,7 +463,7 @@ describe('getStripeOCSStyles', () => {
                 },
             });
 
-            expect(getAppearanceForOCSElement(containerId, 'themeV2')).toEqual(
+            expect(getAppearanceForOCSElement(containerId, CheckoutTheme.THEME_V2)).toEqual(
                 expect.objectContaining({
                     rules: expect.objectContaining({
                         '.RadioIconInner': {
@@ -434,6 +473,123 @@ describe('getStripeOCSStyles', () => {
                     }),
                 }),
             );
+        });
+
+        it('sums accordion header top and bottom margins into accordionItemSpacing', () => {
+            mockGetAppliedStyles({
+                ...defaultStyles,
+                [`#${containerId}--accordion-header-selected`]: {
+                    ...defaultStyles[`#${containerId}--accordion-header-selected`],
+                    'margin-top': '5px',
+                    'margin-bottom': '7px',
+                },
+            });
+
+            expect(getAppearanceForOCSElement(containerId)).toEqual(
+                expect.objectContaining({
+                    variables: expect.objectContaining({
+                        accordionItemSpacing: '12px',
+                    }),
+                }),
+            );
+        });
+
+        it('falls back to 0px accordionItemSpacing when margins are missing', () => {
+            mockGetAppliedStyles({
+                ...defaultStyles,
+                [`#${containerId}--accordion-header-selected`]: {
+                    ...defaultStyles[`#${containerId}--accordion-header-selected`],
+                    'margin-top': undefined,
+                    'margin-bottom': undefined,
+                },
+            });
+
+            expect(getAppearanceForOCSElement(containerId)).toEqual(
+                expect.objectContaining({
+                    variables: expect.objectContaining({
+                        accordionItemSpacing: '0px',
+                    }),
+                }),
+            );
+        });
+
+        it('uses hardcoded 4px ToggleItem border radius and radio inner color for selected border in default theme', () => {
+            expect(getAppearanceForOCSElement(containerId)).toEqual(
+                expect.objectContaining({
+                    rules: expect.objectContaining({
+                        '.ToggleItem': expect.objectContaining({
+                            borderRadius: '4px',
+                        }),
+                        '.ToggleItem--selected': expect.objectContaining({
+                            borderColor: '#4496f6',
+                        }),
+                    }),
+                }),
+            );
+        });
+
+        it('uses form checklist border radius and accordion selected border color for ToggleItem in themeV2', () => {
+            mockGetAppliedStyles({
+                ...defaultStyles,
+                [`#${containerId}--accordion-header.optimizedCheckout-form-checklist-item`]: {
+                    ...defaultStyles[
+                        `#${containerId}--accordion-header.optimizedCheckout-form-checklist-item`
+                    ],
+                    'border-radius': '12px',
+                },
+                [`#${containerId}--accordion-header-selected`]: {
+                    ...defaultStyles[`#${containerId}--accordion-header-selected`],
+                    'border-color': '#abcdef',
+                },
+            });
+
+            expect(getAppearanceForOCSElement(containerId, CheckoutTheme.THEME_V2)).toEqual(
+                expect.objectContaining({
+                    rules: expect.objectContaining({
+                        '.ToggleItem': expect.objectContaining({
+                            borderRadius: '12px',
+                        }),
+                        '.ToggleItem--selected': expect.objectContaining({
+                            borderColor: '#abcdef',
+                        }),
+                    }),
+                }),
+            );
+        });
+
+        it('omits ToggleItem borderRadius for themeV2 when form checklist border radius is missing', () => {
+            mockGetAppliedStyles({
+                ...defaultStyles,
+                [`#${containerId}--accordion-header.optimizedCheckout-form-checklist-item`]: {
+                    ...defaultStyles[
+                        `#${containerId}--accordion-header.optimizedCheckout-form-checklist-item`
+                    ],
+                    'border-radius': undefined,
+                },
+            });
+
+            const appearance = getAppearanceForOCSElement(containerId, CheckoutTheme.THEME_V2);
+
+            expect(appearance.rules?.['.ToggleItem']).not.toHaveProperty('borderRadius');
+        });
+
+        it('omits ToggleItem--selected borderColor for default theme when radio inner background is missing', () => {
+            mockGetAppliedStyles({
+                ...defaultStyles,
+                [`#${containerId}--accordion-header-selected .form-label::after`]: {
+                    ...defaultStyles[
+                        `#${containerId}--accordion-header-selected .form-label::after`
+                    ],
+                    'background-color': undefined,
+                },
+                '.form-checklist-header--selected .form-label::after': {
+                    'background-color': undefined,
+                },
+            });
+
+            const appearance = getAppearanceForOCSElement(containerId);
+
+            expect(appearance.rules?.['.ToggleItem--selected']).not.toHaveProperty('borderColor');
         });
     });
 });

--- a/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.ts
+++ b/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.ts
@@ -4,7 +4,12 @@ import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
 
 import type { StripeAppearanceOptions, StripeCustomFont } from '../stripe-types';
 
-const radioIconInnerScaleList = {
+export enum CheckoutTheme {
+    DEFAULT = 'default',
+    THEME_V2 = 'themeV2',
+}
+
+const radioIconInnerScaleList: Record<CheckoutTheme, number> = {
     default: 0.66,
     themeV2: 0.36,
 };
@@ -65,6 +70,15 @@ const getScaleFromTransformMatrix = (transformMatrixString = ''): number | undef
     return matrixValues[0];
 };
 
+const getAccordionItemSpacing = (
+    accordionSelectedHeaderStyles: Record<string, string | undefined>,
+) => {
+    const marginTop = parseFloat(accordionSelectedHeaderStyles['margin-top'] || '0');
+    const marginBottom = parseFloat(accordionSelectedHeaderStyles['margin-bottom'] || '0');
+
+    return `${marginTop + marginBottom}px`;
+};
+
 export const getFonts = (selector = 'link[href*="font"]'): StripeCustomFont[] => {
     const elementsList: NodeListOf<Element> = document.querySelectorAll(selector);
     const fonts: StripeCustomFont[] = [];
@@ -82,7 +96,7 @@ export const getFonts = (selector = 'link[href*="font"]'): StripeCustomFont[] =>
 
 export const getAppearanceForOCSElement = (
     containerId: string,
-    theme: keyof typeof radioIconInnerScaleList = 'default',
+    theme: CheckoutTheme = CheckoutTheme.DEFAULT,
 ): StripeAppearanceOptions => {
     const defaultAccordionPaddingHorizontal = '18px';
     const defaultAccordionPaddingVertical = '13px';
@@ -178,6 +192,15 @@ export const getAppearanceForOCSElement = (
             radioInnerParsedSize && parseRadioIconSize(radioInnerParsedSize) * radioInnerWidthScale,
     });
 
+    const toggleItemBorderRadius = {
+        [CheckoutTheme.DEFAULT]: '4px',
+        [CheckoutTheme.THEME_V2]: formChecklistStyles['border-radius'],
+    };
+    const toggleItemSelectedBorderColor = {
+        [CheckoutTheme.DEFAULT]: radioInnerChecked['background-color'],
+        [CheckoutTheme.THEME_V2]: accordionSelectedHeaderStyles['border-color'],
+    };
+
     return {
         variables: {
             colorPrimary: formInputStyles['box-shadow'],
@@ -188,6 +211,7 @@ export const getAppearanceForOCSElement = (
             colorTextPlaceholder: formInputStyles.color,
             colorIcon: formInputStyles.color,
             fontFamily: accordionHeaderFontFamily || formInputStyles['font-family'],
+            accordionItemSpacing: getAccordionItemSpacing(accordionSelectedHeaderStyles),
         },
         rules: {
             '.Input': {
@@ -202,8 +226,6 @@ export const getAppearanceForOCSElement = (
                 borderBottom: formChecklistStyles['border-bottom'],
                 borderLeft: formChecklistStyles['border-left'],
                 borderColor: formChecklistStyles['border-color'],
-                marginBottom: accordionSelectedHeaderStyles['margin-bottom'],
-                marginTop: accordionSelectedHeaderStyles['margin-top'],
                 backgroundColor: accordionHeaderStyles['background-color'],
                 boxShadow: 'none',
                 fontSize: accordionItemTitleFontSize,
@@ -243,6 +265,25 @@ export const getAppearanceForOCSElement = (
             '.RadioIconOuter--checked': {
                 stroke: radioOuterChecked['border-color'],
                 fill: radioOuterChecked['background-color'],
+            },
+            '.ToggleItem': {
+                ...(toggleItemBorderRadius[theme]
+                    ? { borderRadius: toggleItemBorderRadius[theme] }
+                    : {}),
+                border: formChecklistStyles['border-bottom'],
+                backgroundColor: accordionHeaderStyles['background-color'],
+                boxShadow: 'none',
+                outline: 'none',
+            },
+            '.ToggleItem--selected': {
+                fontWeight: 'bold',
+                color: accordionHeaderColor,
+                backgroundColor: accordionSelectedHeaderStyles['background-color'],
+                ...(toggleItemSelectedBorderColor[theme]
+                    ? { borderColor: toggleItemSelectedBorderColor[theme] }
+                    : {}),
+                outline: 'none',
+                boxShadow: 'none',
             },
         },
     };

--- a/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.ts
+++ b/packages/stripe-integration/src/stripe-ocs/getStripeOCSStyles.ts
@@ -10,8 +10,8 @@ export enum CheckoutTheme {
 }
 
 const radioIconInnerScaleList: Record<CheckoutTheme, number> = {
-    default: 0.66,
-    themeV2: 0.36,
+    [CheckoutTheme.DEFAULT]: 0.66,
+    [CheckoutTheme.THEME_V2]: 0.36,
 };
 
 const getStylesFromElement = (


### PR DESCRIPTION
## What/Why?
Add styling for Stripe Adaptive Pricing element on checkout page.
Improve test coverage for StripeOCSPaymentMethod component.

## Rollout/Rollback
Rollback this PR

## Testing
Default theme:
<img width="635" height="1147" alt="Screenshot 2026-05-12 at 12 56 45" src="https://github.com/user-attachments/assets/1d49d117-ff98-4223-bec9-9e3b2af5edf1" />
<img width="630" height="494" alt="Screenshot 2026-05-12 at 12 56 57" src="https://github.com/user-attachments/assets/f5605a75-601c-4d89-8a25-fa5a51c5554d" />

Theme V2:
<img width="692" height="1235" alt="Screenshot 2026-05-12 at 12 55 31" src="https://github.com/user-attachments/assets/7d950e99-3fd4-4eb9-8ba2-396c4d69284c" />
<img width="674" height="518" alt="Screenshot 2026-05-12 at 12 55 43" src="https://github.com/user-attachments/assets/78362042-c879-4cf8-afed-d4227a9bad6e" />

test coverage:
<img width="2555" height="322" alt="Screenshot 2026-05-12 at 13 02 26" src="https://github.com/user-attachments/assets/ea9c562b-ded5-4669-8c89-888187106dd5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Stripe OCS initialization options and accordion toggle timing, which can affect checkout payment method selection behavior; however changes are localized and covered by new tests.
> 
> **Overview**
> Adds richer Stripe OCS appearance generation for the Adaptive Pricing element: introduces `CheckoutTheme`, derives `accordionItemSpacing`, and adds new `.ToggleItem`/`.ToggleItem--selected` styling with theme-specific border radius and selected border color.
> 
> Updates `StripeOCSPaymentMethod` to use the new theme enum when building `appearance`, and expands tests to validate theme selection plus new behaviors (forwarding Stripe `onError` to `onUnhandledError` and a delayed/cancelable BC accordion `onToggle` resync when Stripe selection and BC accordion state diverge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a01e0088925eefc8b7c71485c4398c94d8b680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->