### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.921.6",
+        "@bigcommerce/checkout-sdk": "^1.921.7",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.921.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.6.tgz",
-      "integrity": "sha512-7tNLGHgu5aHSSEVpBPBk7g01iZ+tG/4zt4eOkSBJkU3wD2Slcndib2pBewP6rv25UPhtacm5gWbNBAN8o+qCtg==",
+      "version": "1.921.7",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.7.tgz",
+      "integrity": "sha512-G5cCzmZoa8xq4L+DsMnZKL1j7rJhuVxGS+9Ib8LYNhlv7kysbBtPcOsmdHv2ha88FEOcAi7w4NOQ8ppf/PUYhw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.921.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.6.tgz",
-      "integrity": "sha512-7tNLGHgu5aHSSEVpBPBk7g01iZ+tG/4zt4eOkSBJkU3wD2Slcndib2pBewP6rv25UPhtacm5gWbNBAN8o+qCtg==",
+      "version": "1.921.7",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.7.tgz",
+      "integrity": "sha512-G5cCzmZoa8xq4L+DsMnZKL1j7rJhuVxGS+9Ib8LYNhlv7kysbBtPcOsmdHv2ha88FEOcAi7w4NOQ8ppf/PUYhw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.921.6",
+    "@bigcommerce/checkout-sdk": "^1.921.7",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout sdk version
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/3279](https://github.com/bigcommerce/checkout-sdk-js/pull/3279)

## Rollout/Rollback
Rollback this PR and all related

## Testing
In checkout-sdk-js PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only bump, but checkout-sdk drives payment/checkout behavior—risk depends on what changed in 1.921.7 upstream, not visible in this diff.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **^1.921.6** to **^1.921.7** in `package.json` and refreshes the lockfile so checkout-js picks up the corresponding SDK release (linked to checkout-sdk-js PR 3279).
> 
> There are **no application source changes** in this repo—only dependency version and integrity metadata updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06491586fe1927170209867c2c5e8b37b38c3747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->