### PR TITLE
feat(payment): CHECKOUT-10085 Add filter for check method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.922.0",
+        "@bigcommerce/checkout-sdk": "^1.922.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.922.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.0.tgz",
-      "integrity": "sha512-OURiXK4y8xoU+KzDSN53hpNKRcFrXOdKhaRcvzS71lGqerYCgBwKv7hBchHcKXgDxFGIDf1toD8Fpq0PgmAxcg==",
+      "version": "1.922.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.1.tgz",
+      "integrity": "sha512-DHBoCyYd1AHMWJVKhmqM+GEBkGISiS4mBwO7Om/kTwU28TdlgnfvIMWuNVpExmmgRdoyYG0QhgYe5ZGJ2zF6Zw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29786,9 +29786,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.922.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.0.tgz",
-      "integrity": "sha512-OURiXK4y8xoU+KzDSN53hpNKRcFrXOdKhaRcvzS71lGqerYCgBwKv7hBchHcKXgDxFGIDf1toD8Fpq0PgmAxcg==",
+      "version": "1.922.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.1.tgz",
+      "integrity": "sha512-DHBoCyYd1AHMWJVKhmqM+GEBkGISiS4mBwO7Om/kTwU28TdlgnfvIMWuNVpExmmgRdoyYG0QhgYe5ZGJ2zF6Zw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.922.0",
+    "@bigcommerce/checkout-sdk": "^1.922.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -28,6 +28,7 @@ export const defaultCapabilities: Capabilities = {
         invoicePaymentComment: false,
         poConfig: null,
         additionalField: null,
+        hideCheckPaymentMethod: false,
     },
     orderConfirmation: {
         canCreatePersonalAccount: false,

--- a/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
@@ -7,12 +7,14 @@ import {
 import { stripeMethodsFiltering } from '@bigcommerce/checkout/stripe-utils';
 
 import { boltAndBraintreeFilter } from './boltAndBraintreeFilter';
+import { chequePaymentMethodFilter } from './chequePaymentMethodFilter';
 import { multiShippingFilter } from './multiShippingFilter';
 import { selectedHostedPaymentFilter } from './selectedHostedPaymentFilter';
 
 // Order matters. selectedHostedPaymentFilter must run last because it can
 // collapse the list to a single method when a hosted payment is already in flight.
 const FILTERS: PaymentMethodFilter[] = [
+    chequePaymentMethodFilter,
     stripeMethodsFiltering,
     boltAndBraintreeFilter,
     multiShippingFilter,

--- a/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
@@ -7,14 +7,14 @@ import {
 import { stripeMethodsFiltering } from '@bigcommerce/checkout/stripe-utils';
 
 import { boltAndBraintreeFilter } from './boltAndBraintreeFilter';
-import { chequePaymentMethodFilter } from './chequePaymentMethodFilter';
+import { checkPaymentMethodFilter } from './checkPaymentMethodFilter';
 import { multiShippingFilter } from './multiShippingFilter';
 import { selectedHostedPaymentFilter } from './selectedHostedPaymentFilter';
 
 // Order matters. selectedHostedPaymentFilter must run last because it can
 // collapse the list to a single method when a hosted payment is already in flight.
 const FILTERS: PaymentMethodFilter[] = [
-    chequePaymentMethodFilter,
+    checkPaymentMethodFilter,
     stripeMethodsFiltering,
     boltAndBraintreeFilter,
     multiShippingFilter,

--- a/packages/core/src/app/payment/paymentMethodFilters/checkPaymentMethodFilter.spec.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/checkPaymentMethodFilter.spec.ts
@@ -1,0 +1,71 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+import { type PaymentMethodFilterContext } from '@bigcommerce/checkout/payment-integration-api';
+
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+import { getPaymentMethod, getPaypalCreditPaymentMethod } from '../payment-methods.mock';
+
+import { checkPaymentMethodFilter } from './checkPaymentMethodFilter';
+
+describe('checkPaymentMethodFilter', () => {
+    let context: PaymentMethodFilterContext;
+
+    it('hides cheque when capability is true', () => {
+        context = {
+            capabilities: {
+                ...defaultCapabilities,
+                payment: {
+                    ...defaultCapabilities.payment,
+                    hideCheckPaymentMethod: true,
+                },
+            },
+            checkout: getCheckout(),
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            paymentProviderCustomer: undefined,
+        };
+
+        const paypalMethod = getPaypalCreditPaymentMethod();
+
+        const checkVisible: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'cheque',
+            initializationData: {},
+        };
+
+        expect(checkPaymentMethodFilter.apply([checkVisible, paypalMethod], context)).toEqual([
+            paypalMethod,
+        ]);
+    });
+
+    it('keeps cheque when capability is false', () => {
+        context = {
+            capabilities: {
+                ...defaultCapabilities,
+                payment: {
+                    ...defaultCapabilities.payment,
+                    hideCheckPaymentMethod: false,
+                },
+            },
+            checkout: getCheckout(),
+            checkoutSettings: getStoreConfig().checkoutSettings,
+            getPaymentMethod: jest.fn(),
+            paymentProviderCustomer: undefined,
+        };
+
+        const paypalMethod = getPaypalCreditPaymentMethod();
+
+        const checkVisible: PaymentMethod = {
+            ...getPaymentMethod(),
+            id: 'cheque',
+            initializationData: {},
+        };
+
+        expect(checkPaymentMethodFilter.apply([checkVisible, paypalMethod], context)).toEqual([
+            checkVisible,
+            paypalMethod,
+        ]);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/checkPaymentMethodFilter.spec.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/checkPaymentMethodFilter.spec.ts
@@ -12,7 +12,7 @@ import { checkPaymentMethodFilter } from './checkPaymentMethodFilter';
 describe('checkPaymentMethodFilter', () => {
     let context: PaymentMethodFilterContext;
 
-    it('hides cheque when capability is true', () => {
+    it('hides check when capability is true', () => {
         context = {
             capabilities: {
                 ...defaultCapabilities,
@@ -40,7 +40,7 @@ describe('checkPaymentMethodFilter', () => {
         ]);
     });
 
-    it('keeps cheque when capability is false', () => {
+    it('keeps check when capability is false', () => {
         context = {
             capabilities: {
                 ...defaultCapabilities,

--- a/packages/core/src/app/payment/paymentMethodFilters/checkPaymentMethodFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/checkPaymentMethodFilter.ts
@@ -1,0 +1,12 @@
+import { type PaymentMethodFilter } from '@bigcommerce/checkout/payment-integration-api';
+
+export const checkPaymentMethodFilter: PaymentMethodFilter = {
+    name: 'checkPaymentMethodFilter',
+    apply(methods, { capabilities }) {
+        if (capabilities?.payment.hideCheckPaymentMethod) {
+            return methods.filter((method) => method.id !== 'cheque');
+        }
+
+        return methods;
+    },
+};

--- a/packages/core/src/app/payment/paymentMethodFilters/chequePaymentMethodFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/chequePaymentMethodFilter.ts
@@ -1,8 +1,0 @@
-import { type PaymentMethodFilter } from '@bigcommerce/checkout/payment-integration-api';
-
-export const chequePaymentMethodFilter: PaymentMethodFilter = {
-    name: 'chequePaymentMethodFilter',
-    apply(methods, { checkoutSettings }) {
-        // TODO
-    },
-};

--- a/packages/core/src/app/payment/paymentMethodFilters/chequePaymentMethodFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/chequePaymentMethodFilter.ts
@@ -1,0 +1,8 @@
+import { type PaymentMethodFilter } from '@bigcommerce/checkout/payment-integration-api';
+
+export const chequePaymentMethodFilter: PaymentMethodFilter = {
+    name: 'chequePaymentMethodFilter',
+    apply(methods, { checkoutSettings }) {
+        // TODO
+    },
+};


### PR DESCRIPTION
## What/Why?
Add filter for check payment method based on a capability.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which payment methods appear at checkout when a capability is on; default remains visible and behavior is list filtering only, but misconfigured capabilities could hide check for B2B or similar flows.
> 
> **Overview**
> Adds capability-gated hiding of the **check/cheque** payment option at checkout.
> 
> A new `payment.hideCheckPaymentMethod` flag is added to default capabilities (default **false**). When enabled, `checkPaymentMethodFilter` removes the method with id `cheque` from the filtered payment method list; the filter is wired as the first step in `applyPaymentMethodFilters`. Unit tests cover both enabled and disabled behavior.
> 
> `@bigcommerce/checkout-sdk` is bumped from **^1.922.0** to **^1.922.1** (lockfile updated) to align with the capability shape from the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169e4a1482b3e610eb8767e15c0c059f91e8fa9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->