### PR TITLE
feat(checkout): BACK-714 Update options and backorder layout for items

### DIFF
--- a/packages/core/src/app/order/OrderSummaryItem.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.test.tsx
@@ -114,24 +114,8 @@ describe('OrderSummaryItem', () => {
         });
     });
 
-    describe('when bundledItems are present', () => {
-        const bundledItems = [
-            {
-                id: 'b1',
-                name: 'Bundled Hat',
-                bundleLabel: 'Accessories',
-                quantityBackordered: 2,
-                quantityOnHand: 3,
-                backorderMessage: 'Ships in 5 days',
-            },
-            {
-                id: 'b2',
-                name: 'Bundled Scarf',
-                bundleLabel: 'Accessories',
-            },
-        ];
-
-        it('renders each bundled item name with its bundle label', () => {
+    describe('when productOptions include an isMainBundledItem option', () => {
+        it('renders a pick-list option name in bold', () => {
             render(
                 <OrderSummaryItem
                     orderItem={{
@@ -139,86 +123,36 @@ describe('OrderSummaryItem', () => {
                         id: 'foo',
                         name: 'Product',
                         quantity: 1,
-                        bundledItems,
+                        productOptions: [
+                            {
+                                testId: 'cart-item-product-option',
+                                content: 'Pick List: Item A',
+                                name: 'Pick List:',
+                                value: 'Item A',
+                                isMainBundledItem: true,
+                            },
+                            {
+                                testId: 'cart-item-product-option',
+                                content: 'Color: Blue',
+                                name: 'Color:',
+                                value: 'Blue',
+                                isMainBundledItem: false,
+                            },
+                        ],
                     }}
                     shouldExpandBackorderDetails={false}
                 />,
             );
 
-            const nameEls = screen.getAllByTestId('cart-item-bundled-item-name');
+            const options = screen.getAllByTestId('cart-item-product-option');
 
-            expect(nameEls).toHaveLength(2);
-            expect(nameEls[0]).toHaveTextContent('Accessories: Bundled Hat');
-            expect(nameEls[1]).toHaveTextContent('Accessories: Bundled Scarf');
-        });
-
-        it('falls back to the default bundle label when a bundled item has no bundleLabel', () => {
-            render(
-                <OrderSummaryItem
-                    orderItem={{
-                        amount: 10,
-                        id: 'foo',
-                        name: 'Product',
-                        quantity: 1,
-                        bundledItems: [{ id: 'b1', name: 'Bundled Hat' }],
-                    }}
-                    shouldExpandBackorderDetails={false}
-                />,
-            );
-
-            const nameEl = screen.getByTestId('cart-item-bundled-item-name');
-
-            expect(nameEl).toHaveTextContent('Bundle: Bundled Hat');
-            expect(nameEl).not.toHaveTextContent('Bundle::');
-        });
-
-        it('renders nothing for bundled items section when bundledItems is undefined', () => {
-            render(
-                <OrderSummaryItem
-                    orderItem={{ amount: 10, id: 'foo', name: 'Product', quantity: 1 }}
-                    shouldExpandBackorderDetails={false}
-                />,
-            );
-
-            expect(screen.queryByTestId('cart-item-bundled-item-name')).not.toBeInTheDocument();
-        });
-
-        it('renders bundled items in a <ul> element', () => {
-            render(
-                <OrderSummaryItem
-                    orderItem={{
-                        amount: 10,
-                        id: 'foo',
-                        name: 'Product',
-                        quantity: 1,
-                        bundledItems,
-                    }}
-                    shouldExpandBackorderDetails={false}
-                />,
-            );
-
-            expect(screen.getByRole('list')).toBeInTheDocument();
-        });
-
-        it('does not render the bundled items container when bundledItems is an empty array', () => {
-            render(
-                <OrderSummaryItem
-                    orderItem={{
-                        amount: 10,
-                        id: 'foo',
-                        name: 'Product',
-                        quantity: 1,
-                        bundledItems: [],
-                    }}
-                    shouldExpandBackorderDetails={false}
-                />,
-            );
-
-            expect(screen.queryByRole('list')).not.toBeInTheDocument();
+            expect(options[0].querySelector('.body-bold')).toBeInTheDocument();
+            expect(options[0]).toHaveTextContent('Pick List: Item A');
+            expect(options[1].querySelector('.body-bold')).not.toBeInTheDocument();
         });
     });
 
-    describe('when bundled items are backordered and details are expanded', () => {
+    describe('when a product option has stockPosition backorder details', () => {
         let checkoutService: CheckoutService;
 
         const renderWithConfig = (shouldExpandBackorderDetails: boolean) =>
@@ -231,14 +165,18 @@ describe('OrderSummaryItem', () => {
                                 id: 'foo',
                                 name: 'Product',
                                 quantity: 1,
-                                bundledItems: [
+                                productOptions: [
                                     {
-                                        id: 'b1',
-                                        name: 'Bundled Hat',
-                                        bundleLabel: 'Accessories',
-                                        quantityBackordered: 2,
-                                        quantityOnHand: 3,
-                                        backorderMessage: 'Ships in 5 days',
+                                        testId: 'cart-item-product-option',
+                                        content: 'Pick List: Item A',
+                                        name: 'Pick List:',
+                                        value: 'Item A',
+                                        isMainBundledItem: true,
+                                        stockPosition: {
+                                            quantityBackordered: 2,
+                                            quantityOnHand: 3,
+                                            backorderMessage: 'Ships in 5 days',
+                                        },
                                     },
                                 ],
                             }}
@@ -266,7 +204,7 @@ describe('OrderSummaryItem', () => {
             });
         });
 
-        it('renders the backorder quantity and message for the bundled child item', () => {
+        it('renders backorder quantity and message when expanded', () => {
             renderWithConfig(true);
 
             expect(screen.getByTestId('cart-item-backorder-qty')).toBeInTheDocument();
@@ -275,7 +213,7 @@ describe('OrderSummaryItem', () => {
             );
         });
 
-        it('does not render the bundled child backorder details when collapsed', () => {
+        it('does not render backorder details when collapsed', () => {
             renderWithConfig(false);
 
             expect(screen.queryByTestId('cart-item-backorder-qty')).not.toBeInTheDocument();

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -38,8 +38,8 @@ interface OrderSummaryItemProps {
 export interface OrderSummaryItemOption {
     testId: string;
     content: ReactNode;
-    name: string;
-    value: string;
+    name?: string;
+    value?: string;
     isMainBundledItem?: boolean;
     stockPosition?: {
         quantityBackordered?: number;
@@ -155,10 +155,18 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                     >
                         {productOptions.map((option, index) => (
                             <li className="product-option" data-test={option.testId} key={index}>
-                                <span className={option.isMainBundledItem ? 'body-bold' : ''}>
-                                    {option.name}
-                                </span>{' '}
-                                <span>{option.value}</span>
+                                {option.name ? (
+                                    <>
+                                        <span
+                                            className={option.isMainBundledItem ? 'body-bold' : ''}
+                                        >
+                                            {option.name}
+                                        </span>{' '}
+                                        <span>{option.value}</span>
+                                    </>
+                                ) : (
+                                    option.content
+                                )}
                                 {option.stockPosition && (
                                     <OrderSummaryItemBackorderDetails
                                         backorderMessage={option.stockPosition.backorderMessage}

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -114,8 +114,6 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
     orderItem,
     shouldExpandBackorderDetails,
 }) => {
-    console.log('orderItem', orderItem);
-
     const {
         amount,
         amountAfterDiscount,

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -38,6 +38,14 @@ interface OrderSummaryItemProps {
 export interface OrderSummaryItemOption {
     testId: string;
     content: ReactNode;
+    name: string;
+    value: string;
+    isMainBundledItem?: boolean;
+    stockPosition?: {
+        quantityBackordered?: number;
+        quantityOnHand?: number;
+        backorderMessage?: string;
+    };
 }
 
 const OrderSummaryItemBackorderDetails = ({
@@ -106,6 +114,8 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
     orderItem,
     shouldExpandBackorderDetails,
 }) => {
+    console.log('orderItem', orderItem);
+
     const {
         amount,
         amountAfterDiscount,
@@ -117,7 +127,7 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
         quantityBackordered,
         quantityOnHand,
         backorderMessage,
-        bundledItems,
+        // bundledItems,
     } = orderItem;
 
     return (
@@ -132,6 +142,12 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                     <span className="body-bold">{`${quantity} x `}</span>
                     {name}
                 </h4>
+                <OrderSummaryItemBackorderDetails
+                    backorderMessage={backorderMessage}
+                    isExpanded={shouldExpandBackorderDetails}
+                    quantityBackordered={quantityBackordered}
+                    quantityOnHand={quantityOnHand}
+                />
                 {productOptions && productOptions.length > 0 && (
                     <ul
                         className="product-options optimizedCheckout-contentSecondary sub-text-medium"
@@ -139,7 +155,20 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                     >
                         {productOptions.map((option, index) => (
                             <li className="product-option" data-test={option.testId} key={index}>
-                                {option.content}
+                                <span className={option.isMainBundledItem ? 'body-bold' : ''}>
+                                    {option.name}
+                                </span>{' '}
+                                <span>{option.value}</span>
+                                {option.stockPosition && (
+                                    <OrderSummaryItemBackorderDetails
+                                        backorderMessage={option.stockPosition.backorderMessage}
+                                        isExpanded={shouldExpandBackorderDetails}
+                                        quantityBackordered={
+                                            option.stockPosition.quantityBackordered
+                                        }
+                                        quantityOnHand={option.stockPosition.quantityOnHand}
+                                    />
+                                )}
                             </li>
                         ))}
                     </ul>
@@ -152,14 +181,8 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                         {description}
                     </div>
                 )}
-                <OrderSummaryItemBackorderDetails
-                    backorderMessage={backorderMessage}
-                    isExpanded={shouldExpandBackorderDetails}
-                    quantityBackordered={quantityBackordered}
-                    quantityOnHand={quantityOnHand}
-                />
 
-                {bundledItems && bundledItems.length > 0 && (
+                {/* {bundledItems && bundledItems.length > 0 && (
                     <ul className="bundled-items-container">
                         {bundledItems.map((item) => (
                             <li
@@ -188,7 +211,7 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                             </li>
                         ))}
                     </ul>
-                )}
+                )} */}
             </div>
 
             <div className="product-column product-actions">

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -125,7 +125,6 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
         quantityBackordered,
         quantityOnHand,
         backorderMessage,
-        // bundledItems,
     } = orderItem;
 
     return (
@@ -187,37 +186,6 @@ const OrderSummaryItem: FunctionComponent<OrderSummaryItemProps> = ({
                         {description}
                     </div>
                 )}
-
-                {/* {bundledItems && bundledItems.length > 0 && (
-                    <ul className="bundled-items-container">
-                        {bundledItems.map((item) => (
-                            <li
-                                className="bundled-item optimizedCheckout-contentSecondary sub-text-medium"
-                                key={item.id}
-                            >
-                                <div
-                                    className="bundled-item-name"
-                                    data-test="cart-item-bundled-item-name"
-                                >
-                                    <span className="body-bold">
-                                        {item.bundleLabel ? (
-                                            `${item.bundleLabel}:`
-                                        ) : (
-                                            <TranslatedString id="cart.bundled_item_label" />
-                                        )}
-                                    </span>{' '}
-                                    {item.name}
-                                </div>
-                                <OrderSummaryItemBackorderDetails
-                                    backorderMessage={item.backorderMessage}
-                                    isExpanded={shouldExpandBackorderDetails}
-                                    quantityBackordered={item.quantityBackordered}
-                                    quantityOnHand={item.quantityOnHand}
-                                />
-                            </li>
-                        ))}
-                    </ul>
-                )} */}
             </div>
 
             <div className="product-column product-actions">

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -330,12 +330,25 @@ describe('OrderSummaryItems', () => {
             items: {
                 customItems: [],
                 physicalItems: [
-                    { ...getPhysicalItem(), id: '666' },
+                    {
+                        ...getPhysicalItem(),
+                        id: '666',
+                        options: [
+                            {
+                                name: 'Pick List',
+                                nameId: 1,
+                                value: 'Bundled Hat',
+                                valueId: 3,
+                                attributeId: 'attr-picklist',
+                            },
+                        ],
+                    },
                     {
                         ...getPhysicalItem(),
                         id: '777',
                         name: 'Bundled Hat',
                         parentId: '666',
+                        addedByAttributeId: 'attr-picklist',
                         stockPosition: {
                             quantityBackordered: 2,
                             quantityOnHand: 3,
@@ -349,14 +362,17 @@ describe('OrderSummaryItems', () => {
             },
         };
 
-        it('renders the bundled child nested under its parent', () => {
+        it('renders the parent item and hides the bundle child as a separate line item', () => {
             enableBundleExperiment();
 
             renderOrderSummaryItems(bundleProps);
 
-            expect(screen.getByTestId('cart-item-bundled-item-name')).toHaveTextContent(
-                'Bundled Hat',
-            );
+            expect(
+                screen.getByRole('heading', { name: `1 x ${getPhysicalItem().name}` }),
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByRole('heading', { name: '1 x Bundled Hat' }),
+            ).not.toBeInTheDocument();
         });
 
         it('shows the bundled child backorder details when the toggle is turned on', async () => {

--- a/packages/core/src/app/order/OrderSummaryModal.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.test.tsx
@@ -157,12 +157,12 @@ describe('OrderSummaryModal', () => {
                 </CheckoutProvider>,
             );
 
-        it('groups raw bundle children and nests them under the parent', () => {
+        it('renders the bundle parent as a top-level line item', () => {
             renderModal();
 
-            expect(screen.getByTestId('cart-item-bundled-item-name')).toHaveTextContent(
-                'Bundled Hat',
-            );
+            expect(
+                screen.getByRole('heading', { name: `1 x ${getPhysicalItem().name}` }),
+            ).toBeInTheDocument();
         });
 
         it('does not render the bundle child as a separate top-level line item', () => {

--- a/packages/core/src/app/order/mapFromDigital.test.tsx
+++ b/packages/core/src/app/order/mapFromDigital.test.tsx
@@ -28,12 +28,19 @@ describe('mapFromDigital()', () => {
     });
 
     describe('with pickListExperimentEnabled', () => {
-        it('filters out options whose attributeId matches a bundled item', () => {
+        it('marks pick-list option as isMainBundledItem true with stockPosition', () => {
             const bundledChild = {
                 ...getPhysicalItem(),
                 id: '777',
+                name: 'Bundled Product',
                 parentId: '667',
                 addedByAttributeId: 'attr-picklist',
+                stockPosition: {
+                    quantityBackordered: 2,
+                    quantityOnHand: 3,
+                    quantityOutOfStock: 0,
+                    backorderMessage: 'Ships in 5 days',
+                },
             } as unknown as PhysicalItem;
 
             const item = {
@@ -66,23 +73,46 @@ describe('mapFromDigital()', () => {
                 (o) => o.testId === 'cart-item-product-option',
             );
 
-            expect(itemOptions).toHaveLength(1);
-            expect(itemOptions[0].content).toBe('Color: Red');
+            expect(itemOptions).toHaveLength(2);
+
+            const pickListOption = itemOptions.find((o) => o.name === 'Pick List Option:');
+            const colorOption = itemOptions.find((o) => o.name === 'Color:');
+
+            expect(pickListOption?.isMainBundledItem).toBe(true);
+            expect(pickListOption?.stockPosition?.quantityBackordered).toBe(2);
+            expect(pickListOption?.stockPosition?.quantityOnHand).toBe(3);
+            expect(pickListOption?.stockPosition?.backorderMessage).toBe('Ships in 5 days');
+
+            expect(colorOption?.isMainBundledItem).toBe(false);
+            expect(colorOption?.stockPosition).toBeUndefined();
         });
 
-        it('returns bundledItems with backorder details from stockPosition', () => {
+        it('preserves options without attributeId when experiment is enabled', () => {
+            const item = {
+                ...getDigitalItem(),
+                id: '667',
+                options: [
+                    { name: 'Size', nameId: 10, value: 'Large', valueId: 1 },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>();
+
+            const { productOptions = [] } = mapFromDigital(item, bundleItemsMap, true);
+            const itemOptions = productOptions.filter(
+                (o) => o.testId === 'cart-item-product-option',
+            );
+
+            expect(itemOptions).toHaveLength(1);
+            expect(itemOptions[0].isMainBundledItem).toBe(false);
+        });
+
+        it('does not return bundledItems', () => {
             const bundledChild = {
                 ...getPhysicalItem(),
                 id: '777',
-                name: 'Bundled Product',
                 parentId: '667',
                 addedByAttributeId: 'attr-picklist',
-                stockPosition: {
-                    quantityBackordered: 2,
-                    quantityOnHand: 3,
-                    quantityOutOfStock: 0,
-                    backorderMessage: 'Ships in 5 days',
-                },
             } as unknown as PhysicalItem;
 
             const item = { ...getDigitalItem(), id: '667', options: [] as LineItemOption[] };
@@ -93,59 +123,12 @@ describe('mapFromDigital()', () => {
 
             const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
 
-            expect(bundledItems).toHaveLength(1);
-            expect(bundledItems![0].id).toBe('777');
-            expect(bundledItems![0].name).toBe('Bundled Product');
-            expect(bundledItems![0].quantityBackordered).toBe(2);
-            expect(bundledItems![0].quantityOnHand).toBe(3);
-            expect(bundledItems![0].backorderMessage).toBe('Ships in 5 days');
-        });
-
-        it('returns bundledItems with bundleLabel from the matching parent option', () => {
-            const bundledChild = {
-                ...getPhysicalItem(),
-                id: '777',
-                name: 'Bundled Product',
-                parentId: '667',
-                addedByAttributeId: 'attr-picklist',
-            } as unknown as PhysicalItem;
-
-            const item = {
-                ...getDigitalItem(),
-                id: '667',
-                options: [
-                    {
-                        name: 'Pick List Option',
-                        nameId: 11,
-                        value: 'Item A',
-                        valueId: 2,
-                        attributeId: 'attr-picklist',
-                    },
-                ] as LineItemOption[],
-            };
-
-            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([
-                ['667', [bundledChild]],
-            ]);
-
-            const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
-
-            expect(bundledItems).toHaveLength(1);
-            expect(bundledItems![0].bundleLabel).toBe('Pick List Option');
-        });
-
-        it('returns undefined bundledItems when item has no children in the map', () => {
-            const item = { ...getDigitalItem(), id: '667' };
-            const bundleItemsMap = new Map<string | number, PhysicalItem[]>();
-
-            const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
-
             expect(bundledItems).toBeUndefined();
         });
     });
 
     describe('without pickListExperimentEnabled', () => {
-        it('does not filter options and returns no bundledItems', () => {
+        it('maps all options and returns no bundledItems', () => {
             const bundledChild = {
                 ...getPhysicalItem(),
                 id: '777',

--- a/packages/core/src/app/order/mapFromDigital.test.tsx
+++ b/packages/core/src/app/order/mapFromDigital.test.tsx
@@ -128,17 +128,9 @@ describe('mapFromDigital()', () => {
     });
 
     describe('without pickListExperimentEnabled', () => {
-        it('maps all options and returns no bundledItems', () => {
-            const bundledChild = {
-                ...getPhysicalItem(),
-                id: '777',
-                parentId: '667',
-                addedByAttributeId: 'attr-picklist',
-            } as unknown as PhysicalItem;
-
+        it('maps all options without colon separator and does not set name/value', () => {
             const item = {
                 ...getDigitalItem(),
-                id: '667',
                 options: [
                     {
                         name: 'Pick List Option',
@@ -150,19 +142,30 @@ describe('mapFromDigital()', () => {
                 ] as LineItemOption[],
             };
 
+            const { productOptions = [] } = mapFromDigital(item, undefined, false);
+            const itemOption = productOptions.find((o) => o.testId === 'cart-item-product-option');
+
+            expect(itemOption?.content).toBe('Pick List Option Item A');
+            expect(itemOption?.name).toBeUndefined();
+            expect(itemOption?.value).toBeUndefined();
+        });
+
+        it('returns no bundledItems even when map has children', () => {
+            const bundledChild = {
+                ...getPhysicalItem(),
+                id: '777',
+                parentId: '667',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const item = { ...getDigitalItem(), id: '667', options: [] as LineItemOption[] };
+
             const bundleItemsMap = new Map<string | number, PhysicalItem[]>([
                 ['667', [bundledChild]],
             ]);
 
-            const { productOptions = [], bundledItems } = mapFromDigital(
-                item,
-                bundleItemsMap,
-                false,
-            );
+            const { bundledItems } = mapFromDigital(item, bundleItemsMap, false);
 
-            expect(
-                productOptions.filter((o) => o.testId === 'cart-item-product-option'),
-            ).toHaveLength(1);
             expect(bundledItems).toBeUndefined();
         });
     });

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -16,13 +16,42 @@ function mapFromDigital(
     const bundledItemsAddedByAttributeIds = bundledItems?.flatMap(({ addedByAttributeId }) =>
         addedByAttributeId ? [addedByAttributeId] : [],
     );
-    const options = pickListExperimentEnabled
-        ? item.options?.filter(
-              (option) =>
+
+    const mappedOptions = pickListExperimentEnabled
+        ? item.options?.map((option) => {
+              if (
                   option.attributeId &&
-                  !bundledItemsAddedByAttributeIds?.includes(option.attributeId),
-          )
-        : item.options;
+                  bundledItemsAddedByAttributeIds?.includes(option.attributeId)
+              ) {
+                  const bundledItem = bundledItems?.find(
+                      ({ addedByAttributeId }) => addedByAttributeId === option.attributeId,
+                  );
+
+                  return {
+                      testId: 'cart-item-product-option',
+                      content: `${option.name}: ${option.value}`,
+                      name: `${option.name}:`,
+                      value: option.value,
+                      isMainBundledItem: true,
+                      stockPosition: bundledItem ? mapBackorderDetails(bundledItem) : undefined,
+                  };
+              }
+
+              return {
+                  testId: 'cart-item-product-option',
+                  content: `${option.name}: ${option.value}`,
+                  name: `${option.name}:`,
+                  value: option.value,
+                  isMainBundledItem: false,
+              };
+          })
+        : item.options?.map((option) => ({
+              testId: 'cart-item-product-option',
+              content: `${option.name} ${option.value}`,
+              name: `${option.name}:`,
+              value: option.value,
+              isMainBundledItem: false,
+          }));
 
     return {
         id: item.id,
@@ -31,25 +60,7 @@ function mapFromDigital(
         amountAfterDiscount: item.extendedSalePrice,
         name: item.name,
         image: getOrderSummaryItemImage(item),
-        productOptions: [
-            ...(options || []).map((option) => ({
-                testId: 'cart-item-product-option',
-                content: pickListExperimentEnabled
-                    ? `${option.name}: ${option.value}`
-                    : `${option.name} ${option.value}`,
-            })),
-            getDigitalItemDescription(item),
-        ],
-        bundledItems: pickListExperimentEnabled
-            ? bundledItems?.map((bundledItem) => ({
-                  name: bundledItem.name,
-                  id: String(bundledItem.id),
-                  bundleLabel: item.options?.find(
-                      (option) => option.attributeId === bundledItem.addedByAttributeId,
-                  )?.name,
-                  ...mapBackorderDetails(bundledItem),
-              }))
-            : undefined,
+        productOptions: [...(mappedOptions || []), getDigitalItemDescription(item)],
         ...mapBackorderDetails(item),
     };
 }

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -48,8 +48,6 @@ function mapFromDigital(
         : item.options?.map((option) => ({
               testId: 'cart-item-product-option',
               content: `${option.name} ${option.value}`,
-              name: `${option.name}:`,
-              value: option.value,
               isMainBundledItem: false,
           }));
 

--- a/packages/core/src/app/order/mapFromPhysical.test.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.test.tsx
@@ -48,7 +48,7 @@ describe('mapFromPhysical()', () => {
             expect(result.productOptions![0].content).toBe('Color: Red');
         });
 
-        it('filters out options matching a bundled item attributeId', () => {
+        it('marks pick-list option as isMainBundledItem true and keeps all options', () => {
             const child = {
                 ...getPhysicalItem(),
                 id: '777',
@@ -81,11 +81,16 @@ describe('mapFromPhysical()', () => {
 
             const result = mapFromPhysical(parent, bundleItemsMap, true);
 
-            expect(result.productOptions).toHaveLength(1);
-            expect(result.productOptions![0].content).toBe('Color: Blue');
+            expect(result.productOptions).toHaveLength(2);
+
+            const colorOption = result.productOptions!.find((o) => o.name === 'Color:');
+            const pickListOption = result.productOptions!.find((o) => o.name === 'Pick List:');
+
+            expect(colorOption?.isMainBundledItem).toBe(false);
+            expect(pickListOption?.isMainBundledItem).toBe(true);
         });
 
-        it('returns bundledItems with backorder details from stockPosition', () => {
+        it('attaches stockPosition to the pick-list option from the bundled child', () => {
             const child = {
                 ...getPhysicalItem(),
                 id: '777',
@@ -98,29 +103,6 @@ describe('mapFromPhysical()', () => {
                     quantityOutOfStock: 0,
                     backorderMessage: 'Available soon',
                 },
-            } as unknown as PhysicalItem;
-
-            const parent = { ...getPhysicalItem(), id: '666' };
-
-            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
-
-            const { bundledItems } = mapFromPhysical(parent, bundleItemsMap, true);
-
-            expect(bundledItems).toHaveLength(1);
-            expect(bundledItems![0].id).toBe('777');
-            expect(bundledItems![0].name).toBe('Bundled Product');
-            expect(bundledItems![0].quantityBackordered).toBe(1);
-            expect(bundledItems![0].quantityOnHand).toBe(4);
-            expect(bundledItems![0].backorderMessage).toBe('Available soon');
-        });
-
-        it('returns bundledItems with bundleLabel from the matching parent option', () => {
-            const child = {
-                ...getPhysicalItem(),
-                id: '777',
-                name: 'Bundled Product',
-                parentId: '666',
-                addedByAttributeId: 'attr-picklist',
             } as unknown as PhysicalItem;
 
             const parent = {
@@ -139,36 +121,43 @@ describe('mapFromPhysical()', () => {
 
             const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
-            const { bundledItems } = mapFromPhysical(parent, bundleItemsMap, true);
+            const result = mapFromPhysical(parent, bundleItemsMap, true);
+            const pickListOption = result.productOptions!.find((o) => o.name === 'Pick List:');
 
-            expect(bundledItems).toHaveLength(1);
-            expect(bundledItems![0].bundleLabel).toBe('Pick List');
+            expect(pickListOption?.isMainBundledItem).toBe(true);
+            expect(pickListOption?.stockPosition?.quantityBackordered).toBe(1);
+            expect(pickListOption?.stockPosition?.quantityOnHand).toBe(4);
+            expect(pickListOption?.stockPosition?.backorderMessage).toBe('Available soon');
+        });
+
+        it('preserves options without attributeId as isMainBundledItem false', () => {
+            const child = {
+                ...getPhysicalItem(),
+                id: '777',
+                parentId: '666',
+                addedByAttributeId: 'attr-picklist',
+            } as unknown as PhysicalItem;
+
+            const parent = {
+                ...getPhysicalItem(),
+                id: '666',
+                options: [
+                    { name: 'Size', nameId: 10, value: 'Large', valueId: 1 },
+                ] as LineItemOption[],
+            };
+
+            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
+
+            const result = mapFromPhysical(parent, bundleItemsMap, true);
+
+            expect(result.productOptions).toHaveLength(1);
+            expect(result.productOptions![0].isMainBundledItem).toBe(false);
         });
 
         it('returns no bundledItems when the item has no children', () => {
             const result = mapFromPhysical(getPhysicalItem(), new Map(), true);
 
             expect(result.bundledItems).toBeUndefined();
-        });
-
-        it('coerces numeric child id to string in bundledItems', () => {
-            const child = {
-                ...getPhysicalItem(),
-                id: 999,
-                parentId: '666',
-                addedByAttributeId: 'attr-picklist',
-            } as unknown as PhysicalItem;
-
-            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
-
-            const { bundledItems } = mapFromPhysical(
-                { ...getPhysicalItem(), id: '666' },
-                bundleItemsMap,
-                true,
-            );
-
-            expect(typeof bundledItems![0].id).toBe('string');
-            expect(bundledItems![0].id).toBe('999');
         });
     });
 

--- a/packages/core/src/app/order/mapFromPhysical.test.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.test.tsx
@@ -15,11 +15,13 @@ describe('mapFromPhysical()', () => {
             expect(result.quantity).toBe(item.quantity);
         });
 
-        it('formats options without colon separator', () => {
+        it('formats options without colon separator and does not set name/value', () => {
             const item = getPhysicalItem();
             const result = mapFromPhysical(item);
 
             expect(result.productOptions![0].content).toBe('n v');
+            expect(result.productOptions![0].name).toBeUndefined();
+            expect(result.productOptions![0].value).toBeUndefined();
         });
 
         it('returns no bundledItems', () => {

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -15,8 +15,6 @@ function mapFromPhysical(
         addedByAttributeId ? [addedByAttributeId] : [],
     );
 
-    console.log('bundledItemsAddedByAttributeIds', bundledItemsAddedByAttributeIds);
-
     const options = pickListExperimentEnabled
         ? item.options?.map((option) => {
               if (

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -49,11 +49,7 @@ function mapFromPhysical(
           })
         : item.options?.map((option) => ({
               testId: 'cart-item-product-option',
-              content: pickListExperimentEnabled
-                  ? `${option.name}: ${option.value}`
-                  : `${option.name} ${option.value}`,
-              name: `${option.name}:`,
-              value: option.value,
+              content: `${option.name} ${option.value}`,
               isMainBundledItem: false,
           }));
 

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -14,13 +14,50 @@ function mapFromPhysical(
     const bundledItemsAddedByAttributeIds = bundledItems?.flatMap(({ addedByAttributeId }) =>
         addedByAttributeId ? [addedByAttributeId] : [],
     );
+
+    console.log('bundledItemsAddedByAttributeIds', bundledItemsAddedByAttributeIds);
+
     const options = pickListExperimentEnabled
-        ? item.options?.filter(
-              (option) =>
+        ? item.options?.map((option) => {
+              if (
                   option.attributeId &&
-                  !bundledItemsAddedByAttributeIds?.includes(option.attributeId),
-          )
-        : item.options;
+                  bundledItemsAddedByAttributeIds?.includes(option.attributeId)
+              ) {
+                  const bundledItem = bundledItems?.find(
+                      ({ addedByAttributeId }) => addedByAttributeId === option.attributeId,
+                  );
+
+                  return {
+                      testId: 'cart-item-product-option',
+                      content: pickListExperimentEnabled
+                          ? `${option.name}: ${option.value}`
+                          : `${option.name} ${option.value}`,
+                      name: `${option.name}:`,
+                      value: option.value,
+                      isMainBundledItem: true,
+                      stockPosition: bundledItem ? mapBackorderDetails(bundledItem) : undefined,
+                  };
+              }
+
+              return {
+                  testId: 'cart-item-product-option',
+                  content: pickListExperimentEnabled
+                      ? `${option.name}: ${option.value}`
+                      : `${option.name} ${option.value}`,
+                  name: `${option.name}:`,
+                  value: option.value,
+                  isMainBundledItem: false,
+              };
+          })
+        : item.options?.map((option) => ({
+              testId: 'cart-item-product-option',
+              content: pickListExperimentEnabled
+                  ? `${option.name}: ${option.value}`
+                  : `${option.name} ${option.value}`,
+              name: `${option.name}:`,
+              value: option.value,
+              isMainBundledItem: false,
+          }));
 
     return {
         id: item.id,
@@ -30,22 +67,7 @@ function mapFromPhysical(
         name: item.name,
         image: getOrderSummaryItemImage(item),
         description: item.giftWrapping ? item.giftWrapping.name : undefined,
-        productOptions: (options || []).map((option) => ({
-            testId: 'cart-item-product-option',
-            content: pickListExperimentEnabled
-                ? `${option.name}: ${option.value}`
-                : `${option.name} ${option.value}`,
-        })),
-        bundledItems: pickListExperimentEnabled
-            ? bundledItems?.map((bundledItem) => ({
-                  name: bundledItem.name,
-                  id: String(bundledItem.id),
-                  bundleLabel: item.options?.find(
-                      (option) => option.attributeId === bundledItem.addedByAttributeId,
-                  )?.name,
-                  ...mapBackorderDetails(bundledItem),
-              }))
-            : undefined,
+        productOptions: options,
         ...mapBackorderDetails(item),
     };
 }

--- a/packages/core/src/scss/components/checkout/productList/_productList.scss
+++ b/packages/core/src/scss/components/checkout/productList/_productList.scss
@@ -77,7 +77,8 @@
     overflow: hidden;
     transition:
         height $animation-collapse-transitionSpeed $animation-collapse-transitionCurve,
-        opacity $animation-collapse-transitionSpeed $animation-collapse-transitionCurve;
+        opacity $animation-collapse-transitionSpeed $animation-collapse-transitionCurve,
+        margin $animation-collapse-transitionSpeed $animation-collapse-transitionCurve;
 }
 
 .product-actions {

--- a/packages/core/src/scss/components/checkout/productList/_productList.scss
+++ b/packages/core/src/scss/components/checkout/productList/_productList.scss
@@ -99,20 +99,7 @@
     font-weight: fontWeight('medium');
 }
 
-.bundled-items-container {
-    margin-left: 0;
-    margin-top: spacing("quarter");
-
-    .bundled-item {
-        color: color("greys");
-        font-size: fontSize("tiny");
-        margin: 0;
-    }
-
-    .bundled-item-name {
-        margin-bottom: 0;
-    }
-
+.product-option {
     .body-bold {
         font-weight: $fontWeight-bold;
     }


### PR DESCRIPTION
## What/Why?
Update options and backorder layout for items to respect bundle items ordering

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

#### Desktop

https://github.com/user-attachments/assets/fe878c3f-64c7-4ada-a07a-5d892d30297c

#### Mobile

https://github.com/user-attachments/assets/bac0680f-aa56-4fc5-8189-403fc6dfb2bf



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout cart/order-summary presentation and backorder placement for bundle lines; behavior is tied to the pick-list experiment but option rendering paths are shared.
> 
> **Overview**
> Reworks checkout order summary so **pick-list bundle children appear as product options** (in option order) instead of a separate nested **bundled items** list.
> 
> When the pick-list experiment is on, `mapFromPhysical` / `mapFromDigital` **keep all options**, mark matching pick-list rows with **`isMainBundledItem`**, and attach **child `stockPosition`** for backorder copy; they no longer emit **`bundledItems`**. **`OrderSummaryItem`** renders options via **`name` / `value`** (bold label for main bundled picks), shows **backorder blocks under the line title and under each option**, and drops the old bundled-items markup. Styles drop **`.bundled-items-container`** and bold pick-list labels under **`.product-option`**, with a small **backorder collapse** margin transition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb1a4a0854fcb32486795c3db47bbf85172206a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->