### PR TITLE
feat(paymnet): Migrate CyberSource v2 to Resolver Configuration

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -1,9 +1,5 @@
 import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
-import {
-    createCyberSourcePaymentStrategy,
-    createCyberSourceV2PaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import React, { type FunctionComponent, useCallback } from 'react';
 
@@ -43,8 +39,6 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                     integrations: [
                         ...(options.integrations ?? []),
                         createCreditCardPaymentStrategy,
-                        createCyberSourcePaymentStrategy,
-                        createCyberSourceV2PaymentStrategy,
                         createSagePayPaymentStrategy,
                         createCBAMPGSPaymentStrategy,
                     ],

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -29,14 +29,13 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 };
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
-    HostedCreditCardPaymentMethod,
-    [
-        {
-            id: 'hosted-credit-card',
-        },
-        { id: 'credit_card', gateway: 'bluesnapdirect' },
-        { id: 'credit_card', gateway: 'checkoutcom' },
-
-        { id: 'tdonlinemart' },
-    ],
+  HostedCreditCardPaymentMethod,
+  [
+    { id: 'credit_card', gateway: 'bluesnapdirect' },
+    { id: 'credit_card', gateway: 'checkoutcom' },
+    { id: 'cybersourcev' },
+    { id: 'cybersourcev2' },
+    { id: 'hosted-credit-card' },
+    { id: 'tdonlinemart' },
+  ],
 );

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -4,6 +4,7 @@ import {
     type LegacyHostedFormOptions,
 } from '@bigcommerce/checkout-sdk';
 import { createBlueSnapDirectCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
+import { createCyberSourcePaymentStrategy, createCyberSourceV2PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
@@ -256,6 +257,8 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                     ...options,
                     integrations: [
                         createCreditCardPaymentStrategy,
+                        createCyberSourcePaymentStrategy,
+                        createCyberSourceV2PaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,


### PR DESCRIPTION
## What/Why?

<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback

<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which payment strategies run for CyberSource method IDs at checkout; regression risk if resolver matching or initializePayment integration order differs from the previous core path.
> 
> **Overview**
> **CyberSource** hosted card checkout is wired through the **hosted-credit-card-integration** resolver path instead of **core**’s generic hosted credit card wrapper.
> 
> `cybersourcev` and `cybersourcev2` are registered on `HostedCreditCardPaymentMethod`’s `toResolvableComponent` list alongside existing gateways. `HostedCreditCardComponent` now registers `createCyberSourcePaymentStrategy` and `createCyberSourceV2PaymentStrategy` when initializing payment.
> 
> Those CyberSource strategies and imports are **removed** from `packages/core/.../HostedCreditCardPaymentMethod.tsx`, so core no longer loads CyberSource for every hosted-card flow—only the integration package does for the resolved method IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5acb37381fb539db379173eaa0b3ea2afa99ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->