### PR TITLE
core(payments): bump checkout sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.930.1",
+        "@bigcommerce/checkout-sdk": "^1.934.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.930.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.930.1.tgz",
-      "integrity": "sha512-p+V1M2ZV8sNd2Q0Ic2ORBrJora77kGVqEBKuEQScTHCQzWk7dVnX8aJucVdM3vQZWj5CITp80ugRY5W78qLuyw==",
+      "version": "1.934.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.0.tgz",
+      "integrity": "sha512-l8UNW7HqoDnRdSEfQWjPxOhCXk+4kWLaSq760roG0W/Rx4oSKbOFPlor55Z5hVFtTjtBum7YDcPdgr/RvwwE7Q==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.930.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.930.1.tgz",
-      "integrity": "sha512-p+V1M2ZV8sNd2Q0Ic2ORBrJora77kGVqEBKuEQScTHCQzWk7dVnX8aJucVdM3vQZWj5CITp80ugRY5W78qLuyw==",
+      "version": "1.934.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.0.tgz",
+      "integrity": "sha512-l8UNW7HqoDnRdSEfQWjPxOhCXk+4kWLaSq760roG0W/Rx4oSKbOFPlor55Z5hVFtTjtBum7YDcPdgr/RvwwE7Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.930.1",
+    "@bigcommerce/checkout-sdk": "^1.934.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

bump checkout sdk version
[https://github.com/bigcommerce/checkout-sdk-js/pull/3249](https://github.com/bigcommerce/checkout-sdk-js/pull/3249)

## Rollout/Rollback

rollback this commit and this PR
https://github.com/bigcommerce/checkout-sdk-js/pull/3249


## Testing

test results in checkout sdk PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout and payment flows depend on the SDK, so regressions are possible even though this repo only changes the version pin; validation should follow the linked SDK PR tests.
> 
> **Overview**
> Bumps the **`@bigcommerce/checkout-sdk`** dependency from **`^1.930.1`** to **`^1.934.0`** in **`package.json`** and refreshes **`package-lock.json`** so the resolved tarball and integrity hash match the new release.
> 
> There are **no checkout-js source changes** in this PR; behavior updates come from the linked [checkout-sdk-js PR #3249](https://github.com/bigcommerce/checkout-sdk-js/pull/3249).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00780567d86583f54442fffdd1a5d58e44f62725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->