### PR TITLE
feat(checkout): CHECKOUT-10009 add credit limit checks on PO payment method

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -674,7 +674,7 @@ const Payment = (
                         onSubmit={handleSubmit}
                         onUnhandledError={handleError}
                         orderExtraFields={props.orderExtraFields}
-                        selectedMethod={state.selectedMethod}
+                        selectedMethod={state.selectedMethod || props.defaultMethod}
                         shouldDisableSubmit={
                             (uniqueSelectedMethodId &&
                                 state.shouldDisableSubmit[uniqueSelectedMethodId]) ||

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -125,8 +125,8 @@ const PaymentForm: FunctionComponent<
 
     const { checkoutState } = useCheckout();
     const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
-    const selectedMethodDisabledReason = usePoMethodDisabledReason(selectedMethod);
-    const isSubmitDisabled = shouldDisableSubmit || Boolean(selectedMethodDisabledReason);
+    const poMethodDisabledReason = usePoMethodDisabledReason(selectedMethod);
+    const isSubmitDisabled = shouldDisableSubmit || Boolean(poMethodDisabledReason);
     const shouldShowSubmitButtonWhenPaymentNotRequired = isExperimentEnabled(
         checkoutSettings,
         'CHECKOUT-9729.show_submit_button_when_payment_not_required',

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -31,6 +31,7 @@ import {
     getUniquePaymentMethodId,
     PaymentMethodId,
     PaymentMethodList,
+    usePoMethodDisabledReason,
 } from './paymentMethod';
 import PaymentRedeemables from './PaymentRedeemables';
 import PaymentSubmitButton from './PaymentSubmitButton';
@@ -124,6 +125,8 @@ const PaymentForm: FunctionComponent<
 
     const { checkoutState } = useCheckout();
     const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
+    const selectedMethodDisabledReason = usePoMethodDisabledReason(selectedMethod);
+    const isSubmitDisabled = shouldDisableSubmit || Boolean(selectedMethodDisabledReason);
     const shouldShowSubmitButtonWhenPaymentNotRequired = isExperimentEnabled(
         checkoutSettings,
         'CHECKOUT-9729.show_submit_button_when_payment_not_required',
@@ -207,7 +210,7 @@ const PaymentForm: FunctionComponent<
                             selectedMethod && selectedMethod.initializationStrategy?.type
                         }
                         isComplete={!!selectedMethod?.initializationData?.isComplete}
-                        isDisabled={shouldDisableSubmit}
+                        isDisabled={isSubmitDisabled}
                         methodGateway={selectedMethod && selectedMethod.gateway}
                         methodId={selectedMethodId}
                         methodName={

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -13,6 +13,7 @@ import getPaymentMethodName from './getPaymentMethodName';
 import getUniquePaymentMethodId, { parseUniquePaymentMethodId } from './getUniquePaymentMethodId';
 import PaymentMethodTitle, { getPaymentMethodTitle } from './PaymentMethodTitle';
 import PaymentMethodV2 from './PaymentMethodV2';
+import { type PoDisabledReason, usePoMethodDisabledReason } from './usePoMethodDisabledReason';
 
 export interface PaymentMethodListProps {
     isEmbedded?: boolean;
@@ -53,6 +54,9 @@ const PaymentMethodList: FunctionComponent<
     } = useCheckout();
 
     const config = getConfig();
+
+    const chequeMethod = useMemo(() => find(methods, { id: 'cheque' }), [methods]);
+    const chequeDisabledReason = usePoMethodDisabledReason(chequeMethod);
 
     const titleText = useMemo(() => {
         if (config && values.paymentProviderRadio) {
@@ -109,6 +113,9 @@ const PaymentMethodList: FunctionComponent<
 
                     return (
                         <PaymentMethodListItem
+                            disabledReason={
+                                method === chequeMethod ? chequeDisabledReason : undefined
+                            }
                             isDisabled={isInitializingPayment}
                             isEmbedded={isEmbedded}
                             isUsingMultiShipping={isUsingMultiShipping}
@@ -125,6 +132,7 @@ const PaymentMethodList: FunctionComponent<
 };
 
 interface PaymentMethodListItemProps {
+    disabledReason?: PoDisabledReason;
     isDisabled?: boolean;
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
@@ -134,6 +142,7 @@ interface PaymentMethodListItemProps {
 }
 
 const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
+    disabledReason,
     isDisabled,
     isEmbedded,
     isUsingMultiShipping,
@@ -155,12 +164,13 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     const renderPaymentMethodTitle = useCallback(
         (isSelected: boolean) => (
             <PaymentMethodTitle
+                disabledReason={disabledReason}
                 isSelected={isSelected}
                 method={method}
                 onUnhandledError={onUnhandledError}
             />
         ),
-        [method],
+        [disabledReason, method],
     );
 
     if (method.initializationData?.isCustomChecklistItem) {
@@ -171,7 +181,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
         <ChecklistItem
             content={renderPaymentMethod}
             htmlId={`radio-${value}`}
-            isDisabled={isDisabled}
+            isDisabled={isDisabled || Boolean(disabledReason)}
             label={renderPaymentMethodTitle}
             value={value}
         />

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -55,7 +55,7 @@ const PaymentMethodList: FunctionComponent<
 
     const config = getConfig();
 
-    const chequeMethod = useMemo(() => find(methods, { id: 'cheque' }), [methods]);
+    const chequeMethod = find(methods, { id: 'cheque' });
     const chequeDisabledReason = usePoMethodDisabledReason(chequeMethod);
 
     const titleText = useMemo(() => {

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -11,7 +11,11 @@ import React, { type FunctionComponent, memo, type ReactNode } from 'react';
 
 import { BigCommercePaymentsPayLaterBanner } from '@bigcommerce/checkout/bigcommerce-payments-utils';
 import { type CheckoutContextProps } from '@bigcommerce/checkout/contexts';
-import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
+import {
+    TranslatedString,
+    withLanguage,
+    type WithLanguageProps,
+} from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
 import {
     BraintreePaypalCreditBanner,
@@ -29,10 +33,12 @@ import getPaymentMethodName from './getPaymentMethodName';
 import { isHostedCreditCardFieldsetValues } from './HostedCreditCardFieldsetValues';
 import PaymentMethodId from './PaymentMethodId';
 import PaymentMethodType from './PaymentMethodType';
+import { type PoDisabledReason } from './usePoMethodDisabledReason';
 
 export interface PaymentMethodTitleProps {
     method: PaymentMethod;
     isSelected?: boolean;
+    disabledReason?: PoDisabledReason;
     onUnhandledError?(error: Error): void;
 }
 
@@ -397,6 +403,7 @@ const PaymentMethodTitle: FunctionComponent<
     cdnBasePath,
     checkoutSettings,
     storeCountryCode,
+    disabledReason,
     onUnhandledError,
     formik: { values },
     instruments,
@@ -454,7 +461,9 @@ const PaymentMethodTitle: FunctionComponent<
             })}
         >
             <div
-                className="paymentProviderHeader-nameContainer"
+                className={classNames('paymentProviderHeader-nameContainer', {
+                    'paymentProviderHeader-poDisabledContainer': Boolean(disabledReason),
+                })}
                 data-test={`payment-method-${method.id}`}
             >
                 {logoUrl && (
@@ -479,6 +488,24 @@ const PaymentMethodTitle: FunctionComponent<
                         data-test="payment-method-name"
                     >
                         {titleText}
+                    </div>
+                )}
+                {disabledReason && titleText && (
+                    <div
+                        className="paymentProviderHeader-poDisabledMessage"
+                        data-test={`payment-method-disabled-${method.id}`}
+                    >
+                        {disabledReason.kind === 'creditLimit' ? (
+                            <TranslatedString id="payment.errors.disabled_PO_number_credit" />
+                        ) : (
+                            <TranslatedString
+                                data={{
+                                    currency: disabledReason.expectedCurrency,
+                                    name: titleText,
+                                }}
+                                id="payment.errors.disabled_PO_number_currency_mismatch"
+                            />
+                        )}
                     </div>
                 )}
                 {getSubtitle()}

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -10,7 +10,7 @@ import { compact } from 'lodash';
 import React, { type FunctionComponent, memo, type ReactNode } from 'react';
 
 import { BigCommercePaymentsPayLaterBanner } from '@bigcommerce/checkout/bigcommerce-payments-utils';
-import { type CheckoutContextProps } from '@bigcommerce/checkout/contexts';
+import { type CheckoutContextProps, useCapabilities } from '@bigcommerce/checkout/contexts';
 import {
     TranslatedString,
     withLanguage,
@@ -411,6 +411,9 @@ const PaymentMethodTitle: FunctionComponent<
     language,
     method,
 }) => {
+    const {
+        payment: { poConfig },
+    } = useCapabilities();
     const methodName = getPaymentMethodName(language)(method);
     const { logoUrl, titleText, subtitle } = getPaymentMethodTitle(
         language,
@@ -495,12 +498,12 @@ const PaymentMethodTitle: FunctionComponent<
                         className="paymentProviderHeader-poDisabledMessage"
                         data-test={`payment-method-disabled-${method.id}`}
                     >
-                        {disabledReason.kind === 'creditLimit' ? (
+                        {disabledReason === 'creditLimit' ? (
                             <TranslatedString id="payment.errors.disabled_PO_number_credit" />
                         ) : (
                             <TranslatedString
                                 data={{
-                                    currency: disabledReason.expectedCurrency,
+                                    currency: poConfig?.currency ?? '',
                                     name: titleText,
                                 }}
                                 id="payment.errors.disabled_PO_number_currency_mismatch"

--- a/packages/core/src/app/payment/paymentMethod/index.ts
+++ b/packages/core/src/app/payment/paymentMethod/index.ts
@@ -9,6 +9,7 @@ export {
     parseUniquePaymentMethodId,
 } from './getUniquePaymentMethodId';
 export { default as getPaymentMethodName } from './getPaymentMethodName';
+export { usePoMethodDisabledReason } from './usePoMethodDisabledReason';
 export { isHostedCreditCardFieldsetValues } from './HostedCreditCardFieldsetValues';
 export {
     default as CreditCardFieldsetValues,

--- a/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.spec.ts
+++ b/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.spec.ts
@@ -63,10 +63,9 @@ describe('getPoMethodDisabledReason', () => {
     });
 
     it('returns currencyMismatch when poConfig.currency differs from cart currency', () => {
-        expect(getPoMethodDisabledReason({ ...baseArgs, cartCurrencyCode: 'EUR' })).toEqual({
-            kind: 'currencyMismatch',
-            expectedCurrency: 'USD',
-        });
+        expect(getPoMethodDisabledReason({ ...baseArgs, cartCurrencyCode: 'EUR' })).toBe(
+            'currencyMismatch',
+        );
     });
 
     it('treats currency comparison as case-insensitive', () => {
@@ -86,13 +85,11 @@ describe('getPoMethodDisabledReason', () => {
                 cartCurrencyCode: 'EUR',
                 grandTotal: 9999,
             }),
-        ).toEqual({ kind: 'currencyMismatch', expectedCurrency: 'USD' });
+        ).toBe('currencyMismatch');
     });
 
     it('returns creditLimit when grandTotal exceeds the credit limit', () => {
-        expect(getPoMethodDisabledReason({ ...baseArgs, grandTotal: 150 })).toEqual({
-            kind: 'creditLimit',
-        });
+        expect(getPoMethodDisabledReason({ ...baseArgs, grandTotal: 150 })).toBe('creditLimit');
     });
 
     it('returns null when grandTotal is exactly at the credit limit', () => {

--- a/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.spec.ts
+++ b/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.spec.ts
@@ -1,0 +1,105 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getPoMethodDisabledReason } from './usePoMethodDisabledReason';
+
+function getChequeMethod(): PaymentMethod {
+    return {
+        id: 'cheque',
+        logoUrl: '',
+        method: 'offline',
+        supportedCards: [],
+        config: { displayName: 'Purchase Order', testMode: false },
+        type: 'PAYMENT_TYPE_OFFLINE',
+        skipRedirectConfirmationAlert: false,
+    };
+}
+
+describe('getPoMethodDisabledReason', () => {
+    const poConfig = { creditLimit: 100, currency: 'USD' };
+
+    const baseArgs = {
+        method: getChequeMethod(),
+        poConfig,
+        grandTotal: 50,
+        cartCurrencyCode: 'USD',
+    };
+
+    it('returns null when method is not cheque', () => {
+        const method: PaymentMethod = { ...getChequeMethod(), id: 'authorizenet' };
+
+        expect(getPoMethodDisabledReason({ ...baseArgs, method })).toBeNull();
+    });
+
+    it('returns null when poConfig is missing', () => {
+        expect(getPoMethodDisabledReason({ ...baseArgs, poConfig: null })).toBeNull();
+    });
+
+    it('returns null when poConfig.creditLimit is null (no limit configured)', () => {
+        expect(
+            getPoMethodDisabledReason({
+                ...baseArgs,
+                poConfig: { ...poConfig, creditLimit: null },
+                grandTotal: 9999,
+            }),
+        ).toBeNull();
+    });
+
+    it('returns null when poConfig.currency is an empty string', () => {
+        expect(
+            getPoMethodDisabledReason({
+                ...baseArgs,
+                poConfig: { ...poConfig, currency: '' },
+                cartCurrencyCode: 'EUR',
+            }),
+        ).toBeNull();
+    });
+
+    it('returns null when grandTotal is undefined (data still loading)', () => {
+        expect(getPoMethodDisabledReason({ ...baseArgs, grandTotal: undefined })).toBeNull();
+    });
+
+    it('returns null when cartCurrencyCode is missing', () => {
+        expect(getPoMethodDisabledReason({ ...baseArgs, cartCurrencyCode: undefined })).toBeNull();
+    });
+
+    it('returns currencyMismatch when poConfig.currency differs from cart currency', () => {
+        expect(getPoMethodDisabledReason({ ...baseArgs, cartCurrencyCode: 'EUR' })).toEqual({
+            kind: 'currencyMismatch',
+            expectedCurrency: 'USD',
+        });
+    });
+
+    it('treats currency comparison as case-insensitive', () => {
+        expect(
+            getPoMethodDisabledReason({
+                ...baseArgs,
+                poConfig: { ...poConfig, currency: 'usd' },
+                cartCurrencyCode: 'USD',
+            }),
+        ).toBeNull();
+    });
+
+    it('returns currencyMismatch even when grandTotal exceeds the credit limit (currency wins)', () => {
+        expect(
+            getPoMethodDisabledReason({
+                ...baseArgs,
+                cartCurrencyCode: 'EUR',
+                grandTotal: 9999,
+            }),
+        ).toEqual({ kind: 'currencyMismatch', expectedCurrency: 'USD' });
+    });
+
+    it('returns creditLimit when grandTotal exceeds the credit limit', () => {
+        expect(getPoMethodDisabledReason({ ...baseArgs, grandTotal: 150 })).toEqual({
+            kind: 'creditLimit',
+        });
+    });
+
+    it('returns null when grandTotal is exactly at the credit limit', () => {
+        expect(getPoMethodDisabledReason({ ...baseArgs, grandTotal: 100 })).toBeNull();
+    });
+
+    it('returns null when grandTotal is under the limit and currency matches', () => {
+        expect(getPoMethodDisabledReason({ ...baseArgs, grandTotal: 50 })).toBeNull();
+    });
+});

--- a/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.ts
+++ b/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.ts
@@ -1,0 +1,74 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { useMemo } from 'react';
+
+import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
+
+export type PoDisabledReason =
+    | { kind: 'creditLimit' }
+    | { kind: 'currencyMismatch'; expectedCurrency: string };
+
+export interface GetPoMethodDisabledReasonArgs {
+    method: PaymentMethod;
+    poConfig: { creditLimit: number | null; currency: string } | null;
+    grandTotal: number | undefined;
+    cartCurrencyCode: string | undefined;
+}
+
+export function getPoMethodDisabledReason({
+    method,
+    poConfig,
+    grandTotal,
+    cartCurrencyCode,
+}: GetPoMethodDisabledReasonArgs): PoDisabledReason | null {
+    if (
+        method.id !== 'cheque' ||
+        !poConfig ||
+        poConfig.creditLimit == null ||
+        !poConfig.currency ||
+        grandTotal == null ||
+        !cartCurrencyCode
+    ) {
+        return null;
+    }
+
+    if (poConfig.currency.toUpperCase() !== cartCurrencyCode.toUpperCase()) {
+        return { kind: 'currencyMismatch', expectedCurrency: poConfig.currency };
+    }
+
+    if (grandTotal > poConfig.creditLimit) {
+        return { kind: 'creditLimit' };
+    }
+
+    return null;
+}
+
+export function usePoMethodDisabledReason(
+    method: PaymentMethod | undefined,
+): PoDisabledReason | undefined {
+    const {
+        checkoutState: {
+            data: { getCart, getCheckout },
+        },
+    } = useCheckout();
+    const {
+        payment: { poConfig },
+    } = useCapabilities();
+
+    const grandTotal = getCheckout()?.grandTotal;
+    const cartCurrencyCode = getCart()?.currency.code;
+
+    return useMemo(() => {
+        if (!method) {
+            return undefined;
+        }
+
+        return (
+            getPoMethodDisabledReason({
+                method,
+                poConfig,
+                grandTotal,
+                cartCurrencyCode,
+            }) ?? undefined
+        );
+    }, [method, poConfig, grandTotal, cartCurrencyCode]);
+}

--- a/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.ts
+++ b/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.ts
@@ -3,9 +3,7 @@ import { useMemo } from 'react';
 
 import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 
-export type PoDisabledReason =
-    | { kind: 'creditLimit' }
-    | { kind: 'currencyMismatch'; expectedCurrency: string };
+export type PoDisabledReason = 'creditLimit' | 'currencyMismatch';
 
 export interface GetPoMethodDisabledReasonArgs {
     method: PaymentMethod;
@@ -20,23 +18,23 @@ export function getPoMethodDisabledReason({
     grandTotal,
     cartCurrencyCode,
 }: GetPoMethodDisabledReasonArgs): PoDisabledReason | null {
-    if (
-        method.id !== 'cheque' ||
-        !poConfig ||
-        poConfig.creditLimit == null ||
-        !poConfig.currency ||
-        grandTotal == null ||
-        !cartCurrencyCode
-    ) {
+    const creditLimit = poConfig?.creditLimit;
+    const expectedCurrency = poConfig?.currency;
+
+    const isNotPoMethod = method.id !== 'cheque';
+    const isPoConfigIncomplete = creditLimit == null || !expectedCurrency;
+    const isCartDataMissing = grandTotal == null || !cartCurrencyCode;
+
+    if (isNotPoMethod || isPoConfigIncomplete || isCartDataMissing) {
         return null;
     }
 
-    if (poConfig.currency.toUpperCase() !== cartCurrencyCode.toUpperCase()) {
-        return { kind: 'currencyMismatch', expectedCurrency: poConfig.currency };
+    if (expectedCurrency.toUpperCase() !== cartCurrencyCode.toUpperCase()) {
+        return 'currencyMismatch';
     }
 
-    if (grandTotal > poConfig.creditLimit) {
-        return { kind: 'creditLimit' };
+    if (grandTotal > creditLimit) {
+        return 'creditLimit';
     }
 
     return null;
@@ -45,17 +43,16 @@ export function getPoMethodDisabledReason({
 export function usePoMethodDisabledReason(
     method: PaymentMethod | undefined,
 ): PoDisabledReason | undefined {
-    const {
-        checkoutState: {
-            data: { getCart, getCheckout },
-        },
-    } = useCheckout();
+    const { selectedState } = useCheckout(({ data }) => ({
+        grandTotal: data.getCheckout()?.grandTotal,
+        cartCurrencyCode: data.getCart()?.currency.code,
+    }));
     const {
         payment: { poConfig },
     } = useCapabilities();
 
-    const grandTotal = getCheckout()?.grandTotal;
-    const cartCurrencyCode = getCart()?.currency.code;
+    const grandTotal = selectedState?.grandTotal;
+    const cartCurrencyCode = selectedState?.cartCurrencyCode;
 
     return useMemo(() => {
         if (!method) {

--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -64,6 +64,17 @@
     flex-shrink: 1;
 }
 
+.paymentProviderHeader-poDisabledContainer {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.paymentProviderHeader-poDisabledMessage {
+    color: color("greys", "dark");
+    flex-basis: 100%;
+    font-size: fontSize("smallest");
+}
+
 .paymentMethod--creditCard,
 .paymentMethod--hosted,
 .paymentMethod--walletButton {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -403,6 +403,8 @@
                 "phone_number_required_error": "Phone Number is required",
                 "business_name_required_error": "Business Name is required",
                 "only_numbers_error": "{label} must contain only numbers",
+                "disabled_PO_number_credit": "This purchase exceeds your available credit, please select an alternative payment method",
+                "disabled_PO_number_currency_mismatch": "Please use {currency} to utilize the {name}",
                 "additional_action_required": "Please continue with additional actions.",
                 "authorization_expired": "The authorization for this transaction has expired.",
                 "authorization_revoked": "The authorization for this transaction has been revoked.",


### PR DESCRIPTION
## What/Why?

Adds credit limit and currency validation to the Purchase Order (cheque) payment method to prevent buyers from checking out when their order would exceed the PO credit limit available on their account, or when the cart currency doesn't match the currency configured on the PO. Today the PO method is selectable in all cases, and any guard against credit limits happens server-side only after submission — this surfaces the constraint up-front in the UI.

The check reads `poConfig` (`{ creditLimit, currency }`) from the capabilities context. When the cheque method is in the list, a new hook `usePoMethodDisabledReason` computes one of two `PoDisabledReason` values:

- `creditLimit` — when `grandTotal > poConfig.creditLimit`
- `currencyMismatch` — when `poConfig.currency` differs from the cart currency (case-insensitive)

If a reason is returned, the cheque method is disabled in `PaymentMethodList` and an explanatory message is rendered in `PaymentMethodTitle`. The same hook is also called inside `PaymentForm` against the currently selected method so the submit button is blocked when a PO method is pre-selected (e.g. via `defaultMethod`). `Payment.tsx` falls back to `props.defaultMethod` when no method has been explicitly selected so the gate still applies on first render.

Pure logic lives in `getPoMethodDisabledReason` so it can be unit-tested without React/context. Two English strings were added under `payment.errors.disabled_PO_number_credit` and `payment.errors.disabled_PO_number_currency_mismatch`, plus matching `paymentProviderHeader-poDisabled*` styles.

## Rollout/Rollback

Its behind B2B feature flag is gating this change — the check is driven entirely by the presence of `poConfig` in the capabilities response. 
Rollback is code-only: reverting this PR removes the disabled-state UI and the submit gate.

## Testing

- CI checks
- Manual testing (TBA)

**B2B flow**

https://github.com/user-attachments/assets/a1b817e9-3f73-4a8a-993d-12ca5d1a67f0



**OOPC B2C flow**

https://github.com/user-attachments/assets/b68e42cf-3f3e-4a68-87d4-9052a9a86e28



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout payment selection and submit gating for B2B PO flows; logic is guarded by incomplete/missing `poConfig` and cart data but affects order completion paths when enabled.
> 
> **Overview**
> **Purchase Order (cheque) payment** is now gated in checkout using `poConfig` from capabilities (`creditLimit`, `currency`). A new `getPoMethodDisabledReason` / `usePoMethodDisabledReason` flow disables the cheque option when the cart currency does not match (case-insensitive, checked first) or when `grandTotal` exceeds the credit limit; explanatory copy and styles were added under `payment.errors.disabled_PO_*`.
> 
> The **payment step** wires this through the list (`PaymentMethodList` / `PaymentMethodTitle`), blocks **Place Order** when the selected method is invalid (`PaymentForm`), and treats **`defaultMethod`** as the effective selection in `Payment` so pre-selected PO is covered on first paint. Unit tests cover the pure disable logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e89e952e51b1cb8fea45a0096bd69c5899ba19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->