### PR TITLE
chore(other): CHECKOUT-10101 migrate order UI to use selectors with useCheckout

### DIFF
--- a/packages/contexts/src/checkout/useCheckout.tsx
+++ b/packages/contexts/src/checkout/useCheckout.tsx
@@ -1,6 +1,16 @@
-import { useCallback, useContext, useEffect, useRef, useSyncExternalStore } from 'react';
-import CheckoutContext, { type CheckoutContextProps } from './CheckoutContext';
 import { type CheckoutSelectors } from '@bigcommerce/checkout-sdk';
+import { useCallback, useContext, useEffect, useRef, useSyncExternalStore } from 'react';
+
+import CheckoutContext, { type CheckoutContextProps } from './CheckoutContext';
+
+export function useCheckout(): CheckoutContextProps & { selectedState: undefined };
+export function useCheckout<T>(
+    selectFn: (state: CheckoutSelectors) => T,
+): CheckoutContextProps & { selectedState: T };
+// TODO: Remove this overload when withCheckout HOC is deprecated
+export function useCheckout<T>(
+    selectFn: ((state: CheckoutSelectors) => T) | undefined,
+): CheckoutContextProps & { selectedState: T | undefined };
 
 export function useCheckout<T>(
     selectFn?: (state: CheckoutSelectors) => T,

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
@@ -62,9 +62,9 @@ export const OrderConfirmation = ({
         },
         checkoutService: { loadOrder },
     } = useCheckout(({ data, statuses }) => ({
-        getOrder: data.getOrder,
-        getConfig: data.getConfig,
-        isLoadingOrder: statuses.isLoadingOrder,
+        getOrder: data.getOrder(),
+        getConfig: data.getConfig(),
+        isLoadingOrder: statuses.isLoadingOrder(),
     }));
     const { analyticsTracker } = useAnalytics();
 

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
@@ -56,20 +56,14 @@ export const OrderConfirmation = ({
     const embeddedMessengerRef = useRef<EmbeddedCheckoutMessenger | undefined>();
 
     const {
-        checkoutState: {
-            data: { getOrder, getConfig },
-            statuses: { isLoadingOrder },
-        },
+        selectedState: { order, config, isLoadingOrder },
         checkoutService: { loadOrder },
     } = useCheckout(({ data, statuses }) => ({
-        getOrder: data.getOrder(),
-        getConfig: data.getConfig(),
+        order: data.getOrder(),
+        config: data.getConfig(),
         isLoadingOrder: statuses.isLoadingOrder(),
     }));
     const { analyticsTracker } = useAnalytics();
-
-    const config = getConfig();
-    const order = getOrder();
 
     const handleUnhandledError = (e: Error) => {
         setError(e);
@@ -152,7 +146,7 @@ export const OrderConfirmation = ({
         return <RateLimitedPermalinkView />;
     }
 
-    if (!order || !config || isLoadingOrder()) {
+    if (!order || !config || isLoadingOrder) {
         return <OrderConfirmationPageSkeleton />;
     }
 

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
@@ -61,7 +61,11 @@ export const OrderConfirmation = ({
             statuses: { isLoadingOrder },
         },
         checkoutService: { loadOrder },
-    } = useCheckout();
+    } = useCheckout(({ data, statuses }) => ({
+        getOrder: data.getOrder,
+        getConfig: data.getConfig,
+        isLoadingOrder: statuses.isLoadingOrder,
+    }));
     const { analyticsTracker } = useAnalytics();
 
     const config = getConfig();

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -46,14 +46,18 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
 
     const { currency } = useLocale();
 
-    const { checkoutState } = useCheckout(({ data }) => ({
-        getConfig: data.getConfig,
-        getCheckout: data.getCheckout,
-        getOrder: data.getOrder,
+    const {
+        checkoutState: {
+            data: { getConfig, getCheckout, getOrder },
+        },
+    } = useCheckout(({ data: { getConfig, getCheckout, getOrder } }) => ({
+        config: getConfig(),
+        checkout: getCheckout(),
+        order: getOrder(),
     }));
-    const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
-    const checkout = checkoutState.data.getCheckout();
-    const order = checkoutState.data.getOrder();
+    const { checkoutSettings } = getConfig() ?? {};
+    const checkout = getCheckout();
+    const order = getOrder();
 
     // TODO: When removing the experiment, rename `NewOrderSummarySubtotals` to `OrderSummarySubtotals`.
     const isMultiCouponEnabled = isExperimentEnabled(

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -50,10 +50,10 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
         checkoutState: {
             data: { getConfig, getCheckout, getOrder },
         },
-    } = useCheckout(({ data: { getConfig, getCheckout, getOrder } }) => ({
-        config: getConfig(),
-        checkout: getCheckout(),
-        order: getOrder(),
+    } = useCheckout(({ data }) => ({
+        config: data.getConfig(),
+        checkout: data.getCheckout(),
+        order: data.getOrder(),
     }));
     const { checkoutSettings } = getConfig() ?? {};
     const checkout = getCheckout();

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -46,12 +46,16 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
 
     const { currency } = useLocale();
 
-    // TODO: When removing the experiment, rename `NewOrderSummarySubtotals` to `OrderSummarySubtotals`.
-    const { checkoutState } = useCheckout();
+    const { checkoutState } = useCheckout(({ data }) => ({
+        getConfig: data.getConfig,
+        getCheckout: data.getCheckout,
+        getOrder: data.getOrder,
+    }));
     const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
     const checkout = checkoutState.data.getCheckout();
     const order = checkoutState.data.getOrder();
 
+    // TODO: When removing the experiment, rename `NewOrderSummarySubtotals` to `OrderSummarySubtotals`.
     const isMultiCouponEnabled = isExperimentEnabled(
         checkoutSettings,
         'CHECKOUT-9674.multi_coupon_cart_checkout',

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -47,17 +47,13 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
     const { currency } = useLocale();
 
     const {
-        checkoutState: {
-            data: { getConfig, getCheckout, getOrder },
-        },
+        selectedState: { config, checkout, order },
     } = useCheckout(({ data }) => ({
         config: data.getConfig(),
         checkout: data.getCheckout(),
         order: data.getOrder(),
     }));
-    const { checkoutSettings } = getConfig() ?? {};
-    const checkout = getCheckout();
-    const order = getOrder();
+    const { checkoutSettings } = config ?? {};
 
     // TODO: When removing the experiment, rename `NewOrderSummarySubtotals` to `OrderSummarySubtotals`.
     const isMultiCouponEnabled = isExperimentEnabled(

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -51,8 +51,7 @@ const OrderSummaryItemBackorderDetails = ({
     backorderMessage?: string;
 }) => {
     const backorderDetailsRef = useRef<HTMLDivElement>(null);
-    const { checkoutState } = useCheckout();
-    const config = checkoutState.data.getConfig();
+    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
 
     const inventorySettings = config?.inventorySettings;
     const showQuantityOnBackorder = !!inventorySettings?.showQuantityOnBackorder;

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -77,9 +77,8 @@ const ItemCount = ({
     setShowBackorderDetails: React.Dispatch<React.SetStateAction<boolean>>;
     showBackorderDetails: boolean;
 }): ReactElement => {
-    const { checkoutState } = useCheckout();
+    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
     const backorderCount = getBackorderCount(items);
-    const config = checkoutState.data.getConfig();
     const shouldDisplayBackorderDetails =
         !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
         (!!config?.inventorySettings?.showQuantityOnBackorder ||
@@ -195,8 +194,7 @@ const OrderSummaryItems = ({
 }: OrderSummaryItemsProps): ReactElement => {
     const [isExpanded, setIsExpanded] = useState(false);
     const [showBackorderDetails, setShowBackorderDetails] = useState(false);
-    const { checkoutState } = useCheckout();
-    const config = checkoutState.data.getConfig();
+    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
 
     const pickListExperimentEnabled = config
         ? isExperimentEnabled(config.checkoutSettings, 'BACK-425.update_bundle_item_ux', false)

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -59,18 +59,14 @@ const OrderSummaryModal: FunctionComponent<
 }) => {
     const { currency } = useLocale();
     const {
-        checkoutState: {
-            data: { getConfig, getCheckout, getOrder },
-        },
+        selectedState: { config, checkout, order },
     } = useCheckout(({ data }) => ({
-        getConfig: data.getConfig(),
-        getCheckout: data.getCheckout(),
-        getOrder: data.getOrder(),
+        config: data.getConfig(),
+        checkout: data.getCheckout(),
+        order: data.getOrder(),
     }));
     const { themeV2 } = useThemeContext();
-    const { checkoutSettings } = getConfig() ?? {};
-    const checkout = getCheckout();
-    const order = getOrder();
+    const { checkoutSettings } = config ?? {};
 
     const isMultiCouponEnabled = isExperimentEnabled(
         checkoutSettings,

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -58,15 +58,19 @@ const OrderSummaryModal: FunctionComponent<
     ...orderSummarySubtotalsProps
 }) => {
     const { currency } = useLocale();
-    const { checkoutState } = useCheckout(({ data }) => ({
-        getConfig: data.getConfig,
-        getCheckout: data.getCheckout,
-        getOrder: data.getOrder,
+    const {
+        checkoutState: {
+            data: { getConfig, getCheckout, getOrder },
+        },
+    } = useCheckout(({ data }) => ({
+        getConfig: data.getConfig(),
+        getCheckout: data.getCheckout(),
+        getOrder: data.getOrder(),
     }));
     const { themeV2 } = useThemeContext();
-    const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
-    const checkout = checkoutState.data.getCheckout();
-    const order = checkoutState.data.getOrder();
+    const { checkoutSettings } = getConfig() ?? {};
+    const checkout = getCheckout();
+    const order = getOrder();
 
     const isMultiCouponEnabled = isExperimentEnabled(
         checkoutSettings,

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -58,7 +58,11 @@ const OrderSummaryModal: FunctionComponent<
     ...orderSummarySubtotalsProps
 }) => {
     const { currency } = useLocale();
-    const { checkoutState } = useCheckout();
+    const { checkoutState } = useCheckout(({ data }) => ({
+        getConfig: data.getConfig,
+        getCheckout: data.getCheckout,
+        getOrder: data.getOrder,
+    }));
     const { themeV2 } = useThemeContext();
     const { checkoutSettings } = checkoutState.data.getConfig() ?? {};
     const checkout = checkoutState.data.getCheckout();

--- a/packages/core/src/app/order/OrderSummaryPrice.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.test.tsx
@@ -26,6 +26,7 @@ describe('OrderSummaryPrice', () => {
                         isSubmittingOrder: () => isSubmittingOrder,
                     },
                 },
+                selectedState: isSubmittingOrder,
             })),
         );
     };

--- a/packages/core/src/app/order/OrderSummaryPrice.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.tsx
@@ -61,12 +61,11 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
 }) => {
     const [highlight, setHighlight] = useState<boolean>(false);
     const [previousAmount, setPreviousAmount] = useState<OrderSummaryPriceProps['amount']>(amount);
-    const { selectedState: isSubmittingOrder } = useCheckout(({ statuses }) =>
+    const { selectedState: isActionDisabled } = useCheckout(({ statuses }) =>
         statuses.isSubmittingOrder(),
     );
 
     const displayValue = getDisplayValue(amount, zeroLabel);
-    const isActionDisabled = !!isSubmittingOrder;
 
     useEffect(() => {
         setHighlight(amount !== previousAmount);

--- a/packages/core/src/app/order/OrderSummaryPrice.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.tsx
@@ -61,14 +61,12 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
 }) => {
     const [highlight, setHighlight] = useState<boolean>(false);
     const [previousAmount, setPreviousAmount] = useState<OrderSummaryPriceProps['amount']>(amount);
-    const {
-        checkoutState: {
-            statuses: { isSubmittingOrder },
-        },
-    } = useCheckout();
+    const { selectedState: isSubmittingOrder } = useCheckout(({ statuses }) =>
+        statuses.isSubmittingOrder(),
+    );
 
     const displayValue = getDisplayValue(amount, zeroLabel);
-    const isActionDisabled = isSubmittingOrder();
+    const isActionDisabled = !!isSubmittingOrder;
 
     useEffect(() => {
         setHighlight(amount !== previousAmount);


### PR DESCRIPTION
## What/Why?

Reducing unnecessary component re-renders by passing a selector to useCheckout and making it subscribe to a narrower state slice.

This PR focuses specifically on `packages/core/src/app/order` path.

## Rollout/Rollback

Revert the PR

## Testing

CI


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only UI subscription pattern with no auth or payment logic changes; behavior depends on the existing checkout hook experiment flag for narrowed re-renders.
> 
> **Overview**
> Extends **`useCheckout`** with TypeScript overloads so callers get **`selectedState`** typed when a selector is passed (including an optional-selector overload for deprecating **`withCheckout`**).
> 
> Order UI under **`packages/core/src/app/order`** stops reading **`checkoutState.data` / `statuses`** directly and instead passes selectors that pull only what each component needs (e.g. **`getConfig()`**, **`getOrder()`**, **`isLoadingOrder`**, **`isSubmittingOrder()`**) via **`selectedState`**. Loading and submit-disabled behavior stay the same (boolean **`isLoadingOrder`** / **`isActionDisabled`** instead of calling status functions). **`OrderSummaryPrice`** tests mock **`selectedState`** to match the new hook shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9eb34c46751ae54402e5cc6c971b23e4467dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->