### PR TITLE
fix(checkout): CHECKOUT-10037 Remove FE store credit unapply on disableStoreCredit

### DIFF
--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -221,6 +221,45 @@ describe('Payment step', () => {
         expect(screen.getByText(/Payment is not required/)).toBeInTheDocument();
     });
 
+    it('does not apply store credit automatically when disableStoreCredit is true', async () => {
+        const configWithDisableStoreCredit = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    capabilities: {
+                        ...defaultCapabilities,
+                        userJourney: {
+                            ...defaultCapabilities.userJourney,
+                            disableStoreCredit: true,
+                        },
+                    },
+                },
+            },
+        };
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: configWithDisableStoreCredit,
+            checkout: {
+                ...checkoutWithShippingAndBilling,
+                isStoreCreditApplied: false,
+                customer: {
+                    ...customer,
+                    storeCredit: 1000,
+                },
+            },
+        });
+
+        const applyStoreCreditSpy = jest.spyOn(checkoutService, 'applyStoreCredit');
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(applyStoreCreditSpy).not.toHaveBeenCalledWith(true);
+    });
+
     it('does not render amazon if multi-shipping', async () => {
         const amazonPay = {
             ...payments[0],

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -593,11 +593,7 @@ const Payment = (
                 checkoutServiceSubscribe,
             } = props;
 
-            if (disableStoreCredit) {
-                if (props.isStoreCreditApplied) {
-                    await handleStoreCreditChange(false);
-                }
-            } else if (usableStoreCredit) {
+            if (!disableStoreCredit && usableStoreCredit) {
                 await handleStoreCreditChange(true);
             }
 


### PR DESCRIPTION
## What changed

Removed the frontend logic that called `handleStoreCreditChange(false)` when `disableStoreCredit` is `true` and store credit was already applied.

## Why

As discussed, unapplying store credit when `disableStoreCredit` is set should be handled by the backend, not the frontend. This removes the redundant FE call.

## Related

- [x] existing test 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout payment initialization and store-credit application timing; behavior when credit was already applied now depends on the backend rather than an explicit FE unapply call.
> 
> **Overview**
> Stops the payment step from **unapplying** store credit on mount when `disableStoreCredit` is enabled. Previously, if store credit was already applied, the UI called `handleStoreCreditChange(false)`; that path is removed so clearing credit in that scenario is left to the backend.
> 
> Auto-apply on payment load is unchanged: store credit is still applied when `usableStoreCredit` is available and `disableStoreCredit` is false. A payment-step test asserts that with `disableStoreCredit: true`, `applyStoreCredit(true)` is not invoked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b269c46c0331656ca2efcd154e313845391ae716. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->