### PR TITLE
feat(shipping): BACK-683 Update position of shipping expectation message

### DIFF
--- a/packages/core/src/app/shipping/ShippingFormFooter.tsx
+++ b/packages/core/src/app/shipping/ShippingFormFooter.tsx
@@ -50,10 +50,6 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                             <TranslatedString id="shipping.shipping_method_label" />
                         </Legend>
 
-                        {defaultShippingExpectationMessage && (
-                            <p>{defaultShippingExpectationMessage}</p>
-                        )}
-
                         {cartHasChanged && (
                             <Alert type={AlertType.Error}>
                                 <strong>
@@ -72,6 +68,10 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                     shouldShowShippingOptions={shouldShowShippingOptions}
                 />
             </Fieldset>
+
+            {defaultShippingExpectationMessage && (
+                <p className="shipping-ExpectationMessage">{defaultShippingExpectationMessage}</p>
+            )}
 
             {shouldShowOrderComments && <OrderComments />}
 

--- a/packages/core/src/app/shipping/ShippingFormFooter.tsx
+++ b/packages/core/src/app/shipping/ShippingFormFooter.tsx
@@ -50,6 +50,10 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                             <TranslatedString id="shipping.shipping_method_label" />
                         </Legend>
 
+                        {defaultShippingExpectationMessage && (
+                            <p>{defaultShippingExpectationMessage}</p>
+                        )}
+
                         {cartHasChanged && (
                             <Alert type={AlertType.Error}>
                                 <strong>
@@ -68,8 +72,6 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                     shouldShowShippingOptions={shouldShowShippingOptions}
                 />
             </Fieldset>
-
-            {defaultShippingExpectationMessage && <p>{defaultShippingExpectationMessage}</p>}
 
             {shouldShowOrderComments && <OrderComments />}
 

--- a/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
+++ b/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
@@ -20,3 +20,11 @@
 .no-addresses-warning {
     padding: spacing("single") 0 (spacing("single") + spacing("third")) 0;
 }
+
+.shipping-ExpectationMessage {
+    color: $color-secondaryDarkest;
+    font-size: $fontSize-smallest;
+    font-weight: fontWeight("normal");
+    margin-bottom: spacing("half");
+}
+


### PR DESCRIPTION
## What/Why?
Update position of shipping expectation message

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast


<img width="989" height="691" alt="Screenshot 2026-06-18 at 8 49 25 pm" src="https://github.com/user-attachments/assets/a16a9a7a-a96a-4ced-9161-64a8520cb141" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout UI-only styling on optional copy; no changes to shipping logic or APIs.
> 
> **Overview**
> Adds a dedicated **`shipping-ExpectationMessage`** class on the default shipping expectation copy in **`ShippingFormFooter`**, with matching checkout SCSS so the message reads as secondary helper text (smaller type, **`$color-secondaryDarkest`**, normal weight, bottom margin).
> 
> The message still renders after the shipping methods fieldset and before order comments; the change is presentation, not new logic or data flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f3d235fe033b007617e6948ec891a401a39b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->