### PR TITLE
feat(checkout): CHECKOUT-10113 Delete Quote Checkout on Exit

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -57,6 +57,7 @@ import {
     PaymentStep,
     ShippingStep,
 } from './components';
+import { deleteCartOnExit } from './deleteCartOnExit';
 import useB2BToken from './hooks/useB2BToken';
 import { mapCheckoutComponentErrorMessage } from './mapErrorMessage';
 import mapToCheckoutProps from './mapToCheckoutProps';
@@ -149,7 +150,7 @@ const Checkout = ({
 }: CheckoutPageProps): ReactElement => {
     const capabilities = useCapabilities();
     const {
-        userJourney: { requiresB2BToken },
+        userJourney: { requiresB2BToken, quoteConfig },
         orderConfirmation: { invoiceRedirect },
     } = capabilities;
     const { fetchB2BToken } = useB2BToken();
@@ -164,6 +165,12 @@ const Checkout = ({
         isSubscribed: false,
         buttonConfigs: [],
     });
+
+    useEffect(() => {
+        if (quoteConfig?.id) {
+            return deleteCartOnExit(checkoutService);
+        }
+    }, []);
 
     // Initialize refs 1/2
     const stepsRef = useRef<CheckoutStepStatus[]>(steps);

--- a/packages/core/src/app/checkout/deleteCartOnExit/deleteCartOnExit.test.ts
+++ b/packages/core/src/app/checkout/deleteCartOnExit/deleteCartOnExit.test.ts
@@ -1,0 +1,140 @@
+import { deleteCartOnExit } from './deleteCartOnExit';
+
+describe('deleteCartOnExit', () => {
+    let getOrder: jest.Mock;
+    let getCheckout: jest.Mock;
+    let isSubmittingOrder: jest.Mock;
+    let deleteCheckout: jest.Mock;
+    let checkoutService: any;
+    let navigationListeners: Record<string, (event: { navigationType?: string }) => void>;
+    let cleanup: (() => void) | undefined;
+
+    const fireUnload = (
+        type: 'pagehide' | 'beforeunload',
+        { persisted }: { persisted?: boolean } = {},
+    ): void => {
+        const event = new Event(type);
+
+        if (persisted !== undefined) {
+            Object.defineProperty(event, 'persisted', { value: persisted, configurable: true });
+        }
+
+        window.dispatchEvent(event);
+    };
+
+    const watchForExit = (): void => {
+        cleanup = deleteCartOnExit(checkoutService);
+    };
+
+    beforeEach(() => {
+        getOrder = jest.fn().mockReturnValue(undefined);
+        getCheckout = jest.fn().mockReturnValue({ id: 'checkout-123' });
+        isSubmittingOrder = jest.fn().mockReturnValue(false);
+        deleteCheckout = jest.fn().mockResolvedValue(undefined);
+
+        checkoutService = {
+            deleteCheckout,
+            getState: () => ({
+                data: { getOrder, getCheckout },
+                statuses: { isSubmittingOrder },
+            }),
+        };
+
+        navigationListeners = {};
+        (window as any).navigation = {
+            addEventListener: jest.fn(
+                (type: string, cb: (event: { navigationType?: string }) => void) => {
+                    navigationListeners[type] = cb;
+                },
+            ),
+            removeEventListener: jest.fn(),
+        };
+    });
+
+    afterEach(() => {
+        cleanup?.();
+        cleanup = undefined;
+        jest.clearAllMocks();
+        delete (window as any).navigation;
+    });
+
+    it('deletes the checkout on a plain leave', () => {
+        watchForExit();
+
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not delete on a keyboard reload (F5)', () => {
+        watchForExit();
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'F5' }));
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).not.toHaveBeenCalled();
+    });
+
+    it('does not delete on a Navigation API reload', () => {
+        watchForExit();
+
+        navigationListeners.navigate?.({ navigationType: 'reload' });
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).not.toHaveBeenCalled();
+    });
+
+    it('does not delete when an order has been placed', () => {
+        getOrder.mockReturnValue({ orderId: 1 });
+        watchForExit();
+
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).not.toHaveBeenCalled();
+    });
+
+    it('does not delete while an order is being submitted', () => {
+        isSubmittingOrder.mockReturnValue(true);
+        watchForExit();
+
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).not.toHaveBeenCalled();
+    });
+
+    it('does not delete on a bfcache pagehide', () => {
+        watchForExit();
+
+        fireUnload('pagehide', { persisted: true });
+
+        expect(deleteCheckout).not.toHaveBeenCalled();
+    });
+
+    it('does not delete when there is no checkout', () => {
+        getCheckout.mockReturnValue(undefined);
+        watchForExit();
+
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).not.toHaveBeenCalled();
+    });
+
+    it('fires at most once across beforeunload and pagehide', () => {
+        watchForExit();
+
+        fireUnload('beforeunload');
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops deleting after cleanup', () => {
+        watchForExit();
+
+        cleanup?.();
+        cleanup = undefined;
+        fireUnload('pagehide');
+
+        expect(deleteCheckout).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/app/checkout/deleteCartOnExit/deleteCartOnExit.ts
+++ b/packages/core/src/app/checkout/deleteCartOnExit/deleteCartOnExit.ts
@@ -1,0 +1,53 @@
+import { type CheckoutService } from '@bigcommerce/checkout-sdk';
+
+import { watchForReload } from './reloadIntent';
+
+export function deleteCartOnExit(checkoutService: CheckoutService): () => void {
+    let isDeletingCheckout = false;
+
+    const reloadWatcher = watchForReload();
+
+    const shouldSkipDelete = (): boolean => {
+        const state = checkoutService.getState();
+
+        return Boolean(state.data.getOrder()) || state.statuses.isSubmittingOrder();
+    };
+
+    const deleteCartHandler = (event: Event): void => {
+        if (isDeletingCheckout) {
+            return;
+        }
+
+        // bfcache: the page is frozen, not destroyed, and may return via Back.
+        if ('persisted' in event && (event as PageTransitionEvent).persisted) {
+            return;
+        }
+
+        if (reloadWatcher.isReloadIntended()) {
+            return;
+        }
+
+        if (shouldSkipDelete()) {
+            return;
+        }
+
+        if (!checkoutService.getState().data.getCheckout()) {
+            return;
+        }
+
+        isDeletingCheckout = true;
+
+        void checkoutService.deleteCheckout().catch(() => {
+            // Intentionally ignored.
+        });
+    };
+
+    window.addEventListener('pagehide', deleteCartHandler);
+    window.addEventListener('beforeunload', deleteCartHandler);
+
+    return (): void => {
+        window.removeEventListener('pagehide', deleteCartHandler);
+        window.removeEventListener('beforeunload', deleteCartHandler);
+        reloadWatcher.stop();
+    };
+}

--- a/packages/core/src/app/checkout/deleteCartOnExit/index.ts
+++ b/packages/core/src/app/checkout/deleteCartOnExit/index.ts
@@ -1,0 +1,1 @@
+export { deleteCartOnExit } from './deleteCartOnExit';

--- a/packages/core/src/app/checkout/deleteCartOnExit/reloadIntent.ts
+++ b/packages/core/src/app/checkout/deleteCartOnExit/reloadIntent.ts
@@ -1,0 +1,58 @@
+interface BrowserNavigateEvent {
+    navigationType?: string;
+}
+
+interface BrowserNavigation {
+    addEventListener?(type: 'navigate', listener: (event: BrowserNavigateEvent) => void): void;
+    removeEventListener?(type: 'navigate', listener: (event: BrowserNavigateEvent) => void): void;
+}
+
+interface ReloadWatcher {
+    isReloadIntended(): boolean;
+    stop(): void;
+}
+
+export function watchForReload(): ReloadWatcher {
+    let reloadIntended = false;
+
+    const { navigation } = window as unknown as { navigation?: BrowserNavigation };
+
+    const handleNavigate = (event: BrowserNavigateEvent): void => {
+        if (event.navigationType === 'reload') {
+            reloadIntended = true;
+        }
+    };
+
+    navigation?.addEventListener?.('navigate', handleNavigate);
+
+    let resetIntentTimer: number | undefined;
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+        const isReloadKey =
+            event.key === 'F5' ||
+            ((event.ctrlKey || event.metaKey) && (event.key === 'r' || event.key === 'R'));
+
+        if (!isReloadKey) {
+            return;
+        }
+
+        reloadIntended = true;
+
+        window.clearTimeout(resetIntentTimer);
+
+        resetIntentTimer = window.setTimeout(() => {
+            reloadIntended = false;
+        }, 1000);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return {
+        isReloadIntended: (): boolean => reloadIntended,
+        stop: (): void => {
+            navigation?.removeEventListener?.('navigate', handleNavigate);
+            window.removeEventListener('keydown', handleKeyDown);
+            window.clearTimeout(resetIntentTimer);
+        },
+    };
+}


### PR DESCRIPTION
## What/Why?

Delete quote checkout on exiting the checkout page, but not on:
- Jumping to a third-party payment provider.
- Placing an order.
- Refreshing the page.
   - Limitation: Browser-button triggered unload events cannot be detected.
   - Workaround: We support detecting keyboard triggered refresh event. 

## Rollout/Rollback

Revert.

## Testing

### Exiting the checkout page

https://github.com/user-attachments/assets/272e201c-34c1-4e83-9668-b27b06be7de5

### Jumping to a third-party payment provider.

https://github.com/user-attachments/assets/e1288479-d7c2-4fa7-91c0-5d65f30486c2

### Placing an order.

https://github.com/user-attachments/assets/a0f2a22a-6710-497b-aa0f-2f39f41ec489

### Keyboard triggered page refresh

https://github.com/user-attachments/assets/c214f2db-11fd-4bd4-91fe-cbaf2044b87a


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive checkout deletion on unload is scoped to quote flows but depends on browser unload heuristics (reload detection is incomplete for toolbar refresh), so wrong skips or deletes could affect quote cart state.
> 
> **Overview**
> For **quote** checkouts (`quoteConfig.id`), checkout now registers **delete-on-exit** so abandoning the page tears down the checkout via `checkoutService.deleteCheckout()`.
> 
> A new `deleteCartOnExit` helper listens on **`pagehide`** and **`beforeunload`**, with guards so delete does **not** run when an order exists or is submitting, when there is no checkout, on **bfcache** (`persisted`), or when a **reload** was intended (`watchForReload`: F5 / Ctrl|Cmd+R and Navigation API `reload`). Deletes are capped to **once** per exit; listeners and the reload watcher clean up on unmount.
> 
> `CheckoutPage` mounts this behavior in a `useEffect` only when `quoteConfig?.id` is set; unit tests cover the skip paths and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4962e0ffafa39700ee07358632720c2c6e677a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->