### PR TITLE
feat(checkout): Prepare HostedCreditCardComponent for migration from the core

### DIFF
--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 
 import { renderWithoutWrapper } from '@bigcommerce/checkout/test-utils';
 
-import HostedCreditCardComponent from './HostedCreditCardComponent';
+import HostedCreditCardComponent, {
+    type HostedCreditCardComponentProps,
+} from './HostedCreditCardComponent';
+import { type HostedCreditCardFieldsetProps } from './HostedCreditCardFieldset';
+import { type HostedCreditCardValidationProps } from './HostedCreditCardValidation';
 
 jest.mock('@bigcommerce/checkout/credit-card-integration', () => ({
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -31,7 +35,7 @@ jest.mock('./HostedCreditCardFieldset', () => ({
         cardNumberId,
         focusedFieldType,
         additionalFields,
-    }) => (
+    }: HostedCreditCardFieldsetProps) => (
         <div data-test="fieldset">
             {cardCodeId && <div data-test="cc-cvv">{cardCodeId}</div>}
             {cardExpiryId && <div data-test="cc-expiry">{cardExpiryId}</div>}
@@ -44,7 +48,11 @@ jest.mock('./HostedCreditCardFieldset', () => ({
 }));
 
 jest.mock('./HostedCreditCardValidation', () => ({
-    HostedCreditCardValidation: ({ cardCodeId, cardNumberId, focusedFieldType }) => (
+    HostedCreditCardValidation: ({
+        cardCodeId,
+        cardNumberId,
+        focusedFieldType,
+    }: HostedCreditCardValidationProps) => (
         <div data-test="validation">
             {cardCodeId && <div data-test="val-cc-cvv">{cardCodeId}</div>}
             {cardNumberId && <div data-test="val-cc-number">{cardNumberId}</div>}
@@ -53,17 +61,14 @@ jest.mock('./HostedCreditCardValidation', () => ({
     ),
 }));
 
-jest.mock(
-    '@bigcommerce/checkout/instrument-utils',
-    // eslint-disable-next-line  @typescript-eslint/no-unsafe-return
-    () => ({
-        ...jest.requireActual('@bigcommerce/checkout/instrument-utils'),
-        getCreditCardInputStyles: jest.fn().mockResolvedValue({}),
-        isInstrumentCardCodeRequiredSelector: () => () => true,
-        isInstrumentCardNumberRequiredSelector: () => () => true,
-        CreditCardCustomerCodeField: () => <div data-test="customer-code-field" />,
-    }),
-);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('@bigcommerce/checkout/instrument-utils', () => ({
+    ...jest.requireActual('@bigcommerce/checkout/instrument-utils'),
+    getCreditCardInputStyles: jest.fn().mockResolvedValue({}),
+    isInstrumentCardCodeRequiredSelector: () => () => true,
+    isInstrumentCardNumberRequiredSelector: () => () => true,
+    CreditCardCustomerCodeField: () => <div data-test="customer-code-field" />,
+}));
 
 jest.mock('./getHostedCreditCardValidationSchema', () => ({
     getHostedCreditCardValidationSchema: jest.fn(() => ({})),
@@ -72,33 +77,35 @@ jest.mock('./getHostedInstrumentValidationSchema', () => ({
     getHostedInstrumentValidationSchema: jest.fn(() => ({})),
 }));
 
-const getDefaultProps = (overrides = {}) => ({
-    method: {
-        id: 'credit_card',
-        gateway: 'bluesnapdirect',
-        config: {
-            cardCode: true,
-            showCardHolderName: true,
-            requireCustomerCode: false,
+const getDefaultProps = (overrides = {}): HostedCreditCardComponentProps =>
+    ({
+        method: {
+            id: 'credit_card',
+            gateway: 'bluesnapdirect',
+            config: {
+                cardCode: true,
+                isHostedFormEnabled: true,
+                showCardHolderName: true,
+                requireCustomerCode: false,
+            },
         },
-    },
-    checkoutService: {
-        initializePayment: jest.fn().mockResolvedValue(undefined),
-        deinitializePayment: jest.fn(),
-    },
-    checkoutState: {},
-    paymentForm: {
-        setFieldTouched: jest.fn(),
-        setFieldValue: jest.fn(),
-        setSubmitted: jest.fn(),
-        submitForm: jest.fn(),
-    },
-    language: {
-        translate: (key: string) => key,
-    },
-    onUnhandledError: jest.fn(),
-    ...overrides,
-});
+        checkoutService: {
+            initializePayment: jest.fn().mockResolvedValue(undefined),
+            deinitializePayment: jest.fn(),
+        },
+        checkoutState: {},
+        paymentForm: {
+            setFieldTouched: jest.fn(),
+            setFieldValue: jest.fn(),
+            setSubmitted: jest.fn(),
+            submitForm: jest.fn(),
+        },
+        language: {
+            translate: (key: string) => key,
+        },
+        onUnhandledError: jest.fn(),
+        ...overrides,
+    }) as unknown as HostedCreditCardComponentProps;
 
 describe('HostedCreditCardComponent', () => {
     it('renders HostedCreditCardFieldset with correct ids', () => {
@@ -126,6 +133,7 @@ describe('HostedCreditCardComponent', () => {
                         gateway: 'bluesnapdirect',
                         config: {
                             cardCode: true,
+                            isHostedFormEnabled: true,
                             showCardHolderName: true,
                             requireCustomerCode: true,
                         },
@@ -170,6 +178,7 @@ describe('HostedCreditCardComponent', () => {
                         gateway: 'bluesnapdirect',
                         config: {
                             cardCode: false,
+                            isHostedFormEnabled: true,
                             showCardHolderName: false,
                             requireCustomerCode: false,
                         },
@@ -360,6 +369,76 @@ describe('HostedCreditCardComponent', () => {
             accessibilityLabel: 'payment.credit_card_number_label',
             containerId: 'bluesnapdirect-credit_card-ccNumber',
             instrumentId: 'token456',
+        });
+    });
+
+    describe('when Feature_HostedPaymentForm is disabled (isHostedFormEnabled: false)', () => {
+        const getDisabledFlagProps = () =>
+            getDefaultProps({
+                method: {
+                    id: 'credit_card',
+                    gateway: 'bluesnapdirect',
+                    config: {
+                        cardCode: true,
+                        isHostedFormEnabled: false,
+                        showCardHolderName: true,
+                        requireCustomerCode: false,
+                    },
+                },
+            });
+
+        it('does not render HostedCreditCardFieldset', () => {
+            renderWithoutWrapper(<HostedCreditCardComponent {...getDisabledFlagProps()} />);
+
+            expect(screen.queryByTestId('fieldset')).not.toBeInTheDocument();
+        });
+
+        it('calls initializePayment without creditCard options', async () => {
+            const initializePayment = jest.fn().mockResolvedValue(undefined);
+
+            renderWithoutWrapper(
+                <HostedCreditCardComponent
+                    {...getDisabledFlagProps()}
+                    checkoutService={
+                        {
+                            initializePayment,
+                            deinitializePayment: jest.fn(),
+                        } as unknown as HostedCreditCardComponentProps['checkoutService']
+                    }
+                />,
+            );
+
+            fireEvent.click(screen.getByTestId('init-btn'));
+
+            await waitFor(() => expect(initializePayment).toHaveBeenCalled());
+
+            expect(initializePayment.mock.calls[0][0]).not.toHaveProperty('creditCard');
+        });
+    });
+
+    describe('when Feature_HostedPaymentForm is enabled (isHostedFormEnabled: true)', () => {
+        it('renders HostedCreditCardFieldset', () => {
+            renderWithoutWrapper(<HostedCreditCardComponent {...getDefaultProps()} />);
+
+            expect(screen.getByTestId('fieldset')).toBeInTheDocument();
+        });
+
+        it('calls initializePayment with creditCard options', async () => {
+            const initializePayment = jest.fn().mockResolvedValue(undefined);
+
+            renderWithoutWrapper(
+                <HostedCreditCardComponent
+                    {...getDefaultProps({
+                        checkoutService: { initializePayment, deinitializePayment: jest.fn() },
+                    })}
+                />,
+            );
+
+            fireEvent.click(screen.getByTestId('init-btn'));
+
+            await waitFor(() => expect(initializePayment).toHaveBeenCalled());
+
+            expect(initializePayment.mock.calls[0][0]).toHaveProperty('creditCard');
         });
     });
 });

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -48,7 +48,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     const isInstrumentCardNumberRequiredProp =
         isInstrumentCardNumberRequiredSelector(checkoutState);
     const {
-        config: { cardCode, showCardHolderName },
+        config: { cardCode, isHostedFormEnabled, showCardHolderName },
     } = method;
     const isCardCodeRequired = cardCode || cardCode === null;
     const isCardHolderNameRequired = showCardHolderName ?? true;
@@ -260,13 +260,15 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,
                     ],
-                    creditCard: {
-                        form: await getHostedFormOptions(selectedInstrument),
-                        bigpayToken: selectedInstrument?.bigpayToken,
-                    },
+                    ...(isHostedFormEnabled && {
+                        creditCard: {
+                            form: await getHostedFormOptions(selectedInstrument),
+                            bigpayToken: selectedInstrument?.bigpayToken,
+                        },
+                    }),
                 });
             },
-            [getHostedFormOptions, initializePayment],
+            [getHostedFormOptions, initializePayment, isHostedFormEnabled],
         );
 
     const hostedStoredCardValidationSchema = getHostedInstrumentValidationSchema({ language });
@@ -283,13 +285,15 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     return (
         <CreditCardPaymentMethodComponent
             {...props}
-            cardFieldset={hostedFieldset}
-            cardValidationSchema={hostedValidationSchema}
+            {...(isHostedFormEnabled && {
+                cardFieldset: hostedFieldset,
+                cardValidationSchema: hostedValidationSchema,
+                getHostedFormOptions,
+                getStoredCardValidationFieldset: getHostedStoredCardValidationFieldset,
+                storedCardValidationSchema: hostedStoredCardValidationSchema,
+            })}
             deinitializePayment={checkoutService.deinitializePayment}
-            getHostedFormOptions={getHostedFormOptions}
-            getStoredCardValidationFieldset={getHostedStoredCardValidationFieldset}
             initializePayment={initializeHostedCreditCardPayment}
-            storedCardValidationSchema={hostedStoredCardValidationSchema}
         />
     );
 };


### PR DESCRIPTION
## What/Why?

Brings HostedCreditCardComponent in the hosted-credit-card-integration package
to parity with the core implementation regarding Feature_HostedPaymentForm
(isHostedFormEnabled) flag behavior.

Problem: The integration package always passed hosted field props to
CreditCardPaymentMethodComponent regardless of the flag state. When
isHostedFormEnabled is false, the SDK would not initialize the hosted fields,
leaving empty containers in the DOM instead of rendering usable card inputs.

Core behavior (source of truth): withHostedCreditCardFieldset HOC returns
the original component without hosted props when isHostedFormEnabled is false,
causing CreditCardPaymentMethodComponent to fall back to rendering the standard
CreditCardFieldset (regular HTML inputs).

Fix: When isHostedFormEnabled is false, HostedCreditCardComponent now:

Does not pass cardFieldset → CreditCardPaymentMethodComponent renders
regular CreditCardFieldset inputs
Does not include creditCard.form in initializePayment options → SDK
initializes without hosted form
Does not pass hosted validation schemas or getStoredCardValidationFieldset →
component uses its built-in fallback validation
This is a prerequisite for migrating payment strategies into
hosted-credit-card-integration without behavioral regressi
should work with turned on experiment https://github.com/bigcommerce/bigcommerce/pull/67320

## Rollout/Rollback

roll back PR

## Testing
isHostedFormEnabled false

https://github.com/user-attachments/assets/8d1d2e8d-f400-49f7-9f39-3b5f9c8e17d5

isHostedFormEnabled true

https://github.com/user-attachments/assets/13462ae6-cd54-4132-9858-651402b8d4a1

<img width="831" height="767" alt="image" src="https://github.com/user-attachments/assets/8f4c0867-89c5-43b6-8c6d-d184c71b58ed" />
<img width="849" height="776" alt="image" src="https://github.com/user-attachments/assets/0ad9d553-7752-4245-8245-e8fae9bcf7bf" />
<img width="1267" height="394" alt="image" src="https://github.com/user-attachments/assets/f4afca00-ea49-4728-a375-53402dfd532b" />
<img width="783" height="723" alt="image" src="https://github.com/user-attachments/assets/4aad19f5-1802-4c53-bf4f-64c23ab2d44e" />
<img width="822" height="695" alt="image" src="https://github.com/user-attachments/assets/cb63466a-7399-4299-875d-875a82da3442" />
<img width="847" height="709" alt="image" src="https://github.com/user-attachments/assets/685b271f-0155-466a-b491-6fee032755c0" />
<img width="925" height="154" alt="image" src="https://github.com/user-attachments/assets/0efdf632-7a3b-4dbb-b3d3-4a95a667c986" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment step rendering and initializePayment options for credit card checkout; incorrect flag handling could break card entry when the experiment is off or on.
> 
> **Overview**
> **`HostedCreditCardComponent`** now honors **`isHostedFormEnabled`** (Feature_HostedPaymentForm) so the integration package matches core checkout behavior.
> 
> When the flag is **off**, the component no longer passes hosted **`cardFieldset`**, validation schemas, **`getHostedFormOptions`**, or stored-card hosted helpers to **`CreditCardPaymentMethodComponent`**, and **`initializePayment`** omits **`creditCard.form`** so the SDK does not mount hosted fields—allowing the standard **`CreditCardFieldset`** HTML inputs instead of empty hosted containers.
> 
> When the flag is **on**, behavior is unchanged (hosted fieldset and **`creditCard`** init options are still supplied). Tests cover both flag states and tighten default props typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00acd0c98e116f6538ae152a3207e215970ef41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->