### PR TITLE
feat(checkout): CHECKOUT-10140 normalize extraFields behaviour for b2c customer

### DIFF
--- a/packages/core/src/app/address/isEqualAddress.ts
+++ b/packages/core/src/app/address/isEqualAddress.ts
@@ -61,6 +61,11 @@ function normalizeAddress(address: ComparableAddress) {
         {
             ...address,
             customFields: (address.customFields || []).filter(({ fieldValue }) => !!fieldValue),
+            // Normalize `extraFields` so an unchanged address compares equal instead of
+            // refiring update calls. Guards against any future path where one side has `[]`
+            // and the other omits it (e.g. backend behavior flips again, or a saved/customer
+            // address arrives with `[]`).
+            extraFields: address.extraFields || [],
         },
         ignoredFields,
     );


### PR DESCRIPTION
## What/Why?

- API is returning extraFields: [] in consignment addresses for B2C customers, which why our isEqualAddress fails and hence the form opens. staging tests fail https://app.circleci.com/pipelines/github/bigcommerce/bigcommerce/627219/workflows/ad5bf18d-6986-4bb5-ad42-f8b2cdbb39fe/jobs/2824217
- Normalize extraFields before comparison to avoid this behaviour.


## Rollout/Rollback

Revert this PR

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field normalization in address comparison logic with no auth or payment impact; behavior change is limited to avoiding false mismatches.
> 
> **Overview**
> **`isEqualAddress`** now treats missing `extraFields` the same as an empty array during normalization (mirroring existing `customFields` handling).
> 
> This stops B2C consignment addresses from comparing unequal when the API returns `extraFields: []` on one side and omits the property on the other, which was incorrectly opening the address form and triggering redundant updates (including staging test failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd367fb3677c4731a870427591f1f26ea05d663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->