### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.924.0",
+        "@bigcommerce/checkout-sdk": "^1.928.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.924.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.924.0.tgz",
-      "integrity": "sha512-LGQHhCQzeSRYlcPoMm3WCpLInuP0Olv4PeNeUoRdixeLXRWvhpPNhxFykQTKcyARtvYn49+ZT6NtM+OgYwZNlA==",
+      "version": "1.928.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.928.0.tgz",
+      "integrity": "sha512-Y+eE5eOGDFE0JRuPI6KNzcBvb7/iXWfAFKCUh0xCNzQBSdVKJnuLNIPURWAWQyKtt+WvlBdIZNDt2RhTWjyF9Q==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.924.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.924.0.tgz",
-      "integrity": "sha512-LGQHhCQzeSRYlcPoMm3WCpLInuP0Olv4PeNeUoRdixeLXRWvhpPNhxFykQTKcyARtvYn49+ZT6NtM+OgYwZNlA==",
+      "version": "1.928.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.928.0.tgz",
+      "integrity": "sha512-Y+eE5eOGDFE0JRuPI6KNzcBvb7/iXWfAFKCUh0xCNzQBSdVKJnuLNIPURWAWQyKtt+WvlBdIZNDt2RhTWjyF9Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.924.0",
+    "@bigcommerce/checkout-sdk": "^1.928.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout sdk version
To deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3281](https://github.com/bigcommerce/checkout-sdk-js/pull/3281)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3282](https://github.com/bigcommerce/checkout-sdk-js/pull/3282)

## Rollout/Rollback
Rollback this PR

## Testing
In checkout sdk PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment/checkout behavior can change with SDK bumps even when this repo’s code is untouched; risk depends on what landed in checkout-sdk 1.925–1.928.
> 
> **Overview**
> Bumps the **`@bigcommerce/checkout-sdk`** dependency from **^1.924.0** to **^1.928.0** in `package.json` and refreshes **`package-lock.json`** so the resolved tarball and integrity hash match the new release.
> 
> This is a dependency-only change to pull in upstream checkout-sdk work (see linked **checkout-sdk-js** PRs **3281** and **3282**); no application source in this repo is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981191b80bc62f1d31b754ad085073ff6c444dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->