### PR TITLE
chore(other): CHECKOUT-10070 Use selectors with useCheckout for app/s…

### DIFF
--- a/packages/core/src/app/shipping/ConsignmentLineItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItem.tsx
@@ -40,7 +40,7 @@ const ConsignmentLineItem: FunctionComponent<ConsignmentLineItemProps> = ({
     const { unassignedItems } = useMultiShippingConsignmentItems();
     const {
         checkoutService: { assignItemsToAddress: assignItem },
-    } = useCheckout();
+    } = useCheckout(() => undefined);
     const deleteItem = useDeallocateItem();
 
     const toggleAllocateItemsModal = () => {

--- a/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
@@ -29,8 +29,8 @@ export const ConsignmentLineItemContent = ({
     item: MultiShippingTableItemWithType | PhysicalItem;
     isMultiShippingSummary?: boolean;
 }) => {
-    const { checkoutState } = useCheckout();
-    const config = checkoutState.data.getConfig();
+    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
+
     const shouldDisplayBackorderQuantity =
         !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
         config?.inventorySettings?.showQuantityOnBackorder &&

--- a/packages/core/src/app/shipping/ConsignmentListItem.tsx
+++ b/packages/core/src/app/shipping/ConsignmentListItem.tsx
@@ -31,7 +31,7 @@ const ConsignmentListItem: FunctionComponent<ConsignmentListItemProps> = ({
 }: ConsignmentListItemProps) => {
     const {
         checkoutService: { deleteConsignment },
-    } = useCheckout();
+    } = useCheckout(() => undefined);
 
     const handleClose = async () => {
         await deleteConsignment(consignment.id);

--- a/packages/core/src/app/shipping/ShippingAddressForm.tsx
+++ b/packages/core/src/app/shipping/ShippingAddressForm.tsx
@@ -41,17 +41,12 @@ const ShippingAddressForm = ({
     },
     onFieldChange,
 }: ShippingAddressFormProps & ConnectFormikProps<SingleShippingFormValues>): ReactElement => {
-    const {
-        checkoutState: {
-            data: { getCustomer },
-        },
-    } = useCheckout();
+    const { selectedState: customer } = useCheckout(({ data }) => data.getCustomer());
     const { themeV2 } = useThemeContext();
     const {
         shipping: { hideSaveToAddressBookCheck, restrictManualAddressEntry },
     } = useCapabilities();
 
-    const customer = getCustomer();
     const addresses = customer?.addresses || [];
     const shouldShowSaveAddress = !hideSaveToAddressBookCheck && !customer?.isGuest;
 

--- a/packages/core/src/app/shipping/StaticMultiConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticMultiConsignment.tsx
@@ -29,20 +29,16 @@ const StaticMultiConsignment: FunctionComponent<StaticMultiConsignmentProps> = (
     consignmentNumber,
     isShippingDiscountDisplayEnabled,
 }) => {
-    const {
-        checkoutState: {
-            data: { getShippingCountries },
-        },
-    } = useCheckout(({ data }) => ({
-        shippingCountries: data.getShippingCountries(),
-    }));
+    const { selectedState: shippingCountries } = useCheckout(({ data }) =>
+        data.getShippingCountries(),
+    );
 
     const {
         shippingAddress: addressWithoutLocalization,
         selectedShippingOption,
         comparisonShippingCost,
     } = consignment;
-    const address = localizeAddress(addressWithoutLocalization, getShippingCountries());
+    const address = localizeAddress(addressWithoutLocalization, shippingCountries);
     const { paypalFastlaneAddresses } = usePayPalFastlaneAddress();
     const showPayPalFastlaneAddressLabel = isPayPalFastlaneAddress(
         address,

--- a/packages/core/src/app/shipping/StaticMultiConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticMultiConsignment.tsx
@@ -33,7 +33,9 @@ const StaticMultiConsignment: FunctionComponent<StaticMultiConsignmentProps> = (
         checkoutState: {
             data: { getShippingCountries },
         },
-    } = useCheckout();
+    } = useCheckout(({ data }) => ({
+        shippingCountries: data.getShippingCountries(),
+    }));
 
     const {
         shippingAddress: addressWithoutLocalization,

--- a/packages/core/src/app/shipping/hooks/useDeallocateItem.ts
+++ b/packages/core/src/app/shipping/hooks/useDeallocateItem.ts
@@ -5,7 +5,7 @@ import { useCheckout } from '@bigcommerce/checkout/contexts';
 export const useDeallocateItem = () => {
     const {
         checkoutService: { createConsignments, deleteConsignment },
-    } = useCheckout();
+    } = useCheckout(() => undefined);
 
     // this is a workaround to handle removing an item from a consignment
     // current consignment API does not support removing an item directly - Oct 2024

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -119,13 +119,7 @@ const defaultMultiShippingConsignmentItems: MultiShippingConsignmentItemsHook = 
 };
 
 export const useMultiShippingConsignmentItems = (): MultiShippingConsignmentItemsHook => {
-    const {
-        checkoutState: {
-            data: { getCheckout },
-        },
-    } = useCheckout();
-
-    const checkout = getCheckout();
+    const { selectedState: checkout } = useCheckout(({ data }) => data.getCheckout());
 
     if (!checkout) {
         return defaultMultiShippingConsignmentItems;

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -44,6 +44,7 @@ export const useShipping = () => {
                 getBillingAddress,
                 getShippingAddressFields,
                 getShippingCountries,
+                getAddressExtraFields,
             },
             statuses: {
                 isShippingStepPending,
@@ -79,6 +80,7 @@ export const useShipping = () => {
             isDeletingConsignment: isDeletingConsignment(),
             isLoadingCheckout: isLoadingCheckout(),
             getShippingAddressFields,
+            getAddressExtraFields,
         }),
     );
     const {

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -32,7 +32,55 @@ const deleteConsignmentsSelector = createSelector(
 );
 
 export const useShipping = () => {
-    const { checkoutState, checkoutService } = useCheckout();
+    const { checkoutState, checkoutService } = useCheckout(
+        ({
+            data: {
+                getCart,
+                getCheckout,
+                getConfig,
+                getCustomer,
+                getConsignments,
+                getShippingAddress,
+                getBillingAddress,
+                getShippingAddressFields,
+                getShippingCountries,
+            },
+            statuses: {
+                isShippingStepPending,
+                isSelectingShippingOption,
+                isLoadingShippingOptions,
+                isUpdatingConsignment,
+                isCreatingConsignments,
+                isCreatingCustomerAddress,
+                isLoadingShippingCountries,
+                isUpdatingBillingAddress,
+                isUpdatingCheckout,
+                isDeletingConsignment,
+                isLoadingCheckout,
+            },
+        }) => ({
+            cart: getCart(),
+            checkout: getCheckout(),
+            config: getConfig(),
+            customer: getCustomer(),
+            consignments: getConsignments(),
+            shippingAddress: getShippingAddress(),
+            billingAddress: getBillingAddress(),
+            shippingCountries: getShippingCountries(),
+            isShippingStepPending: isShippingStepPending(),
+            isSelectingShippingOption: isSelectingShippingOption(),
+            isLoadingShippingOptions: isLoadingShippingOptions(),
+            isUpdatingConsignment: isUpdatingConsignment(),
+            isCreatingConsignments: isCreatingConsignments(),
+            isCreatingCustomerAddress: isCreatingCustomerAddress(),
+            isLoadingShippingCountries: isLoadingShippingCountries(),
+            isUpdatingBillingAddress: isUpdatingBillingAddress(),
+            isUpdatingCheckout: isUpdatingCheckout(),
+            isDeletingConsignment: isDeletingConsignment(),
+            isLoadingCheckout: isLoadingCheckout(),
+            getShippingAddressFields,
+        }),
+    );
     const {
         userJourney: { hasAddressExtraFields },
     } = useCapabilities();

--- a/packages/core/src/app/shipping/shippingOption/MultiShippingOptions.tsx
+++ b/packages/core/src/app/shipping/shippingOption/MultiShippingOptions.tsx
@@ -25,7 +25,7 @@ export const MultiShippingOptions = ({
     shippingQuoteFailedMessage,
     onUnhandledError,
 }: MultiShippingOptionsV2Props) => {
-    const { checkoutService, checkoutState } = useCheckout();
+    const { checkoutService, checkoutState } = useCheckout((state) => state);
 
     const selectShippingOption = async (consignmentId: string, shippingOptionId: string) => {
         try {


### PR DESCRIPTION
…hipping

## What/Why?

Pass selector functions to `useCheckout` hook for components within **packages/core/src/app/shipping/** path. This is to not subscribe the components to the whole checkout state, but instead wire them with the state slices that are actually required.

The behavior will only change for customers using CheckoutProviderV2 (For those that have `CHECKOUT-9842.roll_out_state_new_checkout_hook` experiment set to `true`)

## Rollout/Rollback

Revert the PR or set `CHECKOUT-9842.roll_out_state_new_checkout_hook` experiment to `false`.

## Testing

CI.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Subscription/refactor only, gated by CHECKOUT-9842; no shipping business logic changes when the experiment is off.
> 
> **Overview**
> Shipping UI under `packages/core/src/app/shipping` now passes **selectors** into `useCheckout` so components subscribe only to the checkout slices they need (when `CHECKOUT-9842.roll_out_state_new_checkout_hook` enables the new hook).
> 
> **Data-driven pieces** read derived values via `selectedState`—e.g. store config for backorder copy, customer for the address book, checkout for multishipping item maps, and shipping countries for localized static consignment addresses. **Action-only call sites** use `useCheckout(() => undefined)` so they keep `checkoutService` without re-rendering on unrelated checkout updates (assign/delete consignment, deallocate item).
> 
> `useShipping` registers a broad selector over cart, addresses, consignments, and loading flags; `MultiShippingOptions` still selects full state for existing loading helpers. With the experiment off, behavior stays on the legacy full-context subscription path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88588cb1663d8862777b97f28e44efbce346dd70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->