### PR TITLE
refactor(checkout): CHECKOUT-10091 Update Shipping Option Style

### DIFF
--- a/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
+++ b/packages/core/src/app/shipping/shippingOption/StaticShippingOption.scss
@@ -52,7 +52,7 @@
     .shippingOption {
         align-items: center;
         display: flex;
-        min-height: remCalc(35px);
+        min-height: remCalc(46px);
     }
 
     .shippingOption-figure,


### PR DESCRIPTION
## What/Why?

Center the shipping option vertically.

## Rollout/Rollback

Revert.

## Testing

### Before
<img width="627" height="175" alt="Screenshot 2026-06-11 at 14 46 18" src="https://github.com/user-attachments/assets/40c549c0-4cda-4e5d-805f-4ccb66cf4fbc" />

### After
<img width="627" height="175" alt="Screenshot 2026-06-11 at 14 58 39" src="https://github.com/user-attachments/assets/e5cf8a90-db94-416d-a09b-0f8bad85ca71" />

### After v2
<img width="627" height="175" alt="Screenshot 2026-06-11 at 14 58 17" src="https://github.com/user-attachments/assets/c2ac4c6f-0af2-4170-b884-c7ff8ea6d909" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout-only SCSS sizing change with no logic, API, or data impact; revertible by restoring the previous min-height.
> 
> **Overview**
> Increases the **minimum height** of flex shipping option rows inside `.shippingOptionLabel` from `remCalc(35px)` to `remCalc(46px)` in `StaticShippingOption.scss`, giving label content more vertical space so figure, description, and price align better when centered with `align-items: center`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03366607931ccf3e41cdbc09de1116ced3771021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->