### PR TITLE
refactor(checkout): CHECKOUT-10091 Update Capabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.922.1",
+        "@bigcommerce/checkout-sdk": "^1.923.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.922.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.1.tgz",
-      "integrity": "sha512-DHBoCyYd1AHMWJVKhmqM+GEBkGISiS4mBwO7Om/kTwU28TdlgnfvIMWuNVpExmmgRdoyYG0QhgYe5ZGJ2zF6Zw==",
+      "version": "1.923.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.923.1.tgz",
+      "integrity": "sha512-CzNp+c4x6TNTqLk3qDFwZLlK/6dFMb9E3GMTdAzChCXQBNsu3LRcE87oNhstJiKV8z1fzeKsGsgdEU1yZaklmA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.922.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.922.1.tgz",
-      "integrity": "sha512-DHBoCyYd1AHMWJVKhmqM+GEBkGISiS4mBwO7Om/kTwU28TdlgnfvIMWuNVpExmmgRdoyYG0QhgYe5ZGJ2zF6Zw==",
+      "version": "1.923.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.923.1.tgz",
+      "integrity": "sha512-CzNp+c4x6TNTqLk3qDFwZLlK/6dFMb9E3GMTdAzChCXQBNsu3LRcE87oNhstJiKV8z1fzeKsGsgdEU1yZaklmA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.922.1",
+    "@bigcommerce/checkout-sdk": "^1.923.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/cheque-payment-integration/src/ChequePaymentMethod.test.tsx
+++ b/packages/cheque-payment-integration/src/ChequePaymentMethod.test.tsx
@@ -100,10 +100,8 @@ describe('ChequePaymentMethod', () => {
 
     describe('PO Number rendering', () => {
         const poConfig = {
-            label: 'PO Number',
-            required: true,
-            creditLimit: 5000,
-            currency: 'USD',
+            field: { label: 'PO Number', required: true },
+            creditLimitCheck: { creditLimit: 5000, currency: 'USD' },
         };
 
         beforeEach(() => {
@@ -121,12 +119,12 @@ describe('ChequePaymentMethod', () => {
         it('renders PoNumber input with the configured label when poConfig is set', () => {
             renderWithCapabilities(<ChequePaymentMethod {...defaultProps} />, { poConfig });
 
-            expect(screen.getByText(poConfig.label)).toBeInTheDocument();
+            expect(screen.getByText(poConfig.field.label)).toBeInTheDocument();
         });
 
-        it('shows the optional suffix when poConfig.required is false', () => {
+        it('shows the optional suffix when poConfig.field.required is false', () => {
             renderWithCapabilities(<ChequePaymentMethod {...defaultProps} />, {
-                poConfig: { ...poConfig, required: false },
+                poConfig: { ...poConfig, field: { ...poConfig.field, required: false } },
             });
 
             expect(screen.getByText(/Optional/i)).toBeInTheDocument();

--- a/packages/cheque-payment-integration/src/ChequePaymentMethod.tsx
+++ b/packages/cheque-payment-integration/src/ChequePaymentMethod.tsx
@@ -55,11 +55,11 @@ const ChequePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         };
     }, [checkoutService, method.gateway, method.id, onUnhandledError]);
 
-    if (poConfig) {
+    if (poConfig?.field) {
         return (
             <PoNumber
-                isRequired={poConfig.required}
-                label={poConfig.label}
+                isRequired={poConfig.field.required}
+                label={poConfig.field.label}
                 language={language}
                 method={method}
                 paymentForm={paymentForm}

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -10,6 +10,8 @@ export const defaultCapabilities: Capabilities = {
         hasAddressExtraFields: false,
         hasOrderExtraFields: false,
         requiresB2BToken: false,
+        hasAddressLabel: false,
+        quoteConfig: null,
     },
     customer: {
         superAdminCompanySelector: false,
@@ -31,7 +33,7 @@ export const defaultCapabilities: Capabilities = {
         hideCheckPaymentMethod: false,
     },
     orderConfirmation: {
-        canCreatePersonalAccount: false,
+        cannotCreatePersonalAccount: false,
         persistB2BMetadata: false,
         invoiceRedirect: false,
     },

--- a/packages/core/src/app/coupon/NewOrderSummarySubtotals.test.tsx
+++ b/packages/core/src/app/coupon/NewOrderSummarySubtotals.test.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
 import {
     CheckoutProvider,
+    defaultCapabilities,
     ExtensionProvider,
     LocaleProvider,
     useCapabilities,
@@ -85,7 +86,12 @@ describe('NewOrderSummarySubtotals', () => {
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
         mockUseMultiCoupon.mockReturnValue(defaultMockReturn);
         mockUseCapabilities.mockReturnValue({
-            userJourney: { disableCoupon: false, disableGiftCertificate: false },
+            ...defaultCapabilities,
+            userJourney: {
+                ...defaultCapabilities.userJourney,
+                disableCoupon: false,
+                disableGiftCertificate: false,
+            },
         });
     });
 
@@ -695,7 +701,12 @@ describe('NewOrderSummarySubtotals', () => {
     describe('disableGiftCertificate and disableCoupon capabilities', () => {
         it('shows "Coupon" label when disableGiftCertificate is true', () => {
             mockUseCapabilities.mockReturnValue({
-                userJourney: { disableCoupon: false, disableGiftCertificate: true },
+                ...defaultCapabilities,
+                userJourney: {
+                    ...defaultCapabilities.userJourney,
+                    disableCoupon: false,
+                    disableGiftCertificate: true,
+                },
             });
 
             renderComponent();
@@ -709,7 +720,12 @@ describe('NewOrderSummarySubtotals', () => {
 
         it('shows "Gift certificate" label when disableCoupon is true', () => {
             mockUseCapabilities.mockReturnValue({
-                userJourney: { disableCoupon: true, disableGiftCertificate: false },
+                ...defaultCapabilities,
+                userJourney: {
+                    ...defaultCapabilities.userJourney,
+                    disableCoupon: true,
+                    disableGiftCertificate: false,
+                },
             });
 
             renderComponent();
@@ -723,7 +739,12 @@ describe('NewOrderSummarySubtotals', () => {
 
         it('shows default toggle label when both flags are false', () => {
             mockUseCapabilities.mockReturnValue({
-                userJourney: { disableCoupon: false, disableGiftCertificate: false },
+                ...defaultCapabilities,
+                userJourney: {
+                    ...defaultCapabilities.userJourney,
+                    disableCoupon: false,
+                    disableGiftCertificate: false,
+                },
             });
 
             renderComponent();
@@ -737,7 +758,12 @@ describe('NewOrderSummarySubtotals', () => {
 
         it('hides entire coupon section when both disableCoupon and disableGiftCertificate are true', () => {
             mockUseCapabilities.mockReturnValue({
-                userJourney: { disableCoupon: true, disableGiftCertificate: true },
+                ...defaultCapabilities,
+                userJourney: {
+                    ...defaultCapabilities.userJourney,
+                    disableCoupon: true,
+                    disableGiftCertificate: true,
+                },
             });
 
             renderComponent();

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -503,7 +503,7 @@ const PaymentMethodTitle: FunctionComponent<
                         ) : (
                             <TranslatedString
                                 data={{
-                                    currency: poConfig?.currency ?? '',
+                                    currency: poConfig?.creditLimitCheck?.currency ?? '',
                                     name: titleText,
                                 }}
                                 id="payment.errors.disabled_PO_number_currency_mismatch"

--- a/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.spec.ts
+++ b/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.spec.ts
@@ -15,7 +15,8 @@ function getChequeMethod(): PaymentMethod {
 }
 
 describe('getPoMethodDisabledReason', () => {
-    const poConfig = { creditLimit: 100, currency: 'USD' };
+    const creditLimitCheck = { creditLimit: 100, currency: 'USD' };
+    const poConfig = { creditLimitCheck };
 
     const baseArgs = {
         method: getChequeMethod(),
@@ -34,21 +35,21 @@ describe('getPoMethodDisabledReason', () => {
         expect(getPoMethodDisabledReason({ ...baseArgs, poConfig: null })).toBeNull();
     });
 
-    it('returns null when poConfig.creditLimit is null (no limit configured)', () => {
+    it('returns null when creditLimitCheck is null (no limit configured)', () => {
         expect(
             getPoMethodDisabledReason({
                 ...baseArgs,
-                poConfig: { ...poConfig, creditLimit: null },
+                poConfig: { creditLimitCheck: null },
                 grandTotal: 9999,
             }),
         ).toBeNull();
     });
 
-    it('returns null when poConfig.currency is an empty string', () => {
+    it('returns null when creditLimitCheck.currency is an empty string', () => {
         expect(
             getPoMethodDisabledReason({
                 ...baseArgs,
-                poConfig: { ...poConfig, currency: '' },
+                poConfig: { creditLimitCheck: { ...creditLimitCheck, currency: '' } },
                 cartCurrencyCode: 'EUR',
             }),
         ).toBeNull();
@@ -62,7 +63,7 @@ describe('getPoMethodDisabledReason', () => {
         expect(getPoMethodDisabledReason({ ...baseArgs, cartCurrencyCode: undefined })).toBeNull();
     });
 
-    it('returns currencyMismatch when poConfig.currency differs from cart currency', () => {
+    it('returns currencyMismatch when creditLimitCheck.currency differs from cart currency', () => {
         expect(getPoMethodDisabledReason({ ...baseArgs, cartCurrencyCode: 'EUR' })).toBe(
             'currencyMismatch',
         );
@@ -72,7 +73,7 @@ describe('getPoMethodDisabledReason', () => {
         expect(
             getPoMethodDisabledReason({
                 ...baseArgs,
-                poConfig: { ...poConfig, currency: 'usd' },
+                poConfig: { creditLimitCheck: { ...creditLimitCheck, currency: 'usd' } },
                 cartCurrencyCode: 'USD',
             }),
         ).toBeNull();

--- a/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.ts
+++ b/packages/core/src/app/payment/paymentMethod/usePoMethodDisabledReason.ts
@@ -7,7 +7,7 @@ export type PoDisabledReason = 'creditLimit' | 'currencyMismatch';
 
 export interface GetPoMethodDisabledReasonArgs {
     method: PaymentMethod;
-    poConfig: { creditLimit: number | null; currency: string } | null;
+    poConfig: { creditLimitCheck: { creditLimit: number; currency: string } | null } | null;
     grandTotal: number | undefined;
     cartCurrencyCode: string | undefined;
 }
@@ -18,8 +18,8 @@ export function getPoMethodDisabledReason({
     grandTotal,
     cartCurrencyCode,
 }: GetPoMethodDisabledReasonArgs): PoDisabledReason | null {
-    const creditLimit = poConfig?.creditLimit;
-    const expectedCurrency = poConfig?.currency;
+    const creditLimit = poConfig?.creditLimitCheck?.creditLimit;
+    const expectedCurrency = poConfig?.creditLimitCheck?.currency;
 
     const isNotPoMethod = method.id !== 'cheque';
     const isPoConfigIncomplete = creditLimit == null || !expectedCurrency;


### PR DESCRIPTION
## What/Why?

Update codebase to reflect the `Capabilities` interface changes below:

* poConfig restructured into two independently-nullable sub-configs
   * field: { label, required } | null
   * creditLimitCheck: { creditLimit, currency } | null
   * outer poConfig remains nullable
* userJourney gains two fields
   * hasAddressLabel: boolean
   * quoteConfig: { id: number } | null
* B2BPaymentMethodFilterType enum values lowercased
   * 'STANDARD' → 'standard'
   * 'INVOICE' → 'invoice'
* orderConfirmation field renamed
   * canCreatePersonalAccount → cannotCreatePersonalAccount

## Rollout/Rollback

Revert.

## Testing

### Tested PO method's config.

<img width="621" height="455" alt="Screenshot 2026-06-11 at 15 30 11" src="https://github.com/user-attachments/assets/3c742024-a433-4dd9-b851-0c69771213d4" />
<img width="621" height="579" alt="Screenshot 2026-06-11 at 15 29 34" src="https://github.com/user-attachments/assets/7ceb9d4a-d2d3-4709-9950-33534357cb98" />

### We should still see disabled the cheque method when:
- PO field is disabled (so we should not see the PO number field).
- but credit limit check is set.
   
<img width="1452" height="832" alt="image" src="https://github.com/user-attachments/assets/44802338-99fd-4057-be81-91ea2e0151a3" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PO/cheque payment gating and credit-limit disable logic against a new capability contract; misaligned upstream capability payloads could hide PO fields or skip limits incorrectly.
> 
> **Overview**
> Aligns checkout-js with updated **`Capabilities`** from **`@bigcommerce/checkout-sdk`** (^1.923.1), mainly around B2B purchase-order payment behavior and default capability shapes.
> 
> **`poConfig`** is no longer flat: PO field UI reads **`poConfig.field`** (`label`, `required`), and cheque/credit-limit disabling reads **`poConfig.creditLimitCheck`** (`creditLimit`, `currency`). Cheque only renders the PO input when **`field`** is present; disabled-message copy for currency mismatch uses **`creditLimitCheck.currency`**.
> 
> **`defaultCapabilities`** adds **`userJourney.hasAddressLabel`** and **`userJourney.quoteConfig`**, and renames **`orderConfirmation.canCreatePersonalAccount`** → **`cannotCreatePersonalAccount`**. Tests that mock capabilities now spread **`defaultCapabilities`** so partial mocks stay valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a55c3b299e4438f421959be879fcaacd0630e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->