### PR TITLE
feat(checkout): CHECKOUT-10108 Accessibility - Make discounts toggle …

### DIFF
--- a/packages/core/src/app/coupon/components/Discounts.tsx
+++ b/packages/core/src/app/coupon/components/Discounts.tsx
@@ -51,6 +51,14 @@ const DiscountsCollapsible: FunctionComponent<{
                 aria-live="polite"
                 className="coupon-discount-toggle cart-priceItem optimizedCheckout-contentPrimary"
                 onClick={() => setIsCouponDiscountsVisible(!isCouponDiscountsVisible)}
+                onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        setIsCouponDiscountsVisible(!isCouponDiscountsVisible);
+                    }
+                }}
+                role="button"
+                tabIndex={0}
             >
                 <span className="cart-priceItem-label body-regular">
                     <div className="toggle-button">


### PR DESCRIPTION
## What/Why?

### What
This adds `role="button"` so `aria-expanded`/`aria-controls` are valid (resolving the finding), and — since the element was previously click-only — also adds `tabIndex={0}` and an Enter/Space `onKeyDown` handler so the toggle is keyboard focusable and operable (WCAG 2.1.1). 

**No visual change. Low-risk markup-only change**

### Why
Google PageSpeed flagged an accessibility issue on the checkout page: "ARIA attributes do not match their roles." The discounts toggle in `packages/core/src/app/coupon/components/Discounts.tsx` was a plain `<div>` (implicit role `generic`) carrying `aria-expanded` and `aria-controls`. The `generic` role does not support those attributes, so they were invalid.


## Rollout/Rollback
Revert the PR to roll back.

## Testing
- `nx test core --testPathPattern=NewOrderSummarySubtotals` passes (50/50).
- Manually verified in DevTools: the toggle now reports `role="button"`, `aria-expanded`/`aria-controls` are valid, and it is focusable and operable via keyboard (Enter/Space).


### Before
<img width="1324" height="675" alt="Before-1" src="https://github.com/user-attachments/assets/60105ab4-0b05-4ca8-9344-6df68b533bd8" />

<img width="1265" height="765" alt="Before-2" src="https://github.com/user-attachments/assets/433946dc-3607-40b7-a459-d022911c757e" />


### After

<img width="1271" height="606" alt="After-1" src="https://github.com/user-attachments/assets/ec032346-b862-4a15-b413-7e1297a589e7" />

<img width="1250" height="707" alt="After-2" src="https://github.com/user-attachments/assets/23b5c8f5-bb4e-4adc-9f49-affcfbbcf7f4" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup-only accessibility change on a single checkout UI toggle; no auth, data, or payment logic touched.
> 
> **Overview**
> Fixes the checkout **applied discounts** collapsible header so `aria-expanded` and `aria-controls` are valid and the control works from the keyboard.
> 
> The click-only `<div>` in `Discounts.tsx` now has **`role="button"`**, **`tabIndex={0}`**, and an **`onKeyDown`** handler that toggles visibility on **Enter** and **Space** (with `preventDefault` on Space). Existing click behavior and `aria-*` wiring to `applied-coupon-discounts-collapsable` are unchanged; no visual or pricing logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40aba57300b6c9f8e8e016e658c31aa43175f8b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->