### PR TITLE
fix(checkout): CHECKOUT-9891 Remove B2B sessionStorage on order completion

### DIFF
--- a/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
+++ b/packages/core/src/app/address/B2BExtraAddressFieldsSessionStorage.test.ts
@@ -38,4 +38,39 @@ describe('B2BExtraFieldsSessionStorage', () => {
             ).toBeUndefined();
         });
     });
+
+    describe('removeAll', () => {
+        it('removes billing, shipping, order, and consignment keys', () => {
+            const fields = { field: 'value' };
+
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, fields);
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY, fields);
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.ORDER_KEY, fields);
+            B2BExtraFieldsSessionStorage.setFields(
+                B2BExtraFieldsSessionStorage.getConsignmentKey('c1'),
+                fields,
+            );
+            B2BExtraFieldsSessionStorage.setFields(
+                B2BExtraFieldsSessionStorage.getConsignmentKey('c2'),
+                fields,
+            );
+
+            B2BExtraFieldsSessionStorage.removeAll();
+
+            expect(B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.BILLING_KEY)).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY)).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY)).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.getConsignmentKey('c1'))).toBeUndefined();
+            expect(B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.getConsignmentKey('c2'))).toBeUndefined();
+        });
+
+        it('does not remove unrelated sessionStorage keys', () => {
+            sessionStorage.setItem('unrelated', 'data');
+
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, { field: 'value' });
+            B2BExtraFieldsSessionStorage.removeAll();
+
+            expect(sessionStorage.getItem('unrelated')).toBe('data');
+        });
+    });
 });

--- a/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
+++ b/packages/core/src/app/address/B2BExtraFieldsSessionStorage.ts
@@ -39,4 +39,23 @@ export class B2BExtraFieldsSessionStorage {
             this.removeFields(tempKey);
         }
     }
+
+    static removeAll(): void {
+        const keysToRemove: string[] = [];
+
+        for (let i = 0; i < sessionStorage.length; i++) {
+            const key = sessionStorage.key(i);
+
+            if (
+                key === this.BILLING_KEY ||
+                key === this.SHIPPING_KEY ||
+                key === this.ORDER_KEY ||
+                (key !== null && key.startsWith(this.CONSIGNMENT_KEY_PREFIX))
+            ) {
+                keysToRemove.push(key);
+            }
+        }
+
+        keysToRemove.forEach((key) => sessionStorage.removeItem(key));
+    }
 }

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -47,6 +47,7 @@ import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integratio
 import { ChecklistSkeleton } from '@bigcommerce/checkout/ui';
 
 import { withAnalytics } from '../analytics';
+import { B2BExtraFieldsSessionStorage } from '../address';
 import { withCheckout } from '../checkout';
 import {
     ErrorModal,
@@ -59,6 +60,7 @@ import { EMPTY_ARRAY, isExperimentEnabled } from '../common/utility';
 import { TermsConditionsType } from '../termsConditions';
 
 import CartStockPositionsChangedModal from './CartStockPositionsChangedModal';
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
 import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
@@ -396,7 +398,6 @@ const Payment = (
 
         const invoiceComment = InvoicePaymentCommentSessionStorage.get();
 
-        // TODO: CHECKOUT-9891 Remove all B2B sessionStorage usages after this all
         await submitB2BMetadata({
             isInvoice: invoiceRedirect,
             invoiceComment,
@@ -442,6 +443,10 @@ const Payment = (
                 const order = state.data.getOrder();
 
                 await persistB2BMetadataIfNeeded();
+
+                B2BExtraFieldsSessionStorage.removeAll();
+                AdditionalPaymentFieldSessionStorage.remove();
+                InvoicePaymentCommentSessionStorage.remove();
 
                 analyticsTracker.paymentComplete();
 


### PR DESCRIPTION
## Summary

- Adds `B2BExtraFieldsSessionStorage.removeAll()` to clear all B2B address extra field keys (billing, shipping, order, all consignment keys) from sessionStorage
- After a successful order submission, clears all three B2B sessionStorage stores: `B2BExtraFieldsSessionStorage`, `AdditionalPaymentFieldSessionStorage`, and `InvoicePaymentCommentSessionStorage`
- Cleanup happens after `persistB2BMetadataIfNeeded()` (so the data is submitted first) and before navigation to order confirmation

## Why

B2B extra fields, additional payment field, and invoice payment comment were saved to sessionStorage during checkout but never removed. This meant stale values from a previous order would persist into the next checkout session in the same browser tab.

## Notes for reviewer

- Cleanup only runs on successful order submission — if the order fails the user stays on the payment page and their entered values are preserved
- `removeAll()` iterates sessionStorage keys rather than hardcoding individual removes, so it handles an arbitrary number of consignment keys