### PR TITLE
feat(checkout): CHECKOUT-9823 billing and shipping extra fields enhancements

### DIFF
--- a/packages/core/src/app/address/AddressSelect.test.tsx
+++ b/packages/core/src/app/address/AddressSelect.test.tsx
@@ -19,7 +19,6 @@ import { getCustomer } from '../customer/customers.mock';
 import { getAddress } from './address.mock';
 import AddressSelect, { type AddressSelectProps } from './AddressSelect';
 import AddressType from './AddressType';
-import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import { getAddressContent } from './SingleLineStaticAddress';
 
 describe('AddressSelect component', () => {
@@ -113,6 +112,28 @@ describe('AddressSelect component', () => {
         expect(onSelectAddress).toHaveBeenCalledWith(getCustomer().addresses[0]);
     });
 
+    it('passes the selected address through to onSelectAddress with its extraFields intact', () => {
+        const onSelectAddress = jest.fn();
+        const addressWithExtras = {
+            ...getCustomer().addresses[0],
+            extraFields: [{ fieldId: '100', fieldValue: 'A-Corp' }],
+        };
+
+        renderAddressSelect({
+            addresses: [addressWithExtras, ...getCustomer().addresses.slice(1)],
+            onSelectAddress,
+        });
+
+        fireEvent.click(screen.getByTestId('address-select-button'));
+        fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
+
+        expect(onSelectAddress).toHaveBeenCalledWith(
+            expect.objectContaining({
+                extraFields: [{ fieldId: '100', fieldValue: 'A-Corp' }],
+            }),
+        );
+    });
+
     it('does not trigger onSelectAddress callback if same address is selected', () => {
         const onSelectAddress = jest.fn();
         const selectedAddress = getCustomer().addresses[0];
@@ -159,79 +180,6 @@ describe('AddressSelect component', () => {
         fireEvent.click(screen.getByTestId('address-select-button'));
 
         expect(screen.getByRole('textbox', { name: 'Search addresses' })).toBeInTheDocument();
-    });
-
-    describe('storageKey / reading extra fields', () => {
-        const storageKey = 'test_storage_key';
-
-        afterEach(() => {
-            B2BExtraFieldsSessionStorage.removeFields(storageKey);
-        });
-
-        it('enriches address with extra fields from session storage when storageKey is provided', () => {
-            const onSelectAddress = jest.fn();
-
-            B2BExtraFieldsSessionStorage.setFields(storageKey, { b2bExtraField_foo: 'bar' });
-
-            renderAddressSelect({ onSelectAddress, storageKey });
-
-            fireEvent.click(screen.getByTestId('address-select-button'));
-            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
-
-            expect(onSelectAddress).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    extraFields: [{ fieldId: 'b2bExtraField_foo', fieldValue: 'bar' }],
-                }),
-            );
-        });
-
-        it('preserves numeric extra field values without string coercion', () => {
-            const onSelectAddress = jest.fn();
-
-            B2BExtraFieldsSessionStorage.setFields(storageKey, { b2bExtraField_num: 42 });
-
-            renderAddressSelect({ onSelectAddress, storageKey });
-
-            fireEvent.click(screen.getByTestId('address-select-button'));
-            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
-
-            expect(onSelectAddress).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    extraFields: [{ fieldId: 'b2bExtraField_num', fieldValue: 42 }],
-                }),
-            );
-        });
-
-        it('does not call onSelectAddress when re-selecting an address whose extra fields match session storage', () => {
-            const onSelectAddress = jest.fn();
-
-            B2BExtraFieldsSessionStorage.setFields(storageKey, { b2bExtraField_foo: 'bar' });
-
-            const selectedAddress = {
-                ...getCustomer().addresses[0],
-                extraFields: [{ fieldId: 'b2bExtraField_foo', fieldValue: 'bar' }],
-            };
-
-            renderAddressSelect({ onSelectAddress, selectedAddress, storageKey });
-
-            fireEvent.click(screen.getByTestId('address-select-button'));
-            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
-
-            expect(onSelectAddress).not.toHaveBeenCalled();
-        });
-
-        it('calls onSelectAddress without extra fields when no storageKey is provided', () => {
-            const onSelectAddress = jest.fn();
-
-            renderAddressSelect({ onSelectAddress });
-
-            fireEvent.click(screen.getByTestId('address-select-button'));
-            fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
-
-            expect(onSelectAddress).toHaveBeenCalledWith(
-                expect.not.objectContaining({ extraFields: expect.anything() }),
-            );
-        });
     });
 
     it('shows Powered By PP Fastlane label', () => {

--- a/packages/core/src/app/address/AddressSelect.test.tsx
+++ b/packages/core/src/app/address/AddressSelect.test.tsx
@@ -112,28 +112,6 @@ describe('AddressSelect component', () => {
         expect(onSelectAddress).toHaveBeenCalledWith(getCustomer().addresses[0]);
     });
 
-    it('passes the selected address through to onSelectAddress with its extraFields intact', () => {
-        const onSelectAddress = jest.fn();
-        const addressWithExtras = {
-            ...getCustomer().addresses[0],
-            extraFields: [{ fieldId: '100', fieldValue: 'A-Corp' }],
-        };
-
-        renderAddressSelect({
-            addresses: [addressWithExtras, ...getCustomer().addresses.slice(1)],
-            onSelectAddress,
-        });
-
-        fireEvent.click(screen.getByTestId('address-select-button'));
-        fireEvent.click(screen.getAllByTestId('address-select-option-action')[0]);
-
-        expect(onSelectAddress).toHaveBeenCalledWith(
-            expect.objectContaining({
-                extraFields: [{ fieldId: '100', fieldValue: 'A-Corp' }],
-            }),
-        );
-    });
-
     it('does not trigger onSelectAddress callback if same address is selected', () => {
         const onSelectAddress = jest.fn();
         const selectedAddress = getCustomer().addresses[0];

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -75,7 +75,6 @@ const AddressSelect = ({
                     }
                 >
                     <AddressSelectButton
-                        addresses={addresses}
                         placeholderText={placeholderText}
                         selectedAddress={selectedAddress}
                         showSingleLineAddress={showSingleLineAddress}

--- a/packages/core/src/app/address/AddressSelect.tsx
+++ b/packages/core/src/app/address/AddressSelect.tsx
@@ -11,7 +11,6 @@ import { DropdownTrigger } from '@bigcommerce/checkout/ui';
 import AddressSelectButton from './AddressSelectButton';
 import { AddressSelectComponent } from './AddressSelectComponent';
 import type AddressType from './AddressType';
-import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import isEqualAddress from './isEqualAddress';
 import { SearchableAddressSelectComponent } from './SearchableAddressSelectComponent';
 
@@ -22,7 +21,6 @@ export interface AddressSelectProps {
     selectedAddress?: Address;
     type: AddressType;
     showSingleLineAddress?: boolean;
-    storageKey?: string;
     onSelectAddress(address: Address): void;
     onUseNewAddress(currentAddress?: Address): void;
     placeholderText?: ReactNode;
@@ -33,7 +31,6 @@ const AddressSelect = ({
     selectedAddress,
     type,
     showSingleLineAddress,
-    storageKey,
     onSelectAddress,
     onUseNewAddress,
     placeholderText,
@@ -44,10 +41,8 @@ const AddressSelect = ({
     const { shouldShowPayPalFastlaneLabel } = usePayPalFastlaneAddress();
 
     const handleSelectAddress = (newAddress: Address) => {
-        const addressWithExtraFields = getAddressWithExtraFields(newAddress, storageKey);
-
-        if (!isEqualAddress(selectedAddress, addressWithExtraFields)) {
-            onSelectAddress(addressWithExtraFields);
+        if (!isEqualAddress(selectedAddress, newAddress)) {
+            onSelectAddress(newAddress);
         }
     };
 
@@ -93,21 +88,5 @@ const AddressSelect = ({
         </div>
     );
 };
-
-function getAddressWithExtraFields(address: Address, storageKey?: string): Address {
-    if (!storageKey) return address;
-
-    const storedExtraFields = B2BExtraFieldsSessionStorage.getFields(storageKey);
-
-    if (!storedExtraFields) return address;
-
-    return {
-        ...address,
-        extraFields: Object.entries(storedExtraFields).map(([fieldId, fieldValue]) => ({
-            fieldId,
-            fieldValue: typeof fieldValue === 'number' ? fieldValue : String(fieldValue),
-        })),
-    };
-}
 
 export default memo(AddressSelect);

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -13,7 +13,7 @@ import StaticAddress from './StaticAddress';
 
 type AddressSelectButtonProps = Pick<
     AddressSelectProps,
-    'selectedAddress' | 'addresses' | 'type' | 'showSingleLineAddress' | 'placeholderText'
+    'selectedAddress' | 'type' | 'showSingleLineAddress' | 'placeholderText'
 >;
 
 const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLanguageProps> = ({

--- a/packages/core/src/app/address/SearchableAddressSelectComponent.test.tsx
+++ b/packages/core/src/app/address/SearchableAddressSelectComponent.test.tsx
@@ -13,7 +13,7 @@ import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
 
 import { getCheckout } from '../checkout/checkouts.mock';
 import { getStoreConfig } from '../config/config.mock';
-import { getCustomer } from '../customer/customers.mock';
+import { getB2BCustomer } from '../customer/customers.mock';
 import { getCountries } from '../geography/countries.mock';
 
 import { getAddress } from './address.mock';
@@ -28,7 +28,7 @@ describe('SearchableAddressSelectComponent', () => {
     let localeContext: LocaleContextType;
 
     const defaultProps: SearchableAddressSelectProps = {
-        addresses: getCustomer().addresses,
+        addresses: getB2BCustomer().addresses,
         onSelectAddress: noop,
         onUseNewAddress: noop,
         type: AddressType.Billing,
@@ -98,7 +98,8 @@ describe('SearchableAddressSelectComponent', () => {
 
     it('calls onSelectAddress with selected address when an address option is clicked', () => {
         const onSelectAddress = jest.fn();
-        const addresses = getCustomer().addresses;
+        const addresses = getB2BCustomer().addresses;
+        const billingAddresses = addresses.filter((address) => address.isBilling);
 
         renderComponent({ onSelectAddress, addresses });
 
@@ -106,11 +107,11 @@ describe('SearchableAddressSelectComponent', () => {
 
         fireEvent.click(firstOptionAction);
 
-        expect(onSelectAddress).toHaveBeenCalledWith(addresses[0]);
+        expect(onSelectAddress).toHaveBeenCalledWith(billingAddresses[0]);
     });
 
     it('filters addresses when user types in search input', () => {
-        const addresses = getCustomer().addresses;
+        const addresses = getB2BCustomer().addresses;
 
         renderComponent({ addresses });
 
@@ -125,11 +126,29 @@ describe('SearchableAddressSelectComponent', () => {
         expect(screen.getByText('Invalid Address')).toBeInTheDocument();
     });
 
-    it('renders all addresses when search query is empty', () => {
-        const addresses = getCustomer().addresses;
+    it('renders only billing addresses on the billing step', () => {
+        const addresses = getB2BCustomer().addresses;
+        const billingAddresses = addresses.filter((address) => address.isBilling);
 
-        renderComponent({ addresses });
+        renderComponent({ addresses, type: AddressType.Billing });
 
-        expect(screen.getAllByTestId('address-select-option')).toHaveLength(addresses.length);
+        expect(screen.getAllByTestId('address-select-option')).toHaveLength(
+            billingAddresses.length,
+        );
+        expect(screen.queryByText('Shipping Only Way')).not.toBeInTheDocument();
+        expect(screen.getByText(/Billing Only Way/)).toBeInTheDocument();
+    });
+
+    it('renders only shipping addresses on the shipping step', () => {
+        const addresses = getB2BCustomer().addresses;
+        const shippingAddresses = addresses.filter((address) => address.isShipping);
+
+        renderComponent({ addresses, type: AddressType.Shipping });
+
+        expect(screen.getAllByTestId('address-select-option')).toHaveLength(
+            shippingAddresses.length,
+        );
+        expect(screen.queryByText('Billing Only Way')).not.toBeInTheDocument();
+        expect(screen.getByText(/Shipping Only Way/)).toBeInTheDocument();
     });
 });

--- a/packages/core/src/app/address/SearchableAddressSelectComponent.tsx
+++ b/packages/core/src/app/address/SearchableAddressSelectComponent.tsx
@@ -37,10 +37,13 @@ export const SearchableAddressSelectComponent: FunctionComponent<SearchableAddre
             ? restrictManualAddressEntryForShipping
             : restrictManualAddressEntryForBilling;
 
-    const filteredAddresses = useMemo(
-        () => searchingAddresses(addresses, searchQuery),
-        [addresses, searchQuery],
-    );
+    const filteredAddresses = useMemo(() => {
+        const addressesByType = addresses.filter((address) =>
+            type === AddressType.Shipping ? address.isShipping : address.isBilling,
+        );
+
+        return searchingAddresses(addressesByType, searchQuery);
+    }, [addresses, searchQuery, type]);
 
     const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
         setSearchQuery(e.target.value);

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -2,6 +2,7 @@ import {
     type Address,
     type CheckoutSelectors,
     type Country,
+    type CustomerAddress,
     type ShippingInitializeOptions,
 } from '@bigcommerce/checkout-sdk';
 import { isEmpty } from 'lodash';
@@ -13,6 +14,7 @@ import { localizeAddress } from '@bigcommerce/checkout/locale';
 import { withCheckout } from '../checkout';
 
 import AddressType from './AddressType';
+import getAddressWithLabel from './getAddressWithLabel';
 
 import './StaticAddress.scss';
 
@@ -27,12 +29,14 @@ export interface StaticAddressEditableProps extends StaticAddressProps {
 
 interface WithCheckoutStaticAddressProps {
     countries?: Country[];
+    customerAddresses?: CustomerAddress[];
 }
 
 const StaticAddress: FunctionComponent<
     StaticAddressEditableProps & WithCheckoutStaticAddressProps
-> = ({ countries, address: addressWithoutLocalization }) => {
-    const address = localizeAddress(addressWithoutLocalization, countries);
+> = ({ countries, customerAddresses, address: addressWithoutLocalization }) => {
+    const addressWithLabel = getAddressWithLabel(addressWithoutLocalization, customerAddresses);
+    const address = localizeAddress(addressWithLabel, countries);
     const isValid = !isEmpty(address);
 
     return !isValid ? null : (
@@ -88,12 +92,13 @@ export function mapToStaticAddressProps(
 ): WithCheckoutStaticAddressProps | null {
     const {
         checkoutState: {
-            data: { getBillingCountries, getShippingCountries },
+            data: { getBillingCountries, getShippingCountries, getCustomer },
         },
     } = context;
 
     return {
         countries: type === AddressType.Billing ? getBillingCountries() : getShippingCountries(),
+        customerAddresses: getCustomer()?.addresses,
     };
 }
 

--- a/packages/core/src/app/address/StaticAddress.tsx
+++ b/packages/core/src/app/address/StaticAddress.tsx
@@ -44,6 +44,12 @@ const StaticAddress: FunctionComponent<
                 </p>
             )}
 
+            {address.label && (
+                <p className="address-entry body-regular">
+                    <span className="label">{address.label}</span>
+                </p>
+            )}
+
             {(address.phone || address.company) && (
                 <p className="address-entry body-regular">
                     <span className="company-name">{`${address.company} `}</span>

--- a/packages/core/src/app/address/getAddressWithCustomerExtraFields.test.ts
+++ b/packages/core/src/app/address/getAddressWithCustomerExtraFields.test.ts
@@ -1,0 +1,93 @@
+import {
+    type Address,
+    type AddressExtraFieldValue,
+    type CustomerAddress,
+} from '@bigcommerce/checkout-sdk';
+
+import { getAddress } from './address.mock';
+import getAddressWithCustomerExtraFields from './getAddressWithCustomerExtraFields';
+
+const extraFields: AddressExtraFieldValue[] = [
+    { fieldId: '100', fieldValue: 'Acme Corp' },
+    { fieldId: '200', fieldValue: 'Engineering' },
+];
+
+function getCustomerAddress(overrides: Partial<CustomerAddress> = {}): CustomerAddress {
+    return {
+        ...getAddress(),
+        id: 1,
+        type: 'residential',
+        ...overrides,
+    } as CustomerAddress;
+}
+
+describe('getAddressWithCustomerExtraFields', () => {
+    it('returns the raw address unchanged when hasAddressExtraFields is false (B2C)', () => {
+        const raw: Address = { ...getAddress() };
+        const customerAddresses: CustomerAddress[] = [getCustomerAddress({ extraFields })];
+
+        const result = getAddressWithCustomerExtraFields(raw, customerAddresses, false);
+
+        expect(result).toBe(raw);
+    });
+
+    it('returns undefined when the raw address is undefined', () => {
+        const result = getAddressWithCustomerExtraFields(
+            undefined,
+            [getCustomerAddress({ extraFields })],
+            true,
+        );
+
+        expect(result).toBeUndefined();
+    });
+
+    it('returns the raw address unchanged when it already has extraFields', () => {
+        const raw: Address = {
+            ...getAddress(),
+            extraFields: [{ fieldId: '100', fieldValue: 'Already Here' }],
+        };
+        const customerAddresses: CustomerAddress[] = [getCustomerAddress({ extraFields })];
+
+        const result = getAddressWithCustomerExtraFields(raw, customerAddresses, true);
+
+        expect(result).toBe(raw);
+    });
+
+    it('returns the raw address unchanged when no customer address matches', () => {
+        const raw: Address = { ...getAddress() };
+        const customerAddresses: CustomerAddress[] = [
+            getCustomerAddress({ address1: 'Some other street', extraFields }),
+        ];
+
+        const result = getAddressWithCustomerExtraFields(raw, customerAddresses, true);
+
+        expect(result).toBe(raw);
+    });
+
+    it('returns the raw address unchanged when the matching customer address has no extraFields', () => {
+        const raw: Address = { ...getAddress() };
+        const customerAddresses: CustomerAddress[] = [getCustomerAddress()];
+
+        const result = getAddressWithCustomerExtraFields(raw, customerAddresses, true);
+
+        expect(result).toBe(raw);
+    });
+
+    it('grafts extraFields from the matching customer address onto the raw address', () => {
+        const raw: Address = { ...getAddress() };
+        const customerAddresses: CustomerAddress[] = [getCustomerAddress({ extraFields })];
+
+        const result = getAddressWithCustomerExtraFields(raw, customerAddresses, true);
+
+        expect(result).toEqual({ ...raw, extraFields });
+        expect(result).not.toBe(raw);
+    });
+
+    it('returns the raw address unchanged when customerAddresses is undefined', () => {
+        const raw: Address = { ...getAddress() };
+
+        const result = getAddressWithCustomerExtraFields(raw, undefined, true);
+
+        expect(result).toBe(raw);
+    });
+});

--- a/packages/core/src/app/address/getAddressWithCustomerExtraFields.ts
+++ b/packages/core/src/app/address/getAddressWithCustomerExtraFields.ts
@@ -1,0 +1,31 @@
+import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import isEqualAddress from './isEqualAddress';
+
+/**
+ * `updateBillingAddress` / `updateShippingAddress` don't round-trip B2B
+ * `extraFields` through the checkout state. Look up the matching customer
+ * address book entry and graft its `extraFields` onto the current address so
+ * the form and validation see the values. No-op for B2C
+ * (`hasAddressExtraFields=false`) and when the address already carries its
+ * own `extraFields`.
+ */
+export default function getAddressWithCustomerExtraFields<T extends Address>(
+    address: T | undefined,
+    customerAddresses: CustomerAddress[] | undefined,
+    hasAddressExtraFields: boolean,
+): T | undefined {
+    if (!hasAddressExtraFields || !address) {
+        return address;
+    }
+
+    if (address.extraFields?.length) {
+        return address;
+    }
+
+    const match = customerAddresses?.find((customerAddress) =>
+        isEqualAddress(customerAddress, address),
+    );
+
+    return match?.extraFields?.length ? { ...address, extraFields: match.extraFields } : address;
+}

--- a/packages/core/src/app/address/getAddressWithLabel.ts
+++ b/packages/core/src/app/address/getAddressWithLabel.ts
@@ -10,6 +10,12 @@ export default function getAddressWithLabel<T extends Address>(
         return address;
     }
 
+    // We match only against the locally loaded `customerAddresses`, not the
+    // full server-side company address book. A company may have many more
+    // addresses on the server than are returned here, so an address selected
+    // from the full book may not appear in this subset and will render without
+    // a label. We accept that gap rather than round-tripping to the API to
+    // resolve a purely cosmetic label.
     const match = customerAddresses.find((customerAddress) =>
         isEqualAddress(address, customerAddress),
     );

--- a/packages/core/src/app/address/getAddressWithLabel.ts
+++ b/packages/core/src/app/address/getAddressWithLabel.ts
@@ -1,0 +1,18 @@
+import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import isEqualAddress from './isEqualAddress';
+
+export default function getAddressWithLabel<T extends Address>(
+    address: T,
+    customerAddresses: CustomerAddress[] = [],
+): T {
+    if (address.label) {
+        return address;
+    }
+
+    const match = customerAddresses.find((customerAddress) =>
+        isEqualAddress(address, customerAddress),
+    );
+
+    return match?.label ? { ...address, label: match.label } : address;
+}

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -10,6 +10,7 @@ export { default as StaticAddress } from './StaticAddress';
 export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';
+export { default as getAddressWithLabel } from './getAddressWithLabel';
 export { reorderAddressFormFields } from './reorderAddressFormFields';
 export {
     default as getAddressFormFieldsValidationSchema,

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -11,6 +11,7 @@ export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';
 export { default as getAddressWithLabel } from './getAddressWithLabel';
+export { default as getAddressWithCustomerExtraFields } from './getAddressWithCustomerExtraFields';
 export { reorderAddressFormFields } from './reorderAddressFormFields';
 export {
     default as getAddressFormFieldsValidationSchema,

--- a/packages/core/src/app/address/isEqualAddress.ts
+++ b/packages/core/src/app/address/isEqualAddress.ts
@@ -50,6 +50,12 @@ function normalizeAddress(address: ComparableAddress) {
         'type',
         'email',
         'country',
+        'extraFields',
+        'isShipping',
+        'isBilling',
+        'isDefaultShipping',
+        'isDefaultBilling',
+        'label',
     ];
 
     return omit(

--- a/packages/core/src/app/address/mapAddressToFormValues.test.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.test.ts
@@ -1,5 +1,6 @@
 import { type Address, type FormField } from '@bigcommerce/checkout-sdk';
 
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import { getFormFields } from './formField.mock';
 import mapAddressToFormValues from './mapAddressToFormValues';
 
@@ -62,7 +63,7 @@ describe('mapAddressToFormValues', () => {
 
         const address = {
             firstName: 'John',
-            extraFields: [{ fieldId: 'b2bExtraField_100', fieldValue: 'Actual Corp' }],
+            extraFields: [{ fieldId: '100', fieldValue: 'Actual Corp' }],
         } as Address;
 
         const result = mapAddressToFormValues(fields, address);
@@ -109,5 +110,56 @@ describe('mapAddressToFormValues', () => {
         const result = mapAddressToFormValues(fields);
 
         expect(result.extraFields?.b2bExtraField_100).toBe('');
+    });
+
+    describe('session storage precedence', () => {
+        const storageKey = 'test_storage_key';
+
+        const extraField: FormField = {
+            custom: false,
+            default: 'Default Corp',
+            id: 'b2bExtraField_100',
+            label: 'Company Name',
+            name: 'b2bExtraField_100',
+            required: false,
+        };
+
+        afterEach(() => {
+            B2BExtraFieldsSessionStorage.removeFields(storageKey);
+        });
+
+        it('prefers extra field value from address over session storage', () => {
+            const fields: FormField[] = [...getFormFields(), extraField];
+
+            B2BExtraFieldsSessionStorage.setFields(storageKey, {
+                b2bExtraField_100: 'Stored Corp',
+            });
+
+            const address = {
+                firstName: 'John',
+                extraFields: [{ fieldId: '100', fieldValue: 'Address Corp' }],
+            } as Address;
+
+            const result = mapAddressToFormValues(fields, address, storageKey);
+
+            expect(result.extraFields?.b2bExtraField_100).toBe('Address Corp');
+        });
+
+        it('falls back to session storage when address has no value for the extra field', () => {
+            const fields: FormField[] = [...getFormFields(), extraField];
+
+            B2BExtraFieldsSessionStorage.setFields(storageKey, {
+                b2bExtraField_100: 'Stored Corp',
+            });
+
+            const address = {
+                firstName: 'John',
+                extraFields: [],
+            } as unknown as Address;
+
+            const result = mapAddressToFormValues(fields, address, storageKey);
+
+            expect(result.extraFields?.b2bExtraField_100).toBe('Stored Corp');
+        });
     });
 });

--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -1,6 +1,7 @@
 import {
     type Address,
     type AddressKey,
+    B2B_EXTRA_FIELD_PREFIX,
     type FormField,
     isExtraField,
 } from '@bigcommerce/checkout-sdk/essential';
@@ -22,6 +23,10 @@ export default function mapAddressToFormValues(
     address?: Address,
     storageKey?: string,
 ): AddressFormValues {
+    const storedExtraFields = storageKey
+        ? B2BExtraFieldsSessionStorage.getFields(storageKey)
+        : undefined;
+
     const values = {
         ...fields.reduce((addressFormValues, field) => {
             const { name, custom, fieldType, default: defaultValue } = field;
@@ -31,12 +36,17 @@ export default function mapAddressToFormValues(
                     addressFormValues.extraFields = {};
                 }
 
-                // sessionStorage-based values will override API side extra field values later
+                // SDK schema prefixes extra-field names with `B2B_EXTRA_FIELD_PREFIX`, but `Address.extraFields[i].fieldId`
+                // is the raw id — strip the prefix when matching. Remove once the SDK normalizes both sides.
+                const rawFieldId = name.startsWith(B2B_EXTRA_FIELD_PREFIX)
+                    ? name.slice(B2B_EXTRA_FIELD_PREFIX.length)
+                    : name;
                 const extraFieldValue = address?.extraFields?.find(
-                    ({ fieldId }) => fieldId === name,
+                    ({ fieldId }) => fieldId === rawFieldId,
                 )?.fieldValue;
 
-                addressFormValues.extraFields[name] = extraFieldValue ?? defaultValue ?? '';
+                addressFormValues.extraFields[name] =
+                    extraFieldValue ?? storedExtraFields?.[name] ?? defaultValue ?? '';
 
                 return addressFormValues;
             }
@@ -83,20 +93,6 @@ export default function mapAddressToFormValues(
 
     if (values.stateOrProvinceCode === undefined) {
         values.stateOrProvinceCode = '';
-    }
-
-    const extraFields = values.extraFields;
-
-    if (storageKey && extraFields) {
-        const storedExtraFields = B2BExtraFieldsSessionStorage.getFields(storageKey);
-
-        if (storedExtraFields) {
-            Object.keys(extraFields).forEach((key) => {
-                if (storedExtraFields[key] !== undefined) {
-                    extraFields[key] = storedExtraFields[key];
-                }
-            });
-        }
     }
 
     return values;

--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -37,7 +37,7 @@ export default function mapAddressToFormValues(
                 }
 
                 // SDK schema prefixes extra-field names with `B2B_EXTRA_FIELD_PREFIX`, but `Address.extraFields[i].fieldId`
-                // is the raw id — strip the prefix when matching. Remove once the SDK normalizes both sides.
+                // is the raw id — strip the prefix when matching.
                 const rawFieldId = name.startsWith(B2B_EXTRA_FIELD_PREFIX)
                     ? name.slice(B2B_EXTRA_FIELD_PREFIX.length)
                     : name;

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -5,7 +5,12 @@ import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, Legend } from '@bigcommerce/checkout/ui';
 
-import { B2BExtraFieldsSessionStorage, isEqualAddress, mapAddressFromFormValues } from '../address';
+import {
+    B2BExtraFieldsSessionStorage,
+    getAddressWithCustomerExtraFields,
+    isEqualAddress,
+    mapAddressFromFormValues,
+} from '../address';
 
 import BillingForm, { type BillingFormValues } from './BillingForm';
 import getBillingMethodId from './getBillingMethodId';
@@ -68,24 +73,15 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
     const customerMessage = checkout.customerMessage;
     const methodId = getBillingMethodId(checkout);
     const rawBillingAddress = getBillingAddress();
-    // B2B extraFields aren't round-tripped by `updateBillingAddress`, so graft
-    // them on from the matching customer address book entry. B2B only — for B2C
-    // there are no extraFields anywhere and this is a no-op passthrough.
-    const billingAddress = useMemo(() => {
-        if (!hasAddressExtraFields || !rawBillingAddress) {
-            return rawBillingAddress;
-        }
-
-        if (rawBillingAddress.extraFields?.length) {
-            return rawBillingAddress;
-        }
-
-        const match = customer.addresses?.find((addr) => isEqualAddress(addr, rawBillingAddress));
-
-        return match?.extraFields?.length
-            ? { ...rawBillingAddress, extraFields: match.extraFields }
-            : rawBillingAddress;
-    }, [hasAddressExtraFields, rawBillingAddress, customer.addresses]);
+    const billingAddress = useMemo(
+        () =>
+            getAddressWithCustomerExtraFields(
+                rawBillingAddress,
+                customer.addresses,
+                hasAddressExtraFields,
+            ),
+        [hasAddressExtraFields, rawBillingAddress, customer.addresses],
+    );
     const handleSubmit = async ({
         orderComment,
         ...addressValues

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -125,7 +125,11 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
                     );
 
                     if (defaultBillingAddress) {
-                        await checkoutService.updateBillingAddress(defaultBillingAddress);
+                        try {
+                            await checkoutService.updateBillingAddress(defaultBillingAddress);
+                        } catch {
+                            /* Do nothing: we should not block shoppers from buying. */
+                        }
                     }
                 }
 

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -36,7 +36,7 @@ const getFieldsWithExtraFields = (
 const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps): ReactElement => {
     const { checkoutService, checkoutState } = useCheckout();
     const {
-        userJourney: { hasAddressExtraFields },
+        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
         billing: { restrictManualAddressEntry },
     } = useCapabilities();
 
@@ -103,6 +103,17 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
         const init = async () => {
             try {
                 await checkoutService.loadBillingAddressFields();
+
+                if (hasCompanyAddressBook && !getBillingAddress()) {
+                    const defaultBillingAddress = customer.addresses?.find(
+                        ({ isDefaultBilling }) => isDefaultBilling,
+                    );
+
+                    if (defaultBillingAddress) {
+                        await checkoutService.updateBillingAddress(defaultBillingAddress);
+                    }
+                }
+
                 onReady();
             } catch (error) {
                 if (error instanceof Error) {

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -1,5 +1,5 @@
 import type { CheckoutSelectors, FormField } from '@bigcommerce/checkout-sdk';
-import React, { type ReactElement, useEffect, useState } from 'react';
+import React, { type ReactElement, useEffect, useMemo, useState } from 'react';
 
 import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -67,7 +67,25 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
     // Below constants are for <BillingForm />'s HOC props
     const customerMessage = checkout.customerMessage;
     const methodId = getBillingMethodId(checkout);
-    const billingAddress = getBillingAddress();
+    const rawBillingAddress = getBillingAddress();
+    // B2B extraFields aren't round-tripped by `updateBillingAddress`, so graft
+    // them on from the matching customer address book entry. B2B only — for B2C
+    // there are no extraFields anywhere and this is a no-op passthrough.
+    const billingAddress = useMemo(() => {
+        if (!hasAddressExtraFields || !rawBillingAddress) {
+            return rawBillingAddress;
+        }
+
+        if (rawBillingAddress.extraFields?.length) {
+            return rawBillingAddress;
+        }
+
+        const match = customer.addresses?.find((addr) => isEqualAddress(addr, rawBillingAddress));
+
+        return match?.extraFields?.length
+            ? { ...rawBillingAddress, extraFields: match.extraFields }
+            : rawBillingAddress;
+    }, [hasAddressExtraFields, rawBillingAddress, customer.addresses]);
     const handleSubmit = async ({
         orderComment,
         ...addressValues

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -1,5 +1,5 @@
 import type { CheckoutSelectors, FormField } from '@bigcommerce/checkout-sdk';
-import React, { type ReactElement, useEffect } from 'react';
+import React, { type ReactElement, useEffect, useState } from 'react';
 
 import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -61,7 +61,8 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
         throw new Error('Unable to access checkout data');
     }
 
-    const isInitializing = isLoadingBillingCountries();
+    const [isApplyingDefaultAddress, setIsApplyingDefaultAddress] = useState(true);
+    const isInitializing = isLoadingBillingCountries() || isApplyingDefaultAddress;
 
     // Below constants are for <BillingForm />'s HOC props
     const customerMessage = checkout.customerMessage;
@@ -119,6 +120,8 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
                 if (error instanceof Error) {
                     onUnhandledError(error);
                 }
+            } finally {
+                setIsApplyingDefaultAddress(false);
             }
         };
 

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -104,7 +104,7 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
             try {
                 await checkoutService.loadBillingAddressFields();
 
-                if (hasCompanyAddressBook && !getBillingAddress()) {
+                if (hasCompanyAddressBook && !getBillingAddress()?.address1) {
                     const defaultBillingAddress = customer.addresses?.find(
                         ({ isDefaultBilling }) => isDefaultBilling,
                     );

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -56,6 +56,7 @@ const BillingForm = ({
     getFields,
     billingAddress,
     setFieldValue,
+    setValues,
     values,
     onUnhandledError,
 }: BillingFormProps & WithLanguageProps & FormikProps<BillingFormValues>) => {
@@ -110,6 +111,13 @@ const BillingForm = ({
 
         try {
             await checkoutService.updateBillingAddress(address);
+
+            if (address.countryCode) {
+                setValues({
+                    ...values,
+                    ...mapAddressToFormValues(getFields(address.countryCode), address as Address),
+                });
+            }
         } catch (error) {
             if (error instanceof Error) {
                 onUnhandledError(error);
@@ -142,7 +150,6 @@ const BillingForm = ({
                                 selectedAddress={
                                     hasValidCustomerAddress ? billingAddress : undefined
                                 }
-                                storageKey={B2BExtraFieldsSessionStorage.BILLING_KEY}
                                 type={AddressType.Billing}
                             />
                         </LoadingOverlay>

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -56,7 +56,6 @@ const BillingForm = ({
     getFields,
     billingAddress,
     setFieldValue,
-    setValues,
     values,
     onUnhandledError,
 }: BillingFormProps & WithLanguageProps & FormikProps<BillingFormValues>) => {
@@ -95,7 +94,6 @@ const BillingForm = ({
     const billingAddresses =
         isGuest && isPayPalFastlaneEnabled ? paypalFastlaneAddresses : addresses;
     const hasAddresses = billingAddresses?.length > 0;
-
     const hasValidCustomerAddress =
         billingAddress &&
         isValidCustomerAddress(
@@ -103,7 +101,6 @@ const BillingForm = ({
             billingAddresses,
             getFields(billingAddress.countryCode),
         );
-
     const isUpdating = isUpdatingBillingAddress() || isUpdatingCheckout();
     const { enableOrderComments } = config.checkoutSettings;
     const shouldShowOrderComments = enableOrderComments && getShippableItemsCount(cart) < 1;
@@ -114,13 +111,6 @@ const BillingForm = ({
 
         try {
             await checkoutService.updateBillingAddress(address);
-
-            if (address.countryCode) {
-                setValues({
-                    ...values,
-                    ...mapAddressToFormValues(getFields(address.countryCode), address as Address),
-                });
-            }
         } catch (error) {
             if (error instanceof Error) {
                 onUnhandledError(error);
@@ -131,8 +121,6 @@ const BillingForm = ({
     };
 
     const handleUseNewAddress = () => {
-        // For B2B, drop any extra fields persisted from a prior submit so the
-        // fresh-address form starts blank instead of carrying values forward.
         if (hasAddressExtraFields) {
             B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.BILLING_KEY);
         }

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -67,6 +67,7 @@ const BillingForm = ({
     const { checkoutService, checkoutState } = useCheckout();
     const {
         billing: { hideSaveToAddressBookCheck, restrictManualAddressEntry },
+        userJourney: { hasAddressExtraFields },
     } = useCapabilities();
 
     const {
@@ -94,6 +95,7 @@ const BillingForm = ({
     const billingAddresses =
         isGuest && isPayPalFastlaneEnabled ? paypalFastlaneAddresses : addresses;
     const hasAddresses = billingAddresses?.length > 0;
+
     const hasValidCustomerAddress =
         billingAddress &&
         isValidCustomerAddress(
@@ -101,6 +103,7 @@ const BillingForm = ({
             billingAddresses,
             getFields(billingAddress.countryCode),
         );
+
     const isUpdating = isUpdatingBillingAddress() || isUpdatingCheckout();
     const { enableOrderComments } = config.checkoutSettings;
     const shouldShowOrderComments = enableOrderComments && getShippableItemsCount(cart) < 1;
@@ -128,6 +131,12 @@ const BillingForm = ({
     };
 
     const handleUseNewAddress = () => {
+        // For B2B, drop any extra fields persisted from a prior submit so the
+        // fresh-address form starts blank instead of carrying values forward.
+        if (hasAddressExtraFields) {
+            B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.BILLING_KEY);
+        }
+
         void handleSelectAddress({});
     };
 

--- a/packages/core/src/app/customer/customers.mock.ts
+++ b/packages/core/src/app/customer/customers.mock.ts
@@ -58,3 +58,55 @@ export function getCustomer(): Customer {
         },
     };
 }
+
+export function getB2BCustomer(): Customer {
+    return {
+        id: 8,
+        email: 'b2b@bigcommerce.com',
+        firstName: 'B2B',
+        fullName: 'B2B Buyer',
+        lastName: 'Buyer',
+        shouldEncourageSignIn: false,
+        storeCredit: 0,
+        addresses: [
+            {
+                ...getShippingAddress(),
+                id: 9,
+                type: 'commercial',
+                isShipping: true,
+                isBilling: true,
+            },
+            {
+                ...getShippingAddress(),
+                id: 10,
+                type: 'commercial',
+                address1: 'Shipping Only Way',
+                isShipping: true,
+                isBilling: false,
+            },
+            {
+                ...getShippingAddress(),
+                id: 11,
+                type: 'commercial',
+                address1: 'Billing Only Way',
+                isShipping: false,
+                isBilling: true,
+            },
+            {
+                ...getShippingAddress(),
+                id: 12,
+                type: 'commercial',
+                address1: 'Invalid B2B Way',
+                firstName: 'Invalid Address',
+                lastName: '',
+                isShipping: true,
+                isBilling: true,
+            },
+        ],
+        isGuest: false,
+        customerGroup: {
+            id: 2,
+            name: 'B2B customer group',
+        },
+    };
+}

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -175,7 +175,6 @@ const ConsignmentAddressSelector = ({
                     placeholderText={<TranslatedString id="shipping.choose_shipping_address" />}
                     selectedAddress={selectedAddress}
                     showSingleLineAddress
-                    storageKey={storageKey}
                     type={AddressType.Shipping}
                 />
             )}

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -68,6 +68,7 @@ function Shipping({
     } = useShipping();
     const {
         shipping: { restrictManualAddressEntry },
+        userJourney: { hasCompanyAddressBook },
     } = useCapabilities();
 
     useEffect(() => {
@@ -78,6 +79,16 @@ function Shipping({
                     loadShippingOptions(),
                     loadBillingAddressFields(),
                 ]);
+
+                if (hasCompanyAddressBook && !shippingAddress) {
+                    const defaultShippingAddress = customer.addresses?.find(
+                        ({ isDefaultShipping }) => isDefaultShipping,
+                    );
+
+                    if (defaultShippingAddress) {
+                        await updateShippingAddress(defaultShippingAddress);
+                    }
+                }
 
                 if (cartHasPromotionalItems && isMultiShippingMode) {
                     setIsMultiShippingUnavailableModalOpen(true);

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -86,7 +86,11 @@ function Shipping({
                     );
 
                     if (defaultShippingAddress) {
-                        await updateShippingAddress(defaultShippingAddress);
+                        try {
+                            await updateShippingAddress(defaultShippingAddress);
+                        } catch {
+                            /* Do nothing: we should not block shoppers from buying. */
+                        }
                     }
                 }
 

--- a/packages/core/src/app/shipping/ShippingAddressForm.tsx
+++ b/packages/core/src/app/shipping/ShippingAddressForm.tsx
@@ -8,7 +8,6 @@ import {
     AddressForm,
     AddressSelect,
     AddressType,
-    B2BExtraFieldsSessionStorage,
     isValidCustomerAddress,
     reorderAddressFormFields,
 } from '../address';
@@ -104,7 +103,6 @@ const ShippingAddressForm = ({
                             onSelectAddress={onAddressSelect}
                             onUseNewAddress={onUseNewAddress}
                             selectedAddress={hasValidCustomerAddress ? shippingAddress : undefined}
-                            storageKey={B2BExtraFieldsSessionStorage.SHIPPING_KEY}
                             type={AddressType.Shipping}
                         />
                     </LoadingOverlay>

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -88,6 +88,7 @@ const SingleShippingForm: React.FC<
 }) => {
     const {
         shipping: { hideBillingSameAsShippingCheck },
+        userJourney: { hasAddressExtraFields },
     } = useCapabilities();
     const {
         consignments,
@@ -253,6 +254,14 @@ const SingleShippingForm: React.FC<
         setIsResettingAddress(true);
 
         try {
+            // For B2B, drop any extra fields persisted from a prior submit so
+            // the fresh-address form starts blank instead of carrying values forward.
+            if (hasAddressExtraFields) {
+                B2BExtraFieldsSessionStorage.removeFields(
+                    B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+                );
+            }
+
             const address = await deleteConsignments();
 
             setValues({

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -254,8 +254,6 @@ const SingleShippingForm: React.FC<
         setIsResettingAddress(true);
 
         try {
-            // For B2B, drop any extra fields persisted from a prior submit so
-            // the fresh-address form starts blank instead of carrying values forward.
             if (hasAddressExtraFields) {
                 B2BExtraFieldsSessionStorage.removeFields(
                     B2BExtraFieldsSessionStorage.SHIPPING_KEY,

--- a/packages/core/src/app/shipping/hooks/useShipping.test.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.test.ts
@@ -254,6 +254,77 @@ describe('useShipping', () => {
         });
     });
 
+    describe('shippingAddress augmentation', () => {
+        const customerExtraFields = [{ fieldId: '100', fieldValue: 'Acme Corp' }];
+
+        it('returns the raw shippingAddress when hasAddressExtraFields is false (B2C)', () => {
+            jest.spyOn(contexts, 'useCapabilities').mockReturnValue({
+                ...defaultCapabilities,
+                userJourney: { ...defaultCapabilities.userJourney, hasAddressExtraFields: false },
+            });
+            jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+                ...getCustomer(),
+                addresses: [
+                    {
+                        ...getShippingAddress(),
+                        id: 5,
+                        type: 'residential',
+                        extraFields: customerExtraFields,
+                    },
+                ],
+            });
+
+            const { result } = renderHook(() => useShipping());
+
+            expect(result.current.shippingAddress?.extraFields).toBeUndefined();
+        });
+
+        it('grafts customer-address extraFields onto shippingAddress when hasAddressExtraFields is true', () => {
+            jest.spyOn(contexts, 'useCapabilities').mockReturnValue({
+                ...defaultCapabilities,
+                userJourney: { ...defaultCapabilities.userJourney, hasAddressExtraFields: true },
+            });
+            jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+                ...getCustomer(),
+                addresses: [
+                    {
+                        ...getShippingAddress(),
+                        id: 5,
+                        type: 'residential',
+                        extraFields: customerExtraFields,
+                    },
+                ],
+            });
+
+            const { result } = renderHook(() => useShipping());
+
+            expect(result.current.shippingAddress?.extraFields).toEqual(customerExtraFields);
+        });
+
+        it('leaves shippingAddress untouched when no customer address matches', () => {
+            jest.spyOn(contexts, 'useCapabilities').mockReturnValue({
+                ...defaultCapabilities,
+                userJourney: { ...defaultCapabilities.userJourney, hasAddressExtraFields: true },
+            });
+            jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue({
+                ...getCustomer(),
+                addresses: [
+                    {
+                        ...getShippingAddress(),
+                        id: 5,
+                        type: 'residential',
+                        address1: 'A different street that will not match',
+                        extraFields: customerExtraFields,
+                    },
+                ],
+            });
+
+            const { result } = renderHook(() => useShipping());
+
+            expect(result.current.shippingAddress?.extraFields).toBeUndefined();
+        });
+    });
+
     it('shouldRenderStripeForm is true if providerWithCustomCheckout is StripeUPE and shouldUseStripeLinkByMinimumAmount returns true', () => {
         jest.mock('@bigcommerce/checkout/instrument-utils', () => ({
             ...jest.requireActual('@bigcommerce/checkout/instrument-utils'),

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { createSelector } from 'reselect';
 
 import {
@@ -9,6 +9,7 @@ import {
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
 
+import { isEqualAddress } from '../../address';
 import { EMPTY_ARRAY, isExperimentEnabled } from '../../common/utility';
 import getBackorderCount from '../../order/getBackorderCount';
 import getProviderWithCustomCheckout from '../../payment/getProviderWithCustomCheckout';
@@ -97,8 +98,27 @@ export const useShipping = () => {
     const shippableItemsCount = getShippableItemsCount(cart);
     const shouldShowMultiShipping = hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
 
-    const shippingAddress =
+    const rawShippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();
+
+    // B2B extraFields aren't round-tripped by `updateShippingAddress`, so graft
+    // them on from the matching customer address book entry. B2B only — for B2C
+    // there are no extraFields anywhere and this is a no-op passthrough.
+    const shippingAddress = useMemo(() => {
+        if (!hasAddressExtraFields || !rawShippingAddress) {
+            return rawShippingAddress;
+        }
+
+        if (rawShippingAddress.extraFields?.length) {
+            return rawShippingAddress;
+        }
+
+        const match = customer.addresses?.find((addr) => isEqualAddress(addr, rawShippingAddress));
+
+        return match?.extraFields?.length
+            ? { ...rawShippingAddress, extraFields: match.extraFields }
+            : rawShippingAddress;
+    }, [hasAddressExtraFields, rawShippingAddress, customer.addresses]);
 
     const providerWithCustomCheckout = getProviderWithCustomCheckout(
         config.checkoutSettings.providerWithCustomCheckout,

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -9,7 +9,7 @@ import {
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
 
-import { isEqualAddress } from '../../address';
+import { getAddressWithCustomerExtraFields } from '../../address';
 import { EMPTY_ARRAY, isExperimentEnabled } from '../../common/utility';
 import getBackorderCount from '../../order/getBackorderCount';
 import getProviderWithCustomCheckout from '../../payment/getProviderWithCustomCheckout';
@@ -101,24 +101,15 @@ export const useShipping = () => {
     const rawShippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();
 
-    // B2B extraFields aren't round-tripped by `updateShippingAddress`, so graft
-    // them on from the matching customer address book entry. B2B only — for B2C
-    // there are no extraFields anywhere and this is a no-op passthrough.
-    const shippingAddress = useMemo(() => {
-        if (!hasAddressExtraFields || !rawShippingAddress) {
-            return rawShippingAddress;
-        }
-
-        if (rawShippingAddress.extraFields?.length) {
-            return rawShippingAddress;
-        }
-
-        const match = customer.addresses?.find((addr) => isEqualAddress(addr, rawShippingAddress));
-
-        return match?.extraFields?.length
-            ? { ...rawShippingAddress, extraFields: match.extraFields }
-            : rawShippingAddress;
-    }, [hasAddressExtraFields, rawShippingAddress, customer.addresses]);
+    const shippingAddress = useMemo(
+        () =>
+            getAddressWithCustomerExtraFields(
+                rawShippingAddress,
+                customer.addresses,
+                hasAddressExtraFields,
+            ),
+        [hasAddressExtraFields, rawShippingAddress, customer.addresses],
+    );
 
     const providerWithCustomCheckout = getProviderWithCustomCheckout(
         config.checkoutSettings.providerWithCustomCheckout,


### PR DESCRIPTION
## What/Why?

CHECKOUT-9823: Billing and shipping enhancements for B2B address-book customers.

- **Auto-select default address on load**: when the `hasCompanyAddressBook` capability is enabled and the checkout has no billing/shipping address set, `Billing.tsx` and `Shipping.tsx` now look up the customer's `isDefaultBilling` / `isDefaultShipping` address and apply it during initialization.
- **Filter address selector by type**: `SearchableAddressSelectComponent` now filters the address list by `isBilling` / `isShipping` based on the current `AddressType` before applying the search query, so the billing selector only shows billing-flagged addresses and shipping only shows shipping-flagged ones.
- **Drop session-storage extra-field merging in `AddressSelect`**: the `storageKey` prop and `getAddressWithExtraFields` helper are removed from `AddressSelect`. Extra-field merging from session storage now happens centrally inside `mapAddressToFormValues`, which also handles the SDK's `B2B_EXTRA_FIELD_PREFIX` mismatch between schema field names and raw `extraFields[i].fieldId`s. Callers in `BillingForm` and `ShippingAddressForm` no longer pass `storageKey`.
- **Re-sync billing form values after address update**: with `enableReinitialize: true`, the form rehydrates via `mapPropsToValues` whenever the billing address prop changes. `getAddressWithCustomerExtraFields` grafts the matching customer address's extraFields onto the billing address (the SDK strips them on updateBillingAddress), so extra fields and other address-derived values stay in sync with the freshly applied address.
- **Render `address.label` in `StaticAddress`**: when an address has a `label`, it is rendered as a new line in the static summary.
- **Bump `@bigcommerce/checkout-sdk` to `^1.918.0`** (required for `B2B_EXTRA_FIELD_PREFIX` export).
- Adds `getB2BCustomer()` mock with mixed billing/shipping flag combinations to back the new test cases in `AddressSelect`, `SearchableAddressSelectComponent`, and `mapAddressToFormValues`.

## Test plan

- [x] Unit tests pass: `AddressSelect.test.tsx`, `SearchableAddressSelectComponent.test.tsx`, `mapAddressToFormValues.test.ts`.
- [x] As a B2B customer with `hasCompanyAddressBook` enabled and no prior billing/shipping address on the cart, load checkout and confirm the default billing and default shipping addresses are auto-applied.
- [x] In the billing address selector, confirm only addresses with `isBilling: true` are listed; in the shipping selector, only `isShipping: true`.
- [x] Select an address with extra fields from the address book on billing — confirm the form re-renders with the extra-field values populated and submits successfully.
- [x] Pre-populate session-storage extra fields, then load checkout — confirm `mapAddressToFormValues` falls back to stored values when the API address has none, and that API values still win when present.
- [x] Confirm an address with a `label` renders the label line in the static address summary on the review step.
- [x] Regression: non-B2B (guest / no `hasCompanyAddressBook`) checkout flow behaves identically to before.


## Rollout/Rollback

Revert this PR

## Testing

- CI checks
- Manual testing (TBA)

**1. B2B Extra Fields Happy Path**

https://github.com/user-attachments/assets/f31ec4b7-98de-4080-8b77-8a5226c24a05


**2. B2B Valid/Invalid Extra Fields behaviour**


https://github.com/user-attachments/assets/0e75649c-8d5d-485e-9ae4-afe72051d5c3



**3. B2C OOPC Flow**

https://github.com/user-attachments/assets/d2bccc3e-930a-4318-adeb-c6f6a1695c8a



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing/shipping initialization and B2B extra-field/session-storage behavior across checkout steps; failures on default-address apply are non-blocking but could leave empty addresses in edge cases.
> 
> **Overview**
> Improves **B2B company address book** checkout: default addresses on load, type-filtered selectors, and a clearer path for **extra fields** and **labels** without merging session storage at address selection.
> 
> When **`hasCompanyAddressBook`** is on and billing/shipping is empty, **`Billing`** and **`Shipping`** apply the customer’s **`isDefaultBilling`** / **`isDefaultShipping`** address during init (failures are swallowed so checkout isn’t blocked). **`SearchableAddressSelectComponent`** filters options by **`isBilling`** / **`isShipping`** before search.
> 
> **`AddressSelect`** no longer takes **`storageKey`** or merges extra fields on pick; **`mapAddressToFormValues`** now maps raw **`fieldId`** values (stripping **`B2B_EXTRA_FIELD_PREFIX`**), prefers address values over session storage, and forms still pass billing/shipping storage keys from **`BillingForm`** / **`SingleShippingForm`**. **`getAddressWithCustomerExtraFields`** grafts book **`extraFields`** onto checkout billing/shipping addresses when the SDK doesn’t round-trip them; **`getAddressWithLabel`** and **`StaticAddress`** show **`label`**. **`isEqualAddress`** ignores B2B metadata so re-select and comparisons stay stable. “Use new address” clears B2B session keys where **`hasAddressExtraFields`** applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4059947798da0e42d33c4ce8d59029202f8d0a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->