### PR TITLE
chore(checkout): BACK-625 Update sdk

### DIFF
--- a/.claude/commands/update-sdk.md
+++ b/.claude/commands/update-sdk.md
@@ -1,16 +1,26 @@
 Update the BigCommerce Checkout SDK to the latest version by running the following steps in the project root directory:
 
-1. Fetch upstream and create a new branch from upstream/master. Use the Bash tool to resolve the version dynamically:
+1. Checkout master:
 ```
-git fetch upstream && SDK_VERSION=$(npm view @bigcommerce/checkout-sdk version | tr '.' '-') && git checkout -b sdk-bump-${SDK_VERSION} upstream/master
+git checkout master
 ```
 
-2. Reinstall all dependencies cleanly:
+2. Fetch upstream and rebase onto upstream/master:
+```
+git fetch upstream && git rebase upstream/master
+```
+
+3. Resolve the latest SDK version and create a new branch:
+```
+SDK_VERSION=$(npm view @bigcommerce/checkout-sdk version | tr '.' '-') && git checkout -b sdk-bump-${SDK_VERSION}
+```
+
+4. Reinstall all dependencies cleanly:
 ```
 npm ci
 ```
 
-3. Install the latest SDK:
+5. Install the latest SDK:
 ```
 npm i @bigcommerce/checkout-sdk@latest
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.921.4",
+        "@bigcommerce/checkout-sdk": "^1.921.6",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.921.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.4.tgz",
-      "integrity": "sha512-DV45rixkDEWSiPj6YDHaXRXm9jGRQ6LfQ8vh+GuIYyIBQbRYgX1ovIxlvJTAOIqxNe6Nmh4t1W1rbj6Tvjq9Ug==",
+      "version": "1.921.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.6.tgz",
+      "integrity": "sha512-7tNLGHgu5aHSSEVpBPBk7g01iZ+tG/4zt4eOkSBJkU3wD2Slcndib2pBewP6rv25UPhtacm5gWbNBAN8o+qCtg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.921.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.4.tgz",
-      "integrity": "sha512-DV45rixkDEWSiPj6YDHaXRXm9jGRQ6LfQ8vh+GuIYyIBQbRYgX1ovIxlvJTAOIqxNe6Nmh4t1W1rbj6Tvjq9Ug==",
+      "version": "1.921.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.6.tgz",
+      "integrity": "sha512-7tNLGHgu5aHSSEVpBPBk7g01iZ+tG/4zt4eOkSBJkU3wD2Slcndib2pBewP6rv25UPhtacm5gWbNBAN8o+qCtg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.921.4",
+    "@bigcommerce/checkout-sdk": "^1.921.6",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/test-mocks/src/line-item.mock.ts
+++ b/packages/test-mocks/src/line-item.mock.ts
@@ -39,6 +39,7 @@ export function getPhysicalItem(): PhysicalItem {
         extendedComparisonPrice: 250,
         isShippingRequired: true,
         addedByPromotion: false,
+        addedByAttributeId: null,
         options: [
             {
                 name: 'n',
@@ -77,6 +78,7 @@ export function getDigitalItem(): DigitalItem {
         extendedSalePrice: 200,
         extendedComparisonPrice: 250,
         addedByPromotion: false,
+        addedByAttributeId: null,
         options: [
             {
                 name: 'm',
@@ -133,6 +135,7 @@ export function getPicklistItem(): PhysicalItem[] {
             extendedComparisonPrice: 250,
             isShippingRequired: true,
             addedByPromotion: false,
+            addedByAttributeId: null,
             options: [
                 {
                     name: 'n',
@@ -166,6 +169,7 @@ export function getPicklistItem(): PhysicalItem[] {
             extendedComparisonPrice: 150,
             isShippingRequired: true,
             addedByPromotion: false,
+            addedByAttributeId: null,
             categoryNames: ['Cat 1'],
             parentId: '666',
             retailPrice: 1,


### PR DESCRIPTION
## What/Why?
Update sdk to release the line item interface bump.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with test mock updates; no checkout UI or payment logic changes in this diff.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **1.921.4** to **1.921.6** in `package.json` and the lockfile so checkout-js picks up the SDK’s updated line item types.
> 
> Test fixtures in **`line-item.mock.ts`** now set **`addedByAttributeId: null`** on physical and digital line items so mocks match the new SDK shape.
> 
> The **`.claude/commands/update-sdk.md`** workflow is split into explicit steps: check out **master**, **rebase** onto **upstream/master**, then create the versioned bump branch (instead of branching directly from **upstream/master** in one command).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870a2485c2f65c93c14c4e0562bc4751e36f2a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->