### PR TITLE
chore(checkout): BACK-714 Display backorder info for picklist items order confirmation page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.934.2",
+        "@bigcommerce/checkout-sdk": "^1.935.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.934.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.2.tgz",
-      "integrity": "sha512-GCsoqyTEH/srOG/YAOHdfhiK3rYN6fUgPGWlZ/SdOHoA5JgwIJA4p8pGlgPmpNeWCf29FhDLd0+c6AtHEkkcZQ==",
+      "version": "1.935.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.935.1.tgz",
+      "integrity": "sha512-DDPqHw8Zl2T/P02QFc085Gl36daRz2bd6lwOwQTBtHmWtkuqNy6wNJ7R/cGqzMtI52AxdwFzL5ELg2nC/loFPg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.934.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.934.2.tgz",
-      "integrity": "sha512-GCsoqyTEH/srOG/YAOHdfhiK3rYN6fUgPGWlZ/SdOHoA5JgwIJA4p8pGlgPmpNeWCf29FhDLd0+c6AtHEkkcZQ==",
+      "version": "1.935.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.935.1.tgz",
+      "integrity": "sha512-DDPqHw8Zl2T/P02QFc085Gl36daRz2bd6lwOwQTBtHmWtkuqNy6wNJ7R/cGqzMtI52AxdwFzL5ELg2nC/loFPg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.934.2",
+    "@bigcommerce/checkout-sdk": "^1.935.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -29,7 +29,11 @@ import mapFromDigital from './mapFromDigital';
 import mapFromGiftCertificate from './mapFromGiftCertificate';
 import mapFromPhysical from './mapFromPhysical';
 import OrderSummaryItem from './OrderSummaryItem';
-import { removeAndBundleItemsTogether, removeBundledItems } from './removeBundledItems';
+import {
+    buildBundleItemsMapFromOrder,
+    removeAndBundleItemsTogether,
+    removeBundledItems,
+} from './removeBundledItems';
 
 // Module-scoped to survive the responsive remount. Safe as MobileView mounts only one instance at a time.
 let backorderDetailsExpanded = false;
@@ -194,7 +198,12 @@ const OrderSummaryItems = ({
 }: OrderSummaryItemsProps): ReactElement => {
     const [isExpanded, setIsExpanded] = useState(false);
     const [showBackorderDetails, setShowBackorderDetails] = useState(getBackorderDetailsExpanded);
-    const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
+    const {
+        selectedState: { config, order },
+    } = useCheckout(({ data }) => ({
+        config: data.getConfig(),
+        order: data.getOrder(),
+    }));
 
     const toggleBackorderDetails = useCallback(() => {
         setShowBackorderDetails((prev) => {
@@ -229,7 +238,9 @@ const OrderSummaryItems = ({
     const expandBackorderDetails = showBackorderSwitch && showBackorderDetails;
 
     const { nonBundledItems, bundleItemsMap } = pickListExperimentEnabled
-        ? removeAndBundleItemsTogether(items)
+        ? order?.bundledItems
+            ? buildBundleItemsMapFromOrder(items, order.bundledItems)
+            : removeAndBundleItemsTogether(items)
         : { nonBundledItems: removeBundledItems(items), bundleItemsMap: undefined };
 
     const collapsedLimit = isSmallScreen()

--- a/packages/core/src/app/order/removeBundledItems.test.ts
+++ b/packages/core/src/app/order/removeBundledItems.test.ts
@@ -7,7 +7,11 @@ import {
 
 import { getDigitalItem, getPhysicalItem } from '../cart/lineItem.mock';
 
-import { removeAndBundleItemsTogether, removeBundledItems } from './removeBundledItems';
+import {
+    buildBundleItemsMapFromOrder,
+    removeAndBundleItemsTogether,
+    removeBundledItems,
+} from './removeBundledItems';
 
 const emptyLineItems = {
     physicalItems: [] as PhysicalItem[],
@@ -15,6 +19,166 @@ const emptyLineItems = {
     giftCertificates: [] as GiftCertificateItem[],
     customItems: null as unknown as CustomItem[],
 };
+
+describe('buildBundleItemsMapFromOrder()', () => {
+    const emptyBundledItems = {
+        physicalItems: [] as PhysicalItem[],
+        digitalItems: [] as DigitalItem[],
+    };
+
+    describe('when there are no items', () => {
+        it('returns empty map and unchanged lineItems', () => {
+            const { nonBundledItems, bundleItemsMap } = buildBundleItemsMapFromOrder(
+                emptyLineItems,
+                emptyBundledItems,
+            );
+
+            expect(nonBundledItems).toEqual(emptyLineItems);
+            expect(bundleItemsMap.size).toBe(0);
+        });
+    });
+
+    describe('when a physical child is linked to a parent via attributeId', () => {
+        const parent = {
+            ...getPhysicalItem(),
+            id: 'parent-1',
+            options: [{ name: 'Color', nameId: 10, value: 'Red', valueId: 20, attributeId: 'attr-1' }],
+        };
+        const child = { ...getPhysicalItem(), id: 'child-1', addedByAttributeId: 'attr-1' };
+        const lineItems = { ...emptyLineItems, physicalItems: [parent] };
+        const orderBundledItems = { ...emptyBundledItems, physicalItems: [child] };
+
+        it('maps the child under the parent id', () => {
+            const { bundleItemsMap } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            expect(bundleItemsMap.size).toBe(1);
+            const children = bundleItemsMap.get('parent-1');
+
+            expect(children).toHaveLength(1);
+            expect(children![0].id).toBe('child-1');
+        });
+
+        it('keeps the parent in nonBundledItems', () => {
+            const { nonBundledItems } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            expect(nonBundledItems.physicalItems).toHaveLength(1);
+            expect(nonBundledItems.physicalItems[0].id).toBe('parent-1');
+        });
+    });
+
+    describe('when a digital child is linked to a digital parent', () => {
+        const parent = {
+            ...getDigitalItem(),
+            id: 'parent-d',
+            options: [{ name: 'Format', nameId: 11, value: 'PDF', valueId: 21, attributeId: 'attr-d' }],
+        };
+        const child = { ...getDigitalItem(), id: 'child-d', addedByAttributeId: 'attr-d' };
+        const lineItems = { ...emptyLineItems, digitalItems: [parent] };
+        const orderBundledItems = { ...emptyBundledItems, digitalItems: [child] };
+
+        it('maps the digital child under the parent id', () => {
+            const { bundleItemsMap } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            const children = bundleItemsMap.get('parent-d');
+
+            expect(children).toHaveLength(1);
+            expect(children![0].id).toBe('child-d');
+        });
+    });
+
+    describe('when a parent has multiple options each matching a different child', () => {
+        const parent = {
+            ...getPhysicalItem(),
+            id: 'parent-multi',
+            options: [
+                { name: 'Size', nameId: 1, value: 'S', valueId: 1, attributeId: 'attr-a' },
+                { name: 'Color', nameId: 2, value: 'Blue', valueId: 2, attributeId: 'attr-b' },
+            ],
+        };
+        const childA = { ...getPhysicalItem(), id: 'child-a', addedByAttributeId: 'attr-a' };
+        const childB = { ...getPhysicalItem(), id: 'child-b', addedByAttributeId: 'attr-b' };
+        const lineItems = { ...emptyLineItems, physicalItems: [parent] };
+        const orderBundledItems = { ...emptyBundledItems, physicalItems: [childA, childB] };
+
+        it('groups all children under the parent id', () => {
+            const { bundleItemsMap } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            const children = bundleItemsMap.get('parent-multi');
+
+            expect(children).toHaveLength(2);
+            expect(children!.map((c) => c.id)).toEqual(['child-a', 'child-b']);
+        });
+    });
+
+    describe('when a bundle child has no addedByAttributeId', () => {
+        const child = { ...getPhysicalItem(), id: 'orphan', addedByAttributeId: undefined };
+        const lineItems = { ...emptyLineItems, physicalItems: [getPhysicalItem()] };
+        const orderBundledItems = { ...emptyBundledItems, physicalItems: [child] };
+
+        it('does not add an entry to the map', () => {
+            const { bundleItemsMap } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            expect(bundleItemsMap.size).toBe(0);
+        });
+    });
+
+    describe('when a parent option has no attributeId', () => {
+        const parent = {
+            ...getPhysicalItem(),
+            id: 'parent-no-attr',
+            options: [{ name: 'Size', nameId: 1, value: 'M', valueId: 2 }],
+        };
+        const child = { ...getPhysicalItem(), id: 'child-x', addedByAttributeId: 'attr-x' };
+        const lineItems = { ...emptyLineItems, physicalItems: [parent] };
+        const orderBundledItems = { ...emptyBundledItems, physicalItems: [child] };
+
+        it('does not link the child', () => {
+            const { bundleItemsMap } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            expect(bundleItemsMap.size).toBe(0);
+        });
+    });
+
+    describe('when a bundle child also appears in lineItems (defensive filter)', () => {
+        const parent = {
+            ...getPhysicalItem(),
+            id: 'parent-2',
+            options: [{ name: 'n', nameId: 1, value: 'v', valueId: 3, attributeId: 'attr-2' }],
+        };
+        const child = { ...getPhysicalItem(), id: 'child-2', addedByAttributeId: 'attr-2' };
+        const lineItems = { ...emptyLineItems, physicalItems: [parent, child] };
+        const orderBundledItems = { ...emptyBundledItems, physicalItems: [child] };
+
+        it('removes the child from nonBundledItems', () => {
+            const { nonBundledItems } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            expect(nonBundledItems.physicalItems).toHaveLength(1);
+            expect(nonBundledItems.physicalItems[0].id).toBe('parent-2');
+        });
+    });
+
+    describe('when item ids are numeric', () => {
+        const parent = {
+            ...getPhysicalItem(),
+            id: 100 as unknown as string,
+            options: [{ name: 'n', nameId: 1, value: 'v', valueId: 3, attributeId: 'attr-num' }],
+        };
+        const child = {
+            ...getPhysicalItem(),
+            id: 200 as unknown as string,
+            addedByAttributeId: 'attr-num',
+        };
+        const lineItems = { ...emptyLineItems, physicalItems: [parent] };
+        const orderBundledItems = { ...emptyBundledItems, physicalItems: [child] };
+
+        it('stringifies ids so map lookup works', () => {
+            const { bundleItemsMap } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
+
+            expect(bundleItemsMap.get('100')).toBeDefined();
+            expect(bundleItemsMap.get('100')![0].id).toBe(200);
+        });
+    });
+});
 
 describe('removeBundledItems()', () => {
     describe('when there are no items', () => {

--- a/packages/core/src/app/order/removeBundledItems.ts
+++ b/packages/core/src/app/order/removeBundledItems.ts
@@ -7,42 +7,48 @@ export function buildBundleItemsMapFromOrder(
     nonBundledItems: LineItemMap;
     bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>>;
 } {
-    const attrToChild = new Map<string, PhysicalItem | DigitalItem>();
+    const attributeItemMap = new Map<string, PhysicalItem | DigitalItem>();
+    const bundledItemIds = new Set<string>();
 
-    for (const child of [...orderBundledItems.physicalItems, ...orderBundledItems.digitalItems]) {
-        if (child.addedByAttributeId) {
-            attrToChild.set(child.addedByAttributeId, child);
+    [...orderBundledItems.physicalItems, ...orderBundledItems.digitalItems].forEach((item) => {
+        if (item.addedByAttributeId) {
+            attributeItemMap.set(item.addedByAttributeId, item);
         }
-    }
 
-    const bundledIds = new Set([
-        ...orderBundledItems.physicalItems.map((item) => String(item.id)),
-        ...orderBundledItems.digitalItems.map((item) => String(item.id)),
-    ]);
+        bundledItemIds.add(String(item.id));
+    });
 
     const bundleItemsMap = new Map<string | number, Array<PhysicalItem | DigitalItem>>();
 
-    for (const parent of [...lineItems.physicalItems, ...lineItems.digitalItems]) {
-        const children = (parent.options ?? []).flatMap((opt) => {
-            if (!opt.attributeId) return [];
+    [...lineItems.physicalItems, ...lineItems.digitalItems].forEach((item) => {
+        if (item.options && item.options.length === 0) {
+            return [];
+        }
 
-            const child = attrToChild.get(opt.attributeId);
+        const children = (item.options ?? []).flatMap((option) => {
+            if (!option.attributeId) {
+                return [];
+            }
 
-            return child ? [child] : [];
+            const bundledItem = attributeItemMap.get(option.attributeId);
+
+            return bundledItem ? [bundledItem] : [];
         });
 
         if (children.length > 0) {
-            bundleItemsMap.set(String(parent.id), children);
+            bundleItemsMap.set(String(item.id), children);
         }
-    }
+    });
 
     return {
         nonBundledItems: {
             ...lineItems,
             physicalItems: lineItems.physicalItems.filter(
-                (item) => !bundledIds.has(String(item.id)),
+                (item) => !bundledItemIds.has(String(item.id)),
             ),
-            digitalItems: lineItems.digitalItems.filter((item) => !bundledIds.has(String(item.id))),
+            digitalItems: lineItems.digitalItems.filter(
+                (item) => !bundledItemIds.has(String(item.id)),
+            ),
         },
         bundleItemsMap,
     };

--- a/packages/core/src/app/order/removeBundledItems.ts
+++ b/packages/core/src/app/order/removeBundledItems.ts
@@ -1,5 +1,53 @@
 import { type DigitalItem, type LineItemMap, type PhysicalItem } from '@bigcommerce/checkout-sdk';
 
+export function buildBundleItemsMapFromOrder(
+    lineItems: LineItemMap,
+    orderBundledItems: Pick<LineItemMap, 'physicalItems' | 'digitalItems'>,
+): {
+    nonBundledItems: LineItemMap;
+    bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>>;
+} {
+    const attrToChild = new Map<string, PhysicalItem | DigitalItem>();
+
+    for (const child of [...orderBundledItems.physicalItems, ...orderBundledItems.digitalItems]) {
+        if (child.addedByAttributeId) {
+            attrToChild.set(child.addedByAttributeId, child);
+        }
+    }
+
+    const bundledIds = new Set([
+        ...orderBundledItems.physicalItems.map((item) => String(item.id)),
+        ...orderBundledItems.digitalItems.map((item) => String(item.id)),
+    ]);
+
+    const bundleItemsMap = new Map<string | number, Array<PhysicalItem | DigitalItem>>();
+
+    for (const parent of [...lineItems.physicalItems, ...lineItems.digitalItems]) {
+        const children = (parent.options ?? []).flatMap((opt) => {
+            if (!opt.attributeId) return [];
+
+            const child = attrToChild.get(opt.attributeId);
+
+            return child ? [child] : [];
+        });
+
+        if (children.length > 0) {
+            bundleItemsMap.set(String(parent.id), children);
+        }
+    }
+
+    return {
+        nonBundledItems: {
+            ...lineItems,
+            physicalItems: lineItems.physicalItems.filter(
+                (item) => !bundledIds.has(String(item.id)),
+            ),
+            digitalItems: lineItems.digitalItems.filter((item) => !bundledIds.has(String(item.id))),
+        },
+        bundleItemsMap,
+    };
+}
+
 export function removeBundledItems(lineItems: LineItemMap): LineItemMap {
     return {
         ...lineItems,


### PR DESCRIPTION
## What/Why?
Display backorder info for picklist items order confirmation page

## Rollout/Rollback
- revert this PR
## Testing
- CI
- Screencast 


https://github.com/user-attachments/assets/7fd406ac-4d4a-4187-93b9-0598227b6d37




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order-summary bundling and backorder display for picklist bundles on confirmation; wrong attribute linking could hide or mis-nest line items, but behavior is gated behind the bundle experiment with a cart fallback.
> 
> **Overview**
> When the picklist bundle experiment is on, **order summary** now prefers **`order.bundledItems`** from checkout state (via SDK **1.935.1**) to attach picklist children to parents using **`addedByAttributeId`** / option **`attributeId`**, instead of relying only on **`parentId`** in cart line items. That path is used on surfaces like **order confirmation**, where bundled children may not appear as normal line items but still need to render under the parent for **backorder details**.
> 
> Adds **`buildBundleItemsMapFromOrder`** in `removeBundledItems.ts` (filters bundled ids from top-level items, builds the same **`bundleItemsMap`** shape as **`removeAndBundleItemsTogether`**). **`OrderSummaryItems`** loads **`order`** from **`useCheckout`** and falls back to the existing cart bundling logic when **`bundledItems`** is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41933576bd5df4d4967b9bfaa824f198a740d3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->