### PR TITLE
fix(checkout): CHECKOUT-10139 Relax phone validation rules

### DIFF
--- a/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
@@ -216,7 +216,7 @@ describe('DynamicFormField Component', () => {
             mockIsValidNumber.mockReturnValue(false);
 
             renderMockFormField({
-                field: phoneFieldMock,
+                field: { ...phoneFieldMock, required: true },
                 isNewPhoneValidationExperimentEnabled: true,
             });
 
@@ -235,7 +235,7 @@ describe('DynamicFormField Component', () => {
             mockIsValidNumber.mockReturnValue(true);
 
             renderMockFormField({
-                field: phoneFieldMock,
+                field: { ...phoneFieldMock, required: true },
                 isNewPhoneValidationExperimentEnabled: true,
             });
 

--- a/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
@@ -13,6 +13,7 @@ import DynamicFormField from './DynamicFormField';
 
 const mockIsValidNumber = jest.fn();
 const mockSetCountry = jest.fn();
+const mockGetSelectedCountryData = jest.fn();
 
 jest.mock('@intl-tel-input/react', () => ({
     __esModule: true,
@@ -26,6 +27,7 @@ jest.mock('@intl-tel-input/react', () => ({
     >(({ inputProps, onChangeNumber, value }, ref) => {
         useImperativeHandle(ref, () => ({
             getInstance: () => ({
+                getSelectedCountryData: mockGetSelectedCountryData,
                 isValidNumber: mockIsValidNumber,
                 setCountry: mockSetCountry,
             }),
@@ -204,11 +206,13 @@ describe('DynamicFormField Component', () => {
             );
 
         beforeEach(() => {
+            mockGetSelectedCountryData.mockClear();
             mockIsValidNumber.mockClear();
             mockSetCountry.mockClear();
         });
 
         it('shows a validation error when the phone number is invalid and the experiment is enabled', async () => {
+            mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
             mockIsValidNumber.mockReturnValue(false);
 
             renderMockFormField({
@@ -227,6 +231,7 @@ describe('DynamicFormField Component', () => {
         });
 
         it('does not show a validation error when the phone number is valid', async () => {
+            mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
             mockIsValidNumber.mockReturnValue(true);
 
             renderMockFormField({

--- a/packages/ui/src/form/DynamicFormField/DynamicFormField.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormField.tsx
@@ -126,6 +126,7 @@ const DynamicFormField: FunctionComponent<DynamicFormFieldProps> = ({
                 onChange={onChange}
                 options={options}
                 placeholder={placeholder}
+                required={required}
                 selectedCountry={selectedCountry}
             />
         </div>

--- a/packages/ui/src/form/DynamicFormField/DynamicFormFieldSelector.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormFieldSelector.tsx
@@ -23,6 +23,7 @@ interface DynamicFormFieldSelectorProps {
     maxLength?: FormFieldType['maxLength'];
     isFloatingLabelEnabled?: boolean;
     isNewPhoneValidationExperimentEnabled: boolean;
+    required?: boolean;
     selectedCountry?: string;
     onChange?(value: string | string[]): void;
 }
@@ -42,6 +43,7 @@ export const DynamicFormFieldSelector: FunctionComponent<DynamicFormFieldSelecto
         maxLength,
         isFloatingLabelEnabled,
         isNewPhoneValidationExperimentEnabled,
+        required,
         selectedCountry,
         onChange,
     }) => {
@@ -101,6 +103,7 @@ export const DynamicFormFieldSelector: FunctionComponent<DynamicFormFieldSelecto
                     maxLength={maxLength || undefined}
                     name={name}
                     onChange={onChange}
+                    required={required}
                     selectedCountry={selectedCountry}
                 />
             );

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
@@ -93,10 +93,21 @@ describe('PhoneFormField', () => {
         expect(mockSetCountry).not.toHaveBeenCalled();
     });
 
-    it('does not auto-set country when a country is already selected in the input', () => {
-        mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
-
-        renderPhoneFormField({ selectedCountry: 'US' });
+    it('does not auto-set country when a value is already present', () => {
+        render(
+            <LocaleContext.Provider value={localeContextMock}>
+                <Formik initialValues={{ phone: '+15551234567' }} onSubmit={jest.fn()}>
+                    <FormProvider initialIsSubmitted>
+                        <PhoneFormField
+                            id="phone"
+                            label="Phone Number"
+                            name="phone"
+                            selectedCountry="US"
+                        />
+                    </FormProvider>
+                </Formik>
+            </LocaleContext.Provider>,
+        );
 
         expect(mockSetCountry).not.toHaveBeenCalled();
     });
@@ -150,6 +161,20 @@ describe('PhoneFormField', () => {
 
         renderPhoneFormField();
 
+        await userEvent.click(screen.getByText('Submit'));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        });
+    });
+
+    it('does not show a validation error when the field is optional', async () => {
+        mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
+        mockIsValidNumber.mockReturnValue(false);
+
+        renderPhoneFormField({ required: false });
+
+        fireEvent.change(screen.getByTestId('phone-text'), { target: { value: '123' } });
         await userEvent.click(screen.getByText('Submit'));
 
         await waitFor(() => {

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
@@ -12,6 +12,7 @@ import { PhoneFormField, type PhoneFormFieldProps } from './PhoneFormField';
 
 const mockIsValidNumber = jest.fn();
 const mockSetCountry = jest.fn();
+const mockGetSelectedCountryData = jest.fn();
 
 jest.mock('@intl-tel-input/react', () => ({
     __esModule: true,
@@ -25,6 +26,7 @@ jest.mock('@intl-tel-input/react', () => ({
     >(({ inputProps, onChangeNumber, value }, ref) => {
         useImperativeHandle(ref, () => ({
             getInstance: () => ({
+                getSelectedCountryData: mockGetSelectedCountryData,
                 isValidNumber: mockIsValidNumber,
                 setCountry: mockSetCountry,
             }),
@@ -68,6 +70,7 @@ describe('PhoneFormField', () => {
         );
 
     beforeEach(() => {
+        mockGetSelectedCountryData.mockClear();
         mockIsValidNumber.mockClear();
         mockSetCountry.mockClear();
     });
@@ -90,26 +93,16 @@ describe('PhoneFormField', () => {
         expect(mockSetCountry).not.toHaveBeenCalled();
     });
 
-    it('does not auto-set country when a value is already present', () => {
-        render(
-            <LocaleContext.Provider value={localeContextMock}>
-                <Formik initialValues={{ phone: '+15551234567' }} onSubmit={jest.fn()}>
-                    <FormProvider initialIsSubmitted>
-                        <PhoneFormField
-                            id="phone"
-                            label="Phone Number"
-                            name="phone"
-                            selectedCountry="US"
-                        />
-                    </FormProvider>
-                </Formik>
-            </LocaleContext.Provider>,
-        );
+    it('does not auto-set country when a country is already selected in the input', () => {
+        mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
+
+        renderPhoneFormField({ selectedCountry: 'US' });
 
         expect(mockSetCountry).not.toHaveBeenCalled();
     });
 
     it('shows a validation error when the phone number is invalid', async () => {
+        mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
         mockIsValidNumber.mockReturnValue(false);
 
         renderPhoneFormField();
@@ -123,6 +116,7 @@ describe('PhoneFormField', () => {
     });
 
     it('does not show a validation error when the phone number is valid', async () => {
+        mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
         mockIsValidNumber.mockReturnValue(true);
 
         renderPhoneFormField();
@@ -130,6 +124,20 @@ describe('PhoneFormField', () => {
         fireEvent.change(screen.getByTestId('phone-text'), {
             target: { value: '+15551234567' },
         });
+        await userEvent.click(screen.getByText('Submit'));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        });
+    });
+
+    it('does not show a validation error when no country is selected', async () => {
+        mockGetSelectedCountryData.mockReturnValue(null);
+        mockIsValidNumber.mockReturnValue(false);
+
+        renderPhoneFormField();
+
+        fireEvent.change(screen.getByTestId('phone-text'), { target: { value: '123' } });
         await userEvent.click(screen.getByText('Submit'));
 
         await waitFor(() => {

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
@@ -116,7 +116,7 @@ describe('PhoneFormField', () => {
         mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
         mockIsValidNumber.mockReturnValue(false);
 
-        renderPhoneFormField();
+        renderPhoneFormField({ required: true });
 
         fireEvent.change(screen.getByTestId('phone-text'), { target: { value: '123' } });
         await userEvent.click(screen.getByText('Submit'));
@@ -130,7 +130,7 @@ describe('PhoneFormField', () => {
         mockGetSelectedCountryData.mockReturnValue({ iso2: 'us' });
         mockIsValidNumber.mockReturnValue(true);
 
-        renderPhoneFormField();
+        renderPhoneFormField({ required: true });
 
         fireEvent.change(screen.getByTestId('phone-text'), {
             target: { value: '+15551234567' },

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.tsx
@@ -42,11 +42,13 @@ export const PhoneFormField: FunctionComponent<PhoneFormFieldProps> = memo(
                 }
 
                 try {
-                    const isPhoneNumberValid = intlTelInputRef.current
-                        ?.getInstance()
-                        ?.isValidNumber();
+                    const intlTelInputInstance = intlTelInputRef.current?.getInstance();
 
-                    if (value && !isPhoneNumberValid) {
+                    if (!intlTelInputInstance?.getSelectedCountryData()) {
+                        return undefined;
+                    }
+
+                    if (value && !intlTelInputInstance.isValidNumber()) {
                         return language.translate('address.phone_number_invalid_error');
                     }
                 } catch {

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.tsx
@@ -37,7 +37,7 @@ export const PhoneFormField: FunctionComponent<PhoneFormFieldProps> = memo(
 
         const validatePhone = useCallback(
             (value: string) => {
-                if (!required && !value) {
+                if (!required) {
                     return undefined;
                 }
 

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.tsx
@@ -15,6 +15,7 @@ export interface PhoneFormFieldProps {
     autocomplete?: string;
     maxLength?: number;
     isFloatingLabelEnabled?: boolean;
+    required?: boolean;
     selectedCountry?: string;
     onChange?(value: string): void;
 }
@@ -27,6 +28,7 @@ export const PhoneFormField: FunctionComponent<PhoneFormFieldProps> = memo(
         autocomplete,
         maxLength,
         isFloatingLabelEnabled,
+        required,
         selectedCountry,
         onChange,
     }) => {
@@ -35,6 +37,10 @@ export const PhoneFormField: FunctionComponent<PhoneFormFieldProps> = memo(
 
         const validatePhone = useCallback(
             (value: string) => {
+                if (!required && !value) {
+                    return undefined;
+                }
+
                 try {
                     const isPhoneNumberValid = intlTelInputRef.current
                         ?.getInstance()
@@ -50,7 +56,7 @@ export const PhoneFormField: FunctionComponent<PhoneFormFieldProps> = memo(
 
                 return undefined;
             },
-            [language],
+            [language, required],
         );
 
         const renderInput = useCallback(

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -26,20 +26,14 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
     intlTelInputRef,
 }) => {
     useEffect(() => {
-        if (!selectedCountry) {
-            return;
-        }
-
-        const intlTelInputInstance = intlTelInputRef.current?.getInstance();
-
-        if (intlTelInputInstance?.getSelectedCountryData()) {
+        if (!selectedCountry || value) {
             return;
         }
 
         const selectedCountryInIsoFormat = selectedCountry.toLowerCase();
 
         if (isIso2(selectedCountryInIsoFormat)) {
-            intlTelInputInstance?.setCountry(selectedCountryInIsoFormat);
+            intlTelInputRef.current?.getInstance()?.setCountry(selectedCountryInIsoFormat);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedCountry]);

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -26,14 +26,20 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
     intlTelInputRef,
 }) => {
     useEffect(() => {
-        if (!selectedCountry || value) {
+        if (!selectedCountry) {
+            return;
+        }
+
+        const intlTelInputInstance = intlTelInputRef.current?.getInstance();
+
+        if (intlTelInputInstance?.getSelectedCountryData()) {
             return;
         }
 
         const selectedCountryInIsoFormat = selectedCountry.toLowerCase();
 
         if (isIso2(selectedCountryInIsoFormat)) {
-            intlTelInputRef.current?.getInstance()?.setCountry(selectedCountryInIsoFormat);
+            intlTelInputInstance?.setCountry(selectedCountryInIsoFormat);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedCountry]);


### PR DESCRIPTION
## What/Why?

Relaxes phone number format validation in the new IntlTelInput phone field (behind `CHECKOUT-9019.use_new_phone_number_validation` experiment): format is now only checked when the field is **required** and **a country is selected** in the phone component. Optional phone fields and fields with no country set accept any value without triggering an invalid-number error.

We want to roll this out ASAP but we also don't want to block any existing customers. So, we decided to roll this out with relaxed rules. In the future we can come back to this and make validation more strict if required by customers.

## Rollout/Rollback

Revert the PR or set `CHECKOUT-9019.use_new_phone_number_validation` to `false`.

## Testing

New CI tests + manual testing:

No validation for optional fields (same behavior as in production right now):

https://github.com/user-attachments/assets/616b8a65-d8f5-4278-98b7-3386d6f0c1f4

Don't block users if country is unset (same behavior as in production right now for all numbers):

https://github.com/user-attachments/assets/bc394ab7-801a-487d-91a4-edca3133931e

Keep the phone validation for defined countries:

https://github.com/user-attachments/assets/92a892e9-4cfa-49b1-80d3-ba10658418ce




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout form validation behavior change only—relaxes optional/missing-country cases and should reduce false positives without touching auth or payments.
> 
> **Overview**
> Intl-tel phone format validation is **tightened to when it actually applies**: the field’s `required` flag is passed from `DynamicFormField` → `PhoneFormField`, and `validatePhone` **skips** format checks for optional fields, when **no country** is selected in the widget, and still only flags non-empty invalid numbers when required.
> 
> Required fields with a selected country continue to use `isValidNumber()` as before; tests mock `getSelectedCountryData` and cover optional, empty, and no-country cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b25782a1ad3f3d9fce276015c26d6897101735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->