### PR TITLE
feat(checkout): CHECKOUT-10149 attach temporary billing component in payment step

### DIFF
--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -16,6 +16,7 @@ import {
     type ExtensionServiceInterface,
     LocaleContext,
     type LocaleContextType,
+    ThemeContext,
 } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
@@ -45,9 +46,11 @@ describe('PaymentForm', () => {
     let defaultProps: PaymentFormProps;
     let localeContext: LocaleContextType;
     let paymentContext: PaymentContextProps;
+    let themeV2: boolean;
     let PaymentFormTest: FunctionComponent<PaymentFormProps>;
 
     beforeEach(() => {
+        themeV2 = false;
         defaultProps = {
             isStoreCreditApplied: true,
             defaultMethodId: getPaymentMethod().id,
@@ -76,11 +79,13 @@ describe('PaymentForm', () => {
             <CheckoutProvider checkoutService={checkoutService}>
                 <PaymentContext.Provider value={paymentContext}>
                     <LocaleContext.Provider value={localeContext}>
-                        <Formik initialValues={null} onSubmit={noop}>
-                            <ExtensionProvider extensionService={extensionService}>
-                                <PaymentForm {...props} />
-                            </ExtensionProvider>
-                        </Formik>
+                        <ThemeContext.Provider value={{ themeV2 }}>
+                            <Formik initialValues={null} onSubmit={noop}>
+                                <ExtensionProvider extensionService={extensionService}>
+                                    <PaymentForm {...props} />
+                                </ExtensionProvider>
+                            </Formik>
+                        </ThemeContext.Provider>
                     </LocaleContext.Provider>
                 </PaymentContext.Provider>
             </CheckoutProvider>
@@ -484,6 +489,24 @@ describe('PaymentForm', () => {
                     }),
                 ),
             ).toBeInTheDocument();
+        });
+    });
+
+    describe('billing-in-payment scaffold (themeV2)', () => {
+        it('renders the placeholder billing block when themeV2 is enabled', () => {
+            themeV2 = true;
+
+            render(<PaymentFormTest {...defaultProps} />);
+
+            expect(screen.getByTestId('payment-billing-block')).toBeInTheDocument();
+        });
+
+        it('does not render the billing block when themeV2 is disabled', () => {
+            themeV2 = false;
+
+            render(<PaymentFormTest {...defaultProps} />);
+
+            expect(screen.queryByTestId('payment-billing-block')).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -10,7 +10,7 @@ import React, { type FunctionComponent, memo, useCallback, useContext, useMemo }
 import { object, type ObjectSchema, string } from 'yup';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
-import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import {
     TranslatedString,
     withLanguage,
@@ -26,6 +26,7 @@ import { getOrderExtraFieldsValidationSchema } from '../formFields';
 import { TermsConditions } from '../termsConditions';
 
 import AdditionalPaymentField from './AdditionalPaymentField';
+import { PaymentBillingBlock } from './billingForm';
 import getPaymentValidationSchema from './getPaymentValidationSchema';
 import InvoicePaymentCommentField from './InvoicePaymentCommentField';
 import { NoPaymentMethods } from './NoPaymentMethods';
@@ -132,6 +133,7 @@ const PaymentForm: FunctionComponent<
     }, [selectedMethod]);
 
     const { selectedState: config } = useCheckout(({ data }) => data.getConfig());
+    const { themeV2 } = useThemeContext();
     const {
         payment: { invoicePaymentComment },
     } = useCapabilities();
@@ -197,6 +199,8 @@ const PaymentForm: FunctionComponent<
                     values={values}
                 />
             )}
+
+            {themeV2 && <PaymentBillingBlock />}
 
             <PaymentRedeemables />
 

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -7,14 +7,6 @@ import React, { type FunctionComponent } from 'react';
  * will live within the payment step. The actual `BillingForm` and
  * same-as-shipping orchestration arrive in CHECKOUT-10150 / CHECKOUT-10151.
  */
-const PaymentBillingBlock: FunctionComponent = () => {
-    return (
-        <div
-            className="paymentBillingBlock"
-            data-test="payment-billing-block"
-            id="payment-billing-block"
-        />
-    );
+export const PaymentBillingBlock: FunctionComponent = () => {
+    return <div className="paymentBillingBlock" data-test="payment-billing-block" />;
 };
-
-export default PaymentBillingBlock;

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -1,0 +1,20 @@
+import React, { type FunctionComponent } from 'react';
+
+/**
+ * Placeholder billing region rendered inside the payment step under themeV2.
+ *
+ * CHECKOUT-10149 scaffolds the branch only — this component establishes where billing
+ * will live within the payment step. The actual `BillingForm` and
+ * same-as-shipping orchestration arrive in CHECKOUT-10150 / CHECKOUT-10151.
+ */
+const PaymentBillingBlock: FunctionComponent = () => {
+    return (
+        <div
+            className="paymentBillingBlock"
+            data-test="payment-billing-block"
+            id="payment-billing-block"
+        />
+    );
+};
+
+export default PaymentBillingBlock;

--- a/packages/core/src/app/payment/billingForm/index.ts
+++ b/packages/core/src/app/payment/billingForm/index.ts
@@ -1,1 +1,1 @@
-export { default as PaymentBillingBlock } from './PaymentBillingBlock';
+export { PaymentBillingBlock } from './PaymentBillingBlock';

--- a/packages/core/src/app/payment/billingForm/index.ts
+++ b/packages/core/src/app/payment/billingForm/index.ts
@@ -1,0 +1,1 @@
+export { default as PaymentBillingBlock } from './PaymentBillingBlock';


### PR DESCRIPTION
## What/Why?

First ticket of the Billing Address in Payment Step epic. Establishes the conditional entry point so the payment step owns billing rendering under `themeV2`, while the legacy standalone Billing step path stays exactly as today. This is wiring + the branch only — no visual change yet; the actual BillingForm and same-as-shipping orchestration land in follow-up tickets (`CHECKOUT-10150 / CHECKOUT-10151`).

Changes:

- New placeholder component `payment/billingForm/PaymentBillingBlock.tsx` (+ `index.ts`) — an empty, well-named billing region (payment-billing-block) marking where billing will live inside the payment step.
- Single `themeV2` gate in `PaymentForm.tsx` — reads `themeV2` from `useThemeContext()` and renders `{themeV2 && <PaymentBillingBlock />}` between the payment-method fieldset and PaymentRedeemables, matching the design's "payment method → billing section" order.
- Tests — added a `ThemeContext.Provider` to the `PaymentForm` test wrapper (the new hook requires it) with a resettable `themeV2` flag, plus cases asserting the block renders when `themeV2` is `ON` and is absent when `OFF`.


## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Placeholder wiring behind an existing theme flag with no billing validation or checkout flow changes when themeV2 is disabled.
> 
> **Overview**
> Under **themeV2**, the payment step now reserves a billing section between the payment-method list and redeemables. **`PaymentForm`** reads `themeV2` from `useThemeContext()` and conditionally mounts a new **`PaymentBillingBlock`** placeholder (`payment-billing-block`); when themeV2 is off, checkout behavior and layout stay the same as today.
> 
> The block is an empty shell only—real billing UI and same-as-shipping flow are deferred to follow-up tickets. Tests wrap **`ThemeContext`** in the payment form harness and assert the placeholder appears only when `themeV2` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03222b68b3ed0e85aa2ed2a2e555a02a0067713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->