### PR TITLE
fix(checkout): CHECKOUT-10023 Fix State/Province field placeholder te…

### DIFF
--- a/packages/core/src/app/address/AddressFormModal.tsx
+++ b/packages/core/src/app/address/AddressFormModal.tsx
@@ -101,7 +101,7 @@ const AddressFormModal: FunctionComponent<AddressFormModalProps> = ({
 
     return (
         <Modal
-            additionalModalClassName={classNames('modal--medium', { themeV2 })}
+            additionalModalClassName={classNames('modal--medium', 'modal--address', { themeV2 })}
             header={
                 <ModalHeader>
                     <TranslatedString id="address.add_address_heading" />

--- a/packages/core/src/scss/components/foundation/modal/_modal.scss
+++ b/packages/core/src/scss/components/foundation/modal/_modal.scss
@@ -67,6 +67,12 @@
             }
         }
 
+        &.modal--address {
+            @include breakpoint("small") {
+                max-width: 680px;
+            }
+        }
+
         &.modal--error,&.modal--confirm {
             padding-bottom: spacing("half");
             padding-left: #{spacing("half") + spacing("double")};


### PR DESCRIPTION
## What/Why?

### What?
Scope a width bump to **only** the **Add Address** modal using an explicit `modal--address` class selector.  Matches the existing `modal--medium` pattern. `EmailLoginForm` (the only other `modal--medium` consumer) is unchanged at 500px.  This will provide enough room for the `State/Province (Optional)` label to render without overlapping at the floating-label font size.

### Why?
On the checkout page, in the **Add Address** modal in the multi-shipping flow, the placeholder text overlaps in the State/Province field within the desktop modal when the field is optional. Thus creating an unpolished shopper UX.


## Rollout/Rollback

Revert the PR.

## Testing

### Before 

#### (Desktop view)

<img width="1248" height="720" alt="Screenshot 2026-05-04 at 11 39 52 am" src="https://github.com/user-attachments/assets/cc89b759-b22a-4a35-a176-2a6fc1cf8d55" />

#### (Mobile view)
<img width="489" height="653" alt="Screenshot 2026-05-04 at 11 41 15 am" src="https://github.com/user-attachments/assets/49ff9586-c328-45a8-b976-41bda9722203" />

### After

#### (Desktop view)

<img width="1141" height="673" alt="Screenshot 2026-05-21 at 12 35 18 am" src="https://github.com/user-attachments/assets/1390515e-94cd-4259-b118-2ddda0939f25" />

#### (Mobile view)

<img width="488" height="613" alt="Screenshot 2026-05-21 at 12 42 40 am" src="https://github.com/user-attachments/assets/f7d0ee88-2ca1-44ae-a28e-f88132c2ef8a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that scopes a wider max width to the Add Address modal on desktop; minimal chance of layout regressions outside modals.
> 
> **Overview**
> Widens the **Add Address** modal on desktop by introducing a new `modal--address` modifier (680px at `breakpoint("small")`) and applying it to `AddressFormModal`.
> 
> Keeps the existing `modal--medium` sizing (500px) for other consumers (e.g., `EmailLoginForm`) by leaving their classes unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd25a68731eaf82321237785d2967a7b516a1e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->