### PR TITLE
refactor(checkout): CHECKOUT-10010 Reduce test noise

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -56,7 +56,7 @@ beforeAll(() => {
         const message = args.map(String).join();
 
         // FIXME: Remove these ignored errors once we have enabled react 18 features
-        if (/Formik|createRoot|React.act|findDOMNode/.test(message)) {
+        if (/Formik|createRoot|React.act|findDOMNode|not wrapped in act/.test(message)) {
             return;
         }
 
@@ -64,7 +64,9 @@ beforeAll(() => {
     };
 
     console.warn = (...args: unknown[]) => {
-        if (args.map(String).join().includes('Formik')) {
+        const message = args.map(String).join();
+
+        if (/Formik|should not be used on a non-HTTPS page/.test(message)) {
             return;
         }
 


### PR DESCRIPTION
## What/Why?

Reduce test noise by ignoring two warnings.
- `Warning: An update to ... inside a test was not wrapped in act(...).`.
- `The BigCommerce Checkout SDK should not be used on a non-HTTPS page`.

## Rollout/Rollback

Revert.

## Testing
Log line counts across the four parallel `test-core` runs on CI:

| Run | Before | After |
|---|---|---|
| 1 | 158,116 | 180 |
| 2 | 50,119 | 1,621 |
| 3 | 63,431 | 867 |
| 4 | 38,904 | 7,277 |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only console filtering; no runtime checkout or production code paths change.
> 
> **Overview**
> Expands Jest global console filters in `jest-setup.ts` so known noisy messages do not flood CI logs during `test-core`.
> 
> **`console.error`** now also suppresses React Testing Library *act(...)* warnings (pattern `not wrapped in act`), in addition to the existing Formik / React 18-related filters.
> 
> **`console.warn`** builds a single joined message (same as error) and suppresses the BigCommerce Checkout SDK non-HTTPS warning via regex, while still filtering Formik warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9ea9f1700c15fd3e7de81a3a9f22f56b3c1cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->