### PR TITLE
feat(payment): PAYPAL-6671 added declined instrument error

### DIFF
--- a/packages/bigcommerce-payments-integration/src/components/BigCommercePaymentsPaymentMethodComponent.test.tsx
+++ b/packages/bigcommerce-payments-integration/src/components/BigCommercePaymentsPaymentMethodComponent.test.tsx
@@ -15,6 +15,7 @@ import { render } from '@testing-library/react';
 import { EventEmitter } from 'events';
 import React from 'react';
 
+import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 import { type PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 import { getPaymentFormServiceMock } from '@bigcommerce/checkout/test-mocks';
 
@@ -346,9 +347,7 @@ describe('BigCommercePaymentsPaymentMethodComponent', () => {
 
         eventEmitter.emit('onError');
 
-        expect(onUnhandledErrorMock).toHaveBeenCalledWith(
-            new Error(props.language.translate('payment.errors.instrument_declined')),
-        );
+        expect(onUnhandledErrorMock).toHaveBeenCalledWith(new InstrumentDeclinedError());
     });
 
     it('passed form validation by calling onValidate callback', async () => {

--- a/packages/bigcommerce-payments-integration/src/components/BigCommercePaymentsPaymentMethodComponent.tsx
+++ b/packages/bigcommerce-payments-integration/src/components/BigCommercePaymentsPaymentMethodComponent.tsx
@@ -15,6 +15,7 @@ import {
 } from '@bigcommerce/checkout-sdk/integrations/bigcommerce-payments';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
+import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
 
 type BigCommercePaymentsProvidersPaymentInitializeOptions =
@@ -46,7 +47,6 @@ const BigCommercePaymentsPaymentMethodComponent: FunctionComponent<
     providerOptionsData,
     children,
     currentInstrument,
-    language,
     shouldConfirmInstrument,
 }) => {
     const buttonActionsRef = useRef<ButtonActions | null>(null);
@@ -133,9 +133,7 @@ const BigCommercePaymentsPaymentMethodComponent: FunctionComponent<
                         paymentForm.disableSubmit(method, true);
 
                         if (error.message === 'INSTRUMENT_DECLINED') {
-                            onUnhandledError(
-                                new Error(language.translate('payment.errors.instrument_declined')),
-                            );
+                            onUnhandledError(new InstrumentDeclinedError());
                         } else {
                             onUnhandledError(error);
                         }

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.test.tsx
@@ -12,6 +12,7 @@ import {
     PaymentFormContext,
     type PaymentFormService,
 } from '@bigcommerce/checkout/contexts';
+import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import {
     getBraintreePaypalPaymentMethod,
@@ -118,9 +119,7 @@ describe('BraintreePaypalPaymentMethod', () => {
 
         eventEmitter.emit('onError');
 
-        expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(
-            new Error(defaultProps.language.translate('payment.errors.instrument_declined')),
-        );
+        expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(new InstrumentDeclinedError());
     });
 
     it('passed form validation by calling onValidate callback', async () => {

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -1,6 +1,7 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { createBraintreePaypalPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
+import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
 import {
@@ -45,7 +46,7 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
     const initializeBraintreePaypalPaymentMethod = useCallback(
         (defaultOptions: PaymentInitializeOptions) => {
-            const { onUnhandledError, language, method, paymentForm } = rest;
+            const { onUnhandledError, method, paymentForm } = rest;
 
             return checkoutService.initializePayment({
                 ...defaultOptions,
@@ -58,9 +59,7 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     },
                     onError: (error: Error) => {
                         if (error.message === 'INSTRUMENT_DECLINED') {
-                            onUnhandledError?.(
-                                new Error(language.translate('payment.errors.instrument_declined')),
-                            );
+                            onUnhandledError?.(new InstrumentDeclinedError());
                         } else {
                             onUnhandledError?.(error);
                         }

--- a/packages/error-handling-utils/src/InstrumentDeclinedError/InstrumentDeclinedError.ts
+++ b/packages/error-handling-utils/src/InstrumentDeclinedError/InstrumentDeclinedError.ts
@@ -1,0 +1,13 @@
+import { CustomError } from '@bigcommerce/checkout/payment-integration-api';
+import { getLanguageService } from '@bigcommerce/checkout/locale';
+
+export default class InstrumentDeclinedError extends CustomError {
+    constructor() {
+        super({
+            message: getLanguageService().translate('payment.errors.instrument_declined'),
+            name: 'INSTRUMENT_DECLINED_ERROR',
+        });
+
+        Object.setPrototypeOf(this, InstrumentDeclinedError.prototype);
+    }
+}

--- a/packages/error-handling-utils/src/index.ts
+++ b/packages/error-handling-utils/src/index.ts
@@ -8,3 +8,4 @@ export {
 } from './ErrorLogger';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as isErrorWithMessage } from './isErrorWithMessage';
+export { default as InstrumentDeclinedError } from './InstrumentDeclinedError/InstrumentDeclinedError';

--- a/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
+++ b/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.test.tsx
@@ -14,6 +14,7 @@ import { render } from '@testing-library/react';
 import { EventEmitter } from 'events';
 import React from 'react';
 
+import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 import { type PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 import { getPaymentFormServiceMock } from '@bigcommerce/checkout/test-mocks';
 
@@ -340,9 +341,7 @@ describe('PayPalCommercePaymentMethodComponent', () => {
 
         eventEmitter.emit('onError');
 
-        expect(onUnhandledErrorMock).toHaveBeenCalledWith(
-            new Error(props.language.translate('payment.errors.instrument_declined')),
-        );
+        expect(onUnhandledErrorMock).toHaveBeenCalledWith(new InstrumentDeclinedError());
     });
 
     it('passed form validation by calling onValidate callback', async () => {

--- a/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.tsx
+++ b/packages/paypal-commerce-integration/src/components/PayPalCommercePaymentMethodComponent.tsx
@@ -14,6 +14,7 @@ import {
 } from '@bigcommerce/checkout-sdk/integrations/paypal-commerce';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
+import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
 
 type PayPalCommerceProvidersPaymentInitializeOptions =
@@ -45,7 +46,6 @@ const PayPalCommercePaymentMethodComponent: FunctionComponent<
     providerOptionsData,
     children,
     currentInstrument,
-    language,
     shouldConfirmInstrument,
 }) => {
     const buttonActionsRef = useRef<ButtonActions | null>(null);
@@ -131,9 +131,7 @@ const PayPalCommercePaymentMethodComponent: FunctionComponent<
                         paymentForm.disableSubmit(method, true);
 
                         if (error.message === 'INSTRUMENT_DECLINED') {
-                            onUnhandledError(
-                                new Error(language.translate('payment.errors.instrument_declined')),
-                            );
+                            onUnhandledError(new InstrumentDeclinedError());
                         } else {
                             onUnhandledError(error);
                         }


### PR DESCRIPTION
## What/Why?
Added declined instrument error to define exactly INSTRUMENT_DECLINED error. We define this error to be able to filter it in sentry to not litter every time- as this behavior is expected and handled

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor centralizes an existing user-facing decline message without changing when it is shown; scope is limited to three payment integrations’ error handlers.
> 
> **Overview**
> Introduces **`InstrumentDeclinedError`** in `error-handling-utils` as a `CustomError` with name `INSTRUMENT_DECLINED_ERROR` and the localized `payment.errors.instrument_declined` message via `getLanguageService()`.
> 
> **BigCommerce Payments**, **Braintree PayPal**, and **PayPal Commerce** payment method components now map provider `onError` payloads with message `INSTRUMENT_DECLINED` to `new InstrumentDeclinedError()` instead of ad hoc `Error` instances built from each component’s `language` prop (that prop is no longer needed for this path). Unit tests were updated to assert the shared error type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aa4b067c49c9ec84138e6dbf24b5287ce55a6f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->