### PR TITLE
chore(checkout): CHECKOUT-100092 fallback to credit card component when vaulted instrument request fails

### DIFF
--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.test.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.test.tsx
@@ -337,6 +337,35 @@ describe('CreditCardPaymentMethod', () => {
             ).toBeInTheDocument();
         });
 
+        it('silently falls back to the card form when loading instruments fails with a 40x', async () => {
+            jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+            jest.spyOn(checkoutService, 'loadInstruments').mockRejectedValue({ status: 401 });
+
+            render(<CreditCardPaymentMethodTest {...defaultProps} method={vaultedMethod} />);
+
+            expect(
+                await screen.findByRole('textbox', { name: 'Credit Card Number' }),
+            ).toBeInTheDocument();
+            expect(defaultProps.onUnhandledError).not.toHaveBeenCalled();
+        });
+
+        it('mounts and calls onUnhandledError when loading instruments fails with a non-40x error', async () => {
+            const error = Object.assign(new Error('Server error'), { status: 500 });
+
+            jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue([]);
+            jest.spyOn(checkoutService, 'loadInstruments').mockRejectedValue(error);
+
+            render(<CreditCardPaymentMethodTest {...defaultProps} method={vaultedMethod} />);
+
+            expect(
+                await screen.findByRole('textbox', { name: 'Credit Card Number' }),
+            ).toBeInTheDocument();
+
+            await waitFor(() => {
+                expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(error);
+            });
+        });
+
         it('deletes the last stored instrument and shows "use new card" view', async () => {
             const instruments = getInstruments();
             const singleInstrument = [instruments[0]];

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodContainer.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodContainer.tsx
@@ -15,7 +15,13 @@ export const CreditCardPaymentMethodComponentContainer = (
 
     useEffect(() => {
         const init = async () => {
-            const { checkoutService, checkoutState, isUsingMultiShipping = false, method } = props;
+            const {
+                checkoutService,
+                checkoutState,
+                isUsingMultiShipping = false,
+                method,
+                onUnhandledError,
+            } = props;
 
             const {
                 data: { getConfig, getCustomer },
@@ -36,7 +42,17 @@ export const CreditCardPaymentMethodComponentContainer = (
             });
 
             if (isInstrumentFeatureAvailableFlag) {
-                await checkoutService.loadInstruments();
+                try {
+                    await checkoutService.loadInstruments();
+                } catch (error) {
+                    const status = (error as { status?: number })?.status;
+                    const is40x = typeof status === 'number' && status >= 400 && status < 500;
+
+                    // For a 40x (e.g. an expired vault token) fall back silently to the credit card fields
+                    if (!is40x && error instanceof Error) {
+                        onUnhandledError(error);
+                    }
+                }
             }
 
             setComponentDidMount(true);


### PR DESCRIPTION
## What/Why?

### What
When `checkoutService.loadInstruments()` fails, the credit card form now still renders so customers can complete their purchase.

- Wrapped `loadInstruments()` in a try/catch in `CreditCardPaymentMethodContainer` and ensured `setComponentDidMount(true)` always runs.
- 40x (e.g. expired/invalid vault token) → fall back silently to the card fields.
- Non-40x (5xx / network / other) → preserve existing behavior via `onUnhandledError(error)`.
- Added unit tests covering both failure paths.

### Why
The container gated all rendering behind a `componentDidMount` flag set only after `loadInstruments()` resolved. The `await` had no try/catch and `void init()` discarded the rejection, so any load failure left the container returning `null` permanently — no card form, no error, no way to pay.

This blocked everyone the vaulting feature targets, including newly registered customers with zero stored cards. The form already falls back to card fields when instruments are empty; it just never got a chance to mount. Decoupling the mount from the load result fixes that.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing


**BEFORE**

https://github.com/user-attachments/assets/f4a2afc7-2555-4eb9-a6d1-d0f263e5fb42



**AFTER**

https://github.com/user-attachments/assets/c8dfa3dd-3ee4-47ee-88e2-249345103082


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the checkout payment mount path for vaulted cards, but behavior is narrowly scoped with tests and improves payability when vault API calls fail.
> 
> **Overview**
> Fixes checkout blocking when vaulted instrument loading fails by **always mounting** the credit card UI after init, instead of leaving the container on `null` when `loadInstruments()` rejects.
> 
> In `CreditCardPaymentMethodContainer`, `loadInstruments()` is now wrapped in **try/catch**: **4xx** responses (e.g. expired vault token) **fall back silently** to manual card entry; **other failures** still invoke **`onUnhandledError`** when the rejection is an `Error`. Unit tests cover both the silent 401 path and the 500 + `onUnhandledError` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b15599f681fffcb64fd112f4ef37411b4d40bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->