### PR TITLE
Revert "feat(paymnet): Migrate CyberSource v2 to Resolver Configuration"

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -1,5 +1,9 @@
 import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
+import {
+    createCyberSourcePaymentStrategy,
+    createCyberSourceV2PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import React, { type FunctionComponent, useCallback } from 'react';
 
@@ -39,6 +43,8 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                     integrations: [
                         ...(options.integrations ?? []),
                         createCreditCardPaymentStrategy,
+                        createCyberSourcePaymentStrategy,
+                        createCyberSourceV2PaymentStrategy,
                         createSagePayPaymentStrategy,
                         createCBAMPGSPaymentStrategy,
                     ],

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -31,11 +31,12 @@ const HostedCreditCardPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
     HostedCreditCardPaymentMethod,
     [
+        {
+            id: 'hosted-credit-card',
+        },
         { id: 'credit_card', gateway: 'bluesnapdirect' },
         { id: 'credit_card', gateway: 'checkoutcom' },
-        { id: 'cybersource' },
-        { id: 'cybersourcev2' },
-        { id: 'hosted-credit-card' },
+
         { id: 'tdonlinemart' },
     ],
 );

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -4,10 +4,6 @@ import {
     type LegacyHostedFormOptions,
 } from '@bigcommerce/checkout-sdk';
 import { createBlueSnapDirectCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
-import {
-    createCyberSourcePaymentStrategy,
-    createCyberSourceV2PaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
@@ -260,8 +256,6 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                     ...options,
                     integrations: [
                         createCreditCardPaymentStrategy,
-                        createCyberSourcePaymentStrategy,
-                        createCyberSourceV2PaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,


### PR DESCRIPTION
Reverts bigcommerce/checkout-js#3047

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment initialization and method resolution for CyberSource; wrong routing could break hosted card checkout for those gateways until verified.
> 
> **Overview**
> This **reverts** the CyberSource resolver migration (PR #3047) by moving CyberSource v1/v2 hosted card handling back to the **core** checkout path instead of `hosted-credit-card-integration`.
> 
> **Core** `HostedCreditCardPaymentMethod` again registers `createCyberSourcePaymentStrategy` and `createCyberSourceV2PaymentStrategy` when calling `initializePayment`. **Hosted-credit-card-integration** drops `cybersource` / `cybersourcev2` from its `toResolvableComponent` IDs and removes those strategies from `HostedCreditCardComponent`’s integration list (BlueSnap, Checkout.com, TD, etc. stay on the resolver side).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6964fb10d7d74cac9dec08da062ec91e7f5d762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->