### PR TITLE
feat(checkout): BACK-603 Update backorders read string

### DIFF
--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmationPage.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmationPage.tsx
@@ -5,7 +5,7 @@ import {
     type StoreCurrency,
 } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
-import DOMPurify from 'dompurify';
+import domPurify from 'dompurify';
 import React, { type ReactElement } from 'react';
 
 import { ErrorModal } from '../../common/error';
@@ -80,7 +80,7 @@ export const OrderConfirmationPage = ({
                     <OrderConfirmationSection>
                         <div
                             dangerouslySetInnerHTML={{
-                                __html: DOMPurify.sanitize(paymentInstructions),
+                                __html: domPurify.sanitize(paymentInstructions),
                             }}
                             data-test="payment-instructions"
                         />

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -57,13 +57,9 @@ const OrderSummaryItemBackorderDetails = ({
     const inventorySettings = config?.inventorySettings;
     const showQuantityOnBackorder = !!inventorySettings?.showQuantityOnBackorder;
     const showBackorderMessage = !!inventorySettings?.showBackorderMessage;
-    const shouldDisplayBackorderMessagesOnStorefront =
-        !!inventorySettings?.shouldDisplayBackorderMessagesOnStorefront;
+    const shouldDisplayBackorderMessages = !!inventorySettings?.shouldDisplayBackorderMessages;
 
-    if (
-        !shouldDisplayBackorderMessagesOnStorefront ||
-        (!showQuantityOnBackorder && !showBackorderMessage)
-    ) {
+    if (!shouldDisplayBackorderMessages || (!showQuantityOnBackorder && !showBackorderMessage)) {
         return null;
     }
 

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -47,7 +47,7 @@ describe('OrderSummaryItems', () => {
                 showQuantityOnHand: false,
                 showBackorderAvailabilityPrompt: false,
                 backorderAvailabilityPrompt: null,
-                shouldDisplayBackorderMessagesOnStorefront: true,
+                shouldDisplayBackorderMessages: true,
             },
         });
     });

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -81,7 +81,7 @@ const ItemCount = ({
     const backorderCount = getBackorderCount(items);
     const config = checkoutState.data.getConfig();
     const shouldDisplayBackorderDetails =
-        !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
+        !!config?.inventorySettings?.shouldDisplayBackorderMessages &&
         (!!config?.inventorySettings?.showQuantityOnBackorder ||
             !!config?.inventorySettings?.showBackorderMessage);
 

--- a/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
+++ b/packages/core/src/app/shipping/ConsignmentLineItemDetail.tsx
@@ -32,7 +32,7 @@ export const ConsignmentLineItemContent = ({
     const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
 
     const shouldDisplayBackorderQuantity =
-        !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
+        !!config?.inventorySettings?.shouldDisplayBackorderMessages &&
         config?.inventorySettings?.showQuantityOnBackorder &&
         !!item.stockPosition?.quantityBackordered;
 

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -166,7 +166,7 @@ export const useShipping = () => {
     );
 
     const showDefaultShippingExpectationPrompt =
-        config.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
+        config.inventorySettings?.shouldDisplayBackorderMessages &&
         config.inventorySettings?.showDefaultShippingExpectationPrompt &&
         getBackorderCount(cart.lineItems) > 0;
     const defaultShippingExpectationPrompt =

--- a/packages/core/types/checkout-sdk.d.ts
+++ b/packages/core/types/checkout-sdk.d.ts
@@ -1,0 +1,7 @@
+declare module '@bigcommerce/checkout-sdk' {
+    interface InventorySettings {
+        shouldDisplayBackorderMessages: boolean;
+    }
+}
+
+export {};


### PR DESCRIPTION
## What/Why?

- Update `shouldDisplayBackorderMessagesOnStorefront` to `shouldDisplayBackorderMessages`. No logic changes. The purpose now extends Storefront.

Context: Updating BCApp `shouldDisplayBackorderMessagesOnStorefront` and need to reflect that here. BCApp currently support both this new and old properties until checkout-js and checkout-sdk-js have will be fully updated.

## Rollout/Rollback

Revert

## Testing

N/A. No logic changes. Just a rename.

ping @animesh1987 @bc-shawnwang 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only with identical conditionals; main risk is config mismatch if the API still sends only the old key before BCApp dual-property support is in place.
> 
> **Overview**
> Renames the inventory config flag **`shouldDisplayBackorderMessagesOnStorefront`** to **`shouldDisplayBackorderMessages`** everywhere checkout decides whether to show backorder UI (cart summary details/link, shipping line items, default shipping expectation prompt). **Behavior is unchanged**—only the property name read from `inventorySettings`.
> 
> Adds a **`@bigcommerce/checkout-sdk` module augmentation** in `packages/core/types/checkout-sdk.d.ts` so TypeScript knows the new field on `InventorySettings`. Test mocks are updated to use the new name.
> 
> Also renames the DOMPurify default import to `domPurify` on the order confirmation page (cosmetic only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ad507f6c79855539fe92c9633498d2940092e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->