### PR TITLE
fix(ui): CHECKOUT-10110 Fix country flag z-index for phone numbers

### DIFF
--- a/packages/ui/src/dropdown/DropdownTrigger.tsx
+++ b/packages/ui/src/dropdown/DropdownTrigger.tsx
@@ -108,7 +108,7 @@ const DropdownTrigger: React.FC<DropdownTriggerProps> = ({
                             style={{
                                 ...style,
                                 width: '100%',
-                                zIndex: 1,
+                                zIndex: 2,
                             }}
                         >
                             {dropdown}


### PR DESCRIPTION
## What/Why?

There is an issue with country flag z-index, which this PR fixes (see testing section for visuals).

## Rollout/Rollback

Revert the PR.

## Testing

Manual on b2b integration store.
Before:

<img width="810" height="478" alt="Screenshot 2026-06-12 at 9 53 38 AM" src="https://github.com/user-attachments/assets/5b1f8468-512f-4dd1-aeaf-bc5161c5f5fc" />

After:

<img width="810" height="478" alt="Screenshot 2026-06-12 at 10 29 13 AM" src="https://github.com/user-attachments/assets/d523014c-68dd-4f58-bfeb-ece9f2b0f02e" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line stacking order change in shared UI with no logic or data impact; minor risk of overlapping other layered elements.
> 
> **Overview**
> Raises the inline **`zIndex`** on the shared **`DropdownTrigger`** popper menu from **1** to **2** so open dropdown panels (including phone country-flag pickers) stack above adjacent trigger content instead of rendering underneath it.
> 
> Because **`DropdownTrigger`** is reused across checkout selects, this is a single stacking-context tweak rather than a phone-field–only override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b3a88ab471e27d0a98dce23051c2d2ec169bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->