### PR TITLE
chore(checkout): CHECKOUT-10143 Bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.934.0",
+        "@bigcommerce/checkout-sdk": "^1.934.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.934.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.0.tgz",
-      "integrity": "sha512-l8UNW7HqoDnRdSEfQWjPxOhCXk+4kWLaSq760roG0W/Rx4oSKbOFPlor55Z5hVFtTjtBum7YDcPdgr/RvwwE7Q==",
+      "version": "1.934.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.2.tgz",
+      "integrity": "sha512-GCsoqyTEH/srOG/YAOHdfhiK3rYN6fUgPGWlZ/SdOHoA5JgwIJA4p8pGlgPmpNeWCf29FhDLd0+c6AtHEkkcZQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.934.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.0.tgz",
-      "integrity": "sha512-l8UNW7HqoDnRdSEfQWjPxOhCXk+4kWLaSq760roG0W/Rx4oSKbOFPlor55Z5hVFtTjtBum7YDcPdgr/RvwwE7Q==",
+      "version": "1.934.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.2.tgz",
+      "integrity": "sha512-GCsoqyTEH/srOG/YAOHdfhiK3rYN6fUgPGWlZ/SdOHoA5JgwIJA4p8pGlgPmpNeWCf29FhDLd0+c6AtHEkkcZQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.934.0",
+    "@bigcommerce/checkout-sdk": "^1.934.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump SDK version.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout SDK upgrades can affect payment and checkout behavior even when this repo’s diff is only dependency files; risk depends on what changed in SDK 1.934.1–1.934.2.
> 
> **Overview**
> Updates the **`@bigcommerce/checkout-sdk`** dependency from **`^1.934.0`** to **`^1.934.2`** in `package.json`, with the matching lockfile entries in `package-lock.json`. There are no application source changes in this PR—only the SDK version pin and resolved package metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5604dc48fcf10b5236f43ffc35900c5d49ffeed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->