### PR TITLE
chore(payment): PAYPAL-6718 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.936.0",
+        "@bigcommerce/checkout-sdk": "^1.936.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.936.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.0.tgz",
-      "integrity": "sha512-vU3+C6I1dCH9Jmr7qlZ+7bkh86XcdO2J8dbr/n10OmKz3HVMzCh9VfGIw3xgB63+VN5YCYlmqVtBsAD8Wuxi2A==",
+      "version": "1.936.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.2.tgz",
+      "integrity": "sha512-XsC/pqRaSVVNPIm4M3p21b/ERD+eVT+43JiC85JMifqeDrTuEx12QZYpjAum3PPjEr5n3hDFbby/Pd9ML82NDw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.936.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.0.tgz",
-      "integrity": "sha512-vU3+C6I1dCH9Jmr7qlZ+7bkh86XcdO2J8dbr/n10OmKz3HVMzCh9VfGIw3xgB63+VN5YCYlmqVtBsAD8Wuxi2A==",
+      "version": "1.936.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.2.tgz",
+      "integrity": "sha512-XsC/pqRaSVVNPIm4M3p21b/ERD+eVT+43JiC85JMifqeDrTuEx12QZYpjAum3PPjEr5n3hDFbby/Pd9ML82NDw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.936.0",
+    "@bigcommerce/checkout-sdk": "^1.936.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-js version
Release https://github.com/bigcommerce/checkout-sdk-js/pull/3304
<!--
  A description about what this pull request implements and its purpose.
  Try to be detailed and describe any technical details to simplify the job
  of the reviewer and the individual on production support.
-->

## Rollout/Rollback
Revert
<!--
Detail how this change will be rolled out. Include reference to any
experiments and how the success will be measured as the experiment is
ramped.

Document rollback procedures. Is rolling back the change as simple as
rolling back an experiment or does it require reverting code? Are there
database migrations that may change our decision to roll forward instead of
back?
-->

## Testing
All test passed
<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment/checkout behavior can change inside the SDK patch release even without app code edits; rollback is reverting the version bump.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **^1.936.0** to **^1.936.2** in `package.json` and refreshes the lockfile so installs resolve **1.936.2** (PAYPAL-6718 / checkout-sdk-js release).
> 
> There are **no checkout-js source changes** in this diff—only the dependency version and `package-lock.json` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a14ce9dd9381b605c0669abf5cba1a31879ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->