### PR TITLE
Revert "feat(checkout): Prepare HostedCreditCardComponent for migrati…

### DIFF
--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
@@ -3,11 +3,7 @@ import React from 'react';
 
 import { renderWithoutWrapper } from '@bigcommerce/checkout/test-utils';
 
-import HostedCreditCardComponent, {
-    type HostedCreditCardComponentProps,
-} from './HostedCreditCardComponent';
-import { type HostedCreditCardFieldsetProps } from './HostedCreditCardFieldset';
-import { type HostedCreditCardValidationProps } from './HostedCreditCardValidation';
+import HostedCreditCardComponent from './HostedCreditCardComponent';
 
 jest.mock('@bigcommerce/checkout/credit-card-integration', () => ({
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -35,7 +31,7 @@ jest.mock('./HostedCreditCardFieldset', () => ({
         cardNumberId,
         focusedFieldType,
         additionalFields,
-    }: HostedCreditCardFieldsetProps) => (
+    }) => (
         <div data-test="fieldset">
             {cardCodeId && <div data-test="cc-cvv">{cardCodeId}</div>}
             {cardExpiryId && <div data-test="cc-expiry">{cardExpiryId}</div>}
@@ -48,11 +44,7 @@ jest.mock('./HostedCreditCardFieldset', () => ({
 }));
 
 jest.mock('./HostedCreditCardValidation', () => ({
-    HostedCreditCardValidation: ({
-        cardCodeId,
-        cardNumberId,
-        focusedFieldType,
-    }: HostedCreditCardValidationProps) => (
+    HostedCreditCardValidation: ({ cardCodeId, cardNumberId, focusedFieldType }) => (
         <div data-test="validation">
             {cardCodeId && <div data-test="val-cc-cvv">{cardCodeId}</div>}
             {cardNumberId && <div data-test="val-cc-number">{cardNumberId}</div>}
@@ -61,14 +53,17 @@ jest.mock('./HostedCreditCardValidation', () => ({
     ),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-jest.mock('@bigcommerce/checkout/instrument-utils', () => ({
-    ...jest.requireActual('@bigcommerce/checkout/instrument-utils'),
-    getCreditCardInputStyles: jest.fn().mockResolvedValue({}),
-    isInstrumentCardCodeRequiredSelector: () => () => true,
-    isInstrumentCardNumberRequiredSelector: () => () => true,
-    CreditCardCustomerCodeField: () => <div data-test="customer-code-field" />,
-}));
+jest.mock(
+    '@bigcommerce/checkout/instrument-utils',
+    // eslint-disable-next-line  @typescript-eslint/no-unsafe-return
+    () => ({
+        ...jest.requireActual('@bigcommerce/checkout/instrument-utils'),
+        getCreditCardInputStyles: jest.fn().mockResolvedValue({}),
+        isInstrumentCardCodeRequiredSelector: () => () => true,
+        isInstrumentCardNumberRequiredSelector: () => () => true,
+        CreditCardCustomerCodeField: () => <div data-test="customer-code-field" />,
+    }),
+);
 
 jest.mock('./getHostedCreditCardValidationSchema', () => ({
     getHostedCreditCardValidationSchema: jest.fn(() => ({})),
@@ -77,35 +72,33 @@ jest.mock('./getHostedInstrumentValidationSchema', () => ({
     getHostedInstrumentValidationSchema: jest.fn(() => ({})),
 }));
 
-const getDefaultProps = (overrides = {}): HostedCreditCardComponentProps =>
-    ({
-        method: {
-            id: 'credit_card',
-            gateway: 'bluesnapdirect',
-            config: {
-                cardCode: true,
-                isHostedFormEnabled: true,
-                showCardHolderName: true,
-                requireCustomerCode: false,
-            },
+const getDefaultProps = (overrides = {}) => ({
+    method: {
+        id: 'credit_card',
+        gateway: 'bluesnapdirect',
+        config: {
+            cardCode: true,
+            showCardHolderName: true,
+            requireCustomerCode: false,
         },
-        checkoutService: {
-            initializePayment: jest.fn().mockResolvedValue(undefined),
-            deinitializePayment: jest.fn(),
-        },
-        checkoutState: {},
-        paymentForm: {
-            setFieldTouched: jest.fn(),
-            setFieldValue: jest.fn(),
-            setSubmitted: jest.fn(),
-            submitForm: jest.fn(),
-        },
-        language: {
-            translate: (key: string) => key,
-        },
-        onUnhandledError: jest.fn(),
-        ...overrides,
-    }) as unknown as HostedCreditCardComponentProps;
+    },
+    checkoutService: {
+        initializePayment: jest.fn().mockResolvedValue(undefined),
+        deinitializePayment: jest.fn(),
+    },
+    checkoutState: {},
+    paymentForm: {
+        setFieldTouched: jest.fn(),
+        setFieldValue: jest.fn(),
+        setSubmitted: jest.fn(),
+        submitForm: jest.fn(),
+    },
+    language: {
+        translate: (key: string) => key,
+    },
+    onUnhandledError: jest.fn(),
+    ...overrides,
+});
 
 describe('HostedCreditCardComponent', () => {
     it('renders HostedCreditCardFieldset with correct ids', () => {
@@ -133,7 +126,6 @@ describe('HostedCreditCardComponent', () => {
                         gateway: 'bluesnapdirect',
                         config: {
                             cardCode: true,
-                            isHostedFormEnabled: true,
                             showCardHolderName: true,
                             requireCustomerCode: true,
                         },
@@ -178,7 +170,6 @@ describe('HostedCreditCardComponent', () => {
                         gateway: 'bluesnapdirect',
                         config: {
                             cardCode: false,
-                            isHostedFormEnabled: true,
                             showCardHolderName: false,
                             requireCustomerCode: false,
                         },
@@ -369,76 +360,6 @@ describe('HostedCreditCardComponent', () => {
             accessibilityLabel: 'payment.credit_card_number_label',
             containerId: 'bluesnapdirect-credit_card-ccNumber',
             instrumentId: 'token456',
-        });
-    });
-
-    describe('when Feature_HostedPaymentForm is disabled (isHostedFormEnabled: false)', () => {
-        const getDisabledFlagProps = () =>
-            getDefaultProps({
-                method: {
-                    id: 'credit_card',
-                    gateway: 'bluesnapdirect',
-                    config: {
-                        cardCode: true,
-                        isHostedFormEnabled: false,
-                        showCardHolderName: true,
-                        requireCustomerCode: false,
-                    },
-                },
-            });
-
-        it('does not render HostedCreditCardFieldset', () => {
-            renderWithoutWrapper(<HostedCreditCardComponent {...getDisabledFlagProps()} />);
-
-            expect(screen.queryByTestId('fieldset')).not.toBeInTheDocument();
-        });
-
-        it('calls initializePayment without creditCard options', async () => {
-            const initializePayment = jest.fn().mockResolvedValue(undefined);
-
-            renderWithoutWrapper(
-                <HostedCreditCardComponent
-                    {...getDisabledFlagProps()}
-                    checkoutService={
-                        {
-                            initializePayment,
-                            deinitializePayment: jest.fn(),
-                        } as unknown as HostedCreditCardComponentProps['checkoutService']
-                    }
-                />,
-            );
-
-            fireEvent.click(screen.getByTestId('init-btn'));
-
-            await waitFor(() => expect(initializePayment).toHaveBeenCalled());
-
-            expect(initializePayment.mock.calls[0][0]).not.toHaveProperty('creditCard');
-        });
-    });
-
-    describe('when Feature_HostedPaymentForm is enabled (isHostedFormEnabled: true)', () => {
-        it('renders HostedCreditCardFieldset', () => {
-            renderWithoutWrapper(<HostedCreditCardComponent {...getDefaultProps()} />);
-
-            expect(screen.getByTestId('fieldset')).toBeInTheDocument();
-        });
-
-        it('calls initializePayment with creditCard options', async () => {
-            const initializePayment = jest.fn().mockResolvedValue(undefined);
-
-            renderWithoutWrapper(
-                <HostedCreditCardComponent
-                    {...getDefaultProps({
-                        checkoutService: { initializePayment, deinitializePayment: jest.fn() },
-                    })}
-                />,
-            );
-
-            fireEvent.click(screen.getByTestId('init-btn'));
-
-            await waitFor(() => expect(initializePayment).toHaveBeenCalled());
-
-            expect(initializePayment.mock.calls[0][0]).toHaveProperty('creditCard');
         });
     });
 });

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -48,7 +48,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     const isInstrumentCardNumberRequiredProp =
         isInstrumentCardNumberRequiredSelector(checkoutState);
     const {
-        config: { cardCode, isHostedFormEnabled, showCardHolderName },
+        config: { cardCode, showCardHolderName },
     } = method;
     const isCardCodeRequired = cardCode || cardCode === null;
     const isCardHolderNameRequired = showCardHolderName ?? true;
@@ -260,15 +260,13 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,
                     ],
-                    ...(isHostedFormEnabled && {
-                        creditCard: {
-                            form: await getHostedFormOptions(selectedInstrument),
-                            bigpayToken: selectedInstrument?.bigpayToken,
-                        },
-                    }),
+                    creditCard: {
+                        form: await getHostedFormOptions(selectedInstrument),
+                        bigpayToken: selectedInstrument?.bigpayToken,
+                    },
                 });
             },
-            [getHostedFormOptions, initializePayment, isHostedFormEnabled],
+            [getHostedFormOptions, initializePayment],
         );
 
     const hostedStoredCardValidationSchema = getHostedInstrumentValidationSchema({ language });
@@ -285,15 +283,13 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     return (
         <CreditCardPaymentMethodComponent
             {...props}
-            {...(isHostedFormEnabled && {
-                cardFieldset: hostedFieldset,
-                cardValidationSchema: hostedValidationSchema,
-                getHostedFormOptions,
-                getStoredCardValidationFieldset: getHostedStoredCardValidationFieldset,
-                storedCardValidationSchema: hostedStoredCardValidationSchema,
-            })}
+            cardFieldset={hostedFieldset}
+            cardValidationSchema={hostedValidationSchema}
             deinitializePayment={checkoutService.deinitializePayment}
+            getHostedFormOptions={getHostedFormOptions}
+            getStoredCardValidationFieldset={getHostedStoredCardValidationFieldset}
             initializePayment={initializeHostedCreditCardPayment}
+            storedCardValidationSchema={hostedStoredCardValidationSchema}
         />
     );
 };


### PR DESCRIPTION
…on from the core (#3046)"

This reverts commit 97fd0569d3a654d19956f0b53ba82797c4c34737.

## What/Why?

revert this PR in case of   TDOnlineMart problem

## Rollout/Rollback

<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment initialization and hosted-field rendering for credit card gateways (including TD Online Mart); intentional rollback of a prior migration that caused production issues.
> 
> **Overview**
> This **reverts** the migration prep that gated hosted credit card UI and payment initialization on `method.config.isHostedFormEnabled` (Feature_HostedPaymentForm).
> 
> **`HostedCreditCardComponent`** again always wires hosted form behavior: it always passes `cardFieldset`, validation schemas, `getHostedFormOptions`, and stored-card validation helpers to `CreditCardPaymentMethodComponent`, and `initializePayment` always includes a `creditCard` block with the hosted form options (no conditional spread).
> 
> Tests drop the disabled/enabled flag scenarios and simplify default props/mocks to match the unconditional behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349d6ce59cfd81d98f2bdbdb7804a4b8fd96b2c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->