### PR TITLE
feat(checkout): CHECKOUT-9813 Submit Invoice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.921.7",
+        "@bigcommerce/checkout-sdk": "^1.922.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.921.7",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.7.tgz",
-      "integrity": "sha512-G5cCzmZoa8xq4L+DsMnZKL1j7rJhuVxGS+9Ib8LYNhlv7kysbBtPcOsmdHv2ha88FEOcAi7w4NOQ8ppf/PUYhw==",
+      "version": "1.922.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.0.tgz",
+      "integrity": "sha512-OURiXK4y8xoU+KzDSN53hpNKRcFrXOdKhaRcvzS71lGqerYCgBwKv7hBchHcKXgDxFGIDf1toD8Fpq0PgmAxcg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.921.7",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.921.7.tgz",
-      "integrity": "sha512-G5cCzmZoa8xq4L+DsMnZKL1j7rJhuVxGS+9Ib8LYNhlv7kysbBtPcOsmdHv2ha88FEOcAi7w4NOQ8ppf/PUYhw==",
+      "version": "1.922.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.0.tgz",
+      "integrity": "sha512-OURiXK4y8xoU+KzDSN53hpNKRcFrXOdKhaRcvzS71lGqerYCgBwKv7hBchHcKXgDxFGIDf1toD8Fpq0PgmAxcg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.921.7",
+    "@bigcommerce/checkout-sdk": "^1.922.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/cart/CartHeaderLink.tsx
+++ b/packages/core/src/app/cart/CartHeaderLink.tsx
@@ -1,0 +1,46 @@
+import React, { type FunctionComponent } from 'react';
+
+import { useCapabilities } from '@bigcommerce/checkout/contexts';
+import { hideEditCartLink } from '@bigcommerce/checkout/utility';
+
+import EditLink from './EditLink';
+
+export interface CartHeaderLinkProps {
+    cartUrl: string;
+    isBuyNowCart: boolean;
+    isMultiShippingMode: boolean;
+    className?: string;
+    label?: React.ReactNode;
+}
+
+const CartHeaderLink: FunctionComponent<CartHeaderLinkProps> = ({
+    cartUrl,
+    className,
+    isBuyNowCart,
+    isMultiShippingMode,
+    label,
+}) => {
+    const {
+        userJourney: { disableEditCart },
+        orderConfirmation: { invoiceRedirect },
+    } = useCapabilities();
+
+    if (invoiceRedirect) {
+        return <EditLink className={className} isInvoiceRedirectEnabled={true} />;
+    }
+
+    if (hideEditCartLink(isBuyNowCart, disableEditCart)) {
+        return null;
+    }
+
+    return (
+        <EditLink
+            className={className}
+            isMultiShippingMode={isMultiShippingMode}
+            label={label}
+            url={cartUrl}
+        />
+    );
+};
+
+export default CartHeaderLink;

--- a/packages/core/src/app/cart/CartHeaderLink.tsx
+++ b/packages/core/src/app/cart/CartHeaderLink.tsx
@@ -5,7 +5,7 @@ import { hideEditCartLink } from '@bigcommerce/checkout/utility';
 
 import EditLink from './EditLink';
 
-export interface CartHeaderLinkProps {
+interface CartHeaderLinkProps {
     cartUrl: string;
     isBuyNowCart: boolean;
     isMultiShippingMode: boolean;
@@ -13,7 +13,7 @@ export interface CartHeaderLinkProps {
     label?: React.ReactNode;
 }
 
-const CartHeaderLink: FunctionComponent<CartHeaderLinkProps> = ({
+export const CartHeaderLink: FunctionComponent<CartHeaderLinkProps> = ({
     cartUrl,
     className,
     isBuyNowCart,
@@ -42,5 +42,3 @@ const CartHeaderLink: FunctionComponent<CartHeaderLinkProps> = ({
         />
     );
 };
-
-export default CartHeaderLink;

--- a/packages/core/src/app/cart/CartSummary.tsx
+++ b/packages/core/src/app/cart/CartSummary.tsx
@@ -4,7 +4,7 @@ import React, { type FunctionComponent } from 'react';
 import { withCheckout } from '../checkout';
 import OrderSummary from '../order/OrderSummary';
 
-import CartHeaderLink from './CartHeaderLink';
+import { CartHeaderLink } from './CartHeaderLink';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import { type RedeemableProps } from './Redeemable';
 import withRedeemable from './withRedeemable';

--- a/packages/core/src/app/cart/CartSummary.tsx
+++ b/packages/core/src/app/cart/CartSummary.tsx
@@ -1,13 +1,10 @@
 import { type Checkout, type ShopperCurrency, type StoreCurrency } from '@bigcommerce/checkout-sdk';
 import React, { type FunctionComponent } from 'react';
 
-import { useCapabilities } from '@bigcommerce/checkout/contexts';
-import { hideEditCartLink } from '@bigcommerce/checkout/utility';
-
 import { withCheckout } from '../checkout';
 import OrderSummary from '../order/OrderSummary';
 
-import EditLink from './EditLink';
+import CartHeaderLink from './CartHeaderLink';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import { type RedeemableProps } from './Redeemable';
 import withRedeemable from './withRedeemable';
@@ -27,19 +24,17 @@ const CartSummary: FunctionComponent<
         isMultiShippingMode: boolean;
     }
 > = ({ cartUrl, isMultiShippingMode, isBuyNowCart, ...props }) => {
-    const {
-        userJourney: { disableEditCart },
-    } = useCapabilities();
-
-    const headerLink = hideEditCartLink(isBuyNowCart, disableEditCart) ? null : (
-        <EditLink isMultiShippingMode={isMultiShippingMode} url={cartUrl} />
-    );
-
     return withRedeemable(OrderSummary)({
         ...props,
         cartUrl,
         isBuyNowCart,
-        headerLink,
+        headerLink: (
+            <CartHeaderLink
+                cartUrl={cartUrl}
+                isBuyNowCart={isBuyNowCart}
+                isMultiShippingMode={isMultiShippingMode}
+            />
+        ),
     });
 };
 

--- a/packages/core/src/app/cart/CartSummaryDrawer.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawer.tsx
@@ -3,7 +3,7 @@ import React, { type FunctionComponent, memo } from 'react';
 import { withCheckout } from '../checkout';
 import OrderSummaryDrawer from '../order/OrderSummaryDrawer';
 
-import CartHeaderLink from './CartHeaderLink';
+import { CartHeaderLink } from './CartHeaderLink';
 import { type WithCheckoutCartSummaryProps } from './CartSummary';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import withRedeemable from './withRedeemable';

--- a/packages/core/src/app/cart/CartSummaryDrawer.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawer.tsx
@@ -1,13 +1,10 @@
 import React, { type FunctionComponent, memo } from 'react';
 
-import { useCapabilities } from '@bigcommerce/checkout/contexts';
-import { hideEditCartLink } from '@bigcommerce/checkout/utility';
-
 import { withCheckout } from '../checkout';
 import OrderSummaryDrawer from '../order/OrderSummaryDrawer';
 
+import CartHeaderLink from './CartHeaderLink';
 import { type WithCheckoutCartSummaryProps } from './CartSummary';
-import EditLink from './EditLink';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import withRedeemable from './withRedeemable';
 
@@ -16,19 +13,16 @@ const CartSummaryDrawer: FunctionComponent<
         isMultiShippingMode: boolean;
     }
 > = ({ cartUrl, isMultiShippingMode, isBuyNowCart, ...props }) => {
-    const {
-        userJourney: { disableEditCart },
-    } = useCapabilities();
-
     return withRedeemable(OrderSummaryDrawer)({
         ...props,
         isBuyNowCart,
         cartUrl,
-        headerLink: hideEditCartLink(isBuyNowCart, disableEditCart) ? null : (
-            <EditLink
+        headerLink: (
+            <CartHeaderLink
+                cartUrl={cartUrl}
                 className="modal-header-link cart-modal-link"
+                isBuyNowCart={isBuyNowCart}
                 isMultiShippingMode={isMultiShippingMode}
-                url={cartUrl}
             />
         ),
     });

--- a/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
@@ -5,7 +5,7 @@ import {
 } from '@bigcommerce/checkout-sdk';
 import React, { type FunctionComponent, useRef, useState } from 'react';
 
-import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
+import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import {
     CollapseCSSTransition,
@@ -13,12 +13,11 @@ import {
     IconChevronDown,
     IconChevronUp,
 } from '@bigcommerce/checkout/ui';
-import { hideEditCartLink } from '@bigcommerce/checkout/utility';
 
 import { ShopperCurrency } from '../currency';
 import OrderSummary from '../order/OrderSummary';
 
-import EditLink from './EditLink';
+import CartHeaderLink from './CartHeaderLink';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import { type RedeemableProps } from './Redeemable';
 import withRedeemable from './withRedeemable';
@@ -45,9 +44,6 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
     const nodeRef = useRef<HTMLDivElement>(null);
 
     const checkoutContext = useCheckout();
-    const {
-        userJourney: { disableEditCart },
-    } = useCapabilities();
     const props = mapToCartSummaryProps(checkoutContext);
 
     if (!props) {
@@ -56,19 +52,16 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
 
     const { cartUrl, isBuyNowCart, checkout } = props;
 
-    const headerLink = hideEditCartLink(isBuyNowCart, disableEditCart) ? null : (
-        <EditLink
-            isMultiShippingMode={isMultiShippingMode}
-            label={<TranslatedString id="cart.go_to_cart_action" />}
-            url={cartUrl}
-        />
-    );
-
     return (
         <div className="cart-summary-drawer">
             <div className="cart-summary-header">
                 <IconArrowLeft />
-                {headerLink}
+                <CartHeaderLink
+                    cartUrl={cartUrl}
+                    isBuyNowCart={isBuyNowCart}
+                    isMultiShippingMode={isMultiShippingMode}
+                    label={<TranslatedString id="cart.go_to_cart_action" />}
+                />
             </div>
             <button
                 aria-expanded={isExpanded}

--- a/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
@@ -17,7 +17,7 @@ import {
 import { ShopperCurrency } from '../currency';
 import OrderSummary from '../order/OrderSummary';
 
-import CartHeaderLink from './CartHeaderLink';
+import { CartHeaderLink } from './CartHeaderLink';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import { type RedeemableProps } from './Redeemable';
 import withRedeemable from './withRedeemable';

--- a/packages/core/src/app/cart/EditLink.tsx
+++ b/packages/core/src/app/cart/EditLink.tsx
@@ -7,15 +7,17 @@ import { ConfirmationModal } from '@bigcommerce/checkout/ui';
 
 export interface EditLinkProps {
     className?: string;
-    isMultiShippingMode: boolean;
-    url: string;
+    url?: string;
+    isInvoiceRedirectEnabled?: boolean;
+    isMultiShippingMode?: boolean;
     label?: React.ReactNode;
 }
 
 const EditLink: FunctionComponent<EditLinkProps> = ({
     className,
-    url,
-    isMultiShippingMode,
+    url = '',
+    isMultiShippingMode = false,
+    isInvoiceRedirectEnabled = false,
     label,
 }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -23,6 +25,20 @@ const EditLink: FunctionComponent<EditLinkProps> = ({
     const gotoCartPage = () => {
         window.location.assign(url);
     };
+
+    if (isInvoiceRedirectEnabled) {
+        return (
+            <a
+                className={classNames(className || 'cart-header-link', 'body-cta')}
+                data-test="cart-edit-link"
+                href="/account.php?action=order_status/#/invoice"
+                id="cart-edit-link"
+                target="_top"
+            >
+                {label || <TranslatedString id="cart.back_to_invoices" />}
+            </a>
+        );
+    }
 
     if (isMultiShippingMode) {
         return (

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -611,12 +611,27 @@ describe('Checkout', () => {
                         getOrder: () => ({ orderId: 123 }) as any,
                     },
                 } as any);
+                jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockResolvedValue(
+                    {} as any,
+                );
+                jest.spyOn(checkoutService, 'persistB2BMetadata').mockResolvedValue({} as any);
+
+                const getState = checkoutService.getState.bind(checkoutService);
+
+                jest.spyOn(checkoutService, 'getState').mockImplementation(() => {
+                    const state = getState();
+
+                    state.data.getB2BReceiptId = () => '123';
+
+                    return state;
+                });
 
                 const invoiceRedirectCapabilities = {
                     ...defaultCapabilities,
                     orderConfirmation: {
                         ...defaultCapabilities.orderConfirmation,
                         invoiceRedirect: true,
+                        persistB2BMetadata: true,
                     },
                 };
 
@@ -649,7 +664,7 @@ describe('Checkout', () => {
 
                 await waitFor(() => {
                     expect(window.location.replace).toHaveBeenCalledWith(
-                        'https://store.url/#/invoice?receiptId=',
+                        'https://store.url/#/invoice?receiptId=123',
                     );
                 });
             } finally {

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -27,6 +27,7 @@ import {
     type AnalyticsContextProps,
     type ExtensionContextProps,
     useCapabilities,
+    useCheckout,
     withExtension,
 } from '@bigcommerce/checkout/contexts';
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
@@ -152,6 +153,7 @@ const Checkout = ({
         orderConfirmation: { invoiceRedirect },
     } = capabilities;
     const { fetchB2BToken } = useB2BToken();
+    const { checkoutService } = useCheckout();
 
     const [state, setState] = useState<CheckoutState>({
         isBillingSameAsShipping: true,
@@ -246,11 +248,12 @@ const Checkout = ({
 
         setState((prevState) => ({ ...prevState, isRedirecting: true }));
 
-        if (invoiceRedirect && orderId !== undefined) {
+        const receiptId = checkoutService.getState().data.getB2BReceiptId();
+
+        if (invoiceRedirect && receiptId) {
             const { links: { siteLink = '' } = {} } = data.getConfig() || {};
 
-            // TODO: CHECKOUT-9813 Get receiptId via B2B v1 API, more details in CHECKOUT-9813
-            window.location.replace(`${siteLink}/#/invoice?receiptId=`);
+            window.location.replace(`${siteLink}/#/invoice?receiptId=${receiptId}`);
 
             return;
         }

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -32,7 +32,7 @@ import {
     orderResponse,
     payments,
 } from '@bigcommerce/checkout/test-framework';
-import { renderWithoutWrapper as render, screen } from '@bigcommerce/checkout/test-utils';
+import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
@@ -699,6 +699,79 @@ describe('Payment step', () => {
             await act(async () => userEvent.click(screen.getByText('Place Order')));
 
             expect(submitOrderSpy).not.toHaveBeenCalled();
+        });
+
+        it('persists B2B metadata after finalizing the order on mount when persistB2BMetadata capability is enabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith({ isInvoice: false, invoiceComment: '' }),
+            );
+        });
+
+        it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            const finalizeSpy = jest
+                .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+                .mockResolvedValue(checkoutService.getState());
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() => expect(finalizeSpy).toHaveBeenCalled());
+
+            expect(persistSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -59,6 +59,7 @@ import { EMPTY_ARRAY, isExperimentEnabled } from '../common/utility';
 import { TermsConditionsType } from '../termsConditions';
 
 import CartStockPositionsChangedModal from './CartStockPositionsChangedModal';
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
 import PaymentContext from './PaymentContext';
@@ -110,6 +111,7 @@ interface WithCheckoutPaymentProps {
     loadCheckout(): Promise<CheckoutSelectors>;
     loadPaymentMethods(): Promise<CheckoutSelectors>;
     refreshB2BPaymentMethods: CheckoutService['refreshB2BPaymentMethods'];
+    submitB2BMetadata: CheckoutService['persistB2BMetadata'];
     submitOrder(values: OrderRequestBody): Promise<CheckoutSelectors>;
     checkoutServiceSubscribe: CheckoutService['subscribe'];
 }
@@ -146,7 +148,7 @@ const Payment = (
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
 
     const {
-        orderConfirmation: { persistB2BMetadata },
+        orderConfirmation: { persistB2BMetadata, invoiceRedirect },
         userJourney: { disableStoreCredit },
     } = useCapabilities();
 
@@ -385,6 +387,22 @@ const Payment = (
             });
     };
 
+    const persistB2BMetadataIfNeeded = async (): Promise<void> => {
+        const { submitB2BMetadata } = props;
+
+        if (!persistB2BMetadata) {
+            return;
+        }
+
+        const invoiceComment = InvoicePaymentCommentSessionStorage.get() ?? '';
+
+        // TODO: CHECKOUT-9891 Remove all B2B sessionStorage usages after this all
+        await submitB2BMetadata({
+            isInvoice: invoiceRedirect,
+            invoiceComment,
+        });
+    };
+
     const handleSubmit = useCallback(
         async (values: PaymentFormValues) => {
             const {
@@ -422,6 +440,8 @@ const Payment = (
                     mapToOrderRequestBody(values, isPaymentDataRequired()),
                 );
                 const order = state.data.getOrder();
+
+                await persistB2BMetadataIfNeeded();
 
                 analyticsTracker.paymentComplete();
 
@@ -612,6 +632,8 @@ const Payment = (
                 });
                 const order = state.data.getOrder();
 
+                await persistB2BMetadataIfNeeded();
+
                 onFinalize(order?.orderId);
             } catch (error) {
                 if (isErrorWithType(error) && error.type !== 'order_finalization_not_required') {
@@ -794,6 +816,7 @@ export function mapToPaymentProps(
         orderExtraFields,
         orderId: checkout.orderId,
         refreshB2BPaymentMethods: checkoutService.refreshB2BPaymentMethods,
+        submitB2BMetadata: checkoutService.persistB2BMetadata,
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,
         shouldLocaliseErrorMessages:
             features['PAYMENTS-6799.localise_checkout_payment_error_messages'],

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -394,7 +394,7 @@ const Payment = (
             return;
         }
 
-        const invoiceComment = InvoicePaymentCommentSessionStorage.get() ?? '';
+        const invoiceComment = InvoicePaymentCommentSessionStorage.get();
 
         // TODO: CHECKOUT-9891 Remove all B2B sessionStorage usages after this all
         await submitB2BMetadata({

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -62,6 +62,7 @@
             "discount_text": "Discount",
             "downloads_action": "Go to Downloads",
             "edit_cart_action": "Edit Cart",
+            "back_to_invoices": "Back to Invoices",
             "go_to_cart_action": "Cart",
             "edit_multi_shipping_cart_message": "New items will default to Shipping Destination #1. Reallocate if you want them shipped to other destinations.",
             "estimated_total_text": "Estimated Total",


### PR DESCRIPTION
## What/Why?

Add UI changes for invoice-to-checkout flow.
- Display "Back to Invoices" link instead of "Edit Cart".
- Save B2B meta data when submitting an invoice.

## Rollout/Rollback

Revert.

## Testing

### Manual testing

https://github.com/user-attachments/assets/d335e4e5-2ef1-4c6a-9af1-d0c206907720



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment submit/finalize and post-order redirects with B2B capabilities; incorrect metadata or redirect logic could affect B2B invoice flows only when those capabilities are enabled.
> 
> **Overview**
> Adds **invoice-to-checkout** behavior: when `invoiceRedirect` is on, the order summary shows **Back to Invoices** (via new `CartHeaderLink` and `EditLink` invoice mode) instead of **Edit Cart**, shared across cart summary and drawer UIs.
> 
> After place order / finalize, checkout can call **`persistB2BMetadata`** (when `persistB2BMetadata` is enabled) with `isInvoice`, plus invoice comment from session storage. **Post-payment redirect** to the B2B invoice view now uses **`getB2BReceiptId()`** in the URL instead of an empty `receiptId`.
> 
> Bumps **`@bigcommerce/checkout-sdk`** to `^1.922.0` and adds locale string `cart.back_to_invoices`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc1bb04f17953f55afc7a4cc5c25ae91208861e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->