### PR TITLE
chore(other): CHECKOUT-10061 Update sdk version

### DIFF
--- a/.claude/commands/update-sdk.md
+++ b/.claude/commands/update-sdk.md
@@ -1,7 +1,18 @@
-Run the following command to update the BigCommerce Checkout SDK to the latest version:
+Update the BigCommerce Checkout SDK to the latest version by running the following steps in the project root directory:
 
+1. Fetch upstream and create a new branch from upstream/master. Use the Bash tool to resolve the version dynamically:
+```
+git fetch upstream && SDK_VERSION=$(npm view @bigcommerce/checkout-sdk version | tr '.' '-') && git checkout -b sdk-bump-${SDK_VERSION} upstream/master
+```
+
+2. Reinstall all dependencies cleanly:
+```
+npm ci
+```
+
+3. Install the latest SDK:
 ```
 npm i @bigcommerce/checkout-sdk@latest
 ```
 
-Use the Bash tool to execute this command in the project root directory.
+Use the Bash tool to execute these commands sequentially in the project root directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.920.1",
+        "@bigcommerce/checkout-sdk": "^1.920.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.920.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.1.tgz",
-      "integrity": "sha512-Ox9HRWqOdBLPo+JFnYJZ22ParBfygE/1Rpn9RaYBi9USUm0uTmqREbLMaDfORbdrE1YRRfzawurDSXyRbvZ51g==",
+      "version": "1.920.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.2.tgz",
+      "integrity": "sha512-eGCbGEr6+wafeDlbEwJMydgvYadVkRu5mllgIpe5CaXPc6KjWmtq0LD1MUT5SvqJNWz5egr8eKTx5yF9JLbgOw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.920.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.1.tgz",
-      "integrity": "sha512-Ox9HRWqOdBLPo+JFnYJZ22ParBfygE/1Rpn9RaYBi9USUm0uTmqREbLMaDfORbdrE1YRRfzawurDSXyRbvZ51g==",
+      "version": "1.920.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.2.tgz",
+      "integrity": "sha512-eGCbGEr6+wafeDlbEwJMydgvYadVkRu5mllgIpe5CaXPc6KjWmtq0LD1MUT5SvqJNWz5egr8eKTx5yF9JLbgOw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.920.1",
+    "@bigcommerce/checkout-sdk": "^1.920.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Update sdk version

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with lockfile-only runtime change; no application source changes.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **1.920.1** to **1.920.2** in `package.json` and `package-lock.json`, pulling in the new published SDK tarball and integrity hash.
> 
> Also expands **`.claude/commands/update-sdk.md`** so the documented bump flow includes fetching upstream, creating a versioned branch, running **`npm ci`**, then installing the latest SDK—instead of only documenting a single install command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf0a3967f6da69fe54c7b40ca8707668e042791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->