### PR TITLE
feat(checkout): CHECKOUT-10133 Accessiblity - wrap applied-coupon lab…

### DIFF
--- a/packages/core/src/app/coupon/components/CouponForm.tsx
+++ b/packages/core/src/app/coupon/components/CouponForm.tsx
@@ -91,10 +91,12 @@ export const CouponForm: FunctionComponent = () => {
                 {Boolean(couponError) && (
                     <Alert additionalClassName="no-padding" type={AlertType.Error}>
                         <ul className="applied-coupon-error-message">
-                            <span>{couponError}</span>
-                            <span onClick={() => setCouponError(null)}>
-                                <IconRemoveCoupon />
-                            </span>
+                            <li>
+                                <span>{couponError}</span>
+                                <span onClick={() => setCouponError(null)}>
+                                    <IconRemoveCoupon />
+                                </span>
+                            </li>
                         </ul>
                     </Alert>
                 )}

--- a/packages/core/src/app/coupon/components/ManageCouponsAndGiftCertificates.tsx
+++ b/packages/core/src/app/coupon/components/ManageCouponsAndGiftCertificates.tsx
@@ -48,9 +48,11 @@ const AppliedCouponsPills: FunctionComponent<{
             {coupons.map(({ code, displayName }) => (
                 <AnimatedCouponTag key={code}>
                     <ul>
-                        <IconCoupon />
-                        {displayName ? `${displayName} (${code})` : code}
-                        <IconRemoveCoupon onClick={() => removeCoupon(code)} />
+                        <li>
+                            <IconCoupon />
+                            {displayName ? `${displayName} (${code})` : code}
+                            <IconRemoveCoupon onClick={() => removeCoupon(code)} />
+                        </li>
                     </ul>
                 </AnimatedCouponTag>
             ))}
@@ -69,9 +71,11 @@ export const ManageCouponsAndGiftCertificates: FunctionComponent = () => {
                 {appliedGiftCertificates.map(({ code }) => (
                     <AnimatedCouponTag key={code}>
                         <ul>
-                            <IconGiftCertificateNew />
-                            {code}
-                            <IconRemoveCoupon onClick={() => removeGiftCertificate(code)} />
+                            <li>
+                                <IconGiftCertificateNew />
+                                {code}
+                                <IconRemoveCoupon onClick={() => removeGiftCertificate(code)} />
+                            </li>
                         </ul>
                     </AnimatedCouponTag>
                 ))}

--- a/packages/core/src/scss/components/checkout/coupon/_coupon.scss
+++ b/packages/core/src/scss/components/checkout/coupon/_coupon.scss
@@ -61,6 +61,10 @@
         padding-left: spacing('quarter');
     }
 
+    ul > li {
+        display: contents;
+    }
+
     ul {
         background: $color-greyLightest;
         color: $color-primary;


### PR DESCRIPTION
## What/Why?

### What
Wraps each `<ul>`'s contents in a single `<li>`, and adds `.applied-coupons-list ul > li { display: contents; }` so the wrapper produces no box — the existing `<ul>`-based pill/error styling and inline/flex layout are unchanged while the `<li>` remains in the accessibility tree. No visual change. Low-risk markup + CSS change. 

### Why
A `<ul>` must contain only `<li>` (plus `<script>`/`<template>`) for screen readers to announce it correctly. This resulted in Google PageSpeed flagging an accessibility issue on the checkout page: "Lists do not contain only `<li>` elements (and script supporting elements)."  In the coupon area, three `<ul>`s rendered non-`<li>` direct children (svg icons, text, spans):
1. Applied-coupon pill (`ManageCouponsAndGiftCertificates.tsx`)
2. Applied gift-certificate pill (`ManageCouponsAndGiftCertificates.tsx`)
3. Coupon error message (`CouponForm.tsx`, `ul.applied-coupon-error-message`)

## Rollout/Rollback
Revert the PR to roll back. 

## Testing
- `nx test core --testPathPattern=NewOrderSummarySubtotals` passes (50/50).
- Verified in Chrome Developer Tools: each `<ul>` now contains a single `<li>`, and the coupon pill, gift-certificate pill, and error message render unchanged.
- Ran PageSpeed insights to ensure the accessibility issues is not flagged after the chnages.

### Before
<img width="1361" height="693" alt="Before-2" src="https://github.com/user-attachments/assets/732fb687-456b-4538-8a83-d4c00e189fea" />

<img width="1360" height="744" alt="Before-1" src="https://github.com/user-attachments/assets/bf07ea79-79d6-41bc-8b63-b1bbe3a29e4c" />


### After
<img width="1369" height="731" alt="After-1" src="https://github.com/user-attachments/assets/edf857c3-0d13-4b06-a9d4-0b31e89b3302" />


<img width="1310" height="679" alt="After-2" src="https://github.com/user-attachments/assets/998abc41-cdb4-4d1d-b941-c9a5962393b2" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup and scoped CSS only in the coupon checkout area; no logic, API, or data changes.
> 
> **Overview**
> Fixes invalid list markup in checkout coupon UI so screen readers and PageSpeed can treat the lists correctly, without changing how the pills and error banner look.
> 
> Each affected `<ul>` (applied coupon pill, gift-certificate pill, and coupon error message) now has a single `<li>` wrapping its icons, text, and dismiss control. **`.applied-coupons-list ul > li { display: contents; }`** keeps the wrapper out of the layout box so existing pill and error styling stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da97021e2d1e670eea35c40ecb6bc04b1710eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->