### PR TITLE
feat(checkout): CHECKOUT-10114 Save shouldSaveAddress Flag for Multi-shipping

### DIFF
--- a/packages/core/src/app/address/AddressForm.tsx
+++ b/packages/core/src/app/address/AddressForm.tsx
@@ -2,7 +2,7 @@ import { type FormField, isExtraField } from '@bigcommerce/checkout-sdk/essentia
 import { forIn, noop } from 'lodash';
 import React, { useCallback, useEffect, useRef } from 'react';
 
-import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import {
     type AutocompleteItem,
@@ -39,6 +39,9 @@ const AddressForm: React.FC<AddressFormProps> = ({
     onChange = noop,
     type,
 }) => {
+    const {
+        userJourney: { hasCompanyAddressBook },
+    } = useCapabilities();
     const { language } = useLocale();
     const {
         selectedState: { config, countries },
@@ -214,7 +217,15 @@ const AddressForm: React.FC<AddressFormProps> = ({
             </Fieldset>
             {shouldShowSaveAddress && (
                 <CheckboxFormField
-                    labelContent={<TranslatedString id="address.save_in_addressbook" />}
+                    labelContent={
+                        <TranslatedString
+                            id={
+                                hasCompanyAddressBook
+                                    ? 'address.save_to_company_addressbook'
+                                    : 'address.save_in_addressbook'
+                            }
+                        />
+                    }
                     name={fieldName ? `${fieldName}.shouldSaveAddress` : 'shouldSaveAddress'}
                 />
             )}

--- a/packages/core/src/app/address/AddressFormModal.test.tsx
+++ b/packages/core/src/app/address/AddressFormModal.test.tsx
@@ -122,6 +122,20 @@ describe('AddressFormModal Component', () => {
         );
     });
 
+    it('does not show save address checkbox when shouldShowSaveAddress is false', () => {
+        renderAddressFormModal({ shouldShowSaveAddress: false });
+
+        expect(
+            screen.queryByLabelText('Save this address in my address book.'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows save address checkbox when shouldShowSaveAddress is true', () => {
+        renderAddressFormModal({ shouldShowSaveAddress: true });
+
+        expect(screen.getByLabelText('Save this address in my address book.')).toBeInTheDocument();
+    });
+
     it('renders prefilled address form in the modal when selectedAddress is present', () => {
         const address = JSON.parse(
             JSON.stringify({

--- a/packages/core/src/app/address/AddressFormModal.tsx
+++ b/packages/core/src/app/address/AddressFormModal.tsx
@@ -42,14 +42,14 @@ export interface AddressFormProps {
 
 const SaveAddress: FunctionComponent<
     AddressFormProps & WithLanguageProps & FormikProps<AddressFormValues>
-> = ({ getFields, values, setFieldValue, isLoading, onRequestClose }) => (
+> = ({ getFields, values, setFieldValue, isLoading, onRequestClose, shouldShowSaveAddress }) => (
     <Form autoComplete="on">
         <LoadingOverlay isLoading={isLoading}>
             <AddressForm
                 countryCode={values.countryCode}
                 formFields={getFields(values.countryCode)}
                 setFieldValue={setFieldValue}
-                shouldShowSaveAddress={false}
+                shouldShowSaveAddress={shouldShowSaveAddress}
                 type={AddressType.Shipping}
             />
             <div className="form-actions">

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -159,6 +159,7 @@ const ConsignmentAddressSelector = ({
                 onRequestClose={handleCloseAddAddressForm}
                 onSaveAddress={handleSaveAddress}
                 selectedAddress={isGuest ? selectedAddress : undefined}
+                shouldShowSaveAddress={hasCompanyAddressBook}
                 storageKey={storageKey}
             />
             {isGuest ? (

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -1123,6 +1123,72 @@ describe('Shipping step', () => {
             expect(B2BSessionStorage.getAddressId(B2BSessionStorage.shippingAddressIdKey)).toBe(1);
         });
 
+        it('shows save address checkbox in multi-shipping new address modal when hasCompanyAddressBook is true', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
+
+            render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            await userEvent.click(screen.getByTestId('address-select-button'));
+            await userEvent.click(screen.getByTestId('add-new-address'));
+
+            expect(
+                screen.getByLabelText('Save this address in my address book.'),
+            ).toBeInTheDocument();
+        });
+
+        it('does not show save address checkbox in multi-shipping new address modal when hasCompanyAddressBook is false', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            await userEvent.click(screen.getByTestId('shipping-mode-toggle'));
+
+            await userEvent.click(await screen.findByTestId('address-select-button'));
+            await userEvent.click(screen.getByTestId('add-new-address'));
+
+            const modal = await screen.findByRole('dialog');
+
+            expect(
+                within(modal).queryByLabelText('Save this address in my address book.'),
+            ).not.toBeInTheDocument();
+        });
+
+        it('does not call createCustomerAddress when hasCompanyAddressBook is true', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
+
+            jest.spyOn(checkoutService, 'createCustomerAddress');
+
+            render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            await userEvent.click(screen.getByTestId('shipping-mode-toggle'));
+
+            await userEvent.click(await screen.findByTestId('address-select-button'));
+            await userEvent.click(screen.getByTestId('add-new-address'));
+
+            const modal = await screen.findByRole('dialog');
+
+            await userEvent.clear(within(modal).getByLabelText('First Name'));
+            await userEvent.type(within(modal).getByLabelText('First Name'), customer.firstName);
+            await userEvent.clear(within(modal).getByLabelText('Last Name'));
+            await userEvent.type(within(modal).getByLabelText('Last Name'), customer.lastName);
+            await userEvent.clear(within(modal).getByTestId('addressLine1Input-text'));
+            await userEvent.type(
+                within(modal).getByTestId('addressLine1Input-text'),
+                shippingAddress.address1,
+            );
+            await userEvent.click(within(modal).getByText('Save Address'));
+
+            await waitFor(() =>
+                expect(checkoutService.createCustomerAddress).not.toHaveBeenCalled(),
+            );
+        });
+
         it('does not store the shipping address id when hasCompanyAddressBook is disabled', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
 

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -1133,9 +1133,7 @@ describe('Shipping step', () => {
             await userEvent.click(screen.getByTestId('address-select-button'));
             await userEvent.click(screen.getByTestId('add-new-address'));
 
-            expect(
-                screen.getByLabelText('Save this address in my address book.'),
-            ).toBeInTheDocument();
+            expect(screen.getByLabelText('Save to company address book.')).toBeInTheDocument();
         });
 
         it('does not show save address checkbox in multi-shipping new address modal when hasCompanyAddressBook is false', async () => {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -38,6 +38,7 @@
             "postal_code_label": "Postal Code",
             "postal_code_required_error": "Postal Code is required",
             "save_in_addressbook": "Save this address in my address book.",
+            "save_to_company_addressbook": "Save to company address book.",
             "search_addresses": "Search addresses",
             "select_country_action": "Select a country",
             "select_state_action": "Select a state",


### PR DESCRIPTION
## What/Why?

Use the `Save this address in my address book.` checkbox to save `shouldSaveAddress` value into API.

## Rollout/Rollback

Revert.

## Testing
### Hiding the checkbox when `hasCompanyAddressBook` is `false`.
<img width="1567" height="1000" alt="Screenshot 2026-07-01 at 12 43 14" src="https://github.com/user-attachments/assets/47644c65-0aa7-4bc8-b345-75e98c55c419" />

### Saving `shouldSaveAddress` value as `true`
<img width="1567" height="1000" alt="Screenshot 2026-07-01 at 12 40 11" src="https://github.com/user-attachments/assets/88d4c58f-ff34-469e-8696-50ce16ec1093" />
<img width="1567" height="1000" alt="Screenshot 2026-07-01 at 12 40 39" src="https://github.com/user-attachments/assets/e558ae49-7077-4738-a5d9-8a3090ec2dfe" />


### Saving `shouldSaveAddress` value as `false`
<img width="1567" height="1000" alt="Screenshot 2026-07-01 at 12 41 08" src="https://github.com/user-attachments/assets/4788032d-7f5a-492d-bc5a-4aaac8660ac8" />
<img width="1567" height="1000" alt="Screenshot 2026-07-01 at 12 41 46" src="https://github.com/user-attachments/assets/842842d6-f4c5-4573-8667-48f619468fe6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-shipping save behavior for B2B logged-in customers (no automatic createCustomerAddress) and relies on shouldSaveAddress reaching consignment APIs; wrong capability wiring could hide the checkbox or skip intended address-book saves.
> 
> **Overview**
> Multi-shipping **add new address** modals now honor **`shouldShowSaveAddress`** instead of always hiding the “Save this address in my address book” checkbox.
> 
> **`ConsignmentAddressSelector`** drives this from **`hasCompanyAddressBook`**: B2B shoppers see the checkbox (so **`shouldSaveAddress`** can flow with the consignment update via existing form mapping), while everyone else still does not. For logged-in customers with the company address book, **`createCustomerAddress`** is no longer called on modal save—address persistence is left to the API flag rather than the legacy customer-address endpoint.
> 
> **`AddressFormModal`** forwards the prop into **`AddressForm`** (replacing a hardcoded `false`). Unit and shipping integration tests cover checkbox visibility and the skipped **`createCustomerAddress`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6a92085485dfee7d7263960f1d2d70e5cdf5c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->