### PR TITLE
feat(payment): PI-5216 Create GooglePayPaymentMethodComponent for accordion-selection direct-pay flow

### DIFF
--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -42,6 +42,7 @@ import {
 import {
     getAddress,
     getCheckout,
+    getCheckoutPayment,
     getPaymentFormServiceMock,
     getPaymentMethod,
     getStoreConfig,
@@ -64,6 +65,28 @@ describe('when using Google Pay payment', () => {
         id: '1113412341',
     };
     const onUnhandledError = jest.fn();
+
+    const storeConfigWithDirectPayDisabled = {
+        ...getStoreConfig(),
+        checkoutSettings: {
+            ...getStoreConfig().checkoutSettings,
+            features: {
+                ...getStoreConfig().checkoutSettings.features,
+                'PI-5111.google_pay_direct_pay_on_click': false,
+            },
+        },
+    };
+
+    const storeConfigWithDirectPayEnabled = {
+        ...getStoreConfig(),
+        checkoutSettings: {
+            ...getStoreConfig().checkoutSettings,
+            features: {
+                ...getStoreConfig().checkoutSettings.features,
+                'PI-5111.google_pay_direct_pay_on_click': true,
+            },
+        },
+    };
 
     beforeEach(() => {
         checkoutService = createCheckoutService();
@@ -88,7 +111,7 @@ describe('when using Google Pay payment', () => {
             language: localeContext.language,
         };
 
-        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(storeConfigWithDirectPayDisabled);
 
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
 
@@ -107,158 +130,235 @@ describe('when using Google Pay payment', () => {
         );
     });
 
-    it('initializes payment method when component mounts', () => {
-        render(<GooglePayPaymentMethodTest {...defaultProps} />);
+    describe('when direct pay is disabled (PI-5111 = false)', () => {
+        it('initializes payment method when component mounts', () => {
+            render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-            expect.objectContaining({
-                integrations: [
-                    createGooglePayAdyenV2PaymentStrategy,
-                    createGooglePayAdyenV3PaymentStrategy,
-                    createGooglePayAuthorizeNetPaymentStrategy,
-                    createGooglePayCheckoutComPaymentStrategy,
-                    createGooglePayCybersourcePaymentStrategy,
-                    createGooglePayOrbitalPaymentStrategy,
-                    createGooglePayStripePaymentStrategy,
-                    createGooglePayWorldpayAccessPaymentStrategy,
-                    createGooglePayBraintreePaymentStrategy,
-                    createGooglePayPPCPPaymentStrategy,
-                    createGooglePayBigCommercePaymentsPaymentStrategy,
-                    createGooglePayTdOnlineMartPaymentStrategy,
-                ],
-            }),
-        );
-    });
-
-    it('renders Visa Checkout as wallet button method', () => {
-        render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-        expect(
-            screen.getByText(
-                defaultProps.language.translate('remote.sign_in_action', {
-                    providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    integrations: [
+                        createGooglePayAdyenV2PaymentStrategy,
+                        createGooglePayAdyenV3PaymentStrategy,
+                        createGooglePayAuthorizeNetPaymentStrategy,
+                        createGooglePayCheckoutComPaymentStrategy,
+                        createGooglePayCybersourcePaymentStrategy,
+                        createGooglePayOrbitalPaymentStrategy,
+                        createGooglePayStripePaymentStrategy,
+                        createGooglePayWorldpayAccessPaymentStrategy,
+                        createGooglePayBraintreePaymentStrategy,
+                        createGooglePayPPCPPaymentStrategy,
+                        createGooglePayBigCommercePaymentsPaymentStrategy,
+                        createGooglePayTdOnlineMartPaymentStrategy,
+                    ],
                 }),
-            ),
-        ).toBeInTheDocument();
-    });
-
-    each([
-        PaymentMethodId.AdyenV2GooglePay,
-        PaymentMethodId.AdyenV3GooglePay,
-        PaymentMethodId.AuthorizeNetGooglePay,
-        PaymentMethodId.BNZGooglePay,
-        PaymentMethodId.BraintreeGooglePay,
-        PaymentMethodId.PayPalCommerceGooglePay,
-        PaymentMethodId.CheckoutcomGooglePay,
-        PaymentMethodId.CybersourceV2GooglePay,
-        PaymentMethodId.OrbitalGooglePay,
-        PaymentMethodId.StripeGooglePay,
-        PaymentMethodId.StripeUPEGooglePay,
-        PaymentMethodId.WorldpayAccessGooglePay,
-        GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-    ]).it('initializes %s with required config', (id: PaymentMethodId) => {
-        method.id = id;
-
-        render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-            expect.objectContaining({
-                methodId: id,
-                gatewayId: method.gateway,
-                [id]: {
-                    walletButton: 'walletButton',
-                    onError: defaultProps.onUnhandledError,
-                    loadingContainerId: 'checkout-app',
-                    onPaymentSelect: expect.any(Function),
-                },
-            }),
-        );
-    });
-
-    each([
-        GooglePayPaymentMethodId.adyenV2GooglePay,
-        GooglePayPaymentMethodId.adyenV3GooglePay,
-        GooglePayPaymentMethodId.authorizeNetGooglePay,
-        GooglePayPaymentMethodId.bnzGooglePay,
-        GooglePayPaymentMethodId.braintreeGooglePay,
-        GooglePayPaymentMethodId.payPalCommerceGooglePay,
-        GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
-        GooglePayPaymentMethodId.checkoutcomGooglePay,
-        GooglePayPaymentMethodId.cybersourceV2GooglePay,
-        GooglePayPaymentMethodId.orbitalGooglePay,
-        GooglePayPaymentMethodId.stripeGooglePay,
-        GooglePayPaymentMethodId.stripeUPEGooglePay,
-        GooglePayPaymentMethodId.worldpayAccessGooglePay,
-        GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-    ]).it('reinitializes method once payment option is selected', async (id: string) => {
-        method.id = id;
-        render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-        const options: PaymentInitializeOptions = (checkoutService.initializePayment as jest.Mock)
-            .mock.calls[0][0];
-
-        (checkoutService.initializePayment as jest.Mock).mockReset();
-
-        options.googlepaybraintree!.onPaymentSelect!();
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (options as Record<string, any>)[id]!.onPaymentSelect!();
-
-        await new Promise((resolve) => process.nextTick(resolve));
-
-        expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
-            methodId: method.id,
+            );
         });
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-            expect.objectContaining({
-                methodId: method.id,
 
-                [method.id]: expect.any(Object),
-            }),
-        );
+        it('renders Visa Checkout as wallet button method', () => {
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(
+                screen.getByText(
+                    defaultProps.language.translate('remote.sign_in_action', {
+                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                    }),
+                ),
+            ).toBeInTheDocument();
+        });
+
+        each([
+            PaymentMethodId.AdyenV2GooglePay,
+            PaymentMethodId.AdyenV3GooglePay,
+            PaymentMethodId.AuthorizeNetGooglePay,
+            PaymentMethodId.BNZGooglePay,
+            PaymentMethodId.BraintreeGooglePay,
+            PaymentMethodId.PayPalCommerceGooglePay,
+            PaymentMethodId.CheckoutcomGooglePay,
+            PaymentMethodId.CybersourceV2GooglePay,
+            PaymentMethodId.OrbitalGooglePay,
+            PaymentMethodId.StripeGooglePay,
+            PaymentMethodId.StripeUPEGooglePay,
+            PaymentMethodId.WorldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('initializes %s with required config', (id: PaymentMethodId) => {
+            method.id = id;
+
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: id,
+                    gatewayId: method.gateway,
+                    [id]: {
+                        walletButton: 'walletButton',
+                        onError: defaultProps.onUnhandledError,
+                        loadingContainerId: 'checkout-app',
+                        onPaymentSelect: expect.any(Function),
+                    },
+                }),
+            );
+        });
+
+        each([
+            GooglePayPaymentMethodId.adyenV2GooglePay,
+            GooglePayPaymentMethodId.adyenV3GooglePay,
+            GooglePayPaymentMethodId.authorizeNetGooglePay,
+            GooglePayPaymentMethodId.bnzGooglePay,
+            GooglePayPaymentMethodId.braintreeGooglePay,
+            GooglePayPaymentMethodId.payPalCommerceGooglePay,
+            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
+            GooglePayPaymentMethodId.checkoutcomGooglePay,
+            GooglePayPaymentMethodId.cybersourceV2GooglePay,
+            GooglePayPaymentMethodId.orbitalGooglePay,
+            GooglePayPaymentMethodId.stripeGooglePay,
+            GooglePayPaymentMethodId.stripeUPEGooglePay,
+            GooglePayPaymentMethodId.worldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('reinitializes method once payment option is selected', async (id: string) => {
+            method.id = id;
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            const options: PaymentInitializeOptions = (checkoutService.initializePayment as jest.Mock)
+                .mock.calls[0][0];
+
+            (checkoutService.initializePayment as jest.Mock).mockReset();
+
+            options.googlepaybraintree!.onPaymentSelect!();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (options as Record<string, any>)[id]!.onPaymentSelect!();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+                methodId: method.id,
+            });
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+
+                    [method.id]: expect.any(Object),
+                }),
+            );
+        });
+
+        each([
+            GooglePayPaymentMethodId.adyenV2GooglePay,
+            GooglePayPaymentMethodId.adyenV3GooglePay,
+            GooglePayPaymentMethodId.authorizeNetGooglePay,
+            GooglePayPaymentMethodId.bnzGooglePay,
+            GooglePayPaymentMethodId.braintreeGooglePay,
+            GooglePayPaymentMethodId.payPalCommerceGooglePay,
+            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
+            GooglePayPaymentMethodId.checkoutcomGooglePay,
+            GooglePayPaymentMethodId.cybersourceV2GooglePay,
+            GooglePayPaymentMethodId.orbitalGooglePay,
+            GooglePayPaymentMethodId.stripeGooglePay,
+            GooglePayPaymentMethodId.stripeUPEGooglePay,
+            GooglePayPaymentMethodId.worldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('catches error during component reinitialization', async (id: string) => {
+            method.id = id;
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(() =>
+                Promise.reject(new Error('test error')),
+            );
+
+            const options: PaymentInitializeOptions = (checkoutService.initializePayment as jest.Mock)
+                .mock.calls[0][0];
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (options as Record<string, any>)[id]!.onPaymentSelect!();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+                methodId: method.id,
+            });
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+
+                    [method.id]: expect.any(Object),
+                }),
+            );
+
+            expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+        });
     });
 
-    each([
-        GooglePayPaymentMethodId.adyenV2GooglePay,
-        GooglePayPaymentMethodId.adyenV3GooglePay,
-        GooglePayPaymentMethodId.authorizeNetGooglePay,
-        GooglePayPaymentMethodId.bnzGooglePay,
-        GooglePayPaymentMethodId.braintreeGooglePay,
-        GooglePayPaymentMethodId.payPalCommerceGooglePay,
-        GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
-        GooglePayPaymentMethodId.checkoutcomGooglePay,
-        GooglePayPaymentMethodId.cybersourceV2GooglePay,
-        GooglePayPaymentMethodId.orbitalGooglePay,
-        GooglePayPaymentMethodId.stripeGooglePay,
-        GooglePayPaymentMethodId.stripeUPEGooglePay,
-        GooglePayPaymentMethodId.worldpayAccessGooglePay,
-        GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-    ]).it('catches error during component reinitialization', async (id: string) => {
-        method.id = id;
-        render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-        jest.spyOn(checkoutService, 'initializePayment').mockImplementation(() =>
-            Promise.reject(new Error('test error')),
-        );
-
-        const options: PaymentInitializeOptions = (checkoutService.initializePayment as jest.Mock)
-            .mock.calls[0][0];
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (options as Record<string, any>)[id]!.onPaymentSelect!();
-
-        await new Promise((resolve) => process.nextTick(resolve));
-
-        expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
-            methodId: method.id,
+    describe('when direct pay is enabled (PI-5111 = true)', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(storeConfigWithDirectPayEnabled);
         });
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-            expect.objectContaining({
-                methodId: method.id,
 
-                [method.id]: expect.any(Object),
-            }),
-        );
+        it('does not render the wallet sign-in button', () => {
+            render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
-        expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+            expect(
+                screen.queryByText(
+                    defaultProps.language.translate('remote.sign_in_action', {
+                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                    }),
+                ),
+            ).not.toBeInTheDocument();
+        });
+
+        it('renders the direct-pay branch so the SDK can inject the branded button', () => {
+            render(<GooglePayPaymentMethodTest {...defaultProps} />);
+
+            expect(screen.getByText('direct pay enabled!!!!!!')).toBeInTheDocument();
+        });
+
+        it('keeps the direct-pay component when checkout.payments is updated mid-flow', () => {
+            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
+
+            const { rerender } = render(<GooglePayPaymentMethodTest {...defaultProps} />);
+
+            // Simulate loadCheckout() populating checkout.payments during the sheet interaction
+            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: method.id }],
+            });
+
+            rerender(<GooglePayPaymentMethodTest {...defaultProps} />);
+
+            // Wallet sign-in UI must NOT appear — direct-pay component stays
+            expect(
+                screen.queryByText(
+                    defaultProps.language.translate('remote.sign_in_action', {
+                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                    }),
+                ),
+            ).not.toBeInTheDocument();
+
+            // The direct-pay branch is still rendered
+            expect(screen.getByText('direct pay enabled!!!!!!')).toBeInTheDocument();
+        });
+    });
+
+    describe('when payment is already selected (express-entry flow)', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: method.id }],
+            });
+        });
+
+        it('renders the wallet UI with a sign-out option regardless of the feature flag', () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(storeConfigWithDirectPayEnabled);
+
+            render(<GooglePayPaymentMethodTest {...defaultProps} />);
+
+            // When payment is already selected, WalletButtonPaymentMethodComponent shows
+            // the signed-in view (sign-out link) rather than the GooglePayPaymentMethodComponent.
+            expect(
+                screen.getByText(
+                    defaultProps.language.translate('remote.sign_out_action', {
+                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                    }),
+                ),
+            ).toBeInTheDocument();
+        });
     });
 });

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -132,7 +132,7 @@ describe('when using Google Pay payment', () => {
         );
     });
 
-    describe('when direct pay is disabled (PI-5111 = false)', () => {
+    describe('when Direct Pay is disabled', () => {
         it('initializes payment method when component mounts', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
@@ -156,7 +156,7 @@ describe('when using Google Pay payment', () => {
             );
         });
 
-        it('renders Visa Checkout as wallet button method', () => {
+        it('renders Google Pay as a wallet button method', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
 
             expect(
@@ -184,7 +184,7 @@ describe('when using Google Pay payment', () => {
             PaymentMethodId.StripeUPEGooglePay,
             PaymentMethodId.WorldpayAccessGooglePay,
             GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-        ]).it('initializes %s with required config', (id: PaymentMethodId) => {
+        ]).it('initializes with required config', (id: PaymentMethodId) => {
             method.id = id;
 
             render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
@@ -293,14 +293,14 @@ describe('when using Google Pay payment', () => {
         });
     });
 
-    describe('when direct pay is enabled (PI-5111 = true)', () => {
+    describe('when Direct Pay is enabled', () => {
         beforeEach(() => {
             jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
                 storeConfigWithDirectPayEnabled,
             );
         });
 
-        it('does not render the wallet sign-in button', () => {
+        it('does not render the wallet button', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
             expect(
@@ -314,20 +314,19 @@ describe('when using Google Pay payment', () => {
             ).not.toBeInTheDocument();
         });
 
-        it('renders the direct-pay branch so the SDK can inject the branded button', () => {
+        it('renders the Direct Pay branch so the SDK can inject the branded button', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
-            // GooglePayPaymentMethodComponent renders null but hides the Place Order button
-            // on mount so the SDK can inject the branded Google Pay button into the container.
+            // GooglePayPaymentMethodComponent renders null, but hides the Place Order button
+            // on mount so the SDK can inject the Google Pay button into the container.
             expect(paymentForm.hidePaymentSubmitButton).toHaveBeenCalledWith(method, true);
         });
 
-        it('keeps the direct-pay component when checkout.payments is updated mid-flow', () => {
+        it('keeps the Direct Pay component when checkout.payments is updated mid-flow', () => {
             jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue(getCheckout());
 
             const { rerender } = render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
-            // Simulate loadCheckout() populating checkout.payments during the sheet interaction
             jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
                 ...getCheckout(),
                 payments: [{ ...getCheckoutPayment(), providerId: method.id }],
@@ -335,7 +334,6 @@ describe('when using Google Pay payment', () => {
 
             rerender(<GooglePayPaymentMethodTest {...defaultProps} />);
 
-            // Wallet sign-in UI must NOT appear — direct-pay component stays
             expect(
                 screen.queryByText(
                     defaultProps.language.translate('remote.sign_in_action', {
@@ -346,13 +344,11 @@ describe('when using Google Pay payment', () => {
                 ),
             ).not.toBeInTheDocument();
 
-            // The direct-pay branch stayed mounted — cleanup (which would call
-            // hidePaymentSubmitButton(method, false)) was never triggered.
             expect(paymentForm.hidePaymentSubmitButton).not.toHaveBeenCalledWith(method, false);
         });
     });
 
-    describe('when payment is already selected (express-entry flow)', () => {
+    describe('when payment is already selected (Express Entry flow)', () => {
         beforeEach(() => {
             jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
                 ...getCheckout(),
@@ -367,8 +363,6 @@ describe('when using Google Pay payment', () => {
 
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
-            // When payment is already selected, WalletButtonPaymentMethodComponent shows
-            // the signed-in view (sign-out link) rather than the GooglePayPaymentMethodComponent.
             expect(
                 screen.getByText(
                     defaultProps.language.translate('remote.sign_out_action', {

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -317,7 +317,9 @@ describe('when using Google Pay payment', () => {
         it('renders the direct-pay branch so the SDK can inject the branded button', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
-            expect(screen.getByText('direct pay enabled!!!!!!')).toBeInTheDocument();
+            // GooglePayPaymentMethodComponent renders null but hides the Place Order button
+            // on mount so the SDK can inject the branded Google Pay button into the container.
+            expect(paymentForm.hidePaymentSubmitButton).toHaveBeenCalledWith(method, true);
         });
 
         it('keeps the direct-pay component when checkout.payments is updated mid-flow', () => {
@@ -344,8 +346,9 @@ describe('when using Google Pay payment', () => {
                 ),
             ).not.toBeInTheDocument();
 
-            // The direct-pay branch is still rendered
-            expect(screen.getByText('direct pay enabled!!!!!!')).toBeInTheDocument();
+            // The direct-pay branch stayed mounted — cleanup (which would call
+            // hidePaymentSubmitButton(method, false)) was never triggered.
+            expect(paymentForm.hidePaymentSubmitButton).not.toHaveBeenCalledWith(method, false);
         });
     });
 

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -111,7 +111,9 @@ describe('when using Google Pay payment', () => {
             language: localeContext.language,
         };
 
-        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(storeConfigWithDirectPayDisabled);
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+            storeConfigWithDirectPayDisabled,
+        );
 
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
 
@@ -160,7 +162,9 @@ describe('when using Google Pay payment', () => {
             expect(
                 screen.getByText(
                     defaultProps.language.translate('remote.sign_in_action', {
-                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                        providerName: getPaymentMethodName(defaultProps.language)(
+                            defaultProps.method,
+                        ),
                     }),
                 ),
             ).toBeInTheDocument();
@@ -218,8 +222,9 @@ describe('when using Google Pay payment', () => {
             method.id = id;
             render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
 
-            const options: PaymentInitializeOptions = (checkoutService.initializePayment as jest.Mock)
-                .mock.calls[0][0];
+            const options: PaymentInitializeOptions = (
+                checkoutService.initializePayment as jest.Mock
+            ).mock.calls[0][0];
 
             (checkoutService.initializePayment as jest.Mock).mockReset();
 
@@ -264,8 +269,9 @@ describe('when using Google Pay payment', () => {
                 Promise.reject(new Error('test error')),
             );
 
-            const options: PaymentInitializeOptions = (checkoutService.initializePayment as jest.Mock)
-                .mock.calls[0][0];
+            const options: PaymentInitializeOptions = (
+                checkoutService.initializePayment as jest.Mock
+            ).mock.calls[0][0];
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (options as Record<string, any>)[id]!.onPaymentSelect!();
@@ -289,7 +295,9 @@ describe('when using Google Pay payment', () => {
 
     describe('when direct pay is enabled (PI-5111 = true)', () => {
         beforeEach(() => {
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(storeConfigWithDirectPayEnabled);
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+                storeConfigWithDirectPayEnabled,
+            );
         });
 
         it('does not render the wallet sign-in button', () => {
@@ -298,7 +306,9 @@ describe('when using Google Pay payment', () => {
             expect(
                 screen.queryByText(
                     defaultProps.language.translate('remote.sign_in_action', {
-                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                        providerName: getPaymentMethodName(defaultProps.language)(
+                            defaultProps.method,
+                        ),
                     }),
                 ),
             ).not.toBeInTheDocument();
@@ -327,7 +337,9 @@ describe('when using Google Pay payment', () => {
             expect(
                 screen.queryByText(
                     defaultProps.language.translate('remote.sign_in_action', {
-                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                        providerName: getPaymentMethodName(defaultProps.language)(
+                            defaultProps.method,
+                        ),
                     }),
                 ),
             ).not.toBeInTheDocument();
@@ -346,7 +358,9 @@ describe('when using Google Pay payment', () => {
         });
 
         it('renders the wallet UI with a sign-out option regardless of the feature flag', () => {
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(storeConfigWithDirectPayEnabled);
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+                storeConfigWithDirectPayEnabled,
+            );
 
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
@@ -355,7 +369,9 @@ describe('when using Google Pay payment', () => {
             expect(
                 screen.getByText(
                     defaultProps.language.translate('remote.sign_out_action', {
-                        providerName: getPaymentMethodName(defaultProps.language)(defaultProps.method),
+                        providerName: getPaymentMethodName(defaultProps.language)(
+                            defaultProps.method,
+                        ),
                     }),
                 ),
             ).toBeInTheDocument();

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -13,8 +13,10 @@ import {
     createGooglePayTdOnlineMartPaymentStrategy,
     createGooglePayWorldpayAccessPaymentStrategy,
 } from '@bigcommerce/checkout-sdk/integrations/google-pay';
-import React, { type FunctionComponent, useCallback } from 'react';
+import { some } from 'lodash';
+import React, { type FunctionComponent, useCallback, useRef } from 'react';
 
+import { useCheckout } from '@bigcommerce/checkout/contexts';
 import {
     type CheckoutButtonResolveId,
     PaymentMethodId,
@@ -23,12 +25,33 @@ import {
 } from '@bigcommerce/checkout/payment-integration-api';
 import { WalletButtonPaymentMethodComponent } from '@bigcommerce/checkout/wallet-button-integration';
 
+import GooglePayPaymentMethodComponent from './GooglePayPaymentMethodComponent';
+
 const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     checkoutService,
     method,
     onUnhandledError,
+    paymentForm,
     ...rest
 }) => {
+    const {
+        checkoutState: {
+            data: { getCheckout, getConfig },
+        },
+    } = useCheckout();
+
+    const checkout = getCheckout();
+    const isPaymentSelected = checkout ? some(checkout.payments, { providerId: method.id }) : false;
+
+    // Capture whether Google Pay was already selected at mount time (express-entry
+    // from PDP/Cart button). If payment becomes selected AFTER mount — during the
+    // direct-pay sheet interaction — we must not switch branches; the SDK will
+    // redirect to order confirmation without any intermediate UI change.
+    const wasPaymentSelectedAtMountRef = useRef(isPaymentSelected);
+
+    const features = getConfig()?.checkoutSettings.features ?? {};
+    const isDirectPayEnabled = Boolean(features['PI-5111.google_pay_direct_pay_on_click'] ?? true);
+
     const initializeGooglePayPayment = useCallback(
         (defaultOptions: PaymentInitializeOptions) => {
             const reinitializePayment = async (options: PaymentInitializeOptions) => {
@@ -163,7 +186,41 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         },
         [checkoutService, method, onUnhandledError],
     );
+    // Express-entry flow: GPay was selected via PDP/Cart/top-of-checkout button.
+    // Payment data is already set — show the existing wallet UI (PaymentView + Place Order).
+    if (wasPaymentSelectedAtMountRef.current) {
+        return (
+            <WalletButtonPaymentMethodComponent
+                {...rest}
+                buttonId="walletButton"
+                deinitializePayment={checkoutService.deinitializePayment}
+                initializePayment={initializeGooglePayPayment}
+                method={method}
+                paymentForm={paymentForm}
+                shouldShowEditButton
+                signOutCustomer={checkoutService.signOutCustomer}
+            />
+        );
+    }
 
+    // Accordion-selection flow (experiment on): replace the Place Order button with a
+    // branded Google Pay button that opens the payment sheet and completes the order directly.
+    if (isDirectPayEnabled) {
+        return (
+            <>
+                <div>{/* direct pay enabled!!!!!! */}</div>
+                <GooglePayPaymentMethodComponent
+                    {...rest}
+                    checkoutService={checkoutService}
+                    method={method}
+                    onUnhandledError={onUnhandledError}
+                    paymentForm={paymentForm}
+                />
+            </>
+        );
+    }
+
+    // Accordion-selection flow (experiment off): legacy wallet-button flow.
     return (
         <WalletButtonPaymentMethodComponent
             {...rest}
@@ -171,7 +228,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             deinitializePayment={checkoutService.deinitializePayment}
             initializePayment={initializeGooglePayPayment}
             method={method}
-            shouldShowEditButton
+            paymentForm={paymentForm}
             signOutCustomer={checkoutService.signOutCustomer}
         />
     );

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -30,10 +30,8 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const checkout = getCheckout();
     const isPaymentSelected = checkout ? some(checkout.payments, { providerId: method.id }) : false;
 
-    // Capture whether Google Pay was already selected at mount time (express-entry
-    // from PDP/Cart button). If payment becomes selected AFTER mount — during the
-    // direct-pay sheet interaction — we must not switch branches; the SDK will
-    // redirect to order confirmation without any intermediate UI change.
+    // Capture whether Google Pay was already selected at mount time
+    // (PDP/Cart/Customer step button)
     const wasPaymentSelectedAtMountRef = useRef(isPaymentSelected);
 
     const features = getConfig()?.checkoutSettings.features ?? {};
@@ -161,8 +159,6 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         [checkoutService, method, onUnhandledError],
     );
 
-    // Express-entry flow: GPay was selected via PDP/Cart/top-of-checkout button.
-    // Payment data is already set — show the existing wallet UI (PaymentView + Place Order).
     if (wasPaymentSelectedAtMountRef.current) {
         return (
             <WalletButtonPaymentMethodComponent
@@ -178,8 +174,6 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         );
     }
 
-    // Accordion-selection flow (experiment on): replace the Place Order button with a
-    // branded Google Pay button that opens the payment sheet and completes the order directly.
     if (isDirectPayEnabled) {
         return (
             <GooglePayPaymentMethodComponent
@@ -192,7 +186,6 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         );
     }
 
-    // Accordion-selection flow (experiment off): legacy wallet-button flow.
     return (
         <WalletButtonPaymentMethodComponent
             {...rest}

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -159,22 +159,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         [checkoutService, method, onUnhandledError],
     );
 
-    if (wasPaymentSelectedAtMountRef.current) {
-        return (
-            <WalletButtonPaymentMethodComponent
-                {...rest}
-                buttonId="walletButton"
-                deinitializePayment={checkoutService.deinitializePayment}
-                initializePayment={initializeGooglePayPayment}
-                method={method}
-                paymentForm={paymentForm}
-                shouldShowEditButton
-                signOutCustomer={checkoutService.signOutCustomer}
-            />
-        );
-    }
-
-    if (isDirectPayEnabled) {
+    if (isDirectPayEnabled && !wasPaymentSelectedAtMountRef.current) {
         return (
             <GooglePayPaymentMethodComponent
                 {...rest}

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -186,6 +186,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         },
         [checkoutService, method, onUnhandledError],
     );
+
     // Express-entry flow: GPay was selected via PDP/Cart/top-of-checkout button.
     // Payment data is already set — show the existing wallet UI (PaymentView + Place Order).
     if (wasPaymentSelectedAtMountRef.current) {
@@ -207,16 +208,13 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     // branded Google Pay button that opens the payment sheet and completes the order directly.
     if (isDirectPayEnabled) {
         return (
-            <>
-                <div>{/* direct pay enabled!!!!!! */}</div>
-                <GooglePayPaymentMethodComponent
-                    {...rest}
-                    checkoutService={checkoutService}
-                    method={method}
-                    onUnhandledError={onUnhandledError}
-                    paymentForm={paymentForm}
-                />
-            </>
+            <GooglePayPaymentMethodComponent
+                {...rest}
+                checkoutService={checkoutService}
+                method={method}
+                onUnhandledError={onUnhandledError}
+                paymentForm={paymentForm}
+            />
         );
     }
 

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -1,18 +1,4 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import {
-    createGooglePayAdyenV2PaymentStrategy,
-    createGooglePayAdyenV3PaymentStrategy,
-    createGooglePayAuthorizeNetPaymentStrategy,
-    createGooglePayBigCommercePaymentsPaymentStrategy,
-    createGooglePayBraintreePaymentStrategy,
-    createGooglePayCheckoutComPaymentStrategy,
-    createGooglePayCybersourcePaymentStrategy,
-    createGooglePayOrbitalPaymentStrategy,
-    createGooglePayPPCPPaymentStrategy,
-    createGooglePayStripePaymentStrategy,
-    createGooglePayTdOnlineMartPaymentStrategy,
-    createGooglePayWorldpayAccessPaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/google-pay';
 import { some } from 'lodash';
 import React, { type FunctionComponent, useCallback, useRef } from 'react';
 
@@ -26,6 +12,7 @@ import {
 import { WalletButtonPaymentMethodComponent } from '@bigcommerce/checkout/wallet-button-integration';
 
 import GooglePayPaymentMethodComponent from './GooglePayPaymentMethodComponent';
+import googlePayIntegrations from './googlePayIntegrations';
 
 const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     checkoutService,
@@ -76,20 +63,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             const loadingContainerId = 'checkout-app';
             const mergedOptions: PaymentInitializeOptions = {
                 ...defaultOptions,
-                integrations: [
-                    createGooglePayAdyenV2PaymentStrategy,
-                    createGooglePayAdyenV3PaymentStrategy,
-                    createGooglePayAuthorizeNetPaymentStrategy,
-                    createGooglePayCheckoutComPaymentStrategy,
-                    createGooglePayCybersourcePaymentStrategy,
-                    createGooglePayOrbitalPaymentStrategy,
-                    createGooglePayStripePaymentStrategy,
-                    createGooglePayWorldpayAccessPaymentStrategy,
-                    createGooglePayBraintreePaymentStrategy,
-                    createGooglePayPPCPPaymentStrategy,
-                    createGooglePayBigCommercePaymentsPaymentStrategy,
-                    createGooglePayTdOnlineMartPaymentStrategy,
-                ],
+                integrations: googlePayIntegrations,
                 [PaymentMethodId.AdyenV2GooglePay]: {
                     loadingContainerId,
                     walletButton: 'walletButton',
@@ -227,6 +201,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             initializePayment={initializeGooglePayPayment}
             method={method}
             paymentForm={paymentForm}
+            shouldShowEditButton
             signOutCustomer={checkoutService.signOutCustomer}
         />
     );

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -37,7 +37,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const wasPaymentSelectedAtMountRef = useRef(isPaymentSelected);
 
     const features = getConfig()?.checkoutSettings.features ?? {};
-    const isDirectPayEnabled = Boolean(features['PI-5111.google_pay_direct_pay_on_click'] ?? true);
+    const isDirectPayEnabled = Boolean(features['PI-5111.google_pay_direct_pay_on_click'] ?? false);
 
     const initializeGooglePayPayment = useCallback(
         (defaultOptions: PaymentInitializeOptions) => {

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -1,0 +1,184 @@
+import '@testing-library/jest-dom';
+import {
+    type CheckoutSelectors,
+    type CheckoutService,
+    createCheckoutService,
+    type LanguageService,
+} from '@bigcommerce/checkout-sdk';
+import {
+    createGooglePayAdyenV2PaymentStrategy,
+    createGooglePayAdyenV3PaymentStrategy,
+    createGooglePayAuthorizeNetPaymentStrategy,
+    createGooglePayBigCommercePaymentsPaymentStrategy,
+    createGooglePayBraintreePaymentStrategy,
+    createGooglePayCheckoutComPaymentStrategy,
+    createGooglePayCybersourcePaymentStrategy,
+    createGooglePayOrbitalPaymentStrategy,
+    createGooglePayPPCPPaymentStrategy,
+    createGooglePayStripePaymentStrategy,
+    createGooglePayTdOnlineMartPaymentStrategy,
+    createGooglePayWorldpayAccessPaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/google-pay';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { type PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
+import { getPaymentFormServiceMock, getPaymentMethod } from '@bigcommerce/checkout/test-mocks';
+
+import GooglePayPaymentMethodComponent from './GooglePayPaymentMethodComponent';
+
+describe('GooglePayPaymentMethodComponent', () => {
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+    let paymentForm: PaymentFormService;
+    let onUnhandledError: jest.Mock;
+
+    const method = {
+        ...getPaymentMethod(),
+        id: 'googlepaybraintree',
+        gateway: 'braintree',
+    };
+
+    const defaultProps = () => ({
+        checkoutService,
+        checkoutState,
+        language: { translate: jest.fn() } as unknown as LanguageService,
+        method,
+        onUnhandledError,
+        paymentForm,
+    });
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+        paymentForm = getPaymentFormServiceMock();
+        onUnhandledError = jest.fn();
+
+        jest.spyOn(checkoutService, 'initializePayment').mockResolvedValue(checkoutState);
+        jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('hides the Place Order button immediately on mount', () => {
+        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        expect(paymentForm.hidePaymentSubmitButton).toHaveBeenCalledWith(method, true);
+    });
+
+    it('does not call initializePayment before the DOM has updated', () => {
+        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        expect(checkoutService.initializePayment).not.toHaveBeenCalled();
+    });
+
+    it('calls initializePayment with container options after setTimeout(0)', () => {
+        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        jest.runAllTimers();
+
+        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+            expect.objectContaining({
+                methodId: method.id,
+                gatewayId: method.gateway,
+                integrations: [
+                    createGooglePayAdyenV2PaymentStrategy,
+                    createGooglePayAdyenV3PaymentStrategy,
+                    createGooglePayAuthorizeNetPaymentStrategy,
+                    createGooglePayCheckoutComPaymentStrategy,
+                    createGooglePayCybersourcePaymentStrategy,
+                    createGooglePayOrbitalPaymentStrategy,
+                    createGooglePayStripePaymentStrategy,
+                    createGooglePayWorldpayAccessPaymentStrategy,
+                    createGooglePayBraintreePaymentStrategy,
+                    createGooglePayPPCPPaymentStrategy,
+                    createGooglePayBigCommercePaymentsPaymentStrategy,
+                    createGooglePayTdOnlineMartPaymentStrategy,
+                ],
+                [method.id]: {
+                    container: 'checkout-payment-continue',
+                    buttonColor: 'default',
+                    buttonSizeMode: 'fill',
+                    buttonType: 'pay',
+                    onError: expect.any(Function),
+                },
+            }),
+        );
+    });
+
+    it('passes onUnhandledError as the onError callback', () => {
+        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        jest.runAllTimers();
+
+        const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        expect((call as Record<string, any>)[method.id].onError).toBe(onUnhandledError);
+    });
+
+    it('renders null — no visible DOM output', () => {
+        const { container } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('restores the Place Order button on unmount', () => {
+        const { unmount } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        unmount();
+
+        expect(paymentForm.hidePaymentSubmitButton).toHaveBeenCalledWith(method, false);
+    });
+
+    it('deinitializes payment on unmount', () => {
+        const { unmount } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        unmount();
+
+        expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+            methodId: method.id,
+            gatewayId: method.gateway,
+        });
+    });
+
+    it('cancels pending initializePayment when unmounting before setTimeout fires', () => {
+        const { unmount } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        unmount();
+
+        jest.runAllTimers();
+
+        expect(checkoutService.initializePayment).not.toHaveBeenCalled();
+    });
+
+    it('calls onUnhandledError when initializePayment rejects', async () => {
+        const error = new Error('initialization failed');
+
+        jest.spyOn(checkoutService, 'initializePayment').mockRejectedValue(error);
+
+        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        jest.runAllTimers();
+
+        await Promise.resolve();
+
+        expect(onUnhandledError).toHaveBeenCalledWith(error);
+    });
+
+    it('does not call onUnhandledError for non-Error rejections', async () => {
+        jest.spyOn(checkoutService, 'initializePayment').mockRejectedValue('string rejection');
+
+        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+
+        jest.runAllTimers();
+
+        await Promise.resolve();
+
+        expect(onUnhandledError).not.toHaveBeenCalled();
+    });
+});

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -51,7 +51,7 @@ describe('GooglePayPaymentMethodComponent', () => {
         jest.useRealTimers();
     });
 
-    it('hides the Place Order button immediately on mount', () => {
+    it('hides the Place Order button on mount', () => {
         render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
 
         expect(paymentForm.hidePaymentSubmitButton).toHaveBeenCalledWith(method, true);

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -117,14 +117,14 @@ describe('GooglePayPaymentMethodComponent', () => {
 
         const call = (checkoutService.initializePayment as jest.Mock).mock.calls[0][0];
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((call as Record<string, any>)[method.id].onError).toBe(onUnhandledError);
     });
 
     it('renders null — no visible DOM output', () => {
         const { container } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
 
-        expect(container.firstChild).toBeNull();
+        expect(container.firstChild).toBeEmptyDOMElement();
     });
 
     it('restores the Place Order button on unmount', () => {

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -5,20 +5,6 @@ import {
     createCheckoutService,
     type LanguageService,
 } from '@bigcommerce/checkout-sdk';
-import {
-    createGooglePayAdyenV2PaymentStrategy,
-    createGooglePayAdyenV3PaymentStrategy,
-    createGooglePayAuthorizeNetPaymentStrategy,
-    createGooglePayBigCommercePaymentsPaymentStrategy,
-    createGooglePayBraintreePaymentStrategy,
-    createGooglePayCheckoutComPaymentStrategy,
-    createGooglePayCybersourcePaymentStrategy,
-    createGooglePayOrbitalPaymentStrategy,
-    createGooglePayPPCPPaymentStrategy,
-    createGooglePayStripePaymentStrategy,
-    createGooglePayTdOnlineMartPaymentStrategy,
-    createGooglePayWorldpayAccessPaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/google-pay';
 import { render } from '@testing-library/react';
 import React from 'react';
 
@@ -26,6 +12,7 @@ import { type PaymentFormService } from '@bigcommerce/checkout/payment-integrati
 import { getPaymentFormServiceMock, getPaymentMethod } from '@bigcommerce/checkout/test-mocks';
 
 import GooglePayPaymentMethodComponent from './GooglePayPaymentMethodComponent';
+import googlePayIntegrations from './googlePayIntegrations';
 
 describe('GooglePayPaymentMethodComponent', () => {
     let checkoutService: CheckoutService;
@@ -85,20 +72,7 @@ describe('GooglePayPaymentMethodComponent', () => {
             expect.objectContaining({
                 methodId: method.id,
                 gatewayId: method.gateway,
-                integrations: [
-                    createGooglePayAdyenV2PaymentStrategy,
-                    createGooglePayAdyenV3PaymentStrategy,
-                    createGooglePayAuthorizeNetPaymentStrategy,
-                    createGooglePayCheckoutComPaymentStrategy,
-                    createGooglePayCybersourcePaymentStrategy,
-                    createGooglePayOrbitalPaymentStrategy,
-                    createGooglePayStripePaymentStrategy,
-                    createGooglePayWorldpayAccessPaymentStrategy,
-                    createGooglePayBraintreePaymentStrategy,
-                    createGooglePayPPCPPaymentStrategy,
-                    createGooglePayBigCommercePaymentsPaymentStrategy,
-                    createGooglePayTdOnlineMartPaymentStrategy,
-                ],
+                integrations: googlePayIntegrations,
                 [method.id]: {
                     container: 'checkout-payment-continue',
                     buttonColor: 'default',

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -104,6 +104,7 @@ describe('GooglePayPaymentMethodComponent', () => {
                     buttonColor: 'default',
                     buttonSizeMode: 'fill',
                     buttonType: 'pay',
+                    loadingContainerId: 'checkout-app',
                     onError: expect.any(Function),
                 },
             }),
@@ -124,7 +125,7 @@ describe('GooglePayPaymentMethodComponent', () => {
     it('renders null — no visible DOM output', () => {
         const { container } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
 
-        expect(container.firstChild).toBeEmptyDOMElement();
+        expect(container).toBeEmptyDOMElement();
     });
 
     it('restores the Place Order button on unmount', () => {

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
@@ -1,0 +1,86 @@
+import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
+import {
+    createGooglePayAdyenV2PaymentStrategy,
+    createGooglePayAdyenV3PaymentStrategy,
+    createGooglePayAuthorizeNetPaymentStrategy,
+    createGooglePayBigCommercePaymentsPaymentStrategy,
+    createGooglePayBraintreePaymentStrategy,
+    createGooglePayCheckoutComPaymentStrategy,
+    createGooglePayCybersourcePaymentStrategy,
+    createGooglePayOrbitalPaymentStrategy,
+    createGooglePayPPCPPaymentStrategy,
+    createGooglePayStripePaymentStrategy,
+    createGooglePayTdOnlineMartPaymentStrategy,
+    createGooglePayWorldpayAccessPaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/google-pay';
+import { type FunctionComponent, useEffect } from 'react';
+
+import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
+
+const GOOGLE_PAY_BUTTON_CONTAINER_ID = 'checkout-payment-continue';
+
+const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = ({
+    checkoutService,
+    method,
+    paymentForm,
+    onUnhandledError,
+}) => {
+    useEffect(() => {
+        // Hiding the Place Order button causes Payment.tsx to render the
+        // #checkout-payment-continue container div.  That state update is
+        // committed to the DOM before any setTimeout(0) macrotask fires, so
+        // by the time initializePayment runs the container is already present
+        // and the SDK can append the branded Google Pay button into it directly.
+        paymentForm.hidePaymentSubmitButton(method, true);
+        const timeoutId = setTimeout(async () => {
+            try {
+                const mergedOptions: PaymentInitializeOptions = {
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                    integrations: [
+                        createGooglePayAdyenV2PaymentStrategy,
+                        createGooglePayAdyenV3PaymentStrategy,
+                        createGooglePayAuthorizeNetPaymentStrategy,
+                        createGooglePayCheckoutComPaymentStrategy,
+                        createGooglePayCybersourcePaymentStrategy,
+                        createGooglePayOrbitalPaymentStrategy,
+                        createGooglePayStripePaymentStrategy,
+                        createGooglePayWorldpayAccessPaymentStrategy,
+                        createGooglePayBraintreePaymentStrategy,
+                        createGooglePayPPCPPaymentStrategy,
+                        createGooglePayBigCommercePaymentsPaymentStrategy,
+                        createGooglePayTdOnlineMartPaymentStrategy,
+                    ],
+                    [method.id]: {
+                        container: GOOGLE_PAY_BUTTON_CONTAINER_ID,
+                        buttonColor: 'default',
+                        buttonSizeMode: 'fill',
+                        buttonType: 'pay',
+                        onError: onUnhandledError,
+                    },
+                };
+
+                await checkoutService.initializePayment(mergedOptions);
+            } catch (error) {
+                if (error instanceof Error) {
+                    onUnhandledError(error);
+                }
+            }
+        }, 0);
+
+        return () => {
+            clearTimeout(timeoutId);
+            paymentForm.hidePaymentSubmitButton(method, false);
+
+            void checkoutService.deinitializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return null;
+};
+
+export default GooglePayPaymentMethodComponent;

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
@@ -14,11 +14,6 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
     onUnhandledError,
 }) => {
     useEffect(() => {
-        // Hiding the Place Order button causes Payment.tsx to render the
-        // #checkout-payment-continue container div.  That state update is
-        // committed to the DOM before any setTimeout(0) macrotask fires, so
-        // by the time initializePayment runs the container is already present
-        // and the SDK can append the branded Google Pay button into it directly.
         paymentForm.hidePaymentSubmitButton(method, true);
 
         const timeoutId = setTimeout(async () => {

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
@@ -1,21 +1,9 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import {
-    createGooglePayAdyenV2PaymentStrategy,
-    createGooglePayAdyenV3PaymentStrategy,
-    createGooglePayAuthorizeNetPaymentStrategy,
-    createGooglePayBigCommercePaymentsPaymentStrategy,
-    createGooglePayBraintreePaymentStrategy,
-    createGooglePayCheckoutComPaymentStrategy,
-    createGooglePayCybersourcePaymentStrategy,
-    createGooglePayOrbitalPaymentStrategy,
-    createGooglePayPPCPPaymentStrategy,
-    createGooglePayStripePaymentStrategy,
-    createGooglePayTdOnlineMartPaymentStrategy,
-    createGooglePayWorldpayAccessPaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/google-pay';
 import { type FunctionComponent, useEffect } from 'react';
 
 import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
+
+import googlePayIntegrations from './googlePayIntegrations';
 
 const GOOGLE_PAY_BUTTON_CONTAINER_ID = 'checkout-payment-continue';
 
@@ -38,20 +26,7 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
                 const mergedOptions: PaymentInitializeOptions = {
                     gatewayId: method.gateway,
                     methodId: method.id,
-                    integrations: [
-                        createGooglePayAdyenV2PaymentStrategy,
-                        createGooglePayAdyenV3PaymentStrategy,
-                        createGooglePayAuthorizeNetPaymentStrategy,
-                        createGooglePayCheckoutComPaymentStrategy,
-                        createGooglePayCybersourcePaymentStrategy,
-                        createGooglePayOrbitalPaymentStrategy,
-                        createGooglePayStripePaymentStrategy,
-                        createGooglePayWorldpayAccessPaymentStrategy,
-                        createGooglePayBraintreePaymentStrategy,
-                        createGooglePayPPCPPaymentStrategy,
-                        createGooglePayBigCommercePaymentsPaymentStrategy,
-                        createGooglePayTdOnlineMartPaymentStrategy,
-                    ],
+                    integrations: googlePayIntegrations,
                     [method.id]: {
                         container: GOOGLE_PAY_BUTTON_CONTAINER_ID,
                         buttonColor: 'default',

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
@@ -32,6 +32,7 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
         // by the time initializePayment runs the container is already present
         // and the SDK can append the branded Google Pay button into it directly.
         paymentForm.hidePaymentSubmitButton(method, true);
+
         const timeoutId = setTimeout(async () => {
             try {
                 const mergedOptions: PaymentInitializeOptions = {
@@ -56,6 +57,7 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
                         buttonColor: 'default',
                         buttonSizeMode: 'fill',
                         buttonType: 'pay',
+                        loadingContainerId: 'checkout-app',
                         onError: onUnhandledError,
                     },
                 };

--- a/packages/google-pay-integration/src/googlePayIntegrations.ts
+++ b/packages/google-pay-integration/src/googlePayIntegrations.ts
@@ -1,0 +1,31 @@
+import {
+    createGooglePayAdyenV2PaymentStrategy,
+    createGooglePayAdyenV3PaymentStrategy,
+    createGooglePayAuthorizeNetPaymentStrategy,
+    createGooglePayBigCommercePaymentsPaymentStrategy,
+    createGooglePayBraintreePaymentStrategy,
+    createGooglePayCheckoutComPaymentStrategy,
+    createGooglePayCybersourcePaymentStrategy,
+    createGooglePayOrbitalPaymentStrategy,
+    createGooglePayPPCPPaymentStrategy,
+    createGooglePayStripePaymentStrategy,
+    createGooglePayTdOnlineMartPaymentStrategy,
+    createGooglePayWorldpayAccessPaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/google-pay';
+
+const googlePayIntegrations = [
+    createGooglePayAdyenV2PaymentStrategy,
+    createGooglePayAdyenV3PaymentStrategy,
+    createGooglePayAuthorizeNetPaymentStrategy,
+    createGooglePayCheckoutComPaymentStrategy,
+    createGooglePayCybersourcePaymentStrategy,
+    createGooglePayOrbitalPaymentStrategy,
+    createGooglePayStripePaymentStrategy,
+    createGooglePayWorldpayAccessPaymentStrategy,
+    createGooglePayBraintreePaymentStrategy,
+    createGooglePayPPCPPaymentStrategy,
+    createGooglePayBigCommercePaymentsPaymentStrategy,
+    createGooglePayTdOnlineMartPaymentStrategy,
+];
+
+export default googlePayIntegrations;


### PR DESCRIPTION
## What/Why?

Create `GooglePayPaymentMethodComponent` for accordion-selection direct-pay flow; when Google Pay is selected from the accordion and the direct pay is enabled:

- we no longer show sign-in/sign-out links
- we render a Google Pay button in place of a 'Place order' button; the new button opens the Google Pay modal
- after the shopper triggers the payment in the Google Pay modal, we execute the payment directly, without 'Place order' step

The direct pay flow is available when the experiment `PI-5111.google_pay_direct_pay_on_click` is enabled. When the experiment is disabled, we use the legacy flow (with sign-in/sign-out).

For express entry (payment through GPay button on PDP/Cart/Customer step in the Checkout), we keep the legacy flow for direct pay enabled/disabled.

## Rollout/Rollback

Revert/disable experiment `PI-5111.google_pay_direct_pay_on_click`

## Testing

Express entry (PDP/Cart/Customer step in Checkout):


https://github.com/user-attachments/assets/b3d945b0-9578-4b6a-a5d0-a2147e0e6407

Legacy Checkout Payment step flow (`PI-5111.google_pay_direct_pay_on_click` experiment off):


https://github.com/user-attachments/assets/9e5edbdc-2dce-4666-9f4b-78e3e9950847

Direct pay flow (`PI-5111.google_pay_direct_pay_on_click` experiment on):


https://github.com/user-attachments/assets/e1ef60f7-184f-4a30-a7c2-3fbc2898c1aa




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout payment UI and initialization timing for Google Pay when an experiment flag is on; express flows are preserved via mount-time payment selection, but payment submit visibility and SDK container wiring affect the payment step.
> 
> **Overview**
> Adds a **Google Pay direct pay** path when checkout feature `PI-5111.google_pay_direct_pay_on_click` is on and the shopper did not already enter via express (Google Pay not selected in `checkout.payments` at mount).
> 
> In that case `GooglePayPaymentMethod` renders new `GooglePayPaymentMethodComponent` instead of the wallet sign-in UI: it hides Place Order, initializes payment after `setTimeout(0)` with the SDK button in `checkout-payment-continue`, and cleans up on unmount. Shared Google Pay strategy factories move to `googlePayIntegrations.ts`.
> 
> **Express entry** (payment already selected at mount) and **flag off** still use `WalletButtonPaymentMethodComponent` with sign-in/sign-out. Tests split legacy vs direct pay vs express behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9acdb077c0e92418e4da87006e272a089023b29f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->