### PR TITLE
feat(checkout): BACK-679 Display backorder details for mobile modals

### DIFF
--- a/packages/core/src/app/order/OrderSummaryDrawer.tsx
+++ b/packages/core/src/app/order/OrderSummaryDrawer.tsx
@@ -65,7 +65,7 @@ const OrderSummaryDrawer: FunctionComponent<
                 handlingAmount={handlingAmount}
                 headerLink={headerLink}
                 isTaxIncluded={isTaxIncluded}
-                items={nonBundledLineItems}
+                items={lineItems}
                 onRemovedCoupon={onRemovedCoupon}
                 onRemovedGiftCertificate={onRemovedGiftCertificate}
                 shippingAmount={shippingAmount}
@@ -86,7 +86,7 @@ const OrderSummaryDrawer: FunctionComponent<
             handlingAmount,
             headerLink,
             isTaxIncluded,
-            nonBundledLineItems,
+            lineItems,
             onRemovedCoupon,
             onRemovedGiftCertificate,
             giftWrappingAmount,

--- a/packages/core/src/app/order/OrderSummaryItem.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.test.tsx
@@ -1,6 +1,11 @@
-import { type CurrencyService } from '@bigcommerce/checkout-sdk';
+import {
+    type CheckoutService,
+    createCheckoutService,
+    type CurrencyService,
+} from '@bigcommerce/checkout-sdk';
 import React from 'react';
 
+import { CheckoutProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
@@ -210,6 +215,69 @@ describe('OrderSummaryItem', () => {
             );
 
             expect(screen.queryByRole('list')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('when bundled items are backordered and details are expanded', () => {
+        let checkoutService: CheckoutService;
+
+        const renderWithConfig = (shouldExpandBackorderDetails: boolean) =>
+            render(
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <LocaleContext.Provider value={localeContext}>
+                        <OrderSummaryItem
+                            orderItem={{
+                                amount: 10,
+                                id: 'foo',
+                                name: 'Product',
+                                quantity: 1,
+                                bundledItems: [
+                                    {
+                                        id: 'b1',
+                                        name: 'Bundled Hat',
+                                        bundleLabel: 'Accessories',
+                                        quantityBackordered: 2,
+                                        quantityOnHand: 3,
+                                        backorderMessage: 'Ships in 5 days',
+                                    },
+                                ],
+                            }}
+                            shouldExpandBackorderDetails={shouldExpandBackorderDetails}
+                        />
+                    </LocaleContext.Provider>
+                </CheckoutProvider>,
+            );
+
+        beforeEach(() => {
+            checkoutService = createCheckoutService();
+
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                ...getStoreConfig(),
+                inventorySettings: {
+                    showQuantityOnBackorder: true,
+                    showBackorderMessage: true,
+                    showQuantityOnHand: false,
+                    showBackorderAvailabilityPrompt: false,
+                    backorderAvailabilityPrompt: null,
+                    shouldDisplayBackorderMessagesOnStorefront: true,
+                },
+            });
+        });
+
+        it('renders the backorder quantity and message for the bundled child item', () => {
+            renderWithConfig(true);
+
+            expect(screen.getByTestId('cart-item-backorder-qty')).toBeInTheDocument();
+            expect(screen.getByTestId('cart-item-backorder-message')).toHaveTextContent(
+                'Ships in 5 days',
+            );
+        });
+
+        it('does not render the bundled child backorder details when collapsed', () => {
+            renderWithConfig(false);
+
+            expect(screen.queryByTestId('cart-item-backorder-qty')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('cart-item-backorder-message')).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/app/order/OrderSummaryItem.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.test.tsx
@@ -259,6 +259,8 @@ describe('OrderSummaryItem', () => {
                     showQuantityOnHand: false,
                     showBackorderAvailabilityPrompt: false,
                     backorderAvailabilityPrompt: null,
+                    showDefaultShippingExpectationPrompt: false,
+                    defaultShippingExpectationPrompt: null,
                     shouldDisplayBackorderMessagesOnStorefront: true,
                 },
             });

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -20,7 +20,7 @@ import { getStoreConfig } from '../config/config.mock';
 
 import OrderSummaryItems, {
     type OrderSummaryItemsProps,
-    resetBackorderDetailsExpanded,
+    setBackorderDetailsExpanded,
 } from './OrderSummaryItems';
 
 describe('OrderSummaryItems', () => {
@@ -84,7 +84,7 @@ describe('OrderSummaryItems', () => {
     afterEach(() => {
         // The toggle selection is held in a module-scoped value so it can survive the
         // responsive remount; reset it between tests to avoid leaking state.
-        resetBackorderDetailsExpanded();
+        setBackorderDetailsExpanded(false);
     });
 
     describe('backorder quantity text', () => {

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -37,6 +37,29 @@ describe('OrderSummaryItems', () => {
         );
     };
 
+    const enableBundleExperiment = () => {
+        const config = getStoreConfig();
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+            ...config,
+            checkoutSettings: {
+                ...config.checkoutSettings,
+                features: {
+                    ...config.checkoutSettings.features,
+                    'BACK-425.update_bundle_item_ux': true,
+                },
+            },
+            inventorySettings: {
+                showQuantityOnBackorder: true,
+                showBackorderMessage: true,
+                showQuantityOnHand: false,
+                showBackorderAvailabilityPrompt: false,
+                backorderAvailabilityPrompt: null,
+                shouldDisplayBackorderMessagesOnStorefront: true,
+            },
+        });
+    };
+
     beforeEach(() => {
         checkoutService = createCheckoutService();
         localeContext = createLocaleContext(getStoreConfig());
@@ -162,7 +185,7 @@ describe('OrderSummaryItems', () => {
         });
     });
 
-    describe('backorder details toggle parity and persistence', () => {
+    describe('backorder details toggle gating (mobile vs desktop) and persistence', () => {
         const backorderItems = {
             customItems: [],
             physicalItems: [
@@ -175,7 +198,54 @@ describe('OrderSummaryItems', () => {
             giftCertificates: [],
         };
 
-        it('renders the toggle on mobile even though the line items count is hidden', () => {
+        // A bundle parent whose only backordered line is its child. With the experiment off the
+        // child is stripped from display, so the backorder toggle would have nothing to show.
+        const hiddenBundleChildBackordered = {
+            customItems: [],
+            physicalItems: [
+                { ...getPhysicalItem(), id: '666' },
+                {
+                    ...getPhysicalItem(),
+                    id: '777',
+                    parentId: '666',
+                    stockPosition: { quantityBackordered: 2 },
+                },
+            ],
+            digitalItems: [],
+            giftCertificates: [],
+        };
+
+        it('renders the toggle on desktop when the bundle experiment is off', () => {
+            renderOrderSummaryItems({
+                displayLineItemsCount: true,
+                items: backorderItems,
+            });
+
+            expect(screen.getByTestId('cart-backorder-link')).toBeInTheDocument();
+        });
+
+        it('hides the toggle on the mobile cart modal when the bundle experiment is off', () => {
+            renderOrderSummaryItems({
+                displayLineItemsCount: false,
+                items: backorderItems,
+            });
+
+            expect(screen.queryByTestId('cart-backorder-link')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('cart-count-total')).not.toBeInTheDocument();
+        });
+
+        it('hides the toggle on the mobile cart modal when only hidden bundle children are backordered (experiment off)', () => {
+            renderOrderSummaryItems({
+                displayLineItemsCount: false,
+                items: hiddenBundleChildBackordered,
+            });
+
+            expect(screen.queryByTestId('cart-backorder-link')).not.toBeInTheDocument();
+        });
+
+        it('renders the toggle on the mobile cart modal when the bundle experiment is on', () => {
+            enableBundleExperiment();
+
             renderOrderSummaryItems({
                 displayLineItemsCount: false,
                 items: backorderItems,
@@ -195,6 +265,9 @@ describe('OrderSummaryItems', () => {
         });
 
         it('persists the selection when the component is remounted across the breakpoint', async () => {
+            // The mobile re-mount only shows the toggle while the bundle experiment is on.
+            enableBundleExperiment();
+
             const { unmount } = renderOrderSummaryItems({
                 displayLineItemsCount: true,
                 items: backorderItems,
@@ -218,29 +291,6 @@ describe('OrderSummaryItems', () => {
     });
 
     describe('backorder details for bundle items (pick-list experiment enabled)', () => {
-        const enableBundleExperiment = () => {
-            const config = getStoreConfig();
-
-            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
-                ...config,
-                checkoutSettings: {
-                    ...config.checkoutSettings,
-                    features: {
-                        ...config.checkoutSettings.features,
-                        'BACK-425.update_bundle_item_ux': true,
-                    },
-                },
-                inventorySettings: {
-                    showQuantityOnBackorder: true,
-                    showBackorderMessage: true,
-                    showQuantityOnHand: false,
-                    showBackorderAvailabilityPrompt: false,
-                    backorderAvailabilityPrompt: null,
-                    shouldDisplayBackorderMessagesOnStorefront: true,
-                },
-            });
-        };
-
         const bundleProps: OrderSummaryItemsProps = {
             displayLineItemsCount: true,
             items: {

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -1,5 +1,4 @@
 import { type CheckoutService, createCheckoutService } from '@bigcommerce/checkout-sdk';
-import { expect } from '@playwright/test';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -19,7 +18,10 @@ import {
 } from '../cart/lineItem.mock';
 import { getStoreConfig } from '../config/config.mock';
 
-import OrderSummaryItems, { type OrderSummaryItemsProps } from './OrderSummaryItems';
+import OrderSummaryItems, {
+    type OrderSummaryItemsProps,
+    resetBackorderDetailsExpanded,
+} from './OrderSummaryItems';
 
 describe('OrderSummaryItems', () => {
     let checkoutService: CheckoutService;
@@ -50,6 +52,12 @@ describe('OrderSummaryItems', () => {
                 shouldDisplayBackorderMessagesOnStorefront: true,
             },
         });
+    });
+
+    afterEach(() => {
+        // The toggle selection is held in a module-scoped value so it can survive the
+        // responsive remount; reset it between tests to avoid leaking state.
+        resetBackorderDetailsExpanded();
     });
 
     describe('backorder quantity text', () => {
@@ -151,6 +159,136 @@ describe('OrderSummaryItems', () => {
             });
 
             expect(screen.queryByTestId('cart-backorder-link')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('backorder details toggle parity and persistence', () => {
+        const backorderItems = {
+            customItems: [],
+            physicalItems: [
+                {
+                    ...getPhysicalItem(),
+                    stockPosition: { quantityBackordered: 3 },
+                },
+            ],
+            digitalItems: [],
+            giftCertificates: [],
+        };
+
+        it('renders the toggle on mobile even though the line items count is hidden', () => {
+            renderOrderSummaryItems({
+                displayLineItemsCount: false,
+                items: backorderItems,
+            });
+
+            expect(screen.getByTestId('cart-backorder-link')).toBeInTheDocument();
+            expect(screen.queryByTestId('cart-count-total')).not.toBeInTheDocument();
+        });
+
+        it('defaults to off on a fresh mount', () => {
+            renderOrderSummaryItems({
+                displayLineItemsCount: true,
+                items: backorderItems,
+            });
+
+            expect(screen.getByRole('switch')).not.toBeChecked();
+        });
+
+        it('persists the selection when the component is remounted across the breakpoint', async () => {
+            const { unmount } = renderOrderSummaryItems({
+                displayLineItemsCount: true,
+                items: backorderItems,
+            });
+
+            await userEvent.click(screen.getByRole('switch'));
+
+            expect(screen.getByRole('switch')).toBeChecked();
+
+            // Simulate the MobileView breakpoint swap: the current subtree unmounts and a
+            // fresh instance (here the mobile variant) mounts in its place.
+            unmount();
+
+            renderOrderSummaryItems({
+                displayLineItemsCount: false,
+                items: backorderItems,
+            });
+
+            expect(screen.getByRole('switch')).toBeChecked();
+        });
+    });
+
+    describe('backorder details for bundle items (pick-list experiment enabled)', () => {
+        const enableBundleExperiment = () => {
+            const config = getStoreConfig();
+
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                ...config,
+                checkoutSettings: {
+                    ...config.checkoutSettings,
+                    features: {
+                        ...config.checkoutSettings.features,
+                        'BACK-425.update_bundle_item_ux': true,
+                    },
+                },
+                inventorySettings: {
+                    showQuantityOnBackorder: true,
+                    showBackorderMessage: true,
+                    showQuantityOnHand: false,
+                    showBackorderAvailabilityPrompt: false,
+                    backorderAvailabilityPrompt: null,
+                    shouldDisplayBackorderMessagesOnStorefront: true,
+                },
+            });
+        };
+
+        const bundleProps: OrderSummaryItemsProps = {
+            displayLineItemsCount: true,
+            items: {
+                customItems: [],
+                physicalItems: [
+                    { ...getPhysicalItem(), id: '666' },
+                    {
+                        ...getPhysicalItem(),
+                        id: '777',
+                        name: 'Bundled Hat',
+                        parentId: '666',
+                        stockPosition: {
+                            quantityBackordered: 2,
+                            quantityOnHand: 3,
+                            quantityOutOfStock: 0,
+                            backorderMessage: 'Ships in 5 days',
+                        },
+                    },
+                ],
+                digitalItems: [],
+                giftCertificates: [],
+            },
+        };
+
+        it('renders the bundled child nested under its parent', () => {
+            enableBundleExperiment();
+
+            renderOrderSummaryItems(bundleProps);
+
+            expect(screen.getByTestId('cart-item-bundled-item-name')).toHaveTextContent(
+                'Bundled Hat',
+            );
+        });
+
+        it('shows the bundled child backorder details when the toggle is turned on', async () => {
+            enableBundleExperiment();
+
+            renderOrderSummaryItems(bundleProps);
+
+            // Collapsed by default — the backorder line is not mounted yet.
+            expect(screen.queryByTestId('cart-item-backorder-qty')).not.toBeInTheDocument();
+
+            await userEvent.click(screen.getByTestId('cart-backorder-link'));
+
+            expect(screen.getByTestId('cart-item-backorder-qty')).toBeInTheDocument();
+            expect(screen.getByTestId('cart-item-backorder-message')).toHaveTextContent(
+                'Ships in 5 days',
+            );
         });
     });
 

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -55,6 +55,8 @@ describe('OrderSummaryItems', () => {
                 showQuantityOnHand: false,
                 showBackorderAvailabilityPrompt: false,
                 backorderAvailabilityPrompt: null,
+                showDefaultShippingExpectationPrompt: false,
+                defaultShippingExpectationPrompt: null,
                 shouldDisplayBackorderMessagesOnStorefront: true,
             },
         });
@@ -72,6 +74,8 @@ describe('OrderSummaryItems', () => {
                 showQuantityOnHand: false,
                 showBackorderAvailabilityPrompt: false,
                 backorderAvailabilityPrompt: null,
+                showDefaultShippingExpectationPrompt: false,
+                defaultShippingExpectationPrompt: null,
                 shouldDisplayBackorderMessagesOnStorefront: true,
             },
         });
@@ -227,6 +231,7 @@ describe('OrderSummaryItems', () => {
         it('hides the toggle on the mobile cart modal when the bundle experiment is off', () => {
             renderOrderSummaryItems({
                 displayLineItemsCount: false,
+                isMobileCartModal: true,
                 items: backorderItems,
             });
 
@@ -237,6 +242,7 @@ describe('OrderSummaryItems', () => {
         it('hides the toggle on the mobile cart modal when only hidden bundle children are backordered (experiment off)', () => {
             renderOrderSummaryItems({
                 displayLineItemsCount: false,
+                isMobileCartModal: true,
                 items: hiddenBundleChildBackordered,
             });
 
@@ -248,6 +254,7 @@ describe('OrderSummaryItems', () => {
 
             renderOrderSummaryItems({
                 displayLineItemsCount: false,
+                isMobileCartModal: true,
                 items: backorderItems,
             });
 
@@ -283,6 +290,7 @@ describe('OrderSummaryItems', () => {
 
             renderOrderSummaryItems({
                 displayLineItemsCount: false,
+                isMobileCartModal: true,
                 items: backorderItems,
             });
 

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -296,6 +296,32 @@ describe('OrderSummaryItems', () => {
 
             expect(screen.getByRole('switch')).toBeChecked();
         });
+
+        it('keeps line item details collapsed on the gated mobile modal even if previously expanded', async () => {
+            // Turn the toggle on where it is available (desktop) so the module-scoped selection
+            // persists as expanded.
+            const { unmount } = renderOrderSummaryItems({
+                displayLineItemsCount: true,
+                items: backorderItems,
+            });
+
+            await userEvent.click(screen.getByRole('switch'));
+
+            expect(screen.getByTestId('cart-item-backorder-qty')).toBeInTheDocument();
+
+            unmount();
+
+            // Mobile cart modal with the experiment off: the toggle is gated away, so the persisted
+            // selection must NOT expand the line item details.
+            renderOrderSummaryItems({
+                displayLineItemsCount: false,
+                isMobileCartModal: true,
+                items: backorderItems,
+            });
+
+            expect(screen.queryByTestId('cart-backorder-link')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('cart-item-backorder-qty')).not.toBeInTheDocument();
+        });
     });
 
     describe('backorder details for bundle items (pick-list experiment enabled)', () => {

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -31,12 +31,7 @@ import mapFromPhysical from './mapFromPhysical';
 import OrderSummaryItem from './OrderSummaryItem';
 import { removeAndBundleItemsTogether, removeBundledItems } from './removeBundledItems';
 
-// The backorder-details toggle must survive the responsive remount (desktop/mobile
-// breakpoint swap unmounts and remounts the order summary subtree) and stay consistent
-// between the desktop and mobile instances. Because <MobileView> renders mutually
-// exclusive subtrees, only one OrderSummaryItems is mounted at a time, so a module-scoped
-// value written on toggle and read on mount is sufficient. It re-initializes to OFF on a
-// full page reload, which matches the requirement of persisting across resize only.
+// Module-scoped to survive the responsive remount. Safe as MobileView mounts only one instance at a time.
 let backorderDetailsExpanded = false;
 
 const getBackorderDetailsExpanded = (): boolean => backorderDetailsExpanded;

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -218,11 +218,19 @@ const OrderSummaryItems = ({
         !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
         (!!config?.inventorySettings?.showQuantityOnBackorder ||
             !!config?.inventorySettings?.showBackorderMessage);
-    const showBackorderToggle = shouldDisplayBackorderDetails && backorderCount > 0;
-
     const pickListExperimentEnabled = config
         ? isExperimentEnabled(config.checkoutSettings, 'BACK-425.update_bundle_item_ux', false)
         : false;
+
+    // The item-count heading is hidden only in the mobile cart modal. There, bundle children are
+    // not rendered while the bundle experiment is off, so gate the backorder toggle behind the
+    // experiment to stop it appearing when only hidden bundle children are backordered.
+    const isMobileCartModal = !displayLineItemsCount;
+
+    const showBackorderToggle =
+        shouldDisplayBackorderDetails &&
+        backorderCount > 0 &&
+        (!isMobileCartModal || pickListExperimentEnabled);
 
     const { nonBundledItems, bundleItemsMap } = pickListExperimentEnabled
         ? removeAndBundleItemsTogether(items)

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -36,12 +36,8 @@ let backorderDetailsExpanded = false;
 
 const getBackorderDetailsExpanded = (): boolean => backorderDetailsExpanded;
 
-const setBackorderDetailsExpanded = (value: boolean): void => {
+export const setBackorderDetailsExpanded = (value: boolean): void => {
     backorderDetailsExpanded = value;
-};
-
-export const resetBackorderDetailsExpanded = (): void => {
-    setBackorderDetailsExpanded(false);
 };
 
 interface AnimatedProductItemProps {

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -227,6 +227,11 @@ const OrderSummaryItems = ({
         backorderCount > 0 &&
         (!isMobileCartModal || pickListExperimentEnabled);
 
+    // Only expand line-item backorder details when the toggle is actually available; otherwise the
+    // persisted (module-scoped) selection could expand details on a surface where the toggle is
+    // hidden (e.g. the mobile cart modal with the bundle experiment off).
+    const expandBackorderDetails = showBackorderToggle && showBackorderDetails;
+
     const { nonBundledItems, bundleItemsMap } = pickListExperimentEnabled
         ? removeAndBundleItemsTogether(items)
         : { nonBundledItems: removeBundledItems(items), bundleItemsMap: undefined };
@@ -262,7 +267,7 @@ const OrderSummaryItems = ({
                 isExpanded={isExpanded}
                 items={nonBundledItems}
                 pickListExperimentEnabled={pickListExperimentEnabled}
-                showBackorderDetails={showBackorderDetails}
+                showBackorderDetails={expandBackorderDetails}
             />
 
             {shouldShowActions && <CartActions isExpanded={isExpanded} onToggle={handleToggle} />}

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -78,6 +78,7 @@ const COLLAPSED_ITEMS_LIMIT_SMALL_SCREEN = 3;
 export interface OrderSummaryItemsProps {
     displayLineItemsCount: boolean;
     items: LineItemMap;
+    isMobileCartModal?: boolean;
 }
 
 const SummaryHeading = ({
@@ -193,6 +194,7 @@ const CartActions = ({
 const OrderSummaryItems = ({
     displayLineItemsCount = true,
     items,
+    isMobileCartModal = false,
 }: OrderSummaryItemsProps): ReactElement => {
     const [isExpanded, setIsExpanded] = useState(false);
     const [showBackorderDetails, setShowBackorderDetails] = useState(getBackorderDetailsExpanded);
@@ -217,13 +219,13 @@ const OrderSummaryItems = ({
         ? isExperimentEnabled(config.checkoutSettings, 'BACK-425.update_bundle_item_ux', false)
         : false;
 
-    // The item-count heading is hidden only in the mobile cart modal, where bundle children are
-    // not rendered while the bundle experiment is off. Gate the backorder toggle behind the
-    // experiment there so it can't appear when only hidden bundle children are backordered.
+    // On the mobile cart modal, bundle children are not rendered while the bundle experiment is
+    // off, so gate the backorder toggle behind the experiment there to stop it appearing when
+    // only hidden bundle children are backordered.
     const showBackorderToggle =
         shouldDisplayBackorderDetails &&
         backorderCount > 0 &&
-        (displayLineItemsCount || pickListExperimentEnabled);
+        (!isMobileCartModal || pickListExperimentEnabled);
 
     const { nonBundledItems, bundleItemsMap } = pickListExperimentEnabled
         ? removeAndBundleItemsTogether(items)

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -1,4 +1,5 @@
 import { type DigitalItem, type LineItemMap, type PhysicalItem } from '@bigcommerce/checkout-sdk';
+import classNames from 'classnames';
 import React, {
     type FunctionComponent,
     type ReactElement,
@@ -29,6 +30,24 @@ import mapFromGiftCertificate from './mapFromGiftCertificate';
 import mapFromPhysical from './mapFromPhysical';
 import OrderSummaryItem from './OrderSummaryItem';
 import { removeAndBundleItemsTogether, removeBundledItems } from './removeBundledItems';
+
+// The backorder-details toggle must survive the responsive remount (desktop/mobile
+// breakpoint swap unmounts and remounts the order summary subtree) and stay consistent
+// between the desktop and mobile instances. Because <MobileView> renders mutually
+// exclusive subtrees, only one OrderSummaryItems is mounted at a time, so a module-scoped
+// value written on toggle and read on mount is sufficient. It re-initializes to OFF on a
+// full page reload, which matches the requirement of persisting across resize only.
+let backorderDetailsExpanded = false;
+
+const getBackorderDetailsExpanded = (): boolean => backorderDetailsExpanded;
+
+const setBackorderDetailsExpanded = (value: boolean): void => {
+    backorderDetailsExpanded = value;
+};
+
+export const resetBackorderDetailsExpanded = (): void => {
+    backorderDetailsExpanded = false;
+};
 
 interface AnimatedProductItemProps {
     children: ReactNode;
@@ -66,30 +85,25 @@ export interface OrderSummaryItemsProps {
     items: LineItemMap;
 }
 
-const ItemCount = ({
-    items,
+const SummaryHeading = ({
+    displayLineItemsCount,
     nonBundledItems,
     showBackorderDetails,
-    setShowBackorderDetails,
+    showBackorderToggle,
+    toggleBackorderDetails,
 }: {
-    items: LineItemMap;
+    displayLineItemsCount: boolean;
     nonBundledItems: LineItemMap;
-    setShowBackorderDetails: React.Dispatch<React.SetStateAction<boolean>>;
     showBackorderDetails: boolean;
-}): ReactElement => {
-    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
-    const handleBackorderToggle = useCallback(
-        () => setShowBackorderDetails((prev) => !prev),
-        [setShowBackorderDetails],
-    );
-    const backorderCount = getBackorderCount(items);
-    const shouldDisplayBackorderDetails =
-        !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
-        (!!config?.inventorySettings?.showQuantityOnBackorder ||
-            !!config?.inventorySettings?.showBackorderMessage);
-
-    return (
-        <div className="cart-section-heading-container">
+    showBackorderToggle: boolean;
+    toggleBackorderDetails(): void;
+}): ReactElement => (
+    <div
+        className={classNames('cart-section-heading-container', {
+            'cart-section-heading-container--switch-only': !displayLineItemsCount,
+        })}
+    >
+        {displayLineItemsCount && (
             <h3
                 className="cart-section-heading optimizedCheckout-contentPrimary body-medium"
                 data-test="cart-count-total"
@@ -99,17 +113,17 @@ const ItemCount = ({
                     id="cart.item_count_text"
                 />
             </h3>
-            {shouldDisplayBackorderDetails && backorderCount > 0 && (
-                <Switch
-                    checked={showBackorderDetails}
-                    label={<TranslatedString id="cart.backorder_details" />}
-                    onChange={handleBackorderToggle}
-                    testId="cart-backorder-link"
-                />
-            )}
-        </div>
-    );
-};
+        )}
+        {showBackorderToggle && (
+            <Switch
+                checked={showBackorderDetails}
+                label={<TranslatedString id="cart.backorder_details" />}
+                onChange={toggleBackorderDetails}
+                testId="cart-backorder-link"
+            />
+        )}
+    </div>
+);
 
 const ProductList = ({
     items,
@@ -186,8 +200,25 @@ const OrderSummaryItems = ({
     items,
 }: OrderSummaryItemsProps): ReactElement => {
     const [isExpanded, setIsExpanded] = useState(false);
-    const [showBackorderDetails, setShowBackorderDetails] = useState(false);
+    const [showBackorderDetails, setShowBackorderDetails] = useState(getBackorderDetailsExpanded);
     const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
+
+    const toggleBackorderDetails = useCallback(() => {
+        setShowBackorderDetails((prev) => {
+            const next = !prev;
+
+            setBackorderDetailsExpanded(next);
+
+            return next;
+        });
+    }, []);
+
+    const backorderCount = getBackorderCount(items);
+    const shouldDisplayBackorderDetails =
+        !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
+        (!!config?.inventorySettings?.showQuantityOnBackorder ||
+            !!config?.inventorySettings?.showBackorderMessage);
+    const showBackorderToggle = shouldDisplayBackorderDetails && backorderCount > 0;
 
     const pickListExperimentEnabled = config
         ? isExperimentEnabled(config.checkoutSettings, 'BACK-425.update_bundle_item_ux', false)
@@ -213,12 +244,13 @@ const OrderSummaryItems = ({
 
     return (
         <>
-            {displayLineItemsCount && (
-                <ItemCount
-                    items={items}
+            {(displayLineItemsCount || showBackorderToggle) && (
+                <SummaryHeading
+                    displayLineItemsCount={displayLineItemsCount}
                     nonBundledItems={nonBundledItems}
-                    setShowBackorderDetails={setShowBackorderDetails}
                     showBackorderDetails={showBackorderDetails}
+                    showBackorderToggle={showBackorderToggle}
+                    toggleBackorderDetails={toggleBackorderDetails}
                 />
             )}
             <ProductList

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -46,7 +46,7 @@ const setBackorderDetailsExpanded = (value: boolean): void => {
 };
 
 export const resetBackorderDetailsExpanded = (): void => {
-    backorderDetailsExpanded = false;
+    setBackorderDetailsExpanded(false);
 };
 
 interface AnimatedProductItemProps {
@@ -222,15 +222,13 @@ const OrderSummaryItems = ({
         ? isExperimentEnabled(config.checkoutSettings, 'BACK-425.update_bundle_item_ux', false)
         : false;
 
-    // The item-count heading is hidden only in the mobile cart modal. There, bundle children are
-    // not rendered while the bundle experiment is off, so gate the backorder toggle behind the
-    // experiment to stop it appearing when only hidden bundle children are backordered.
-    const isMobileCartModal = !displayLineItemsCount;
-
+    // The item-count heading is hidden only in the mobile cart modal, where bundle children are
+    // not rendered while the bundle experiment is off. Gate the backorder toggle behind the
+    // experiment there so it can't appear when only hidden bundle children are backordered.
     const showBackorderToggle =
         shouldDisplayBackorderDetails &&
         backorderCount > 0 &&
-        (!isMobileCartModal || pickListExperimentEnabled);
+        (displayLineItemsCount || pickListExperimentEnabled);
 
     const { nonBundledItems, bundleItemsMap } = pickListExperimentEnabled
         ? removeAndBundleItemsTogether(items)

--- a/packages/core/src/app/order/OrderSummaryModal.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.test.tsx
@@ -11,6 +11,7 @@ import { getStoreConfig } from '../config/config.mock';
 
 import mapToOrderSummarySubtotalsProps from './mapToOrderSummarySubtotalsProps';
 import { getOrder } from './orders.mock';
+import { resetBackorderDetailsExpanded } from './OrderSummaryItems';
 import OrderSummaryModal from './OrderSummaryModal';
 
 let order: Order;
@@ -25,6 +26,11 @@ describe('OrderSummaryModal', () => {
         order = getOrder();
 
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+    });
+
+    afterEach(() => {
+        // The backorder toggle selection is module-scoped; reset it so it can't leak between tests.
+        resetBackorderDetailsExpanded();
     });
 
     it('renders order summary', () => {
@@ -128,6 +134,8 @@ describe('OrderSummaryModal', () => {
                     showQuantityOnHand: false,
                     showBackorderAvailabilityPrompt: false,
                     backorderAvailabilityPrompt: null,
+                    showDefaultShippingExpectationPrompt: false,
+                    defaultShippingExpectationPrompt: null,
                     shouldDisplayBackorderMessagesOnStorefront: true,
                 },
             });

--- a/packages/core/src/app/order/OrderSummaryModal.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.test.tsx
@@ -1,11 +1,12 @@
 import { createCheckoutService, type Order } from '@bigcommerce/checkout-sdk';
 import React from 'react';
 
-import { LocaleProvider } from '@bigcommerce/checkout/contexts';
-import { getLanguageService } from '@bigcommerce/checkout/locale';
+import { CheckoutProvider, LocaleContext, LocaleProvider } from '@bigcommerce/checkout/contexts';
+import { createLocaleContext, getLanguageService } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 import { SMALL_SCREEN_MAX_WIDTH } from '@bigcommerce/checkout/ui';
 
+import { getPhysicalItem } from '../cart/lineItem.mock';
 import { getStoreConfig } from '../config/config.mock';
 
 import mapToOrderSummarySubtotalsProps from './mapToOrderSummarySubtotalsProps';
@@ -78,6 +79,113 @@ describe('OrderSummaryModal', () => {
                 }),
             ).toBeInTheDocument();
             expect(screen.getByText('Tax Included in Total:')).toBeInTheDocument();
+        });
+    });
+
+    describe('when the bundle pick-list experiment is enabled', () => {
+        const localeContext = createLocaleContext(getStoreConfig());
+
+        // Raw line items, exactly as the mobile drawer now passes them through: a bundle
+        // parent plus a backordered child carrying a parentId. Before the fix the drawer
+        // pre-stripped the child via removeBundledItems, so it never reached this point.
+        const bundleItems = {
+            customItems: [],
+            physicalItems: [
+                { ...getPhysicalItem(), id: '666', quantity: 1 },
+                {
+                    ...getPhysicalItem(),
+                    id: '777',
+                    name: 'Bundled Hat',
+                    parentId: '666',
+                    quantity: 1,
+                    stockPosition: {
+                        quantityBackordered: 2,
+                        quantityOnHand: 3,
+                        quantityOutOfStock: 0,
+                        backorderMessage: 'Ships in 5 days',
+                    },
+                },
+            ],
+            digitalItems: [],
+            giftCertificates: [],
+        };
+
+        beforeEach(() => {
+            const config = getStoreConfig();
+
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                ...config,
+                checkoutSettings: {
+                    ...config.checkoutSettings,
+                    features: {
+                        ...config.checkoutSettings.features,
+                        'BACK-425.update_bundle_item_ux': true,
+                    },
+                },
+                inventorySettings: {
+                    showQuantityOnBackorder: true,
+                    showBackorderMessage: true,
+                    showQuantityOnHand: false,
+                    showBackorderAvailabilityPrompt: false,
+                    backorderAvailabilityPrompt: null,
+                    shouldDisplayBackorderMessagesOnStorefront: true,
+                },
+            });
+        });
+
+        const renderModal = () =>
+            render(
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <LocaleContext.Provider value={localeContext}>
+                        <OrderSummaryModal
+                            {...mapToOrderSummarySubtotalsProps(getOrder(), true)}
+                            isOpen={true}
+                            items={bundleItems}
+                            shopperCurrency={getStoreConfig().shopperCurrency}
+                            storeCurrency={getStoreConfig().currency}
+                            total={getOrder().orderAmount}
+                        />
+                    </LocaleContext.Provider>
+                </CheckoutProvider>,
+            );
+
+        it('groups raw bundle children and nests them under the parent', () => {
+            renderModal();
+
+            expect(screen.getByTestId('cart-item-bundled-item-name')).toHaveTextContent(
+                'Bundled Hat',
+            );
+        });
+
+        it('does not render the bundle child as a separate top-level line item', () => {
+            renderModal();
+
+            expect(
+                screen.queryByRole('heading', { name: '1 x Bundled Hat' }),
+            ).not.toBeInTheDocument();
+        });
+
+        it('keeps the bundle child hidden when the experiment is disabled (gating intact)', () => {
+            const config = getStoreConfig();
+
+            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+                ...config,
+                checkoutSettings: {
+                    ...config.checkoutSettings,
+                    features: {
+                        ...config.checkoutSettings.features,
+                        'BACK-425.update_bundle_item_ux': false,
+                    },
+                },
+            });
+
+            renderModal();
+
+            // Experiment off: the child must neither nest nor appear as its own line item.
+            expect(screen.queryByTestId('cart-item-bundled-item-name')).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole('heading', { name: '1 x Bundled Hat' }),
+            ).not.toBeInTheDocument();
         });
     });
 

--- a/packages/core/src/app/order/OrderSummaryModal.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.test.tsx
@@ -11,7 +11,7 @@ import { getStoreConfig } from '../config/config.mock';
 
 import mapToOrderSummarySubtotalsProps from './mapToOrderSummarySubtotalsProps';
 import { getOrder } from './orders.mock';
-import { resetBackorderDetailsExpanded } from './OrderSummaryItems';
+import { setBackorderDetailsExpanded } from './OrderSummaryItems';
 import OrderSummaryModal from './OrderSummaryModal';
 
 let order: Order;
@@ -30,7 +30,7 @@ describe('OrderSummaryModal', () => {
 
     afterEach(() => {
         // The backorder toggle selection is module-scoped; reset it so it can't leak between tests.
-        resetBackorderDetailsExpanded();
+        setBackorderDetailsExpanded(false);
     });
 
     it('renders order summary', () => {

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -27,6 +27,7 @@ import OrderSummaryPrice from './OrderSummaryPrice';
 import OrderSummarySection from './OrderSummarySection';
 import OrderSummarySubtotals, { type OrderSummarySubtotalsProps } from './OrderSummarySubtotals';
 import OrderSummaryTotal from './OrderSummaryTotal';
+import { removeBundledItems } from './removeBundledItems';
 
 export interface OrderSummaryDrawerProps {
     children: ReactNode;
@@ -93,10 +94,15 @@ const OrderSummaryModal: FunctionComponent<
     const displayInclusiveTax = isTaxIncluded && taxes && taxes.length > 0;
     const isTotalDiscountVisible = Boolean(totalDiscount && totalDiscount > 0);
 
+    // The item list (OrderSummaryItems) receives the raw line items so it can do its own
+    // experiment-aware bundle grouping. The subheader count, however, must exclude bundle
+    // children so the "X items" total matches the desktop summary.
+    const nonBundledItems = removeBundledItems(items);
+
     const subHeaderText = (
         <OrderModalSummarySubheader
             amountWithCurrency={<ShopperCurrency amount={total} />}
-            items={items}
+            items={nonBundledItems}
             shopperCurrencyCode={shopperCurrency.code}
             storeCurrencyCode={storeCurrency.code}
         />

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -136,7 +136,7 @@ const OrderSummaryModal: FunctionComponent<
             onRequestClose={onRequestClose}
         >
             <OrderSummarySection>
-                <OrderSummaryItems displayLineItemsCount={false} items={items} />
+                <OrderSummaryItems displayLineItemsCount={false} isMobileCartModal items={items} />
             </OrderSummarySection>
             {isMultiCouponEnabledForCheckout || isMultiCouponEnabledForOrder ? (
                 <NewOrderSummarySubtotals

--- a/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
+++ b/packages/core/src/scss/components/checkout/checkoutAddress/_checkoutAddress.scss
@@ -27,4 +27,3 @@
     font-weight: fontWeight("normal");
     margin-bottom: spacing("base");
 }
-

--- a/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
+++ b/packages/core/src/scss/components/checkout/checkoutCart/_checkoutCart.scss
@@ -74,6 +74,10 @@
     justify-content: space-between;
     margin-bottom: spacing("single");
 
+    &--switch-only {
+        justify-content: flex-end;
+    }
+
     .cart-section-heading {
         margin-bottom: 0;
     }


### PR DESCRIPTION
## What/Why?
Display backorder details for mobile modals

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast


https://github.com/user-attachments/assets/26dd974b-ff30-4675-8b32-9c908c6d12d7



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout order-summary UX changes affect mobile modals, bundle experiment gating, and shared module-scoped backorder toggle state across breakpoints; behavior is heavily tested but still customer-facing cart UI.
> 
> **Overview**
> Enables the **Backorder details** switch in the mobile cart modal (when inventory settings allow) and wires it so shoppers can expand per-line backorder quantity and messages, including on **bundled** children when `BACK-425.update_bundle_item_ux` is on.
> 
> **`OrderSummaryItems`** now treats the heading as optional item count plus an optional toggle: the modal passes `isMobileCartModal` and hides the count while still showing the switch when appropriate. On mobile, the toggle is shown only if the bundle pick-list experiment is enabled (so a backorder on a hidden bundle child does not surface a useless switch). Toggle state is stored in a **module-scoped** flag so it survives responsive remounts; line items only expand when the toggle is actually rendered, so a desktop “on” selection does not leak expanded UI on a gated mobile modal.
> 
> **`OrderSummaryDrawer`** forwards **raw** line items into the modal instead of pre-stripped bundles; **`OrderSummaryModal`** still uses `removeBundledItems` for the header item count only. Styling adds `cart-section-heading-container--switch-only` to right-align the switch when there is no heading count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ad74ac9076555b705fb14d6ca48f0d055b185c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->