### PR TITLE
chore(other): CHECKOUT-9818 Update checkout sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.917.0",
+        "@bigcommerce/checkout-sdk": "^1.919.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,10 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.917.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.917.0.tgz",
-      "integrity": "sha512-iZg+BjFpaXmcRcEyIgLmhe/X1ijGzEUYJymM+zeiw6ouUtMH4GTuCGsB9S3oIMbLGdsGbao6NU/4PxzVk8b+UA==",
+      "version": "1.919.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.919.0.tgz",
+      "integrity": "sha512-LK588yJzk8fz1u47aN2fAdzrtOHETokCtxYU01zHRLIjCl+rq84A4mSdX9M6Uf/L8lrvqYhxDVcxL4+5vCvTiw==",
+      "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",
@@ -29785,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.917.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.917.0.tgz",
-      "integrity": "sha512-iZg+BjFpaXmcRcEyIgLmhe/X1ijGzEUYJymM+zeiw6ouUtMH4GTuCGsB9S3oIMbLGdsGbao6NU/4PxzVk8b+UA==",
+      "version": "1.919.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.919.0.tgz",
+      "integrity": "sha512-LK588yJzk8fz1u47aN2fAdzrtOHETokCtxYU01zHRLIjCl+rq84A4mSdX9M6Uf/L8lrvqYhxDVcxL4+5vCvTiw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.917.0",
+    "@bigcommerce/checkout-sdk": "^1.919.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,11 +53,17 @@ function appConfig(options, argv) {
             cache: {
                 type: 'filesystem',
             },
+            snapshot: {
+                managedPaths: [
+                    /^(.+?[\\/]node_modules[\\/](?!\.cache)(?!@bigcommerce[\\/]checkout-sdk)(?:@.+?[\\/])?.+?)(?:[\\/].*)?$/,
+                ],
+            },
             devtool: isProduction ? 'source-map' : 'eval-source-map',
             resolve: {
                 alias,
                 extensions: ['.ts', '.tsx', '.js'],
                 mainFields: ['browser', 'module', 'main'],
+                symlinks: false,
             },
             optimization: {
                 runtimeChunk: 'single',
@@ -171,11 +177,12 @@ function appConfig(options, argv) {
             ].filter(Boolean),
             module: {
                 rules: [
-                    ...(isProduction ?  [{
+                    {
                         test: /\.[tj]sx?$/,
                         enforce: 'pre',
                         loader: require.resolve('source-map-loader'),
-                    }]: []),
+                        include: /[\\/]node_modules[\\/]@bigcommerce[\\/]checkout-sdk[\\/]/,
+                    },
                     {
                         test: /\.tsx?$/,
                         include: tsLoaderIncludes,
@@ -294,11 +301,17 @@ function loaderConfig(options, argv) {
                 ),
             },
             mode,
+            snapshot: {
+                managedPaths: [
+                    /^(.+?[\\/]node_modules[\\/](?!\.cache)(?!@bigcommerce[\\/]checkout-sdk)(?:@.+?[\\/])?.+?)(?:[\\/].*)?$/,
+                ],
+            },
             devtool: isProduction ? 'source-map' : 'eval-source-map',
             resolve: {
                 alias,
                 extensions: ['.ts', '.tsx', '.js'],
                 mainFields: ['module', 'browser', 'main'],
+                symlinks: false,
             },
             output: {
                 path: isProduction ? join(__dirname, 'dist') : join(__dirname, 'build'),


### PR DESCRIPTION
## What/Why?

- Bump @bigcommerce/checkout-sdk from ^1.917.0 to ^1.919.0.
- Update webpack config

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout SDK drives payment and checkout behavior; webpack changes affect how that dependency is cached and source-mapped in production builds.
> 
> **Overview**
> Upgrades **`@bigcommerce/checkout-sdk`** from **^1.917.0** to **^1.919.0** in `package.json` and the lockfile.
> 
> Webpack is tuned so the SDK is treated as a first-class dependency during builds: **`snapshot.managedPaths`** excludes `@bigcommerce/checkout-sdk` from immutable `node_modules` caching (app and loader configs), and **`resolve.symlinks`** is set to **`false`** in both configs. The app bundle’s **`source-map-loader`** now always runs for **`@bigcommerce/checkout-sdk`** under `node_modules` (not only in production and not for the whole tree).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 984d0a41e7cd0bf44c66b8a71e4377e398d2027d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->