### PR TITLE
Revert "feat(paymnet): Migrate CyberSource v2 to Resolver Configuration (#3015)"

### DIFF
--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -31,13 +31,13 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     HostedCreditCardPaymentMethod,
     [
-        { id: 'cba_mpgs' },
-        { id: 'credit_card', gateway: 'bluesnapdirect' },
-        { id: 'credit_card', gateway: 'checkoutcom' },
-        { id: 'cybersourcev2' },
         {
             id: 'hosted-credit-card',
         },
+        { id: 'credit_card', gateway: 'bluesnapdirect' },
+        { id: 'credit_card', gateway: 'checkoutcom' },
+
         { id: 'tdonlinemart' },
+        { id: 'cba_mpgs' },
     ],
 );


### PR DESCRIPTION
revert Migrate CyberSource v2 due tests

This reverts commit e51a1fcd93bbf24d27a7d34d031645c84e96646b.

## What/Why?

<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback

<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes resolver configuration/mapping for which payment method IDs use the hosted credit card component, with no business logic changes.
> 
> **Overview**
> Reorders and adjusts the `toResolvableComponent` resolver mappings in `HostedCreditCardPaymentMethod.tsx`.
> 
> This effectively removes the `cybersourcev2` (and related) IDs from being resolved to the hosted credit card integration, while keeping support for `hosted-credit-card`, `credit_card` (Bluesnap/Checkout.com), `tdonlinemart`, and `cba_mpgs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01689999162593da8e960d6de78149fb0443d606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->