### PR TITLE
fix(payment): PI-5401 [Google Pay] Block flow when terms and conditions are unchecked

### DIFF
--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -296,5 +296,38 @@ describe('GooglePayPaymentMethodComponent', () => {
 
             expect(event.stopPropagation).not.toHaveBeenCalled();
         });
+
+        it('does not update payment form after unmount when validateForm is pending', async () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+                storeConfigWithTermsRequired,
+            );
+            (paymentForm.getFormValues as jest.Mock).mockReturnValue({ terms: false });
+
+            let resolveValidateForm: (errors: { terms?: string }) => void;
+
+            (paymentForm.validateForm as jest.Mock).mockReturnValue(
+                new Promise((resolve) => {
+                    resolveValidateForm = resolve;
+                }),
+            );
+
+            const { unmount } = renderComponent();
+
+            fireClickOn(googlePayButton);
+
+            expect(paymentForm.validateForm).toHaveBeenCalled();
+            expect(paymentForm.setSubmitted).not.toHaveBeenCalled();
+
+            unmount();
+
+            resolveValidateForm!({
+                terms: 'terms_and_conditions.agreement_required_error',
+            });
+
+            await Promise.resolve();
+
+            expect(paymentForm.setSubmitted).not.toHaveBeenCalled();
+            expect(paymentForm.setFieldTouched).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -61,6 +61,9 @@ describe('GooglePayPaymentMethodComponent', () => {
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
 
         (paymentForm.getFormValues as jest.Mock).mockReturnValue({ terms: false });
+        (paymentForm.validateForm as jest.Mock).mockResolvedValue({
+            terms: 'terms_and_conditions.agreement_required_error',
+        });
     });
 
     afterEach(() => {
@@ -218,7 +221,7 @@ describe('GooglePayPaymentMethodComponent', () => {
             expect(paymentForm.setFieldTouched).not.toHaveBeenCalled();
         });
 
-        it('blocks the click when T&C is required and unchecked', () => {
+        it('blocks the click when T&C is required and unchecked', async () => {
             jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
                 storeConfigWithTermsRequired,
             );
@@ -230,6 +233,10 @@ describe('GooglePayPaymentMethodComponent', () => {
 
             expect(event.stopPropagation).toHaveBeenCalled();
             expect(event.preventDefault).toHaveBeenCalled();
+
+            await Promise.resolve();
+
+            expect(paymentForm.validateForm).toHaveBeenCalled();
             expect(paymentForm.setSubmitted).toHaveBeenCalledWith(true);
             expect(paymentForm.setFieldTouched).toHaveBeenCalledWith('terms', true);
         });

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.test.tsx
@@ -8,11 +8,16 @@ import {
 import { render } from '@testing-library/react';
 import React from 'react';
 
+import { CheckoutProvider } from '@bigcommerce/checkout/contexts';
 import { type PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
-import { getPaymentFormServiceMock, getPaymentMethod } from '@bigcommerce/checkout/test-mocks';
+import {
+    getPaymentFormServiceMock,
+    getPaymentMethod,
+    getStoreConfig,
+} from '@bigcommerce/checkout/test-mocks';
 
-import GooglePayPaymentMethodComponent from './GooglePayPaymentMethodComponent';
 import googlePayIntegrations from './googlePayIntegrations';
+import GooglePayPaymentMethodComponent from './GooglePayPaymentMethodComponent';
 
 describe('GooglePayPaymentMethodComponent', () => {
     let checkoutService: CheckoutService;
@@ -26,14 +31,22 @@ describe('GooglePayPaymentMethodComponent', () => {
         gateway: 'braintree',
     };
 
-    const defaultProps = () => ({
+    const buildProps = (overrides: Partial<{ paymentForm: PaymentFormService }> = {}) => ({
         checkoutService,
         checkoutState,
         language: { translate: jest.fn() } as unknown as LanguageService,
         method,
         onUnhandledError,
         paymentForm,
+        ...overrides,
     });
+
+    const renderComponent = (overrides: Partial<{ paymentForm: PaymentFormService }> = {}) =>
+        render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <GooglePayPaymentMethodComponent {...buildProps(overrides)} />
+            </CheckoutProvider>,
+        );
 
     beforeEach(() => {
         jest.useFakeTimers();
@@ -45,6 +58,9 @@ describe('GooglePayPaymentMethodComponent', () => {
 
         jest.spyOn(checkoutService, 'initializePayment').mockResolvedValue(checkoutState);
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+
+        (paymentForm.getFormValues as jest.Mock).mockReturnValue({ terms: false });
     });
 
     afterEach(() => {
@@ -52,19 +68,19 @@ describe('GooglePayPaymentMethodComponent', () => {
     });
 
     it('hides the Place Order button on mount', () => {
-        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        renderComponent();
 
         expect(paymentForm.hidePaymentSubmitButton).toHaveBeenCalledWith(method, true);
     });
 
     it('does not call initializePayment before the DOM has updated', () => {
-        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        renderComponent();
 
         expect(checkoutService.initializePayment).not.toHaveBeenCalled();
     });
 
     it('calls initializePayment with container options after setTimeout(0)', () => {
-        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        renderComponent();
 
         jest.runAllTimers();
 
@@ -86,7 +102,7 @@ describe('GooglePayPaymentMethodComponent', () => {
     });
 
     it('passes onUnhandledError as the onError callback', () => {
-        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        renderComponent();
 
         jest.runAllTimers();
 
@@ -97,13 +113,13 @@ describe('GooglePayPaymentMethodComponent', () => {
     });
 
     it('renders null — no visible DOM output', () => {
-        const { container } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        const { container } = renderComponent();
 
         expect(container).toBeEmptyDOMElement();
     });
 
     it('restores the Place Order button on unmount', () => {
-        const { unmount } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        const { unmount } = renderComponent();
 
         unmount();
 
@@ -111,7 +127,7 @@ describe('GooglePayPaymentMethodComponent', () => {
     });
 
     it('deinitializes payment on unmount', () => {
-        const { unmount } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        const { unmount } = renderComponent();
 
         unmount();
 
@@ -122,7 +138,7 @@ describe('GooglePayPaymentMethodComponent', () => {
     });
 
     it('cancels pending initializePayment when unmounting before setTimeout fires', () => {
-        const { unmount } = render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        const { unmount } = renderComponent();
 
         unmount();
 
@@ -136,7 +152,7 @@ describe('GooglePayPaymentMethodComponent', () => {
 
         jest.spyOn(checkoutService, 'initializePayment').mockRejectedValue(error);
 
-        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        renderComponent();
 
         jest.runAllTimers();
 
@@ -148,12 +164,130 @@ describe('GooglePayPaymentMethodComponent', () => {
     it('does not call onUnhandledError for non-Error rejections', async () => {
         jest.spyOn(checkoutService, 'initializePayment').mockRejectedValue('string rejection');
 
-        render(<GooglePayPaymentMethodComponent {...defaultProps()} />);
+        renderComponent();
 
         jest.runAllTimers();
 
         await Promise.resolve();
 
         expect(onUnhandledError).not.toHaveBeenCalled();
+    });
+
+    describe('Terms and conditions guard', () => {
+        let googlePayContainer: HTMLDivElement;
+        let googlePayButton: HTMLButtonElement;
+
+        const storeConfigWithTermsRequired = {
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                enableTermsAndConditions: true,
+            },
+        };
+
+        const fireClickOn = (target: HTMLElement) => {
+            const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+            jest.spyOn(event, 'stopPropagation');
+            jest.spyOn(event, 'preventDefault');
+            target.dispatchEvent(event);
+
+            return event;
+        };
+
+        beforeEach(() => {
+            googlePayContainer = document.createElement('div');
+            googlePayContainer.id = 'checkout-payment-continue';
+            googlePayButton = document.createElement('button');
+            googlePayContainer.appendChild(googlePayButton);
+            document.body.appendChild(googlePayContainer);
+        });
+
+        afterEach(() => {
+            document.body.removeChild(googlePayContainer);
+        });
+
+        it('does not block the click when T&C is not required', () => {
+            renderComponent();
+
+            const event = fireClickOn(googlePayButton);
+
+            expect(event.stopPropagation).not.toHaveBeenCalled();
+            expect(event.preventDefault).not.toHaveBeenCalled();
+            expect(paymentForm.setSubmitted).not.toHaveBeenCalled();
+            expect(paymentForm.setFieldTouched).not.toHaveBeenCalled();
+        });
+
+        it('blocks the click when T&C is required and unchecked', () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+                storeConfigWithTermsRequired,
+            );
+            (paymentForm.getFormValues as jest.Mock).mockReturnValue({ terms: false });
+
+            renderComponent();
+
+            const event = fireClickOn(googlePayButton);
+
+            expect(event.stopPropagation).toHaveBeenCalled();
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(paymentForm.setSubmitted).toHaveBeenCalledWith(true);
+            expect(paymentForm.setFieldTouched).toHaveBeenCalledWith('terms', true);
+        });
+
+        it('does not block the click when T&C is required and the checkbox is checked', () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+                storeConfigWithTermsRequired,
+            );
+            (paymentForm.getFormValues as jest.Mock).mockReturnValue({ terms: true });
+
+            renderComponent();
+
+            const event = fireClickOn(googlePayButton);
+
+            expect(event.stopPropagation).not.toHaveBeenCalled();
+            expect(event.preventDefault).not.toHaveBeenCalled();
+            expect(paymentForm.setSubmitted).not.toHaveBeenCalled();
+        });
+
+        it('reads the current paymentForm after re-renders', () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+                storeConfigWithTermsRequired,
+            );
+            (paymentForm.getFormValues as jest.Mock).mockReturnValue({ terms: false });
+
+            const { rerender } = renderComponent();
+
+            // Simulate the user ticking the checkbox
+            const updatedPaymentForm = getPaymentFormServiceMock();
+
+            updatedPaymentForm.getFormValues.mockReturnValue({ terms: true });
+
+            rerender(
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <GooglePayPaymentMethodComponent
+                        {...buildProps({ paymentForm: updatedPaymentForm })}
+                    />
+                </CheckoutProvider>,
+            );
+
+            const event = fireClickOn(googlePayButton);
+
+            expect(event.stopPropagation).not.toHaveBeenCalled();
+        });
+
+        it('removes the document click listener on unmount', () => {
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
+                storeConfigWithTermsRequired,
+            );
+            (paymentForm.getFormValues as jest.Mock).mockReturnValue({ terms: false });
+
+            const { unmount } = renderComponent();
+
+            unmount();
+
+            const event = fireClickOn(googlePayButton);
+
+            expect(event.stopPropagation).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
@@ -32,6 +32,8 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
     paymentFormRef.current = paymentForm;
 
     useEffect(() => {
+        let isMounted = true;
+
         paymentFormRef.current.hidePaymentSubmitButton(method, true);
 
         const guardTermsConditions = (event: MouseEvent) => {
@@ -49,6 +51,10 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
                 event.preventDefault();
 
                 void paymentFormRef.current.validateForm().then((errors) => {
+                    if (!isMounted) {
+                        return;
+                    }
+
                     paymentFormRef.current.setSubmitted(true);
 
                     if (errors.terms) {
@@ -85,6 +91,7 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
         }, 0);
 
         return () => {
+            isMounted = false;
             clearTimeout(timeoutId);
             document.removeEventListener('click', guardTermsConditions, true);
             paymentFormRef.current.hidePaymentSubmitButton(method, false);

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
@@ -47,8 +47,14 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
             if (isTermsConditionsRequired && !terms) {
                 event.stopPropagation();
                 event.preventDefault();
-                paymentFormRef.current.setSubmitted(true);
-                paymentFormRef.current.setFieldTouched('terms', true);
+
+                void paymentFormRef.current.validateForm().then((errors) => {
+                    paymentFormRef.current.setSubmitted(true);
+
+                    if (errors.terms) {
+                        paymentFormRef.current.setFieldTouched('terms', true);
+                    }
+                });
             }
         };
 

--- a/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethodComponent.tsx
@@ -1,7 +1,11 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
-import { type FunctionComponent, useEffect } from 'react';
+import { type FunctionComponent, useEffect, useRef } from 'react';
 
-import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
+import { useCheckout } from '@bigcommerce/checkout/contexts';
+import {
+    type PaymentFormService,
+    type PaymentMethodProps,
+} from '@bigcommerce/checkout/payment-integration-api';
 
 import googlePayIntegrations from './googlePayIntegrations';
 
@@ -13,8 +17,42 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
     paymentForm,
     onUnhandledError,
 }) => {
+    const {
+        checkoutState: {
+            data: { getConfig },
+        },
+    } = useCheckout();
+
+    const isTermsConditionsRequired = Boolean(
+        getConfig()?.checkoutSettings.enableTermsAndConditions,
+    );
+
+    const paymentFormRef = useRef<PaymentFormService>(paymentForm);
+
+    paymentFormRef.current = paymentForm;
+
     useEffect(() => {
-        paymentForm.hidePaymentSubmitButton(method, true);
+        paymentFormRef.current.hidePaymentSubmitButton(method, true);
+
+        const guardTermsConditions = (event: MouseEvent) => {
+            const container = document.getElementById(GOOGLE_PAY_BUTTON_CONTAINER_ID);
+            const target = event.target;
+
+            if (!container || !(target instanceof Node) || !container.contains(target)) {
+                return;
+            }
+
+            const { terms } = paymentFormRef.current.getFormValues();
+
+            if (isTermsConditionsRequired && !terms) {
+                event.stopPropagation();
+                event.preventDefault();
+                paymentFormRef.current.setSubmitted(true);
+                paymentFormRef.current.setFieldTouched('terms', true);
+            }
+        };
+
+        document.addEventListener('click', guardTermsConditions, true);
 
         const timeoutId = setTimeout(async () => {
             try {
@@ -42,7 +80,8 @@ const GooglePayPaymentMethodComponent: FunctionComponent<PaymentMethodProps> = (
 
         return () => {
             clearTimeout(timeoutId);
-            paymentForm.hidePaymentSubmitButton(method, false);
+            document.removeEventListener('click', guardTermsConditions, true);
+            paymentFormRef.current.hidePaymentSubmitButton(method, false);
 
             void checkoutService.deinitializePayment({
                 gatewayId: method.gateway,


### PR DESCRIPTION
## What/Why?

Google Pay button in direct-pay flow ignores whether terms and conditions checkbox is checked, allowing shopper to continue the payment without accepting the terms.

This PR introduces an event listener, that listens for a click on Google Pay button and stops event propagation to keep Google Pay modal from opening when shopper didn't consent to the terms and conditions (didn't check the checkbox). After that, `terms` field value is updated, to show appropriate error message, similarly to when default Place order button is used.

## Rollout/Rollback

Revert

## Testing

Before, terms and conditions checkbox is ignored:


https://github.com/user-attachments/assets/d6bcab7a-1b5e-4a3a-ac1c-4726aa5adc8c

After:


https://github.com/user-attachments/assets/6fbd7112-8a48-4de3-b4b4-ffbd295097df



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment-step behavior change on a document-level capture listener; scoped to Google Pay container and T&C-enabled stores, with tests covering edge cases.
> 
> **Overview**
> **Google Pay** in the direct-pay flow no longer opens when store **terms and conditions** are enabled and the shopper has not checked the agreement box.
> 
> `GooglePayPaymentMethodComponent` reads `enableTermsAndConditions` via `useCheckout`, keeps a ref to the latest `paymentForm`, and registers a **capture-phase** document click listener on the Google Pay container (`checkout-payment-continue`). When T&C are required and `terms` is false, it stops the click, runs `validateForm`, sets submitted state, and touches the `terms` field so errors match the standard Place Order path. Cleanup removes the listener and skips form updates after unmount if validation is still pending.
> 
> Tests wrap the component in `CheckoutProvider` and add a **Terms and conditions guard** suite covering optional T&C, blocked/allowed clicks, re-rendered form values, listener teardown, and async validation after unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56fd707d915521917f692c07817ae8382a90e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->