### PR TITLE
chore(checkout): BACK-714 Fix lint issue in buildBundleItemsMapFromOrder test file

### DIFF
--- a/packages/core/src/app/order/removeBundledItems.test.ts
+++ b/packages/core/src/app/order/removeBundledItems.test.ts
@@ -42,7 +42,9 @@ describe('buildBundleItemsMapFromOrder()', () => {
         const parent = {
             ...getPhysicalItem(),
             id: 'parent-1',
-            options: [{ name: 'Color', nameId: 10, value: 'Red', valueId: 20, attributeId: 'attr-1' }],
+            options: [
+                { name: 'Color', nameId: 10, value: 'Red', valueId: 20, attributeId: 'attr-1' },
+            ],
         };
         const child = { ...getPhysicalItem(), id: 'child-1', addedByAttributeId: 'attr-1' };
         const lineItems = { ...emptyLineItems, physicalItems: [parent] };
@@ -52,6 +54,7 @@ describe('buildBundleItemsMapFromOrder()', () => {
             const { bundleItemsMap } = buildBundleItemsMapFromOrder(lineItems, orderBundledItems);
 
             expect(bundleItemsMap.size).toBe(1);
+
             const children = bundleItemsMap.get('parent-1');
 
             expect(children).toHaveLength(1);
@@ -70,7 +73,9 @@ describe('buildBundleItemsMapFromOrder()', () => {
         const parent = {
             ...getDigitalItem(),
             id: 'parent-d',
-            options: [{ name: 'Format', nameId: 11, value: 'PDF', valueId: 21, attributeId: 'attr-d' }],
+            options: [
+                { name: 'Format', nameId: 11, value: 'PDF', valueId: 21, attributeId: 'attr-d' },
+            ],
         };
         const child = { ...getDigitalItem(), id: 'child-d', addedByAttributeId: 'attr-d' };
         const lineItems = { ...emptyLineItems, digitalItems: [parent] };
@@ -245,6 +250,7 @@ describe('removeAndBundleItemsTogether()', () => {
             const { bundleItemsMap } = removeAndBundleItemsTogether(items);
 
             expect(bundleItemsMap.size).toBe(1);
+
             const children = bundleItemsMap.get(String(parent.id));
 
             expect(children).toHaveLength(1);
@@ -262,6 +268,7 @@ describe('removeAndBundleItemsTogether()', () => {
             const { nonBundledItems, bundleItemsMap } = removeAndBundleItemsTogether(items);
 
             expect(nonBundledItems.physicalItems).toHaveLength(1);
+
             const children = bundleItemsMap.get(String(parent.id));
 
             expect(children).toHaveLength(2);


### PR DESCRIPTION
## What/Why?
Fix lint issue in buildBundleItemsMapFromOrder test file

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only formatting; no runtime or bundling logic changes.
> 
> **Overview**
> **Formatting-only** updates in `removeBundledItems.test.ts` for `buildBundleItemsMapFromOrder` / `removeAndBundleItemsTogether` tests.
> 
> Parent fixture `options` arrays are split across multiple lines, and a few blank lines are added between assertions (e.g. after `bundleItemsMap.size` checks). **No test logic or production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b4ca8d80f3298057bd8ccad679b0fb402b1c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->