### PR TITLE
Revert "feat(payment): PI-4748 Migrate CBA MPGS to Resolver Configuration (#3005)

### DIFF
--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -38,6 +38,5 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
         { id: 'credit_card', gateway: 'checkoutcom' },
 
         { id: 'tdonlinemart' },
-        { id: 'cba_mpgs' },
     ],
 );


### PR DESCRIPTION
…"

This reverts commit d569f171578dec5340a28a66244b3aee508417ab.

## What/Why?

revert this PR in case of this 3ds problems

## Rollout/Rollback

Rollback PR

## Testing

1) With 3ds and manual card input

https://github.com/user-attachments/assets/45f4c272-3dcc-49a2-ae1c-2d7f5cfa74d3

2)without 3ds

https://github.com/user-attachments/assets/844fa819-e4a3-4e1b-97d6-3232412c8281

3) with saved card

https://github.com/user-attachments/assets/66bbdae6-e73d-4ce4-b713-754636d81af4

4) with saved card and 3ds

https://github.com/user-attachments/assets/a0c575c5-bb46-4a6f-b1ec-565029b1922c


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which UI/integration handles CBA MPGS at checkout, including 3DS flows; scope is narrow but payment-critical for that gateway.
> 
> **Overview**
> Reverts the **PI-4748** wiring that routed **CBA MPGS** through the hosted credit card resolver by **removing** `{ id: 'cba_mpgs' }` from the `toResolvableComponent` IDs in `HostedCreditCardPaymentMethod.tsx`.
> 
> Checkout will no longer resolve that method to `HostedCreditCardComponent` via this package; behavior should match the pre-migration path (intended to address **3DS** issues called out in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf9f61d868cc4c03d055eb2d5b7d89d9c967970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->