### PR TITLE
feat(shipping): BACK-683 Update position of shipping expectation message under shipping method

### DIFF
--- a/packages/core/src/app/shipping/ShippingFormFooter.tsx
+++ b/packages/core/src/app/shipping/ShippingFormFooter.tsx
@@ -49,6 +49,11 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                         <Legend>
                             <TranslatedString id="shipping.shipping_method_label" />
                         </Legend>
+                        {defaultShippingExpectationMessage && (
+                            <p className="shipping-ExpectationMessage">
+                                {defaultShippingExpectationMessage}
+                            </p>
+                        )}
 
                         {cartHasChanged && (
                             <Alert type={AlertType.Error}>
@@ -68,10 +73,6 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                     shouldShowShippingOptions={shouldShowShippingOptions}
                 />
             </Fieldset>
-
-            {defaultShippingExpectationMessage && (
-                <p className="shipping-ExpectationMessage">{defaultShippingExpectationMessage}</p>
-            )}
 
             {shouldShowOrderComments && <OrderComments />}
 

--- a/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
+++ b/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
@@ -25,6 +25,6 @@
     color: $color-secondaryDarkest;
     font-size: $fontSize-smallest;
     font-weight: fontWeight("normal");
-    margin-bottom: spacing("half");
+    margin-bottom: spacing("base");
 }
 


### PR DESCRIPTION
## What/Why?
Update position of shipping expectation message under shipping method

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screenshot

<img width="1117" height="881" alt="Screenshot 2026-06-19 at 2 53 41 pm" src="https://github.com/user-attachments/assets/936cb3e1-b0b3-4869-bae2-b7f089b56a44" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational layout change only; no logic, data, or API behavior changes.
> 
> **Overview**
> The **default shipping expectation message** (e.g. backorder copy) now renders **inside the shipping method fieldset legend**, directly under the “Shipping method” heading, instead of below the whole shipping options block.
> 
> Spacing for `.shipping-ExpectationMessage` is increased slightly (`margin-bottom` from `spacing("half")` to `spacing("base")`) to match the new placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b70cc06a12bc80c5965988d38770065afd28cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->