### PR TITLE
feat(checkout): CHECKOUT-9819 Post-order B2B metadata submission and extra fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.923.1",
+        "@bigcommerce/checkout-sdk": "^1.924.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.923.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.923.1.tgz",
-      "integrity": "sha512-CzNp+c4x6TNTqLk3qDFwZLlK/6dFMb9E3GMTdAzChCXQBNsu3LRcE87oNhstJiKV8z1fzeKsGsgdEU1yZaklmA==",
+      "version": "1.924.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.924.0.tgz",
+      "integrity": "sha512-LGQHhCQzeSRYlcPoMm3WCpLInuP0Olv4PeNeUoRdixeLXRWvhpPNhxFykQTKcyARtvYn49+ZT6NtM+OgYwZNlA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.923.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.923.1.tgz",
-      "integrity": "sha512-CzNp+c4x6TNTqLk3qDFwZLlK/6dFMb9E3GMTdAzChCXQBNsu3LRcE87oNhstJiKV8z1fzeKsGsgdEU1yZaklmA==",
+      "version": "1.924.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.924.0.tgz",
+      "integrity": "sha512-LGQHhCQzeSRYlcPoMm3WCpLInuP0Olv4PeNeUoRdixeLXRWvhpPNhxFykQTKcyARtvYn49+ZT6NtM+OgYwZNlA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.923.1",
+    "@bigcommerce/checkout-sdk": "^1.924.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -33,13 +33,18 @@ import {
     payments,
 } from '@bigcommerce/checkout/test-framework';
 import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+import { getPoNumber, setPoNumber } from '@bigcommerce/checkout/utility';
 
+import { B2BExtraFieldsSessionStorage } from '../address';
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
 import {
     createEmbeddedCheckoutStylesheet,
     createEmbeddedCheckoutSupport,
 } from '../embeddedCheckout';
+
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 
 describe('Payment step', () => {
     let checkout: CheckoutPageNodeObject;
@@ -57,6 +62,7 @@ describe('Payment step', () => {
 
     afterEach(() => {
         checkout.resetHandlers();
+        sessionStorage.clear();
     });
 
     afterAll(() => {
@@ -775,8 +781,281 @@ describe('Payment step', () => {
             render(<CheckoutTest {...defaultProps} />);
 
             await waitFor(() =>
-                expect(persistSpy).toHaveBeenCalledWith({ isInvoice: false, invoiceComment: '' }),
+                expect(persistSpy).toHaveBeenCalledWith({
+                    isInvoice: false,
+                    invoiceComment: '',
+                    poNumber: '',
+                    referenceNumber: '',
+                    extraFields: [],
+                    extraInfo: {},
+                }),
             );
+        });
+
+        it('persists the full B2B metadata payload from sessionStorage and clears it afterwards', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            setPoNumber('PO-123');
+            AdditionalPaymentFieldSessionStorage.set('REF-456');
+            InvoicePaymentCommentSessionStorage.set('Please rush this order');
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.ORDER_KEY, {
+                costCentre: 'Engineering',
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                department: 'Finance',
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY, {
+                dock: 'B7',
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith({
+                    isInvoice: false,
+                    invoiceComment: 'Please rush this order',
+                    poNumber: 'PO-123',
+                    referenceNumber: 'REF-456',
+                    extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                    extraInfo: {
+                        addressExtraFields: {
+                            billingAddressExtraFields: [
+                                { fieldName: 'department', fieldValue: 'Finance' },
+                            ],
+                            shippingAddressExtraFields: [{ fieldName: 'dock', fieldValue: 'B7' }],
+                        },
+                    },
+                }),
+            );
+
+            // The shipping key is cleared last, so once it is gone every earlier key is too.
+            await waitFor(() =>
+                expect(
+                    B2BExtraFieldsSessionStorage.getFields(
+                        B2BExtraFieldsSessionStorage.SHIPPING_KEY,
+                    ),
+                ).toBeUndefined(),
+            );
+
+            expect(getPoNumber()).toBe('');
+            expect(AdditionalPaymentFieldSessionStorage.get()).toBe('');
+            expect(InvoicePaymentCommentSessionStorage.get()).toBe('');
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY),
+            ).toBeUndefined();
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.BILLING_KEY),
+            ).toBeUndefined();
+        });
+
+        it('persists the stored billing and shipping address IDs and clears them afterwards', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                111,
+            );
+            B2BExtraFieldsSessionStorage.setAddressId(
+                B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                222,
+            );
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        extraInfo: {
+                            billingAddressId: 111,
+                            shipppingAddressId: 222,
+                        },
+                    }),
+                ),
+            );
+
+            // The shipping address ID is cleared last, so once it is gone the billing one is too.
+            await waitFor(() =>
+                expect(
+                    B2BExtraFieldsSessionStorage.getAddressId(
+                        B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+                    ),
+                ).toBeUndefined(),
+            );
+
+            expect(
+                B2BExtraFieldsSessionStorage.getAddressId(
+                    B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+                ),
+            ).toBeUndefined();
+        });
+
+        it('persists B2B metadata with isInvoice true when the invoiceRedirect capability is enabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            InvoicePaymentCommentSessionStorage.set('Invoice me');
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: {
+                    ...checkoutSettings,
+                    storeConfig: {
+                        ...checkoutSettings.storeConfig,
+                        checkoutSettings: {
+                            ...checkoutSettings.storeConfig.checkoutSettings,
+                            capabilities: {
+                                ...defaultCapabilities,
+                                orderConfirmation: {
+                                    ...defaultCapabilities.orderConfirmation,
+                                    persistB2BMetadata: true,
+                                    invoiceRedirect: true,
+                                },
+                            },
+                        },
+                    },
+                },
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        isInvoice: true,
+                        invoiceComment: 'Invoice me',
+                    }),
+                ),
+            );
+        });
+
+        it('does not clear B2B sessionStorage when persisting metadata fails', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            setPoNumber('PO-123');
+            InvoicePaymentCommentSessionStorage.set('Keep me');
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.ORDER_KEY, {
+                costCentre: 'Engineering',
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockRejectedValue(new Error('Persist failed'));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() => expect(persistSpy).toHaveBeenCalled());
+
+            expect(getPoNumber()).toBe('PO-123');
+            expect(InvoicePaymentCommentSessionStorage.get()).toBe('Keep me');
+            expect(
+                B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY),
+            ).toEqual({ costCentre: 'Engineering' });
         });
 
         it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -58,8 +58,8 @@ import {
 import { EMPTY_ARRAY, isExperimentEnabled } from '../common/utility';
 import { TermsConditionsType } from '../termsConditions';
 
+import { buildB2BMetadataOptions, clearB2BMetadataStorage } from './b2bMetadata';
 import CartStockPositionsChangedModal from './CartStockPositionsChangedModal';
-import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
 import PaymentContext from './PaymentContext';
@@ -83,6 +83,7 @@ export interface PaymentProps {
 }
 
 interface WithCheckoutPaymentProps {
+    addressExtraFields?: FormField[];
     availableStoreCredit: number;
     b2bToken?: string;
     cart?: Cart;
@@ -388,19 +389,20 @@ const Payment = (
     };
 
     const persistB2BMetadataIfNeeded = async (): Promise<void> => {
-        const { submitB2BMetadata } = props;
+        const { addressExtraFields, orderExtraFields, submitB2BMetadata } = props;
 
         if (!persistB2BMetadata) {
             return;
         }
 
-        const invoiceComment = InvoicePaymentCommentSessionStorage.get();
-
-        // TODO: CHECKOUT-9891 Remove all B2B sessionStorage usages after this all
-        await submitB2BMetadata({
-            isInvoice: invoiceRedirect,
-            invoiceComment,
+        const metaDataPayload = buildB2BMetadataOptions(invoiceRedirect, {
+            orderExtraFields,
+            addressExtraFields,
         });
+
+        await submitB2BMetadata(metaDataPayload);
+
+        clearB2BMetadataStorage();
     };
 
     const handleSubmit = useCallback(
@@ -736,6 +738,7 @@ export function mapToPaymentProps(
 ): WithCheckoutPaymentProps | null {
     const {
         data: {
+            getAddressExtraFields,
             getCart,
             getCheckout,
             getConfig,
@@ -781,6 +784,10 @@ export function mapToPaymentProps(
         ? getOrderExtraFields()
         : undefined;
 
+    const addressExtraFields = capabilities.userJourney.hasAddressExtraFields
+        ? getAddressExtraFields()
+        : undefined;
+
     const { defaultMethod, filteredMethods } = getFilteredPaymentMethodsWithDefault({
         checkout,
         checkoutSettings: config.checkoutSettings,
@@ -793,6 +800,7 @@ export function mapToPaymentProps(
     return {
         applyStoreCredit: checkoutService.applyStoreCredit,
         availableStoreCredit: customer.storeCredit,
+        addressExtraFields,
         b2bToken: checkoutState.data.getB2BToken(),
         cart: getCart(),
         consignments,

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -395,12 +395,12 @@ const Payment = (
             return;
         }
 
-        const metaDataPayload = buildB2BMetadataOptions(invoiceRedirect, {
+        const metadataPayload = buildB2BMetadataOptions(invoiceRedirect, {
             orderExtraFields,
             addressExtraFields,
         });
 
-        await submitB2BMetadata(metaDataPayload);
+        await submitB2BMetadata(metadataPayload);
 
         clearB2BMetadataStorage();
     };

--- a/packages/core/src/app/payment/b2bMetadata.test.ts
+++ b/packages/core/src/app/payment/b2bMetadata.test.ts
@@ -1,0 +1,108 @@
+import { type FormField } from '@bigcommerce/checkout-sdk';
+
+import { B2BExtraFieldsSessionStorage } from '../address';
+
+import { buildAddressExtraInfo, buildExtraFields, buildOrderExtraFields } from './b2bMetadata';
+
+describe('b2bMetadata', () => {
+    const orderExtraFields = [
+        { name: 'field_25', label: 'Cost Centre' },
+        { name: 'field_26', label: 'Department' },
+    ] as FormField[];
+
+    afterEach(() => {
+        sessionStorage.clear();
+    });
+
+    describe('buildExtraFields', () => {
+        it('maps each stored field name to its label from the field definitions', () => {
+            expect(buildExtraFields({ field_25: 'Engineering' }, orderExtraFields)).toEqual([
+                { fieldName: 'Cost Centre', fieldValue: 'Engineering' },
+            ]);
+        });
+
+        it('falls back to the stored field name when no matching definition is found', () => {
+            expect(buildExtraFields({ field_99: 'value' }, orderExtraFields)).toEqual([
+                { fieldName: 'field_99', fieldValue: 'value' },
+            ]);
+        });
+
+        it('falls back to the stored field name when no definitions are provided', () => {
+            expect(buildExtraFields({ field_25: 'Engineering' })).toEqual([
+                { fieldName: 'field_25', fieldValue: 'Engineering' },
+            ]);
+        });
+
+        it('returns an empty array when nothing is stored', () => {
+            expect(buildExtraFields(undefined, orderExtraFields)).toEqual([]);
+        });
+    });
+
+    describe('buildOrderExtraFields', () => {
+        it('reads the stored order extra fields and maps names to labels', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.ORDER_KEY, {
+                field_25: 'Engineering',
+                field_26: 'Finance',
+            });
+
+            expect(buildOrderExtraFields(orderExtraFields)).toEqual([
+                { fieldName: 'Cost Centre', fieldValue: 'Engineering' },
+                { fieldName: 'Department', fieldValue: 'Finance' },
+            ]);
+        });
+    });
+
+    describe('buildAddressExtraInfo', () => {
+        const addressExtraFields = [
+            { name: 'field_30', label: 'Floor' },
+            { name: 'field_31', label: 'Dock' },
+        ] as FormField[];
+
+        it('maps billing and shipping address field names to their labels', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                field_30: '3',
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY, {
+                field_31: 'B7',
+            });
+
+            expect(buildAddressExtraInfo(addressExtraFields)).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'Floor', fieldValue: '3' }],
+                    shippingAddressExtraFields: [{ fieldName: 'Dock', fieldValue: 'B7' }],
+                },
+            });
+        });
+
+        it('falls back to the stored field name when no field definitions are provided', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                field_30: '3',
+            });
+
+            expect(buildAddressExtraInfo()).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'field_30', fieldValue: '3' }],
+                    shippingAddressExtraFields: [],
+                },
+            });
+        });
+
+        it('excludes the shouldSaveAddress flag from the address extra fields payload', () => {
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.BILLING_KEY, {
+                field_30: '3',
+                shouldSaveAddress: true,
+            });
+            B2BExtraFieldsSessionStorage.setFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY, {
+                field_31: 'B7',
+                shouldSaveAddress: false,
+            });
+
+            expect(buildAddressExtraInfo(addressExtraFields)).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'Floor', fieldValue: '3' }],
+                    shippingAddressExtraFields: [{ fieldName: 'Dock', fieldValue: 'B7' }],
+                },
+            });
+        });
+    });
+});

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -7,8 +7,8 @@ import { B2BExtraFieldsSessionStorage } from '../address';
 import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
 import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
 
-export type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
-export type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
+type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
+type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
 
 export const buildExtraFields = (
     stored?: Record<string, unknown>,
@@ -79,7 +79,7 @@ export const buildAddressExtraInfo = (addressExtraFields?: FormField[]): B2BMeta
     return extraInfo;
 };
 
-export interface B2BMetadataFieldDefinitions {
+interface B2BMetadataFieldDefinitions {
     orderExtraFields?: FormField[];
     addressExtraFields?: FormField[];
 }

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -11,11 +11,11 @@ type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields'
 type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
 
 export const buildExtraFields = (
-    stored?: Record<string, unknown>,
+    storedExtraFields?: Record<string, unknown>,
     fields?: FormField[],
 ): B2BMetadataExtraField[] =>
-    stored
-        ? Object.entries(stored).map(([fieldName, fieldValue]) => ({
+    storedExtraFields
+        ? Object.entries(storedExtraFields).map(([fieldName, fieldValue]) => ({
               // The API expects the field label, but values are stored keyed by field name (id).
               fieldName: fields?.find((field) => field.name === fieldName)?.label ?? fieldName,
               fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
@@ -33,13 +33,13 @@ export const buildOrderExtraFields = (orderExtraFields?: FormField[]): B2BMetada
 const SHOULD_SAVE_ADDRESS_KEY = 'shouldSaveAddress';
 
 const omitShouldSaveAddress = (
-    stored?: Record<string, unknown>,
+    storedExtraFields?: Record<string, unknown>,
 ): Record<string, unknown> | undefined => {
-    if (!stored) {
-        return stored;
+    if (!storedExtraFields) {
+        return storedExtraFields;
     }
 
-    const { [SHOULD_SAVE_ADDRESS_KEY]: _shouldSaveAddress, ...rest } = stored;
+    const { [SHOULD_SAVE_ADDRESS_KEY]: _shouldSaveAddress, ...rest } = storedExtraFields;
 
     return rest;
 };

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -1,0 +1,113 @@
+import { type FormField, type PersistB2BMetadataOptions } from '@bigcommerce/checkout-sdk';
+
+import { clearPoNumber, getPoNumber } from '@bigcommerce/checkout/utility';
+
+import { B2BExtraFieldsSessionStorage } from '../address';
+
+import { AdditionalPaymentFieldSessionStorage } from './AdditionalPaymentFieldSessionStorage';
+import { InvoicePaymentCommentSessionStorage } from './InvoicePaymentCommentSessionStorage';
+
+export type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
+export type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
+
+export const buildExtraFields = (
+    stored?: Record<string, unknown>,
+    fields?: FormField[],
+): B2BMetadataExtraField[] =>
+    stored
+        ? Object.entries(stored).map(([fieldName, fieldValue]) => ({
+              // The API expects the field label, but values are stored keyed by field name (id).
+              fieldName: fields?.find((field) => field.name === fieldName)?.label ?? fieldName,
+              fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
+          }))
+        : [];
+
+export const buildOrderExtraFields = (orderExtraFields?: FormField[]): B2BMetadataExtraField[] =>
+    buildExtraFields(
+        B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.ORDER_KEY),
+        orderExtraFields,
+    );
+
+// TODO: CHECKOUT-10080`shouldSaveAddress` is persisted alongside the address extra fields for a separate
+// "save to company address book" task, so it must not be sent in the post-order payload.
+const SHOULD_SAVE_ADDRESS_KEY = 'shouldSaveAddress';
+
+const omitShouldSaveAddress = (
+    stored?: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+    if (!stored) {
+        return stored;
+    }
+
+    const { [SHOULD_SAVE_ADDRESS_KEY]: _shouldSaveAddress, ...rest } = stored;
+
+    return rest;
+};
+
+export const buildAddressExtraInfo = (addressExtraFields?: FormField[]): B2BMetadataExtraInfo => {
+    const billing = omitShouldSaveAddress(
+        B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.BILLING_KEY),
+    );
+    const shipping = omitShouldSaveAddress(
+        B2BExtraFieldsSessionStorage.getFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY),
+    );
+    const billingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
+        B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+    );
+    const shippingAddressId = B2BExtraFieldsSessionStorage.getAddressId(
+        B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+    );
+
+    const extraInfo: B2BMetadataExtraInfo = {};
+
+    if (billing || shipping) {
+        extraInfo.addressExtraFields = {
+            billingAddressExtraFields: buildExtraFields(billing, addressExtraFields),
+            shippingAddressExtraFields: buildExtraFields(shipping, addressExtraFields),
+        };
+    }
+
+    if (billingAddressId) {
+        extraInfo.billingAddressId = billingAddressId;
+    }
+
+    if (shippingAddressId) {
+        // The SDK field is spelled with a triple "p" (shipppingAddressId).
+        extraInfo.shipppingAddressId = shippingAddressId;
+    }
+
+    return extraInfo;
+};
+
+export interface B2BMetadataFieldDefinitions {
+    orderExtraFields?: FormField[];
+    addressExtraFields?: FormField[];
+}
+
+export const buildB2BMetadataOptions = (
+    isInvoice: PersistB2BMetadataOptions['isInvoice'],
+    { orderExtraFields, addressExtraFields }: B2BMetadataFieldDefinitions = {},
+): PersistB2BMetadataOptions => ({
+    isInvoice,
+    invoiceComment: InvoicePaymentCommentSessionStorage.get(),
+    poNumber: getPoNumber(),
+    referenceNumber: AdditionalPaymentFieldSessionStorage.get(),
+    extraFields: buildOrderExtraFields(orderExtraFields),
+    extraInfo: buildAddressExtraInfo(addressExtraFields),
+});
+
+// Clear all B2B sessionStorage after a successful persist.
+export const clearB2BMetadataStorage = (): void => {
+    clearPoNumber();
+    AdditionalPaymentFieldSessionStorage.remove();
+    InvoicePaymentCommentSessionStorage.remove();
+    B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.ORDER_KEY);
+    B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.BILLING_KEY);
+    B2BExtraFieldsSessionStorage.removeFields(B2BExtraFieldsSessionStorage.SHIPPING_KEY);
+    B2BExtraFieldsSessionStorage.removeAddressId(
+        B2BExtraFieldsSessionStorage.BILLING_ADDRESS_ID_KEY,
+    );
+    B2BExtraFieldsSessionStorage.removeAddressId(
+        B2BExtraFieldsSessionStorage.SHIPPING_ADDRESS_ID_KEY,
+    );
+};

--- a/packages/utility/src/storage/poNumberStorage.ts
+++ b/packages/utility/src/storage/poNumberStorage.ts
@@ -1,4 +1,4 @@
-const KEY = 'PoNumber';
+const KEY = 'poNumber';
 
 export const getPoNumber = (): string => sessionStorage.getItem(KEY) ?? '';
 


### PR DESCRIPTION
### What/Why

Submit all B2B checkout metadata to the post-order `persistB2BMetadata` SDK call in a single consolidated payload, and add support for address extra fields.

Previously only the invoice comment was persisted after order submission. B2B orders also carry a PO number, reference number, order extra fields, and per-address (billing/shipping) extra fields and address IDs that were collected during checkout but never submitted post-order. This change gathers all of that from session storage and sends it in one call.

### Changes

- **New `b2bMetadata.ts` helper** — builds the `PersistB2BMetadataOptions` payload from session storage:
  - `invoiceComment`, `poNumber`, `referenceNumber`
  - order `extraFields` (mapped from field name → API-expected field label)
  - `extraInfo` with billing/shipping `addressExtraFields` and address IDs
  - `clearB2BMetadataStorage()` clears all B2B session storage after a successful persist.
- **`Payment.tsx`** — `persistB2BMetadataIfNeeded` now uses `buildB2BMetadataOptions(...)` and clears storage afterward; wires in `addressExtraFields` via `getAddressExtraFields()` gated on the `hasAddressExtraFields` capability.
- **`poNumberStorage.ts`** — fixed session storage key casing `PoNumber` → `poNumber` for consistency with the other B2B storage keys.
- **SDK bump** — `@bigcommerce/checkout-sdk` `^1.923.1` → `^1.924.0` (provides the updated `PersistB2BMetadataOptions` type with `extraFields`/`extraInfo`).
- Tests added for `b2bMetadata.ts` and expanded `Payment.test.tsx` coverage.

### Notes

- `shouldSaveAddress` is intentionally stripped from the address extra-fields payload — it belongs to the separate "save to company address book" task (CHECKOUT-10080) and must not be sent post-order.
- The SDK field `shipppingAddressId` is spelled with a triple "p" — this is the SDK's spelling, not a typo here.

### Rollout/Rollback

This change is gated behind existing B2B capabilities (`hasAddressExtraFields`, `hasCompanyAddressBook`) and the `persistB2BMetadata` flag — when these are off, behavior is unchanged, so there is no impact to non-B2B storefronts.

Rollback is code-only (revert this PR); there are no database migrations or data backfills involved. Reverting restores the prior behavior of persisting only the invoice comment.

### Testing

- CI checks
- Manual testing: complete a B2B order with invoice, PO number, reference number, and order/address extra fields; verify all values reach the post-order metadata call and session storage is cleared.

https://github.com/user-attachments/assets/419998ea-53c1-4294-943a-1b150161562b


**Quick image comparisons of OOPC & existing B2b payload**
<img width="1576" height="776" alt="Screenshot 2026-06-12 at 4 27 25 pm" src="https://github.com/user-attachments/assets/e8838541-762e-46a5-a8b5-c04a9bc57605" />
<img width="1584" height="773" alt="Screenshot 2026-06-12 at 4 27 37 pm" src="https://github.com/user-attachments/assets/298f94f5-4b0a-4e61-aeee-104bc969b3bd" />
<img width="1464" height="615" alt="Screenshot 2026-06-12 at 4 27 53 pm" src="https://github.com/user-attachments/assets/68466e56-8f00-41bf-9a9b-efd5edca8cc7" />

**Storage cleared**
<img width="1577" height="751" alt="Screenshot 2026-06-12 at 4 48 29 pm" src="https://github.com/user-attachments/assets/69d53683-ece3-4137-8984-2b8e556a2f75" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes B2B post-order data submission and PO number session key migration; behavior stays behind `persistB2BMetadata` and related capabilities, but failed persists could leave stale storage until retry.
> 
> **Overview**
> **Post-order B2B metadata** now sends a single `persistB2BMetadata` payload built from session storage—invoice comment, PO number, reference number, order extra fields (labels mapped from form definitions), and billing/shipping address extra fields plus address IDs—instead of only the invoice comment.
> 
> New **`b2bMetadata`** helpers assemble `PersistB2BMetadataOptions` and **`clearB2BMetadataStorage`** runs only after a successful persist; **`Payment`** wires `addressExtraFields` when `hasAddressExtraFields` is enabled. **`shouldSaveAddress`** is stripped from the address payload.
> 
> **`poNumber`** session storage key casing is normalized (`PoNumber` → `poNumber`). **`@bigcommerce/checkout-sdk`** is bumped to **^1.924.0** for the expanded metadata types. Unit and payment-step tests cover full payloads, invoice flag, address IDs, and no clear on persist failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8890cd264ea74f92b8ee850d5274464886a4aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->