### PR TITLE
feat(product): BACK-679 Update bundle to show label

### DIFF
--- a/packages/core/src/app/order/OrderSummaryItem.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.test.tsx
@@ -114,6 +114,7 @@ describe('OrderSummaryItem', () => {
             {
                 id: 'b1',
                 name: 'Bundled Hat',
+                bundleLabel: 'Accessories',
                 quantityBackordered: 2,
                 quantityOnHand: 3,
                 backorderMessage: 'Ships in 5 days',
@@ -121,6 +122,7 @@ describe('OrderSummaryItem', () => {
             {
                 id: 'b2',
                 name: 'Bundled Scarf',
+                bundleLabel: 'Accessories',
             },
         ];
 
@@ -141,8 +143,8 @@ describe('OrderSummaryItem', () => {
             const nameEls = screen.getAllByTestId('cart-item-bundled-item-name');
 
             expect(nameEls).toHaveLength(2);
-            expect(nameEls[0]).toHaveTextContent('Bundled Hat');
-            expect(nameEls[1]).toHaveTextContent('Bundled Scarf');
+            expect(nameEls[0]).toHaveTextContent('Accessories: Bundled Hat');
+            expect(nameEls[1]).toHaveTextContent('Accessories: Bundled Scarf');
         });
 
         it('renders nothing for bundled items section when bundledItems is undefined', () => {

--- a/packages/core/src/app/order/OrderSummaryItem.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.test.tsx
@@ -126,7 +126,7 @@ describe('OrderSummaryItem', () => {
             },
         ];
 
-        it('renders each bundled item name with the Bundle label', () => {
+        it('renders each bundled item name with its bundle label', () => {
             render(
                 <OrderSummaryItem
                     orderItem={{
@@ -145,6 +145,26 @@ describe('OrderSummaryItem', () => {
             expect(nameEls).toHaveLength(2);
             expect(nameEls[0]).toHaveTextContent('Accessories: Bundled Hat');
             expect(nameEls[1]).toHaveTextContent('Accessories: Bundled Scarf');
+        });
+
+        it('falls back to the default bundle label when a bundled item has no bundleLabel', () => {
+            render(
+                <OrderSummaryItem
+                    orderItem={{
+                        amount: 10,
+                        id: 'foo',
+                        name: 'Product',
+                        quantity: 1,
+                        bundledItems: [{ id: 'b1', name: 'Bundled Hat' }],
+                    }}
+                    shouldExpandBackorderDetails={false}
+                />,
+            );
+
+            const nameEl = screen.getByTestId('cart-item-bundled-item-name');
+
+            expect(nameEl).toHaveTextContent('Bundle: Bundled Hat');
+            expect(nameEl).not.toHaveTextContent('Bundle::');
         });
 
         it('renders nothing for bundled items section when bundledItems is undefined', () => {

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -172,11 +172,10 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                                 >
                                     <span className="body-bold">
                                         {item.bundleLabel ? (
-                                            item.bundleLabel
+                                            `${item.bundleLabel}:`
                                         ) : (
                                             <TranslatedString id="cart.bundled_item_label" />
                                         )}
-                                        :
                                     </span>{' '}
                                     {item.name}
                                 </div>

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -170,7 +170,14 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                                     className="bundled-item-name"
                                     data-test="cart-item-bundled-item-name"
                                 >
-                                    <span className="body-bold">{item.bundleLabel}:</span>{' '}
+                                    <span className="body-bold">
+                                        {item.bundleLabel ? (
+                                            item.bundleLabel
+                                        ) : (
+                                            <TranslatedString id="cart.bundled_item_label" />
+                                        )}
+                                        :
+                                    </span>{' '}
                                     {item.name}
                                 </div>
                                 <OrderSummaryItemBackorderDetails

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -23,6 +23,7 @@ export interface OrderItemType {
     bundledItems?: Array<{
         id: string;
         name: string;
+        bundleLabel?: string;
         quantityBackordered?: number;
         quantityOnHand?: number;
         backorderMessage?: string;
@@ -169,9 +170,7 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                                     className="bundled-item-name"
                                     data-test="cart-item-bundled-item-name"
                                 >
-                                    <span className="body-bold">
-                                        <TranslatedString id="cart.bundled_item_label" />
-                                    </span>{' '}
+                                    <span className="body-bold">{item.bundleLabel}:</span>{' '}
                                     {item.name}
                                 </div>
                                 <OrderSummaryItemBackorderDetails

--- a/packages/core/src/app/order/mapFromDigital.test.tsx
+++ b/packages/core/src/app/order/mapFromDigital.test.tsx
@@ -101,6 +101,39 @@ describe('mapFromDigital()', () => {
             expect(bundledItems![0].backorderMessage).toBe('Ships in 5 days');
         });
 
+        it('returns bundledItems with bundleLabel from the matching parent option', () => {
+            const bundledChild = {
+                ...getPhysicalItem(),
+                id: '777',
+                name: 'Bundled Product',
+                parentId: '667',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const item = {
+                ...getDigitalItem(),
+                id: '667',
+                options: [
+                    {
+                        name: 'Pick List Option',
+                        nameId: 11,
+                        value: 'Item A',
+                        valueId: 2,
+                        attributeId: 'attr-picklist',
+                    },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([
+                ['667', [bundledChild]],
+            ]);
+
+            const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
+
+            expect(bundledItems).toHaveLength(1);
+            expect(bundledItems![0].bundleLabel).toBe('Pick List Option');
+        });
+
         it('returns undefined bundledItems when item has no children in the map', () => {
             const item = { ...getDigitalItem(), id: '667' };
             const bundleItemsMap = new Map<string | number, PhysicalItem[]>();

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -44,6 +44,9 @@ function mapFromDigital(
             ? bundledItems?.map((bundledItem) => ({
                   name: bundledItem.name,
                   id: String(bundledItem.id),
+                  bundleLabel: item.options?.find(
+                      (option) => option.attributeId === bundledItem.addedByAttributeId,
+                  )?.name,
                   ...mapBackorderDetails(bundledItem),
               }))
             : undefined,

--- a/packages/core/src/app/order/mapFromPhysical.test.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.test.tsx
@@ -114,6 +114,37 @@ describe('mapFromPhysical()', () => {
             expect(bundledItems![0].backorderMessage).toBe('Available soon');
         });
 
+        it('returns bundledItems with bundleLabel from the matching parent option', () => {
+            const child = {
+                ...getPhysicalItem(),
+                id: '777',
+                name: 'Bundled Product',
+                parentId: '666',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const parent = {
+                ...getPhysicalItem(),
+                id: '666',
+                options: [
+                    {
+                        name: 'Pick List',
+                        nameId: 11,
+                        value: 'Item A',
+                        valueId: 2,
+                        attributeId: 'attr-picklist',
+                    },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
+
+            const { bundledItems } = mapFromPhysical(parent, bundleItemsMap, true);
+
+            expect(bundledItems).toHaveLength(1);
+            expect(bundledItems![0].bundleLabel).toBe('Pick List');
+        });
+
         it('returns no bundledItems when the item has no children', () => {
             const result = mapFromPhysical(getPhysicalItem(), new Map(), true);
 

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -37,10 +37,13 @@ function mapFromPhysical(
                 : `${option.name} ${option.value}`,
         })),
         bundledItems: pickListExperimentEnabled
-            ? bundledItems?.map((item) => ({
-                  name: item.name,
-                  id: String(item.id),
-                  ...mapBackorderDetails(item),
+            ? bundledItems?.map((bundledItem) => ({
+                  name: bundledItem.name,
+                  id: String(bundledItem.id),
+                  bundleLabel: item.options?.find(
+                      (option) => option.attributeId === bundledItem.addedByAttributeId,
+                  )?.name,
+                  ...mapBackorderDetails(bundledItem),
               }))
             : undefined,
         ...mapBackorderDetails(item),


### PR DESCRIPTION
## What/Why?
Update bundle items to show label of the bundle

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast


<img width="989" height="691" alt="Screenshot 2026-06-18 at 11 02 51 pm" src="https://github.com/user-attachments/assets/cefda6aa-fb3a-4a0c-9c30-dd1a1edcf3ea" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only checkout order summary change with a safe fallback when `bundleLabel` is missing; mapping runs only on the existing pick-list experiment path.
> 
> **Overview**
> Bundled line items in checkout order summary now show a **per-item label** (e.g. `Accessories: Bundled Hat`) instead of always using the generic translated “Bundle” prefix.
> 
> When the pick-list experiment is on, `mapFromPhysical` and `mapFromDigital` set optional `bundleLabel` on each bundled child by matching the parent option whose `attributeId` equals the child’s `addedByAttributeId` and using that option’s **name**. `OrderSummaryItem` renders `bundleLabel` with a trailing colon when present; otherwise it keeps the existing `cart.bundled_item_label` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeff13b01ba895ed93a567ac96574eaf4f33309a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->