### PR TITLE
feat(checkout): CHECKOUT-10026 Add new Google Places API services

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocompleteService.ts
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocompleteService.ts
@@ -1,5 +1,5 @@
 import getGoogleAutocompleteScriptLoader from './getGoogleAutocompleteScriptLoader';
-import type GoogleAutocompleteScriptLoader from './GoogleAutocompleteScriptLoader';
+import { type GoogleMapsPlacesScriptLoader } from './googleAutocompleteTypes';
 
 export default class GoogleAutocompleteService {
     private _autocompletePromise?: Promise<google.maps.places.AutocompleteService>;
@@ -7,7 +7,7 @@ export default class GoogleAutocompleteService {
 
     constructor(
         private _apiKey: string,
-        private _scriptLoader: GoogleAutocompleteScriptLoader = getGoogleAutocompleteScriptLoader(),
+        private _scriptLoader: GoogleMapsPlacesScriptLoader = getGoogleAutocompleteScriptLoader(),
     ) {}
 
     getAutocompleteService(): Promise<google.maps.places.AutocompleteService> {

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
@@ -39,6 +39,12 @@ export interface GoogleAutocompleteWindow extends Window {
     };
 }
 
+// Satisfied by both legacy API (GoogleAutocompleteScriptLoader via`@bigcommerce/script-loader`)
+// and by new API (NewGooglePlacesApiScriptLoader's via importLibrary path)
+export interface GoogleMapsPlacesScriptLoader {
+    loadMapsSdk(apiKey: string): Promise<GoogleMapsSdk>;
+}
+
 export type GoogleAddressFieldType =
     | 'postal_town'
     | 'administrative_area_level_1'

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.test.ts
@@ -1,0 +1,107 @@
+import { NewGooglePlacesApiScriptLoader } from './NewGooglePlacesApiScriptLoader';
+
+type MutableWindow = Record<string, any>;
+
+describe('NewGooglePlacesApiScriptLoader', () => {
+    const placesLibrary = {
+        AutocompleteSuggestion: {},
+        AutocompleteSessionToken: {},
+        Place: {},
+        AutocompleteService: {},
+        PlacesService: {},
+    };
+
+    afterEach(() => {
+        // this only removes the google property for test isolation
+        delete (window as MutableWindow).google;
+        document.head
+            .querySelectorAll('script[src*="maps.googleapis.com"]')
+            .forEach((node) => node.remove());
+    });
+
+    describe('when importLibrary is already available', () => {
+        let importLibrary: jest.Mock;
+
+        beforeEach(() => {
+            importLibrary = jest.fn().mockResolvedValue(placesLibrary);
+            (window as MutableWindow).google = { maps: { importLibrary } };
+        });
+
+        it('loads the places library via the existing importLibrary without bootstrapping', async () => {
+            const loader = new NewGooglePlacesApiScriptLoader();
+
+            const library = await loader.loadPlacesLibrary('foo');
+
+            expect(importLibrary).toHaveBeenCalledWith('places');
+            expect(library).toBe(placesLibrary);
+            expect(document.head.querySelector('script[src*="maps.googleapis.com"]')).toBeNull();
+        });
+
+        it('memoizes the library so importLibrary is only called once', async () => {
+            const loader = new NewGooglePlacesApiScriptLoader();
+
+            await loader.loadPlacesLibrary('foo');
+            await loader.loadPlacesLibrary('foo');
+            await loader.loadPlacesLibrary('foo');
+
+            expect(importLibrary).toHaveBeenCalledTimes(1);
+        });
+
+        it('clears the cached promise on failure so a later call can retry', async () => {
+            importLibrary
+                .mockRejectedValueOnce(new Error('places unavailable'))
+                .mockResolvedValueOnce(placesLibrary);
+
+            const loader = new NewGooglePlacesApiScriptLoader();
+
+            await expect(loader.loadPlacesLibrary('foo')).rejects.toThrow('places unavailable');
+
+            const library = await loader.loadPlacesLibrary('foo');
+
+            expect(library).toBe(placesLibrary);
+            expect(importLibrary).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('#loadMapsSdk()', () => {
+        it('reuses the same underlying library promise as loadPlacesLibrary, without loading a second script', async () => {
+            const importLibrary = jest.fn().mockResolvedValue(placesLibrary);
+
+            (window as MutableWindow).google = { maps: { importLibrary } };
+
+            const loader = new NewGooglePlacesApiScriptLoader();
+
+            await loader.loadPlacesLibrary('foo');
+
+            const sdk = await loader.loadMapsSdk('foo');
+
+            expect(importLibrary).toHaveBeenCalledTimes(1);
+            expect(sdk).toEqual({
+                places: {
+                    AutocompleteService: placesLibrary.AutocompleteService,
+                    PlacesService: placesLibrary.PlacesService,
+                },
+            });
+        });
+    });
+
+    describe('when importLibrary is missing', () => {
+        it('bootstraps the Maps JS loader so importLibrary becomes available', () => {
+            const loader = new NewGooglePlacesApiScriptLoader();
+
+            // The bootstrap installs `importLibrary` synchronously so we do not await it here.
+            loader.loadPlacesLibrary('foo').catch(() => undefined);
+
+            expect(typeof (window as MutableWindow).google.maps.importLibrary).toBe('function');
+
+            const script = document.head.querySelector<HTMLScriptElement>(
+                'script[src*="maps.googleapis.com"]',
+            );
+
+            expect(script).not.toBeNull();
+            expect(script?.src).toContain('key=foo');
+            expect(script?.src).toContain('libraries=places');
+            expect(script?.src).toContain('callback=google.maps.__ib__');
+        });
+    });
+});

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
@@ -30,7 +30,6 @@ interface BootstrapGlobalScope {
  */
 function bootstrapGoogleMapsImportLibrary({ key, v, language }: MapsBootstrapConfig): void {
     const CALLBACK_KEY = '__ib__';
-    const doc = document;
     const globalScope: BootstrapGlobalScope = window;
     const googleNs = (globalScope.google = globalScope.google || {});
     const mapsNs = (googleNs.maps = googleNs.maps || {});
@@ -59,10 +58,10 @@ function bootstrapGoogleMapsImportLibrary({ key, v, language }: MapsBootstrapCon
                 params.set('language', language);
             }
 
-            const script = doc.createElement('script');
+            const script = document.createElement('script');
 
             script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
-            script.nonce = doc.querySelector<HTMLScriptElement>('script[nonce]')?.nonce ?? '';
+            script.nonce = document.querySelector<HTMLScriptElement>('script[nonce]')?.nonce ?? '';
 
             script.onerror = () => {
                 // Clear the cached promise so a later retry appends a fresh <script> tag
@@ -71,7 +70,7 @@ function bootstrapGoogleMapsImportLibrary({ key, v, language }: MapsBootstrapCon
             };
 
             mapsNs[CALLBACK_KEY] = resolve;
-            doc.head.append(script);
+            document.head.append(script);
         });
 
         return loadPromise;

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
@@ -6,6 +6,15 @@ interface MapsBootstrapConfig {
 
 import { type GoogleMapsSdk } from '../googleAutocompleteTypes';
 
+interface BootstrapGlobalScope {
+    google?: {
+        maps?: {
+            importLibrary?: (library: string, ...rest: unknown[]) => Promise<unknown>;
+            [key: string]: unknown;
+        };
+    };
+}
+
 /**
  * This is based on the official Google Maps JavaScript API loader example:
  * https://developers.google.com/maps/documentation/javascript/load-maps-js-api
@@ -22,7 +31,7 @@ import { type GoogleMapsSdk } from '../googleAutocompleteTypes';
 function bootstrapGoogleMapsImportLibrary({ key, v, language }: MapsBootstrapConfig): void {
     const CALLBACK_KEY = '__ib__';
     const doc = document;
-    const globalScope = window as Record<string, any>;
+    const globalScope: BootstrapGlobalScope = window;
     const googleNs = (globalScope.google = globalScope.google || {});
     const mapsNs = (googleNs.maps = googleNs.maps || {});
 
@@ -71,7 +80,7 @@ function bootstrapGoogleMapsImportLibrary({ key, v, language }: MapsBootstrapCon
     mapsNs.importLibrary = (library: string, ...rest: unknown[]): Promise<unknown> => {
         requestedLibraries.add(library);
 
-        return loadScript().then(() => mapsNs.importLibrary(library, ...rest));
+        return loadScript().then(() => mapsNs.importLibrary?.(library, ...rest));
     };
 }
 

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
@@ -54,8 +54,13 @@ function bootstrapGoogleMapsImportLibrary({ key, v, language }: MapsBootstrapCon
 
             script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
             script.nonce = doc.querySelector<HTMLScriptElement>('script[nonce]')?.nonce ?? '';
-            script.onerror = () =>
+
+            script.onerror = () => {
+                // Clear the cached promise so a later retry appends a fresh <script> tag
+                loadPromise = undefined;
                 reject(new Error('The Google Maps JavaScript API could not load.'));
+            };
+
             mapsNs[CALLBACK_KEY] = resolve;
             doc.head.append(script);
         });

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiScriptLoader.ts
@@ -1,0 +1,103 @@
+interface MapsBootstrapConfig {
+    key: string;
+    v: string;
+    language?: string;
+}
+
+import { type GoogleMapsSdk } from '../googleAutocompleteTypes';
+
+/**
+ * This is based on the official Google Maps JavaScript API loader example:
+ * https://developers.google.com/maps/documentation/javascript/load-maps-js-api
+ *
+ * This loader is only ever reached when the CHECKOUT-10026.new_google_places_api flag is on for a
+ * store. Stores with the flag off never construct or call this class, so they keep loading
+ * the Maps JS API exactly as they do today, via GoogleAutocompleteScriptLoader.
+ *
+ * When the flag IS on, both the new Places API classes and the legacy
+ * AutocompleteService/PlacesService classes must share this same loader instance/promise.
+ * This is because both old and new API share the same Google's Maps JS API
+ * and it breaks if loaded twice on the same page.
+ */
+function bootstrapGoogleMapsImportLibrary({ key, v, language }: MapsBootstrapConfig): void {
+    const CALLBACK_KEY = '__ib__';
+    const doc = document;
+    const globalScope = window as Record<string, any>;
+    const googleNs = (globalScope.google = globalScope.google || {});
+    const mapsNs = (googleNs.maps = googleNs.maps || {});
+
+    if (typeof mapsNs.importLibrary === 'function') {
+        return;
+    }
+
+    const requestedLibraries = new Set<string>();
+    let loadPromise: Promise<void> | undefined;
+
+    const loadScript = (): Promise<void> => {
+        if (loadPromise) {
+            return loadPromise;
+        }
+
+        loadPromise = new Promise<void>((resolve, reject) => {
+            const params = new URLSearchParams({
+                key,
+                v,
+                callback: `google.maps.${CALLBACK_KEY}`,
+                libraries: [...requestedLibraries].join(','),
+            });
+
+            if (language) {
+                params.set('language', language);
+            }
+
+            const script = doc.createElement('script');
+
+            script.src = `https://maps.googleapis.com/maps/api/js?${params.toString()}`;
+            script.nonce = doc.querySelector<HTMLScriptElement>('script[nonce]')?.nonce ?? '';
+            script.onerror = () =>
+                reject(new Error('The Google Maps JavaScript API could not load.'));
+            mapsNs[CALLBACK_KEY] = resolve;
+            doc.head.append(script);
+        });
+
+        return loadPromise;
+    };
+
+    mapsNs.importLibrary = (library: string, ...rest: unknown[]): Promise<unknown> => {
+        requestedLibraries.add(library);
+
+        return loadScript().then(() => mapsNs.importLibrary(library, ...rest));
+    };
+}
+
+export class NewGooglePlacesApiScriptLoader {
+    private _placesPromise?: Promise<google.maps.PlacesLibrary>;
+
+    loadPlacesLibrary(apiKey: string): Promise<google.maps.PlacesLibrary> {
+        if (this._placesPromise) {
+            return this._placesPromise;
+        }
+
+        // `importLibrary` is the single entry point for the new Places classes.
+        if (typeof google === 'undefined' || typeof google.maps?.importLibrary !== 'function') {
+            bootstrapGoogleMapsImportLibrary({ key: apiKey, v: 'weekly', language: 'en' });
+        }
+
+        this._placesPromise = (
+            google.maps.importLibrary('places') as Promise<google.maps.PlacesLibrary>
+        ).catch((e) => {
+            this._placesPromise = undefined;
+            throw e;
+        });
+
+        return this._placesPromise;
+    }
+
+    // Adapter so GoogleAutocompleteService (legacy AutocompleteService/PlacesService) can be
+    // handed this loader and reuse the already-loaded script instead of loading its own.
+    loadMapsSdk(apiKey: string): Promise<GoogleMapsSdk> {
+        return this.loadPlacesLibrary(apiKey).then(({ AutocompleteService, PlacesService }) => ({
+            places: { AutocompleteService, PlacesService },
+        }));
+    }
+}

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.test.ts
@@ -1,0 +1,202 @@
+import { type NewGooglePlacesApiScriptLoader } from './NewGooglePlacesApiScriptLoader';
+import { NewGooglePlacesApiService } from './NewGooglePlacesApiService';
+
+const mockPlaceAddressComponents = [
+    { longText: 'New South Wales', shortText: 'NSW', types: ['administrative_area_level_1'] },
+    { longText: 'Australia', shortText: 'AU', types: ['country'] },
+];
+
+const mockFetchFields = jest.fn().mockResolvedValue(undefined);
+
+const mockPlaceFromPrediction = {
+    fetchFields: mockFetchFields,
+    addressComponents: mockPlaceAddressComponents,
+    displayName: '123 Main St',
+};
+
+const mockToPlace = jest.fn().mockReturnValue(mockPlaceFromPrediction);
+
+const mockSuggestions = [
+    {
+        placePrediction: {
+            placeId: 'place-1',
+            text: { text: '123 Main St, NY', matches: [] },
+            mainText: { text: '123 Main St' },
+            toPlace: mockToPlace,
+        },
+    },
+];
+
+const MockPlace = jest.fn().mockImplementation(({ id }: { id: string }) => ({
+    id,
+    fetchFields: mockFetchFields,
+    addressComponents: mockPlaceAddressComponents,
+    displayName: '123 Main St',
+}));
+
+const MockSessionToken = jest.fn().mockImplementation(() => ({}));
+
+const mockPlacesLibrary = {
+    AutocompleteSuggestion: {
+        fetchAutocompleteSuggestions: jest.fn().mockResolvedValue({ suggestions: mockSuggestions }),
+    },
+    AutocompleteSessionToken: MockSessionToken,
+    Place: MockPlace,
+};
+
+const mockScriptLoader = {
+    loadPlacesLibrary: jest.fn().mockResolvedValue(mockPlacesLibrary),
+} as unknown as NewGooglePlacesApiScriptLoader;
+
+describe('NewGooglePlacesApiService', () => {
+    let service: NewGooglePlacesApiService;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        service = new NewGooglePlacesApiService('test-api-key', mockScriptLoader);
+    });
+
+    describe('getSuggestions', () => {
+        it('returns suggestions mapped to AutocompleteItems', async () => {
+            const result = await service.getSuggestions('123 Main', ['address']);
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toMatchObject({ id: 'place-1', label: '123 Main St, NY' });
+        });
+
+        it('passes input and mapped types to fetchAutocompleteSuggestions', async () => {
+            await service.getSuggestions('123 Main', ['address']);
+
+            expect(
+                mockPlacesLibrary.AutocompleteSuggestion.fetchAutocompleteSuggestions,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: '123 Main',
+                    includedPrimaryTypes: ['street_address'],
+                }),
+            );
+        });
+
+        it('maps a string country restriction to includedRegionCodes array', async () => {
+            await service.getSuggestions('123 Main', ['address'], { country: 'US' });
+
+            expect(
+                mockPlacesLibrary.AutocompleteSuggestion.fetchAutocompleteSuggestions,
+            ).toHaveBeenCalledWith(expect.objectContaining({ includedRegionCodes: ['US'] }));
+        });
+
+        it('maps an array country restriction to includedRegionCodes', async () => {
+            await service.getSuggestions('123 Main', ['address'], { country: ['US', 'CA'] });
+
+            expect(
+                mockPlacesLibrary.AutocompleteSuggestion.fetchAutocompleteSuggestions,
+            ).toHaveBeenCalledWith(expect.objectContaining({ includedRegionCodes: ['US', 'CA'] }));
+        });
+
+        it('omits includedRegionCodes when no componentRestrictions provided', async () => {
+            await service.getSuggestions('123 Main', ['address']);
+
+            expect(
+                mockPlacesLibrary.AutocompleteSuggestion.fetchAutocompleteSuggestions,
+            ).toHaveBeenCalledWith(expect.objectContaining({ includedRegionCodes: undefined }));
+        });
+    });
+
+    describe('getPlaceDetails', () => {
+        it('fetches place details via the SDK with the mapped field mask', async () => {
+            await service.getPlaceDetails('place-1', ['addressComponents', 'displayName']);
+
+            expect(MockPlace).toHaveBeenCalledWith({ id: 'place-1' });
+            expect(mockFetchFields).toHaveBeenCalledWith({
+                fields: ['addressComponents', 'displayName'],
+            });
+        });
+
+        it('translates legacy snake_case field names into SDK field names', async () => {
+            await service.getPlaceDetails('place-1', ['address_components', 'name']);
+
+            expect(mockFetchFields).toHaveBeenCalledWith({
+                fields: ['addressComponents', 'displayName'],
+            });
+        });
+
+        it('uses default fields when none provided', async () => {
+            await service.getPlaceDetails('place-1');
+
+            expect(mockFetchFields).toHaveBeenCalledWith({
+                fields: ['addressComponents', 'displayName'],
+            });
+        });
+
+        it('maps addressComponents to the legacy GeocoderAddressComponent shape', async () => {
+            const result = await service.getPlaceDetails('place-1');
+
+            expect(result.address_components).toEqual([
+                {
+                    long_name: 'New South Wales',
+                    short_name: 'NSW',
+                    types: ['administrative_area_level_1'],
+                },
+                { long_name: 'Australia', short_name: 'AU', types: ['country'] },
+            ]);
+        });
+
+        it('maps displayName to the name field', async () => {
+            const result = await service.getPlaceDetails('place-1');
+
+            expect(result.name).toBe('123 Main St');
+        });
+
+        it('rejects when fetchFields fails', async () => {
+            mockFetchFields.mockRejectedValueOnce(new Error('Maps JS auth failed'));
+
+            await expect(service.getPlaceDetails('place-1')).rejects.toThrow('Maps JS auth failed');
+        });
+
+        it('falls back to a tokenless Place lookup when no matching prediction is cached', async () => {
+            await service.getPlaceDetails('unknown-place');
+
+            expect(MockPlace).toHaveBeenCalledWith({ id: 'unknown-place' });
+            expect(mockToPlace).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('session tokens', () => {
+        it('creates a session token and passes it to fetchAutocompleteSuggestions', async () => {
+            await service.getSuggestions('123 Main', ['address']);
+
+            expect(MockSessionToken).toHaveBeenCalledTimes(1);
+            expect(
+                mockPlacesLibrary.AutocompleteSuggestion.fetchAutocompleteSuggestions,
+            ).toHaveBeenCalledWith(expect.objectContaining({ sessionToken: expect.any(Object) }));
+        });
+
+        it('reuses the same token across keystrokes within one session', async () => {
+            await service.getSuggestions('1', ['address']);
+            await service.getSuggestions('12', ['address']);
+
+            expect(MockSessionToken).toHaveBeenCalledTimes(1);
+
+            const { calls } =
+                mockPlacesLibrary.AutocompleteSuggestion.fetchAutocompleteSuggestions.mock;
+
+            expect(calls[0][0].sessionToken).toBe(calls[1][0].sessionToken);
+        });
+
+        it('concludes the session via the prediction toPlace() and starts a fresh token next time', async () => {
+            await service.getSuggestions('123 Main', ['address']);
+
+            const result = await service.getPlaceDetails('place-1');
+
+            // Resolved through the cached prediction, not a freshly constructed Place.
+            expect(mockToPlace).toHaveBeenCalledTimes(1);
+            expect(MockPlace).not.toHaveBeenCalled();
+            expect(result.name).toBe('123 Main St');
+
+            // The next address entry opens a brand-new session.
+            await service.getSuggestions('456 Oak', ['address']);
+
+            expect(MockSessionToken).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.ts
@@ -53,17 +53,19 @@ export class NewGooglePlacesApiService {
     ): Promise<google.maps.places.PlaceResult> {
         const place = await this.resolvePlace(placeId);
 
-        await place.fetchFields({ fields: mapLegacyToNewPlaceDetailsFieldMask(fields) });
+        try {
+            await place.fetchFields({ fields: mapLegacyToNewPlaceDetailsFieldMask(fields) });
 
-        // Fetching details ends the autocomplete session and the next entry should start a new one
-        this.resetSession();
-
-        return {
-            address_components: place.addressComponents?.map(
-                mapNewToLegacyGeocoderAddressComponent,
-            ),
-            name: place.displayName ?? '',
-        };
+            return {
+                address_components: place.addressComponents?.map(
+                    mapNewToLegacyGeocoderAddressComponent,
+                ),
+                name: place.displayName ?? '',
+            };
+        } finally {
+            // Fetching details ends the autocomplete session and the next entry should start a new one
+            this.resetSession();
+        }
     }
 
     private async resolvePlace(placeId: string): Promise<google.maps.places.Place> {

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.ts
@@ -1,0 +1,103 @@
+import type { AutocompleteItem } from '@bigcommerce/checkout/ui';
+
+import type { GoogleAutocompleteOptionTypes } from '../googleAutocompleteTypes';
+
+import getNewGooglePlacesApiScriptLoader from './getNewGooglePlacesApiScriptLoader';
+import { type NewGooglePlacesApiScriptLoader } from './NewGooglePlacesApiScriptLoader';
+import {
+    mapLegacyToNewIncludedPrimaryTypes,
+    mapLegacyToNewPlaceDetailsFieldMask,
+    mapNewToLegacyGeocoderAddressComponent,
+    mapSuggestionsToAutocompleteItems,
+} from './utils';
+
+export class NewGooglePlacesApiService {
+    private _sessionToken?: google.maps.places.AutocompleteSessionToken;
+    private _predictionsById = new Map<string, google.maps.places.PlacePrediction>();
+
+    constructor(
+        private _apiKey: string,
+        private _scriptLoader: NewGooglePlacesApiScriptLoader = getNewGooglePlacesApiScriptLoader(),
+    ) {}
+
+    async getSuggestions(
+        input: string,
+        types: GoogleAutocompleteOptionTypes[] | undefined,
+        componentRestrictions?: google.maps.places.ComponentRestrictions,
+    ): Promise<AutocompleteItem[]> {
+        const { AutocompleteSuggestion, AutocompleteSessionToken } =
+            await this._scriptLoader.loadPlacesLibrary(this._apiKey);
+
+        if (!this._sessionToken) {
+            this._sessionToken = new AutocompleteSessionToken();
+        }
+
+        const includedRegionCodes = this.convertToRegionCodes(componentRestrictions?.country);
+        const includedPrimaryTypes = mapLegacyToNewIncludedPrimaryTypes(types ?? ['geocode']);
+
+        const { suggestions } = await AutocompleteSuggestion.fetchAutocompleteSuggestions({
+            input,
+            includedPrimaryTypes,
+            includedRegionCodes,
+            sessionToken: this._sessionToken,
+        });
+
+        this.cachePredictions(suggestions);
+
+        return mapSuggestionsToAutocompleteItems(suggestions);
+    }
+
+    async getPlaceDetails(
+        placeId: string,
+        fields?: string[],
+    ): Promise<google.maps.places.PlaceResult> {
+        const place = await this.resolvePlace(placeId);
+
+        await place.fetchFields({ fields: mapLegacyToNewPlaceDetailsFieldMask(fields) });
+
+        // Fetching details ends the autocomplete session and the next entry should start a new one
+        this.resetSession();
+
+        return {
+            address_components: place.addressComponents?.map(
+                mapNewToLegacyGeocoderAddressComponent,
+            ),
+            name: place.displayName ?? '',
+        };
+    }
+
+    private async resolvePlace(placeId: string): Promise<google.maps.places.Place> {
+        const prediction = this._predictionsById.get(placeId);
+
+        if (prediction) {
+            return prediction.toPlace();
+        }
+
+        const { Place } = await this._scriptLoader.loadPlacesLibrary(this._apiKey);
+
+        return new Place({ id: placeId });
+    }
+
+    private cachePredictions(suggestions: google.maps.places.AutocompleteSuggestion[]): void {
+        for (const { placePrediction } of suggestions) {
+            if (placePrediction) {
+                this._predictionsById.set(placePrediction.placeId, placePrediction);
+            }
+        }
+    }
+
+    private resetSession(): void {
+        this._sessionToken = undefined;
+        this._predictionsById.clear();
+    }
+
+    private convertToRegionCodes(
+        country: string | string[] | null | undefined,
+    ): string[] | undefined {
+        if (!country) {
+            return undefined;
+        }
+
+        return Array.isArray(country) ? country : [country];
+    }
+}

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/NewGooglePlacesApiService.ts
@@ -2,7 +2,7 @@ import type { AutocompleteItem } from '@bigcommerce/checkout/ui';
 
 import type { GoogleAutocompleteOptionTypes } from '../googleAutocompleteTypes';
 
-import getNewGooglePlacesApiScriptLoader from './getNewGooglePlacesApiScriptLoader';
+import { getNewGooglePlacesApiScriptLoader } from './getNewGooglePlacesApiScriptLoader';
 import { type NewGooglePlacesApiScriptLoader } from './NewGooglePlacesApiScriptLoader';
 import {
     mapLegacyToNewIncludedPrimaryTypes,

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/getNewGooglePlacesApiScriptLoader.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/getNewGooglePlacesApiScriptLoader.ts
@@ -2,7 +2,7 @@ import { NewGooglePlacesApiScriptLoader } from './NewGooglePlacesApiScriptLoader
 
 let instance: NewGooglePlacesApiScriptLoader;
 
-export default function getNewGooglePlacesApiScriptLoader(): NewGooglePlacesApiScriptLoader {
+export function getNewGooglePlacesApiScriptLoader(): NewGooglePlacesApiScriptLoader {
     if (!instance) {
         instance = new NewGooglePlacesApiScriptLoader();
     }

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/getNewGooglePlacesApiScriptLoader.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/getNewGooglePlacesApiScriptLoader.ts
@@ -1,0 +1,11 @@
+import { NewGooglePlacesApiScriptLoader } from './NewGooglePlacesApiScriptLoader';
+
+let instance: NewGooglePlacesApiScriptLoader;
+
+export default function getNewGooglePlacesApiScriptLoader(): NewGooglePlacesApiScriptLoader {
+    if (!instance) {
+        instance = new NewGooglePlacesApiScriptLoader();
+    }
+
+    return instance;
+}

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/index.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/index.ts
@@ -1,2 +1,1 @@
-export { default as getNewGooglePlacesApiScriptLoader } from './getNewGooglePlacesApiScriptLoader';
 export { NewGooglePlacesApiService } from './NewGooglePlacesApiService';

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/index.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/index.ts
@@ -1,0 +1,2 @@
+export { default as getNewGooglePlacesApiScriptLoader } from './getNewGooglePlacesApiScriptLoader';
+export { NewGooglePlacesApiService } from './NewGooglePlacesApiService';

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/utils.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/utils.test.ts
@@ -1,0 +1,145 @@
+import {
+    isNewPlacesApiPermissionDenied,
+    mapLegacyToNewIncludedPrimaryTypes,
+    mapLegacyToNewPlaceDetailsFieldMask,
+    mapNewToLegacyGeocoderAddressComponent,
+    mapSuggestionsToAutocompleteItems,
+} from './utils';
+
+describe('mapLegacyToNewPlaceDetailsFieldMask', () => {
+    it('maps legacy snake_case field names to new-API camelCase names', () => {
+        expect(mapLegacyToNewPlaceDetailsFieldMask(['address_components', 'name'])).toEqual([
+            'addressComponents',
+            'displayName',
+        ]);
+    });
+
+    it('passes through new-API field names unchanged', () => {
+        expect(mapLegacyToNewPlaceDetailsFieldMask(['addressComponents', 'displayName'])).toEqual([
+            'addressComponents',
+            'displayName',
+        ]);
+    });
+
+    it('de-duplicates fields that map to the same name', () => {
+        expect(mapLegacyToNewPlaceDetailsFieldMask(['name', 'displayName'])).toEqual([
+            'displayName',
+        ]);
+    });
+
+    it('defaults to address components and display name when none provided', () => {
+        expect(mapLegacyToNewPlaceDetailsFieldMask()).toEqual(['addressComponents', 'displayName']);
+        expect(mapLegacyToNewPlaceDetailsFieldMask([])).toEqual([
+            'addressComponents',
+            'displayName',
+        ]);
+    });
+});
+
+describe('mapLegacyToNewIncludedPrimaryTypes', () => {
+    it('maps "address" to "street_address"', () => {
+        expect(mapLegacyToNewIncludedPrimaryTypes(['address'])).toEqual(['street_address']);
+    });
+
+    it('keeps "establishment" as-is', () => {
+        expect(mapLegacyToNewIncludedPrimaryTypes(['establishment'])).toEqual(['establishment']);
+    });
+
+    it('returns undefined for "geocode" (no direct equivalent)', () => {
+        expect(mapLegacyToNewIncludedPrimaryTypes(['geocode'])).toBeUndefined();
+    });
+
+    it('filters out null-mapped types and returns the rest', () => {
+        expect(mapLegacyToNewIncludedPrimaryTypes(['geocode', 'address'])).toEqual([
+            'street_address',
+        ]);
+    });
+
+    it('returns undefined for an empty array', () => {
+        expect(mapLegacyToNewIncludedPrimaryTypes([])).toBeUndefined();
+    });
+});
+
+describe('mapSuggestionsToAutocompleteItems', () => {
+    it('maps a suggestion to an autocomplete item', () => {
+        const mockSuggestions: google.maps.places.AutocompleteSuggestion[] = [
+            {
+                placePrediction: {
+                    placeId: 'place-1',
+                    text: {
+                        text: '123 Main St, New York',
+                        matches: [{ startOffset: 0, endOffset: 3 }],
+                    },
+                    mainText: { text: '123 Main St' },
+                } as google.maps.places.PlacePrediction,
+            },
+        ];
+
+        const items = mapSuggestionsToAutocompleteItems(mockSuggestions);
+
+        expect(items).toHaveLength(1);
+        expect(items[0]).toMatchObject({
+            id: 'place-1',
+            label: '123 Main St, New York',
+            value: '123 Main St',
+            highlightedSlices: [{ offset: 0, length: 3 }],
+        });
+    });
+
+    it('skips suggestions without placePrediction', () => {
+        const mockSuggestionsWithoutPlacePrediction: google.maps.places.AutocompleteSuggestion[] = [
+            { placePrediction: null },
+        ];
+
+        expect(mapSuggestionsToAutocompleteItems(mockSuggestionsWithoutPlacePrediction)).toEqual(
+            [],
+        );
+    });
+});
+
+describe('mapNewToLegacyGeocoderAddressComponent', () => {
+    it('maps an AddressComponent to a GeocoderAddressComponent', () => {
+        const addressComponentMock = {
+            longText: 'New York',
+            shortText: 'NY',
+            types: ['locality', 'political'],
+        } as google.maps.places.AddressComponent;
+
+        expect(mapNewToLegacyGeocoderAddressComponent(addressComponentMock)).toEqual({
+            long_name: 'New York',
+            short_name: 'NY',
+            types: ['locality', 'political'],
+        });
+    });
+
+    it('falls back to empty strings and empty array when fields are missing', () => {
+        const component = {} as google.maps.places.AddressComponent;
+
+        expect(mapNewToLegacyGeocoderAddressComponent(component)).toEqual({
+            long_name: '',
+            short_name: '',
+            types: [],
+        });
+    });
+});
+
+describe('isNewPlacesApiPermissionDenied', () => {
+    it('returns true for an RpcError with PERMISSION_DENIED (code 7)', () => {
+        expect(isNewPlacesApiPermissionDenied({ name: 'RpcError', code: 7 })).toBe(true);
+    });
+
+    it('returns false for an RpcError with some transient code', () => {
+        expect(isNewPlacesApiPermissionDenied({ name: 'RpcError', code: 14 })).toBe(false);
+    });
+
+    it('returns false for a non-RpcError carrying code 7', () => {
+        expect(isNewPlacesApiPermissionDenied({ name: 'TypeError', code: 7 })).toBe(false);
+    });
+
+    it('returns false for unrelated error shapes and non-objects', () => {
+        expect(isNewPlacesApiPermissionDenied(new Error('boom'))).toBe(false);
+        expect(isNewPlacesApiPermissionDenied(undefined)).toBe(false);
+        expect(isNewPlacesApiPermissionDenied(null)).toBe(false);
+        expect(isNewPlacesApiPermissionDenied('PERMISSION_DENIED')).toBe(false);
+    });
+});

--- a/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/utils.ts
+++ b/packages/core/src/app/address/googleAutocomplete/newGooglePlacesApi/utils.ts
@@ -1,0 +1,73 @@
+import { type AutocompleteItem } from '@bigcommerce/checkout/ui';
+
+import { type GoogleAutocompleteOptionTypes } from '../googleAutocompleteTypes';
+
+const LEGACY_TO_NEW_TYPE_MAP: Record<GoogleAutocompleteOptionTypes, string | null> = {
+    geocode: null,
+    address: 'street_address',
+    establishment: 'establishment',
+};
+
+const LEGACY_TO_NEW_FIELD_MAP: Record<string, string> = {
+    address_components: 'addressComponents',
+    name: 'displayName',
+};
+
+export const mapLegacyToNewIncludedPrimaryTypes = (
+    legacyTypes: GoogleAutocompleteOptionTypes[],
+): string[] | undefined => {
+    const mapped = legacyTypes
+        .map((legacyType) => LEGACY_TO_NEW_TYPE_MAP[legacyType])
+        .filter((newType): newType is string => newType !== null);
+
+    return mapped.length > 0 ? mapped : undefined;
+};
+
+export const mapSuggestionsToAutocompleteItems = (
+    suggestions: google.maps.places.AutocompleteSuggestion[],
+): AutocompleteItem[] =>
+    suggestions.flatMap((suggestion) => {
+        const { placePrediction } = suggestion;
+
+        if (!placePrediction) return [];
+
+        return [
+            {
+                label: placePrediction.text?.text ?? '',
+                value: placePrediction.mainText?.text ?? '',
+                highlightedSlices: (placePrediction.text?.matches ?? []).map(
+                    ({ startOffset, endOffset }) => ({
+                        offset: startOffset,
+                        length: endOffset - startOffset,
+                    }),
+                ),
+                id: placePrediction.placeId,
+            },
+        ];
+    });
+
+export const mapLegacyToNewPlaceDetailsFieldMask = (fields?: string[]): string[] => {
+    const source = fields?.length ? fields : ['address_components', 'name'];
+
+    return Array.from(new Set(source.map((field) => LEGACY_TO_NEW_FIELD_MAP[field] ?? field)));
+};
+
+export const mapNewToLegacyGeocoderAddressComponent = (newAddressComponent: {
+    longText?: string | null;
+    shortText?: string | null;
+    types?: string[] | null;
+}): google.maps.GeocoderAddressComponent => ({
+    long_name: newAddressComponent.longText ?? '',
+    short_name: newAddressComponent.shortText ?? '',
+    types: newAddressComponent.types ?? [],
+});
+
+// places.googleapis.com is gRPC-Web, so failures arrive as an `RpcError` with a numeric gRPC status `code`.
+// Code 7 is a consistent PERMISSION_DENIED and not anything transient
+const GRPC_PERMISSION_DENIED = 7;
+
+export const isNewPlacesApiPermissionDenied = (error: unknown): boolean => {
+    const rpcError = error as { name?: unknown; code?: unknown } | null | undefined;
+
+    return rpcError?.name === 'RpcError' && rpcError.code === GRPC_PERMISSION_DENIED;
+};


### PR DESCRIPTION
## What/Why?

Adds a new, self-contained `newGooglePlacesApi/` module (script loader, session-token service, mapping utils) implementing the new version of Google's Places API (Autocomplete). This is Part 1 of the work and in Part 2 I actually will wire it up with our existing service and with our new experiment flag.

This PR also includes a small type-only refactor so `GoogleAutocompleteService` depends on a shared `GoogleMapsPlacesScriptLoader` interface instead of the legacy loader class, enabling loader sharing in a later PR.

As mentioned, nothing is wired up yet so no existing code in production calls the new module, and GoogleAutocompleteService's behavior is unchanged. This should have zero behavior change.

## Rollout/Rollback

Revert the PR, but in practice the revert of this PR will do nothing - it purely adds the service without connecting it to any components.

## Testing

New CI tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production paths are untouched; changes are additive module code plus a type-only constructor dependency on GoogleAutocompleteService with the same default loader.
> 
> **Overview**
> Introduces a self-contained **`newGooglePlacesApi/`** stack for Google’s **Places (New)** autocomplete flow—script loading via `importLibrary`, **`NewGooglePlacesApiService`** for suggestions and place details, and mapping helpers so responses still look like legacy **`PlaceResult`** / **`AutocompleteItem`** shapes. Session tokens, prediction caching, and **`toPlace()`** on selection are handled in the service; **`isNewPlacesApiPermissionDenied`** is included for future gRPC error handling.
> 
> **`GoogleAutocompleteService`** now depends on a shared **`GoogleMapsPlacesScriptLoader`** interface instead of the legacy loader class, so a follow-up can inject **`NewGooglePlacesApiScriptLoader`** (which also implements **`loadMapsSdk`** for legacy **`AutocompleteService`/`PlacesService`**) and avoid loading Maps JS twice.
> 
> **No checkout wiring or feature flag usage in this PR**—existing autocomplete behavior is unchanged until Part 2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 325fa175b5a9328c9b233c4fedf7303abf4de00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->