### PR TITLE
chore(payment): PAYPAL-6439 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.916.0",
+        "@bigcommerce/checkout-sdk": "^1.917.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,10 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.916.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.916.0.tgz",
-      "integrity": "sha512-e2jifxUxGUwJ4wb7jKGBLup+6Eb2cPwBifXmU2hiGyICP9hm241fRU6KbV93Buevg95j7DZthEmUYMDFX3yGJg==",
-      "license": "MIT",
+      "version": "1.917.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.917.0.tgz",
+      "integrity": "sha512-iZg+BjFpaXmcRcEyIgLmhe/X1ijGzEUYJymM+zeiw6ouUtMH4GTuCGsB9S3oIMbLGdsGbao6NU/4PxzVk8b+UA==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",
@@ -29786,9 +29785,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.916.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.916.0.tgz",
-      "integrity": "sha512-e2jifxUxGUwJ4wb7jKGBLup+6Eb2cPwBifXmU2hiGyICP9hm241fRU6KbV93Buevg95j7DZthEmUYMDFX3yGJg==",
+      "version": "1.917.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.917.0.tgz",
+      "integrity": "sha512-iZg+BjFpaXmcRcEyIgLmhe/X1ijGzEUYJymM+zeiw6ouUtMH4GTuCGsB9S3oIMbLGdsGbao6NU/4PxzVk8b+UA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.916.0",
+    "@bigcommerce/checkout-sdk": "^1.917.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bumped checkout-sdk-js version

## Rollout/Rollback
Revert

## Testing
Not needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment/checkout behavior is delegated to the SDK; risk depends on 1.917.0 changes not visible in this diff, with rollback via revert as noted.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **^1.916.0** to **^1.917.0** in `package.json` and `package-lock.json` (PAYPAL-6439). There are **no application source changes** in this repo—checkout behavior for PayPal and other SDK-backed flows will follow whatever shipped in **1.917.0** of the external package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab435450e0aaabc62bd273347c1f7347c4eceb0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->