### PR TITLE
feat(checkout): CHECKOUT-10057 Add payment comment

### DIFF
--- a/packages/core/src/app/payment/InvoicePaymentCommentField.test.tsx
+++ b/packages/core/src/app/payment/InvoicePaymentCommentField.test.tsx
@@ -1,0 +1,57 @@
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { createLocaleContext } from '@bigcommerce/checkout/locale';
+import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
+
+import { getStoreConfig } from '../config/config.mock';
+
+import InvoicePaymentCommentField from './InvoicePaymentCommentField';
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
+
+describe('InvoicePaymentCommentField', () => {
+    const localeContext: LocaleContextType = createLocaleContext(getStoreConfig());
+
+    const renderField = (initialValue = '') =>
+        render(
+            <LocaleContext.Provider value={localeContext}>
+                <Formik initialValues={{ invoicePaymentComment: initialValue }} onSubmit={noop}>
+                    <InvoicePaymentCommentField />
+                </Formik>
+            </LocaleContext.Provider>,
+        );
+
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('renders a textarea labeled "Payment comment"', () => {
+        renderField();
+
+        expect(screen.getByText('Payment comment')).toBeInTheDocument();
+        expect(screen.getByTestId('invoicePaymentComment-input')).toBeInTheDocument();
+    });
+
+    it('writes the typed value to session storage on change', () => {
+        renderField();
+
+        fireEvent.change(screen.getByTestId('invoicePaymentComment-input'), {
+            target: { value: 'hello world' },
+        });
+
+        expect(InvoicePaymentCommentSessionStorage.get()).toBe('hello world');
+    });
+
+    it('removes the key from session storage when the field is cleared', () => {
+        sessionStorage.setItem(InvoicePaymentCommentSessionStorage.KEY, 'existing');
+        renderField('existing');
+
+        fireEvent.change(screen.getByTestId('invoicePaymentComment-input'), {
+            target: { value: '' },
+        });
+
+        expect(sessionStorage.getItem(InvoicePaymentCommentSessionStorage.KEY)).toBeNull();
+    });
+});

--- a/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
+++ b/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
@@ -11,10 +11,12 @@ const InvoicePaymentCommentField: FunctionComponent = () => {
         ({ field }: FieldProps<string>) => (
             <TextArea
                 {...field}
+                id="invoicePaymentComment"
                 onChange={(event) => {
                     field.onChange(event);
                     InvoicePaymentCommentSessionStorage.set(event.target.value);
                 }}
+                rows={4}
                 testId="invoicePaymentComment-input"
             />
         ),
@@ -22,11 +24,14 @@ const InvoicePaymentCommentField: FunctionComponent = () => {
     );
 
     return (
-        <FormField
-            input={renderInput}
-            labelContent={<TranslatedString id="payment.invoice_payment_comment_label" />}
-            name="invoicePaymentComment"
-        />
+        <div className="dynamic-form-field">
+            <FormField
+                id="invoicePaymentComment"
+                input={renderInput}
+                labelContent={<TranslatedString id="payment.invoice_payment_comment_label" />}
+                name="invoicePaymentComment"
+            />
+        </div>
     );
 };
 

--- a/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
+++ b/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
@@ -1,0 +1,33 @@
+import { type FieldProps } from 'formik';
+import React, { type FunctionComponent, useCallback } from 'react';
+
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { FormField, TextArea } from '@bigcommerce/checkout/ui';
+
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
+
+const InvoicePaymentCommentField: FunctionComponent = () => {
+    const renderInput = useCallback(
+        ({ field }: FieldProps<string>) => (
+            <TextArea
+                {...field}
+                onChange={(event) => {
+                    field.onChange(event);
+                    InvoicePaymentCommentSessionStorage.set(event.target.value);
+                }}
+                testId="invoicePaymentComment-input"
+            />
+        ),
+        [],
+    );
+
+    return (
+        <FormField
+            input={renderInput}
+            labelContent={<TranslatedString id="payment.invoice_payment_comment_label" />}
+            name="invoicePaymentComment"
+        />
+    );
+};
+
+export default InvoicePaymentCommentField;

--- a/packages/core/src/app/payment/InvoicePaymentCommentSessionStorage.test.ts
+++ b/packages/core/src/app/payment/InvoicePaymentCommentSessionStorage.test.ts
@@ -1,0 +1,39 @@
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
+
+describe('InvoicePaymentCommentSessionStorage', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('writes the value to session storage', () => {
+        InvoicePaymentCommentSessionStorage.set('foo');
+
+        expect(sessionStorage.getItem(InvoicePaymentCommentSessionStorage.KEY)).toBe('foo');
+    });
+
+    it('removes the key when set to an empty string', () => {
+        sessionStorage.setItem(InvoicePaymentCommentSessionStorage.KEY, 'existing');
+
+        InvoicePaymentCommentSessionStorage.set('');
+
+        expect(sessionStorage.getItem(InvoicePaymentCommentSessionStorage.KEY)).toBeNull();
+    });
+
+    it('returns an empty string when the key is absent', () => {
+        expect(InvoicePaymentCommentSessionStorage.get()).toBe('');
+    });
+
+    it('returns the stored value when present', () => {
+        sessionStorage.setItem(InvoicePaymentCommentSessionStorage.KEY, 'hello');
+
+        expect(InvoicePaymentCommentSessionStorage.get()).toBe('hello');
+    });
+
+    it('removes the key on remove()', () => {
+        sessionStorage.setItem(InvoicePaymentCommentSessionStorage.KEY, 'gone soon');
+
+        InvoicePaymentCommentSessionStorage.remove();
+
+        expect(sessionStorage.getItem(InvoicePaymentCommentSessionStorage.KEY)).toBeNull();
+    });
+});

--- a/packages/core/src/app/payment/InvoicePaymentCommentSessionStorage.ts
+++ b/packages/core/src/app/payment/InvoicePaymentCommentSessionStorage.ts
@@ -1,0 +1,21 @@
+export class InvoicePaymentCommentSessionStorage {
+    static readonly KEY = 'invoicePaymentComment';
+
+    static get(): string {
+        return sessionStorage.getItem(this.KEY) ?? '';
+    }
+
+    static set(value: string): void {
+        if (value === '') {
+            sessionStorage.removeItem(this.KEY);
+
+            return;
+        }
+
+        sessionStorage.setItem(this.KEY, value);
+    }
+
+    static remove(): void {
+        sessionStorage.removeItem(this.KEY);
+    }
+}

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -11,13 +11,14 @@ import React, { type FunctionComponent } from 'react';
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
 import {
     CheckoutProvider,
+    defaultCapabilities,
     ExtensionProvider,
     type ExtensionServiceInterface,
     LocaleContext,
     type LocaleContextType,
 } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
-import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
 
 import { B2BExtraFieldsSessionStorage } from '../address';
 import { getCart } from '../cart/carts.mock';
@@ -25,6 +26,7 @@ import { createErrorLogger } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
 
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 import { getPaymentMethod } from './payment-methods.mock';
 import PaymentContext, { type PaymentContextProps } from './PaymentContext';
 import PaymentForm, { type PaymentFormProps } from './PaymentForm';
@@ -278,6 +280,80 @@ describe('PaymentForm', () => {
             render(<PaymentFormTest {...defaultProps} />);
 
             expect(screen.queryByTestId('order-extra-fields')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('invoice payment comment', () => {
+        const enableCapability = () => {
+            const storeConfig = getStoreConfig();
+
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                ...storeConfig,
+                checkoutSettings: {
+                    ...storeConfig.checkoutSettings,
+                    capabilities: {
+                        ...defaultCapabilities,
+                        payment: {
+                            ...defaultCapabilities.payment,
+                            invoicePaymentComment: true,
+                        },
+                    },
+                },
+            });
+        };
+
+        beforeEach(() => {
+            sessionStorage.clear();
+        });
+
+        it('renders the textarea when the capability is enabled', () => {
+            enableCapability();
+
+            render(<PaymentFormTest {...defaultProps} />);
+
+            expect(screen.getByTestId('invoicePaymentComment-input')).toBeInTheDocument();
+            expect(
+                screen.getByText(
+                    localeContext.language.translate('payment.invoice_payment_comment_label'),
+                ),
+            ).toBeInTheDocument();
+        });
+
+        it('does not render the textarea when the capability is disabled', () => {
+            render(<PaymentFormTest {...defaultProps} />);
+
+            expect(screen.queryByTestId('invoicePaymentComment-input')).not.toBeInTheDocument();
+        });
+
+        it('seeds the textarea from session storage when a value is stored', () => {
+            enableCapability();
+            InvoicePaymentCommentSessionStorage.set('restored comment');
+
+            render(<PaymentFormTest {...defaultProps} />);
+
+            expect(screen.getByDisplayValue('restored comment')).toBeInTheDocument();
+        });
+
+        it('writes typed values to session storage and strips them from the submit payload', async () => {
+            enableCapability();
+
+            const onSubmit = jest.fn();
+
+            render(<PaymentFormTest {...defaultProps} onSubmit={onSubmit} />);
+
+            fireEvent.change(screen.getByTestId('invoicePaymentComment-input'), {
+                target: { value: 'note for invoice' },
+            });
+
+            expect(InvoicePaymentCommentSessionStorage.get()).toBe('note for invoice');
+
+            fireEvent.submit(screen.getByTestId('payment-form'));
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.not.objectContaining({ invoicePaymentComment: expect.anything() }),
+            );
         });
     });
 });

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -9,7 +9,7 @@ import React, { type FunctionComponent, memo, useCallback, useContext, useMemo }
 import { type ObjectSchema } from 'yup';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
-import { useCheckout } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import {
     TranslatedString,
     withLanguage,
@@ -24,6 +24,8 @@ import { getOrderExtraFieldsValidationSchema } from '../formFields';
 import { TermsConditions } from '../termsConditions';
 
 import getPaymentValidationSchema from './getPaymentValidationSchema';
+import InvoicePaymentCommentField from './InvoicePaymentCommentField';
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 import { NoPaymentMethods } from './NoPaymentMethods';
 import { getInitialOrderExtraFieldsValues, OrderExtraFieldsFieldset } from './orderExtraFields';
 import {
@@ -123,6 +125,9 @@ const PaymentForm: FunctionComponent<
     }, [selectedMethod]);
 
     const { checkoutState } = useCheckout();
+    const {
+        payment: { invoicePaymentComment },
+    } = useCapabilities();
     const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
     const shouldShowSubmitButtonWhenPaymentNotRequired = isExperimentEnabled(
         checkoutSettings,
@@ -196,6 +201,8 @@ const PaymentForm: FunctionComponent<
             {orderExtraFields && orderExtraFields.length > 0 && (
                 <OrderExtraFieldsFieldset formFields={orderExtraFields} />
             )}
+
+            {invoicePaymentComment && <InvoicePaymentCommentField />}
 
             <div className="form-actions">
                 {hideSubmitPaymentButton ? (
@@ -339,12 +346,18 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
                     orderExtraFields,
                     storedOrderExtraFields,
                 ),
+                invoicePaymentComment: InvoicePaymentCommentSessionStorage.get(),
             };
         },
 
         handleSubmit: (values, { props: { onSubmit = noop } }) => {
-            const { orderExtraFields, ...rest } = values as PaymentFormValues & {
+            const {
+                orderExtraFields,
+                invoicePaymentComment: _invoicePaymentComment,
+                ...rest
+            } = values as PaymentFormValues & {
                 orderExtraFields?: Record<string, unknown>;
+                invoicePaymentComment?: string;
             };
 
             if (orderExtraFields && Object.keys(orderExtraFields).length > 0) {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -300,6 +300,7 @@
             "credit_card_number_mismatch_error": "The card number entered does not match the card stored in your account",
             "credit_debit_card_text": "Credit/Debit Card",
             "open_banking_display_name_text": "Open Banking",
+            "invoice_payment_comment_label": "Payment comment",
             "payment_methods_text": "Payment Methods",
             "redeemable_payments_text": "Redeemable Payments",
             "instrument_storage_options_text": "Payment Storage Options",


### PR DESCRIPTION
## What/Why?

Add payment comment text area for invoice-to-checkout flow.

Any payment comment will be saved as order comment at the end of the invoice flow.

## Rollout/Rollback

Revert.

## Testing

<img width="674" height="637" alt="Screenshot 2026-06-03 at 16 49 35" src="https://github.com/user-attachments/assets/908dee97-61a8-4deb-8823-220a65401326" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are behind a capability flag, use client-side session storage, and only affect payment UI and submit shaping—not auth or payment processing.
> 
> **Overview**
> Adds an optional **Payment comment** textarea on the payment step when the `payment.invoicePaymentComment` checkout capability is enabled (invoice-to-checkout).
> 
> Comment text is kept in **session storage** as the shopper types (including restore on reload) and is **removed from the payment form submit payload** so it is not sent with standard payment values—intended for use later in the invoice flow as an order comment. English copy is added via `payment.invoice_payment_comment_label`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c68142f872f5275f7d25b4f6825ca0067cde901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->