### PR TITLE
chore(payment): PAYPAL-6433 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.909.4",
+        "@bigcommerce/checkout-sdk": "^1.912.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,10 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.909.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.909.4.tgz",
-      "integrity": "sha512-zf5qyioVe40GABjcThTVfDqdnH1HzIwsTunn3V3xLFSYtvIwjAfd/NVFbMBP2rG169rohMeCTfpH9JX1quDKRA==",
-      "license": "MIT",
+      "version": "1.912.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.912.0.tgz",
+      "integrity": "sha512-ikzmv7fzX0iO55hqkp/nmLC3nT8DfoeaLMV7PPSAFFe67IYO2H3ueY64TJzFOVr+wRVdwIJ7rnI2rWuB0GuALA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",
@@ -29786,9 +29785,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.909.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.909.4.tgz",
-      "integrity": "sha512-zf5qyioVe40GABjcThTVfDqdnH1HzIwsTunn3V3xLFSYtvIwjAfd/NVFbMBP2rG169rohMeCTfpH9JX1quDKRA==",
+      "version": "1.912.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.912.0.tgz",
+      "integrity": "sha512-ikzmv7fzX0iO55hqkp/nmLC3nT8DfoeaLMV7PPSAFFe67IYO2H3ueY64TJzFOVr+wRVdwIJ7rnI2rWuB0GuALA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.909.4",
+    "@bigcommerce/checkout-sdk": "^1.912.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bumped checkout-sdk-js version

## Rollout/Rollback
Revert PR

## Testing
Not needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a core checkout dependency, which can change runtime behavior in payment/checkout flows even though this PR only touches dependency metadata.
> 
> **Overview**
> **Updates dependency:** bumps `@bigcommerce/checkout-sdk` from `^1.909.4` to `^1.912.0` in `package.json` and aligns `package-lock.json` (resolved tarball + integrity) to the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3193c2bd3ca83f176ed194745cab528836c36ce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->