### PR TITLE
chore(checkout) CHECKOUT-10021 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.920.2",
+        "@bigcommerce/checkout-sdk": "^1.921.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.920.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.2.tgz",
-      "integrity": "sha512-eGCbGEr6+wafeDlbEwJMydgvYadVkRu5mllgIpe5CaXPc6KjWmtq0LD1MUT5SvqJNWz5egr8eKTx5yF9JLbgOw==",
+      "version": "1.921.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.1.tgz",
+      "integrity": "sha512-HUKZ6TZgJVb9vv3Xsfbt8naBhkgA4J607JunJZM9taAKYAWp7Oc+ariPq2MTkm5PMAOcq/c0JGJjh3c10IElAw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.920.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.920.2.tgz",
-      "integrity": "sha512-eGCbGEr6+wafeDlbEwJMydgvYadVkRu5mllgIpe5CaXPc6KjWmtq0LD1MUT5SvqJNWz5egr8eKTx5yF9JLbgOw==",
+      "version": "1.921.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.1.tgz",
+      "integrity": "sha512-HUKZ6TZgJVb9vv3Xsfbt8naBhkgA4J607JunJZM9taAKYAWp7Oc+ariPq2MTkm5PMAOcq/c0JGJjh3c10IElAw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.920.2",
+    "@bigcommerce/checkout-sdk": "^1.921.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

bump sdk version to release https://github.com/bigcommerce/checkout-sdk-js/pull/3275

## Rollout/Rollback

Revert this PR

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout behavior depends on the SDK; risk is in whatever changed in 1.921.1, not in local code, so validate checkout/payment flows after upgrade.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **^1.920.2** to **^1.921.1** in `package.json` and refreshes **`package-lock.json`** so the app picks up the published SDK release (CHECKOUT-10021 / checkout-sdk-js #3275).
> 
> There are **no application source changes** in this repo—only the dependency pin and lockfile entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc10ed02174b4d060303448738c634502d683dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->