### PR TITLE
feat(checkout): CHECKOUT-10081 Use cannotCreatePersonalAccount 

### DIFF
--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.test.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.test.tsx
@@ -15,6 +15,7 @@ import {
     type AnalyticsEvents,
     AnalyticsProviderMock,
     CheckoutProvider,
+    defaultCapabilities,
     ExtensionProvider,
     type ExtensionServiceInterface,
     type LocaleContextType,
@@ -248,6 +249,70 @@ describe('OrderConfirmation', () => {
                 confirmPassword: password,
             }),
         );
+    });
+
+    describe('when cannotCreatePersonalAccount capability is enabled', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                ...getStoreConfig(),
+                checkoutSettings: {
+                    ...getStoreConfig().checkoutSettings,
+                    capabilities: {
+                        ...defaultCapabilities,
+                        orderConfirmation: {
+                            ...defaultCapabilities.orderConfirmation,
+                            cannotCreatePersonalAccount: true,
+                        },
+                    },
+                },
+            });
+        });
+
+        it('does not render the create account form', async () => {
+            render(<ComponentTest {...defaultProps} />);
+
+            await waitFor(() => {
+                expect(analyticsTracker.orderPurchased).toHaveBeenCalled();
+            });
+
+            expect(
+                screen.getByText(
+                    localeContext.language.translate('order_confirmation.continue_shopping'),
+                ),
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByText(
+                    localeContext.language.translate('customer.create_account_text'),
+                ),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(
+                    localeContext.language.translate('customer.create_account_action'),
+                ),
+            ).not.toBeInTheDocument();
+        });
+
+        it('does not render the set password form for an existing customer', async () => {
+            jest.spyOn(checkoutState.data, 'getOrder').mockReturnValue({
+                ...getOrder(),
+                customerId: 1,
+            });
+
+            render(<ComponentTest {...defaultProps} />);
+
+            await waitFor(() => {
+                expect(analyticsTracker.orderPurchased).toHaveBeenCalled();
+            });
+
+            expect(
+                screen.queryByText(localeContext.language.translate('customer.set_password_text')),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(
+                    localeContext.language.translate('customer.set_password_action'),
+                ),
+            ).not.toBeInTheDocument();
+        });
     });
 
     it('renders continue shopping button', async () => {

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
@@ -5,7 +5,7 @@ import {
 import { createRequestSender } from '@bigcommerce/request-sender';
 import React, { type ReactElement, useEffect, useRef, useState } from 'react';
 
-import { useAnalytics, useCheckout } from '@bigcommerce/checkout/contexts';
+import { useAnalytics, useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { OrderConfirmationPageSkeleton } from '@bigcommerce/checkout/ui';
 
@@ -63,6 +63,9 @@ export const OrderConfirmation = ({
         checkoutService: { loadOrder },
     } = useCheckout();
     const { analyticsTracker } = useAnalytics();
+    const {
+        orderConfirmation: { cannotCreatePersonalAccount },
+    } = useCapabilities();
 
     const config = getConfig();
     const order = getOrder();
@@ -170,6 +173,7 @@ export const OrderConfirmation = ({
 
     return (
         <OrderConfirmationPage
+            cannotCreatePersonalAccount={cannotCreatePersonalAccount}
             currency={currency}
             customerCanBeCreated={customerCanBeCreated}
             error={error}

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmationPage.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmationPage.tsx
@@ -25,6 +25,7 @@ import { ContinueButton } from './ContinueButton';
 import { OrderSummaryContainer } from './OrderSummaryContainer';
 
 interface OrderConfirmationPageProps {
+    cannotCreatePersonalAccount: boolean;
     order: Order;
     supportEmail: string;
     supportPhoneNumber: string | undefined;
@@ -44,6 +45,7 @@ interface OrderConfirmationPageProps {
 }
 
 export const OrderConfirmationPage = ({
+    cannotCreatePersonalAccount,
     currency,
     customerCanBeCreated,
     error,
@@ -85,7 +87,7 @@ export const OrderConfirmationPage = ({
                     </OrderConfirmationSection>
                 )}
 
-                {shouldShowPasswordForm && !hasSignedUp && (
+                {!cannotCreatePersonalAccount && shouldShowPasswordForm && !hasSignedUp && (
                     <GuestSignUpForm
                         customerCanBeCreated={customerCanBeCreated}
                         isSigningUp={isSigningUp}


### PR DESCRIPTION
## What/Why?

When `cannotCreatePersonalAccount ` is `true`, hide the account sign-up form on the order confirmation page.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating of an existing form; no changes to account-creation APIs or auth flows.
> 
> **Overview**
> When checkout settings expose **`orderConfirmation.cannotCreatePersonalAccount`**, the order confirmation page no longer shows guest account creation or “set password” UI.
> 
> `OrderConfirmation` reads the flag via **`useCapabilities`** and passes it to **`OrderConfirmationPage`**, which only renders **`GuestSignUpForm`** when the capability is off and the existing `shouldShowPasswordForm` / `hasSignedUp` checks still pass. Continue shopping and the rest of the page are unchanged.
> 
> Tests cover both new-guest and existing-customer flows with the capability enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb515331b448f636570f15720af77c373db12c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->