### PR TITLE
feat(paymnet): Migrate CyberSource v2 to Resolver Configuration

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -1,9 +1,5 @@
 import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
-import {
-    createCyberSourcePaymentStrategy,
-    createCyberSourceV2PaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import React, { type FunctionComponent, useCallback } from 'react';
 
@@ -43,8 +39,6 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                     integrations: [
                         ...(options.integrations ?? []),
                         createCreditCardPaymentStrategy,
-                        createCyberSourcePaymentStrategy,
-                        createCyberSourceV2PaymentStrategy,
                         createSagePayPaymentStrategy,
                         createCBAMPGSPaymentStrategy,
                     ],

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -31,12 +31,11 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     HostedCreditCardPaymentMethod,
     [
-        {
-            id: 'hosted-credit-card',
-        },
         { id: 'credit_card', gateway: 'bluesnapdirect' },
         { id: 'credit_card', gateway: 'checkoutcom' },
-
+        { id: 'cybersource' },
+        { id: 'cybersourcev2' },
+        { id: 'hosted-credit-card' },
         { id: 'tdonlinemart' },
     ],
 );

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -4,6 +4,10 @@ import {
     type LegacyHostedFormOptions,
 } from '@bigcommerce/checkout-sdk';
 import { createBlueSnapDirectCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
+import {
+    createCyberSourcePaymentStrategy,
+    createCyberSourceV2PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
@@ -256,6 +260,8 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                     ...options,
                     integrations: [
                         createCreditCardPaymentStrategy,
+                        createCyberSourcePaymentStrategy,
+                        createCyberSourceV2PaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,


### PR DESCRIPTION
## What/Why?

Migrates the cybersource payment method to the new resolver-based architecture by registering it in the HostedCreditCardPaymentMethod component resolver (packages/hosted-credit-card-integration).

remove from knownMethods was in other PR
https://github.com/bigcommerce/checkout-js/pull/2815

## Rollout/Rollback

roll back this commt

## Testing

isHostedFormEnabled false

https://github.com/user-attachments/assets/8c64bf8a-fb1a-4175-8f47-3950a21c89af

isHostedFormEnabled true

https://github.com/user-attachments/assets/96206fc8-e3fc-49eb-b8b2-22e37f9b0758

<img width="948" height="455" alt="Screenshot 2026-05-28 at 19 10 58" src="https://github.com/user-attachments/assets/5b19d063-3ac9-4068-90e9-ed31054ccebe" />
<img width="1043" height="931" alt="Screenshot 2026-05-28 at 19 10 34" src="https://github.com/user-attachments/assets/62ff7743-8246-4775-9ca4-42258e07d2e7" />
<img width="923" height="964" alt="Screenshot 2026-05-28 at 19 10 50" src="https://github.com/user-attachments/assets/2022fbfc-81c5-41e5-bbed-f3e4f1e66507" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which component resolves CyberSource and where payment strategies are registered; incorrect resolver or init wiring could break CyberSource checkout despite being a mostly mechanical migration.
> 
> **Overview**
> **CyberSource** and **CyberSource v2** checkout UI and payment initialization move from the core `HostedCreditCardPaymentMethod` into the resolver-based `hosted-credit-card-integration` package.
> 
> The resolver now maps method ids `cybersource` and `cybersourcev2` to `HostedCreditCardPaymentMethod`, and `HostedCreditCardComponent` registers `createCyberSourcePaymentStrategy` and `createCyberSourceV2PaymentStrategy` when calling `initializePayment`. The core hosted credit card wrapper drops those integrations (along with their imports) so CyberSource is only wired through the new resolver path, consistent with other hosted-card gateways in that package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e55d62d1f9593026fdc8c912e8a2f5c8e4a717a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->