### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.915.0",
+        "@bigcommerce/checkout-sdk": "^1.916.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.915.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.915.0.tgz",
-      "integrity": "sha512-jHRHYW4rGl9+A+waNYqPohqzx9M4kv5iEIEFsv3iq2lCS0ZgfIZ19H5heNt0416PEOdTd452MM7XQa7BOavP/w==",
+      "version": "1.916.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.916.1.tgz",
+      "integrity": "sha512-AuyVD6goEs4O8e8oGHmEXdjFa1YjkOayA+RSR5G02bS04c9pWkj6IbDARrGSYk2kK2wXhobxstJhWhth63kTZg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.915.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.915.0.tgz",
-      "integrity": "sha512-jHRHYW4rGl9+A+waNYqPohqzx9M4kv5iEIEFsv3iq2lCS0ZgfIZ19H5heNt0416PEOdTd452MM7XQa7BOavP/w==",
+      "version": "1.916.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.916.1.tgz",
+      "integrity": "sha512-AuyVD6goEs4O8e8oGHmEXdjFa1YjkOayA+RSR5G02bS04c9pWkj6IbDARrGSYk2kK2wXhobxstJhWhth63kTZg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.915.0",
+    "@bigcommerce/checkout-sdk": "^1.916.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -23,9 +23,11 @@ export const defaultCapabilities: Capabilities = {
         hideSaveToAddressBookCheck: false,
     },
     payment: {
+        additionalField: null,
         paymentMethodFiltering: false,
         b2bPaymentMethodFilter: false,
         poPaymentMethod: false,
+        poConfig: null,
         additionalPaymentNotes: false,
         excludeOfflineForInvoice: false,
         excludePPSDK: false,


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-js version
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/3257](https://github.com/bigcommerce/checkout-sdk-js/pull/3257)

## Rollout/Rollback
Rollback this PR

## Testing
In Checkout-sdk-js PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps a core dependency (`@bigcommerce/checkout-sdk`) which can change checkout/payment behavior indirectly. Also updates `defaultCapabilities` to include new payment capability fields, which could affect feature-flag defaults if consumed elsewhere.
> 
> **Overview**
> Upgrades `@bigcommerce/checkout-sdk` from `1.915.0` to `1.916.1` (including lockfile updates).
> 
> Updates `defaultCapabilities` in `Capability.ts` to add new `payment` capability defaults (`additionalField` and `poConfig`, both `null`) to match the updated SDK `Capabilities` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8661adcab71cf52ae0cbab45ce6e7879492441b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->