### PR TITLE
feat(checkout): BACK-425 Bundle picklist under parent items

### DIFF
--- a/packages/core/src/app/order/OrderSummaryDrawer.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.tsx
@@ -15,7 +15,7 @@ import getItemsCount from './getItemsCount';
 import getLineItemsCount from './getLineItemsCount';
 import OrderSummaryModal from './OrderSummaryModal';
 import { type OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
-import removeBundledItems from './removeBundledItems';
+import { removeBundledItems } from './removeBundledItems';
 
 export interface OrderSummaryDrawerProps {
     lineItems: LineItemMap;

--- a/packages/core/src/app/order/OrderSummaryItem.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.test.tsx
@@ -108,4 +108,57 @@ describe('OrderSummaryItem', () => {
             );
         });
     });
+
+    describe('when bundledItems are present', () => {
+        const bundledItems = [
+            {
+                id: 'b1',
+                name: 'Bundled Hat',
+                quantityBackordered: 2,
+                quantityOnHand: 3,
+                backorderMessage: 'Ships in 5 days',
+            },
+            {
+                id: 'b2',
+                name: 'Bundled Scarf',
+            },
+        ];
+
+        it('renders each bundled item name with the Bundle label', () => {
+            render(
+                <OrderSummaryItem
+                    orderItem={{ amount: 10, id: 'foo', name: 'Product', quantity: 1, bundledItems }}
+                    shouldExpandBackorderDetails={false}
+                />,
+            );
+
+            const nameEls = screen.getAllByTestId('cart-item-bundled-item-name');
+
+            expect(nameEls).toHaveLength(2);
+            expect(nameEls[0]).toHaveTextContent('Bundled Hat');
+            expect(nameEls[1]).toHaveTextContent('Bundled Scarf');
+        });
+
+        it('renders nothing for bundled items section when bundledItems is undefined', () => {
+            render(
+                <OrderSummaryItem
+                    orderItem={{ amount: 10, id: 'foo', name: 'Product', quantity: 1 }}
+                    shouldExpandBackorderDetails={false}
+                />,
+            );
+
+            expect(screen.queryByTestId('cart-item-bundled-item-name')).not.toBeInTheDocument();
+        });
+
+        it('renders a bundled-items-container element', () => {
+            const { container } = render(
+                <OrderSummaryItem
+                    orderItem={{ amount: 10, id: 'foo', name: 'Product', quantity: 1, bundledItems }}
+                    shouldExpandBackorderDetails={false}
+                />,
+            );
+
+            expect(container.querySelector('.bundled-items-container')).toBeInTheDocument();
+        });
+    });
 });

--- a/packages/core/src/app/order/OrderSummaryItem.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.test.tsx
@@ -127,7 +127,13 @@ describe('OrderSummaryItem', () => {
         it('renders each bundled item name with the Bundle label', () => {
             render(
                 <OrderSummaryItem
-                    orderItem={{ amount: 10, id: 'foo', name: 'Product', quantity: 1, bundledItems }}
+                    orderItem={{
+                        amount: 10,
+                        id: 'foo',
+                        name: 'Product',
+                        quantity: 1,
+                        bundledItems,
+                    }}
                     shouldExpandBackorderDetails={false}
                 />,
             );
@@ -150,15 +156,38 @@ describe('OrderSummaryItem', () => {
             expect(screen.queryByTestId('cart-item-bundled-item-name')).not.toBeInTheDocument();
         });
 
-        it('renders a bundled-items-container element', () => {
-            const { container } = render(
+        it('renders bundled items in a <ul> element', () => {
+            render(
                 <OrderSummaryItem
-                    orderItem={{ amount: 10, id: 'foo', name: 'Product', quantity: 1, bundledItems }}
+                    orderItem={{
+                        amount: 10,
+                        id: 'foo',
+                        name: 'Product',
+                        quantity: 1,
+                        bundledItems,
+                    }}
                     shouldExpandBackorderDetails={false}
                 />,
             );
 
-            expect(container.querySelector('.bundled-items-container')).toBeInTheDocument();
+            expect(screen.getByRole('list')).toBeInTheDocument();
+        });
+
+        it('does not render the bundled items container when bundledItems is an empty array', () => {
+            render(
+                <OrderSummaryItem
+                    orderItem={{
+                        amount: 10,
+                        id: 'foo',
+                        name: 'Product',
+                        quantity: 1,
+                        bundledItems: [],
+                    }}
+                    shouldExpandBackorderDetails={false}
+                />,
+            );
+
+            expect(screen.queryByRole('list')).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -20,6 +20,13 @@ export interface OrderItemType {
     quantityBackordered?: number;
     quantityOnHand?: number;
     backorderMessage?: string;
+    bundledItems?: Array<{
+        id: string;
+        name: string;
+        quantityBackordered?: number;
+        quantityOnHand?: number;
+        backorderMessage?: string;
+    }>;
 }
 
 interface OrderSummaryItemProps {
@@ -67,9 +74,14 @@ const OrderSummaryItemBackorderDetails = ({
 
     return (
         <CollapseCSSTransition isVisible={isExpanded} nodeRef={backorderDetailsRef}>
-            <div className="product-backorder-details-container" ref={backorderDetailsRef}>
+            {/* <div className="product-backorder-details-container" ref={backorderDetailsRef}> */}
+            <div
+                className="product-backorder-details-container product-options optimizedCheckout-contentSecondary sub-text-medium"
+                ref={backorderDetailsRef}
+            >
                 {shouldDisplayQuantityOnHand && (
-                    <div className="sub-text" data-test="cart-item-onhand-qty">
+                    // <div className="sub-text" data-test="cart-item-onhand-qty">
+                    <div className="product-option" data-test="cart-item-onhand-qty">
                         <TranslatedString
                             data={{ count: quantityOnHand }}
                             id="cart.ready_to_ship_count_text"
@@ -77,7 +89,8 @@ const OrderSummaryItemBackorderDetails = ({
                     </div>
                 )}
                 {shouldDisplayQuantityOnBackorder && (
-                    <div className="sub-text" data-test="cart-item-backorder-qty">
+                    // <div className="sub-text" data-test="cart-item-backorder-qty">
+                    <div className="product-option" data-test="cart-item-backorder-qty">
                         <TranslatedString
                             data={{ count: quantityBackordered }}
                             id="cart.backorder_count_text"
@@ -85,7 +98,8 @@ const OrderSummaryItemBackorderDetails = ({
                     </div>
                 )}
                 {shouldDisplayBackorderMessage && (
-                    <div className="sub-text" data-test="cart-item-backorder-message">
+                    // <div className="sub-text" data-test="cart-item-backorder-message">
+                    <div className="product-option" data-test="cart-item-backorder-message">
                         {backorderMessage}
                     </div>
                 )}
@@ -109,7 +123,10 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
         quantityBackordered,
         quantityOnHand,
         backorderMessage,
+        bundledItems,
     } = orderItem;
+
+    console.log(bundledItems);
 
     return (
         <div className="product" data-test="cart-item">
@@ -149,6 +166,25 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                     quantityBackordered={quantityBackordered}
                     quantityOnHand={quantityOnHand}
                 />
+
+                <div style={{ marginTop: '10px' }}>
+                    {bundledItems?.map((item) => (
+                        <li
+                            className="product-options optimizedCheckout-contentSecondary sub-text-medium"
+                            key={item.id}
+                        >
+                            <div className="product-option" style={{ marginBottom: '0' }}>
+                                <span style={{ fontWeight: 'bold' }}>Bundle:</span> {item.name}
+                            </div>
+                            <OrderSummaryItemBackorderDetails
+                                backorderMessage={item.backorderMessage}
+                                isExpanded={shouldExpandBackorderDetails}
+                                quantityBackordered={item.quantityBackordered}
+                                quantityOnHand={item.quantityBackordered}
+                            />
+                        </li>
+                    ))}
+                </div>
             </div>
 
             <div className="product-column product-actions">

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -159,27 +159,32 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                     quantityOnHand={quantityOnHand}
                 />
 
-                <div className="bundled-items-container">
-                    {bundledItems?.map((item) => (
-                        <li
-                            className="bundled-item optimizedCheckout-contentSecondary sub-text-medium"
-                            key={item.id}
-                        >
-                            <div
-                                className="bundled-item-name"
-                                data-test="cart-item-bundled-item-name"
+                {bundledItems && bundledItems.length > 0 && (
+                    <ul className="bundled-items-container">
+                        {bundledItems.map((item) => (
+                            <li
+                                className="bundled-item optimizedCheckout-contentSecondary sub-text-medium"
+                                key={item.id}
                             >
-                                <span className="body-bold">Bundle:</span> {item.name}
-                            </div>
-                            <OrderSummaryItemBackorderDetails
-                                backorderMessage={item.backorderMessage}
-                                isExpanded={shouldExpandBackorderDetails}
-                                quantityBackordered={item.quantityBackordered}
-                                quantityOnHand={item.quantityOnHand}
-                            />
-                        </li>
-                    ))}
-                </div>
+                                <div
+                                    className="bundled-item-name"
+                                    data-test="cart-item-bundled-item-name"
+                                >
+                                    <span className="body-bold">
+                                        <TranslatedString id="cart.bundled_item_label" />
+                                    </span>{' '}
+                                    {item.name}
+                                </div>
+                                <OrderSummaryItemBackorderDetails
+                                    backorderMessage={item.backorderMessage}
+                                    isExpanded={shouldExpandBackorderDetails}
+                                    quantityBackordered={item.quantityBackordered}
+                                    quantityOnHand={item.quantityOnHand}
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                )}
             </div>
 
             <div className="product-column product-actions">

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -74,14 +74,12 @@ const OrderSummaryItemBackorderDetails = ({
 
     return (
         <CollapseCSSTransition isVisible={isExpanded} nodeRef={backorderDetailsRef}>
-            {/* <div className="product-backorder-details-container" ref={backorderDetailsRef}> */}
             <div
-                className="product-backorder-details-container product-options optimizedCheckout-contentSecondary sub-text-medium"
+                className="product-backorder-details-container optimizedCheckout-contentSecondary sub-text-medium"
                 ref={backorderDetailsRef}
             >
                 {shouldDisplayQuantityOnHand && (
-                    // <div className="sub-text" data-test="cart-item-onhand-qty">
-                    <div className="product-option" data-test="cart-item-onhand-qty">
+                    <div data-test="cart-item-onhand-qty">
                         <TranslatedString
                             data={{ count: quantityOnHand }}
                             id="cart.ready_to_ship_count_text"
@@ -89,8 +87,7 @@ const OrderSummaryItemBackorderDetails = ({
                     </div>
                 )}
                 {shouldDisplayQuantityOnBackorder && (
-                    // <div className="sub-text" data-test="cart-item-backorder-qty">
-                    <div className="product-option" data-test="cart-item-backorder-qty">
+                    <div data-test="cart-item-backorder-qty">
                         <TranslatedString
                             data={{ count: quantityBackordered }}
                             id="cart.backorder_count_text"
@@ -98,10 +95,7 @@ const OrderSummaryItemBackorderDetails = ({
                     </div>
                 )}
                 {shouldDisplayBackorderMessage && (
-                    // <div className="sub-text" data-test="cart-item-backorder-message">
-                    <div className="product-option" data-test="cart-item-backorder-message">
-                        {backorderMessage}
-                    </div>
+                    <div data-test="cart-item-backorder-message">{backorderMessage}</div>
                 )}
             </div>
         </CollapseCSSTransition>
@@ -125,8 +119,6 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
         backorderMessage,
         bundledItems,
     } = orderItem;
-
-    console.log(bundledItems);
 
     return (
         <div className="product" data-test="cart-item">
@@ -167,20 +159,23 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                     quantityOnHand={quantityOnHand}
                 />
 
-                <div style={{ marginTop: '10px' }}>
+                <div className="bundled-items-container">
                     {bundledItems?.map((item) => (
                         <li
-                            className="product-options optimizedCheckout-contentSecondary sub-text-medium"
+                            className="bundled-item optimizedCheckout-contentSecondary sub-text-medium"
                             key={item.id}
                         >
-                            <div className="product-option" style={{ marginBottom: '0' }}>
-                                <span style={{ fontWeight: 'bold' }}>Bundle:</span> {item.name}
+                            <div
+                                className="bundled-item-name"
+                                data-test="cart-item-bundled-item-name"
+                            >
+                                <span className="body-bold">Bundle:</span> {item.name}
                             </div>
                             <OrderSummaryItemBackorderDetails
                                 backorderMessage={item.backorderMessage}
                                 isExpanded={shouldExpandBackorderDetails}
                                 quantityBackordered={item.quantityBackordered}
-                                quantityOnHand={item.quantityBackordered}
+                                quantityOnHand={item.quantityOnHand}
                             />
                         </li>
                     ))}

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -195,30 +195,16 @@ const OrderSummaryItems = ({
 }: OrderSummaryItemsProps): ReactElement => {
     const [isExpanded, setIsExpanded] = useState(false);
     const [showBackorderDetails, setShowBackorderDetails] = useState(false);
-    let nonBundledItems: LineItemMap;
-    let bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>> | undefined;
-    let nonBundledAndBundleMap;
     const { checkoutState } = useCheckout();
     const config = checkoutState.data.getConfig();
 
-    if (!config) {
-        return <></>;
-    }
+    const pickListExperimentEnabled = config
+        ? isExperimentEnabled(config.checkoutSettings, 'BACK-425.update_bundle_item_ux', false)
+        : false;
 
-    const pickListExperimentEnabled = isExperimentEnabled(
-        config.checkoutSettings,
-        'BACK-425.update_bundle_item_ux',
-        false,
-    );
-
-    if (pickListExperimentEnabled) {
-        nonBundledAndBundleMap = removeAndBundleItemsTogether(items);
-
-        nonBundledItems = nonBundledAndBundleMap.nonBundledItems;
-        bundleItemsMap = nonBundledAndBundleMap.bundleItemsMap;
-    } else {
-        nonBundledItems = removeBundledItems(items);
-    }
+    const { nonBundledItems, bundleItemsMap } = pickListExperimentEnabled
+        ? removeAndBundleItemsTogether(items)
+        : { nonBundledItems: removeBundledItems(items), bundleItemsMap: undefined };
 
     const collapsedLimit = isSmallScreen()
         ? COLLAPSED_ITEMS_LIMIT_SMALL_SCREEN

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -1,4 +1,4 @@
-import { type LineItemMap } from '@bigcommerce/checkout-sdk';
+import { type DigitalItem, type LineItemMap, type PhysicalItem } from '@bigcommerce/checkout-sdk';
 import React, {
     type FunctionComponent,
     type ReactElement,
@@ -26,7 +26,7 @@ import mapFromDigital from './mapFromDigital';
 import mapFromGiftCertificate from './mapFromGiftCertificate';
 import mapFromPhysical from './mapFromPhysical';
 import OrderSummaryItem from './OrderSummaryItem';
-import removeBundledItems from './removeBundledItems';
+import { removeAndBundleItemsTogether, removeBundledItems } from './removeBundledItems';
 
 interface AnimatedProductItemProps {
     children: ReactNode;
@@ -122,22 +122,26 @@ const ProductList = ({
     isExpanded,
     collapsedLimit,
     showBackorderDetails,
+    bundleItemsMap,
+    pickListExperimentEnabled,
 }: {
     items: LineItemMap;
     isExpanded: boolean;
     collapsedLimit: number;
     showBackorderDetails: boolean;
+    bundleItemsMap?: Map<string | number, Array<PhysicalItem | DigitalItem>>;
+    pickListExperimentEnabled?: boolean;
 }): ReactElement => {
     const summaryItems = [
         ...items.physicalItems
             .slice()
             .sort((item) => item.variantId)
-            .map((item) => mapFromPhysical(item)),
+            .map((item) => mapFromPhysical(item, bundleItemsMap, pickListExperimentEnabled)),
         ...items.giftCertificates.slice().map(mapFromGiftCertificate),
         ...items.digitalItems
             .slice()
             .sort((item) => item.variantId)
-            .map(mapFromDigital),
+            .map((item) => mapFromDigital(item, bundleItemsMap)),
         ...(items.customItems || []).map(mapFromCustom),
     ].slice(0, isExpanded ? undefined : collapsedLimit);
 
@@ -187,9 +191,21 @@ const OrderSummaryItems = ({
     displayLineItemsCount = true,
     items,
 }: OrderSummaryItemsProps): ReactElement => {
+    const pickListExperimentEnabled = true;
     const [isExpanded, setIsExpanded] = useState(false);
     const [showBackorderDetails, setShowBackorderDetails] = useState(false);
-    const nonBundledItems = removeBundledItems(items);
+    let nonBundledItems: LineItemMap;
+    let bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>> | undefined;
+    let nonBundledAndBundleMap;
+
+    if (pickListExperimentEnabled) {
+        nonBundledAndBundleMap = removeAndBundleItemsTogether(items);
+
+        nonBundledItems = nonBundledAndBundleMap.nonBundledItems;
+        bundleItemsMap = nonBundledAndBundleMap.bundleItemsMap;
+    } else {
+        nonBundledItems = removeBundledItems(items);
+    }
 
     const collapsedLimit = isSmallScreen()
         ? COLLAPSED_ITEMS_LIMIT_SMALL_SCREEN
@@ -216,9 +232,11 @@ const OrderSummaryItems = ({
                 />
             )}
             <ProductList
+                bundleItemsMap={bundleItemsMap}
                 collapsedLimit={collapsedLimit}
                 isExpanded={isExpanded}
                 items={nonBundledItems}
+                pickListExperimentEnabled={pickListExperimentEnabled}
                 showBackorderDetails={showBackorderDetails}
             />
 

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -19,6 +19,8 @@ import {
     isSmallScreen,
 } from '@bigcommerce/checkout/ui';
 
+import { isExperimentEnabled } from '../common/utility';
+
 import getBackorderCount from './getBackorderCount';
 import getItemsCount from './getItemsCount';
 import mapFromCustom from './mapFromCustom';
@@ -191,12 +193,23 @@ const OrderSummaryItems = ({
     displayLineItemsCount = true,
     items,
 }: OrderSummaryItemsProps): ReactElement => {
-    const pickListExperimentEnabled = true;
     const [isExpanded, setIsExpanded] = useState(false);
     const [showBackorderDetails, setShowBackorderDetails] = useState(false);
     let nonBundledItems: LineItemMap;
     let bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>> | undefined;
     let nonBundledAndBundleMap;
+    const { checkoutState } = useCheckout();
+    const config = checkoutState.data.getConfig();
+
+    if (!config) {
+        return <></>;
+    }
+
+    const pickListExperimentEnabled = isExperimentEnabled(
+        config.checkoutSettings,
+        'BACK-425.update_bundle_item_ux',
+        false,
+    );
 
     if (pickListExperimentEnabled) {
         nonBundledAndBundleMap = removeAndBundleItemsTogether(items);

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -143,7 +143,7 @@ const ProductList = ({
         ...items.digitalItems
             .slice()
             .sort((item) => item.variantId)
-            .map((item) => mapFromDigital(item, bundleItemsMap)),
+            .map((item) => mapFromDigital(item, bundleItemsMap, pickListExperimentEnabled)),
         ...(items.customItems || []).map(mapFromCustom),
     ].slice(0, isExpanded ? undefined : collapsedLimit);
 

--- a/packages/core/src/app/order/mapFromDigital.test.tsx
+++ b/packages/core/src/app/order/mapFromDigital.test.tsx
@@ -1,6 +1,6 @@
-import { type LineItemOption } from '@bigcommerce/checkout-sdk';
+import { type LineItemOption, type PhysicalItem } from '@bigcommerce/checkout-sdk';
 
-import { getDigitalItem } from '../cart/lineItem.mock';
+import { getDigitalItem, getPhysicalItem } from '../cart/lineItem.mock';
 
 import mapFromDigital from './mapFromDigital';
 
@@ -25,5 +25,117 @@ describe('mapFromDigital()', () => {
         expect(productOptions[0].testId).toBe('cart-item-digital-product');
 
         expect(productOptions[0].content).toMatchSnapshot();
+    });
+
+    describe('with pickListExperimentEnabled', () => {
+        it('filters out options whose attributeId matches a bundled item', () => {
+            const bundledChild = {
+                ...getPhysicalItem(),
+                id: '777',
+                parentId: '667',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const item = {
+                ...getDigitalItem(),
+                id: '667',
+                options: [
+                    { name: 'Color', nameId: 10, value: 'Red', valueId: 1, attributeId: 'attr-color' },
+                    {
+                        name: 'Pick List Option',
+                        nameId: 11,
+                        value: 'Item A',
+                        valueId: 2,
+                        attributeId: 'attr-picklist',
+                    },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+                ['667', [bundledChild]],
+            ]);
+
+            const { productOptions = [] } = mapFromDigital(item, bundleItemsMap, true);
+            const itemOptions = productOptions.filter((o) => o.testId === 'cart-item-product-option');
+
+            expect(itemOptions).toHaveLength(1);
+            expect(itemOptions[0].content).toBe('Color Red');
+        });
+
+        it('returns bundledItems with backorder details from stockPosition', () => {
+            const bundledChild = {
+                ...getPhysicalItem(),
+                id: '777',
+                name: 'Bundled Product',
+                parentId: '667',
+                addedByAttributeId: 'attr-picklist',
+                stockPosition: {
+                    quantityBackordered: 2,
+                    quantityOnHand: 3,
+                    quantityOutOfStock: 0,
+                    backorderMessage: 'Ships in 5 days',
+                },
+            } as unknown as PhysicalItem;
+
+            const item = { ...getDigitalItem(), id: '667', options: [] as LineItemOption[] };
+
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+                ['667', [bundledChild]],
+            ]);
+
+            const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
+
+            expect(bundledItems).toHaveLength(1);
+            expect(bundledItems![0].id).toBe('777');
+            expect(bundledItems![0].name).toBe('Bundled Product');
+            expect(bundledItems![0].quantityBackordered).toBe(2);
+            expect(bundledItems![0].quantityOnHand).toBe(3);
+            expect(bundledItems![0].backorderMessage).toBe('Ships in 5 days');
+        });
+
+        it('returns undefined bundledItems when item has no children in the map', () => {
+            const item = { ...getDigitalItem(), id: '667' };
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>();
+
+            const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
+
+            expect(bundledItems).toBeUndefined();
+        });
+    });
+
+    describe('without pickListExperimentEnabled', () => {
+        it('does not filter options and returns no bundledItems', () => {
+            const bundledChild = {
+                ...getPhysicalItem(),
+                id: '777',
+                parentId: '667',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const item = {
+                ...getDigitalItem(),
+                id: '667',
+                options: [
+                    {
+                        name: 'Pick List Option',
+                        nameId: 11,
+                        value: 'Item A',
+                        valueId: 2,
+                        attributeId: 'attr-picklist',
+                    },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+                ['667', [bundledChild]],
+            ]);
+
+            const { productOptions = [], bundledItems } = mapFromDigital(item, bundleItemsMap, false);
+
+            expect(productOptions.filter((o) => o.testId === 'cart-item-product-option')).toHaveLength(
+                1,
+            );
+            expect(bundledItems).toBeUndefined();
+        });
     });
 });

--- a/packages/core/src/app/order/mapFromDigital.test.tsx
+++ b/packages/core/src/app/order/mapFromDigital.test.tsx
@@ -40,7 +40,13 @@ describe('mapFromDigital()', () => {
                 ...getDigitalItem(),
                 id: '667',
                 options: [
-                    { name: 'Color', nameId: 10, value: 'Red', valueId: 1, attributeId: 'attr-color' },
+                    {
+                        name: 'Color',
+                        nameId: 10,
+                        value: 'Red',
+                        valueId: 1,
+                        attributeId: 'attr-color',
+                    },
                     {
                         name: 'Pick List Option',
                         nameId: 11,
@@ -51,15 +57,17 @@ describe('mapFromDigital()', () => {
                 ] as LineItemOption[],
             };
 
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([
                 ['667', [bundledChild]],
             ]);
 
             const { productOptions = [] } = mapFromDigital(item, bundleItemsMap, true);
-            const itemOptions = productOptions.filter((o) => o.testId === 'cart-item-product-option');
+            const itemOptions = productOptions.filter(
+                (o) => o.testId === 'cart-item-product-option',
+            );
 
             expect(itemOptions).toHaveLength(1);
-            expect(itemOptions[0].content).toBe('Color Red');
+            expect(itemOptions[0].content).toBe('Color: Red');
         });
 
         it('returns bundledItems with backorder details from stockPosition', () => {
@@ -79,7 +87,7 @@ describe('mapFromDigital()', () => {
 
             const item = { ...getDigitalItem(), id: '667', options: [] as LineItemOption[] };
 
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([
                 ['667', [bundledChild]],
             ]);
 
@@ -95,7 +103,7 @@ describe('mapFromDigital()', () => {
 
         it('returns undefined bundledItems when item has no children in the map', () => {
             const item = { ...getDigitalItem(), id: '667' };
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>();
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>();
 
             const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
 
@@ -126,15 +134,19 @@ describe('mapFromDigital()', () => {
                 ] as LineItemOption[],
             };
 
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([
                 ['667', [bundledChild]],
             ]);
 
-            const { productOptions = [], bundledItems } = mapFromDigital(item, bundleItemsMap, false);
-
-            expect(productOptions.filter((o) => o.testId === 'cart-item-product-option')).toHaveLength(
-                1,
+            const { productOptions = [], bundledItems } = mapFromDigital(
+                item,
+                bundleItemsMap,
+                false,
             );
+
+            expect(
+                productOptions.filter((o) => o.testId === 'cart-item-product-option'),
+            ).toHaveLength(1);
             expect(bundledItems).toBeUndefined();
         });
     });

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -34,7 +34,9 @@ function mapFromDigital(
         productOptions: [
             ...(options || []).map((option) => ({
                 testId: 'cart-item-product-option',
-                content: `${option.name} ${option.value}`,
+                content: pickListExperimentEnabled
+                    ? `${option.name}: ${option.value}`
+                    : `${option.name} ${option.value}`,
             })),
             getDigitalItemDescription(item),
         ],

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -13,8 +13,8 @@ function mapFromDigital(
     pickListExperimentEnabled?: boolean,
 ): OrderItemType {
     const bundledItems = bundleItemsMap?.get(String(item.id));
-    const bundledItemsAddedByAttributeIds = bundledItems?.map(
-        (bundledItem) => bundledItem.addedByAttributeId,
+    const bundledItemsAddedByAttributeIds = bundledItems?.flatMap(({ addedByAttributeId }) =>
+        addedByAttributeId ? [addedByAttributeId] : [],
     );
     const options = pickListExperimentEnabled
         ? item.options?.filter(

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -1,4 +1,4 @@
-import { type DigitalItem } from '@bigcommerce/checkout-sdk';
+import { type DigitalItem, type PhysicalItem } from '@bigcommerce/checkout-sdk';
 import React from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -7,7 +7,23 @@ import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { mapBackorderDetails } from './mapBackorderDetails';
 import { type OrderItemType, type OrderSummaryItemOption } from './OrderSummaryItem';
 
-function mapFromDigital(item: DigitalItem): OrderItemType {
+function mapFromDigital(
+    item: DigitalItem,
+    bundleItemsMap?: Map<string | number, Array<PhysicalItem | DigitalItem>>,
+    pickListExperimentEnabled?: boolean,
+): OrderItemType {
+    const bundledItems = bundleItemsMap?.get(String(item.id));
+    const bundledItemsAddedByAttributeIds = bundledItems?.map(
+        (bundledItem) => bundledItem.addedByAttributeId,
+    );
+    const options = pickListExperimentEnabled
+        ? item.options?.filter(
+              (option) =>
+                  option.attributeId &&
+                  !bundledItemsAddedByAttributeIds?.includes(option.attributeId),
+          )
+        : item.options;
+
     return {
         id: item.id,
         quantity: item.quantity,
@@ -16,7 +32,7 @@ function mapFromDigital(item: DigitalItem): OrderItemType {
         name: item.name,
         image: getOrderSummaryItemImage(item),
         productOptions: [
-            ...(item.options || []).map((option) => ({
+            ...(options || []).map((option) => ({
                 testId: 'cart-item-product-option',
                 content: `${option.name} ${option.value}`,
             })),

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -38,6 +38,13 @@ function mapFromDigital(
             })),
             getDigitalItemDescription(item),
         ],
+        bundledItems: pickListExperimentEnabled
+            ? bundledItems?.map((bundledItem) => ({
+                  name: bundledItem.name,
+                  id: String(bundledItem.id),
+                  ...mapBackorderDetails(bundledItem),
+              }))
+            : undefined,
         ...mapBackorderDetails(item),
     };
 }

--- a/packages/core/src/app/order/mapFromPhysical.test.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.test.tsx
@@ -34,7 +34,13 @@ describe('mapFromPhysical()', () => {
             const item = {
                 ...getPhysicalItem(),
                 options: [
-                    { name: 'Color', nameId: 10, value: 'Red', valueId: 1, attributeId: 'attr-color' },
+                    {
+                        name: 'Color',
+                        nameId: 10,
+                        value: 'Red',
+                        valueId: 1,
+                        attributeId: 'attr-color',
+                    },
                 ] as LineItemOption[],
             };
             const result = mapFromPhysical(item, undefined, true);
@@ -54,7 +60,13 @@ describe('mapFromPhysical()', () => {
                 ...getPhysicalItem(),
                 id: '666',
                 options: [
-                    { name: 'Color', nameId: 10, value: 'Blue', valueId: 1, attributeId: 'attr-color' },
+                    {
+                        name: 'Color',
+                        nameId: 10,
+                        value: 'Blue',
+                        valueId: 1,
+                        attributeId: 'attr-color',
+                    },
                     {
                         name: 'Pick List',
                         nameId: 11,
@@ -65,9 +77,7 @@ describe('mapFromPhysical()', () => {
                 ] as LineItemOption[],
             };
 
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
-                ['666', [child]],
-            ]);
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
             const result = mapFromPhysical(parent, bundleItemsMap, true);
 
@@ -92,9 +102,7 @@ describe('mapFromPhysical()', () => {
 
             const parent = { ...getPhysicalItem(), id: '666' };
 
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
-                ['666', [child]],
-            ]);
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
             const { bundledItems } = mapFromPhysical(parent, bundleItemsMap, true);
 
@@ -120,9 +128,7 @@ describe('mapFromPhysical()', () => {
                 addedByAttributeId: 'attr-picklist',
             } as unknown as PhysicalItem;
 
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
-                ['666', [child]],
-            ]);
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
             const { bundledItems } = mapFromPhysical(
                 { ...getPhysicalItem(), id: '666' },
@@ -158,9 +164,7 @@ describe('mapFromPhysical()', () => {
                 ] as LineItemOption[],
             };
 
-            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
-                ['666', [child]],
-            ]);
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
             const result = mapFromPhysical(parent, bundleItemsMap, false);
 

--- a/packages/core/src/app/order/mapFromPhysical.test.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.test.tsx
@@ -1,0 +1,171 @@
+import { type LineItemOption, type PhysicalItem } from '@bigcommerce/checkout-sdk';
+
+import { getPhysicalItem } from '../cart/lineItem.mock';
+
+import mapFromPhysical from './mapFromPhysical';
+
+describe('mapFromPhysical()', () => {
+    describe('without bundleItemsMap (legacy path)', () => {
+        it('maps basic item fields', () => {
+            const item = getPhysicalItem();
+            const result = mapFromPhysical(item);
+
+            expect(result.id).toBe(item.id);
+            expect(result.name).toBe(item.name);
+            expect(result.quantity).toBe(item.quantity);
+        });
+
+        it('formats options without colon separator', () => {
+            const item = getPhysicalItem();
+            const result = mapFromPhysical(item);
+
+            expect(result.productOptions![0].content).toBe('n v');
+        });
+
+        it('returns no bundledItems', () => {
+            const result = mapFromPhysical(getPhysicalItem());
+
+            expect(result.bundledItems).toBeUndefined();
+        });
+    });
+
+    describe('with pickListExperimentEnabled', () => {
+        it('formats options with colon separator', () => {
+            const item = {
+                ...getPhysicalItem(),
+                options: [
+                    { name: 'Color', nameId: 10, value: 'Red', valueId: 1, attributeId: 'attr-color' },
+                ] as LineItemOption[],
+            };
+            const result = mapFromPhysical(item, undefined, true);
+
+            expect(result.productOptions![0].content).toBe('Color: Red');
+        });
+
+        it('filters out options matching a bundled item attributeId', () => {
+            const child = {
+                ...getPhysicalItem(),
+                id: '777',
+                parentId: '666',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const parent = {
+                ...getPhysicalItem(),
+                id: '666',
+                options: [
+                    { name: 'Color', nameId: 10, value: 'Blue', valueId: 1, attributeId: 'attr-color' },
+                    {
+                        name: 'Pick List',
+                        nameId: 11,
+                        value: 'Item A',
+                        valueId: 2,
+                        attributeId: 'attr-picklist',
+                    },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+                ['666', [child]],
+            ]);
+
+            const result = mapFromPhysical(parent, bundleItemsMap, true);
+
+            expect(result.productOptions).toHaveLength(1);
+            expect(result.productOptions![0].content).toBe('Color: Blue');
+        });
+
+        it('returns bundledItems with backorder details from stockPosition', () => {
+            const child = {
+                ...getPhysicalItem(),
+                id: '777',
+                name: 'Bundled Product',
+                parentId: '666',
+                addedByAttributeId: 'attr-picklist',
+                stockPosition: {
+                    quantityBackordered: 1,
+                    quantityOnHand: 4,
+                    quantityOutOfStock: 0,
+                    backorderMessage: 'Available soon',
+                },
+            } as unknown as PhysicalItem;
+
+            const parent = { ...getPhysicalItem(), id: '666' };
+
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+                ['666', [child]],
+            ]);
+
+            const { bundledItems } = mapFromPhysical(parent, bundleItemsMap, true);
+
+            expect(bundledItems).toHaveLength(1);
+            expect(bundledItems![0].id).toBe('777');
+            expect(bundledItems![0].name).toBe('Bundled Product');
+            expect(bundledItems![0].quantityBackordered).toBe(1);
+            expect(bundledItems![0].quantityOnHand).toBe(4);
+            expect(bundledItems![0].backorderMessage).toBe('Available soon');
+        });
+
+        it('returns no bundledItems when the item has no children', () => {
+            const result = mapFromPhysical(getPhysicalItem(), new Map(), true);
+
+            expect(result.bundledItems).toBeUndefined();
+        });
+
+        it('coerces numeric child id to string in bundledItems', () => {
+            const child = {
+                ...getPhysicalItem(),
+                id: 999,
+                parentId: '666',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+                ['666', [child]],
+            ]);
+
+            const { bundledItems } = mapFromPhysical(
+                { ...getPhysicalItem(), id: '666' },
+                bundleItemsMap,
+                true,
+            );
+
+            expect(typeof bundledItems![0].id).toBe('string');
+            expect(bundledItems![0].id).toBe('999');
+        });
+    });
+
+    describe('without pickListExperimentEnabled', () => {
+        it('does not filter options and returns no bundledItems even when map has children', () => {
+            const child = {
+                ...getPhysicalItem(),
+                id: '777',
+                parentId: '666',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const parent = {
+                ...getPhysicalItem(),
+                id: '666',
+                options: [
+                    {
+                        name: 'Pick List',
+                        nameId: 11,
+                        value: 'Item A',
+                        valueId: 2,
+                        attributeId: 'attr-picklist',
+                    },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, Array<PhysicalItem>>([
+                ['666', [child]],
+            ]);
+
+            const result = mapFromPhysical(parent, bundleItemsMap, false);
+
+            expect(result.productOptions).toHaveLength(1);
+            expect(result.bundledItems).toBeUndefined();
+        });
+    });
+});

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -32,13 +32,17 @@ function mapFromPhysical(
         description: item.giftWrapping ? item.giftWrapping.name : undefined,
         productOptions: (options || []).map((option) => ({
             testId: 'cart-item-product-option',
-            content: `${option.name}: ${option.value}`,
+            content: pickListExperimentEnabled
+                ? `${option.name}: ${option.value}`
+                : `${option.name} ${option.value}`,
         })),
-        bundledItems: bundledItems?.map((item) => ({
-            name: item.name,
-            id: String(item.id),
-            ...mapBackorderDetails(item),
-        })),
+        bundledItems: pickListExperimentEnabled
+            ? bundledItems?.map((item) => ({
+                  name: item.name,
+                  id: String(item.id),
+                  ...mapBackorderDetails(item),
+              }))
+            : undefined,
         ...mapBackorderDetails(item),
     };
 }

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -1,10 +1,27 @@
-import { type PhysicalItem } from '@bigcommerce/checkout-sdk';
+import { type DigitalItem, type PhysicalItem } from '@bigcommerce/checkout-sdk';
 
 import getOrderSummaryItemImage from './getOrderSummaryItemImage';
 import { mapBackorderDetails } from './mapBackorderDetails';
 import { type OrderItemType } from './OrderSummaryItem';
 
-function mapFromPhysical(item: PhysicalItem): OrderItemType {
+function mapFromPhysical(
+    item: PhysicalItem,
+    bundleItemsMap?: Map<string | number, Array<PhysicalItem | DigitalItem>>,
+    pickListExperimentEnabled?: boolean,
+): OrderItemType {
+    const bundledItems = bundleItemsMap?.get(String(item.id));
+
+    const bundledItemsAddedByAttributeIds = bundledItems?.map(
+        (bundledItem) => bundledItem.addedByAttributeId,
+    );
+    const options = pickListExperimentEnabled
+        ? item.options?.filter(
+              (option) =>
+                  option.attributeId &&
+                  !bundledItemsAddedByAttributeIds?.includes(option.attributeId),
+          )
+        : item.options;
+
     return {
         id: item.id,
         quantity: item.quantity,
@@ -13,9 +30,14 @@ function mapFromPhysical(item: PhysicalItem): OrderItemType {
         name: item.name,
         image: getOrderSummaryItemImage(item),
         description: item.giftWrapping ? item.giftWrapping.name : undefined,
-        productOptions: (item.options || []).map((option) => ({
+        productOptions: (options || []).map((option) => ({
             testId: 'cart-item-product-option',
-            content: `${option.name} ${option.value}`,
+            content: `${option.name}: ${option.value}`,
+        })),
+        bundledItems: bundledItems?.map((item) => ({
+            name: item.name,
+            id: String(item.id),
+            ...mapBackorderDetails(item),
         })),
         ...mapBackorderDetails(item),
     };

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -11,8 +11,8 @@ function mapFromPhysical(
 ): OrderItemType {
     const bundledItems = bundleItemsMap?.get(String(item.id));
 
-    const bundledItemsAddedByAttributeIds = bundledItems?.map(
-        (bundledItem) => bundledItem.addedByAttributeId,
+    const bundledItemsAddedByAttributeIds = bundledItems?.flatMap(({ addedByAttributeId }) =>
+        addedByAttributeId ? [addedByAttributeId] : [],
     );
     const options = pickListExperimentEnabled
         ? item.options?.filter(

--- a/packages/core/src/app/order/removeBundledItems.test.ts
+++ b/packages/core/src/app/order/removeBundledItems.test.ts
@@ -5,63 +5,120 @@ import {
     type PhysicalItem,
 } from '@bigcommerce/checkout-sdk';
 
-import { getPhysicalItem } from '../cart/lineItem.mock';
+import { getDigitalItem, getPhysicalItem } from '../cart/lineItem.mock';
 
-import removeBundledItems from './removeBundledItems';
+import { removeAndBundleItemsTogether, removeBundledItems } from './removeBundledItems';
+
+const emptyLineItems = {
+    physicalItems: [] as PhysicalItem[],
+    digitalItems: [] as DigitalItem[],
+    giftCertificates: [] as GiftCertificateItem[],
+    customItems: null as unknown as CustomItem[],
+};
 
 describe('removeBundledItems()', () => {
     describe('when there are no items', () => {
-        const items = {
-            physicalItems: [] as PhysicalItem[],
-            digitalItems: [] as DigitalItem[],
-            giftCertificates: [] as GiftCertificateItem[],
-            // for now, force it to be null this way.
-            customItems: null as unknown as CustomItem[],
-        };
-
         it('returns zero', () => {
-            expect(removeBundledItems(items)).toEqual(items);
+            expect(removeBundledItems(emptyLineItems)).toEqual(emptyLineItems);
         });
     });
 
     describe('when there are items with parentId', () => {
-        const emptyItems = {
-            physicalItems: [] as PhysicalItem[],
-            digitalItems: [] as DigitalItem[],
-            giftCertificates: [] as GiftCertificateItem[],
-            // for now, force it to be null this way.
-            customItems: null as unknown as CustomItem[],
-        };
-
         const items = {
-            physicalItems: [
-                {
-                    ...getPhysicalItem(),
-                    parentId: '123-abc',
-                },
-            ],
-            digitalItems: [] as DigitalItem[],
-            giftCertificates: [] as GiftCertificateItem[],
-            // for now, force it to be null this way.
-            customItems: null as unknown as CustomItem[],
+            ...emptyLineItems,
+            physicalItems: [{ ...getPhysicalItem(), parentId: '123-abc' }],
         };
 
         it('removes items with parentId', () => {
-            expect(removeBundledItems(items)).toEqual(emptyItems);
+            expect(removeBundledItems(items)).toEqual(emptyLineItems);
         });
     });
 
     describe('when there are items without parentId', () => {
-        const items = {
-            physicalItems: [getPhysicalItem()],
-            digitalItems: [] as DigitalItem[],
-            giftCertificates: [] as GiftCertificateItem[],
-            // for now, force it to be null this way.
-            customItems: null as unknown as CustomItem[],
-        };
+        const items = { ...emptyLineItems, physicalItems: [getPhysicalItem()] };
 
         it('keeps all items', () => {
             expect(removeBundledItems(items)).toEqual(items);
+        });
+    });
+});
+
+describe('removeAndBundleItemsTogether()', () => {
+    describe('when there are no items', () => {
+        it('returns empty nonBundledItems and empty map', () => {
+            const { nonBundledItems, bundleItemsMap } =
+                removeAndBundleItemsTogether(emptyLineItems);
+
+            expect(nonBundledItems).toEqual(emptyLineItems);
+            expect(bundleItemsMap.size).toBe(0);
+        });
+    });
+
+    describe('when all items have no parentId', () => {
+        const items = { ...emptyLineItems, physicalItems: [getPhysicalItem()] };
+
+        it('keeps all items in nonBundledItems and map is empty', () => {
+            const { nonBundledItems, bundleItemsMap } = removeAndBundleItemsTogether(items);
+
+            expect(nonBundledItems.physicalItems).toHaveLength(1);
+            expect(bundleItemsMap.size).toBe(0);
+        });
+    });
+
+    describe('when a physical item has a parentId', () => {
+        const parent = getPhysicalItem();
+        const child = { ...getPhysicalItem(), id: '777', parentId: String(parent.id) };
+        const items = { ...emptyLineItems, physicalItems: [parent, child] };
+
+        it('removes the child from nonBundledItems', () => {
+            const { nonBundledItems } = removeAndBundleItemsTogether(items);
+
+            expect(nonBundledItems.physicalItems).toHaveLength(1);
+            expect(nonBundledItems.physicalItems[0].id).toBe(parent.id);
+        });
+
+        it('adds the child to the map under the parent id key', () => {
+            const { bundleItemsMap } = removeAndBundleItemsTogether(items);
+
+            expect(bundleItemsMap.size).toBe(1);
+            const children = bundleItemsMap.get(String(parent.id));
+
+            expect(children).toHaveLength(1);
+            expect(children![0].id).toBe('777');
+        });
+    });
+
+    describe('when multiple children share the same parentId', () => {
+        const parent = getPhysicalItem();
+        const child1 = { ...getPhysicalItem(), id: '777', parentId: String(parent.id) };
+        const child2 = { ...getPhysicalItem(), id: '888', parentId: String(parent.id) };
+        const items = { ...emptyLineItems, physicalItems: [parent, child1, child2] };
+
+        it('groups all children under the same map key', () => {
+            const { nonBundledItems, bundleItemsMap } = removeAndBundleItemsTogether(items);
+
+            expect(nonBundledItems.physicalItems).toHaveLength(1);
+            const children = bundleItemsMap.get(String(parent.id));
+
+            expect(children).toHaveLength(2);
+        });
+    });
+
+    describe('when a digital item has a parentId', () => {
+        const parent = getDigitalItem();
+        const child = { ...getDigitalItem(), id: '999', parentId: String(parent.id) };
+        const items = { ...emptyLineItems, digitalItems: [parent, child] };
+
+        it('removes the child from nonBundledItems and adds it to the map', () => {
+            const { nonBundledItems, bundleItemsMap } = removeAndBundleItemsTogether(items);
+
+            expect(nonBundledItems.digitalItems).toHaveLength(1);
+            expect(nonBundledItems.digitalItems[0].id).toBe(parent.id);
+
+            const children = bundleItemsMap.get(String(parent.id));
+
+            expect(children).toHaveLength(1);
+            expect(children![0].id).toBe('999');
         });
     });
 });

--- a/packages/core/src/app/order/removeBundledItems.ts
+++ b/packages/core/src/app/order/removeBundledItems.ts
@@ -1,9 +1,49 @@
-import { type LineItemMap } from '@bigcommerce/checkout-sdk';
+import { type DigitalItem, type LineItemMap, type PhysicalItem } from '@bigcommerce/checkout-sdk';
 
-export default function removeBundledItems(lineItems: LineItemMap): LineItemMap {
+export function removeBundledItems(lineItems: LineItemMap): LineItemMap {
     return {
         ...lineItems,
         physicalItems: lineItems.physicalItems.filter((item) => typeof item.parentId !== 'string'),
         digitalItems: lineItems.digitalItems.filter((item) => typeof item.parentId !== 'string'),
+    };
+}
+
+export function removeAndBundleItemsTogether(items: LineItemMap): {
+    nonBundledItems: LineItemMap;
+    bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>>;
+} {
+    const bundleItemsMap = new Map<string | number, Array<PhysicalItem | DigitalItem>>();
+
+    const nonBundledItems = {
+        ...items,
+        physicalItems: items.physicalItems.filter((item) => {
+            if (typeof item.parentId === 'string') {
+                const key = String(item.parentId);
+                const existing = bundleItemsMap.get(key);
+
+                bundleItemsMap.set(key, existing ? [...existing, item] : [item]);
+
+                return false;
+            }
+
+            return true;
+        }),
+        digitalItems: items.digitalItems.filter((item) => {
+            if (typeof item.parentId === 'string') {
+                const key = String(item.parentId);
+                const existing = bundleItemsMap.get(key);
+
+                bundleItemsMap.set(key, existing ? [...existing, item] : [item]);
+
+                return false;
+            }
+
+            return true;
+        }),
+    };
+
+    return {
+        nonBundledItems,
+        bundleItemsMap,
     };
 }

--- a/packages/core/src/scss/components/checkout/productList/_productList.scss
+++ b/packages/core/src/scss/components/checkout/productList/_productList.scss
@@ -63,7 +63,7 @@
     margin-bottom: spacing("eighth");
 }
 
-.product-options {
+.product-options, .product-backorder-details-container {
     color: color("greys");
     font-size: fontSize("tiny");
     margin: 0;
@@ -97,6 +97,20 @@
     color: $color-secondaryDarkest;
     text-decoration: line-through;
     font-weight: fontWeight('medium');
+}
+
+.bundled-items-container {
+    margin-top: spacing("quarter");
+
+    .bundled-item {
+        color: color("greys");
+        font-size: fontSize("tiny");
+        margin: 0;
+    }
+
+    .bundled-item-name {
+        margin-bottom: 0;
+    }
 }
 
 // =============================================================================

--- a/packages/core/src/scss/components/checkout/productList/_productList.scss
+++ b/packages/core/src/scss/components/checkout/productList/_productList.scss
@@ -100,6 +100,7 @@
 }
 
 .bundled-items-container {
+    margin-left: 0;
     margin-top: spacing("quarter");
 
     .bundled-item {
@@ -110,6 +111,10 @@
 
     .bundled-item-name {
         margin-bottom: 0;
+    }
+
+    .body-bold {
+        font-weight: $fontWeight-bold;
     }
 }
 

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -75,6 +75,7 @@
             "backorder_quantities_changed_heading": "The backorder quantities have changed for below items:",
             "cart_stock_modal_destination": "Destination #{consignmentNumber}",
             "ready_to_ship_count_text": "{count} ready to ship",
+            "bundled_item_label": "Bundle:",
             "show_backorder_details": "Show backorder details",
             "hide_backorder_details": "Hide backorder details",
             "print_action": "Print",


### PR DESCRIPTION
## What/Why?
Update bundle item UX, and display backorder information where necessary.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

#### Experiment on

https://github.com/user-attachments/assets/11156aee-2867-4a44-884f-52cb03c14da4

#### Experiment off

https://github.com/user-attachments/assets/e4bf0d0a-d6ad-4d2a-b925-d03ae3454ea8




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout display-only change behind a feature flag; cart totals and payment logic are unchanged, with drawer summary still on the legacy path.
> 
> **Overview**
> When experiment **`BACK-425.update_bundle_item_ux`** is on, checkout order summary **nests pick-list / bundle children under their parent line** instead of only dropping them from the list.
> 
> **Line-item processing:** Adds `removeAndBundleItemsTogether` to group `parentId` children into a map keyed by parent while keeping top-level lines; `removeBundledItems` becomes a named export. `OrderSummaryItems` switches between the two paths based on the experiment.
> 
> **Mapping & UI:** `mapFromPhysical` / `mapFromDigital` accept the bundle map and experiment flag—hiding product options tied to bundled `attributeId`s, using `name: value` option formatting when enabled, and attaching `bundledItems` with backorder fields. `OrderSummaryItem` renders a **Bundle:** labeled sub-list and reuses backorder detail UI for each child; styles and `cart.bundled_item_label` copy are added.
> 
> **Out of scope in this PR:** `OrderSummaryDrawer` still only calls `removeBundledItems`, so the mobile drawer/modal path does not show nested bundles when the experiment is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1f67cc7619afcc6451d7db1dcaff983b765f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->