### PR TITLE
feat(checkout): Migrate CBA MPGS to Resolver Configuration

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -1,4 +1,3 @@
-import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import {
     createCyberSourcePaymentStrategy,
@@ -46,7 +45,6 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                         createCyberSourcePaymentStrategy,
                         createCyberSourceV2PaymentStrategy,
                         createSagePayPaymentStrategy,
-                        createCBAMPGSPaymentStrategy,
                     ],
                     creditCard: getHostedFormOptions && {
                         form: await getHostedFormOptions(selectedInstrument),

--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -1,3 +1,4 @@
+import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import {
     createCyberSourcePaymentStrategy,
@@ -6,6 +7,9 @@ import {
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import React, { type FunctionComponent, useCallback } from 'react';
 
+import { useCheckout } from '@bigcommerce/checkout/contexts';
+
+import { isExperimentEnabled } from '../../common/utility';
 import {
     withHostedCreditCardFieldset,
     type WithInjectedHostedCreditCardFieldsetProps,
@@ -34,6 +38,13 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
     initializePayment,
     ...rest
 }) => {
+    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
+    const isCBAMPGSResolverEnabled = isExperimentEnabled(
+        config?.checkoutSettings,
+        'PI-4748.cba_resolver_configuration',
+        false,
+    );
+
     const initializeHostedCreditCardPayment: CreditCardPaymentMethodProps['initializePayment'] =
         useCallback(
             async (options, selectedInstrument) => {
@@ -45,13 +56,14 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                         createCyberSourcePaymentStrategy,
                         createCyberSourceV2PaymentStrategy,
                         createSagePayPaymentStrategy,
+                        ...(!isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
                     ],
                     creditCard: getHostedFormOptions && {
                         form: await getHostedFormOptions(selectedInstrument),
                     },
                 });
             },
-            [getHostedFormOptions, initializePayment],
+            [getHostedFormOptions, initializePayment, isCBAMPGSResolverEnabled],
         );
 
     return (

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodV2.tsx
@@ -58,11 +58,15 @@ const PaymentMethodContainer: ComponentType<
         setValidationSchema,
     };
 
-    const ResolvedPaymentMethod = resolvePaymentMethod({
-        id: method.id,
-        gateway: method.gateway,
-        type: method.type,
-    });
+    const config = checkoutState.data.getConfig();
+    const ResolvedPaymentMethod = resolvePaymentMethod(
+        {
+            id: method.id,
+            gateway: method.gateway,
+            type: method.type,
+        },
+        config?.checkoutSettings,
+    );
 
     if (!ResolvedPaymentMethod) {
         return (

--- a/packages/core/src/app/payment/resolvePaymentMethod.ts
+++ b/packages/core/src/app/payment/resolvePaymentMethod.ts
@@ -1,3 +1,4 @@
+import type { CheckoutSettings } from '@bigcommerce/checkout-sdk';
 import { type ComponentType } from 'react';
 
 import {
@@ -5,15 +6,36 @@ import {
     type PaymentMethodResolveId,
 } from '@bigcommerce/checkout/payment-integration-api';
 
+import { isExperimentEnabled } from '../common/utility';
 import { resolveLazyComponent } from '../common/resolver';
 import * as lazyPaymentMethods from '../generated/paymentIntegrations';
 
 export default function resolvePaymentMethod(
     query: PaymentMethodResolveId,
+    checkoutSettings?: CheckoutSettings,
 ): ComponentType<PaymentMethodProps> | undefined {
     const { ComponentRegistry, ...allExports } = lazyPaymentMethods;
+    const filteredMethods = Object.fromEntries(
+        Object.entries(ComponentRegistry).map(([key, value]) => {
+            const methods = value.filter((resolveId) => {
+                const { experiment } = resolveId as PaymentMethodResolveId;
+
+                if (!experiment) {
+                    return true;
+                }
+
+                // should be normalized after config
+                const normalizedKey = experiment.replace('_', '.');
+
+                return isExperimentEnabled(checkoutSettings, normalizedKey, false);
+            });
+
+            return [key, methods];
+        }),
+    );
+
     const components = Object.fromEntries(
-        Object.keys(ComponentRegistry).map((key) => [
+        Object.keys(filteredMethods).map((key) => [
             key,
             allExports[key as keyof typeof allExports],
         ]),
@@ -22,6 +44,6 @@ export default function resolvePaymentMethod(
     return resolveLazyComponent<PaymentMethodResolveId, PaymentMethodProps>(
         query,
         components,
-        ComponentRegistry,
+        filteredMethods,
     );
 }

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -38,5 +38,6 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
         { id: 'credit_card', gateway: 'checkoutcom' },
 
         { id: 'tdonlinemart' },
+        { id: 'cba_mpgs' },
     ],
 );

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -30,6 +30,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     HostedCreditCardPaymentMethod,
+    // experiment should be write with underscore because point after build will set this value like variable
     [
         {
             id: 'hosted-credit-card',
@@ -38,6 +39,6 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
         { id: 'credit_card', gateway: 'checkoutcom' },
 
         { id: 'tdonlinemart' },
-        { id: 'cba_mpgs' },
+        { id: 'cba_mpgs', experiment: 'PI-4748_cba_resolver_configuration' },
     ],
 );

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
@@ -93,7 +93,15 @@ const getDefaultProps = (overrides = {}): HostedCreditCardComponentProps =>
             initializePayment: jest.fn().mockResolvedValue(undefined),
             deinitializePayment: jest.fn(),
         },
-        checkoutState: {},
+        checkoutState: {
+            data: {
+                getConfig: jest.fn().mockReturnValue({
+                    checkoutSettings: {
+                        features: {},
+                    },
+                }),
+            },
+        },
         paymentForm: {
             setFieldTouched: jest.fn(),
             setFieldValue: jest.fn(),

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -44,6 +44,11 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
 }) => {
     const [focusedFieldType, setFocusedFieldType] = useState<string>();
 
+    const isCBAMPGSResolverEnabled =
+        checkoutState.data.getConfig()?.checkoutSettings.features?.[
+            'PI-4748.cba_resolver_configuration'
+        ] ?? false;
+
     const { setFieldTouched, setFieldValue, setSubmitted, submitForm } = paymentForm;
     const isInstrumentCardCodeRequiredProp = isInstrumentCardCodeRequiredSelector(checkoutState);
     const isInstrumentCardNumberRequiredProp =
@@ -258,7 +263,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                     integrations: [
                         createCreditCardPaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
-                        createCBAMPGSPaymentStrategy,
+                        ...(isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,
                     ],
@@ -270,7 +275,12 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                     }),
                 });
             },
-            [getHostedFormOptions, initializePayment, isHostedFormEnabled],
+            [
+                getHostedFormOptions,
+                initializePayment,
+                isHostedFormEnabled,
+                isCBAMPGSResolverEnabled,
+            ],
         );
 
     const hostedStoredCardValidationSchema = getHostedInstrumentValidationSchema({ language });

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -4,6 +4,7 @@ import {
     type LegacyHostedFormOptions,
 } from '@bigcommerce/checkout-sdk';
 import { createBlueSnapDirectCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
+import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
@@ -257,6 +258,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                     integrations: [
                         createCreditCardPaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
+                        createCBAMPGSPaymentStrategy,
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,
                     ],

--- a/packages/payment-integration-api/src/PaymentMethodResolveId.ts
+++ b/packages/payment-integration-api/src/PaymentMethodResolveId.ts
@@ -4,6 +4,7 @@ type PaymentMethodResolveId = RequireAtLeastOne<{
     id?: string;
     gateway?: string;
     type?: string;
+    experiment?: string;
 }>;
 
 export default PaymentMethodResolveId;


### PR DESCRIPTION
## What/Why?

Migrate CBA MPGS payment method to the new resolver-based architecture by registering it in the HostedCreditCardPaymentMethod component resolver (packages/hosted-credit-card-integration).

The migration is gated behind the PI-4748.cba_resolver_configuration experiment:

Experiment ON — CBA MPGS routes through the new resolver flow (HostedCreditCardComponent), where createCBAMPGSPaymentStrategy is included conditionally.
Experiment OFF — CBA MPGS falls back to the legacy V1 flow (HostedCreditCardPaymentMethod in core), where createCBAMPGSPaymentStrategy is added to the integration list conditionally.
The experiment flag is checked via isExperimentEnabled in core and directly via checkoutSettings.features in the hosted-credit-card-integration package (where the utility is not available). Both conditional blocks are intentionally duplicated to make cleanup straightforward once the experiment is fully rolled out.

Added global functional for experiment 

## Rollout/Rollback
roll back this commit 

## Testing
without 3ds isHostedFormEnabled false

https://github.com/user-attachments/assets/1e6a2220-3134-4c0b-8ac8-09edb63462a1

with 3ds isHostedFormEnabled false

https://github.com/user-attachments/assets/0051827e-c690-49e0-a91b-e75a33107084

without 3ds isHostedFormEnabled true

https://github.com/user-attachments/assets/fee735a1-a32b-4c00-b516-ecc53f26f7b8

with 3ds isHostedFormEnabled true

https://github.com/user-attachments/assets/d040a04d-1863-4020-98cc-a4109ce6f82f

<img width="450" height="674" alt="image" src="https://github.com/user-attachments/assets/32884da3-375c-453f-87e4-9bccec7ad6d5" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which payment UI and SDK integration list run for CBA MPGS, but behavior is gated and the two paths are mutually exclusive for the strategy registration.
> 
> **Overview**
> **CBA MPGS** checkout routing is migrated behind **`PI-4748.cba_resolver_configuration`**, with complementary legacy vs resolver behavior so only one path owns **`createCBAMPGSPaymentStrategy`**.
> 
> Payment method resolution now supports an optional **`experiment`** on **`PaymentMethodResolveId`**. **`resolvePaymentMethod`** filters registry entries with **`isExperimentEnabled`** (underscore keys normalized to dots), and **`PaymentMethodV2`** passes **`checkoutSettings`** into that resolver. **`cba_mpgs`** is registered on the hosted-credit-card integration resolver only when the flag is on.
> 
> With the experiment **on**, checkout uses the hosted-credit-card integration and conditionally adds the CBA MPGS strategy there. With it **off**, resolution falls back to legacy **V1** and the core **`HostedCreditCardPaymentMethod`** keeps registering that strategy instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d6c3f8e45dfb917cbe076911b2fd79ab3e7e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->