### PR TITLE
fix(shipping): CHECKOUT-9999 Update autocomplete to to avoid cursor jumping to end on edit

### DIFF
--- a/packages/ui/src/autocomplete/Autocomplete.test.tsx
+++ b/packages/ui/src/autocomplete/Autocomplete.test.tsx
@@ -59,6 +59,39 @@ describe('Autocomplete Component', () => {
         expect(container.innerHTML).toContain('vfoo');
     });
 
+    it('preserves cursor position when typing after an autocomplete selection', async () => {
+        const initialValues = { value: '' };
+
+        render(
+            <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+                {({ values, setFieldValue }) => (
+                    <Autocomplete
+                        initialValue={values.value}
+                        items={items}
+                        onChange={(val) => setFieldValue('value', val)}
+                        onSelect={(val) => setFieldValue('value', val?.value)}
+                    />
+                )}
+            </Formik>,
+        );
+
+        // Select 'foo' from the list → Formik sets value to 'vfoo'
+        await userEvent.type(screen.getByRole('textbox'), 'foo');
+        await userEvent.click(screen.getByText('foo'));
+
+        // Re-render passes new initialValue; place cursor at position 1 (between 'v' and 'f')
+        const input = screen.getByRole('textbox');
+
+        input.focus();
+        (input as HTMLInputElement).setSelectionRange(1, 1);
+
+        // Type 'x' — onChange updates Formik → initialValue becomes 'vxfoo';
+        // useLayoutEffect must restore cursor to 2, not let it jump to end (5)
+        await userEvent.keyboard('x');
+
+        expect((input as HTMLInputElement).selectionStart).toBe(2);
+    });
+
     it('select item by keyboard', async () => {
         const initialValues = { value: '' };
 

--- a/packages/ui/src/autocomplete/AutocompleteContent.tsx
+++ b/packages/ui/src/autocomplete/AutocompleteContent.tsx
@@ -1,6 +1,6 @@
 import type { GetInputPropsOptions, GetItemPropsOptions, GetMenuPropsOptions } from 'downshift';
 import { includes, isNumber } from 'lodash';
-import React, { type ReactNode } from 'react';
+import React, { type ReactNode, useCallback, useLayoutEffect, useRef } from 'react';
 
 import { Label } from '../form';
 import { Popover, PopoverList } from '../popover';
@@ -36,11 +36,43 @@ const AutocompleteContent: React.FC<AutocompleteContentProps> = ({
     listTestId,
     children,
 }) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const selectionRef = useRef<{ start: number | null; end: number | null }>({
+        start: null,
+        end: null,
+    });
+
     const baseInputProps = getInputProps({ value: initialValue });
     const combinedProps = { ...baseInputProps, ...inputProps };
 
     // Extract labelText to avoid passing it to input element
     const { labelText: _labelText, ...validInputProps } = combinedProps;
+
+    const originalOnChange = validInputProps.onChange;
+    const handleChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            selectionRef.current = {
+                start: e.target.selectionStart,
+                end: e.target.selectionEnd,
+            };
+            originalOnChange?.(e);
+        },
+        [originalOnChange],
+    );
+
+    useLayoutEffect(() => {
+        const input = inputRef.current;
+
+        if (!input || document.activeElement !== input) {
+            return;
+        }
+
+        const { start, end } = selectionRef.current;
+
+        if (start !== null) {
+            input.setSelectionRange(start, end ?? start);
+        }
+    }, [initialValue]);
 
     const getProps = (index: number, itemId: string) => {
         const autocompleteItem = items.find((item) => item.id === itemId);
@@ -58,7 +90,7 @@ const AutocompleteContent: React.FC<AutocompleteContentProps> = ({
 
     return (
         <>
-            <input {...validInputProps} />
+            <input ref={inputRef} {...validInputProps} onChange={handleChange} />
             {inputProps && includes(inputProps.className, 'floating') && (
                 <Label
                     htmlFor={inputProps.id}


### PR DESCRIPTION
## What/Why?
Update autocomplete component to to avoid cursor jumping to end on edit.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

### Before

https://github.com/user-attachments/assets/27ca3767-72e2-4ca6-ba73-9d5778be54cc


### After

https://github.com/user-attachments/assets/39e1d914-5b28-4fe0-a168-227a25d1e22e



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `AutocompleteContent` handles input `onChange` and selection restoration, which could affect typing/selection behavior across all autocomplete usages. Scope is small but touches core input interaction logic.
> 
> **Overview**
> Fixes a cursor-jump issue in `AutocompleteContent` when the parent re-renders with a new `initialValue` (e.g., after selecting an item and then editing mid-string).
> 
> The input now tracks `selectionStart`/`selectionEnd` on each change and uses `useLayoutEffect` to restore the selection after `initialValue` updates, and a new test asserts cursor position is preserved after an autocomplete selection followed by typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a39efeaed048e7da97b97dbdfec24d59140c9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->