### PR TITLE
fix(checkout): PAYPAL-6440 Fix T&C checkbox can be bypassed durring PSD2 flow but it is required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.928.0",
+        "@bigcommerce/checkout-sdk": "^1.930.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.928.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.928.0.tgz",
-      "integrity": "sha512-Y+eE5eOGDFE0JRuPI6KNzcBvb7/iXWfAFKCUh0xCNzQBSdVKJnuLNIPURWAWQyKtt+WvlBdIZNDt2RhTWjyF9Q==",
+      "version": "1.930.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.930.1.tgz",
+      "integrity": "sha512-p+V1M2ZV8sNd2Q0Ic2ORBrJora77kGVqEBKuEQScTHCQzWk7dVnX8aJucVdM3vQZWj5CITp80ugRY5W78qLuyw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.928.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.928.0.tgz",
-      "integrity": "sha512-Y+eE5eOGDFE0JRuPI6KNzcBvb7/iXWfAFKCUh0xCNzQBSdVKJnuLNIPURWAWQyKtt+WvlBdIZNDt2RhTWjyF9Q==",
+      "version": "1.930.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.930.1.tgz",
+      "integrity": "sha512-p+V1M2ZV8sNd2Q0Ic2ORBrJora77kGVqEBKuEQScTHCQzWk7dVnX8aJucVdM3vQZWj5CITp80ugRY5W78qLuyw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.928.0",
+    "@bigcommerce/checkout-sdk": "^1.930.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.test.tsx
@@ -27,9 +27,9 @@ import BraintreePaypalPaymentMethod from './BraintreePaypalPaymentMethod';
 describe('BraintreePaypalPaymentMethod', () => {
     let eventEmitter: EventEmitter;
     let BraintreePaypalPaymentMethodTest: FunctionComponent;
-    let paymentForm: PaymentFormService;
     let localeContext: LocaleContextType;
 
+    const paymentForm: PaymentFormService = getPaymentFormServiceMock();
     const checkoutService = createCheckoutService();
     const checkoutState = checkoutService.getState();
     const defaultProps = {
@@ -39,19 +39,16 @@ describe('BraintreePaypalPaymentMethod', () => {
         language: { translate: jest.fn() } as unknown as LanguageService,
         method: getBraintreePaypalPaymentMethod(),
         onUnhandledError: jest.fn(),
-
-        paymentForm: {
-            hidePaymentSubmitButton: jest.fn(),
-            setSubmitted: jest.fn(),
-            submitForm: jest.fn(),
-        } as unknown as PaymentFormService,
+        paymentForm,
     };
 
     beforeEach(() => {
+        // jest.spyOn(paymentForm, 'validateForm').mockResolvedValue({});
         const providerError = new Error('INSTRUMENT_DECLINED');
 
         eventEmitter = new EventEmitter();
-        paymentForm = getPaymentFormServiceMock();
+        // paymentForm = getPaymentFormServiceMock();
+        jest.spyOn(paymentForm, 'validateForm').mockResolvedValue({});
         localeContext = createLocaleContext(getStoreConfig());
 
         jest.spyOn(checkoutState.data, 'getCart').mockReturnValue(getCart());
@@ -111,6 +108,8 @@ describe('BraintreePaypalPaymentMethod', () => {
                 onError: expect.any(Function),
                 onRenderButton: expect.any(Function),
                 submitForm: expect.any(Function),
+                onValidate: expect.any(Function),
+                onInitButton: expect.any(Function),
                 containerId: '#checkout-payment-continue',
             },
         });
@@ -124,6 +123,61 @@ describe('BraintreePaypalPaymentMethod', () => {
         expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(
             new Error(defaultProps.language.translate('payment.errors.instrument_declined')),
         );
+    });
+
+    it('passed form validation by calling onValidate callback', async () => {
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('onValidate', async (resolve: () => void, reject: () => void) => {
+                if (options.braintree?.onError) {
+                    await options.braintree.onValidate?.(resolve, reject);
+                }
+            });
+
+            return Promise.resolve(checkoutState);
+        });
+
+        const validationSuccess = jest.fn();
+
+        render(<BraintreePaypalPaymentMethodTest />);
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        eventEmitter.emit('onValidate', validationSuccess, () => {});
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.paymentForm.validateForm).toHaveBeenCalled();
+        expect(validationSuccess).toHaveBeenCalled();
+    });
+
+    it('is not passing form validation by calling onValidate callback', async () => {
+        jest.spyOn(paymentForm, 'validateForm').mockResolvedValue({
+            field1: 'validation error message',
+            field2: 'validation error message',
+        });
+
+        jest.spyOn(checkoutService, 'initializePayment').mockImplementation((options) => {
+            eventEmitter.on('onValidate', async (resolve: () => void, reject: () => void) => {
+                if (options.braintree?.onError) {
+                    await options.braintree.onValidate?.(resolve, reject);
+                }
+            });
+
+            return Promise.resolve(checkoutState);
+        });
+
+        const validationReject = jest.fn();
+
+        render(<BraintreePaypalPaymentMethodTest />);
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        eventEmitter.emit('onValidate', () => {}, validationReject);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(paymentForm.validateForm).toHaveBeenCalled();
+        expect(paymentForm.setSubmitted).toHaveBeenCalled();
+        expect(paymentForm.setFieldTouched).toHaveBeenCalledTimes(2);
+        expect(validationReject).toHaveBeenCalled();
     });
 
     it('hides payment submit button by calling onRenderButton callback', () => {

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.test.tsx
@@ -43,11 +43,9 @@ describe('BraintreePaypalPaymentMethod', () => {
     };
 
     beforeEach(() => {
-        // jest.spyOn(paymentForm, 'validateForm').mockResolvedValue({});
         const providerError = new Error('INSTRUMENT_DECLINED');
 
         eventEmitter = new EventEmitter();
-        // paymentForm = getPaymentFormServiceMock();
         jest.spyOn(paymentForm, 'validateForm').mockResolvedValue({});
         localeContext = createLocaleContext(getStoreConfig());
 

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -1,6 +1,6 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { createBraintreePaypalPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
-import React, { type FunctionComponent, useCallback } from 'react';
+import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
 import {
@@ -9,10 +9,40 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
+interface ButtonActions {
+    disable: () => void;
+    enable: () => void;
+}
+
 const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     checkoutService,
     ...rest
 }) => {
+    const buttonActionsRef = useRef<ButtonActions | null>(null);
+    const termsValue = rest.paymentForm.getFieldValue('terms');
+
+    const validateForm = async () => {
+        const validationErrors = await rest.paymentForm.validateForm();
+
+        return Object.keys(validationErrors);
+    };
+
+    const validateButton = async () => {
+        if (!buttonActionsRef.current) return;
+
+        const keysValidation = await validateForm();
+
+        if (keysValidation.length) {
+            buttonActionsRef.current.disable();
+        } else {
+            buttonActionsRef.current.enable();
+        }
+    };
+
+    useEffect(() => {
+        void validateButton();
+    }, [termsValue]);
+
     const initializeBraintreePaypalPaymentMethod = useCallback(
         (defaultOptions: PaymentInitializeOptions) => {
             const { onUnhandledError, language, method, paymentForm } = rest;
@@ -34,6 +64,22 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                         } else {
                             onUnhandledError?.(error);
                         }
+                    },
+                    onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
+                        const keysValidation = await validateForm();
+
+                        if (keysValidation.length) {
+                            paymentForm.setSubmitted(true);
+                            keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
+
+                            return reject();
+                        }
+
+                        return resolve();
+                    },
+                    onInitButton: async (actions: ButtonActions) => {
+                        buttonActionsRef.current = actions;
+                        await validateButton();
                     },
                     onRenderButton: () => {
                         paymentForm.hidePaymentSubmitButton(method, true);

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -1,7 +1,7 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import {
-    BraintreePaypalPaymentInitializeOptions,
-    createBraintreePaypalPaymentStrategy
+    type BraintreePaypalPaymentInitializeOptions,
+    createBraintreePaypalPaymentStrategy,
 } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
 

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -1,5 +1,8 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import { createBraintreePaypalPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
+import {
+    BraintreePaypalPaymentInitializeOptions,
+    createBraintreePaypalPaymentStrategy
+} from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
@@ -84,7 +87,7 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     onRenderButton: () => {
                         paymentForm.hidePaymentSubmitButton(method, true);
                     },
-                },
+                } as BraintreePaypalPaymentInitializeOptions,
             });
         },
         [rest, checkoutService],

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -1,8 +1,5 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import {
-    type BraintreePaypalPaymentInitializeOptions,
-    createBraintreePaypalPaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/braintree';
+import { createBraintreePaypalPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
@@ -87,7 +84,7 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     onRenderButton: () => {
                         paymentForm.hidePaymentSubmitButton(method, true);
                     },
-                } as BraintreePaypalPaymentInitializeOptions,
+                },
             });
         },
         [rest, checkoutService],


### PR DESCRIPTION
## What/Why?

We have a specific scenario related to PSD2 for Braintree where the total amount was changed on the Checkout page, but a different amount had previously been authorized on the Cart page using Braintree's Smart Payment button.

For this scenario T&C checkbox can be bypassed but it is required. We should fix this behavior.

**NOTE**: Related on https://github.com/bigcommerce/checkout-sdk-js/pull/3288

## Rollout/Rollback

Revert

## Testing

Verified changes on the staging store

With vaulted feature:
https://github.com/user-attachments/assets/e82c2f57-43ad-47bf-8d96-4a7812c87fb5


Without vaulted feature:
https://github.com/user-attachments/assets/68ae4c69-fd74-4a96-80ed-50bc3bf90bb8




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment submission gating for Braintree PayPal in a PSD2-specific flow; behavior is localized but affects checkout completion when terms or other form fields are invalid.
> 
> **Overview**
> Fixes a PSD2 edge case where shoppers could complete Braintree PayPal checkout without accepting required terms when the cart total changed after an earlier Smart Payment authorization.
> 
> **`BraintreePaypalPaymentMethod`** now wires checkout form validation into the SDK via **`onValidate`** (blocks PayPal when validation fails, marks fields touched) and **`onInitButton`** (enables/disables the PayPal button from validation state). A **`useEffect`** tied to the **`terms`** field re-runs that enable/disable logic when the checkbox changes.
> 
> **`@bigcommerce/checkout-sdk`** is bumped to **^1.930.1** to match the companion SDK PR. Tests cover success and failure paths for **`onValidate`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1b41ff0f198410121241d8cb92cc5fd1a65447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->