### PR TITLE
feat(checkout): CHECKOUT-10037 Disable store credit UI and unapply when capability flag is set

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -147,6 +147,7 @@ const Payment = (
 
     const {
         orderConfirmation: { persistB2BMetadata },
+        userJourney: { disableStoreCredit },
     } = useCapabilities();
 
     const renderCartStockPositionsChangedModal = (
@@ -572,7 +573,11 @@ const Payment = (
                 checkoutServiceSubscribe,
             } = props;
 
-            if (usableStoreCredit) {
+            if (disableStoreCredit) {
+                if (props.isStoreCreditApplied) {
+                    await handleStoreCreditChange(false);
+                }
+            } else if (usableStoreCredit) {
                 await handleStoreCreditChange(true);
             }
 
@@ -662,6 +667,7 @@ const Payment = (
                         defaultGatewayId={props.defaultMethod?.gateway}
                         defaultMethodId={props.defaultMethod?.id || ''}
                         didExceedSpamLimit={state.didExceedSpamLimit}
+                        disableStoreCredit={disableStoreCredit}
                         isEmbedded={props.isEmbedded}
                         isInitializingPayment={props.isInitializingPayment}
                         isPaymentDataRequired={props.isPaymentDataRequired}

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -188,6 +188,29 @@ describe('PaymentForm', () => {
         expect(screen.queryByText(/store credit/)).not.toBeInTheDocument();
     });
 
+    it('does not render store credit field when disableStoreCredit is true even if store credit is available', () => {
+        render(
+            <PaymentFormTest {...defaultProps} disableStoreCredit={true} usableStoreCredit={100} />,
+        );
+
+        expect(screen.queryByRole('checkbox', { name: /store credit/ })).not.toBeInTheDocument();
+        expect(screen.queryByText(/store credit/)).not.toBeInTheDocument();
+    });
+
+    it('renders store credit field when disableStoreCredit is false and store credit is available', () => {
+        render(
+            <PaymentFormTest
+                {...defaultProps}
+                disableStoreCredit={false}
+                usableStoreCredit={100}
+            />,
+        );
+
+        expect(
+            screen.getByRole('checkbox', { name: 'Apply $112.00 store credit to order' }),
+        ).toBeInTheDocument();
+    });
+
     it('shows overlay if store credit can cover total cost of order', () => {
         jest.spyOn(defaultProps, 'isPaymentDataRequired').mockReturnValue(false);
 

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -40,6 +40,7 @@ import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
 
 export interface PaymentFormProps {
     availableStoreCredit?: number;
+    disableStoreCredit?: boolean;
     defaultGatewayId?: string;
     defaultMethodId: string;
     didExceedSpamLimit?: boolean;
@@ -70,6 +71,7 @@ const PaymentForm: FunctionComponent<
     PaymentFormProps & FormikProps<PaymentFormValues> & WithLanguageProps
 > = ({
     availableStoreCredit = 0,
+    disableStoreCredit = false,
     didExceedSpamLimit,
     isEmbedded,
     isInitializingPayment,
@@ -146,7 +148,7 @@ const PaymentForm: FunctionComponent<
 
     return (
         <Form className="checkout-form" testId="payment-form">
-            {usableStoreCredit > 0 && (
+            {usableStoreCredit > 0 && !disableStoreCredit && (
                 <StoreCreditField
                     availableStoreCredit={availableStoreCredit}
                     isStoreCreditApplied={isStoreCreditApplied}


### PR DESCRIPTION
## Summary

- When the `disableStoreCredit` capability flag (`userJourney.disableStoreCredit`) is `true`, the store credit checkbox is hidden from the Payment step UI
- On Payment component mount, if `disableStoreCredit` is `true` and store credit is currently applied, it is automatically unapplied via `applyStoreCredit(false)`
- The existing apply-on-mount behaviour (auto-apply when `usableStoreCredit > 0`) is preserved when the flag is `false`

## What changed

**`PaymentForm.tsx`**
- Added `disableStoreCredit?: boolean` prop
- Gate `StoreCreditField` render with `!disableStoreCredit`

**`Payment.tsx`**
- Added `disableStoreCredit` to `WithCheckoutPaymentProps`, sourced from `capabilities.userJourney.disableStoreCredit`
- Init `useEffect` now unapplies store credit when `disableStoreCredit` is `true` and credit was already applied
- Passes `disableStoreCredit` down to `PaymentForm`

**`PaymentForm.test.tsx`**
- Added test: store credit field is hidden when `disableStoreCredit={true}` even if credit is available
- Added test: store credit field renders when `disableStoreCredit={false}` and credit is available

## Testing
Including cases:
- disableStoreCredit: false - show apply store credit option
- disableStoreCredit: true and not applied store credit to cart - hide apply store credit option
- disableStoreCredit: true and applied store credit to cart - hide apply store credit option and unapply store credit from cart

https://github.com/user-attachments/assets/08ca2eb0-4602-452e-97ce-d77f8e55bf5a



## Reviewer notes

The `disableStoreCredit` flag already existed in the `Capabilities` type (`userJourney.disableStoreCredit`) — this PR wires it into the checkout UI for the first time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, flag-gated payment UI and init logic with unit tests; no auth or payment-provider changes.
> 
> **Overview**
> Wires the existing **`userJourney.disableStoreCredit`** capability into the Payment step so merchants can turn off store credit for certain journeys.
> 
> When the flag is **true**, the store credit checkbox is **not rendered** (`PaymentForm` gates `StoreCreditField`), and on Payment mount any **already-applied** store credit is **cleared** via `applyStoreCredit(false)` before the rest of init runs. When the flag is **false**, behavior is unchanged: usable store credit is still **auto-applied** on mount when available.
> 
> Tests cover hiding vs showing the store credit UI for `disableStoreCredit` true/false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e65d9c4d0954ec752072193d9a4552290737d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->