### PR TITLE
feat(checkout): CHECKOUT-9819 add additional payment field for b2b

### DIFF
--- a/packages/cheque-payment-integration/src/PoNumber.tsx
+++ b/packages/cheque-payment-integration/src/PoNumber.tsx
@@ -30,12 +30,12 @@ const PoNumber: FunctionComponent<PoNumberProps> = ({
 }) => {
     useEffect(() => {
         setFieldValue(PO_NUMBER_FIELD_NAME, getPoNumber());
-        setValidationSchema(method, getPoNumberValidationSchema(language, isRequired));
+        setValidationSchema(method, getPoNumberValidationSchema(language, isRequired, label));
 
         return () => {
             setValidationSchema(method, null);
         };
-    }, [isRequired, language, method, setFieldValue, setValidationSchema]);
+    }, [isRequired, label, language, method, setFieldValue, setValidationSchema]);
 
     const renderInput = useCallback(
         ({ field }: FieldProps<string>) => (
@@ -67,7 +67,7 @@ const PoNumber: FunctionComponent<PoNumberProps> = ({
                             {!isRequired && (
                                 <span>
                                     {' '}
-                                    <TranslatedString id="payment.po_number_optional" />
+                                    <TranslatedString id="common.optional_text" />
                                 </span>
                             )}
                         </label>

--- a/packages/cheque-payment-integration/src/getPoNumberValidationSchema.ts
+++ b/packages/cheque-payment-integration/src/getPoNumberValidationSchema.ts
@@ -5,12 +5,15 @@ import { object, type ObjectSchema, string } from 'yup';
 export default memoize(function getPoNumberValidationSchema(
     language: LanguageService,
     isRequired: boolean,
+    label: string,
 ): ObjectSchema {
     if (!isRequired) {
         return object({});
     }
 
     return object({
-        poNumber: string().trim().required(language.translate('payment.po_number_required_error')),
+        poNumber: string()
+            .trim()
+            .required(language.translate('payment.errors.field_required_error', { label })),
     });
 });

--- a/packages/core/src/app/payment/AdditionalPaymentField.test.tsx
+++ b/packages/core/src/app/payment/AdditionalPaymentField.test.tsx
@@ -1,0 +1,80 @@
+import { Formik } from 'formik';
+import { noop } from 'lodash';
+import React from 'react';
+
+import { LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { createLocaleContext } from '@bigcommerce/checkout/locale';
+import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
+
+import { getStoreConfig } from '../config/config.mock';
+
+import AdditionalPaymentField from './AdditionalPaymentField';
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
+
+describe('AdditionalPaymentField', () => {
+    const localeContext: LocaleContextType = createLocaleContext(getStoreConfig());
+
+    const renderField = (
+        { label = 'Notes', isRequired = false }: { label?: string; isRequired?: boolean } = {},
+        initialValue = '',
+    ) =>
+        render(
+            <LocaleContext.Provider value={localeContext}>
+                <Formik initialValues={{ additionalPaymentField: initialValue }} onSubmit={noop}>
+                    <AdditionalPaymentField isRequired={isRequired} label={label} />
+                </Formik>
+            </LocaleContext.Provider>,
+        );
+
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('renders the provided label and an input', () => {
+        renderField({ label: 'Delivery instructions' });
+
+        expect(screen.getByText('Delivery instructions')).toBeInTheDocument();
+        expect(screen.getByTestId('additionalPaymentField-input')).toBeInTheDocument();
+    });
+
+    it('shows the optional hint when isRequired is false', () => {
+        renderField({ isRequired: false });
+
+        expect(
+            screen.getByText(
+                localeContext.language.translate('common.optional_text'),
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('does not show the optional hint when isRequired is true', () => {
+        renderField({ isRequired: true });
+
+        expect(
+            screen.queryByText(
+                localeContext.language.translate('common.optional_text'),
+            ),
+        ).not.toBeInTheDocument();
+    });
+
+    it('writes the typed value to session storage on change', () => {
+        renderField();
+
+        fireEvent.change(screen.getByTestId('additionalPaymentField-input'), {
+            target: { value: 'leave at front door' },
+        });
+
+        expect(AdditionalPaymentFieldSessionStorage.get()).toBe('leave at front door');
+    });
+
+    it('removes the key from session storage when the field is cleared', () => {
+        sessionStorage.setItem(AdditionalPaymentFieldSessionStorage.KEY, 'existing');
+        renderField({}, 'existing');
+
+        fireEvent.change(screen.getByTestId('additionalPaymentField-input'), {
+            target: { value: '' },
+        });
+
+        expect(sessionStorage.getItem(AdditionalPaymentFieldSessionStorage.KEY)).toBeNull();
+    });
+});

--- a/packages/core/src/app/payment/AdditionalPaymentField.test.tsx
+++ b/packages/core/src/app/payment/AdditionalPaymentField.test.tsx
@@ -41,9 +41,7 @@ describe('AdditionalPaymentField', () => {
         renderField({ isRequired: false });
 
         expect(
-            screen.getByText(
-                localeContext.language.translate('common.optional_text'),
-            ),
+            screen.getByText(localeContext.language.translate('common.optional_text')),
         ).toBeInTheDocument();
     });
 
@@ -51,9 +49,7 @@ describe('AdditionalPaymentField', () => {
         renderField({ isRequired: true });
 
         expect(
-            screen.queryByText(
-                localeContext.language.translate('common.optional_text'),
-            ),
+            screen.queryByText(localeContext.language.translate('common.optional_text')),
         ).not.toBeInTheDocument();
     });
 

--- a/packages/core/src/app/payment/AdditionalPaymentField.tsx
+++ b/packages/core/src/app/payment/AdditionalPaymentField.tsx
@@ -1,0 +1,57 @@
+import { type FieldProps } from 'formik';
+import React, { type FunctionComponent, useCallback } from 'react';
+
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { FormField, TextInput } from '@bigcommerce/checkout/ui';
+
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
+
+interface AdditionalPaymentFieldProps {
+    label: string;
+    isRequired: boolean;
+}
+
+const AdditionalPaymentField: FunctionComponent<AdditionalPaymentFieldProps> = ({
+    label,
+    isRequired,
+}) => {
+    const renderInput = useCallback(
+        ({ field }: FieldProps<string>) => (
+            <TextInput
+                {...field}
+                id="additionalPaymentField"
+                onChange={(event) => {
+                    field.onChange(event);
+                    AdditionalPaymentFieldSessionStorage.set(event.target.value);
+                }}
+                testId="additionalPaymentField-input"
+            />
+        ),
+        [],
+    );
+
+    return (
+        <div className="dynamic-form-field">
+            <FormField
+                id="additionalPaymentField"
+                input={renderInput}
+                labelContent={
+                    <>
+                        {label}
+                        {!isRequired && (
+                            <>
+                                {' '}
+                                <small>
+                                    <TranslatedString id="common.optional_text" />
+                                </small>
+                            </>
+                        )}
+                    </>
+                }
+                name="additionalPaymentField"
+            />
+        </div>
+    );
+};
+
+export default AdditionalPaymentField;

--- a/packages/core/src/app/payment/AdditionalPaymentFieldSessionStorage.test.ts
+++ b/packages/core/src/app/payment/AdditionalPaymentFieldSessionStorage.test.ts
@@ -1,0 +1,39 @@
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
+
+describe('AdditionalPaymentFieldSessionStorage', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('writes the value to session storage', () => {
+        AdditionalPaymentFieldSessionStorage.set('foo');
+
+        expect(sessionStorage.getItem(AdditionalPaymentFieldSessionStorage.KEY)).toBe('foo');
+    });
+
+    it('removes the key when set to an empty string', () => {
+        sessionStorage.setItem(AdditionalPaymentFieldSessionStorage.KEY, 'existing');
+
+        AdditionalPaymentFieldSessionStorage.set('');
+
+        expect(sessionStorage.getItem(AdditionalPaymentFieldSessionStorage.KEY)).toBeNull();
+    });
+
+    it('returns an empty string when the key is absent', () => {
+        expect(AdditionalPaymentFieldSessionStorage.get()).toBe('');
+    });
+
+    it('returns the stored value when present', () => {
+        sessionStorage.setItem(AdditionalPaymentFieldSessionStorage.KEY, 'hello');
+
+        expect(AdditionalPaymentFieldSessionStorage.get()).toBe('hello');
+    });
+
+    it('removes the key on remove()', () => {
+        sessionStorage.setItem(AdditionalPaymentFieldSessionStorage.KEY, 'gone soon');
+
+        AdditionalPaymentFieldSessionStorage.remove();
+
+        expect(sessionStorage.getItem(AdditionalPaymentFieldSessionStorage.KEY)).toBeNull();
+    });
+});

--- a/packages/core/src/app/payment/AdditionalPaymentFieldSessionStorage.ts
+++ b/packages/core/src/app/payment/AdditionalPaymentFieldSessionStorage.ts
@@ -1,0 +1,21 @@
+export class AdditionalPaymentFieldSessionStorage {
+    static readonly KEY = 'additionalPaymentField';
+
+    static get(): string {
+        return sessionStorage.getItem(this.KEY) ?? '';
+    }
+
+    static set(value: string): void {
+        if (value === '') {
+            sessionStorage.removeItem(this.KEY);
+
+            return;
+        }
+
+        sessionStorage.setItem(this.KEY, value);
+    }
+
+    static remove(): void {
+        sessionStorage.removeItem(this.KEY);
+    }
+}

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -663,6 +663,7 @@ const Payment = (
             <ChecklistSkeleton isLoading={!state.isReady}>
                 {shouldShowPaymentForm && (
                     <PaymentForm
+                        additionalField={props.capabilities.payment.additionalField}
                         availableStoreCredit={props.availableStoreCredit}
                         defaultGatewayId={props.defaultMethod?.gateway}
                         defaultMethodId={props.defaultMethod?.id || ''}

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -397,9 +397,7 @@ describe('PaymentForm', () => {
             expect(screen.getByTestId('additionalPaymentField-input')).toBeInTheDocument();
             expect(screen.getByText('Order notes')).toBeInTheDocument();
             expect(
-                screen.getByText(
-                    localeContext.language.translate('common.optional_text'),
-                ),
+                screen.getByText(localeContext.language.translate('common.optional_text')),
             ).toBeInTheDocument();
         });
 
@@ -418,9 +416,7 @@ describe('PaymentForm', () => {
             );
 
             expect(
-                screen.queryByText(
-                    localeContext.language.translate('common.optional_text'),
-                ),
+                screen.queryByText(localeContext.language.translate('common.optional_text')),
             ).not.toBeInTheDocument();
         });
 

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -26,6 +26,7 @@ import { createErrorLogger } from '../common/error';
 import { getStoreConfig } from '../config/config.mock';
 import { getCustomer } from '../customer/customers.mock';
 
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
 import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 import { getPaymentMethod } from './payment-methods.mock';
 import PaymentContext, { type PaymentContextProps } from './PaymentContext';
@@ -377,6 +378,114 @@ describe('PaymentForm', () => {
             expect(onSubmit).toHaveBeenCalledWith(
                 expect.not.objectContaining({ invoicePaymentComment: expect.anything() }),
             );
+        });
+    });
+
+    describe('additional payment field', () => {
+        beforeEach(() => {
+            sessionStorage.clear();
+        });
+
+        it('renders the field when the additionalField capability is set', () => {
+            render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    additionalField={{ label: 'Order notes', required: false }}
+                />,
+            );
+
+            expect(screen.getByTestId('additionalPaymentField-input')).toBeInTheDocument();
+            expect(screen.getByText('Order notes')).toBeInTheDocument();
+            expect(
+                screen.getByText(
+                    localeContext.language.translate('common.optional_text'),
+                ),
+            ).toBeInTheDocument();
+        });
+
+        it('does not render the field when the additionalField capability is null', () => {
+            render(<PaymentFormTest {...defaultProps} />);
+
+            expect(screen.queryByTestId('additionalPaymentField-input')).not.toBeInTheDocument();
+        });
+
+        it('hides the optional hint when the field is required', () => {
+            render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    additionalField={{ label: 'Order notes', required: true }}
+                />,
+            );
+
+            expect(
+                screen.queryByText(
+                    localeContext.language.translate('common.optional_text'),
+                ),
+            ).not.toBeInTheDocument();
+        });
+
+        it('seeds the field from session storage when a value is stored', () => {
+            AdditionalPaymentFieldSessionStorage.set('restored note');
+
+            render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    additionalField={{ label: 'Order notes', required: false }}
+                />,
+            );
+
+            expect(screen.getByDisplayValue('restored note')).toBeInTheDocument();
+        });
+
+        it('writes typed values to session storage and strips them from the submit payload', async () => {
+            const onSubmit = jest.fn();
+
+            render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    additionalField={{ label: 'Order notes', required: false }}
+                    onSubmit={onSubmit}
+                />,
+            );
+
+            fireEvent.change(screen.getByTestId('additionalPaymentField-input'), {
+                target: { value: 'special handling' },
+            });
+
+            expect(AdditionalPaymentFieldSessionStorage.get()).toBe('special handling');
+
+            fireEvent.submit(screen.getByTestId('payment-form'));
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.not.objectContaining({ additionalPaymentField: expect.anything() }),
+            );
+        });
+
+        it('blocks submit and shows a validation error when required and empty', async () => {
+            const onSubmit = jest.fn();
+
+            render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    additionalField={{ label: 'Order notes', required: true }}
+                    onSubmit={onSubmit}
+                />,
+            );
+
+            fireEvent.submit(screen.getByTestId('payment-form'));
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(onSubmit).not.toHaveBeenCalled();
+            expect(
+                screen.getByText(
+                    localeContext.language.translate('payment.errors.field_required_error', {
+                        label: 'Order notes',
+                    }),
+                ),
+            ).toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -1,4 +1,5 @@
 import {
+    type Capabilities,
     ExtensionRegion,
     type FormField,
     type PaymentMethod,
@@ -6,7 +7,7 @@ import {
 import { type FormikProps, type FormikState, withFormik, type WithFormikConfig } from 'formik';
 import { isEmpty, isNil, noop, omitBy } from 'lodash';
 import React, { type FunctionComponent, memo, useCallback, useContext, useMemo } from 'react';
-import { type ObjectSchema } from 'yup';
+import { object, type ObjectSchema, string } from 'yup';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
 import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
@@ -23,6 +24,8 @@ import { isExperimentEnabled } from '../common/utility';
 import { getOrderExtraFieldsValidationSchema } from '../formFields';
 import { TermsConditions } from '../termsConditions';
 
+import AdditionalPaymentField from './AdditionalPaymentField';
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
 import getPaymentValidationSchema from './getPaymentValidationSchema';
 import InvoicePaymentCommentField from './InvoicePaymentCommentField';
 import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
@@ -42,6 +45,7 @@ import SpamProtectionField from './SpamProtectionField';
 import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
 
 export interface PaymentFormProps {
+    additionalField?: Capabilities['payment']['additionalField'];
     availableStoreCredit?: number;
     disableStoreCredit?: boolean;
     defaultGatewayId?: string;
@@ -73,6 +77,7 @@ export interface PaymentFormProps {
 const PaymentForm: FunctionComponent<
     PaymentFormProps & FormikProps<PaymentFormValues> & WithLanguageProps
 > = ({
+    additionalField,
     availableStoreCredit = 0,
     disableStoreCredit = false,
     didExceedSpamLimit,
@@ -195,6 +200,13 @@ const PaymentForm: FunctionComponent<
             )}
 
             <PaymentRedeemables />
+
+            {additionalField && (
+                <AdditionalPaymentField
+                    isRequired={additionalField.required}
+                    label={additionalField.label}
+                />
+            )}
 
             {isTermsConditionsRequired && (
                 <TermsConditions
@@ -352,6 +364,7 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
                     storedOrderExtraFields,
                 ),
                 invoicePaymentComment: InvoicePaymentCommentSessionStorage.get(),
+                additionalPaymentField: AdditionalPaymentFieldSessionStorage.get(),
             };
         },
 
@@ -359,10 +372,12 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
             const {
                 orderExtraFields,
                 invoicePaymentComment: _invoicePaymentComment,
+                additionalPaymentField: _additionalPaymentField,
                 ...rest
             } = values as PaymentFormValues & {
                 orderExtraFields?: Record<string, unknown>;
                 invoicePaymentComment?: string;
+                additionalPaymentField?: string;
             };
 
             if (orderExtraFields && Object.keys(orderExtraFields).length > 0) {
@@ -378,6 +393,7 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
         },
 
         validationSchema: ({
+            additionalField,
             isPaymentDataRequired,
             language,
             isTermsConditionsRequired = false,
@@ -391,16 +407,31 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
                 language,
             });
 
-            if (!orderExtraFields || orderExtraFields.length === 0) {
-                return paymentSchema;
+            const withOrderExtraFields =
+                orderExtraFields && orderExtraFields.length > 0
+                    ? paymentSchema.concat(
+                          getOrderExtraFieldsValidationSchema({
+                              formFields: orderExtraFields,
+                              translate: getTranslateAddressError(orderExtraFields, language),
+                          }),
+                      )
+                    : paymentSchema;
+
+            if (additionalField?.required) {
+                return withOrderExtraFields.concat(
+                    object({
+                        additionalPaymentField: string()
+                            .trim()
+                            .required(
+                                language.translate('payment.errors.field_required_error', {
+                                    label: additionalField.label,
+                                }),
+                            ),
+                    }) as ObjectSchema<Partial<PaymentFormValues>>,
+                );
             }
 
-            return paymentSchema.concat(
-                getOrderExtraFieldsValidationSchema({
-                    formFields: orderExtraFields,
-                    translate: getTranslateAddressError(orderExtraFields, language),
-                }),
-            );
+            return withOrderExtraFields;
         },
     };
 

--- a/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
+++ b/packages/core/src/scss/components/checkout/paymentProvider/_paymentProvider.scss
@@ -73,6 +73,7 @@
     color: color("greys", "dark");
     flex-basis: 100%;
     font-size: fontSize("smallest");
+    line-height: lineHeight("base");
 }
 
 .paymentMethod--creditCard,

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -201,9 +201,6 @@
             "unsupported_error": "The following payment methods are not supported by Embedded Checkout: {methods}. Please contact us for assistance."
         },
         "payment": {
-            "po_number_label": "PO Number / Reference Number",
-            "po_number_optional": "(Optional)",
-            "po_number_required_error": "PO Number / Reference Number is required.",
             "affirm_name_text": "Affirm",
             "affirm_display_name_text": "Pay over time",
             "affirm_body_text": "You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.",
@@ -401,6 +398,7 @@
             "phone_number_label": "Phone Number",
             "errors": {
                 "account_number_required_error": "Account Number is required",
+                "field_required_error": "{label} is required",
                 "routing_number_required_error": "Routing Number is required",
                 "phone_number_required_error": "Phone Number is required",
                 "business_name_required_error": "Business Name is required",


### PR DESCRIPTION
## What/Why?

Add the additional payment field based on payment.additionalField capability in the payment form.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

https://github.com/user-attachments/assets/798985f5-7ff5-455a-acda-0c8fbbda6159


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout payment form validation and submit handling; the new field’s value is session-only and not sent in the submit payload, so downstream order mapping must already read it from storage if required.
> 
> **Overview**
> Adds a **configurable extra text field** on the payment step when `capabilities.payment.additionalField` is set (custom label and optional/required). The value is kept in **session storage**, restored on reload, validated when required, and **omitted from the Formik submit payload** (same pattern as the invoice payment comment).
> 
> **PO / reference number** validation and copy are aligned with this approach: optional hint uses `common.optional_text`, and required errors use the shared `payment.errors.field_required_error` with the field label. PO-specific English strings were removed in favor of that generic error key.
> 
> Includes unit tests for the new field and storage helper, plus a small style tweak for the PO-disabled message line height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745ca5f2646e6d8d935a7a0fcf68e05487aa25d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->