### PR TITLE
feat(paymnet): Migrate CyberSource v2 to Resolver Configuration

### DIFF
--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -31,13 +31,13 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     HostedCreditCardPaymentMethod,
     [
+        { id: 'cba_mpgs' },
+        { id: 'credit_card', gateway: 'bluesnapdirect' },
+        { id: 'credit_card', gateway: 'checkoutcom' },
+        { id: 'cybersourcev2' },
         {
             id: 'hosted-credit-card',
         },
-        { id: 'credit_card', gateway: 'bluesnapdirect' },
-        { id: 'credit_card', gateway: 'checkoutcom' },
-
         { id: 'tdonlinemart' },
-        { id: 'cba_mpgs' },
     ],
 );


### PR DESCRIPTION
## What/Why?

Migrates the cybersource payment method to the new resolver-based architecture by registering it in the HostedCreditCardPaymentMethod component resolver (packages/hosted-credit-card-integration).

remove from knownMethods  was in other PR 
https://github.com/bigcommerce/checkout-js/pull/2815

## Rollout/Rollback

Rollback this PR

## Testing

[<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->](https://github.com/user-attachments/assets/7992c6e3-9e43-4be8-b5e6-a21a4de38d23)

<img width="776" height="987" alt="image" src="https://github.com/user-attachments/assets/9429d76e-7c6b-4bdc-b0e1-6dd89af7336f" />
<img width="834" height="1034" alt="image" src="https://github.com/user-attachments/assets/647be6c2-76b9-47c4-a242-63017834c641" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates resolver configuration for `HostedCreditCardPaymentMethod` by adding support for `cybersourcev2` and reordering resolve IDs, with no changes to payment processing logic.
> 
> **Overview**
> Updates `HostedCreditCardPaymentMethod`’s `toResolvableComponent` registration to include **`cybersourcev2`** in the resolver configuration, so it resolves through the hosted credit card integration.
> 
> Also reorders the registered resolve IDs (e.g., moves `cba_mpgs` and the `credit_card` gateway entries) without changing the component implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca997fdbbc0fa159703a6a6474089c44e23435f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->