### PR TITLE
chore(payment): PAYPAL-5902 clean up Braintree Credit Card 3D Secure options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.919.0",
+        "@bigcommerce/checkout-sdk": "^1.920.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.919.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.919.0.tgz",
-      "integrity": "sha512-LK588yJzk8fz1u47aN2fAdzrtOHETokCtxYU01zHRLIjCl+rq84A4mSdX9M6Uf/L8lrvqYhxDVcxL4+5vCvTiw==",
+      "version": "1.920.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.1.tgz",
+      "integrity": "sha512-Ox9HRWqOdBLPo+JFnYJZ22ParBfygE/1Rpn9RaYBi9USUm0uTmqREbLMaDfORbdrE1YRRfzawurDSXyRbvZ51g==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.919.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.919.0.tgz",
-      "integrity": "sha512-LK588yJzk8fz1u47aN2fAdzrtOHETokCtxYU01zHRLIjCl+rq84A4mSdX9M6Uf/L8lrvqYhxDVcxL4+5vCvTiw==",
+      "version": "1.920.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.1.tgz",
+      "integrity": "sha512-Ox9HRWqOdBLPo+JFnYJZ22ParBfygE/1Rpn9RaYBi9USUm0uTmqREbLMaDfORbdrE1YRRfzawurDSXyRbvZ51g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.919.0",
+    "@bigcommerce/checkout-sdk": "^1.920.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/braintree-integration/src/BraintreeCreditCardsPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeCreditCardsPaymentMethod.tsx
@@ -1,15 +1,7 @@
 import { type CardInstrument, type LegacyHostedFormOptions } from '@bigcommerce/checkout-sdk';
 import { createBraintreeCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import { compact, forIn } from 'lodash';
-import React, {
-    createRef,
-    type FunctionComponent,
-    type ReactNode,
-    type RefObject,
-    useCallback,
-    useRef,
-    useState,
-} from 'react';
+import React, { type FunctionComponent, type ReactNode, useCallback, useState } from 'react';
 
 import {
     CreditCardPaymentMethodComponent,
@@ -28,30 +20,18 @@ import {
     isInstrumentCardCodeRequiredSelector,
     isInstrumentCardNumberRequiredSelector,
 } from '@bigcommerce/checkout/instrument-utils';
-import { TranslatedString } from '@bigcommerce/checkout/locale';
 import {
     type PaymentMethodProps,
     type PaymentMethodResolveId,
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
-import { Modal } from '@bigcommerce/checkout/ui';
-
-interface BraintreeCreditCardPaymentMethodRef {
-    threeDSecureContentRef: RefObject<HTMLDivElement>;
-    cancelThreeDSecureVerification?(): void;
-}
 
 const BraintreeCreditCardsPaymentMethod: FunctionComponent<PaymentMethodProps> = (props) => {
     const { checkoutService, checkoutState, paymentForm, language, method, onUnhandledError } =
         props;
     const { isHostedFormEnabled } = method.config;
 
-    const [threeDSecureContent, setThreeDSecureContent] = useState<HTMLElement>();
     const [focusedFieldType, setFocusedFieldType] = useState<string>();
-
-    const ref = useRef<BraintreeCreditCardPaymentMethodRef>({
-        threeDSecureContentRef: createRef(),
-    });
 
     const { cardCode, showCardHolderName, requireCustomerCode } = method.config;
     const { setFieldTouched, setFieldValue, setSubmitted, submitForm } = paymentForm;
@@ -255,24 +235,6 @@ const BraintreeCreditCardsPaymentMethod: FunctionComponent<PaymentMethodProps> =
                     ...options,
                     integrations: [createBraintreeCreditCardPaymentStrategy],
                     braintree: {
-                        threeDSecure: {
-                            addFrame(
-                                error: Error | undefined,
-                                content: HTMLIFrameElement,
-                                cancel: () => Promise<unknown> | undefined,
-                            ) {
-                                if (error) {
-                                    return onUnhandledError(error);
-                                }
-
-                                setThreeDSecureContent(content);
-                                ref.current.cancelThreeDSecureVerification = cancel;
-                            },
-                            removeFrame() {
-                                setThreeDSecureContent(undefined);
-                                ref.current.cancelThreeDSecureVerification = undefined;
-                            },
-                        },
                         onPaymentError(error: Error) {
                             if (error.message === 'THREEDS_VERIFICATION_FAILED') {
                                 onUnhandledError?.(
@@ -294,21 +256,6 @@ const BraintreeCreditCardsPaymentMethod: FunctionComponent<PaymentMethodProps> =
             },
             [getHostedFormOptions, initializePayment, onUnhandledError],
         );
-
-    const appendThreeDSecureContent = useCallback(() => {
-        if (ref.current.threeDSecureContentRef.current && threeDSecureContent) {
-            ref.current.threeDSecureContentRef.current.appendChild(threeDSecureContent);
-        }
-    }, [threeDSecureContent]);
-
-    const cancelThreeDSecureModalFlow = useCallback(() => {
-        setThreeDSecureContent(undefined);
-
-        if (ref.current.cancelThreeDSecureVerification) {
-            ref.current.cancelThreeDSecureVerification();
-            ref.current.cancelThreeDSecureVerification = undefined;
-        }
-    }, []);
 
     if (!method.config.isHostedFormEnabled) {
         return (
@@ -348,16 +295,6 @@ const BraintreeCreditCardsPaymentMethod: FunctionComponent<PaymentMethodProps> =
                     isCardExpiryRequired: true,
                 })}
             />
-
-            <Modal
-                additionalBodyClassName="modal-body--center"
-                closeButtonLabel={<TranslatedString id="common.close_action" />}
-                isOpen={!!threeDSecureContent}
-                onAfterOpen={appendThreeDSecureContent}
-                onRequestClose={cancelThreeDSecureModalFlow}
-            >
-                <div ref={ref.current.threeDSecureContentRef} />
-            </Modal>
         </>
     );
 };

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -24,7 +24,7 @@ export const defaultCapabilities: Capabilities = {
     },
     payment: {
         paymentMethodFiltering: false,
-        b2bPaymentMethodFilter: false,
+        b2bPaymentMethodFilterType: null,
         poPaymentMethod: false,
         additionalPaymentNotes: false,
         excludeOfflineForInvoice: false,


### PR DESCRIPTION
## What/Why?

Clean up the Braintree Credit Card 3D Secure update. (Remove deprecated options)
Updated the `checkout-sdk-js` version

## Rollout/Rollback

Revert

## Testing

CI Passed + Manual

https://private-user-images.githubusercontent.com/284702205/598673276-b7f6f90f-ecd4-4a7a-b0c3-ae869e4feb00.mov?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Nzk4Njk3MTQsIm5iZiI6MTc3OTg2OTQxNCwicGF0aCI6Ii8yODQ3MDIyMDUvNTk4NjczMjc2LWI3ZjZmOTBmLWVjZDQtNGE3YS1iMGMzLWFlODY5ZTRmZWIwMC5tb3Y_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNTI3JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDUyN1QwODEwMTRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT04NGZmZDNkYmVlNjRhYzQ4NjczMjM1ZjFmZjFmY2EyMDBjMTkxOWY3YWEzNjE5MTAxZTMwODA1YTc5YmRkNmNjJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9dmlkZW8lMkZxdWlja3RpbWUifQ.jAr9lNvRAIbMqYDGi97eriH-cvIvrkvmVJMxEJa2iss



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment UX for Braintree 3DS moves entirely to the SDK; incorrect SDK behavior would affect card checkout, and the capability rename must stay in sync with SDK consumers.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from `^1.919.0` to **`^1.920.1`** so Braintree credit card 3DS is handled in the SDK instead of checkout-js.
> 
> **Braintree credit cards:** Removes the local 3DS modal flow—`threeDSecure` `addFrame`/`removeFrame` hooks, iframe state/refs, and the **`Modal`** wrapper—while keeping **`onPaymentError`** mapping for `THREEDS_VERIFICATION_FAILED`.
> 
> **Capabilities:** Replaces the boolean **`b2bPaymentMethodFilter`** default with **`b2bPaymentMethodFilterType: null`** to align with the updated SDK capability shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7597ccb53d1c5efa3880a353bffa769dfc78fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->