### PR TITLE
chore(checkout): CHECKOUT-10140 bump sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.935.1",
+        "@bigcommerce/checkout-sdk": "^1.936.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.935.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.935.1.tgz",
-      "integrity": "sha512-DDPqHw8Zl2T/P02QFc085Gl36daRz2bd6lwOwQTBtHmWtkuqNy6wNJ7R/cGqzMtI52AxdwFzL5ELg2nC/loFPg==",
+      "version": "1.936.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.0.tgz",
+      "integrity": "sha512-vU3+C6I1dCH9Jmr7qlZ+7bkh86XcdO2J8dbr/n10OmKz3HVMzCh9VfGIw3xgB63+VN5YCYlmqVtBsAD8Wuxi2A==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.935.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.935.1.tgz",
-      "integrity": "sha512-DDPqHw8Zl2T/P02QFc085Gl36daRz2bd6lwOwQTBtHmWtkuqNy6wNJ7R/cGqzMtI52AxdwFzL5ELg2nC/loFPg==",
+      "version": "1.936.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.0.tgz",
+      "integrity": "sha512-vU3+C6I1dCH9Jmr7qlZ+7bkh86XcdO2J8dbr/n10OmKz3HVMzCh9VfGIw3xgB63+VN5YCYlmqVtBsAD8Wuxi2A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.935.1",
+    "@bigcommerce/checkout-sdk": "^1.936.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk-js version to release https://github.com/bigcommerce/checkout-sdk-js/pull/3303

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout SDK upgrades can affect payment and checkout flows even without local code changes; risk depends on what changed in SDK 1.936.0.
> 
> **Overview**
> Updates the checkout app’s **`@bigcommerce/checkout-sdk`** dependency from **`^1.935.1`** to **`^1.936.0`**, with matching lockfile entries for the new tarball version and integrity hash.
> 
> There are **no source changes** in this repo—only `package.json` and `package-lock.json`—so behavior comes entirely from whatever shipped in the SDK release (checkout-sdk-js [#3303](https://github.com/bigcommerce/checkout-sdk-js/pull/3303)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e898132a2f4a199af45d249d46e7c583d292d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->