### PR TITLE
fix(checkout): CHECKOUT-9019 Remove phone number component auto-placeholder

### DIFF
--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -48,6 +48,7 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
     return (
         <span className="iti-wrapper">
             <IntlTelInput
+                autoPlaceholder="off"
                 inputProps={{
                     'aria-labelledby': `${id}-label ${id}-field-error-message`,
                     // using spread to avoid type error, data-test is valid but types are incorrect on the library side


### PR DESCRIPTION
## What/Why?

Removes the auto-generated example number placeholder from the phone input field (e.g. +61 412 345 678). This is a minor accessibility improvement: placeholder text disappears on typing (problematic for users with cognitive impairments), typically fails WCAG 1.4.3 contrast requirements, and can be mistaken for a pre-filled value. The field remains clearly identified via the floating label and the country selector's accessible name.

Implementation: sets autoPlaceholder="off" on the IntlTelInput component.

## Rollout/Rollback

Revert the PR.

## Testing

CI + visual.

Before:

<img width="838" height="506" alt="Screenshot 2026-06-18 at 2 28 12 PM" src="https://github.com/user-attachments/assets/258fdced-2f4d-4aee-81a9-54d14b4e5439" />

After:

<img width="838" height="506" alt="Screenshot 2026-06-18 at 2 22 48 PM" src="https://github.com/user-attachments/assets/40de1308-b823-4ca4-a3ef-34210364352f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prop change on a UI form component with no auth, data, or validation logic changes.
> 
> **Overview**
> Disables **intl-tel-input**’s country-specific example placeholder on checkout phone fields by setting `autoPlaceholder="off"` on `IntlTelInput` in `PhoneInput.tsx`.
> 
> Users no longer see sample numbers (e.g. +61 412 345 678) in the empty field; identification still comes from the floating label and country selector accessible name, addressing placeholder-related accessibility concerns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66c22b564cbb111fc3f3965a39edca662d6e100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->