### PR TITLE
feat(checkout): CHECKOUT-10038 Refresh B2B Payment Methods Cache

### DIFF
--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -674,6 +674,29 @@ describe('Payment step', () => {
             expect(refreshSpy).not.toHaveBeenCalled();
         });
 
+        it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
+            mockB2BTokenEndpoints();
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithB2B(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
+                new Error('B2B payments refresh failed'),
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(screen.getByText(/place order/i)).toBeInTheDocument();
+        });
+
         it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
             mockB2BTokenEndpoints();
             checkout.setRequestHandler(

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -14,6 +14,7 @@ import {
     type AnalyticsEvents,
     AnalyticsProviderMock,
     CheckoutProvider,
+    defaultCapabilities,
     ExtensionProvider,
     type ExtensionServiceInterface,
     LocaleProvider,
@@ -482,5 +483,226 @@ describe('Payment step', () => {
         await userEvent.click(screen.getByText('Ok'));
 
         expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
+    });
+
+    describe('B2B payment methods refresh', () => {
+        const B2B_BASE_URL = 'https://api-b2b.test';
+
+        const createConfigWithB2B = () => ({
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                b2bApiSettings: {
+                    baseUrl: B2B_BASE_URL,
+                    clientId: 'fake-client-id',
+                },
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    capabilities: {
+                        ...defaultCapabilities,
+                        userJourney: {
+                            ...defaultCapabilities.userJourney,
+                            requiresB2BToken: true,
+                        },
+                    },
+                },
+            },
+        });
+
+        const mockB2BTokenEndpoints = () => {
+            checkout.setRequestHandler(
+                rest.get('/customer/current.jwt', (_, res, ctx) =>
+                    res(ctx.json({ token: 'fake-jwt' })),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.post(`${B2B_BASE_URL}/api/v2/login`, (_, res, ctx) =>
+                    res(ctx.json({ code: 0, data: { token: 'fake-b2b-token' } })),
+                ),
+            );
+        };
+
+        it('refreshes B2B payment methods on mount when b2bToken is loaded and orderId is present on checkout', async () => {
+            mockB2BTokenEndpoints();
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithB2B(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(refreshSpy).toHaveBeenCalled();
+        });
+
+        it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
+            mockB2BTokenEndpoints();
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithB2B(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(refreshSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not refresh B2B payment methods on mount for non-B2B user even when orderId is present', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    orderId: 12345,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(refreshSpy).not.toHaveBeenCalled();
+        });
+
+        it('refreshes B2B payment methods before submitting order for B2B user', async () => {
+            mockB2BTokenEndpoints();
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(ctx.json(orderResponse)),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+            );
+
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithB2B(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+            const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            refreshSpy.mockClear();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            expect(refreshSpy).toHaveBeenCalledTimes(1);
+            expect(submitOrderSpy).toHaveBeenCalledTimes(1);
+
+            const refreshCallOrder = refreshSpy.mock.invocationCallOrder[0];
+            const submitOrderCallOrder = submitOrderSpy.mock.invocationCallOrder[0];
+
+            expect(refreshCallOrder).toBeLessThan(submitOrderCallOrder);
+        });
+
+        it('does not refresh B2B payment methods before submitting order for non-B2B user', async () => {
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(ctx.json(orderResponse)),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+            );
+
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            expect(refreshSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
+            mockB2BTokenEndpoints();
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(ctx.json(orderResponse)),
+                ),
+            );
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithB2B(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
+                new Error('B2B payments refresh failed'),
+            );
+
+            const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            expect(submitOrderSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -486,47 +486,26 @@ describe('Payment step', () => {
     });
 
     describe('B2B payment methods refresh', () => {
-        const B2B_BASE_URL = 'https://api-b2b.test';
-
-        const createConfigWithB2B = () => ({
+        const createConfigWithPersistB2BMetadata = () => ({
             ...checkoutSettings,
             storeConfig: {
                 ...checkoutSettings.storeConfig,
-                b2bApiSettings: {
-                    baseUrl: B2B_BASE_URL,
-                    clientId: 'fake-client-id',
-                },
                 checkoutSettings: {
                     ...checkoutSettings.storeConfig.checkoutSettings,
                     capabilities: {
                         ...defaultCapabilities,
-                        userJourney: {
-                            ...defaultCapabilities.userJourney,
-                            requiresB2BToken: true,
+                        orderConfirmation: {
+                            ...defaultCapabilities.orderConfirmation,
+                            persistB2BMetadata: true,
                         },
                     },
                 },
             },
         });
 
-        const mockB2BTokenEndpoints = () => {
-            checkout.setRequestHandler(
-                rest.get('/customer/current.jwt', (_, res, ctx) =>
-                    res(ctx.json({ token: 'fake-jwt' })),
-                ),
-            );
-            checkout.setRequestHandler(
-                rest.post(`${B2B_BASE_URL}/api/v2/login`, (_, res, ctx) =>
-                    res(ctx.json({ code: 0, data: { token: 'fake-b2b-token' } })),
-                ),
-            );
-        };
-
-        it('refreshes B2B payment methods on mount when b2bToken is loaded and orderId is present on checkout', async () => {
-            mockB2BTokenEndpoints();
-
+        it('refreshes B2B payment methods on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithB2B(),
+                config: createConfigWithPersistB2BMetadata(),
                 checkout: {
                     ...checkoutWithShippingAndBilling,
                     customer,
@@ -546,10 +525,8 @@ describe('Payment step', () => {
         });
 
         it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
-            mockB2BTokenEndpoints();
-
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithB2B(),
+                config: createConfigWithPersistB2BMetadata(),
                 checkout: {
                     ...checkoutWithShippingAndBilling,
                     customer,
@@ -567,7 +544,7 @@ describe('Payment step', () => {
             expect(refreshSpy).not.toHaveBeenCalled();
         });
 
-        it('does not refresh B2B payment methods on mount for non-B2B user even when orderId is present', async () => {
+        it('does not refresh B2B payment methods on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 checkout: {
                     ...checkoutWithShippingAndBilling,
@@ -586,8 +563,7 @@ describe('Payment step', () => {
             expect(refreshSpy).not.toHaveBeenCalled();
         });
 
-        it('refreshes B2B payment methods before submitting order for B2B user', async () => {
-            mockB2BTokenEndpoints();
+        it('refreshes B2B payment methods before submitting order when persistB2BMetadata capability is enabled', async () => {
             checkout.setRequestHandler(
                 rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
                     res(ctx.json(orderResponse)),
@@ -609,7 +585,7 @@ describe('Payment step', () => {
             });
 
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithB2B(),
+                config: createConfigWithPersistB2BMetadata(),
                 checkout: {
                     ...checkoutWithShippingAndBilling,
                     customer,
@@ -638,7 +614,7 @@ describe('Payment step', () => {
             expect(refreshCallOrder).toBeLessThan(submitOrderCallOrder);
         });
 
-        it('does not refresh B2B payment methods before submitting order for non-B2B user', async () => {
+        it('does not refresh B2B payment methods before submitting order when persistB2BMetadata capability is disabled', async () => {
             checkout.setRequestHandler(
                 rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
                     res(ctx.json(orderResponse)),
@@ -675,10 +651,8 @@ describe('Payment step', () => {
         });
 
         it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
-            mockB2BTokenEndpoints();
-
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithB2B(),
+                config: createConfigWithPersistB2BMetadata(),
                 checkout: {
                     ...checkoutWithShippingAndBilling,
                     customer,
@@ -698,7 +672,6 @@ describe('Payment step', () => {
         });
 
         it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
-            mockB2BTokenEndpoints();
             checkout.setRequestHandler(
                 rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
                     res(ctx.json(orderResponse)),
@@ -706,7 +679,7 @@ describe('Payment step', () => {
             );
 
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithB2B(),
+                config: createConfigWithPersistB2BMetadata(),
                 checkout: {
                     ...checkoutWithShippingAndBilling,
                     customer,

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -82,6 +82,7 @@ export interface PaymentProps {
 
 interface WithCheckoutPaymentProps {
     availableStoreCredit: number;
+    b2bToken?: string;
     cart?: Cart;
     consignments?: Consignment[];
     cartUrl: string;
@@ -93,6 +94,7 @@ interface WithCheckoutPaymentProps {
     isTermsConditionsRequired: boolean;
     methods: PaymentMethod[];
     orderExtraFields?: FormField[];
+    orderId?: number;
     shouldExecuteSpamCheck: boolean;
     shouldLocaliseErrorMessages: boolean;
     shouldShowSubmitPaymentButton: boolean;
@@ -106,6 +108,7 @@ interface WithCheckoutPaymentProps {
     isPaymentDataRequired(): boolean;
     loadCheckout(): Promise<CheckoutSelectors>;
     loadPaymentMethods(): Promise<CheckoutSelectors>;
+    refreshB2BPaymentMethods: CheckoutService['refreshB2BPaymentMethods'];
     submitOrder(values: OrderRequestBody): Promise<CheckoutSelectors>;
     checkoutServiceSubscribe: CheckoutService['subscribe'];
 }
@@ -379,12 +382,14 @@ const Payment = (
     const handleSubmit = useCallback(
         async (values: PaymentFormValues) => {
             const {
+                b2bToken,
                 defaultMethod,
                 loadPaymentMethods,
                 isPaymentDataRequired,
                 onCartChangedError = noop,
                 onSubmit = noop,
                 onSubmitError = noop,
+                refreshB2BPaymentMethods,
                 submitOrder,
                 analyticsTracker,
             } = props;
@@ -404,6 +409,10 @@ const Payment = (
             }
 
             try {
+                if (b2bToken) {
+                    await refreshB2BPaymentMethods();
+                }
+
                 const state = await submitOrder(
                     mapToOrderRequestBody(values, isPaymentDataRequired()),
                 );
@@ -548,10 +557,13 @@ const Payment = (
     useEffect(() => {
         const init = async () => {
             const {
+                b2bToken,
                 finalizeOrderIfNeeded,
                 onFinalize = noop,
                 onFinalizeError = noop,
                 onReady = noop,
+                orderId,
+                refreshB2BPaymentMethods,
                 usableStoreCredit,
                 checkoutServiceSubscribe,
             } = props;
@@ -561,6 +573,10 @@ const Payment = (
             }
 
             await loadPaymentMethodsOrThrow();
+
+            if (b2bToken && orderId) {
+                await refreshB2BPaymentMethods();
+            }
 
             try {
                 const state = await finalizeOrderIfNeeded({
@@ -742,6 +758,7 @@ export function mapToPaymentProps(
     return {
         applyStoreCredit: checkoutService.applyStoreCredit,
         availableStoreCredit: customer.storeCredit,
+        b2bToken: checkoutState.data.getB2BToken(),
         cart: getCart(),
         consignments,
         cartUrl: config.links.cartLink,
@@ -758,6 +775,8 @@ export function mapToPaymentProps(
         loadPaymentMethods: checkoutService.loadPaymentMethods,
         methods: filteredMethods,
         orderExtraFields,
+        orderId: checkout.orderId,
+        refreshB2BPaymentMethods: checkoutService.refreshB2BPaymentMethods,
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,
         shouldLocaliseErrorMessages:
             features['PAYMENTS-6799.localise_checkout_payment_error_messages'],

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -410,6 +410,7 @@ const Payment = (
 
             try {
                 if (b2bToken) {
+                    // TODO CHECKOUT-10062 Refactor the capability flag
                     await refreshB2BPaymentMethods();
                 }
 
@@ -577,6 +578,7 @@ const Payment = (
 
             if (b2bToken && orderId) {
                 try {
+                    // TODO CHECKOUT-10062 Refactor the capability flag
                     await refreshB2BPaymentMethods();
                 } catch (error) {
                     if (error instanceof Error) {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -562,6 +562,7 @@ const Payment = (
                 onFinalize = noop,
                 onFinalizeError = noop,
                 onReady = noop,
+                onUnhandledError = noop,
                 orderId,
                 refreshB2BPaymentMethods,
                 usableStoreCredit,
@@ -575,7 +576,13 @@ const Payment = (
             await loadPaymentMethodsOrThrow();
 
             if (b2bToken && orderId) {
-                await refreshB2BPaymentMethods();
+                try {
+                    await refreshB2BPaymentMethods();
+                } catch (error) {
+                    if (error instanceof Error) {
+                        onUnhandledError(error);
+                    }
+                }
             }
 
             try {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -39,6 +39,7 @@ import { type ObjectSchema } from 'yup';
 import {
     type AnalyticsContextProps,
     type CheckoutContextProps,
+    useCapabilities,
 } from '@bigcommerce/checkout/contexts';
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
@@ -143,6 +144,10 @@ const Payment = (
     const grandTotalChangeUnsubscribe = useRef<() => void>();
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
+
+    const {
+        orderConfirmation: { persistB2BMetadata },
+    } = useCapabilities();
 
     const renderCartStockPositionsChangedModal = (
         error: CartStockPositionsChangedError,
@@ -382,7 +387,6 @@ const Payment = (
     const handleSubmit = useCallback(
         async (values: PaymentFormValues) => {
             const {
-                b2bToken,
                 defaultMethod,
                 loadPaymentMethods,
                 isPaymentDataRequired,
@@ -409,8 +413,7 @@ const Payment = (
             }
 
             try {
-                if (b2bToken) {
-                    // TODO CHECKOUT-10062 Refactor the capability flag
+                if (persistB2BMetadata) {
                     await refreshB2BPaymentMethods();
                 }
 
@@ -558,7 +561,6 @@ const Payment = (
     useEffect(() => {
         const init = async () => {
             const {
-                b2bToken,
                 finalizeOrderIfNeeded,
                 onFinalize = noop,
                 onFinalizeError = noop,
@@ -576,9 +578,8 @@ const Payment = (
 
             await loadPaymentMethodsOrThrow();
 
-            if (b2bToken && orderId) {
+            if (persistB2BMetadata && orderId) {
                 try {
-                    // TODO CHECKOUT-10062 Refactor the capability flag
                     await refreshB2BPaymentMethods();
                 } catch (error) {
                     if (error instanceof Error) {


### PR DESCRIPTION
## What/Why?

Refresh B2B payment methods cache:
- On mount of the Payment step (post-redirect after jumping to a third-party payment site).
- Inside handleSubmit, before placing the order.

## Rollout/Rollback

Revert.

## Testing

<img width="1508" height="824" alt="Screenshot 2026-05-27 at 13 50 18" src="https://github.com/user-attachments/assets/fbd0d994-5034-47fd-97b4-5b9ae1925aff" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order submission flow for B2B checkouts by inserting a network call before place order; mount-time failures are non-blocking but submit-time failures block checkout completion.
> 
> **Overview**
> When **`orderConfirmation.persistB2BMetadata`** is enabled, the payment step now calls **`checkoutService.refreshB2BPaymentMethods`** so B2B payment options stay in sync after off-site redirects and right before placing an order.
> 
> On **payment step init**, a refresh runs only if the checkout already has an **`orderId`** (typical return from a third-party payment). Failures are reported via **`onUnhandledError`** but initialization still completes so the shopper can pay.
> 
> On **Place Order**, the same refresh runs **before** **`submitOrder`** when the capability is on. A failed refresh aborts submit (no order placed). When the capability is off, refresh is skipped in both paths.
> 
> Checkout props now pass **`orderId`**, **`refreshB2BPaymentMethods`**, and **`b2bToken`** into **`Payment`**. Tests cover mount/submit gating, call ordering, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2b1f145395d3020ce01f0cd7fcc67fa57bb0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->