### PR TITLE
chore(other): CHECKOUT-10069 Use selectors with useCheckout for app/customer paths

### DIFF
--- a/packages/contexts/src/checkout/useCheckout.tsx
+++ b/packages/contexts/src/checkout/useCheckout.tsx
@@ -1,15 +1,6 @@
-import { type CheckoutSelectors } from '@bigcommerce/checkout-sdk';
 import { useCallback, useContext, useEffect, useRef, useSyncExternalStore } from 'react';
-
 import CheckoutContext, { type CheckoutContextProps } from './CheckoutContext';
-
-// TODO: Remove TypeScript function overloads once CheckoutProviderV2 is fully rolled out
-export function useCheckout<T>(
-    selectFn: (state: CheckoutSelectors) => T,
-): CheckoutContextProps & { selectedState: T };
-export function useCheckout(
-    selectFn?: undefined,
-): CheckoutContextProps & { selectedState: undefined };
+import { type CheckoutSelectors } from '@bigcommerce/checkout-sdk';
 
 export function useCheckout<T>(
     selectFn?: (state: CheckoutSelectors) => T,

--- a/packages/contexts/src/checkout/useCheckout.tsx
+++ b/packages/contexts/src/checkout/useCheckout.tsx
@@ -1,6 +1,15 @@
-import { useCallback, useContext, useEffect, useRef, useSyncExternalStore } from 'react';
-import CheckoutContext, { type CheckoutContextProps } from './CheckoutContext';
 import { type CheckoutSelectors } from '@bigcommerce/checkout-sdk';
+import { useCallback, useContext, useEffect, useRef, useSyncExternalStore } from 'react';
+
+import CheckoutContext, { type CheckoutContextProps } from './CheckoutContext';
+
+// TODO: Remove TypeScript function overloads once CheckoutProviderV2 is fully rolled out
+export function useCheckout<T>(
+    selectFn: (state: CheckoutSelectors) => T,
+): CheckoutContextProps & { selectedState: T };
+export function useCheckout(
+    selectFn?: undefined,
+): CheckoutContextProps & { selectedState: undefined };
 
 export function useCheckout<T>(
     selectFn?: (state: CheckoutSelectors) => T,

--- a/packages/core/src/app/customer/GuestFormContainer.tsx
+++ b/packages/core/src/app/customer/GuestFormContainer.tsx
@@ -47,33 +47,28 @@ export const GuestFormContainer: React.FC<GuestFormContainerProps> = ({
     onWalletButtonClick,
     onUnhandledError,
 }) => {
-    const { checkoutState, checkoutService } = useCheckout(
-        ({
-            data: { isPaymentDataRequired, getConfig, getCart },
-            statuses: {
-                isInitializingCustomer,
-                isContinuingAsGuest,
-                isExecutingPaymentMethodCheckout,
-            },
-        }) => ({
-            isPaymentDataRequired: isPaymentDataRequired(),
-            config: getConfig(),
-            cart: getCart(),
-            isInitializingCustomer: isInitializingCustomer(),
-            isContinuingAsGuest: isContinuingAsGuest(),
-            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
-        }),
-    );
     const {
-        data: { isPaymentDataRequired, getConfig, getCart },
-        statuses: { isInitializingCustomer, isContinuingAsGuest, isExecutingPaymentMethodCheckout },
-    } = checkoutState;
+        selectedState: {
+            isPaymentDataRequired,
+            config,
+            cart,
+            isInitializingCustomer,
+            isContinuingAsGuest,
+            isExecutingPaymentMethodCheckout,
+        },
+        checkoutService,
+    } = useCheckout(({ data, statuses }) => ({
+        isPaymentDataRequired: data.isPaymentDataRequired(),
+        config: data.getConfig(),
+        cart: data.getCart(),
+        isInitializingCustomer: statuses.isInitializingCustomer(),
+        isContinuingAsGuest: statuses.isContinuingAsGuest(),
+        isExecutingPaymentMethodCheckout: statuses.isExecutingPaymentMethodCheckout(),
+    }));
 
     const { deinitializeCustomer, initializeCustomer } = checkoutService;
 
-    const config = getConfig();
-    const cart = getCart();
-    const isLoadingGuestForm = isContinuingAsGuest() || isExecutingPaymentMethodCheckout();
+    const isLoadingGuestForm = isContinuingAsGuest || isExecutingPaymentMethodCheckout;
 
     if (!config || !cart) {
         return null;
@@ -93,12 +88,12 @@ export const GuestFormContainer: React.FC<GuestFormContainerProps> = ({
     const customCheckoutProvider = getProviderWithCustomCheckout(providerWithCustomCheckout);
 
     const checkoutButtons =
-        isWalletButtonsOnTop || !isPaymentDataRequired() ? null : (
+        isWalletButtonsOnTop || !isPaymentDataRequired ? null : (
             <CheckoutButtonList
                 checkEmbeddedSupport={checkEmbeddedSupport}
                 deinitialize={deinitializeCustomer}
                 initialize={initializeCustomer}
-                isInitializing={isInitializingCustomer()}
+                isInitializing={isInitializingCustomer}
                 methodIds={checkoutButtonIds}
                 onClick={onWalletButtonClick}
                 onError={onUnhandledError}
@@ -117,9 +112,9 @@ export const GuestFormContainer: React.FC<GuestFormContainerProps> = ({
                 initialize={initializeCustomer}
                 isExpressPrivacyPolicy={isExpressPrivacyPolicy}
                 isLoading={
-                    isContinuingAsGuest() ||
-                    isInitializingCustomer() ||
-                    isExecutingPaymentMethodCheckout()
+                    isContinuingAsGuest ||
+                    isInitializingCustomer ||
+                    isExecutingPaymentMethodCheckout
                 }
                 onChangeEmail={handleChangeEmail}
                 onContinueAsGuest={handleContinueAsGuest}

--- a/packages/core/src/app/customer/GuestFormContainer.tsx
+++ b/packages/core/src/app/customer/GuestFormContainer.tsx
@@ -47,28 +47,33 @@ export const GuestFormContainer: React.FC<GuestFormContainerProps> = ({
     onWalletButtonClick,
     onUnhandledError,
 }) => {
+    const { checkoutState, checkoutService } = useCheckout(
+        ({
+            data: { isPaymentDataRequired, getConfig, getCart },
+            statuses: {
+                isInitializingCustomer,
+                isContinuingAsGuest,
+                isExecutingPaymentMethodCheckout,
+            },
+        }) => ({
+            isPaymentDataRequired: isPaymentDataRequired(),
+            config: getConfig(),
+            cart: getCart(),
+            isInitializingCustomer: isInitializingCustomer(),
+            isContinuingAsGuest: isContinuingAsGuest(),
+            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+        }),
+    );
     const {
-        selectedState: {
-            isPaymentDataRequired,
-            config,
-            cart,
-            isInitializingCustomer,
-            isContinuingAsGuest,
-            isExecutingPaymentMethodCheckout,
-        },
-        checkoutService,
-    } = useCheckout(({ data, statuses }) => ({
-        isPaymentDataRequired: data.isPaymentDataRequired(),
-        config: data.getConfig(),
-        cart: data.getCart(),
-        isInitializingCustomer: statuses.isInitializingCustomer(),
-        isContinuingAsGuest: statuses.isContinuingAsGuest(),
-        isExecutingPaymentMethodCheckout: statuses.isExecutingPaymentMethodCheckout(),
-    }));
+        data: { isPaymentDataRequired, getConfig, getCart },
+        statuses: { isInitializingCustomer, isContinuingAsGuest, isExecutingPaymentMethodCheckout },
+    } = checkoutState;
 
     const { deinitializeCustomer, initializeCustomer } = checkoutService;
 
-    const isLoadingGuestForm = isContinuingAsGuest || isExecutingPaymentMethodCheckout;
+    const config = getConfig();
+    const cart = getCart();
+    const isLoadingGuestForm = isContinuingAsGuest() || isExecutingPaymentMethodCheckout();
 
     if (!config || !cart) {
         return null;
@@ -88,12 +93,12 @@ export const GuestFormContainer: React.FC<GuestFormContainerProps> = ({
     const customCheckoutProvider = getProviderWithCustomCheckout(providerWithCustomCheckout);
 
     const checkoutButtons =
-        isWalletButtonsOnTop || !isPaymentDataRequired ? null : (
+        isWalletButtonsOnTop || !isPaymentDataRequired() ? null : (
             <CheckoutButtonList
                 checkEmbeddedSupport={checkEmbeddedSupport}
                 deinitialize={deinitializeCustomer}
                 initialize={initializeCustomer}
-                isInitializing={isInitializingCustomer}
+                isInitializing={isInitializingCustomer()}
                 methodIds={checkoutButtonIds}
                 onClick={onWalletButtonClick}
                 onError={onUnhandledError}
@@ -112,9 +117,9 @@ export const GuestFormContainer: React.FC<GuestFormContainerProps> = ({
                 initialize={initializeCustomer}
                 isExpressPrivacyPolicy={isExpressPrivacyPolicy}
                 isLoading={
-                    isContinuingAsGuest ||
-                    isInitializingCustomer ||
-                    isExecutingPaymentMethodCheckout
+                    isContinuingAsGuest() ||
+                    isInitializingCustomer() ||
+                    isExecutingPaymentMethodCheckout()
                 }
                 onChangeEmail={handleChangeEmail}
                 onContinueAsGuest={handleContinueAsGuest}

--- a/packages/core/src/app/customer/GuestFormContainer.tsx
+++ b/packages/core/src/app/customer/GuestFormContainer.tsx
@@ -47,7 +47,23 @@ export const GuestFormContainer: React.FC<GuestFormContainerProps> = ({
     onWalletButtonClick,
     onUnhandledError,
 }) => {
-    const { checkoutState, checkoutService } = useCheckout();
+    const { checkoutState, checkoutService } = useCheckout(
+        ({
+            data: { isPaymentDataRequired, getConfig, getCart },
+            statuses: {
+                isInitializingCustomer,
+                isContinuingAsGuest,
+                isExecutingPaymentMethodCheckout,
+            },
+        }) => ({
+            isPaymentDataRequired: isPaymentDataRequired(),
+            config: getConfig(),
+            cart: getCart(),
+            isInitializingCustomer: isInitializingCustomer(),
+            isContinuingAsGuest: isContinuingAsGuest(),
+            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+        }),
+    );
     const {
         data: { isPaymentDataRequired, getConfig, getCart },
         statuses: { isInitializingCustomer, isContinuingAsGuest, isExecutingPaymentMethodCheckout },

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -65,7 +65,17 @@ const LoginForm: FunctionComponent<
     isFloatingLabelEnabled,
     viewType = CustomerViewType.Login,
 }) => {
-    const { checkoutState } = useCheckout();
+    const { checkoutState } = useCheckout(
+        ({
+            data: { getCart, getConfig },
+            statuses: { isExecutingPaymentMethodCheckout, isSigningIn },
+        }) => ({
+            cart: getCart(),
+            config: getConfig(),
+            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+            isSigningIn: isSigningIn(),
+        }),
+    );
 
     const {
         data: { getCart, getConfig },

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -65,24 +65,14 @@ const LoginForm: FunctionComponent<
     isFloatingLabelEnabled,
     viewType = CustomerViewType.Login,
 }) => {
-    const { checkoutState } = useCheckout(
-        ({
-            data: { getCart, getConfig },
-            statuses: { isExecutingPaymentMethodCheckout, isSigningIn },
-        }) => ({
-            cart: getCart(),
-            config: getConfig(),
-            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
-            isSigningIn: isSigningIn(),
-        }),
-    );
-
     const {
-        data: { getCart, getConfig },
-        statuses: { isExecutingPaymentMethodCheckout, isSigningIn },
-    } = checkoutState;
-    const cart = getCart();
-    const config = getConfig();
+        selectedState: { cart, config, isExecutingPaymentMethodCheckout, isSigningIn },
+    } = useCheckout(({ data: { getCart, getConfig }, statuses }) => ({
+        cart: getCart(),
+        config: getConfig(),
+        isExecutingPaymentMethodCheckout: statuses.isExecutingPaymentMethodCheckout(),
+        isSigningIn: statuses.isSigningIn(),
+    }));
 
     if (!cart || !config) {
         throw new Error('cart is not available');
@@ -204,17 +194,15 @@ const LoginForm: FunctionComponent<
                 <div className="form-actions">
                     {shouldRedirectToStorefrontForAuth ? (
                         <RedirectToStorefrontLogin
-                            isDisabled={Boolean(
-                                isSigningIn() || isExecutingPaymentMethodCheckout(),
-                            )}
-                            isLoading={Boolean(isSigningIn() || isExecutingPaymentMethodCheckout())}
+                            isDisabled={isSigningIn || isExecutingPaymentMethodCheckout}
+                            isLoading={isSigningIn || isExecutingPaymentMethodCheckout}
                         />
                     ) : (
                         <Button
                             className="body-bold"
-                            disabled={isSigningIn() || isExecutingPaymentMethodCheckout()}
+                            disabled={isSigningIn || isExecutingPaymentMethodCheckout}
                             id="checkout-customer-continue"
-                            isLoading={isSigningIn() || isExecutingPaymentMethodCheckout()}
+                            isLoading={isSigningIn || isExecutingPaymentMethodCheckout}
                             testId="customer-continue-button"
                             type="submit"
                             variant={ButtonVariant.Primary}

--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -65,14 +65,24 @@ const LoginForm: FunctionComponent<
     isFloatingLabelEnabled,
     viewType = CustomerViewType.Login,
 }) => {
+    const { checkoutState } = useCheckout(
+        ({
+            data: { getCart, getConfig },
+            statuses: { isExecutingPaymentMethodCheckout, isSigningIn },
+        }) => ({
+            cart: getCart(),
+            config: getConfig(),
+            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+            isSigningIn: isSigningIn(),
+        }),
+    );
+
     const {
-        selectedState: { cart, config, isExecutingPaymentMethodCheckout, isSigningIn },
-    } = useCheckout(({ data: { getCart, getConfig }, statuses }) => ({
-        cart: getCart(),
-        config: getConfig(),
-        isExecutingPaymentMethodCheckout: statuses.isExecutingPaymentMethodCheckout(),
-        isSigningIn: statuses.isSigningIn(),
-    }));
+        data: { getCart, getConfig },
+        statuses: { isExecutingPaymentMethodCheckout, isSigningIn },
+    } = checkoutState;
+    const cart = getCart();
+    const config = getConfig();
 
     if (!cart || !config) {
         throw new Error('cart is not available');
@@ -194,15 +204,17 @@ const LoginForm: FunctionComponent<
                 <div className="form-actions">
                     {shouldRedirectToStorefrontForAuth ? (
                         <RedirectToStorefrontLogin
-                            isDisabled={isSigningIn || isExecutingPaymentMethodCheckout}
-                            isLoading={isSigningIn || isExecutingPaymentMethodCheckout}
+                            isDisabled={Boolean(
+                                isSigningIn() || isExecutingPaymentMethodCheckout(),
+                            )}
+                            isLoading={Boolean(isSigningIn() || isExecutingPaymentMethodCheckout())}
                         />
                     ) : (
                         <Button
                             className="body-bold"
-                            disabled={isSigningIn || isExecutingPaymentMethodCheckout}
+                            disabled={isSigningIn() || isExecutingPaymentMethodCheckout()}
                             id="checkout-customer-continue"
-                            isLoading={isSigningIn || isExecutingPaymentMethodCheckout}
+                            isLoading={isSigningIn() || isExecutingPaymentMethodCheckout()}
                             testId="customer-continue-button"
                             type="submit"
                             variant={ButtonVariant.Primary}

--- a/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
+++ b/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
@@ -13,13 +13,7 @@ export const RedirectToStorefrontLogin: React.FC<RedirectToStorefrontLoginProps>
     isDisabled,
     isLoading,
 }) => {
-    const {
-        checkoutState: {
-            data: { getConfig },
-        },
-    } = useCheckout();
-
-    const config = getConfig();
+    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
 
     if (!config) {
         return null;

--- a/packages/core/src/app/customer/useCustomer.ts
+++ b/packages/core/src/app/customer/useCustomer.ts
@@ -83,61 +83,19 @@ export interface UseCustomerReturn {
 }
 
 export const useCustomer = (): UseCustomerReturn => {
-    const { checkoutState, checkoutService } = useCheckout(
-        ({
-            data: {
-                getBillingAddress,
-                getCustomerAccountFields,
-                getCheckout,
-                getCustomer,
-                getCart,
-                getSignInEmail,
-                getConfig,
-                isPaymentDataRequired,
-            },
-            errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
-            statuses: {
-                isContinuingAsGuest,
-                isExecutingPaymentMethodCheckout,
-                isInitializingCustomer,
-                isSigningIn,
-                isSendingSignInEmail,
-                isCreatingCustomerAccount,
-            },
-        }) => ({
-            billingAddress: getBillingAddress(),
-            checkout: getCheckout(),
-            customer: getCustomer(),
-            cart: getCart(),
-            signInEmail: getSignInEmail(),
-            config: getConfig(),
-            isPaymentDataRequired: isPaymentDataRequired(),
-            signInError: getSignInError(),
-            signInEmailError: getSignInEmailError(),
-            createCustomerAccountError: getCreateCustomerAccountError(),
-            isContinuingAsGuest: isContinuingAsGuest(),
-            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
-            isInitializingCustomer: isInitializingCustomer(),
-            isSigningIn: isSigningIn(),
-            isSendingSignInEmail: isSendingSignInEmail(),
-            isCreatingCustomerAccount: isCreatingCustomerAccount(),
-            getCustomerAccountFields,
-        }),
-    );
-
     const {
-        data: {
-            getBillingAddress,
-            getCustomerAccountFields,
-            getCheckout,
-            getCustomer,
-            getCart,
-            getSignInEmail,
-            getConfig,
+        selectedState: {
+            billingAddress,
+            checkout,
+            customer,
+            cart,
+            signInEmail,
+            config,
+            customerAccountFields,
             isPaymentDataRequired,
-        },
-        errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
-        statuses: {
+            signInError,
+            signInEmailError,
+            createCustomerAccountError,
             isContinuingAsGuest,
             isExecutingPaymentMethodCheckout,
             isInitializingCustomer,
@@ -145,14 +103,26 @@ export const useCustomer = (): UseCustomerReturn => {
             isSendingSignInEmail,
             isCreatingCustomerAccount,
         },
-    } = checkoutState;
-
-    const billingAddress = getBillingAddress();
-    const checkout = getCheckout();
-    const customer = getCustomer();
-    const cart = getCart();
-    const signInEmail = getSignInEmail();
-    const config = getConfig();
+        checkoutService,
+    } = useCheckout(({ data, errors, statuses }) => ({
+        billingAddress: data.getBillingAddress(),
+        checkout: data.getCheckout(),
+        customer: data.getCustomer(),
+        cart: data.getCart(),
+        signInEmail: data.getSignInEmail(),
+        config: data.getConfig(),
+        customerAccountFields: data.getCustomerAccountFields(),
+        isPaymentDataRequired: data.isPaymentDataRequired(),
+        signInError: errors.getSignInError(),
+        signInEmailError: errors.getSignInEmailError(),
+        createCustomerAccountError: errors.getCreateCustomerAccountError(),
+        isContinuingAsGuest: statuses.isContinuingAsGuest(),
+        isExecutingPaymentMethodCheckout: statuses.isExecutingPaymentMethodCheckout(),
+        isInitializingCustomer: statuses.isInitializingCustomer(),
+        isSigningIn: statuses.isSigningIn(),
+        isSendingSignInEmail: statuses.isSendingSignInEmail(),
+        isCreatingCustomerAccount: statuses.isCreatingCustomerAccount(),
+    }));
 
     // Return null-like data if essential data is missing
     if (!checkout || !config || !cart) {
@@ -191,7 +161,7 @@ export const useCustomer = (): UseCustomerReturn => {
         isBuyNowCart: cart.source === 'BUY_NOW',
 
         // Form data
-        customerAccountFields: getCustomerAccountFields(),
+        customerAccountFields,
         canSubscribe,
         defaultShouldSubscribe,
         requiresMarketingConsent,
@@ -207,23 +177,23 @@ export const useCustomer = (): UseCustomerReturn => {
         shouldRedirectToStorefrontForAuth,
 
         // Status flags
-        isContinuingAsGuest: isContinuingAsGuest(),
-        isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
-        isInitializing: isInitializingCustomer(),
-        isSigningIn: isSigningIn(),
-        isSendingSignInEmail: isSendingSignInEmail(),
-        isCreatingAccount: isCreatingCustomerAccount(),
+        isContinuingAsGuest,
+        isExecutingPaymentMethodCheckout,
+        isInitializing: isInitializingCustomer,
+        isSigningIn,
+        isSendingSignInEmail,
+        isCreatingAccount: isCreatingCustomerAccount,
 
         // Errors
-        signInError: getSignInError(),
-        signInEmailError: getSignInEmailError(),
-        createAccountError: getCreateCustomerAccountError(),
+        signInError,
+        signInEmailError,
+        createAccountError: createCustomerAccountError,
 
         // Other data
         signInEmail,
         checkoutButtonIds,
         providerWithCustomCheckout: customCheckoutProvider,
-        isPaymentDataRequired: isPaymentDataRequired(),
+        isPaymentDataRequired,
         shouldRenderStripeForm:
             customCheckoutProvider === PaymentMethodId.StripeUPE &&
             shouldUseStripeLinkByMinimumAmount(cart),

--- a/packages/core/src/app/customer/useCustomer.ts
+++ b/packages/core/src/app/customer/useCustomer.ts
@@ -83,19 +83,61 @@ export interface UseCustomerReturn {
 }
 
 export const useCustomer = (): UseCustomerReturn => {
+    const { checkoutState, checkoutService } = useCheckout(
+        ({
+            data: {
+                getBillingAddress,
+                getCustomerAccountFields,
+                getCheckout,
+                getCustomer,
+                getCart,
+                getSignInEmail,
+                getConfig,
+                isPaymentDataRequired,
+            },
+            errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
+            statuses: {
+                isContinuingAsGuest,
+                isExecutingPaymentMethodCheckout,
+                isInitializingCustomer,
+                isSigningIn,
+                isSendingSignInEmail,
+                isCreatingCustomerAccount,
+            },
+        }) => ({
+            billingAddress: getBillingAddress(),
+            checkout: getCheckout(),
+            customer: getCustomer(),
+            cart: getCart(),
+            signInEmail: getSignInEmail(),
+            config: getConfig(),
+            isPaymentDataRequired: isPaymentDataRequired(),
+            signInError: getSignInError(),
+            signInEmailError: getSignInEmailError(),
+            createCustomerAccountError: getCreateCustomerAccountError(),
+            isContinuingAsGuest: isContinuingAsGuest(),
+            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+            isInitializingCustomer: isInitializingCustomer(),
+            isSigningIn: isSigningIn(),
+            isSendingSignInEmail: isSendingSignInEmail(),
+            isCreatingCustomerAccount: isCreatingCustomerAccount(),
+            getCustomerAccountFields,
+        }),
+    );
+
     const {
-        selectedState: {
-            billingAddress,
-            checkout,
-            customer,
-            cart,
-            signInEmail,
-            config,
-            customerAccountFields,
+        data: {
+            getBillingAddress,
+            getCustomerAccountFields,
+            getCheckout,
+            getCustomer,
+            getCart,
+            getSignInEmail,
+            getConfig,
             isPaymentDataRequired,
-            signInError,
-            signInEmailError,
-            createCustomerAccountError,
+        },
+        errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
+        statuses: {
             isContinuingAsGuest,
             isExecutingPaymentMethodCheckout,
             isInitializingCustomer,
@@ -103,26 +145,14 @@ export const useCustomer = (): UseCustomerReturn => {
             isSendingSignInEmail,
             isCreatingCustomerAccount,
         },
-        checkoutService,
-    } = useCheckout(({ data, errors, statuses }) => ({
-        billingAddress: data.getBillingAddress(),
-        checkout: data.getCheckout(),
-        customer: data.getCustomer(),
-        cart: data.getCart(),
-        signInEmail: data.getSignInEmail(),
-        config: data.getConfig(),
-        customerAccountFields: data.getCustomerAccountFields(),
-        isPaymentDataRequired: data.isPaymentDataRequired(),
-        signInError: errors.getSignInError(),
-        signInEmailError: errors.getSignInEmailError(),
-        createCustomerAccountError: errors.getCreateCustomerAccountError(),
-        isContinuingAsGuest: statuses.isContinuingAsGuest(),
-        isExecutingPaymentMethodCheckout: statuses.isExecutingPaymentMethodCheckout(),
-        isInitializingCustomer: statuses.isInitializingCustomer(),
-        isSigningIn: statuses.isSigningIn(),
-        isSendingSignInEmail: statuses.isSendingSignInEmail(),
-        isCreatingCustomerAccount: statuses.isCreatingCustomerAccount(),
-    }));
+    } = checkoutState;
+
+    const billingAddress = getBillingAddress();
+    const checkout = getCheckout();
+    const customer = getCustomer();
+    const cart = getCart();
+    const signInEmail = getSignInEmail();
+    const config = getConfig();
 
     // Return null-like data if essential data is missing
     if (!checkout || !config || !cart) {
@@ -161,7 +191,7 @@ export const useCustomer = (): UseCustomerReturn => {
         isBuyNowCart: cart.source === 'BUY_NOW',
 
         // Form data
-        customerAccountFields,
+        customerAccountFields: getCustomerAccountFields(),
         canSubscribe,
         defaultShouldSubscribe,
         requiresMarketingConsent,
@@ -177,23 +207,23 @@ export const useCustomer = (): UseCustomerReturn => {
         shouldRedirectToStorefrontForAuth,
 
         // Status flags
-        isContinuingAsGuest,
-        isExecutingPaymentMethodCheckout,
-        isInitializing: isInitializingCustomer,
-        isSigningIn,
-        isSendingSignInEmail,
-        isCreatingAccount: isCreatingCustomerAccount,
+        isContinuingAsGuest: isContinuingAsGuest(),
+        isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+        isInitializing: isInitializingCustomer(),
+        isSigningIn: isSigningIn(),
+        isSendingSignInEmail: isSendingSignInEmail(),
+        isCreatingAccount: isCreatingCustomerAccount(),
 
         // Errors
-        signInError,
-        signInEmailError,
-        createAccountError: createCustomerAccountError,
+        signInError: getSignInError(),
+        signInEmailError: getSignInEmailError(),
+        createAccountError: getCreateCustomerAccountError(),
 
         // Other data
         signInEmail,
         checkoutButtonIds,
         providerWithCustomCheckout: customCheckoutProvider,
-        isPaymentDataRequired,
+        isPaymentDataRequired: isPaymentDataRequired(),
         shouldRenderStripeForm:
             customCheckoutProvider === PaymentMethodId.StripeUPE &&
             shouldUseStripeLinkByMinimumAmount(cart),

--- a/packages/core/src/app/customer/useCustomer.ts
+++ b/packages/core/src/app/customer/useCustomer.ts
@@ -121,7 +121,7 @@ export const useCustomer = (): UseCustomerReturn => {
             isSigningIn: isSigningIn(),
             isSendingSignInEmail: isSendingSignInEmail(),
             isCreatingCustomerAccount: isCreatingCustomerAccount(),
-            getCustomerAccountFields,
+            customerAccountFields: getCustomerAccountFields(),
         }),
     );
 

--- a/packages/core/src/app/customer/useCustomer.ts
+++ b/packages/core/src/app/customer/useCustomer.ts
@@ -83,7 +83,47 @@ export interface UseCustomerReturn {
 }
 
 export const useCustomer = (): UseCustomerReturn => {
-    const { checkoutState, checkoutService } = useCheckout();
+    const { checkoutState, checkoutService } = useCheckout(
+        ({
+            data: {
+                getBillingAddress,
+                getCustomerAccountFields,
+                getCheckout,
+                getCustomer,
+                getCart,
+                getSignInEmail,
+                getConfig,
+                isPaymentDataRequired,
+            },
+            errors: { getSignInError, getSignInEmailError, getCreateCustomerAccountError },
+            statuses: {
+                isContinuingAsGuest,
+                isExecutingPaymentMethodCheckout,
+                isInitializingCustomer,
+                isSigningIn,
+                isSendingSignInEmail,
+                isCreatingCustomerAccount,
+            },
+        }) => ({
+            billingAddress: getBillingAddress(),
+            checkout: getCheckout(),
+            customer: getCustomer(),
+            cart: getCart(),
+            signInEmail: getSignInEmail(),
+            config: getConfig(),
+            isPaymentDataRequired: isPaymentDataRequired(),
+            signInError: getSignInError(),
+            signInEmailError: getSignInEmailError(),
+            createCustomerAccountError: getCreateCustomerAccountError(),
+            isContinuingAsGuest: isContinuingAsGuest(),
+            isExecutingPaymentMethodCheckout: isExecutingPaymentMethodCheckout(),
+            isInitializingCustomer: isInitializingCustomer(),
+            isSigningIn: isSigningIn(),
+            isSendingSignInEmail: isSendingSignInEmail(),
+            isCreatingCustomerAccount: isCreatingCustomerAccount(),
+            getCustomerAccountFields,
+        }),
+    );
 
     const {
         data: {


### PR DESCRIPTION
## What/Why?

Pass selector functions to `useCheckout` hook for components within **packages/core/src/app/customer/** path. This is to not subscribe the components to the whole checkout state, but instead wire them with the state slices that are actually required.

The behavior will only change for customers using CheckoutProviderV2 (For those that have `CHECKOUT-9842.roll_out_state_new_checkout_hook` experiment set to `true`)

## Rollout/Rollback

Revert the PR or set `CHECKOUT-9842.roll_out_state_new_checkout_hook` experiment to `false`.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only subscription/selector wiring in customer UI with no intended auth or payment logic changes.
> 
> **Overview**
> Customer checkout UI under `app/customer` now passes **selector functions** into `useCheckout` so subscription updates can be scoped to the cart/config/status slices each caller needs (aligned with **CHECKOUT-10069** / the checkout hook experiment).
> 
> **`GuestFormContainer`**, **`LoginForm`**, and **`useCustomer`** declare selectors for payment-required flags, config/cart, and guest/sign-in/initialization statuses (plus billing/customer/errors in `useCustomer`). **`RedirectToStorefrontLogin`** is updated to read storefront links from **`selectedState`** via `useCheckout(({ data }) => data.getConfig())` instead of pulling `getConfig` off `checkoutState` alone.
> 
> Behavior should stay the same; the diff mainly registers selectors ahead of narrower re-renders when the experiment path is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebdc964695b885c1c898c3f316eea724551d0982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->