### PR TITLE
fix(checkout): CHECKOUT-10138 Make sure checkout settings are defined

### DIFF
--- a/packages/contexts/src/theme/ThemeProvider.tsx
+++ b/packages/contexts/src/theme/ThemeProvider.tsx
@@ -13,7 +13,7 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
 
     let themeV2 = false;
 
-    if (config) {
+    if (config?.checkoutSettings) {
         const newThemeExperimentEnabled = Boolean(
             config.checkoutSettings.features['CHECKOUT-7962.update_font_style_on_checkout_page'] ??
                 true,


### PR DESCRIPTION
## What/Why?

I did a quick investigation on this sentry issue: https://bigcommerce.sentry.io/issues/7547058371/?project=1542560
I could not find an obvious root cause - useCheckout work seems unrelated based on Claude evaluation.

In any case, I'm adding a check for `checkoutSetting` in this PR to make sure we don't evaluate `checkoutSettings` when they are undefined.

## Rollout/Rollback

Revert the PR.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive guard in theme selection; behavior unchanged when checkoutSettings is present.
> 
> **Overview**
> **ThemeProvider** no longer reads theme experiment/setting flags unless **`checkoutSettings`** is present on checkout config.
> 
> The guard changes from **`if (config)`** to **`if (config?.checkoutSettings)`**, so a config object without settings skips the nested **`features`** / **`checkoutUserExperienceSettings`** access and keeps **`themeV2`** at **`false`** instead of throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d48c6cb9b86e435f93568485b4d314e69cfb015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->