### PR TITLE
feat(checkout): CHECKOUT-10104 implement pre order request for b2b flow

### DIFF
--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -544,7 +544,7 @@ describe('Payment step', () => {
             },
         });
 
-        it('persists pre-order B2B metadata on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
+        it('refreshes B2B payment methods on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 config: createConfigWithPersistB2BMetadata(),
                 checkout: {
@@ -562,10 +562,11 @@ describe('Payment step', () => {
 
             await checkout.waitForPaymentStep();
 
-            expect(preOrderSpy).toHaveBeenCalled();
+            // On mount it is called with no payload, which only refreshes the B2B payment methods.
+            expect(preOrderSpy).toHaveBeenCalledWith();
         });
 
-        it('does not persist pre-order B2B metadata on mount when checkout has no orderId', async () => {
+        it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 config: createConfigWithPersistB2BMetadata(),
                 checkout: {
@@ -585,7 +586,7 @@ describe('Payment step', () => {
             expect(preOrderSpy).not.toHaveBeenCalled();
         });
 
-        it('does not persist pre-order B2B metadata on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
+        it('does not refresh B2B payment methods on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 checkout: {
                     ...checkoutWithShippingAndBilling,
@@ -604,7 +605,7 @@ describe('Payment step', () => {
             expect(preOrderSpy).not.toHaveBeenCalled();
         });
 
-        it('completes initialization and renders the payment step when mount-time pre-order persist fails', async () => {
+        it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 config: createConfigWithPersistB2BMetadata(),
                 checkout: {
@@ -625,7 +626,16 @@ describe('Payment step', () => {
             expect(screen.getByText(/place order/i)).toBeInTheDocument();
         });
 
-        it('persists pre-order B2B metadata with the stored metadata but without the invoice fields', async () => {
+        it('persists pre-order B2B metadata with the stored metadata but without the invoice fields when submitting order', async () => {
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(ctx.json(orderResponse)),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+            );
+
             const location = window.location;
 
             Object.defineProperty(window, 'location', {
@@ -650,13 +660,8 @@ describe('Payment step', () => {
                 checkout: {
                     ...checkoutWithShippingAndBilling,
                     customer,
-                    orderId: 12345,
                 },
             });
-
-            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
-                checkoutService.getState(),
-            );
 
             const preOrderSpy = jest
                 .spyOn(checkoutService, 'persistPreOrderB2BMetadata')
@@ -664,14 +669,16 @@ describe('Payment step', () => {
 
             render(<CheckoutTest {...defaultProps} />);
 
-            await waitFor(() =>
-                expect(preOrderSpy).toHaveBeenCalledWith({
-                    poNumber: 'PO-123',
-                    referenceNumber: 'REF-456',
-                    extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
-                    extraInfo: {},
-                }),
-            );
+            await checkout.waitForPaymentStep();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            expect(preOrderSpy).toHaveBeenCalledWith({
+                poNumber: 'PO-123',
+                referenceNumber: 'REF-456',
+                extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                extraInfo: {},
+            });
 
             const payload = preOrderSpy.mock.calls[0][0];
 

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -526,7 +526,7 @@ describe('Payment step', () => {
         expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
     });
 
-    describe('B2B payment methods refresh', () => {
+    describe('B2B metadata', () => {
         const createConfigWithPersistB2BMetadata = () => ({
             ...checkoutSettings,
             storeConfig: {
@@ -544,7 +544,7 @@ describe('Payment step', () => {
             },
         });
 
-        it('refreshes B2B payment methods on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
+        it('persists pre-order B2B metadata on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 config: createConfigWithPersistB2BMetadata(),
                 checkout: {
@@ -554,18 +554,18 @@ describe('Payment step', () => {
                 },
             });
 
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+            const preOrderSpy = jest
+                .spyOn(checkoutService, 'persistPreOrderB2BMetadata')
                 .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
             render(<CheckoutTest {...defaultProps} />);
 
             await checkout.waitForPaymentStep();
 
-            expect(refreshSpy).toHaveBeenCalled();
+            expect(preOrderSpy).toHaveBeenCalled();
         });
 
-        it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
+        it('does not persist pre-order B2B metadata on mount when checkout has no orderId', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 config: createConfigWithPersistB2BMetadata(),
                 checkout: {
@@ -574,18 +574,18 @@ describe('Payment step', () => {
                 },
             });
 
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+            const preOrderSpy = jest
+                .spyOn(checkoutService, 'persistPreOrderB2BMetadata')
                 .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
             render(<CheckoutTest {...defaultProps} />);
 
             await checkout.waitForPaymentStep();
 
-            expect(refreshSpy).not.toHaveBeenCalled();
+            expect(preOrderSpy).not.toHaveBeenCalled();
         });
 
-        it('does not refresh B2B payment methods on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
+        it('does not persist pre-order B2B metadata on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 checkout: {
                     ...checkoutWithShippingAndBilling,
@@ -593,18 +593,93 @@ describe('Payment step', () => {
                 },
             });
 
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+            const preOrderSpy = jest
+                .spyOn(checkoutService, 'persistPreOrderB2BMetadata')
                 .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
             render(<CheckoutTest {...defaultProps} />);
 
             await checkout.waitForPaymentStep();
 
-            expect(refreshSpy).not.toHaveBeenCalled();
+            expect(preOrderSpy).not.toHaveBeenCalled();
         });
 
-        it('refreshes B2B payment methods before submitting order when persistB2BMetadata capability is enabled', async () => {
+        it('completes initialization and renders the payment step when mount-time pre-order persist fails', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'persistPreOrderB2BMetadata').mockRejectedValue(
+                new Error('B2B pre-order metadata persistence failed'),
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(screen.getByText(/place order/i)).toBeInTheDocument();
+        });
+
+        it('persists pre-order B2B metadata with the stored metadata but without the invoice fields', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            B2BSessionStorage.set(B2BSessionStorage.poNumberKey, 'PO-123');
+            B2BSessionStorage.set(B2BSessionStorage.additionalPaymentFieldKey, 'REF-456');
+            // Invoice comment is stored for the post-order persist but must not reach the pre-order payload.
+            B2BSessionStorage.set(B2BSessionStorage.invoiceCommentKey, 'Invoice me');
+            B2BSessionStorage.set(B2BSessionStorage.orderExtraFieldsKey, {
+                costCentre: 'Engineering',
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const preOrderSpy = jest
+                .spyOn(checkoutService, 'persistPreOrderB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(preOrderSpy).toHaveBeenCalledWith({
+                    poNumber: 'PO-123',
+                    referenceNumber: 'REF-456',
+                    extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                    extraInfo: {},
+                }),
+            );
+
+            const payload = preOrderSpy.mock.calls[0][0];
+
+            expect(payload).not.toHaveProperty('isInvoice');
+            expect(payload).not.toHaveProperty('invoiceComment');
+        });
+
+        it('persists B2B metadata before submitting order when persistB2BMetadata capability is enabled', async () => {
             checkout.setRequestHandler(
                 rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
                     res(ctx.json(orderResponse)),
@@ -633,8 +708,8 @@ describe('Payment step', () => {
                 },
             });
 
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+            const preOrderSpy = jest
+                .spyOn(checkoutService, 'persistPreOrderB2BMetadata')
                 .mockImplementation(() => Promise.resolve(checkoutService.getState()));
             const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
 
@@ -642,20 +717,20 @@ describe('Payment step', () => {
 
             await checkout.waitForPaymentStep();
 
-            refreshSpy.mockClear();
+            preOrderSpy.mockClear();
 
             await act(async () => userEvent.click(screen.getByText('Place Order')));
 
-            expect(refreshSpy).toHaveBeenCalledTimes(1);
+            expect(preOrderSpy).toHaveBeenCalledTimes(1);
             expect(submitOrderSpy).toHaveBeenCalledTimes(1);
 
-            const refreshCallOrder = refreshSpy.mock.invocationCallOrder[0];
+            const preOrderCallOrder = preOrderSpy.mock.invocationCallOrder[0];
             const submitOrderCallOrder = submitOrderSpy.mock.invocationCallOrder[0];
 
-            expect(refreshCallOrder).toBeLessThan(submitOrderCallOrder);
+            expect(preOrderCallOrder).toBeLessThan(submitOrderCallOrder);
         });
 
-        it('does not refresh B2B payment methods before submitting order when persistB2BMetadata capability is disabled', async () => {
+        it('does not persist B2B metadata before submitting order when persistB2BMetadata capability is disabled', async () => {
             checkout.setRequestHandler(
                 rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
                     res(ctx.json(orderResponse)),
@@ -678,8 +753,8 @@ describe('Payment step', () => {
 
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
 
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+            const preOrderSpy = jest
+                .spyOn(checkoutService, 'persistPreOrderB2BMetadata')
                 .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
             render(<CheckoutTest {...defaultProps} />);
@@ -688,31 +763,10 @@ describe('Payment step', () => {
 
             await act(async () => userEvent.click(screen.getByText('Place Order')));
 
-            expect(refreshSpy).not.toHaveBeenCalled();
+            expect(preOrderSpy).not.toHaveBeenCalled();
         });
 
-        it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
-                new Error('B2B payments refresh failed'),
-            );
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            expect(screen.getByText(/place order/i)).toBeInTheDocument();
-        });
-
-        it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
+        it('does not submit the order when persisting B2B metadata fails before submit', async () => {
             checkout.setRequestHandler(
                 rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
                     res(ctx.json(orderResponse)),
@@ -727,8 +781,8 @@ describe('Payment step', () => {
                 },
             });
 
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
-                new Error('B2B payments refresh failed'),
+            jest.spyOn(checkoutService, 'persistPreOrderB2BMetadata').mockRejectedValue(
+                new Error('B2B metadata persistence failed'),
             );
 
             const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
@@ -763,9 +817,6 @@ describe('Payment step', () => {
                 },
             });
 
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
             jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
                 checkoutService.getState(),
             );
@@ -822,9 +873,6 @@ describe('Payment step', () => {
                 },
             });
 
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
             jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
                 checkoutService.getState(),
             );
@@ -893,9 +941,6 @@ describe('Payment step', () => {
                 },
             });
 
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
             jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
                 checkoutService.getState(),
             );
@@ -968,9 +1013,6 @@ describe('Payment step', () => {
                 },
             });
 
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
             jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
                 checkoutService.getState(),
             );
@@ -1018,9 +1060,6 @@ describe('Payment step', () => {
                 },
             });
 
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
             jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
                 checkoutService.getState(),
             );

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -111,7 +111,7 @@ interface WithCheckoutPaymentProps {
     isPaymentDataRequired(): boolean;
     loadCheckout(): Promise<CheckoutSelectors>;
     loadPaymentMethods(): Promise<CheckoutSelectors>;
-    submitPreOrderMetaData: CheckoutService['persistPreOrderB2BMetadata'];
+    syncPreOrderB2BMetadata: CheckoutService['persistPreOrderB2BMetadata'];
     submitB2BMetadata: CheckoutService['persistB2BMetadata'];
     submitOrder(values: OrderRequestBody): Promise<CheckoutSelectors>;
     checkoutServiceSubscribe: CheckoutService['subscribe'];
@@ -389,7 +389,7 @@ const Payment = (
     };
 
     const persistPreOrderB2BMetadataIfNeeded = async (): Promise<void> => {
-        const { addressExtraFields, orderExtraFields, submitPreOrderMetaData } = props;
+        const { addressExtraFields, orderExtraFields, syncPreOrderB2BMetadata } = props;
 
         if (!persistB2BMetadata) {
             return;
@@ -397,7 +397,7 @@ const Payment = (
 
         const metadataPayload = buildB2BMetadataOptions({ orderExtraFields, addressExtraFields });
 
-        await submitPreOrderMetaData(metadataPayload);
+        await syncPreOrderB2BMetadata(metadataPayload);
     };
 
     const persistB2BMetadataIfNeeded = async (): Promise<void> => {
@@ -599,6 +599,7 @@ const Payment = (
                 onReady = noop,
                 onUnhandledError = noop,
                 orderId,
+                syncPreOrderB2BMetadata,
                 usableStoreCredit,
                 checkoutServiceSubscribe,
             } = props;
@@ -609,9 +610,10 @@ const Payment = (
 
             await loadPaymentMethodsOrThrow();
 
-            if (orderId) {
+            if (persistB2BMetadata && orderId) {
                 try {
-                    await persistPreOrderB2BMetadataIfNeeded();
+                    // Calling without a payload only refreshes the B2B payment methods.
+                    await syncPreOrderB2BMetadata();
                 } catch (error) {
                     if (error instanceof Error) {
                         onUnhandledError(error);
@@ -827,7 +829,7 @@ export function mapToPaymentProps(
         methods: filteredMethods,
         orderExtraFields,
         orderId: checkout.orderId,
-        submitPreOrderMetaData: checkoutService.persistPreOrderB2BMetadata,
+        syncPreOrderB2BMetadata: checkoutService.persistPreOrderB2BMetadata,
         submitB2BMetadata: checkoutService.persistB2BMetadata,
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,
         shouldLocaliseErrorMessages:

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -111,7 +111,7 @@ interface WithCheckoutPaymentProps {
     isPaymentDataRequired(): boolean;
     loadCheckout(): Promise<CheckoutSelectors>;
     loadPaymentMethods(): Promise<CheckoutSelectors>;
-    refreshB2BPaymentMethods: CheckoutService['refreshB2BPaymentMethods'];
+    submitPreOrderMetaData: CheckoutService['persistPreOrderB2BMetadata'];
     submitB2BMetadata: CheckoutService['persistB2BMetadata'];
     submitOrder(values: OrderRequestBody): Promise<CheckoutSelectors>;
     checkoutServiceSubscribe: CheckoutService['subscribe'];
@@ -388,6 +388,18 @@ const Payment = (
             });
     };
 
+    const persistPreOrderB2BMetadataIfNeeded = async (): Promise<void> => {
+        const { addressExtraFields, orderExtraFields, submitPreOrderMetaData } = props;
+
+        if (!persistB2BMetadata) {
+            return;
+        }
+
+        const metadataPayload = buildB2BMetadataOptions({ orderExtraFields, addressExtraFields });
+
+        await submitPreOrderMetaData(metadataPayload);
+    };
+
     const persistB2BMetadataIfNeeded = async (): Promise<void> => {
         const { addressExtraFields, orderExtraFields, submitB2BMetadata } = props;
 
@@ -395,10 +407,10 @@ const Payment = (
             return;
         }
 
-        const metadataPayload = buildB2BMetadataOptions(invoiceRedirect, {
-            orderExtraFields,
-            addressExtraFields,
-        });
+        const metadataPayload = buildB2BMetadataOptions(
+            { orderExtraFields, addressExtraFields },
+            invoiceRedirect,
+        );
 
         await submitB2BMetadata(metadataPayload);
 
@@ -414,7 +426,6 @@ const Payment = (
                 onCartChangedError = noop,
                 onSubmit = noop,
                 onSubmitError = noop,
-                refreshB2BPaymentMethods,
                 submitOrder,
                 analyticsTracker,
             } = props;
@@ -434,9 +445,7 @@ const Payment = (
             }
 
             try {
-                if (persistB2BMetadata) {
-                    await refreshB2BPaymentMethods();
-                }
+                await persistPreOrderB2BMetadataIfNeeded();
 
                 const state = await submitOrder(
                     mapToOrderRequestBody(values, isPaymentDataRequired()),
@@ -590,7 +599,6 @@ const Payment = (
                 onReady = noop,
                 onUnhandledError = noop,
                 orderId,
-                refreshB2BPaymentMethods,
                 usableStoreCredit,
                 checkoutServiceSubscribe,
             } = props;
@@ -601,9 +609,9 @@ const Payment = (
 
             await loadPaymentMethodsOrThrow();
 
-            if (persistB2BMetadata && orderId) {
+            if (orderId) {
                 try {
-                    await refreshB2BPaymentMethods();
+                    await persistPreOrderB2BMetadataIfNeeded();
                 } catch (error) {
                     if (error instanceof Error) {
                         onUnhandledError(error);
@@ -819,7 +827,7 @@ export function mapToPaymentProps(
         methods: filteredMethods,
         orderExtraFields,
         orderId: checkout.orderId,
-        refreshB2BPaymentMethods: checkoutService.refreshB2BPaymentMethods,
+        submitPreOrderMetaData: checkoutService.persistPreOrderB2BMetadata,
         submitB2BMetadata: checkoutService.persistB2BMetadata,
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,
         shouldLocaliseErrorMessages:

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -1,7 +1,7 @@
 import {
+    type B2BOrderMetadataOptions,
     type FormField,
     type PersistB2BMetadataOptions,
-    type PreOrderB2BMetadataOptions,
 } from '@bigcommerce/checkout-sdk';
 
 import { B2BSessionStorage, type B2BStoredMetadata } from '@bigcommerce/checkout/utility';
@@ -83,7 +83,7 @@ interface B2BMetadataFieldDefinitions {
 
 export function buildB2BMetadataOptions(
     fields?: B2BMetadataFieldDefinitions,
-): PreOrderB2BMetadataOptions;
+): B2BOrderMetadataOptions;
 export function buildB2BMetadataOptions(
     fields: B2BMetadataFieldDefinitions | undefined,
     isInvoice: PersistB2BMetadataOptions['isInvoice'],
@@ -92,7 +92,7 @@ export function buildB2BMetadataOptions(
 export function buildB2BMetadataOptions(
     { orderExtraFields, addressExtraFields }: B2BMetadataFieldDefinitions = {},
     isInvoice?: PersistB2BMetadataOptions['isInvoice'],
-): PersistB2BMetadataOptions | PreOrderB2BMetadataOptions {
+): PersistB2BMetadataOptions | B2BOrderMetadataOptions {
     const {
         invoiceComment,
         poNumber,
@@ -101,7 +101,7 @@ export function buildB2BMetadataOptions(
         ...storedAddressMetadata
     } = B2BSessionStorage.getAll();
 
-    const options: PreOrderB2BMetadataOptions = {
+    const options: B2BOrderMetadataOptions = {
         poNumber,
         referenceNumber: additionalPaymentField,
         extraFields: buildExtraFields(storedOrderExtraFields, orderExtraFields),

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -1,4 +1,8 @@
-import { type FormField, type PersistB2BMetadataOptions } from '@bigcommerce/checkout-sdk';
+import {
+    type FormField,
+    type PersistB2BMetadataOptions,
+    type PreOrderB2BMetadataOptions,
+} from '@bigcommerce/checkout-sdk';
 
 import { B2BSessionStorage, type B2BStoredMetadata } from '@bigcommerce/checkout/utility';
 
@@ -77,10 +81,18 @@ interface B2BMetadataFieldDefinitions {
     addressExtraFields?: FormField[];
 }
 
-export const buildB2BMetadataOptions = (
+export function buildB2BMetadataOptions(
+    fields?: B2BMetadataFieldDefinitions,
+): PreOrderB2BMetadataOptions;
+export function buildB2BMetadataOptions(
+    fields: B2BMetadataFieldDefinitions | undefined,
     isInvoice: PersistB2BMetadataOptions['isInvoice'],
+): PersistB2BMetadataOptions;
+
+export function buildB2BMetadataOptions(
     { orderExtraFields, addressExtraFields }: B2BMetadataFieldDefinitions = {},
-): PersistB2BMetadataOptions => {
+    isInvoice?: PersistB2BMetadataOptions['isInvoice'],
+): PersistB2BMetadataOptions | PreOrderB2BMetadataOptions {
     const {
         invoiceComment,
         poNumber,
@@ -89,15 +101,19 @@ export const buildB2BMetadataOptions = (
         ...storedAddressMetadata
     } = B2BSessionStorage.getAll();
 
-    return {
-        isInvoice,
-        invoiceComment,
+    const options: PreOrderB2BMetadataOptions = {
         poNumber,
         referenceNumber: additionalPaymentField,
         extraFields: buildExtraFields(storedOrderExtraFields, orderExtraFields),
         extraInfo: buildAddressExtraInfo(storedAddressMetadata, addressExtraFields),
     };
-};
+
+    if (isInvoice === undefined) {
+        return options;
+    }
+
+    return { ...options, isInvoice, invoiceComment };
+}
 
 // Clear all B2B sessionStorage after a successful persist.
 export const clearB2BMetadataStorage = (): void => {


### PR DESCRIPTION
## What/Why?

- Implement pre order request for b2b flow by integrating new `cart-order/extra-info` endpoint.
- Consolidate refreshPaymentMethods in the same request

Depends on sdk PR: https://github.com/bigcommerce/checkout-sdk-js/pull/3294

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing 


https://github.com/user-attachments/assets/e60f2ef9-0668-4496-848b-f89bbafd8cdf



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes B2B payment-step timing and API calls around order submit and metadata persistence; failures before submit block order placement, but behavior is covered by tests and depends on the companion SDK release.
> 
> **Overview**
> **B2B checkout** now calls **`persistPreOrderB2BMetadata`** (SDK) instead of **`refreshB2BPaymentMethods`** when `persistB2BMetadata` is enabled. Pre-order metadata is sent on payment step init (when `orderId` exists) and again immediately before **`submitOrder`**; post-order **`persistB2BMetadata`** is unchanged and still runs after a successful submit or after finalize-on-mount.
> 
> **`buildB2BMetadataOptions`** is split via overloads: without an `isInvoice` argument it returns **`PreOrderB2BMetadataOptions`** (PO, reference, extra fields/info only—**no** `isInvoice` / `invoiceComment`). With `invoiceRedirect` it still builds the full post-order payload.
> 
> Tests were renamed and expanded to cover pre-order gating, mount-time failure tolerance, payload shape, and submit ordering relative to order placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3806ce63d17ebb9b56e51a06f33941954bed747c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->