### PR TITLE
feat(checkout): CHECKOUT-10103 Accessibility - wrap promotion banners…

### DIFF
--- a/packages/core/src/app/promotion/PromotionBannerList.tsx
+++ b/packages/core/src/app/promotion/PromotionBannerList.tsx
@@ -23,7 +23,9 @@ const PromotionBannerList: FunctionComponent<PromotionBannerListProps> = ({ prom
         <div className="discountBanner">
             <ul className="discountBannerList">
                 {banners.map((banner, index) => (
-                    <PromotionBanner key={index} message={banner.text} />
+                    <li key={index}>
+                        <PromotionBanner message={banner.text} />
+                    </li>
                 ))}
             </ul>
         </div>


### PR DESCRIPTION
## What/Why?

### What
The promotion banner on the checkout page rendered a `<ul class="discountBannerList">` whose direct children were `<div>` alert boxes (each `PromotionBanner` renders an `Alert` `<div>`).  

This PR wraps each `PromotionBanner` in an `<li>`. No visual change.

### Why
Google PageSpeed flagged an accessibility issue on checkout: "Lists do not contain only `<li>` elements".  A `<ul>` must contain only `<li>` for screen readers to announce it correctly.


## Rollout/Rollback
Revert the PR.

## Testing

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

- Unit tests pass: `nx test core --testPathPattern=PromotionBannerList`. 
- Verified DOM: `<ul class="discountBannerList">` now contains `<li>` children, each wrapping the alert `<div>`.
- PageSpeed accessibility report: No issue for discount  banners.

### Before

<img width="1100" height="711" alt="Before-1" src="https://github.com/user-attachments/assets/140274f9-e071-436c-8b54-9c9890deecac" />

<img width="1346" height="738" alt="before-2" src="https://github.com/user-attachments/assets/b5fb4e29-4b92-4aca-ad22-f18b19a60ffe" />


### After

<img width="1061" height="631" alt="after-1" src="https://github.com/user-attachments/assets/586f5a13-c104-48d6-8d4d-d86d95c3d641" />

(No accessibility  issues reported on the discount banner)
<img width="1346" height="726" alt="after-2" src="https://github.com/user-attachments/assets/76c35209-ddd4-4a54-bcc4-be13ce682cc4" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single markup change in checkout header promotion list with no logic, API, or styling updates beyond semantic HTML.
> 
> **Overview**
> Fixes checkout promotion banner markup so `discountBannerList` `<ul>` children are `<li>` elements wrapping each `PromotionBanner`, instead of alert `<div>`s as direct list children.
> 
> This addresses PageSpeed / screen-reader rules (“lists must contain only `<li>` elements”) with no intended visual change; existing list reset styles on `discountBannerList` stay in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77d28022a755e8f39649477a3e0b16d2336d637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->