### PR TITLE
chore(checkout): BACK-714 Change color and formatting for backorder messaging

### DIFF
--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -87,7 +87,10 @@ const OrderSummaryItemBackorderDetails = ({
                 ref={backorderDetailsRef}
             >
                 {shouldDisplayQuantityOnHand && (
-                    <div data-test="cart-item-onhand-qty">
+                    <div
+                        className="product-backorder-status product-backorder-status--onhand"
+                        data-test="cart-item-onhand-qty"
+                    >
                         <TranslatedString
                             data={{ count: quantityOnHand }}
                             id="cart.ready_to_ship_count_text"
@@ -95,7 +98,10 @@ const OrderSummaryItemBackorderDetails = ({
                     </div>
                 )}
                 {shouldDisplayQuantityOnBackorder && (
-                    <div data-test="cart-item-backorder-qty">
+                    <div
+                        className="product-backorder-status product-backorder-status--backorder"
+                        data-test="cart-item-backorder-qty"
+                    >
                         <TranslatedString
                             data={{ count: quantityBackordered }}
                             id="cart.backorder_count_text"
@@ -103,7 +109,12 @@ const OrderSummaryItemBackorderDetails = ({
                     </div>
                 )}
                 {shouldDisplayBackorderMessage && (
-                    <div data-test="cart-item-backorder-message">{backorderMessage}</div>
+                    <div
+                        className="product-backorder-lead-time"
+                        data-test="cart-item-backorder-message"
+                    >
+                        {backorderMessage}
+                    </div>
                 )}
             </div>
         </CollapseCSSTransition>

--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -110,7 +110,7 @@ const OrderSummaryItemBackorderDetails = ({
                 )}
                 {shouldDisplayBackorderMessage && (
                     <div
-                        className="product-backorder-lead-time"
+                        className="product-backorder-message"
                         data-test="cart-item-backorder-message"
                     >
                         {backorderMessage}

--- a/packages/core/src/scss/components/checkout/productList/_productList.scss
+++ b/packages/core/src/scss/components/checkout/productList/_productList.scss
@@ -64,7 +64,6 @@
 }
 
 .product-options, .product-backorder-details-container {
-    color: color("greys");
     font-size: fontSize("tiny");
     margin: 0;
 }
@@ -79,6 +78,43 @@
         height $animation-collapse-transitionSpeed $animation-collapse-transitionCurve,
         opacity $animation-collapse-transitionSpeed $animation-collapse-transitionCurve,
         margin $animation-collapse-transitionSpeed $animation-collapse-transitionCurve;
+}
+
+.product-backorder-status {
+    align-items: center;
+    display: flex;
+
+    &::before {
+        border-radius: 50%;
+        content: '';
+        display: inline-block;
+        flex-shrink: 0;
+        height: remCalc(8px);
+        margin-right: spacing("quarter");
+        width: remCalc(8px);
+    }
+
+    &--onhand {
+        color: $color-successDarker;
+
+        &::before {
+            background-color: $color-successDark;
+        }
+    }
+
+    &--backorder {
+        color: $color-warningDark;
+
+        &::before {
+            background-color: $color-warningDark;
+        }
+    }
+}
+
+.product-backorder-lead-time {
+    color: $color-warningDark;
+    padding-left: calc(#{remCalc(8px)} + #{spacing("quarter")});
+    padding-bottom: spacing("quarter");
 }
 
 .product-actions {

--- a/packages/core/src/scss/components/checkout/productList/_productList.scss
+++ b/packages/core/src/scss/components/checkout/productList/_productList.scss
@@ -111,7 +111,7 @@
     }
 }
 
-.product-backorder-lead-time {
+.product-backorder-message {
     color: $color-warningDark;
     padding-left: calc(#{remCalc(8px)} + #{spacing("quarter")});
     padding-bottom: spacing("quarter");

--- a/packages/core/src/scss/settings/global/color/_color.scss
+++ b/packages/core/src/scss/settings/global/color/_color.scss
@@ -47,9 +47,12 @@ $color-infoLight:                   #f5f5f5;
 
 $color-success:                     #004d0d;
 $color-successLight:                #d3f5d9;
+$color-successDark:                 #16A34A;
+$color-successDarker:               #15803D;
 
 $color-warning:                     #d1a162;
 $color-warningLight:                #fbf7ee;
+$color-warningDark:                 #B45309;
 
 // Text
 // -----------------------------------------------------------------------------

--- a/packages/core/src/scss/settings/global/color/_color.scss
+++ b/packages/core/src/scss/settings/global/color/_color.scss
@@ -47,12 +47,12 @@ $color-infoLight:                   #f5f5f5;
 
 $color-success:                     #004d0d;
 $color-successLight:                #d3f5d9;
-$color-successDark:                 #16A34A;
-$color-successDarker:               #15803D;
+$color-successDark:                 #16a34a;
+$color-successDarker:               #15803d;
 
 $color-warning:                     #d1a162;
 $color-warningLight:                #fbf7ee;
-$color-warningDark:                 #B45309;
+$color-warningDark:                 #b45309;
 
 // Text
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## What/Why?
Change color and formatting for backorder messaging. Make backorder messaging easier to read.

## Rollout/Rollback
- revert this PR

## Testing
- CI
- Screencast

https://github.com/user-attachments/assets/5002b340-9636-45c5-983a-3afb355269a2




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to checkout order summary markup and styles; inventory logic and `data-test` hooks are unchanged.
> 
> **Overview**
> Checkout order summary **backorder details** are restyled so on-hand vs backorder stock reads at a glance instead of sharing generic grey secondary text.
> 
> `OrderSummaryItem` wires **ready-to-ship** and **backorder quantity** rows to `product-backorder-status` modifiers (`--onhand` / `--backorder`), and the free-text backorder copy to `product-backorder-message`. Product list SCSS adds **8px status dots** (green for on-hand, amber for backorder), applies the new success/warning palette to those lines, indents the message under the dot, and drops the blanket grey color on `.product-backorder-details-container`. Global color settings add **`$color-successDark`**, **`$color-successDarker`**, and **`$color-warningDark`** for these states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8dfdc3805c2652c7422c39905838fb20576142a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->