### PR TITLE
fix(other): CHECKOUT-9953 Remove isInitialValid from Formik as it is deprecated

### DIFF
--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -197,21 +197,7 @@ export default withLanguage(
             ),
             orderComment: customerMessage,
         }),
-        isInitialValid: ({ billingAddress, getFields, language }) => {
-            if (!billingAddress) return false;
-
-            const fields = getFields(billingAddress.countryCode);
-            const formValues = mapAddressToFormValues(
-                fields,
-                billingAddress,
-                B2BExtraFieldsSessionStorage.BILLING_KEY,
-            );
-
-            return getAddressFormFieldsValidationSchema({
-                language,
-                formFields: fields,
-            }).isValidSync(formValues);
-        },
+        validateOnMount: true,
         validationSchema: ({
             language,
             getFields,

--- a/packages/core/src/app/common/form/withFormikExtended.tsx
+++ b/packages/core/src/app/common/form/withFormikExtended.tsx
@@ -19,7 +19,7 @@ export default function withFormikExtended<
         const DecoratedComponent: ComponentType<
             TOuterProps & FormikProps<TValues> & WithFormikExtendedProps
         > = (props) => {
-            const { resetForm, isInitialValueLoaded, initialValues } = props;
+            const { resetForm, validateForm, isInitialValueLoaded, initialValues } = props;
             const previousIsInitialValueLoadedRef = useRef(isInitialValueLoaded);
 
             useEffect(() => {
@@ -28,10 +28,11 @@ export default function withFormikExtended<
                     isInitialValueLoaded === true
                 ) {
                     resetForm({ values: initialValues ?? {} });
+                    void validateForm(initialValues ?? {});
                 }
 
                 previousIsInitialValueLoadedRef.current = isInitialValueLoaded;
-            }, [isInitialValueLoaded, initialValues, resetForm]);
+            }, [isInitialValueLoaded, initialValues, resetForm, validateForm]);
 
             return <OriginalComponent {...props} />;
         };

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -350,22 +350,7 @@ export default withLanguage(
                 B2BExtraFieldsSessionStorage.SHIPPING_KEY,
             ),
         }),
-        isInitialValid: ({ shippingAddress, getFields, language, validateMaxLength }) => {
-            if (!shippingAddress) return false;
-
-            const fields = getFields(shippingAddress.countryCode);
-            const formValues = mapAddressToFormValues(
-                fields,
-                shippingAddress,
-                B2BExtraFieldsSessionStorage.SHIPPING_KEY,
-            );
-
-            return getAddressFormFieldsValidationSchema({
-                language,
-                formFields: fields,
-                validateMaxLength,
-            }).isValidSync(formValues);
-        },
+        validateOnMount: true,
         validationSchema: ({
             language,
             getFields,

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
@@ -162,12 +162,7 @@ export default withLanguage(
                 shippingAddress,
             ),
         }),
-        isInitialValid: ({ shippingAddress, getFields, language }) =>
-            !!shippingAddress &&
-            getAddressFormFieldsValidationSchema({
-                language,
-                formFields: getFields(shippingAddress.countryCode),
-            }).isValidSync(shippingAddress),
+        validateOnMount: true,
         validationSchema: ({
             language,
             getFields,


### PR DESCRIPTION
## What/Why?

This PR removes the custom `isInitialValid` pattern and replaces it with Formik's built-in `validateOnMount: true` across the following address forms:

- BillingForm.tsx
- SingleShippingForm.tsx
- StripeShippingForm.tsx

In addition, see changes in `withFormikExtended.tsx`. When initial values load asynchronously (e.g. pre-filled address data arrives), it now calls `validateForm()` immediately after `resetForm()`, so validity state is in sync right away.

## Rollout/Rollback

Revert this PR.

## Testing

No new UI is introduced - this only affects form validation state.
Tested with CI + manual testing on VM store:

https://github.com/user-attachments/assets/62b7b0cf-b6fd-436b-b353-f69f760e190d



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkout billing/shipping forms compute initial validity and `isValid` after async address load, which can affect continue buttons, shipping autosave, and when shipping options appear.
> 
> **Overview**
> Replaces deprecated Formik **`isInitialValid`** (sync Yup checks on mapped address values) with **`validateOnMount: true`** on **billing**, **single shipping**, and **Stripe UPE shipping** forms so initial validity still runs through the normal validation schema.
> 
> Updates **`withFormikExtended`** so when **`isInitialValueLoaded`** flips from false to true—after **`resetForm`** with loaded **`initialValues`**—it also calls **`validateForm`**, keeping correct **`isValid`** for forms that render before checkout address data is ready (shipping flows using deferred load).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48bfde4bd046fa7da8b3b6448d37a79f152e77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->