### PR TITLE
fix(checkout): CHECKOUT-9967 show specific invalid billing address ti…

### DIFF
--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
@@ -319,4 +319,15 @@ describe('mapSubmitOrderErrorTitle()', () => {
 
         expect(title).toEqual(translate('common.invalid_shipping_address'));
     });
+
+    it('returns correct title when error type is "invalid_billing_address"', () => {
+        const title = mapSubmitOrderErrorTitle(
+            {
+                type: 'invalid_billing_address',
+            },
+            translate,
+        );
+
+        expect(title).toEqual(translate('common.invalid_billing_address'));
+    });
 });

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -82,5 +82,9 @@ export function mapSubmitOrderErrorTitle(
         return translate('common.invalid_shipping_address');
     }
 
+    if (error.type === 'invalid_billing_address') {
+        return translate('common.invalid_billing_address');
+    }
+
     return translate('common.error_heading');
 }

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -112,6 +112,7 @@
             "loading_text": "Loading",
             "missing_shipping_method_heading": "Shipping method unavailable",
             "invalid_shipping_address": "Invalid shipping address",
+            "invalid_billing_address": "Invalid billing address",
             "ok_action": "Ok",
             "error_code": "Error code:",
             "request_id": "Request ID:",


### PR DESCRIPTION
## What/Why?

When the order endpoint returns `type: "invalid_billing_address"`, the error modal showed the generic "Something's gone wrong" header. `mapSubmitOrderErrorTitle` had cases for `invalid_shipping_address` and friends, but not the billing equivalent.

This PR adds the `invalid_billing_address` case to `mapSubmitOrderErrorTitle` and a matching `common.invalid_billing_address` translation. Paired with the checkout-sdk-js PR that surfaces the typed error, the modal now shows "Invalid billing address" with the backend-provided message.

## Rollout/Rollback
Revert

## Testing

- New unit test for the `invalid_billing_address` title mapping.
- `jest mapSubmitOrderErrorMessage` → 24/24 pass.
- Manual: with the SDK bump in place, force the order endpoint to return `{ status: 400, type: "invalid_billing_address", title: "Invalid billing address" }` and confirm the modal title reads "Invalid billing address" instead of "Something's gone wrong".