### PR TITLE
chore(ui): CHECKOUT-10112 Fix Playwright tests for phone validation by preserving data-test id

### DIFF
--- a/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
@@ -33,7 +33,6 @@ jest.mock('@intl-tel-input/react', () => ({
 
         return (
             <input
-                data-test="iti-phone-input"
                 {...inputProps}
                 onChange={(e) => onChangeNumber?.(e.target.value)}
                 value={value ?? ''}
@@ -217,7 +216,7 @@ describe('DynamicFormField Component', () => {
                 isNewPhoneValidationExperimentEnabled: true,
             });
 
-            fireEvent.change(screen.getByTestId('iti-phone-input'), {
+            fireEvent.change(screen.getByTestId('phone-text'), {
                 target: { value: '123' },
             });
             await userEvent.click(screen.getByText('Submit'));
@@ -235,7 +234,7 @@ describe('DynamicFormField Component', () => {
                 isNewPhoneValidationExperimentEnabled: true,
             });
 
-            fireEvent.change(screen.getByTestId('iti-phone-input'), {
+            fireEvent.change(screen.getByTestId('phone-text'), {
                 target: { value: '+15551234567' },
             });
             await userEvent.click(screen.getByText('Submit'));

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
@@ -32,7 +32,6 @@ jest.mock('@intl-tel-input/react', () => ({
 
         return (
             <input
-                data-test="iti-phone-input"
                 {...inputProps}
                 onChange={(e) => onChangeNumber?.(e.target.value)}
                 value={value ?? ''}
@@ -76,7 +75,7 @@ describe('PhoneFormField', () => {
     it('renders IntlTelInput', () => {
         renderPhoneFormField();
 
-        expect(screen.getByTestId('iti-phone-input')).toBeInTheDocument();
+        expect(screen.getByTestId('phone-text')).toBeInTheDocument();
     });
 
     it('auto-sets country when selectedCountry is provided and the field value is empty', () => {
@@ -115,7 +114,7 @@ describe('PhoneFormField', () => {
 
         renderPhoneFormField();
 
-        fireEvent.change(screen.getByTestId('iti-phone-input'), { target: { value: '123' } });
+        fireEvent.change(screen.getByTestId('phone-text'), { target: { value: '123' } });
         await userEvent.click(screen.getByText('Submit'));
 
         await waitFor(() => {
@@ -128,7 +127,7 @@ describe('PhoneFormField', () => {
 
         renderPhoneFormField();
 
-        fireEvent.change(screen.getByTestId('iti-phone-input'), {
+        fireEvent.change(screen.getByTestId('phone-text'), {
             target: { value: '+15551234567' },
         });
         await userEvent.click(screen.getByText('Submit'));

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -50,6 +50,8 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
             <IntlTelInput
                 inputProps={{
                     'aria-labelledby': `${id}-label ${id}-field-error-message`,
+                    // using the spread to avoid type error, types are incorrect on the library side
+                    ...{ 'data-test': `${id}-text` },
                     autoComplete: autocomplete,
                     id,
                     maxLength,

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -50,7 +50,7 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
             <IntlTelInput
                 inputProps={{
                     'aria-labelledby': `${id}-label ${id}-field-error-message`,
-                    // using the spread to avoid type error, types are incorrect on the library side
+                    // using spread to avoid type error, data-test is valid but types are incorrect on the library side
                     ...{ 'data-test': `${id}-text` },
                     autoComplete: autocomplete,
                     id,


### PR DESCRIPTION
## What/Why?

Playwright tests are failing for staging when the phone number experiment is on: https://app.circleci.com/pipelines/github/bigcommerce/bigcommerce/622404/workflows/cf969e77-2f22-4db3-acba-e3d7f138215a/jobs/2797290/tests

This is because the previous phone component had `data-test="phoneInput-text"`, while the new component doesn't have this id anymore.

Solution: add it to the new component as well, so that tests can run successfully for both scenarios.


## Rollout/Rollback

Revert the PR.

## Testing

Deploying to integration to verify that tests pass: https://app.circleci.com/pipelines/github/bigcommerce/functional-tests/62421/workflows/e8b19889-5500-4eb0-99ae-da5819edaea0/jobs/159415/tests
(2 of the tests still fail, but this is because they have phone numbers with extensions and that's a separate issue that will be resolved on the tests side)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness attribute only on the phone input; no change to validation or submission behavior.
> 
> **Overview**
> Restores a stable **`data-test`** hook on the new IntlTelInput-based phone field so automated checkout tests can target the input when the phone validation experiment is on.
> 
> **`PhoneInput`** now passes **`data-test="${id}-text"`** on the underlying input (via a spread to satisfy **`@intl-tel-input/react`** typings). For the standard **`id="phone"`** field, that yields **`phone-text`**, matching the legacy **`phoneInput-text`** convention described in the PR.
> 
> Unit tests in **`DynamicFormField.test.tsx`** and **`PhoneFormField.test.tsx`** were updated to query **`phone-text`** instead of the mock-only **`iti-phone-input`** attribute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c249278c20e269d5e0aad433d5982b4d452a8284. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->