### PR TITLE
feat(checkout): CHECKOUT-9819 implement post order request for b2b user

### DIFF
--- a/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
+++ b/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
@@ -3,6 +3,8 @@ export class B2BExtraFieldsSessionStorage {
     static readonly SHIPPING_KEY = 'b2bAddressExtraFields_shipping';
     static readonly CONSIGNMENT_KEY_PREFIX = 'b2bAddressExtraFields_consignment_';
     static readonly ORDER_KEY = 'b2bOrderExtraFields';
+    static readonly BILLING_ADDRESS_ID_KEY = 'b2bBillingAddressId';
+    static readonly SHIPPING_ADDRESS_ID_KEY = 'b2bShippingAddressId';
 
     static getConsignmentKey(consignmentId: string): string {
         return `${this.CONSIGNMENT_KEY_PREFIX}${consignmentId}`;
@@ -27,6 +29,20 @@ export class B2BExtraFieldsSessionStorage {
     }
 
     static removeFields(key: string): void {
+        sessionStorage.removeItem(key);
+    }
+
+    static setAddressId(key: string, id: number): void {
+        sessionStorage.setItem(key, String(id));
+    }
+
+    static getAddressId(key: string): number | undefined {
+        const raw = sessionStorage.getItem(key);
+
+        return raw ? Number(raw) : undefined;
+    }
+
+    static removeAddressId(key: string): void {
         sessionStorage.removeItem(key);
     }
 

--- a/packages/core/src/app/billing/Billing.test.tsx
+++ b/packages/core/src/app/billing/Billing.test.tsx
@@ -47,6 +47,7 @@ import {
     waitFor,
 } from '@bigcommerce/checkout/test-utils';
 
+import { B2BExtraFieldsSessionStorage } from '../address';
 import Checkout from '../checkout/Checkout';
 import { type CheckoutInitializerProps } from '../checkout/CheckoutInitializer';
 import { getCheckoutPayment } from '../checkout/checkouts.mock';
@@ -77,6 +78,7 @@ describe('Billing step', () => {
     afterEach(() => {
         jest.unmock('lodash');
         checkout.resetHandlers();
+        sessionStorage.clear();
     });
 
     afterAll(() => {
@@ -565,6 +567,101 @@ describe('Billing step', () => {
             expect(
                 screen.queryByText(/no billing address to choose from/i),
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('B2B company address book', () => {
+        const companyAddressBookCapabilities = {
+            ...defaultCapabilities,
+            userJourney: {
+                ...defaultCapabilities.userJourney,
+                hasCompanyAddressBook: true,
+            },
+        };
+
+        const CheckoutWithCompanyAddressBook: FunctionComponent<CheckoutInitializerProps> = (
+            props,
+        ) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleProvider
+                    checkoutService={checkoutService}
+                    languageService={getLanguageService()}
+                >
+                    <AnalyticsProviderMock>
+                        <ExtensionProvider extensionService={extensionService}>
+                            <ThemeProvider>
+                                <CapabilitiesContext.Provider
+                                    value={companyAddressBookCapabilities}
+                                >
+                                    <Checkout {...props} />
+                                </CapabilitiesContext.Provider>
+                            </ThemeProvider>
+                        </ExtensionProvider>
+                    </AnalyticsProviderMock>
+                </LocaleProvider>
+            </CheckoutProvider>
+        );
+
+        // With hasCompanyAddressBook enabled the searchable address book is rendered, which only
+        // lists addresses flagged for billing. shippingAddress3 is given id 3 and isBilling.
+        const customerWithCompanyBillingAddress = {
+            ...customer,
+            addresses: [{ ...shippingAddress3, id: 3, isBilling: true }],
+        };
+        const checkoutWithCompanyBillingAddress = {
+            ...checkoutWithShipping,
+            customer: customerWithCompanyBillingAddress,
+        };
+
+        it('stores the selected billing address id when hasCompanyAddressBook is enabled', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
+                checkout: checkoutWithCompanyBillingAddress,
+            });
+
+            jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
+
+            await checkout.waitForBillingStep();
+
+            await act(async () => {
+                await userEvent.click(screen.getByTestId('address-select-button'));
+                await userEvent.click(screen.getByTestId('address-select-option-action'));
+            });
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBe(3);
+        });
+
+        it('does not store the billing address id when hasCompanyAddressBook is disabled', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
+                checkout: checkoutWithCustomer,
+            });
+
+            jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForBillingStep();
+
+            await act(async () => {
+                await userEvent.click(screen.getByTestId('address-select-button'));
+                // shippingAddress3 is the customer's saved address with id 3.
+                await userEvent.click(screen.getByText(shippingAddress3.address1));
+            });
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -1,4 +1,9 @@
-import { type Address, type FormField, isExtraField } from '@bigcommerce/checkout-sdk/essential';
+import {
+    type Address,
+    type CustomerAddress,
+    type FormField,
+    isExtraField,
+} from '@bigcommerce/checkout-sdk/essential';
 import { type FormikProps, withFormik } from 'formik';
 import React, { type RefObject, useRef, useState } from 'react';
 import { lazy } from 'yup';
@@ -66,7 +71,7 @@ const BillingForm = ({
     const { checkoutService, checkoutState } = useCheckout();
     const {
         billing: { hideSaveToAddressBookCheck, restrictManualAddressEntry },
-        userJourney: { hasAddressExtraFields },
+        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
     } = useCapabilities();
 
     const {
@@ -109,6 +114,17 @@ const BillingForm = ({
     const handleSelectAddress = async (address: Partial<Address>) => {
         setIsResettingAddress(true);
 
+        B2BExtraFieldsSessionStorage.removeAddressId(
+            B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+        );
+
+        if (hasCompanyAddressBook && (address as CustomerAddress).id) {
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                (address as CustomerAddress).id,
+            );
+        }
+
         try {
             await checkoutService.updateBillingAddress(address);
         } catch (error) {
@@ -124,6 +140,10 @@ const BillingForm = ({
         if (hasAddressExtraFields) {
             B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.BILLING_KEY);
         }
+
+        B2BExtraFieldsSessionStorage.removeAddressId(
+            B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+        );
 
         void handleSelectAddress({});
     };

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -33,13 +33,18 @@ import {
     payments,
 } from '@bigcommerce/checkout/test-framework';
 import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+import { getPoNumber, setPoNumber } from '@bigcommerce/checkout/utility';
 
+import { B2BExtraFieldsSessionStorage } from '../address';
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
 import {
     createEmbeddedCheckoutStylesheet,
     createEmbeddedCheckoutSupport,
 } from '../embeddedCheckout';
+
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 
 describe('Payment step', () => {
     let checkout: CheckoutPageNodeObject;
@@ -57,6 +62,7 @@ describe('Payment step', () => {
 
     afterEach(() => {
         checkout.resetHandlers();
+        sessionStorage.clear();
     });
 
     afterAll(() => {
@@ -775,8 +781,281 @@ describe('Payment step', () => {
             render(<CheckoutTest {...defaultProps} />);
 
             await waitFor(() =>
-                expect(persistSpy).toHaveBeenCalledWith({ isInvoice: false, invoiceComment: '' }),
+                expect(persistSpy).toHaveBeenCalledWith({
+                    isInvoice: false,
+                    invoiceComment: '',
+                    poNumber: '',
+                    referenceNumber: '',
+                    extraFields: [],
+                    extraInfo: {},
+                }),
             );
+        });
+
+        it('persists the full B2B metadata payload from sessionStorage and clears it afterwards', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            setPoNumber('PO-123');
+            AdditionalPaymentFieldSessionStorage.set('REF-456');
+            InvoicePaymentCommentSessionStorage.set('Please rush this order');
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.ORDER_KEY, {
+                costCentre: 'Engineering',
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                department: 'Finance',
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY, {
+                dock: 'B7',
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith({
+                    isInvoice: false,
+                    invoiceComment: 'Please rush this order',
+                    poNumber: 'PO-123',
+                    referenceNumber: 'REF-456',
+                    extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                    extraInfo: {
+                        addressExtraFields: {
+                            billingAddressExtraFields: [
+                                { fieldName: 'department', fieldValue: 'Finance' },
+                            ],
+                            shippingAddressExtraFields: [{ fieldName: 'dock', fieldValue: 'B7' }],
+                        },
+                    },
+                }),
+            );
+
+            // The shipping key is cleared last, so once it is gone every earlier key is too.
+            await waitFor(() =>
+                expect(
+                    B2BExtraFieldsSessionStorage.getFields(
+                        B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+                    ),
+                ).toBeUndefined(),
+            );
+
+            expect(getPoNumber()).toBe('');
+            expect(AdditionalPaymentFieldSessionStorage.get()).toBe('');
+            expect(InvoicePaymentCommentSessionStorage.get()).toBe('');
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY),
+            ).toBeUndefined();
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.BILLING_KEY),
+            ).toBeUndefined();
+        });
+
+        it('persists the stored billing and shipping address IDs and clears them afterwards', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                111,
+            );
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                222,
+            );
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        extraInfo: {
+                            billingAddressId: 111,
+                            shipppingAddressId: 222,
+                        },
+                    }),
+                ),
+            );
+
+            // The shipping address ID is cleared last, so once it is gone the billing one is too.
+            await waitFor(() =>
+                expect(
+                    B2BExtraFieldsSessionStorage.getAddressId(
+                        B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                    ),
+                ).toBeUndefined(),
+            );
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBeUndefined();
+        });
+
+        it('persists B2B metadata with isInvoice true when the invoiceRedirect capability is enabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            InvoicePaymentCommentSessionStorage.set('Invoice me');
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: {
+                    ...checkoutSettings,
+                    storeConfig: {
+                        ...checkoutSettings.storeConfig,
+                        checkoutSettings: {
+                            ...checkoutSettings.storeConfig.checkoutSettings,
+                            capabilities: {
+                                ...defaultCapabilities,
+                                orderConfirmation: {
+                                    ...defaultCapabilities.orderConfirmation,
+                                    persistB2BMetadata: true,
+                                    invoiceRedirect: true,
+                                },
+                            },
+                        },
+                    },
+                },
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        isInvoice: true,
+                        invoiceComment: 'Invoice me',
+                    }),
+                ),
+            );
+        });
+
+        it('does not clear B2B sessionStorage when persisting metadata fails', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            setPoNumber('PO-123');
+            InvoicePaymentCommentSessionStorage.set('Keep me');
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.ORDER_KEY, {
+                costCentre: 'Engineering',
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockRejectedValue(new Error('Persist failed'));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() => expect(persistSpy).toHaveBeenCalled());
+
+            expect(getPoNumber()).toBe('PO-123');
+            expect(InvoicePaymentCommentSessionStorage.get()).toBe('Keep me');
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY),
+            ).toEqual({ costCentre: 'Engineering' });
         });
 
         it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -58,8 +58,8 @@ import {
 import { EMPTY_ARRAY, isExperimentEnabled } from '../common/utility';
 import { TermsConditionsType } from '../termsConditions';
 
+import { buildB2BMetadataOptions, clearB2BMetadataStorage } from './b2bMetadata';
 import CartStockPositionsChangedModal from './CartStockPositionsChangedModal';
-import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
 import PaymentContext from './PaymentContext';
@@ -394,13 +394,11 @@ const Payment = (
             return;
         }
 
-        const invoiceComment = InvoicePaymentCommentSessionStorage.get();
+        const metaDataPayload = buildB2BMetadataOptions(invoiceRedirect);
 
-        // TODO: CHECKOUT-9891 Remove all B2B sessionStorage usages after this all
-        await submitB2BMetadata({
-            isInvoice: invoiceRedirect,
-            invoiceComment,
-        });
+        await submitB2BMetadata(metaDataPayload);
+
+        clearB2BMetadataStorage();
     };
 
     const handleSubmit = useCallback(

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -83,6 +83,7 @@ export interface PaymentProps {
 }
 
 interface WithCheckoutPaymentProps {
+    addressExtraFields?: FormField[];
     availableStoreCredit: number;
     b2bToken?: string;
     cart?: Cart;
@@ -388,13 +389,16 @@ const Payment = (
     };
 
     const persistB2BMetadataIfNeeded = async (): Promise<void> => {
-        const { submitB2BMetadata } = props;
+        const { addressExtraFields, orderExtraFields, submitB2BMetadata } = props;
 
         if (!persistB2BMetadata) {
             return;
         }
 
-        const metaDataPayload = buildB2BMetadataOptions(invoiceRedirect);
+        const metaDataPayload = buildB2BMetadataOptions(invoiceRedirect, {
+            orderExtraFields,
+            addressExtraFields,
+        });
 
         await submitB2BMetadata(metaDataPayload);
 
@@ -734,6 +738,7 @@ export function mapToPaymentProps(
 ): WithCheckoutPaymentProps | null {
     const {
         data: {
+            getAddressExtraFields,
             getCart,
             getCheckout,
             getConfig,
@@ -779,6 +784,10 @@ export function mapToPaymentProps(
         ? getOrderExtraFields()
         : undefined;
 
+    const addressExtraFields = capabilities.userJourney.hasAddressExtraFields
+        ? getAddressExtraFields()
+        : undefined;
+
     const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
         checkout,
         checkoutSettings: config.checkoutSettings,
@@ -791,6 +800,7 @@ export function mapToPaymentProps(
     return {
         applyStoreCredit: checkoutService.applyStoreCredit,
         availableStoreCredit: customer.storeCredit,
+        addressExtraFields,
         b2bToken: checkoutState.data.getB2BToken(),
         cart: getCart(),
         consignments,

--- a/packages/core/src/app/payment/b2bMetadata.test.ts
+++ b/packages/core/src/app/payment/b2bMetadata.test.ts
@@ -1,0 +1,90 @@
+import { type FormField } from '@bigcommerce/checkout-sdk';
+
+import { B2BExtraFieldsSessionStorage } from '../address';
+
+import { buildAddressExtraInfo, buildExtraFields, buildOrderExtraFields } from './b2bMetadata';
+
+describe('b2bMetadata', () => {
+    const orderExtraFields = [
+        { name: 'field_25', label: 'Cost Centre' },
+        { name: 'field_26', label: 'Department' },
+    ] as FormField[];
+
+    afterEach(() => {
+        sessionStorage.clear();
+    });
+
+    describe('buildExtraFields', () => {
+        it('maps each stored field name to its label from the field definitions', () => {
+            expect(buildExtraFields({ field_25: 'Engineering' }, orderExtraFields)).toEqual([
+                { fieldName: 'Cost Centre', fieldValue: 'Engineering' },
+            ]);
+        });
+
+        it('falls back to the stored field name when no matching definition is found', () => {
+            expect(buildExtraFields({ field_99: 'value' }, orderExtraFields)).toEqual([
+                { fieldName: 'field_99', fieldValue: 'value' },
+            ]);
+        });
+
+        it('falls back to the stored field name when no definitions are provided', () => {
+            expect(buildExtraFields({ field_25: 'Engineering' })).toEqual([
+                { fieldName: 'field_25', fieldValue: 'Engineering' },
+            ]);
+        });
+
+        it('returns an empty array when nothing is stored', () => {
+            expect(buildExtraFields(undefined, orderExtraFields)).toEqual([]);
+        });
+    });
+
+    describe('buildOrderExtraFields', () => {
+        it('reads the stored order extra fields and maps names to labels', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.ORDER_KEY, {
+                field_25: 'Engineering',
+                field_26: 'Finance',
+            });
+
+            expect(buildOrderExtraFields(orderExtraFields)).toEqual([
+                { fieldName: 'Cost Centre', fieldValue: 'Engineering' },
+                { fieldName: 'Department', fieldValue: 'Finance' },
+            ]);
+        });
+    });
+
+    describe('buildAddressExtraInfo', () => {
+        const addressExtraFields = [
+            { name: 'field_30', label: 'Floor' },
+            { name: 'field_31', label: 'Dock' },
+        ] as FormField[];
+
+        it('maps billing and shipping address field names to their labels', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                field_30: '3',
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY, {
+                field_31: 'B7',
+            });
+
+            expect(buildAddressExtraInfo(addressExtraFields)).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'Floor', fieldValue: '3' }],
+                    shippingAddressExtraFields: [{ fieldName: 'Dock', fieldValue: 'B7' }],
+                },
+            });
+        });
+
+        it('falls back to the stored field name when no field definitions are provided', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                field_30: '3',
+            });
+
+            expect(buildAddressExtraInfo()).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'field_30', fieldValue: '3' }],
+                    shippingAddressExtraFields: [],
+                },
+            });
+        });
+    });
+});

--- a/packages/core/src/app/payment/b2bMetadata.test.ts
+++ b/packages/core/src/app/payment/b2bMetadata.test.ts
@@ -86,5 +86,23 @@ describe('b2bMetadata', () => {
                 },
             });
         });
+
+        it('excludes the shouldSaveAddress flag from the address extra fields payload', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                field_30: '3',
+                shouldSaveAddress: true,
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY, {
+                field_31: 'B7',
+                shouldSaveAddress: false,
+            });
+
+            expect(buildAddressExtraInfo(addressExtraFields)).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'Floor', fieldValue: '3' }],
+                    shippingAddressExtraFields: [{ fieldName: 'Dock', fieldValue: 'B7' }],
+                },
+            });
+        });
     });
 });

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -1,0 +1,86 @@
+import { type PersistB2BMetadataOptions } from '@bigcommerce/checkout-sdk';
+
+import { clearPoNumber, getPoNumber } from '@bigcommerce/checkout/utility';
+
+import { B2BExtraFieldsSessionStorage } from '../address';
+
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
+
+export type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
+export type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
+
+export const buildExtraFields = (stored?: Record<string, unknown>): B2BMetadataExtraField[] =>
+    stored
+        ? Object.entries(stored).map(([fieldName, fieldValue]) => ({
+              fieldName,
+              fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
+          }))
+        : [];
+
+export const buildOrderExtraFields = (): B2BMetadataExtraField[] =>
+    buildExtraFields(
+        B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY),
+    );
+
+export const buildAddressExtraInfo = (): B2BMetadataExtraInfo => {
+    const billing = B2BExtraFieldsSessionStorage.getFields(
+        B2BExtraFieldsSessionStorage.BILLING_KEY,
+    );
+    const shipping = B2BExtraFieldsSessionStorage.getFields(
+        B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+    );
+    const billingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
+        B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+    );
+    const shippingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
+        B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+    );
+
+    const extraInfo: B2BMetadataExtraInfo = {};
+
+    if (billing || shipping) {
+        extraInfo.addressExtraFields = {
+            billingAddressExtraFields: buildExtraFields(billing),
+            shippingAddressExtraFields: buildExtraFields(shipping),
+        };
+    }
+
+    if (billingAddressId) {
+        extraInfo.billingAddressId = billingAddressId;
+    }
+
+    if (shippingAddressId) {
+        // The SDK field is spelled with a triple "p" (shipppingAddressId).
+        extraInfo.shipppingAddressId = shippingAddressId;
+    }
+
+    return extraInfo;
+};
+
+export const buildB2BMetadataOptions = (
+    isInvoice: PersistB2BMetadataOptions['isInvoice'],
+): PersistB2BMetadataOptions => ({
+    isInvoice,
+    invoiceComment: InvoicePaymentCommentSessionStorage.get(),
+    poNumber: getPoNumber(),
+    referenceNumber: AdditionalPaymentFieldSessionStorage.get(),
+    extraFields: buildOrderExtraFields(),
+    extraInfo: buildAddressExtraInfo(),
+});
+
+// Clear all B2B sessionStorage after a successful persist.
+export const clearB2BMetadataStorage = (): void => {
+    clearPoNumber();
+    AdditionalPaymentFieldSessionStorage.remove();
+    InvoicePaymentCommentSessionStorage.remove();
+    B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.ORDER_KEY);
+    B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.BILLING_KEY);
+    B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY);
+    B2BExtraFieldsSessionStorage.removeAddressId(
+        B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+    );
+    B2BExtraFieldsSessionStorage.removeAddressId(
+        B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+    );
+};

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -1,4 +1,4 @@
-import { type PersistB2BMetadataOptions } from '@bigcommerce/checkout-sdk';
+import { type FormField, type PersistB2BMetadataOptions } from '@bigcommerce/checkout-sdk';
 
 import { clearPoNumber, getPoNumber } from '@bigcommerce/checkout/utility';
 
@@ -10,20 +10,25 @@ import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSess
 export type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
 export type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
 
-export const buildExtraFields = (stored?: Record<string, unknown>): B2BMetadataExtraField[] =>
+export const buildExtraFields = (
+    stored?: Record<string, unknown>,
+    fields?: FormField[],
+): B2BMetadataExtraField[] =>
     stored
         ? Object.entries(stored).map(([fieldName, fieldValue]) => ({
-              fieldName,
+              // The API expects the field label, but values are stored keyed by field name (id).
+              fieldName: fields?.find((field) => field.name === fieldName)?.label ?? fieldName,
               fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
           }))
         : [];
 
-export const buildOrderExtraFields = (): B2BMetadataExtraField[] =>
+export const buildOrderExtraFields = (orderExtraFields?: FormField[]): B2BMetadataExtraField[] =>
     buildExtraFields(
         B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY),
+        orderExtraFields,
     );
 
-export const buildAddressExtraInfo = (): B2BMetadataExtraInfo => {
+export const buildAddressExtraInfo = (addressExtraFields?: FormField[]): B2BMetadataExtraInfo => {
     const billing = B2BExtraFieldsSessionStorage.getFields(
         B2BExtraFieldsSessionStorage.BILLING_KEY,
     );
@@ -41,8 +46,8 @@ export const buildAddressExtraInfo = (): B2BMetadataExtraInfo => {
 
     if (billing || shipping) {
         extraInfo.addressExtraFields = {
-            billingAddressExtraFields: buildExtraFields(billing),
-            shippingAddressExtraFields: buildExtraFields(shipping),
+            billingAddressExtraFields: buildExtraFields(billing, addressExtraFields),
+            shippingAddressExtraFields: buildExtraFields(shipping, addressExtraFields),
         };
     }
 
@@ -58,15 +63,21 @@ export const buildAddressExtraInfo = (): B2BMetadataExtraInfo => {
     return extraInfo;
 };
 
+export interface B2BMetadataFieldDefinitions {
+    orderExtraFields?: FormField[];
+    addressExtraFields?: FormField[];
+}
+
 export const buildB2BMetadataOptions = (
     isInvoice: PersistB2BMetadataOptions['isInvoice'],
+    { orderExtraFields, addressExtraFields }: B2BMetadataFieldDefinitions = {},
 ): PersistB2BMetadataOptions => ({
     isInvoice,
     invoiceComment: InvoicePaymentCommentSessionStorage.get(),
     poNumber: getPoNumber(),
     referenceNumber: AdditionalPaymentFieldSessionStorage.get(),
-    extraFields: buildOrderExtraFields(),
-    extraInfo: buildAddressExtraInfo(),
+    extraFields: buildOrderExtraFields(orderExtraFields),
+    extraInfo: buildAddressExtraInfo(addressExtraFields),
 });
 
 // Clear all B2B sessionStorage after a successful persist.

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -28,12 +28,28 @@ export const buildOrderExtraFields = (orderExtraFields?: FormField[]): B2BMetada
         orderExtraFields,
     );
 
+// TODO: CHECKOUT-10080`shouldSaveAddress` is persisted alongside the address extra fields for a separate
+// "save to company address book" task, so it must not be sent in the post-order payload.
+const SHOULD_SAVE_ADDRESS_KEY = 'shouldSaveAddress';
+
+const omitShouldSaveAddress = (
+    stored?: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+    if (!stored) {
+        return stored;
+    }
+
+    const { [SHOULD_SAVE_ADDRESS_KEY]: _shouldSaveAddress, ...rest } = stored;
+
+    return rest;
+};
+
 export const buildAddressExtraInfo = (addressExtraFields?: FormField[]): B2BMetadataExtraInfo => {
-    const billing = B2BExtraFieldsSessionStorage.getFields(
-        B2BExtraFieldsSessionStorage.BILLING_KEY,
+    const billing = omitShouldSaveAddress(
+        B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.BILLING_KEY),
     );
-    const shipping = B2BExtraFieldsSessionStorage.getFields(
-        B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+    const shipping = omitShouldSaveAddress(
+        B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY),
     );
     const billingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
         B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -32,6 +32,7 @@ import {
     checkoutWithShipping,
     checkoutWithShippingAndBilling,
     consignment,
+    customer,
     payments,
     shippingAddress,
     shippingQuoteFailedMessage,
@@ -43,6 +44,7 @@ import {
     within,
 } from '@bigcommerce/checkout/test-utils';
 
+import { B2BExtraFieldsSessionStorage } from '../address';
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
 import {
@@ -66,6 +68,7 @@ describe('Shipping step', () => {
     afterEach(() => {
         jest.unmock('lodash');
         checkout.resetHandlers();
+        sessionStorage.clear();
     });
 
     afterAll(() => {
@@ -1059,6 +1062,91 @@ describe('Shipping step', () => {
             expect(
                 screen.queryByText(/no shipping address to choose from/i),
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('B2B company address book', () => {
+        const companyAddressBookCapabilities = {
+            ...defaultCapabilities,
+            userJourney: {
+                ...defaultCapabilities.userJourney,
+                hasCompanyAddressBook: true,
+            },
+        };
+
+        const CheckoutWithCompanyAddressBook: FunctionComponent<CheckoutProps> = (props) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleProvider
+                    checkoutService={checkoutService}
+                    languageService={getLanguageService()}
+                >
+                    <AnalyticsProviderMock>
+                        <ExtensionProvider extensionService={extensionService}>
+                            <ThemeProvider>
+                                <CapabilitiesContext.Provider
+                                    value={companyAddressBookCapabilities}
+                                >
+                                    <Checkout {...props} />
+                                </CapabilitiesContext.Provider>
+                            </ThemeProvider>
+                        </ExtensionProvider>
+                    </AnalyticsProviderMock>
+                </LocaleProvider>
+            </CheckoutProvider>
+        );
+
+        it('stores the selected shipping address id when hasCompanyAddressBook is enabled', async () => {
+            // The searchable address book only lists addresses flagged for shipping.
+            const checkoutWithCompanyShippingAddress = {
+                ...checkoutWithMultiShippingCart,
+                customer: {
+                    ...customer,
+                    addresses: [{ ...shippingAddress, id: 1, isShipping: true }],
+                },
+            };
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart, {
+                checkout: checkoutWithCompanyShippingAddress,
+            });
+
+            jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            await userEvent.click(screen.getByTestId('address-select-button'));
+            await userEvent.click(screen.getByTestId('address-select-option-action'));
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                ),
+            ).toBe(1);
+        });
+
+        it('does not store the shipping address id when hasCompanyAddressBook is disabled', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
+
+            jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            await userEvent.click(screen.getByTestId('address-select-button'));
+            // 111 Testing Rd is the customer's saved address with id 1.
+            await userEvent.click(screen.getByText(/111 Testing Rd/i));
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                ),
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -165,6 +165,22 @@ function Shipping({
                 );
             }
 
+            // Copy shipping address ID to billing when billing same as shipping
+            const shippingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+            );
+
+            if (shippingAddressId) {
+                B2BExtraFieldsSessionStorage.setAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                    shippingAddressId,
+                );
+            } else {
+                B2BExtraFieldsSessionStorage.removeAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                );
+            }
+
             if (!isEqualAddress(updatedShippingAddress, billingAddress)) {
                 promises.push(updateBillingAddress(updatedShippingAddress));
             }

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -1,4 +1,4 @@
-import { type Address, type FormField } from '@bigcommerce/checkout-sdk';
+import { type Address, type CustomerAddress, type FormField } from '@bigcommerce/checkout-sdk';
 import { type FormikProps } from 'formik';
 import { debounce, type DebouncedFunc, isEqual, noop } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -88,7 +88,7 @@ const SingleShippingForm: React.FC<
 }) => {
     const {
         shipping: { hideBillingSameAsShippingCheck },
-        userJourney: { hasAddressExtraFields },
+        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
     } = useCapabilities();
     const {
         consignments,
@@ -236,6 +236,17 @@ const SingleShippingForm: React.FC<
     const handleAddressSelect = async (address: Address) => {
         setIsResettingAddress(true);
 
+        B2BExtraFieldsSessionStorage.removeAddressId(
+            B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+        );
+
+        if (hasCompanyAddressBook && (address as CustomerAddress).id) {
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                (address as CustomerAddress).id,
+            );
+        }
+
         try {
             await updateAddress(address);
 
@@ -259,6 +270,10 @@ const SingleShippingForm: React.FC<
                     B2BExtraFieldsSessionStorage.SHIPPING_KEY,
                 );
             }
+
+            B2BExtraFieldsSessionStorage.removeAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+            );
 
             const address = await deleteConsignments();
 

--- a/packages/utility/src/storage/poNumberStorage.ts
+++ b/packages/utility/src/storage/poNumberStorage.ts
@@ -1,4 +1,4 @@
-const KEY = 'PoNumber';
+const KEY = 'poNumber';
 
 export const getPoNumber = (): string => sessionStorage.getItem(KEY) ?? '';
 


### PR DESCRIPTION
## What/Why?

This PR implements the post-order B2B metadata request for the normal (non-invoice) B2B checkout flow as part of CHECKOUT-9819.

Previously, on order submission only the invoice comment was persisted via `submitB2BMetadata`. This change consolidates **all** B2B data captured during checkout — PO number, reference number, invoice comment, order extra fields, and address extra fields/IDs — into a single metadata payload that is sent after a successful order, then clears the associated sessionStorage.

**Technical details:**

- **New `b2bMetadata.ts` helper** (`packages/core/src/app/payment/b2bMetadata.ts`) centralizes payload assembly and storage cleanup:
  - `buildB2BMetadataOptions()` builds the full `PersistB2BMetadataOptions` payload (invoice flag, invoice comment, PO number, reference number, order extra fields, address extra info).
  - `buildExtraFields()` maps stored values to the API shape, sending the field **label** rather than the field name/id (values are stored keyed by name, but the API expects the label).
  - `buildAddressExtraInfo()` collects billing/shipping address extra fields plus the selected billing/shipping address IDs.
  - `clearB2BMetadataStorage()` clears every B2B sessionStorage entry after a successful persist.
- **Payment** (`packages/core/src/app/payment/Payment.tsx`): `persistB2BMetadataIfNeeded` now builds and submits the consolidated payload and then clears storage. Address extra fields are wired into props via `getAddressExtraFields()`, gated on the `hasAddressExtraFields` capability.
- **Bug fix** (`packages/utility/src/storage/poNumberStorage.ts`): corrects the storage key casing from `PoNumber` → `poNumber` so the PO number is read back correctly.

## Rollout/Rollback

This change is gated behind existing B2B capabilities (`hasAddressExtraFields`, `hasCompanyAddressBook`) and the `persistB2BMetadata` flag — when these are off, behavior is unchanged, so there is no impact to non-B2B storefronts.

Rollback is code-only (revert this PR); there are no database migrations or data backfills involved. Reverting restores the prior behavior of persisting only the invoice comment.


## Testing

- CI checks
- Manual testing 


https://github.com/user-attachments/assets/6b334760-3618-4c70-89b7-2a0121d93b39


