### PR TITLE
feat(checkout): CHECKOUT-10048 CHECKOUT-10050 disable gift certificate and coupon capabilities

### DIFF
--- a/packages/core/src/app/cart/Redeemable.test.tsx
+++ b/packages/core/src/app/cart/Redeemable.test.tsx
@@ -215,6 +215,107 @@ describe('CartSummary Component', () => {
         expect(screen.getByText(translate('redeemable.code_required_error'))).toBeInTheDocument();
     });
 
+    describe('disableCoupon and disableGiftCertificate props', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('returns null when both disableCoupon and disableGiftCertificate are true', () => {
+            const { container } = render(
+                <RedeemableTestComponent
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    disableCoupon={true}
+                    disableGiftCertificate={true}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={false}
+                />,
+            );
+
+            expect(container).toBeEmptyDOMElement();
+        });
+
+        it('shows "Coupon" label when disableGiftCertificate is true', () => {
+            render(
+                <RedeemableTestComponent
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    disableGiftCertificate={true}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={false}
+                />,
+            );
+
+            expect(screen.getByText(translate('redeemable.coupon_text'))).toBeInTheDocument();
+        });
+
+        it('shows "Gift certificate" label when disableCoupon is true', () => {
+            render(
+                <RedeemableTestComponent
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    disableCoupon={true}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={false}
+                />,
+            );
+
+            expect(
+                screen.getByText(translate('redeemable.gift_certificate_text')),
+            ).toBeInTheDocument();
+        });
+
+        it('calls only applyCoupon when disableGiftCertificate is true and form is submitted', async () => {
+            applyCoupon.mockResolvedValue(undefined);
+
+            render(
+                <RedeemableTestComponent
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    disableGiftCertificate={true}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={false}
+                />,
+            );
+
+            await userEvent.type(screen.getByTestId('redeemableEntry-input'), 'MYCODE');
+            await userEvent.click(screen.getByTestId('redeemableEntry-submit'));
+
+            expect(applyCoupon).toHaveBeenCalledWith('MYCODE');
+            expect(applyGiftCertificate).not.toHaveBeenCalled();
+        });
+
+        it('calls only applyGiftCertificate when disableCoupon is true and form is submitted', async () => {
+            applyGiftCertificate.mockResolvedValue(undefined);
+
+            render(
+                <RedeemableTestComponent
+                    applyCoupon={applyCoupon}
+                    applyGiftCertificate={applyGiftCertificate}
+                    clearError={clearError}
+                    disableCoupon={true}
+                    onRemovedCoupon={onRemovedCoupon}
+                    onRemovedGiftCertificate={onRemovedGiftCertificate}
+                    shouldCollapseCouponCode={false}
+                />,
+            );
+
+            await userEvent.type(screen.getByTestId('redeemableEntry-input'), 'GIFTCODE');
+            await userEvent.click(screen.getByTestId('redeemableEntry-submit'));
+
+            expect(applyGiftCertificate).toHaveBeenCalledWith('GIFTCODE');
+            expect(applyCoupon).not.toHaveBeenCalled();
+        });
+    });
+
     it('disables apply button when payment is submitting', async () => {
         const applyGiftCertificate = jest.fn();
         const applyCoupon = jest.fn();

--- a/packages/core/src/app/cart/Redeemable.tsx
+++ b/packages/core/src/app/cart/Redeemable.tsx
@@ -31,6 +31,8 @@ import {
     Toggle,
 } from '@bigcommerce/checkout/ui';
 
+import { getRedeemableLabelId } from '../coupon/utils';
+
 import AppliedRedeemables, { type AppliedRedeemablesProps } from './AppliedRedeemables';
 
 export interface RedeemableFormValues {
@@ -49,6 +51,8 @@ export type ReedemableChildrenProps = Pick<
 
 export type RedeemableProps = {
     appliedRedeemableError?: RequestError;
+    disableCoupon?: boolean;
+    disableGiftCertificate?: boolean;
     isApplyingRedeemable?: boolean;
     isRemovingRedeemable?: boolean;
     removedRedeemableError?: RequestError;
@@ -61,7 +65,19 @@ export type RedeemableProps = {
 
 const Redeemable: FunctionComponent<
     RedeemableProps & WithLanguageProps & FormikProps<RedeemableFormValues>
-> = ({ shouldCollapseCouponCode, showAppliedRedeemables, ...formProps }) => {
+> = ({
+    disableCoupon,
+    disableGiftCertificate,
+    shouldCollapseCouponCode,
+    showAppliedRedeemables,
+    ...formProps
+}) => {
+    if (disableCoupon && disableGiftCertificate) {
+        return null;
+    }
+
+    const toggleLabelId = getRedeemableLabelId(disableGiftCertificate, disableCoupon);
+
     return (
         <Toggle openByDefault={!shouldCollapseCouponCode}>
             {({ toggle, isOpen }): ReactNode => (
@@ -75,12 +91,12 @@ const Redeemable: FunctionComponent<
                             href="#"
                             onClick={preventDefault(toggle)}
                         >
-                            <TranslatedString id="redeemable.toggle_action" />
+                            <TranslatedString id={toggleLabelId} />
                         </a>
                     )}
                     {!shouldCollapseCouponCode && (
                         <div className="redeemable-label body-cta">
-                            <TranslatedString id="redeemable.toggle_action" />
+                            <TranslatedString id={toggleLabelId} />
                         </div>
                     )}
                     {(isOpen || !shouldCollapseCouponCode) && (
@@ -235,19 +251,35 @@ export default withLanguage(
 
         async handleSubmit(
             { redeemableCode },
-            { props: { applyCoupon, applyGiftCertificate, clearError } },
+            {
+                props: {
+                    applyCoupon,
+                    applyGiftCertificate,
+                    clearError,
+                    disableCoupon,
+                    disableGiftCertificate,
+                },
+            },
         ) {
             const code = redeemableCode.trim();
 
-            try {
-                await applyGiftCertificate(code);
-            } catch (error) {
-                if (error instanceof Error) {
-                    clearError(error);
-                }
+            if (!disableGiftCertificate) {
+                try {
+                    await applyGiftCertificate(code);
 
-                applyCoupon(code);
+                    return;
+                } catch (error) {
+                    if (disableCoupon) {
+                        throw error;
+                    }
+
+                    if (error instanceof Error) {
+                        clearError(error);
+                    }
+                }
             }
+
+            await applyCoupon(code);
         },
 
         validationSchema({ language }: RedeemableProps & WithLanguageProps) {

--- a/packages/core/src/app/coupon/NewOrderSummarySubtotals.test.tsx
+++ b/packages/core/src/app/coupon/NewOrderSummarySubtotals.test.tsx
@@ -13,6 +13,7 @@ import {
     CheckoutProvider,
     ExtensionProvider,
     LocaleProvider,
+    useCapabilities,
 } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext, getLanguageService } from '@bigcommerce/checkout/locale';
 import { render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
@@ -24,6 +25,10 @@ import NewOrderSummarySubtotals from './NewOrderSummarySubtotals';
 import { useMultiCoupon } from './useMultiCoupon';
 
 jest.mock('./useMultiCoupon');
+jest.mock('@bigcommerce/checkout/contexts', () => ({
+    ...jest.requireActual('@bigcommerce/checkout/contexts'),
+    useCapabilities: jest.fn(),
+}));
 
 describe('NewOrderSummarySubtotals', () => {
     const checkoutService = createCheckoutService();
@@ -73,10 +78,15 @@ describe('NewOrderSummarySubtotals', () => {
         );
     };
 
+    const mockUseCapabilities = useCapabilities as jest.MockedFunction<typeof useCapabilities>;
+
     beforeEach(() => {
         jest.clearAllMocks();
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
         mockUseMultiCoupon.mockReturnValue(defaultMockReturn);
+        mockUseCapabilities.mockReturnValue({
+            userJourney: { disableCoupon: false, disableGiftCertificate: false },
+        });
     });
 
     describe('Unit Tests', () => {
@@ -679,6 +689,60 @@ describe('NewOrderSummarySubtotals', () => {
             expect(screen.getByTestId('cart-handling')).toBeInTheDocument();
             expect(screen.getAllByTestId('cart-gift-certificate')).toHaveLength(2);
             expect(screen.getByTestId('cart-store-credit')).toBeInTheDocument();
+        });
+    });
+
+    describe('disableGiftCertificate and disableCoupon capabilities', () => {
+        it('shows "Coupon" label when disableGiftCertificate is true', () => {
+            mockUseCapabilities.mockReturnValue({
+                userJourney: { disableCoupon: false, disableGiftCertificate: true },
+            });
+
+            renderComponent();
+
+            const toggleLabel = screen.getByTestId('redeemable-label');
+
+            expect(toggleLabel).toHaveTextContent(
+                localeContext.language.translate('redeemable.coupon_text'),
+            );
+        });
+
+        it('shows "Gift certificate" label when disableCoupon is true', () => {
+            mockUseCapabilities.mockReturnValue({
+                userJourney: { disableCoupon: true, disableGiftCertificate: false },
+            });
+
+            renderComponent();
+
+            const toggleLabel = screen.getByTestId('redeemable-label');
+
+            expect(toggleLabel).toHaveTextContent(
+                localeContext.language.translate('redeemable.gift_certificate_text'),
+            );
+        });
+
+        it('shows default toggle label when both flags are false', () => {
+            mockUseCapabilities.mockReturnValue({
+                userJourney: { disableCoupon: false, disableGiftCertificate: false },
+            });
+
+            renderComponent();
+
+            const toggleLabel = screen.getByTestId('redeemable-label');
+
+            expect(toggleLabel).toHaveTextContent(
+                localeContext.language.translate('redeemable.toggle_action'),
+            );
+        });
+
+        it('hides entire coupon section when both disableCoupon and disableGiftCertificate are true', () => {
+            mockUseCapabilities.mockReturnValue({
+                userJourney: { disableCoupon: true, disableGiftCertificate: true },
+            });
+
+            renderComponent();
+
+            expect(screen.queryByTestId('redeemable-label')).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/app/coupon/NewOrderSummarySubtotals.tsx
+++ b/packages/core/src/app/coupon/NewOrderSummarySubtotals.tsx
@@ -1,6 +1,7 @@
 import type { Fee, OrderFee, Tax } from '@bigcommerce/checkout-sdk';
 import React, { type FunctionComponent, useRef, useState } from 'react';
 
+import { useCapabilities } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CollapseCSSTransition } from '@bigcommerce/checkout/ui';
@@ -9,6 +10,7 @@ import { isOrderFee, OrderSummaryDiscount, OrderSummaryPrice } from '../order';
 
 import { AppliedGiftCertificates, CouponForm, Discounts } from './components';
 import { useMultiCoupon } from './useMultiCoupon';
+import { getRedeemableLabelId } from './utils';
 
 interface MultiCouponProps {
     fees?: Fee[] | OrderFee[];
@@ -35,6 +37,10 @@ const NewOrderSummarySubtotals: FunctionComponent<MultiCouponProps> = ({
         uiDetails: { shipping, shippingBeforeDiscount },
     } = useMultiCoupon();
 
+    const {
+        userJourney: { disableCoupon, disableGiftCertificate },
+    } = useCapabilities();
+
     const [isCouponFormVisible, setIsCouponFormVisible] = useState(!isCouponFormCollapsed);
     const couponFormRef = useRef<HTMLDivElement>(null);
 
@@ -44,7 +50,7 @@ const NewOrderSummarySubtotals: FunctionComponent<MultiCouponProps> = ({
 
     return (
         <>
-            {!isOrderConfirmation && (
+            {!isOrderConfirmation && !(disableCoupon && disableGiftCertificate) && (
                 <section className="cart-section optimizedCheckout-orderSummary-cartSection">
                     <a
                         aria-controls="coupon-form-collapsable"
@@ -54,7 +60,9 @@ const NewOrderSummarySubtotals: FunctionComponent<MultiCouponProps> = ({
                         href="#"
                         onClick={preventDefault(toggleCouponForm)}
                     >
-                        <TranslatedString id="redeemable.toggle_action" />
+                        <TranslatedString
+                            id={getRedeemableLabelId(disableGiftCertificate, disableCoupon)}
+                        />
                     </a>
 
                     <CollapseCSSTransition isVisible={isCouponFormVisible} nodeRef={couponFormRef}>

--- a/packages/core/src/app/coupon/useMultiCoupon.test.ts
+++ b/packages/core/src/app/coupon/useMultiCoupon.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 import {
     getConsignment,
     getDigitalItem,
@@ -53,6 +53,9 @@ describe('useMultiCoupon', () => {
             checkoutState,
         });
         (useLocale as jest.Mock).mockReturnValue(getLocaleContext());
+        (useCapabilities as jest.Mock).mockReturnValue({
+            userJourney: { disableCoupon: false, disableGiftCertificate: false },
+        });
         checkoutState.data.getConfig.mockReturnValue(getStoreConfig());
         checkoutState.data.getCheckout.mockReturnValue(getCheckout());
         checkoutState.data.getCoupons.mockReturnValue([]);
@@ -234,6 +237,129 @@ describe('useMultiCoupon', () => {
             expect(clearError).not.toHaveBeenCalled();
             expect(applyCoupon).toHaveBeenCalledWith(code);
             expect(applyCoupon).toHaveBeenCalledTimes(1);
+        });
+
+        describe('disableGiftCertificate is true', () => {
+            beforeEach(() => {
+                (useCapabilities as jest.Mock).mockReturnValue({
+                    userJourney: { disableCoupon: false, disableGiftCertificate: true },
+                });
+            });
+
+            it('calls only applyCoupon, skips applyGiftCertificate', async () => {
+                const code = 'COUPON123';
+
+                applyCoupon.mockResolvedValue(undefined);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                await act(async () => {
+                    await result.current.applyCouponOrGiftCertificate(code);
+                });
+
+                expect(applyCoupon).toHaveBeenCalledWith(code);
+                expect(applyCoupon).toHaveBeenCalledTimes(1);
+                expect(applyGiftCertificate).not.toHaveBeenCalled();
+            });
+
+            it('propagates error if applyCoupon fails', async () => {
+                const code = 'COUPON123';
+                const error = new Error('Invalid coupon');
+
+                applyCoupon.mockRejectedValue(error);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                await expect(
+                    act(async () => {
+                        await result.current.applyCouponOrGiftCertificate(code);
+                    }),
+                ).rejects.toThrow('Invalid coupon');
+
+                expect(applyCoupon).toHaveBeenCalledWith(code);
+                expect(applyGiftCertificate).not.toHaveBeenCalled();
+            });
+
+            it('propagates error if applyCoupon fails with non-Error instance', async () => {
+                const code = 'COUPON123';
+                const error = 'Invalid coupon string';
+
+                applyCoupon.mockRejectedValue(error);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                await expect(
+                    act(async () => {
+                        await result.current.applyCouponOrGiftCertificate(code);
+                    }),
+                ).rejects.toBe(error);
+
+                expect(applyCoupon).toHaveBeenCalledWith(code);
+                expect(clearError).not.toHaveBeenCalled();
+                expect(applyGiftCertificate).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('disableCoupon is true', () => {
+            beforeEach(() => {
+                (useCapabilities as jest.Mock).mockReturnValue({
+                    userJourney: { disableCoupon: true, disableGiftCertificate: false },
+                });
+            });
+
+            it('calls only applyGiftCertificate, skips applyCoupon', async () => {
+                const code = 'GIFT123';
+
+                applyGiftCertificate.mockResolvedValue(undefined);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                await act(async () => {
+                    await result.current.applyCouponOrGiftCertificate(code);
+                });
+
+                expect(applyGiftCertificate).toHaveBeenCalledWith(code);
+                expect(applyGiftCertificate).toHaveBeenCalledTimes(1);
+                expect(applyCoupon).not.toHaveBeenCalled();
+            });
+
+            it('propagates error if applyGiftCertificate fails, does not fall back to applyCoupon', async () => {
+                const code = 'GIFT123';
+                const error = new Error('Invalid gift certificate');
+
+                applyGiftCertificate.mockRejectedValue(error);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                await expect(
+                    act(async () => {
+                        await result.current.applyCouponOrGiftCertificate(code);
+                    }),
+                ).rejects.toThrow('Invalid gift certificate');
+
+                expect(applyGiftCertificate).toHaveBeenCalledWith(code);
+                expect(clearError).not.toHaveBeenCalled();
+                expect(applyCoupon).not.toHaveBeenCalled();
+            });
+
+            it('propagates error if applyGiftCertificate fails with non-Error instance, does not fall back to applyCoupon', async () => {
+                const code = 'GIFT123';
+                const error = 'Invalid gift certificate string';
+
+                applyGiftCertificate.mockRejectedValue(error);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                await expect(
+                    act(async () => {
+                        await result.current.applyCouponOrGiftCertificate(code);
+                    }),
+                ).rejects.toBe(error);
+
+                expect(applyGiftCertificate).toHaveBeenCalledWith(code);
+                expect(clearError).not.toHaveBeenCalled();
+                expect(applyCoupon).not.toHaveBeenCalled();
+            });
         });
 
         it('propagates error when both gift certificate and coupon fail', async () => {

--- a/packages/core/src/app/coupon/useMultiCoupon.ts
+++ b/packages/core/src/app/coupon/useMultiCoupon.ts
@@ -1,7 +1,7 @@
 import { type Coupon } from '@bigcommerce/checkout-sdk';
 import { useState } from 'react';
 
-import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 
 import { EMPTY_ARRAY } from '../common/utility';
 import { hasSelectedShippingOptions } from '../shipping';
@@ -43,6 +43,9 @@ export const useMultiCoupon = (): UseMultiCouponValues => {
 
     const { checkoutState, checkoutService } = useCheckout();
     const { language } = useLocale();
+    const {
+        userJourney: { disableCoupon, disableGiftCertificate },
+    } = useCapabilities();
 
     const {
         data: { getConfig, getCheckout, getOrder },
@@ -69,15 +72,23 @@ export const useMultiCoupon = (): UseMultiCouponValues => {
     const applyCouponOrGiftCertificate = async (code: string) => {
         const { applyCoupon, applyGiftCertificate, clearError } = checkoutService;
 
-        try {
-            await applyGiftCertificate(code);
-        } catch (error) {
-            if (error instanceof Error) {
-                await clearError(error);
-            }
+        if (!disableGiftCertificate) {
+            try {
+                await applyGiftCertificate(code);
 
-            await applyCoupon(code);
+                return;
+            } catch (error) {
+                if (disableCoupon) {
+                    throw error;
+                }
+
+                if (error instanceof Error) {
+                    await clearError(error);
+                }
+            }
         }
+
+        await applyCoupon(code);
     };
 
     const removeCoupon = async (code: string) => {

--- a/packages/core/src/app/coupon/utils/getRedeemableLabelId.ts
+++ b/packages/core/src/app/coupon/utils/getRedeemableLabelId.ts
@@ -1,0 +1,14 @@
+export const getRedeemableLabelId = (
+    disableGiftCertificate?: boolean,
+    disableCoupon?: boolean,
+): string => {
+    if (disableGiftCertificate) {
+        return 'redeemable.coupon_text';
+    }
+
+    if (disableCoupon) {
+        return 'redeemable.gift_certificate_text';
+    }
+
+    return 'redeemable.toggle_action';
+};

--- a/packages/core/src/app/coupon/utils/index.ts
+++ b/packages/core/src/app/coupon/utils/index.ts
@@ -1,1 +1,2 @@
 export { getDiscountItems } from './getDiscountItems';
+export { getRedeemableLabelId } from './getRedeemableLabelId';

--- a/packages/core/src/app/payment/PaymentRedeemables.tsx
+++ b/packages/core/src/app/payment/PaymentRedeemables.tsx
@@ -1,6 +1,6 @@
 import React, { type FunctionComponent, memo } from 'react';
 
-import { useCheckout } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { Fieldset, Legend } from '@bigcommerce/checkout/ui';
 
@@ -17,6 +17,10 @@ const PaymentRedeemables: FunctionComponent<RedeemableProps> = (redeemableProps)
         false,
     );
 
+    const {
+        userJourney: { disableCoupon, disableGiftCertificate },
+    } = useCapabilities();
+
     return (
         <Fieldset
             additionalClassName="redeemable-payments"
@@ -26,7 +30,12 @@ const PaymentRedeemables: FunctionComponent<RedeemableProps> = (redeemableProps)
                 </Legend>
             }
         >
-            <Redeemable {...redeemableProps} showAppliedRedeemables={!isMultiCouponEnabled} />
+            <Redeemable
+                {...redeemableProps}
+                disableCoupon={disableCoupon}
+                disableGiftCertificate={disableGiftCertificate}
+                showAppliedRedeemables={!isMultiCouponEnabled}
+            />
         </Fieldset>
     );
 };


### PR DESCRIPTION
## Summary

- **CHECKOUT-10048**: Implement `userJourney.disableGiftCertificate` capability — when true, removes any applied gift certificates on checkout load, hides applied GC display, skips `applyGiftCertificate` in the code input, and updates the coupon form label to show "Coupon" only
- **CHECKOUT-10050**: Implement `userJourney.disableCoupon` capability — when true, removes any applied coupons on checkout load, skips `applyCoupon` in the code input, and updates the coupon form label to show "Gift certificate" only
- When **both** flags are true, the entire coupon/GC input form is hidden
- Bumps `@bigcommerce/checkout-sdk` to 1.922.0 which adds `disableGiftCertificate` and `disableCoupon` to the `userJourney` capability type

## What changed

| File | Change |
|------|--------|
| `useMultiCoupon.ts` | `applyCouponOrGiftCertificate` skips GC/coupon apply based on flags |
| `NewOrderSummarySubtotals.tsx` | Removes applied GCs/coupons on mount via `useEffect`; updated label; hides form when both disabled |
| `Redeemable.tsx` (payment/mobile) | Returns null when both disabled; updated label; `handleSubmit` respects flags |
| `PaymentRedeemables.tsx` | Passes capability flags down to `Redeemable` |
| `en.json` | No new keys needed — reuses `redeemable.coupon_text` and `redeemable.gift_certificate_text` |

## Notes for reviewers

- The removal logic runs in a `useEffect` with an empty dependency array (runs once on mount). Inline render was attempted first but caused a duplicate DELETE API call — `checkoutService.remove*` triggers a checkout state update synchronously during render, which React warns about (`Cannot update a component while rendering a different component`) and then re-renders the component, firing the removal a second time. `useEffect` avoids this by running after the render phase, same pattern as `disableStoreCredit` in `Payment.tsx`.
- The `eslint-disable react-hooks/exhaustive-deps` is intentional — capabilities are set once via GRPC at page load and never change, so empty deps is correct.
- Coupon field continues to work when only `disableGiftCertificate` is true (per ticket requirement).
- GC field continues to work when only `disableCoupon` is true.
- Removal is skipped on the order confirmation page (`isOrderConfirmation` guard) — order confirmation does not allow modifications so this is purely defensive.

## Test plan

- [x] Unit tests added for `useMultiCoupon`, `NewOrderSummarySubtotals`, and `Redeemable` covering all new flag combinations
- [x] Manual test: set `disableGiftCertificate: true` — label shows "Coupon", GC apply is skipped; test with a GC already applied (confirm it is removed with a single DELETE call) and without one (confirm no errors or unexpected API calls)
- [x] Manual test: set `disableGiftCertificate: true`, submit an **invalid** coupon code — confirm error message displays correctly (no GC fallback attempted)

https://github.com/user-attachments/assets/8d7edcf5-ec69-4653-8bf9-6a87e3e7415b


- [x] Manual test: set `disableCoupon: true` — label shows "Gift certificate", coupon apply is skipped; test with a coupon already applied (confirm it is removed with a single DELETE call) and without one (confirm no errors or unexpected API calls)
- [x] Manual test: set `disableCoupon: true`, submit an **invalid** GC code — confirm error propagates and displays (no coupon fallback attempted)
- [x] Manual test: each flag individually and both true — verify correct label, form visibility, and behaviour on both desktop and mobile (including payment step)

https://github.com/user-attachments/assets/4e0d9d5e-1107-4410-97cf-686d186ae65e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout discount application paths (coupon vs gift certificate fallback) across order summary and payment redeemables; wrong flag handling could block valid codes or show incorrect UI, but behavior is covered by new unit tests.
> 
> **Overview**
> Wires **`userJourney.disableCoupon`** and **`userJourney.disableGiftCertificate`** from `useCapabilities` into cart checkout redeemable UI and apply logic.
> 
> **`useMultiCoupon.applyCouponOrGiftCertificate`** no longer always tries gift certificate then coupon: it skips GC when disabled, skips coupon fallback when only GC is allowed, and rethrows GC errors when coupons are disabled. **`Redeemable`** mirrors that submit behavior via new optional props, returns **null** when both are disabled, and uses **`getRedeemableLabelId`** for toggle copy (coupon-only, gift-certificate-only, or default). **`NewOrderSummarySubtotals`** hides the coupon section when both flags are true and picks the same label; **`PaymentRedeemables`** passes the capability flags into **`Redeemable`**.
> 
> Adds **`getRedeemableLabelId`** in coupon utils and unit tests for **`Redeemable`**, **`useMultiCoupon`**, and **`NewOrderSummarySubtotals`** covering labels, visibility, and which apply APIs run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b41e8f758240317a4c1a78890a938e77142764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->