### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.921.3",
+        "@bigcommerce/checkout-sdk": "^1.921.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.921.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.3.tgz",
-      "integrity": "sha512-O9dnYYMeBtaToZ9yWhNOS+wcHOsqRJ/gEz1AF2stTp+5FN1AcOXCZM4ZCmtBAN0QSm2KrrCbXFwE8RARxPKljA==",
+      "version": "1.921.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.4.tgz",
+      "integrity": "sha512-DV45rixkDEWSiPj6YDHaXRXm9jGRQ6LfQ8vh+GuIYyIBQbRYgX1ovIxlvJTAOIqxNe6Nmh4t1W1rbj6Tvjq9Ug==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.921.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.3.tgz",
-      "integrity": "sha512-O9dnYYMeBtaToZ9yWhNOS+wcHOsqRJ/gEz1AF2stTp+5FN1AcOXCZM4ZCmtBAN0QSm2KrrCbXFwE8RARxPKljA==",
+      "version": "1.921.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.4.tgz",
+      "integrity": "sha512-DV45rixkDEWSiPj6YDHaXRXm9jGRQ6LfQ8vh+GuIYyIBQbRYgX1ovIxlvJTAOIqxNe6Nmh4t1W1rbj6Tvjq9Ug==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.921.3",
+    "@bigcommerce/checkout-sdk": "^1.921.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-js version:
To deploy: [https://github.com/bigcommerce/checkout-sdk-js/pull/3274](https://github.com/bigcommerce/checkout-sdk-js/pull/3274)

## Rollout/Rollback
Rollback this PR

## Testing
in checkout-sdk PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only dependency and lockfile pins change in checkout-js; rollout risk depends on the linked SDK release, with rollback by reverting this PR.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **`^1.921.3`** to **`^1.921.4`** in **`package.json`** and refreshes **`package-lock.json`** so checkout-js picks up the latest SDK release (aligned with [checkout-sdk-js#3274](https://github.com/bigcommerce/checkout-sdk-js/pull/3274)).
> 
> There are **no other code changes** in this repo—behavior and fixes come from the published SDK package after install/deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a16391b50ed9d6e8e00b36158ecaf1d9c31008be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->