### PR TITLE
chore(core): CHECKOUT-9926 Move base.scss file to scss folder

### DIFF
--- a/packages/core/src/app/address/AddressForm.scss
+++ b/packages/core/src/app/address/AddressForm.scss
@@ -1,4 +1,4 @@
-@import "../ui/Base";
+@import "../../scss/Base";
 @import "../../scss/themeV2/mixins";
 
 .checkout-address:has(.floating-form-field) {

--- a/packages/core/src/app/address/AddressSelect.scss
+++ b/packages/core/src/app/address/AddressSelect.scss
@@ -1,4 +1,4 @@
-@import "../ui/Base";
+@import "../../scss/Base";
 
 .dropdown--select {
     cursor: pointer;

--- a/packages/core/src/app/address/StaticAddress.scss
+++ b/packages/core/src/app/address/StaticAddress.scss
@@ -1,4 +1,4 @@
-@import "../ui/Base";
+@import "../../scss/Base";
 
 .checkout-address--static {
     .address-entry {

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.scss
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.scss
@@ -1,4 +1,4 @@
-@import '../../ui/Base';
+@import '../../../scss/Base';
 
 $googleLogoHeight: 18px;
 

--- a/packages/core/src/app/cart/AppliedRedeemable.scss
+++ b/packages/core/src/app/cart/AppliedRedeemable.scss
@@ -1,4 +1,4 @@
-@import '../ui/Base';
+@import '../../scss/Base';
 
 .form-checklist-checkbox ~ .form-label-redeemable {
     &:hover {

--- a/packages/core/src/app/checkout/components/BackorderQuantitiesChangedBanner.scss
+++ b/packages/core/src/app/checkout/components/BackorderQuantitiesChangedBanner.scss
@@ -1,4 +1,4 @@
-@import '../../ui/Base';
+@import '../../../scss/Base';
 
 .checkout-backorder-quantities-banner {
     align-items: center;

--- a/packages/core/src/app/common/error/ErrorCode.scss
+++ b/packages/core/src/app/common/error/ErrorCode.scss
@@ -1,4 +1,4 @@
-@import '../../ui/Base';
+@import '../../../scss/Base';
 
 .errorCode {
     font-size: fontSize("tiny");

--- a/packages/core/src/app/customer/CreateAccountForm.scss
+++ b/packages/core/src/app/customer/CreateAccountForm.scss
@@ -1,4 +1,4 @@
-@import "../ui/Base";
+@import "../../scss/Base";
 
 .create-account-form {
     display: flex;

--- a/packages/core/src/app/promotion/PromotionBannerList.scss
+++ b/packages/core/src/app/promotion/PromotionBannerList.scss
@@ -1,4 +1,4 @@
-@import '../ui/Base';
+@import '../../scss/Base';
 
 .discountBanner {
     margin-top: spacing("single");

--- a/packages/core/src/app/shipping/ItemSplitTooltip.scss
+++ b/packages/core/src/app/shipping/ItemSplitTooltip.scss
@@ -1,4 +1,4 @@
-@import '../ui/Base';
+@import '../../scss/Base';
 
 .item-split-tooltip {
     .icon {

--- a/packages/core/src/app/shipping/MultiShippingForm.scss
+++ b/packages/core/src/app/shipping/MultiShippingForm.scss
@@ -1,4 +1,4 @@
-@import '../ui/Base';
+@import '../../scss/Base';
 
 $quantity-input-container-width: 60%;
 $quantity-input-container-width-small-screen: 90%;

--- a/packages/core/src/app/shipping/ShippingHeader.scss
+++ b/packages/core/src/app/shipping/ShippingHeader.scss
@@ -1,4 +1,4 @@
-@import '../ui/Base';
+@import '../../scss/Base';
 
 .shipping-header {
     flex-direction: column;

--- a/packages/core/src/app/shipping/StaticConsignment.scss
+++ b/packages/core/src/app/shipping/StaticConsignment.scss
@@ -1,4 +1,4 @@
-@import '../ui/Base';
+@import '../../scss/Base';
 
 .staticConsignment {
     width: 100%;

--- a/packages/core/src/app/shipping/StaticMultiConsignment.scss
+++ b/packages/core/src/app/shipping/StaticMultiConsignment.scss
@@ -1,4 +1,4 @@
-@import '../ui/Base';
+@import '../../scss/Base';
 
 .staticMultiConsignmentContainer {
     ul {

--- a/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.scss
+++ b/packages/core/src/app/shipping/shippingOption/ShippingOptionsForm.scss
@@ -1,4 +1,4 @@
-@import '../../ui/Base';
+@import '../../../scss/Base';
 
 .shippingOptions-panel {
     border: container("border");

--- a/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -1,4 +1,4 @@
-@import '../../ui/Base';
+@import '../../../scss/Base';
 
 // Static Shipping Option
 // ---------------------------------------------------

--- a/packages/core/src/app/ui/Base.scss
+++ b/packages/core/src/app/ui/Base.scss
@@ -1,5 +1,0 @@
-@import '../../../../../node_modules/@bigcommerce/citadel/src/tools/toolkit';
-@import '../../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
-@import '../../scss/settings/foundation/foundation';
-
-$global-radius: 4px;

--- a/packages/core/src/scss/Base.scss
+++ b/packages/core/src/scss/Base.scss
@@ -1,0 +1,5 @@
+@import '../../../../node_modules/@bigcommerce/citadel/src/tools/toolkit';
+@import '../../../../node_modules/@bigcommerce/citadel/src/settings/global/global';
+@import './settings/foundation/foundation';
+
+$global-radius: 4px;


### PR DESCRIPTION
## What/Why?

Since we are migrating everything out of the `core/app/ui` folder, I want to migrate this scss file as well and move it to scss folder for now. A proper fix would be to move all scss files to `packages/ui` so that's something we still need to do going forward: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10027

## Rollout/Rollback

Revert this PR

## Testing

No visual changes expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this is a path-only refactor for shared SCSS imports, but it could break styling builds if any remaining `ui/Base` import paths were missed or bundler include paths differ.
> 
> **Overview**
> Moves the shared SCSS entrypoint from `app/ui/Base.scss` to `scss/Base.scss` and updates checkout-related component stylesheets to import the new location.
> 
> No styling rules are materially changed; this is a relocation to support migrating away from `core/app/ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfef880107ba49b0abf6839f6cff8ab3c098bf48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->