### PR TITLE
feat(checkout): CHECKOUT-9819 persist company address book address IDs

### DIFF
--- a/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
+++ b/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
@@ -38,4 +38,60 @@ describe('B2BExtraFieldsSessionStorage', () => {
             ).toBeUndefined();
         });
     });
+
+    describe('copyShippingToBilling', () => {
+        it('copies shipping fields and address id to billing', () => {
+            const fields = { b2bExtraField_100: 'Acme Corp' };
+
+            B2BExtraFieldsSessionStorage.setFields(
+                B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+                fields,
+            );
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                42,
+            );
+
+            B2BExtraFieldsSessionStorage.copyShippingToBilling();
+
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.BILLING_KEY),
+            ).toEqual(fields);
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBe(42);
+        });
+
+        it('removes the billing address id when shipping has none', () => {
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                99,
+            );
+
+            B2BExtraFieldsSessionStorage.copyShippingToBilling();
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBeUndefined();
+        });
+
+        it('leaves billing fields untouched when shipping has no fields', () => {
+            const billingFields = { b2bExtraField_200: 'Existing' };
+
+            B2BExtraFieldsSessionStorage.setFields(
+                B2BExtraFieldsSessionStorage.BILLING_KEY,
+                billingFields,
+            );
+
+            B2BExtraFieldsSessionStorage.copyShippingToBilling();
+
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.BILLING_KEY),
+            ).toEqual(billingFields);
+        });
+    });
 });

--- a/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
+++ b/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
@@ -46,6 +46,22 @@ export class B2BExtraFieldsSessionStorage {
         sessionStorage.removeItem(key);
     }
 
+    static copyShippingToBilling(): void {
+        const shippingFields = this.getFields(this.SHIPPING_KEY);
+
+        if (shippingFields) {
+            this.setFields(this.BILLING_KEY, shippingFields);
+        }
+
+        const shippingAddressId = this.getAddressId(this.SHIPPING_ADDRESS_ID_KEY);
+
+        if (shippingAddressId) {
+            this.setAddressId(this.BILLING_ADDRESS_ID_KEY, shippingAddressId);
+        } else {
+            this.removeAddressId(this.BILLING_ADDRESS_ID_KEY);
+        }
+    }
+
     static reassignConsignmentKey(consignmentId: string): void {
         const tempKey = this.getConsignmentKey('');
         const fields = this.getFields(tempKey);

--- a/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
+++ b/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
@@ -3,6 +3,8 @@ export class B2BExtraFieldsSessionStorage {
     static readonly SHIPPING_KEY = 'b2bAddressExtraFields_shipping';
     static readonly CONSIGNMENT_KEY_PREFIX = 'b2bAddressExtraFields_consignment_';
     static readonly ORDER_KEY = 'b2bOrderExtraFields';
+    static readonly BILLING_ADDRESS_ID_KEY = 'b2bBillingAddressId';
+    static readonly SHIPPING_ADDRESS_ID_KEY = 'b2bShippingAddressId';
 
     static getConsignmentKey(consignmentId: string): string {
         return `${this.CONSIGNMENT_KEY_PREFIX}${consignmentId}`;
@@ -27,6 +29,20 @@ export class B2BExtraFieldsSessionStorage {
     }
 
     static removeFields(key: string): void {
+        sessionStorage.removeItem(key);
+    }
+
+    static setAddressId(key: string, id: number): void {
+        sessionStorage.setItem(key, String(id));
+    }
+
+    static getAddressId(key: string): number | undefined {
+        const raw = sessionStorage.getItem(key);
+
+        return raw ? Number(raw) : undefined;
+    }
+
+    static removeAddressId(key: string): void {
         sessionStorage.removeItem(key);
     }
 

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -10,6 +10,7 @@ export { default as StaticAddress } from './StaticAddress';
 export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';
+export { default as setDefaultAddress } from './setDefaultAddress';
 export { default as getAddressWithLabel } from './getAddressWithLabel';
 export { default as getAddressWithCustomerExtraFields } from './getAddressWithCustomerExtraFields';
 export { reorderAddressFormFields } from './reorderAddressFormFields';

--- a/packages/core/src/app/address/setDefaultAddress.spec.ts
+++ b/packages/core/src/app/address/setDefaultAddress.spec.ts
@@ -115,6 +115,19 @@ describe('setDefaultAddress', () => {
             expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
         });
 
+        it('clears a stale stored id when no book address matches', async () => {
+            B2BExtraFieldsSessionStorage.setAddressId(shippingIdKey, 99);
+
+            await setDefaultAddress({
+                type: AddressType.Shipping,
+                currentAddress: getAddress(),
+                addresses: [getCustomerAddress({ id: 3, address1: 'Somewhere else' })],
+                updateAddress,
+            });
+
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
+        });
+
         it('keeps the stored id when it still matches the current address', async () => {
             B2BExtraFieldsSessionStorage.setAddressId(shippingIdKey, 42);
 

--- a/packages/core/src/app/address/setDefaultAddress.spec.ts
+++ b/packages/core/src/app/address/setDefaultAddress.spec.ts
@@ -1,0 +1,150 @@
+import { type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import { getAddress } from './address.mock';
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
+import setDefaultAddress from './setDefaultAddress';
+
+describe('setDefaultAddress', () => {
+    const addressIdKey = B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY;
+
+    const getCustomerAddress = (overrides: Partial<CustomerAddress> = {}): CustomerAddress => ({
+        ...getAddress(),
+        id: 1,
+        type: 'residential',
+        ...overrides,
+    });
+
+    let updateAddress: jest.Mock;
+
+    beforeEach(() => {
+        sessionStorage.clear();
+        updateAddress = jest.fn().mockResolvedValue(undefined);
+    });
+
+    describe('when there is no current address', () => {
+        it('applies the default address and stores its id', async () => {
+            const defaultAddress = getCustomerAddress({ id: 7 });
+
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress: undefined,
+                addresses: [defaultAddress],
+                defaultAddress,
+                updateAddress,
+            });
+
+            expect(updateAddress).toHaveBeenCalledWith(defaultAddress);
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(7);
+        });
+
+        it('applies the default address but does not store an id when it has none', async () => {
+            const defaultAddress = getCustomerAddress({ id: undefined as unknown as number });
+
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress: undefined,
+                addresses: [defaultAddress],
+                defaultAddress,
+                updateAddress,
+            });
+
+            expect(updateAddress).toHaveBeenCalledWith(defaultAddress);
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+        });
+
+        it('does nothing when there is no default address', async () => {
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress: undefined,
+                addresses: [getCustomerAddress()],
+                defaultAddress: undefined,
+                updateAddress,
+            });
+
+            expect(updateAddress).not.toHaveBeenCalled();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+        });
+
+        it('does not store an id when applying the default address fails', async () => {
+            updateAddress.mockRejectedValue(new Error('update failed'));
+
+            const defaultAddress = getCustomerAddress({ id: 7 });
+
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress: undefined,
+                addresses: [defaultAddress],
+                defaultAddress,
+                updateAddress,
+            });
+
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+        });
+    });
+
+    describe('when there is a pre-existing address', () => {
+        it('recovers the book id by matching the current address', async () => {
+            const currentAddress = getAddress();
+            const matchingAddress = getCustomerAddress({ id: 42 });
+
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress,
+                addresses: [
+                    getCustomerAddress({ id: 3, address1: 'Somewhere else' }),
+                    matchingAddress,
+                ],
+                defaultAddress: undefined,
+                updateAddress,
+            });
+
+            expect(updateAddress).not.toHaveBeenCalled();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(42);
+        });
+
+        it('does nothing when no book address matches', async () => {
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress: getAddress(),
+                addresses: [getCustomerAddress({ id: 3, address1: 'Somewhere else' })],
+                defaultAddress: undefined,
+                updateAddress,
+            });
+
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+        });
+
+        it('keeps the stored id when it still matches the current address', async () => {
+            B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, 42);
+
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress: getAddress(),
+                addresses: [getCustomerAddress({ id: 42 })],
+                defaultAddress: undefined,
+                updateAddress,
+            });
+
+            expect(updateAddress).not.toHaveBeenCalled();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(42);
+        });
+
+        it('replaces a stale stored id when the current address matches a different entry', async () => {
+            B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, 99);
+
+            await setDefaultAddress({
+                addressIdKey,
+                currentAddress: getAddress(),
+                addresses: [
+                    getCustomerAddress({ id: 3, address1: 'Somewhere else' }),
+                    getCustomerAddress({ id: 42 }),
+                ],
+                defaultAddress: undefined,
+                updateAddress,
+            });
+
+            expect(updateAddress).not.toHaveBeenCalled();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(42);
+        });
+    });
+});

--- a/packages/core/src/app/address/setDefaultAddress.spec.ts
+++ b/packages/core/src/app/address/setDefaultAddress.spec.ts
@@ -1,16 +1,20 @@
 import { type CustomerAddress } from '@bigcommerce/checkout-sdk';
 
 import { getAddress } from './address.mock';
+import AddressType from './AddressType';
 import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import setDefaultAddress from './setDefaultAddress';
 
 describe('setDefaultAddress', () => {
-    const addressIdKey = B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY;
+    const shippingIdKey = B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY;
+    const billingIdKey = B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY;
 
     const getCustomerAddress = (overrides: Partial<CustomerAddress> = {}): CustomerAddress => ({
         ...getAddress(),
         id: 1,
         type: 'residential',
+        isShipping: true,
+        isBilling: true,
         ...overrides,
     });
 
@@ -23,62 +27,61 @@ describe('setDefaultAddress', () => {
 
     describe('when there is no current address', () => {
         it('applies the default address and stores its id', async () => {
-            const defaultAddress = getCustomerAddress({ id: 7 });
+            const defaultAddress = getCustomerAddress({ id: 7, isDefaultShipping: true });
 
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress: undefined,
                 addresses: [defaultAddress],
-                defaultAddress,
                 updateAddress,
             });
 
             expect(updateAddress).toHaveBeenCalledWith(defaultAddress);
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(7);
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBe(7);
         });
 
         it('applies the default address but does not store an id when it has none', async () => {
-            const defaultAddress = getCustomerAddress({ id: undefined as unknown as number });
+            const defaultAddress = getCustomerAddress({
+                id: undefined as unknown as number,
+                isDefaultShipping: true,
+            });
 
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress: undefined,
                 addresses: [defaultAddress],
-                defaultAddress,
                 updateAddress,
             });
 
             expect(updateAddress).toHaveBeenCalledWith(defaultAddress);
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
         });
 
         it('does nothing when there is no default address', async () => {
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress: undefined,
                 addresses: [getCustomerAddress()],
-                defaultAddress: undefined,
                 updateAddress,
             });
 
             expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
         });
 
         it('does not store an id when applying the default address fails', async () => {
             updateAddress.mockRejectedValue(new Error('update failed'));
 
-            const defaultAddress = getCustomerAddress({ id: 7 });
+            const defaultAddress = getCustomerAddress({ id: 7, isDefaultShipping: true });
 
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress: undefined,
                 addresses: [defaultAddress],
-                defaultAddress,
                 updateAddress,
             });
 
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
         });
     });
 
@@ -88,63 +91,102 @@ describe('setDefaultAddress', () => {
             const matchingAddress = getCustomerAddress({ id: 42 });
 
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress,
                 addresses: [
                     getCustomerAddress({ id: 3, address1: 'Somewhere else' }),
                     matchingAddress,
                 ],
-                defaultAddress: undefined,
                 updateAddress,
             });
 
             expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(42);
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBe(42);
         });
 
         it('does nothing when no book address matches', async () => {
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress: getAddress(),
                 addresses: [getCustomerAddress({ id: 3, address1: 'Somewhere else' })],
-                defaultAddress: undefined,
                 updateAddress,
             });
 
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
         });
 
         it('keeps the stored id when it still matches the current address', async () => {
-            B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, 42);
+            B2BExtraFieldsSessionStorage.setAddressId(shippingIdKey, 42);
 
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress: getAddress(),
                 addresses: [getCustomerAddress({ id: 42 })],
-                defaultAddress: undefined,
                 updateAddress,
             });
 
             expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(42);
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBe(42);
         });
 
         it('replaces a stale stored id when the current address matches a different entry', async () => {
-            B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, 99);
+            B2BExtraFieldsSessionStorage.setAddressId(shippingIdKey, 99);
 
             await setDefaultAddress({
-                addressIdKey,
+                type: AddressType.Shipping,
                 currentAddress: getAddress(),
                 addresses: [
                     getCustomerAddress({ id: 3, address1: 'Somewhere else' }),
                     getCustomerAddress({ id: 42 }),
                 ],
-                defaultAddress: undefined,
                 updateAddress,
             });
 
             expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BExtraFieldsSessionStorage.getAddressId(addressIdKey)).toBe(42);
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBe(42);
+        });
+    });
+
+    describe('when company rows duplicate fields across types', () => {
+        it('matches a shipping row over a content-identical billing-only row for the shipping key', async () => {
+            const billingOnly = getCustomerAddress({ id: 50, isShipping: false, isBilling: true });
+            const shippingRow = getCustomerAddress({ id: 42, isShipping: true, isBilling: false });
+
+            await setDefaultAddress({
+                type: AddressType.Shipping,
+                currentAddress: getAddress(),
+                addresses: [billingOnly, shippingRow],
+                updateAddress,
+            });
+
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBe(42);
+        });
+
+        it('does not store a billing-only row id under the shipping key', async () => {
+            const billingOnly = getCustomerAddress({ id: 50, isShipping: false, isBilling: true });
+
+            await setDefaultAddress({
+                type: AddressType.Shipping,
+                currentAddress: getAddress(),
+                addresses: [billingOnly],
+                updateAddress,
+            });
+
+            expect(B2BExtraFieldsSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
+        });
+
+        it('matches a billing row over a content-identical shipping-only row for the billing key', async () => {
+            const shippingOnly = getCustomerAddress({ id: 60, isShipping: true, isBilling: false });
+            const billingRow = getCustomerAddress({ id: 24, isShipping: false, isBilling: true });
+
+            await setDefaultAddress({
+                type: AddressType.Billing,
+                currentAddress: getAddress(),
+                addresses: [shippingOnly, billingRow],
+                updateAddress,
+            });
+
+            expect(B2BExtraFieldsSessionStorage.getAddressId(billingIdKey)).toBe(24);
         });
     });
 });

--- a/packages/core/src/app/address/setDefaultAddress.ts
+++ b/packages/core/src/app/address/setDefaultAddress.ts
@@ -1,23 +1,34 @@
 import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
 
+import AddressType from './AddressType';
 import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
 import isEqualAddress from './isEqualAddress';
 
 interface SetDefaultAddressOptions {
-    addressIdKey: string;
+    type: AddressType;
     currentAddress?: Address;
     addresses?: CustomerAddress[];
-    defaultAddress?: CustomerAddress;
     updateAddress(address: Address): Promise<unknown>;
 }
 
 export default async function setDefaultAddress({
-    addressIdKey,
+    type,
     currentAddress,
     addresses,
-    defaultAddress,
     updateAddress,
 }: SetDefaultAddressOptions): Promise<void> {
+    const isShipping = type === AddressType.Shipping;
+    const addressIdKey = isShipping
+        ? B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY
+        : B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY;
+
+    const filteredAddresses = addresses?.filter((address) =>
+        isShipping ? address.isShipping : address.isBilling,
+    );
+    const defaultAddress = filteredAddresses?.find((address) =>
+        isShipping ? address.isDefaultShipping : address.isDefaultBilling,
+    );
+
     if (!currentAddress?.address1) {
         if (!defaultAddress) {
             return;
@@ -37,7 +48,7 @@ export default async function setDefaultAddress({
     }
 
     const storedAddressId = B2BExtraFieldsSessionStorage.getAddressId(addressIdKey);
-    const storedIdStillMatches = addresses?.some(
+    const storedIdStillMatches = filteredAddresses?.some(
         (address) => address.id === storedAddressId && isEqualAddress(address, currentAddress),
     );
 
@@ -46,7 +57,9 @@ export default async function setDefaultAddress({
     }
 
     // Pre-existing address (e.g. resumed checkout): recover its book ID by matching.
-    const matchedAddress = addresses?.find((address) => isEqualAddress(address, currentAddress));
+    const matchedAddress = filteredAddresses?.find((address) =>
+        isEqualAddress(address, currentAddress),
+    );
 
     if (matchedAddress?.id) {
         B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, matchedAddress.id);

--- a/packages/core/src/app/address/setDefaultAddress.ts
+++ b/packages/core/src/app/address/setDefaultAddress.ts
@@ -56,12 +56,15 @@ export default async function setDefaultAddress({
         return;
     }
 
-    // Pre-existing address (e.g. resumed checkout): recover its book ID by matching.
+    // Pre-existing address (e.g. resumed checkout): recover its book ID by matching,
+    // or clear a stale ID when the address no longer corresponds to a book entry.
     const matchedAddress = filteredAddresses?.find((address) =>
         isEqualAddress(address, currentAddress),
     );
 
     if (matchedAddress?.id) {
         B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, matchedAddress.id);
+    } else {
+        B2BExtraFieldsSessionStorage.removeAddressId(addressIdKey);
     }
 }

--- a/packages/core/src/app/address/setDefaultAddress.ts
+++ b/packages/core/src/app/address/setDefaultAddress.ts
@@ -1,0 +1,54 @@
+import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import { B2BExtraFieldsSessionStorage } from './B2BExtraFieldsSessionStorage';
+import isEqualAddress from './isEqualAddress';
+
+interface SetDefaultAddressOptions {
+    addressIdKey: string;
+    currentAddress?: Address;
+    addresses?: CustomerAddress[];
+    defaultAddress?: CustomerAddress;
+    updateAddress(address: Address): Promise<unknown>;
+}
+
+export default async function setDefaultAddress({
+    addressIdKey,
+    currentAddress,
+    addresses,
+    defaultAddress,
+    updateAddress,
+}: SetDefaultAddressOptions): Promise<void> {
+    if (!currentAddress?.address1) {
+        if (!defaultAddress) {
+            return;
+        }
+
+        try {
+            await updateAddress(defaultAddress);
+
+            if (defaultAddress.id) {
+                B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, defaultAddress.id);
+            }
+        } catch {
+            /* Do nothing: we should not block shoppers from buying. */
+        }
+
+        return;
+    }
+
+    const storedAddressId = B2BExtraFieldsSessionStorage.getAddressId(addressIdKey);
+    const storedIdStillMatches = addresses?.some(
+        (address) => address.id === storedAddressId && isEqualAddress(address, currentAddress),
+    );
+
+    if (storedAddressId && storedIdStillMatches) {
+        return;
+    }
+
+    // Pre-existing address (e.g. resumed checkout): recover its book ID by matching.
+    const matchedAddress = addresses?.find((address) => isEqualAddress(address, currentAddress));
+
+    if (matchedAddress?.id) {
+        B2BExtraFieldsSessionStorage.setAddressId(addressIdKey, matchedAddress.id);
+    }
+}

--- a/packages/core/src/app/billing/Billing.test.tsx
+++ b/packages/core/src/app/billing/Billing.test.tsx
@@ -47,6 +47,7 @@ import {
     waitFor,
 } from '@bigcommerce/checkout/test-utils';
 
+import { B2BExtraFieldsSessionStorage } from '../address';
 import Checkout from '../checkout/Checkout';
 import { type CheckoutInitializerProps } from '../checkout/CheckoutInitializer';
 import { getCheckoutPayment } from '../checkout/checkouts.mock';
@@ -77,6 +78,7 @@ describe('Billing step', () => {
     afterEach(() => {
         jest.unmock('lodash');
         checkout.resetHandlers();
+        sessionStorage.clear();
     });
 
     afterAll(() => {
@@ -565,6 +567,101 @@ describe('Billing step', () => {
             expect(
                 screen.queryByText(/no billing address to choose from/i),
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('B2B company address book', () => {
+        const companyAddressBookCapabilities = {
+            ...defaultCapabilities,
+            userJourney: {
+                ...defaultCapabilities.userJourney,
+                hasCompanyAddressBook: true,
+            },
+        };
+
+        const CheckoutWithCompanyAddressBook: FunctionComponent<CheckoutInitializerProps> = (
+            props,
+        ) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleProvider
+                    checkoutService={checkoutService}
+                    languageService={getLanguageService()}
+                >
+                    <AnalyticsProviderMock>
+                        <ExtensionProvider extensionService={extensionService}>
+                            <ThemeProvider>
+                                <CapabilitiesContext.Provider
+                                    value={companyAddressBookCapabilities}
+                                >
+                                    <Checkout {...props} />
+                                </CapabilitiesContext.Provider>
+                            </ThemeProvider>
+                        </ExtensionProvider>
+                    </AnalyticsProviderMock>
+                </LocaleProvider>
+            </CheckoutProvider>
+        );
+
+        // With hasCompanyAddressBook enabled the searchable address book is rendered, which only
+        // lists addresses flagged for billing. shippingAddress3 is given id 3 and isBilling.
+        const customerWithCompanyBillingAddress = {
+            ...customer,
+            addresses: [{ ...shippingAddress3, id: 3, isBilling: true }],
+        };
+        const checkoutWithCompanyBillingAddress = {
+            ...checkoutWithShipping,
+            customer: customerWithCompanyBillingAddress,
+        };
+
+        it('stores the selected billing address id when hasCompanyAddressBook is enabled', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
+                checkout: checkoutWithCompanyBillingAddress,
+            });
+
+            jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
+
+            await checkout.waitForBillingStep();
+
+            await act(async () => {
+                await userEvent.click(screen.getByTestId('address-select-button'));
+                await userEvent.click(screen.getByTestId('address-select-option-action'));
+            });
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBe(3);
+        });
+
+        it('does not store the billing address id when hasCompanyAddressBook is disabled', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
+                checkout: checkoutWithCustomer,
+            });
+
+            jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForBillingStep();
+
+            await act(async () => {
+                await userEvent.click(screen.getByTestId('address-select-button'));
+                // shippingAddress3 is the customer's saved address with id 3.
+                await userEvent.click(screen.getByText(shippingAddress3.address1));
+            });
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -6,6 +6,7 @@ import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, Legend } from '@bigcommerce/checkout/ui';
 
 import {
+    AddressType,
     B2BExtraFieldsSessionStorage,
     getAddressWithCustomerExtraFields,
     isEqualAddress,
@@ -122,12 +123,9 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
 
                 if (hasCompanyAddressBook) {
                     await setDefaultAddress({
-                        addressIdKey: B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                        type: AddressType.Billing,
                         currentAddress: getBillingAddress(),
                         addresses: customer.addresses,
-                        defaultAddress: customer.addresses?.find(
-                            ({ isDefaultBilling }) => isDefaultBilling,
-                        ),
                         updateAddress: checkoutService.updateBillingAddress,
                     });
                 }

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -10,6 +10,7 @@ import {
     getAddressWithCustomerExtraFields,
     isEqualAddress,
     mapAddressFromFormValues,
+    setDefaultAddress,
 } from '../address';
 
 import BillingForm, { type BillingFormValues } from './BillingForm';
@@ -119,18 +120,16 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
             try {
                 await checkoutService.loadBillingAddressFields();
 
-                if (hasCompanyAddressBook && !getBillingAddress()?.address1) {
-                    const defaultBillingAddress = customer.addresses?.find(
-                        ({ isDefaultBilling }) => isDefaultBilling,
-                    );
-
-                    if (defaultBillingAddress) {
-                        try {
-                            await checkoutService.updateBillingAddress(defaultBillingAddress);
-                        } catch {
-                            /* Do nothing: we should not block shoppers from buying. */
-                        }
-                    }
+                if (hasCompanyAddressBook) {
+                    await setDefaultAddress({
+                        addressIdKey: B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                        currentAddress: getBillingAddress(),
+                        addresses: customer.addresses,
+                        defaultAddress: customer.addresses?.find(
+                            ({ isDefaultBilling }) => isDefaultBilling,
+                        ),
+                        updateAddress: checkoutService.updateBillingAddress,
+                    });
                 }
 
                 onReady();

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -1,4 +1,9 @@
-import { type Address, type FormField, isExtraField } from '@bigcommerce/checkout-sdk/essential';
+import {
+    type Address,
+    type CustomerAddress,
+    type FormField,
+    isExtraField,
+} from '@bigcommerce/checkout-sdk/essential';
 import { type FormikProps, withFormik } from 'formik';
 import React, { type RefObject, useRef, useState } from 'react';
 import { lazy } from 'yup';
@@ -66,7 +71,7 @@ const BillingForm = ({
     const { checkoutService, checkoutState } = useCheckout();
     const {
         billing: { hideSaveToAddressBookCheck, restrictManualAddressEntry },
-        userJourney: { hasAddressExtraFields },
+        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
     } = useCapabilities();
 
     const {
@@ -109,6 +114,17 @@ const BillingForm = ({
     const handleSelectAddress = async (address: Partial<Address>) => {
         setIsResettingAddress(true);
 
+        B2BExtraFieldsSessionStorage.removeAddressId(
+            B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+        );
+
+        if (hasCompanyAddressBook && (address as CustomerAddress).id) {
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                (address as CustomerAddress).id,
+            );
+        }
+
         try {
             await checkoutService.updateBillingAddress(address);
         } catch (error) {
@@ -124,6 +140,10 @@ const BillingForm = ({
         if (hasAddressExtraFields) {
             B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.BILLING_KEY);
         }
+
+        B2BExtraFieldsSessionStorage.removeAddressId(
+            B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+        );
 
         void handleSelectAddress({});
     };

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -5,7 +5,7 @@ import {
     isExtraField,
 } from '@bigcommerce/checkout-sdk/essential';
 import { type FormikProps, withFormik } from 'formik';
-import React, { type RefObject, useRef, useState } from 'react';
+import React, { type RefObject, useEffect, useRef, useState } from 'react';
 import { lazy } from 'yup';
 
 import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
@@ -111,22 +111,40 @@ const BillingForm = ({
     const shouldShowOrderComments = enableOrderComments && getShippableItemsCount(cart) < 1;
     const shouldShowSaveAddress = !hideSaveToAddressBookCheck && !isGuest;
 
+    // Once the address form opens (selected address is invalid or no longer matches a
+    // book entry), the stored book id can't faithfully represent it, so drop it.
+    useEffect(() => {
+        if (
+            hasCompanyAddressBook &&
+            !hasValidCustomerAddress &&
+            B2BExtraFieldsSessionStorage.getAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+            )
+        ) {
+            B2BExtraFieldsSessionStorage.removeAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+            );
+        }
+    }, [hasCompanyAddressBook, hasValidCustomerAddress]);
+
     const handleSelectAddress = async (address: Partial<Address>) => {
         setIsResettingAddress(true);
 
-        B2BExtraFieldsSessionStorage.removeAddressId(
-            B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
-        );
-
-        if (hasCompanyAddressBook && (address as CustomerAddress).id) {
-            B2BExtraFieldsSessionStorage.setAddressId(
-                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
-                (address as CustomerAddress).id,
-            );
-        }
-
         try {
             await checkoutService.updateBillingAddress(address);
+
+            B2BExtraFieldsSessionStorage.removeAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+            );
+
+            const selectedAddressId = (address as CustomerAddress).id;
+
+            if (hasCompanyAddressBook && selectedAddressId) {
+                B2BExtraFieldsSessionStorage.setAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                    selectedAddressId,
+                );
+            }
         } catch (error) {
             if (error instanceof Error) {
                 onUnhandledError(error);
@@ -140,10 +158,6 @@ const BillingForm = ({
         if (hasAddressExtraFields) {
             B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.BILLING_KEY);
         }
-
-        B2BExtraFieldsSessionStorage.removeAddressId(
-            B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
-        );
 
         void handleSelectAddress({});
     };

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -32,6 +32,7 @@ import {
     checkoutWithShipping,
     checkoutWithShippingAndBilling,
     consignment,
+    customer,
     payments,
     shippingAddress,
     shippingQuoteFailedMessage,
@@ -43,6 +44,7 @@ import {
     within,
 } from '@bigcommerce/checkout/test-utils';
 
+import { B2BExtraFieldsSessionStorage } from '../address';
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
 import {
@@ -66,6 +68,7 @@ describe('Shipping step', () => {
     afterEach(() => {
         jest.unmock('lodash');
         checkout.resetHandlers();
+        sessionStorage.clear();
     });
 
     afterAll(() => {
@@ -1059,6 +1062,91 @@ describe('Shipping step', () => {
             expect(
                 screen.queryByText(/no shipping address to choose from/i),
             ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('B2B company address book', () => {
+        const companyAddressBookCapabilities = {
+            ...defaultCapabilities,
+            userJourney: {
+                ...defaultCapabilities.userJourney,
+                hasCompanyAddressBook: true,
+            },
+        };
+
+        const CheckoutWithCompanyAddressBook: FunctionComponent<CheckoutProps> = (props) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleProvider
+                    checkoutService={checkoutService}
+                    languageService={getLanguageService()}
+                >
+                    <AnalyticsProviderMock>
+                        <ExtensionProvider extensionService={extensionService}>
+                            <ThemeProvider>
+                                <CapabilitiesContext.Provider
+                                    value={companyAddressBookCapabilities}
+                                >
+                                    <Checkout {...props} />
+                                </CapabilitiesContext.Provider>
+                            </ThemeProvider>
+                        </ExtensionProvider>
+                    </AnalyticsProviderMock>
+                </LocaleProvider>
+            </CheckoutProvider>
+        );
+
+        it('stores the selected shipping address id when hasCompanyAddressBook is enabled', async () => {
+            // The searchable address book only lists addresses flagged for shipping.
+            const checkoutWithCompanyShippingAddress = {
+                ...checkoutWithMultiShippingCart,
+                customer: {
+                    ...customer,
+                    addresses: [{ ...shippingAddress, id: 1, isShipping: true }],
+                },
+            };
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart, {
+                checkout: checkoutWithCompanyShippingAddress,
+            });
+
+            jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            await userEvent.click(screen.getByTestId('address-select-button'));
+            await userEvent.click(screen.getByTestId('address-select-option-action'));
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                ),
+            ).toBe(1);
+        });
+
+        it('does not store the shipping address id when hasCompanyAddressBook is disabled', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
+
+            jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            await userEvent.click(screen.getByTestId('address-select-button'));
+            // 111 Testing Rd is the customer's saved address with id 1.
+            await userEvent.click(screen.getByText(/111 Testing Rd/i));
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                ),
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -6,7 +6,12 @@ import { useCapabilities } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, ConfirmationModal } from '@bigcommerce/checkout/ui';
 
-import { B2BExtraFieldsSessionStorage, isEqualAddress, mapAddressFromFormValues } from '../address';
+import {
+    B2BExtraFieldsSessionStorage,
+    isEqualAddress,
+    mapAddressFromFormValues,
+    setDefaultAddress,
+} from '../address';
 import type CheckoutStepStatus from '../checkout/CheckoutStepStatus';
 
 import { useShipping } from './hooks/useShipping';
@@ -80,18 +85,16 @@ function Shipping({
                     loadBillingAddressFields(),
                 ]);
 
-                if (hasCompanyAddressBook && !shippingAddress) {
-                    const defaultShippingAddress = customer.addresses?.find(
-                        ({ isDefaultShipping }) => isDefaultShipping,
-                    );
-
-                    if (defaultShippingAddress) {
-                        try {
-                            await updateShippingAddress(defaultShippingAddress);
-                        } catch {
-                            /* Do nothing: we should not block shoppers from buying. */
-                        }
-                    }
+                if (hasCompanyAddressBook) {
+                    await setDefaultAddress({
+                        addressIdKey: B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                        currentAddress: shippingAddress,
+                        addresses: customer.addresses,
+                        defaultAddress: customer.addresses?.find(
+                            ({ isDefaultShipping }) => isDefaultShipping,
+                        ),
+                        updateAddress: updateShippingAddress,
+                    });
                 }
 
                 if (cartHasPromotionalItems && isMultiShippingMode) {

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -7,6 +7,7 @@ import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, ConfirmationModal } from '@bigcommerce/checkout/ui';
 
 import {
+    AddressType,
     B2BExtraFieldsSessionStorage,
     isEqualAddress,
     mapAddressFromFormValues,
@@ -87,12 +88,9 @@ function Shipping({
 
                 if (hasCompanyAddressBook) {
                     await setDefaultAddress({
-                        addressIdKey: B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                        type: AddressType.Shipping,
                         currentAddress: shippingAddress,
                         addresses: customer.addresses,
-                        defaultAddress: customer.addresses?.find(
-                            ({ isDefaultShipping }) => isDefaultShipping,
-                        ),
                         updateAddress: updateShippingAddress,
                     });
                 }

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -118,6 +118,15 @@ function Shipping({
 
             if (isMultiShippingMode && consignments.length) {
                 await updateShippingAddress(consignments[0].shippingAddress);
+
+                if (hasCompanyAddressBook) {
+                    await setDefaultAddress({
+                        type: AddressType.Shipping,
+                        currentAddress: consignments[0].shippingAddress,
+                        addresses: customer.addresses,
+                        updateAddress: updateShippingAddress,
+                    });
+                }
             } else {
                 await deleteConsignments();
             }

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -165,6 +165,22 @@ function Shipping({
                 );
             }
 
+            // Copy shipping address ID to billing when billing same as shipping
+            const shippingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+            );
+
+            if (shippingAddressId) {
+                B2BExtraFieldsSessionStorage.setAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                    shippingAddressId,
+                );
+            } else {
+                B2BExtraFieldsSessionStorage.removeAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                );
+            }
+
             if (!isEqualAddress(updatedShippingAddress, billingAddress)) {
                 promises.push(updateBillingAddress(updatedShippingAddress));
             }

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -155,32 +155,7 @@ function Shipping({
         }
 
         if (values.billingSameAsShipping && updatedShippingAddress && !hasRemoteBilling) {
-            const shippingExtraFields = B2BExtraFieldsSessionStorage.getFields(
-                B2BExtraFieldsSessionStorage.SHIPPING_KEY,
-            );
-
-            if (shippingExtraFields) {
-                B2BExtraFieldsSessionStorage.setFields(
-                    B2BExtraFieldsSessionStorage.BILLING_KEY,
-                    shippingExtraFields,
-                );
-            }
-
-            // Copy shipping address ID to billing when billing same as shipping
-            const shippingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
-                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
-            );
-
-            if (shippingAddressId) {
-                B2BExtraFieldsSessionStorage.setAddressId(
-                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
-                    shippingAddressId,
-                );
-            } else {
-                B2BExtraFieldsSessionStorage.removeAddressId(
-                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
-                );
-            }
+            B2BExtraFieldsSessionStorage.copyShippingToBilling();
 
             if (!isEqualAddress(updatedShippingAddress, billingAddress)) {
                 promises.push(updateBillingAddress(updatedShippingAddress));

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -14,6 +14,7 @@ import {
     getAddressFormFieldsValidationSchema,
     getTranslateAddressError,
     isEqualAddress,
+    isValidCustomerAddress,
     mapAddressFromFormValues,
     mapAddressToFormValues,
 } from '../address';
@@ -92,6 +93,7 @@ const SingleShippingForm: React.FC<
     } = useCapabilities();
     const {
         consignments,
+        customer,
         deinitializeShippingMethod: deinitialize,
         deleteConsignments,
         initializeShippingMethod: initialize,
@@ -101,6 +103,13 @@ const SingleShippingForm: React.FC<
         shouldShowOrderComments,
         updateShippingAddress: updateAddress,
     } = useShipping();
+
+    const hasValidShippingCustomerAddress = isValidCustomerAddress(
+        shippingAddress,
+        customer.addresses,
+        getFields(shippingAddress?.countryCode),
+        validateMaxLength,
+    );
 
     const propsRef = useRef({ values, shippingAddress, isValid });
     const debouncedUpdateAddressRef = useRef<
@@ -113,6 +122,22 @@ const SingleShippingForm: React.FC<
     const [isResettingAddress, setIsResettingAddress] = useState(false);
     const [isUpdatingShippingData, setIsUpdatingShippingData] = useState(false);
     const [hasRequestedShippingOptions, setHasRequestedShippingOptions] = useState(false);
+
+    // Once the address form opens (selected address is invalid or no longer matches a
+    // book entry), the stored book id can't faithfully represent it, so drop it.
+    useEffect(() => {
+        if (
+            hasCompanyAddressBook &&
+            !hasValidShippingCustomerAddress &&
+            B2BExtraFieldsSessionStorage.getAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+            )
+        ) {
+            B2BExtraFieldsSessionStorage.removeAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+            );
+        }
+    }, [hasCompanyAddressBook, hasValidShippingCustomerAddress]);
 
     const stateOrProvinceCodeFormField = useMemo(() => {
         return getFields(values.shippingAddress?.countryCode).find(
@@ -236,19 +261,21 @@ const SingleShippingForm: React.FC<
     const handleAddressSelect = async (address: Address) => {
         setIsResettingAddress(true);
 
-        B2BExtraFieldsSessionStorage.removeAddressId(
-            B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
-        );
-
-        if (hasCompanyAddressBook && (address as CustomerAddress).id) {
-            B2BExtraFieldsSessionStorage.setAddressId(
-                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
-                (address as CustomerAddress).id,
-            );
-        }
-
         try {
             await updateAddress(address);
+
+            B2BExtraFieldsSessionStorage.removeAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+            );
+
+            const selectedAddressId = (address as CustomerAddress).id;
+
+            if (hasCompanyAddressBook && selectedAddressId) {
+                B2BExtraFieldsSessionStorage.setAddressId(
+                    B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                    selectedAddressId,
+                );
+            }
 
             setValues({
                 ...propsRef.current.values,
@@ -265,6 +292,8 @@ const SingleShippingForm: React.FC<
         setIsResettingAddress(true);
 
         try {
+            const address = await deleteConsignments();
+
             if (hasAddressExtraFields) {
                 B2BExtraFieldsSessionStorage.removeFields(
                     B2BExtraFieldsSessionStorage.SHIPPING_KEY,
@@ -274,8 +303,6 @@ const SingleShippingForm: React.FC<
             B2BExtraFieldsSessionStorage.removeAddressId(
                 B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
             );
-
-            const address = await deleteConsignments();
 
             setValues({
                 ...propsRef.current.values,

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -1,4 +1,4 @@
-import { type Address, type FormField } from '@bigcommerce/checkout-sdk';
+import { type Address, type CustomerAddress, type FormField } from '@bigcommerce/checkout-sdk';
 import { type FormikProps } from 'formik';
 import { debounce, type DebouncedFunc, isEqual, noop } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -88,7 +88,7 @@ const SingleShippingForm: React.FC<
 }) => {
     const {
         shipping: { hideBillingSameAsShippingCheck },
-        userJourney: { hasAddressExtraFields },
+        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
     } = useCapabilities();
     const {
         consignments,
@@ -236,6 +236,17 @@ const SingleShippingForm: React.FC<
     const handleAddressSelect = async (address: Address) => {
         setIsResettingAddress(true);
 
+        B2BExtraFieldsSessionStorage.removeAddressId(
+            B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+        );
+
+        if (hasCompanyAddressBook && (address as CustomerAddress).id) {
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                (address as CustomerAddress).id,
+            );
+        }
+
         try {
             await updateAddress(address);
 
@@ -259,6 +270,10 @@ const SingleShippingForm: React.FC<
                     B2BExtraFieldsSessionStorage.SHIPPING_KEY,
                 );
             }
+
+            B2BExtraFieldsSessionStorage.removeAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+            );
 
             const address = await deleteConsignments();
 


### PR DESCRIPTION
## What/Why?

First of two stacked PRs for CHECKOUT-9819 (B2B metadata persistence). This PR adds the **capture** half: persisting the selected company address book address IDs to `sessionStorage` so a later step can include them in the post-order B2B metadata payload.

When the `hasCompanyAddressBook` capability is enabled, B2B shoppers select billing/shipping addresses from a company address book, and each selection carries a backend address `id`. This change records that `id` at selection time so it survives until order submission.

**Changes:**
- **`B2BExtraFieldsSessionStorage`** — two new keys (`BILLING_ADDRESS_ID_KEY`, `SHIPPING_ADDRESS_ID_KEY`) and `setAddressId` / `getAddressId` / `removeAddressId` helpers.
- **`BillingForm`** — on address select, store the billing address `id` (only when `hasCompanyAddressBook` and the selected address has an `id`); clear it on manual entry / address reset.
- **`SingleShippingForm`** — same behavior for the shipping address `id`; cleared when consignments are deleted.
- **`Shipping`** — when billing-same-as-shipping is in effect, copy the stored shipping address `id` to the billing key (or clear it if absent), keeping the two in sync.

No consumer reads these IDs yet — that lands in the stacked follow-up PR (`CHECKOUT-9819-persistB2BMetaData`, post-order submission). On its own this change is dormant and side-effect-free beyond writing to `sessionStorage`.
https://github.com/bigcommerce/checkout-js/pull/3081

## Rollout/Rollback

Revert this PR

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout shipping/billing initialization and address selection when hasCompanyAddressBook is enabled; incorrect ID matching could mis-associate book entries, though behavior is gated and IDs are not consumed until a follow-up PR.
> 
> **Overview**
> When **`hasCompanyAddressBook`** is on, checkout now **persists company address book `id`s** for billing and shipping in `sessionStorage` (new keys and helpers on **`B2BExtraFieldsSessionStorage`**), including **`copyShippingToBilling`** so billing-same-as-shipping keeps extra fields and the shipping book id in sync.
> 
> **`setDefaultAddress`** centralizes B2B init: apply the default book address when checkout has none, or **match / refresh / clear** stored ids for resumed checkouts (shipping vs billing rows filtered by `isShipping` / `isBilling`). **`Billing`** and **`Shipping`** call it on load (and shipping again when leaving multi-ship mode) instead of only applying defaults when `address1` was empty.
> 
> **`BillingForm`** and **`SingleShippingForm`** set the stored id after a book selection, clear it on “new address” or when the manual form opens because the current address is no longer a valid book entry. Integration tests assert ids are written only with the capability enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25df931d8aade5b3fa43bb8df5ad9bccff2582e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->