### PR TITLE
feat(checkout): CHECKOUT-10026 Connect new Google Places API behind feature flag

### DIFF
--- a/packages/core/src/app/address/AddressForm.tsx
+++ b/packages/core/src/app/address/AddressForm.tsx
@@ -61,6 +61,11 @@ const AddressForm: React.FC<AddressFormProps> = ({
         'CHECKOUT-9019.use_new_phone_number_validation',
         false,
     );
+    const isNewGooglePlacesApiEnabled = isExperimentEnabled(
+        config?.checkoutSettings,
+        'CHECKOUT-10026.new_google_places_api',
+        false,
+    );
     const countriesWithAutocomplete = ['US', 'CA', 'AU', 'NZ', 'GB'];
 
     const containerRef = useRef<HTMLDivElement>(null);
@@ -174,6 +179,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
                                     countryCode={countryCode}
                                     field={field}
                                     isFloatingLabelEnabled={isFloatingLabelEnabledValue}
+                                    isNewPlacesApiEnabled={isNewGooglePlacesApiEnabled}
                                     key={field.id}
                                     nextElement={nextElementRef.current || undefined}
                                     onChange={handleAutocompleteChange}

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
@@ -47,35 +47,37 @@ const gRpcPermissionDeniedErrorMock = { name: 'RpcError', code: 7 };
 const gRpcSomeOtherErrorMock = { name: 'RpcError', code: 14 };
 
 describe('GoogleAutocomplete', () => {
-    let mockGetPlacePredictions: jest.Mock;
-    let mockGetDetails: jest.Mock;
-    let mockGetSuggestions: jest.Mock;
-    let mockGetPlaceDetails: jest.Mock;
+    let mockGetLegacyApiSuggestions: jest.Mock;
+    let mockGetLegacyApiPlaceDetails: jest.Mock;
+    let mockGetNewApiSuggestions: jest.Mock;
+    let mockGetNewApiPlaceDetails: jest.Mock;
     let defaultProps: GoogleAutocompleteProps;
 
     beforeEach(() => {
         resetNewGooglePlacesApiState();
 
-        mockGetPlacePredictions = jest.fn();
-        mockGetDetails = jest.fn();
-        mockGetSuggestions = jest.fn().mockResolvedValue(newApiSuggestions);
-        mockGetPlaceDetails = jest.fn().mockResolvedValue(newApiPlaceResult);
+        mockGetLegacyApiSuggestions = jest.fn();
+        mockGetLegacyApiPlaceDetails = jest.fn();
+        mockGetNewApiSuggestions = jest.fn().mockResolvedValue(newApiSuggestions);
+        mockGetNewApiPlaceDetails = jest.fn().mockResolvedValue(newApiPlaceResult);
 
         MockLegacyService.mockImplementation(
             () =>
                 ({
-                    getAutocompleteService: jest
+                    getAutocompleteService: jest.fn().mockResolvedValue({
+                        getPlacePredictions: mockGetLegacyApiSuggestions,
+                    }),
+                    getPlacesServices: jest
                         .fn()
-                        .mockResolvedValue({ getPlacePredictions: mockGetPlacePredictions }),
-                    getPlacesServices: jest.fn().mockResolvedValue({ getDetails: mockGetDetails }),
+                        .mockResolvedValue({ getDetails: mockGetLegacyApiPlaceDetails }),
                 }) as unknown as LegacyGoogleAutocompleteService,
         );
 
         MockPlacesApiService.mockImplementation(
             () =>
                 ({
-                    getSuggestions: mockGetSuggestions,
-                    getPlaceDetails: mockGetPlaceDetails,
+                    getSuggestions: mockGetNewApiSuggestions,
+                    getPlaceDetails: mockGetNewApiPlaceDetails,
                 }) as unknown as NewGooglePlacesApiService,
         );
 
@@ -95,7 +97,7 @@ describe('GoogleAutocomplete', () => {
             await userEvent.type(screen.getByRole('textbox'), '123');
 
             await screen.findByText('123 New API Ave');
-            expect(mockGetPlacePredictions).not.toHaveBeenCalled();
+            expect(mockGetLegacyApiSuggestions).not.toHaveBeenCalled();
         });
 
         it('calls onSelect with the new API place result when a suggestion is picked', async () => {
@@ -111,41 +113,45 @@ describe('GoogleAutocomplete', () => {
                     expect.objectContaining({ id: 'new-place-1' }),
                 ),
             );
-            expect(mockGetDetails).not.toHaveBeenCalled();
+            expect(mockGetLegacyApiPlaceDetails).not.toHaveBeenCalled();
         });
     });
 
     describe('new API unavailable (fall back to legacy)', () => {
         beforeEach(() => {
-            mockGetPlacePredictions.mockImplementation((_req, cb) => cb(legacySuggestions, 'OK'));
-            mockGetDetails.mockImplementation((_req, cb) => cb(legacyPlaceResult, 'OK'));
+            mockGetLegacyApiSuggestions.mockImplementation((_req, cb) =>
+                cb(legacySuggestions, 'OK'),
+            );
+            mockGetLegacyApiPlaceDetails.mockImplementation((_req, cb) =>
+                cb(legacyPlaceResult, 'OK'),
+            );
         });
 
         it('falls back to the legacy service for suggestions when the new API is denied', async () => {
-            mockGetSuggestions.mockRejectedValue(gRpcPermissionDeniedErrorMock);
+            mockGetNewApiSuggestions.mockRejectedValue(gRpcPermissionDeniedErrorMock);
 
             render(<GoogleAutocomplete {...defaultProps} />);
 
             await userEvent.type(screen.getByRole('textbox'), '123');
 
             await screen.findByText('123 Legacy St, New York');
-            expect(mockGetPlacePredictions).toHaveBeenCalled();
+            expect(mockGetLegacyApiSuggestions).toHaveBeenCalled();
         });
 
         it('does not fall back to legacy for a non-permission suggestions failure', async () => {
-            mockGetSuggestions.mockRejectedValue(gRpcSomeOtherErrorMock);
+            mockGetNewApiSuggestions.mockRejectedValue(gRpcSomeOtherErrorMock);
 
             render(<GoogleAutocomplete {...defaultProps} />);
 
             await userEvent.type(screen.getByRole('textbox'), '123');
 
-            await waitFor(() => expect(mockGetSuggestions).toHaveBeenCalled());
+            await waitFor(() => expect(mockGetNewApiSuggestions).toHaveBeenCalled());
             expect(screen.queryByText('123 Legacy St, New York')).not.toBeInTheDocument();
-            expect(mockGetPlacePredictions).not.toHaveBeenCalled();
+            expect(mockGetLegacyApiSuggestions).not.toHaveBeenCalled();
         });
 
         it('latches onto legacy after a permission denial and stops retrying the new API', async () => {
-            mockGetSuggestions.mockRejectedValue(gRpcPermissionDeniedErrorMock);
+            mockGetNewApiSuggestions.mockRejectedValue(gRpcPermissionDeniedErrorMock);
 
             render(<GoogleAutocomplete {...defaultProps} />);
 
@@ -154,16 +160,18 @@ describe('GoogleAutocomplete', () => {
             // First request hits the new API, is denied, and latches the fallback flag.
             await userEvent.type(input, '1');
             await screen.findByText('123 Legacy St, New York');
-            expect(mockGetSuggestions).toHaveBeenCalledTimes(1);
+            expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1);
 
             // A later request goes straight to legacy without retrying the new API.
             await userEvent.type(input, '2');
-            await waitFor(() => expect(mockGetPlacePredictions).toHaveBeenCalledTimes(2));
-            expect(mockGetSuggestions).toHaveBeenCalledTimes(1);
+            // legacy is called twice for both cases
+            await waitFor(() => expect(mockGetLegacyApiSuggestions).toHaveBeenCalledTimes(2));
+            // new api is called only once for previous input
+            expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1);
         });
 
         it('keeps retrying the new API on later input after a transient failure, without falling back', async () => {
-            mockGetSuggestions.mockRejectedValue(gRpcSomeOtherErrorMock);
+            mockGetNewApiSuggestions.mockRejectedValue(gRpcSomeOtherErrorMock);
 
             render(<GoogleAutocomplete {...defaultProps} />);
 
@@ -171,18 +179,18 @@ describe('GoogleAutocomplete', () => {
 
             // First request fails transiently; no fallback and no latch, since it's not a permission denial.
             await userEvent.type(input, '1');
-            await waitFor(() => expect(mockGetSuggestions).toHaveBeenCalledTimes(1));
-            expect(mockGetPlacePredictions).not.toHaveBeenCalled();
+            await waitFor(() => expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1));
+            expect(mockGetLegacyApiSuggestions).not.toHaveBeenCalled();
 
             // The new API is tried again on the next input, since the failure was not permanent.
             await userEvent.type(input, '2');
-            await waitFor(() => expect(mockGetSuggestions).toHaveBeenCalledTimes(2));
+            await waitFor(() => expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(2));
         });
 
         it('falls back to the legacy service for place details when the new API denies permission', async () => {
             // Suggestions still come from the new API so the dropdown has an item to click,
             // but getPlaceDetails is denied, forcing the legacy getDetails fallback.
-            mockGetPlaceDetails.mockRejectedValue(gRpcPermissionDeniedErrorMock);
+            mockGetNewApiPlaceDetails.mockRejectedValue(gRpcPermissionDeniedErrorMock);
 
             render(<GoogleAutocomplete {...defaultProps} />);
 
@@ -196,11 +204,11 @@ describe('GoogleAutocomplete', () => {
                     expect.objectContaining({ id: 'new-place-1' }),
                 ),
             );
-            expect(mockGetDetails).toHaveBeenCalled();
+            expect(mockGetLegacyApiPlaceDetails).toHaveBeenCalled();
         });
 
         it('does not fall back to legacy for a non-permission place details failure', async () => {
-            mockGetPlaceDetails.mockRejectedValue(new Error('new API down'));
+            mockGetNewApiPlaceDetails.mockRejectedValue(new Error('new API down'));
 
             render(<GoogleAutocomplete {...defaultProps} />);
 
@@ -208,16 +216,20 @@ describe('GoogleAutocomplete', () => {
             await screen.findByText('123 New API Ave');
             await userEvent.click(screen.getByText('123 New API Ave'));
 
-            await waitFor(() => expect(mockGetPlaceDetails).toHaveBeenCalled());
-            expect(mockGetDetails).not.toHaveBeenCalled();
+            await waitFor(() => expect(mockGetNewApiPlaceDetails).toHaveBeenCalled());
+            expect(mockGetLegacyApiPlaceDetails).not.toHaveBeenCalled();
             expect(defaultProps.onSelect).not.toHaveBeenCalled();
         });
     });
 
     describe('new API disabled via experiment flag', () => {
         beforeEach(() => {
-            mockGetPlacePredictions.mockImplementation((_req, cb) => cb(legacySuggestions, 'OK'));
-            mockGetDetails.mockImplementation((_req, cb) => cb(legacyPlaceResult, 'OK'));
+            mockGetLegacyApiSuggestions.mockImplementation((_req, cb) =>
+                cb(legacySuggestions, 'OK'),
+            );
+            mockGetLegacyApiPlaceDetails.mockImplementation((_req, cb) =>
+                cb(legacyPlaceResult, 'OK'),
+            );
         });
 
         it('goes straight to the legacy service for suggestions without calling the new API', async () => {
@@ -226,7 +238,7 @@ describe('GoogleAutocomplete', () => {
             await userEvent.type(screen.getByRole('textbox'), '123');
 
             await screen.findByText('123 Legacy St, New York');
-            expect(mockGetSuggestions).not.toHaveBeenCalled();
+            expect(mockGetNewApiSuggestions).not.toHaveBeenCalled();
         });
 
         it('goes straight to the legacy service for place details without calling the new API', async () => {
@@ -242,7 +254,7 @@ describe('GoogleAutocomplete', () => {
                     expect.objectContaining({ id: 'legacy-place-1' }),
                 ),
             );
-            expect(mockGetPlaceDetails).not.toHaveBeenCalled();
+            expect(mockGetNewApiPlaceDetails).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
@@ -1,0 +1,248 @@
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+
+import GoogleAutocomplete, {
+    type GoogleAutocompleteProps,
+    resetNewGooglePlacesApiState,
+} from './GoogleAutocomplete';
+import LegacyGoogleAutocompleteService from './GoogleAutocompleteService';
+import { NewGooglePlacesApiService } from './newGooglePlacesApi/NewGooglePlacesApiService';
+
+jest.mock('./GoogleAutocompleteService');
+jest.mock('./newGooglePlacesApi/NewGooglePlacesApiService');
+
+const MockLegacyService = LegacyGoogleAutocompleteService as jest.MockedClass<
+    typeof LegacyGoogleAutocompleteService
+>;
+const MockPlacesApiService = NewGooglePlacesApiService as jest.MockedClass<
+    typeof NewGooglePlacesApiService
+>;
+
+const legacySuggestions = [
+    {
+        description: '123 Legacy St, New York',
+        structured_formatting: { main_text: '123 Legacy St' },
+        matched_substrings: [],
+        place_id: 'legacy-place-1',
+    },
+];
+
+const legacyPlaceResult = {
+    name: '123 Legacy St',
+    address_components: [],
+} as google.maps.places.PlaceResult;
+
+const newApiSuggestions = [
+    { id: 'new-place-1', label: '123 New API Ave', value: '123 New API Ave' },
+];
+
+const newApiPlaceResult = {
+    name: '123 New API Ave',
+    address_components: [],
+} as google.maps.places.PlaceResult;
+
+const gRpcPermissionDeniedErrorMock = { name: 'RpcError', code: 7 };
+const gRpcSomeOtherErrorMock = { name: 'RpcError', code: 14 };
+
+describe('GoogleAutocomplete', () => {
+    let mockGetPlacePredictions: jest.Mock;
+    let mockGetDetails: jest.Mock;
+    let mockGetSuggestions: jest.Mock;
+    let mockGetPlaceDetails: jest.Mock;
+    let defaultProps: GoogleAutocompleteProps;
+
+    beforeEach(() => {
+        resetNewGooglePlacesApiState();
+
+        mockGetPlacePredictions = jest.fn();
+        mockGetDetails = jest.fn();
+        mockGetSuggestions = jest.fn().mockResolvedValue(newApiSuggestions);
+        mockGetPlaceDetails = jest.fn().mockResolvedValue(newApiPlaceResult);
+
+        MockLegacyService.mockImplementation(
+            () =>
+                ({
+                    getAutocompleteService: jest
+                        .fn()
+                        .mockResolvedValue({ getPlacePredictions: mockGetPlacePredictions }),
+                    getPlacesServices: jest.fn().mockResolvedValue({ getDetails: mockGetDetails }),
+                }) as unknown as LegacyGoogleAutocompleteService,
+        );
+
+        MockPlacesApiService.mockImplementation(
+            () =>
+                ({
+                    getSuggestions: mockGetSuggestions,
+                    getPlaceDetails: mockGetPlaceDetails,
+                }) as unknown as NewGooglePlacesApiService,
+        );
+
+        defaultProps = {
+            apiKey: 'test-api-key',
+            isAutocompleteEnabled: true,
+            isNewPlacesApiEnabled: true,
+            onSelect: jest.fn(),
+            onChange: jest.fn(),
+        };
+    });
+
+    describe('new API available (preferred path)', () => {
+        it('shows suggestions from the new API', async () => {
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '123');
+
+            await screen.findByText('123 New API Ave');
+            expect(mockGetPlacePredictions).not.toHaveBeenCalled();
+        });
+
+        it('calls onSelect with the new API place result when a suggestion is picked', async () => {
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '123');
+            await screen.findByText('123 New API Ave');
+            await userEvent.click(screen.getByText('123 New API Ave'));
+
+            await waitFor(() =>
+                expect(defaultProps.onSelect).toHaveBeenCalledWith(
+                    newApiPlaceResult,
+                    expect.objectContaining({ id: 'new-place-1' }),
+                ),
+            );
+            expect(mockGetDetails).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('new API unavailable (fall back to legacy)', () => {
+        beforeEach(() => {
+            mockGetPlacePredictions.mockImplementation((_req, cb) => cb(legacySuggestions, 'OK'));
+            mockGetDetails.mockImplementation((_req, cb) => cb(legacyPlaceResult, 'OK'));
+        });
+
+        it('falls back to the legacy service for suggestions when the new API is denied', async () => {
+            mockGetSuggestions.mockRejectedValue(gRpcPermissionDeniedErrorMock);
+
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '123');
+
+            await screen.findByText('123 Legacy St, New York');
+            expect(mockGetPlacePredictions).toHaveBeenCalled();
+        });
+
+        it('does not fall back to legacy for a non-permission suggestions failure', async () => {
+            mockGetSuggestions.mockRejectedValue(gRpcSomeOtherErrorMock);
+
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '123');
+
+            await waitFor(() => expect(mockGetSuggestions).toHaveBeenCalled());
+            expect(screen.queryByText('123 Legacy St, New York')).not.toBeInTheDocument();
+            expect(mockGetPlacePredictions).not.toHaveBeenCalled();
+        });
+
+        it('latches onto legacy after a permission denial and stops retrying the new API', async () => {
+            mockGetSuggestions.mockRejectedValue(gRpcPermissionDeniedErrorMock);
+
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            const input = screen.getByRole('textbox');
+
+            // First request hits the new API, is denied, and latches the fallback flag.
+            await userEvent.type(input, '1');
+            await screen.findByText('123 Legacy St, New York');
+            expect(mockGetSuggestions).toHaveBeenCalledTimes(1);
+
+            // A later request goes straight to legacy without retrying the new API.
+            await userEvent.type(input, '2');
+            await waitFor(() => expect(mockGetPlacePredictions).toHaveBeenCalledTimes(2));
+            expect(mockGetSuggestions).toHaveBeenCalledTimes(1);
+        });
+
+        it('keeps retrying the new API on later input after a transient failure, without falling back', async () => {
+            mockGetSuggestions.mockRejectedValue(gRpcSomeOtherErrorMock);
+
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            const input = screen.getByRole('textbox');
+
+            // First request fails transiently; no fallback and no latch, since it's not a permission denial.
+            await userEvent.type(input, '1');
+            await waitFor(() => expect(mockGetSuggestions).toHaveBeenCalledTimes(1));
+            expect(mockGetPlacePredictions).not.toHaveBeenCalled();
+
+            // The new API is tried again on the next input, since the failure was not permanent.
+            await userEvent.type(input, '2');
+            await waitFor(() => expect(mockGetSuggestions).toHaveBeenCalledTimes(2));
+        });
+
+        it('falls back to the legacy service for place details when the new API denies permission', async () => {
+            // Suggestions still come from the new API so the dropdown has an item to click,
+            // but getPlaceDetails is denied, forcing the legacy getDetails fallback.
+            mockGetPlaceDetails.mockRejectedValue(gRpcPermissionDeniedErrorMock);
+
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '1');
+            await screen.findByText('123 New API Ave');
+            await userEvent.click(screen.getByText('123 New API Ave'));
+
+            await waitFor(() =>
+                expect(defaultProps.onSelect).toHaveBeenCalledWith(
+                    legacyPlaceResult,
+                    expect.objectContaining({ id: 'new-place-1' }),
+                ),
+            );
+            expect(mockGetDetails).toHaveBeenCalled();
+        });
+
+        it('does not fall back to legacy for a non-permission place details failure', async () => {
+            mockGetPlaceDetails.mockRejectedValue(new Error('new API down'));
+
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '1');
+            await screen.findByText('123 New API Ave');
+            await userEvent.click(screen.getByText('123 New API Ave'));
+
+            await waitFor(() => expect(mockGetPlaceDetails).toHaveBeenCalled());
+            expect(mockGetDetails).not.toHaveBeenCalled();
+            expect(defaultProps.onSelect).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('new API disabled via experiment flag', () => {
+        beforeEach(() => {
+            mockGetPlacePredictions.mockImplementation((_req, cb) => cb(legacySuggestions, 'OK'));
+            mockGetDetails.mockImplementation((_req, cb) => cb(legacyPlaceResult, 'OK'));
+        });
+
+        it('goes straight to the legacy service for suggestions without calling the new API', async () => {
+            render(<GoogleAutocomplete {...defaultProps} isNewPlacesApiEnabled={false} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '123');
+
+            await screen.findByText('123 Legacy St, New York');
+            expect(mockGetSuggestions).not.toHaveBeenCalled();
+        });
+
+        it('goes straight to the legacy service for place details without calling the new API', async () => {
+            render(<GoogleAutocomplete {...defaultProps} isNewPlacesApiEnabled={false} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '1');
+            await screen.findByText('123 Legacy St, New York');
+            await userEvent.click(screen.getByText('123 Legacy St, New York'));
+
+            await waitFor(() =>
+                expect(defaultProps.onSelect).toHaveBeenCalledWith(
+                    legacyPlaceResult,
+                    expect.objectContaining({ id: 'legacy-place-1' }),
+                ),
+            );
+            expect(mockGetPlaceDetails).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -1,14 +1,13 @@
 import { noop } from 'lodash';
-import React, { useRef, useState } from 'react';
+import React from 'react';
 
 import { Autocomplete, type AutocompleteItem } from '@bigcommerce/checkout/ui';
 
-import GoogleAutocompleteService from './GoogleAutocompleteService';
 import { type GoogleAutocompleteOptionTypes } from './googleAutocompleteTypes';
-import { NewGooglePlacesApiService } from './newGooglePlacesApi';
-import { getNewGooglePlacesApiScriptLoader } from './newGooglePlacesApi/getNewGooglePlacesApiScriptLoader';
-import { isNewPlacesApiPermissionDenied } from './newGooglePlacesApi/utils';
+import { useGoogleAutocomplete } from './useGoogleAutocomplete';
 import './GoogleAutocomplete.scss';
+
+export { resetNewGooglePlacesApiState } from './useGoogleAutocomplete';
 
 export interface GoogleAutocompleteProps {
     initialValue?: string;
@@ -25,24 +24,6 @@ export interface GoogleAutocompleteProps {
     onChange?(value: string, isOpen: boolean): void;
 }
 
-const toAutocompleteItems = (
-    results?: google.maps.places.AutocompletePrediction[],
-): AutocompleteItem[] => {
-    return (results || []).map((result) => ({
-        label: result.description,
-        value: result.structured_formatting.main_text,
-        highlightedSlices: result.matched_substrings,
-        id: result.place_id,
-    }));
-};
-
-// module-scoped because we want to persist across all checkout steps
-const newGooglePlacesApiState = { isUnavailable: false };
-
-export function resetNewGooglePlacesApiState(): void {
-    newGooglePlacesApiState.isUnavailable = false;
-}
-
 const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     initialValue,
     onToggleOpen = noop,
@@ -57,158 +38,17 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     types,
     apiKey,
 }) => {
-    const [items, setItems] = useState<AutocompleteItem[]>([]);
-    const [autoComplete, setAutoComplete] = useState<string>('off');
-    const newGooglePlacesApiServiceRef = useRef<NewGooglePlacesApiService>();
-    const googleAutocompleteServiceRef = useRef<GoogleAutocompleteService>();
-    const latestNewApiInputRef = useRef<string>();
-
-    if (!newGooglePlacesApiServiceRef.current) {
-        newGooglePlacesApiServiceRef.current = new NewGooglePlacesApiService(apiKey);
-    }
-
-    if (!googleAutocompleteServiceRef.current) {
-        // When the new Places API is enabled, the legacy service must share the same script-loader instance.
-        // Otherwise Maps JS API that they depend on will be loaded twice and that breaks both services
-        googleAutocompleteServiceRef.current = new GoogleAutocompleteService(
-            apiKey,
-            isNewPlacesApiEnabled ? getNewGooglePlacesApiScriptLoader() : undefined,
-        );
-    }
-
-    const isUsingLegacyApi = () => !isNewPlacesApiEnabled || newGooglePlacesApiState.isUnavailable;
-
-    const finalizeSelection = (
-        place: google.maps.places.PlaceResult | null,
-        item: AutocompleteItem,
-    ) => {
-        if (nextElement) {
-            nextElement.focus();
-        }
-
-        onSelect(place, item);
-    };
-
-    const fetchSuggestionsWithLegacyApi = (input: string): void => {
-        const service = googleAutocompleteServiceRef.current;
-
-        if (!service) return;
-
-        service.getAutocompleteService().then((autocompleteService) => {
-            autocompleteService.getPlacePredictions(
-                { input, types: types || ['geocode'], componentRestrictions },
-                (results) => {
-                    setItems(toAutocompleteItems(results ?? undefined));
-                },
-            );
-        });
-    };
-
-    const fetchSuggestionsWithNewApi = (input: string): void => {
-        const service = newGooglePlacesApiServiceRef.current;
-
-        if (!service) return;
-
-        latestNewApiInputRef.current = input;
-
-        service
-            .getSuggestions(input, types, componentRestrictions)
-            .then((results) => {
-                if (latestNewApiInputRef.current === input) {
-                    setItems(results);
-                }
-            })
-            .catch((error) => {
-                if (isNewPlacesApiPermissionDenied(error)) {
-                    newGooglePlacesApiState.isUnavailable = true;
-                    fetchSuggestionsWithLegacyApi(input);
-
-                    return;
-                }
-
-                if (latestNewApiInputRef.current === input) {
-                    setItems([]);
-                }
-            });
-    };
-
-    const selectWithLegacyApi = (item: AutocompleteItem): void => {
-        const service = googleAutocompleteServiceRef.current;
-
-        if (!service) return;
-
-        service.getPlacesServices().then((placesService) => {
-            placesService.getDetails(
-                { placeId: item.id, fields: fields || ['address_components', 'name'] },
-                (result) => {
-                    finalizeSelection(result, item);
-                },
-            );
-        });
-    };
-
-    const selectWithNewApi = (item: AutocompleteItem): void => {
-        const service = newGooglePlacesApiServiceRef.current;
-
-        if (!service) return;
-
-        service
-            .getPlaceDetails(item.id, fields)
-            .then((result) => finalizeSelection(result, item))
-            .catch((error) => {
-                if (isNewPlacesApiPermissionDenied(error)) {
-                    newGooglePlacesApiState.isUnavailable = true;
-                    selectWithLegacyApi(item);
-                }
-            });
-    };
-
-    const handleSelect = (item: AutocompleteItem) => {
-        if (isUsingLegacyApi()) {
-            selectWithLegacyApi(item);
-
-            return;
-        }
-
-        selectWithNewApi(item);
-    };
-
-    const resetAutocomplete = (): void => {
-        setItems([]);
-        setAutoComplete('off');
-    };
-
-    const setAutocompleteValue = (input: string): void => {
-        setAutoComplete(input && input.length ? 'nope' : 'off');
-    };
-
-    const fetchSuggestions = (input: string): void => {
-        if (isUsingLegacyApi()) {
-            fetchSuggestionsWithLegacyApi(input);
-
-            return;
-        }
-
-        fetchSuggestionsWithNewApi(input);
-    };
-
-    const handleChange = (input: string) => {
-        onChange(input, false);
-
-        if (!isAutocompleteEnabled) {
-            return resetAutocomplete();
-        }
-
-        setAutocompleteValue(input);
-
-        if (!input) {
-            setItems([]);
-
-            return;
-        }
-
-        fetchSuggestions(input);
-    };
+    const { items, autoComplete, handleSelect, handleChange } = useGoogleAutocomplete({
+        apiKey,
+        fields,
+        nextElement,
+        isAutocompleteEnabled,
+        isNewPlacesApiEnabled,
+        types,
+        componentRestrictions,
+        onSelect,
+        onChange,
+    });
 
     return (
         <Autocomplete

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -61,6 +61,7 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     const [autoComplete, setAutoComplete] = useState<string>('off');
     const newGooglePlacesApiServiceRef = useRef<NewGooglePlacesApiService>();
     const googleAutocompleteServiceRef = useRef<GoogleAutocompleteService>();
+    const latestNewApiInputRef = useRef<string>();
 
     if (!newGooglePlacesApiServiceRef.current) {
         newGooglePlacesApiServiceRef.current = new NewGooglePlacesApiService(apiKey);
@@ -108,13 +109,25 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
 
         if (!service) return;
 
+        latestNewApiInputRef.current = input;
+
         service
             .getSuggestions(input, types, componentRestrictions)
-            .then(setItems)
+            .then((results) => {
+                if (latestNewApiInputRef.current === input) {
+                    setItems(results);
+                }
+            })
             .catch((error) => {
                 if (isNewPlacesApiPermissionDenied(error)) {
                     newGooglePlacesApiState.isUnavailable = true;
                     fetchSuggestionsWithLegacyApi(input);
+
+                    return;
+                }
+
+                if (latestNewApiInputRef.current === input) {
+                    setItems([]);
                 }
             });
     };

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -76,7 +76,7 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
         );
     }
 
-    const isUsingLegacyApi = !isNewPlacesApiEnabled || newGooglePlacesApiState.isUnavailable;
+    const isUsingLegacyApi = () => !isNewPlacesApiEnabled || newGooglePlacesApiState.isUnavailable;
 
     const finalizeSelection = (
         place: google.maps.places.PlaceResult | null,
@@ -164,7 +164,7 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     };
 
     const handleSelect = (item: AutocompleteItem) => {
-        if (isUsingLegacyApi) {
+        if (isUsingLegacyApi()) {
             selectWithLegacyApi(item);
 
             return;
@@ -183,7 +183,7 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     };
 
     const fetchSuggestions = (input: string): void => {
-        if (isUsingLegacyApi) {
+        if (isUsingLegacyApi()) {
             fetchSuggestionsWithLegacyApi(input);
 
             return;

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.tsx
@@ -5,6 +5,9 @@ import { Autocomplete, type AutocompleteItem } from '@bigcommerce/checkout/ui';
 
 import GoogleAutocompleteService from './GoogleAutocompleteService';
 import { type GoogleAutocompleteOptionTypes } from './googleAutocompleteTypes';
+import { NewGooglePlacesApiService } from './newGooglePlacesApi';
+import { getNewGooglePlacesApiScriptLoader } from './newGooglePlacesApi/getNewGooglePlacesApiScriptLoader';
+import { isNewPlacesApiPermissionDenied } from './newGooglePlacesApi/utils';
 import './GoogleAutocomplete.scss';
 
 export interface GoogleAutocompleteProps {
@@ -15,6 +18,7 @@ export interface GoogleAutocompleteProps {
     nextElement?: HTMLElement;
     inputProps?: any;
     isAutocompleteEnabled?: boolean;
+    isNewPlacesApiEnabled?: boolean;
     types?: GoogleAutocompleteOptionTypes[];
     onSelect?(place: google.maps.places.PlaceResult, item: AutocompleteItem): void;
     onToggleOpen?(state: { inputValue: string; isOpen: boolean }): void;
@@ -32,6 +36,13 @@ const toAutocompleteItems = (
     }));
 };
 
+// module-scoped because we want to persist across all checkout steps
+const newGooglePlacesApiState = { isUnavailable: false };
+
+export function resetNewGooglePlacesApiState(): void {
+    newGooglePlacesApiState.isUnavailable = false;
+}
+
 const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     initialValue,
     onToggleOpen = noop,
@@ -40,6 +51,7 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
     onSelect = noop,
     nextElement,
     isAutocompleteEnabled,
+    isNewPlacesApiEnabled = false,
     onChange = noop,
     componentRestrictions,
     types,
@@ -47,32 +59,105 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
 }) => {
     const [items, setItems] = useState<AutocompleteItem[]>([]);
     const [autoComplete, setAutoComplete] = useState<string>('off');
+    const newGooglePlacesApiServiceRef = useRef<NewGooglePlacesApiService>();
     const googleAutocompleteServiceRef = useRef<GoogleAutocompleteService>();
 
-    if (!googleAutocompleteServiceRef.current) {
-        googleAutocompleteServiceRef.current = new GoogleAutocompleteService(apiKey);
+    if (!newGooglePlacesApiServiceRef.current) {
+        newGooglePlacesApiServiceRef.current = new NewGooglePlacesApiService(apiKey);
     }
 
-    const onSelectHandler = (item: AutocompleteItem) => {
+    if (!googleAutocompleteServiceRef.current) {
+        // When the new Places API is enabled, the legacy service must share the same script-loader instance.
+        // Otherwise Maps JS API that they depend on will be loaded twice and that breaks both services
+        googleAutocompleteServiceRef.current = new GoogleAutocompleteService(
+            apiKey,
+            isNewPlacesApiEnabled ? getNewGooglePlacesApiScriptLoader() : undefined,
+        );
+    }
+
+    const isUsingLegacyApi = !isNewPlacesApiEnabled || newGooglePlacesApiState.isUnavailable;
+
+    const finalizeSelection = (
+        place: google.maps.places.PlaceResult | null,
+        item: AutocompleteItem,
+    ) => {
+        if (nextElement) {
+            nextElement.focus();
+        }
+
+        onSelect(place, item);
+    };
+
+    const fetchSuggestionsWithLegacyApi = (input: string): void => {
+        const service = googleAutocompleteServiceRef.current;
+
+        if (!service) return;
+
+        service.getAutocompleteService().then((autocompleteService) => {
+            autocompleteService.getPlacePredictions(
+                { input, types: types || ['geocode'], componentRestrictions },
+                (results) => {
+                    setItems(toAutocompleteItems(results ?? undefined));
+                },
+            );
+        });
+    };
+
+    const fetchSuggestionsWithNewApi = (input: string): void => {
+        const service = newGooglePlacesApiServiceRef.current;
+
+        if (!service) return;
+
+        service
+            .getSuggestions(input, types, componentRestrictions)
+            .then(setItems)
+            .catch((error) => {
+                if (isNewPlacesApiPermissionDenied(error)) {
+                    newGooglePlacesApiState.isUnavailable = true;
+                    fetchSuggestionsWithLegacyApi(input);
+                }
+            });
+    };
+
+    const selectWithLegacyApi = (item: AutocompleteItem): void => {
         const service = googleAutocompleteServiceRef.current;
 
         if (!service) return;
 
         service.getPlacesServices().then((placesService) => {
             placesService.getDetails(
-                {
-                    placeId: item.id,
-                    fields: fields || ['address_components', 'name'],
-                },
+                { placeId: item.id, fields: fields || ['address_components', 'name'] },
                 (result) => {
-                    if (nextElement) {
-                        nextElement.focus();
-                    }
-
-                    onSelect(result, item);
+                    finalizeSelection(result, item);
                 },
             );
         });
+    };
+
+    const selectWithNewApi = (item: AutocompleteItem): void => {
+        const service = newGooglePlacesApiServiceRef.current;
+
+        if (!service) return;
+
+        service
+            .getPlaceDetails(item.id, fields)
+            .then((result) => finalizeSelection(result, item))
+            .catch((error) => {
+                if (isNewPlacesApiPermissionDenied(error)) {
+                    newGooglePlacesApiState.isUnavailable = true;
+                    selectWithLegacyApi(item);
+                }
+            });
+    };
+
+    const handleSelect = (item: AutocompleteItem) => {
+        if (isUsingLegacyApi) {
+            selectWithLegacyApi(item);
+
+            return;
+        }
+
+        selectWithNewApi(item);
     };
 
     const resetAutocomplete = (): void => {
@@ -84,34 +169,17 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
         setAutoComplete(input && input.length ? 'nope' : 'off');
     };
 
-    const setItemsFromInput = (input: string): void => {
-        if (!input) {
-            setItems([]);
+    const fetchSuggestions = (input: string): void => {
+        if (isUsingLegacyApi) {
+            fetchSuggestionsWithLegacyApi(input);
 
             return;
         }
 
-        const service = googleAutocompleteServiceRef.current;
-
-        if (!service) return;
-
-        service.getAutocompleteService().then((autocompleteService) => {
-            autocompleteService.getPlacePredictions(
-                {
-                    input,
-                    types: types || ['geocode'],
-                    componentRestrictions,
-                },
-                (results) => {
-                    const autocompleteItems = toAutocompleteItems(results ?? undefined);
-
-                    setItems(autocompleteItems);
-                },
-            );
-        });
+        fetchSuggestionsWithNewApi(input);
     };
 
-    const onChangeHandler = (input: string) => {
+    const handleChange = (input: string) => {
         onChange(input, false);
 
         if (!isAutocompleteEnabled) {
@@ -119,7 +187,14 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
         }
 
         setAutocompleteValue(input);
-        setItemsFromInput(input);
+
+        if (!input) {
+            setItems([]);
+
+            return;
+        }
+
+        fetchSuggestions(input);
     };
 
     return (
@@ -133,8 +208,8 @@ const GoogleAutocomplete: React.FC<GoogleAutocompleteProps> = ({
             }}
             items={items}
             listTestId="address-autocomplete-suggestions"
-            onChange={onChangeHandler}
-            onSelect={onSelectHandler}
+            onChange={handleChange}
+            onSelect={handleSelect}
             onToggleOpen={onToggleOpen}
         >
             <div className="co-googleAutocomplete-footer" />

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocompleteFormField.tsx
@@ -21,6 +21,7 @@ export interface GoogleAutocompleteFormFieldProps {
     nextElement?: HTMLElement;
     parentFieldName?: string;
     isFloatingLabelEnabled?: boolean;
+    isNewPlacesApiEnabled?: boolean;
     onSelect(place: google.maps.places.PlaceResult, item: AutocompleteItem): void;
     onToggleOpen?(state: { inputValue: string; isOpen: boolean }): void;
     onChange(value: string, isOpen: boolean): void;
@@ -37,6 +38,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
     onChange,
     onToggleOpen,
     isFloatingLabelEnabled,
+    isNewPlacesApiEnabled,
 }) => {
     const fieldName = parentFieldName ? `${parentFieldName}.${name}` : name;
 
@@ -68,6 +70,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
                 isAutocompleteEnabled={
                     countryCode ? supportedCountries.includes(countryCode) : false
                 }
+                isNewPlacesApiEnabled={isNewPlacesApiEnabled}
                 nextElement={nextElement}
                 onChange={onChange}
                 onSelect={onSelect}
@@ -78,6 +81,7 @@ const GoogleAutocompleteFormField: FunctionComponent<GoogleAutocompleteFormField
             apiKey,
             countryCode,
             inputProps,
+            isNewPlacesApiEnabled,
             nextElement,
             onChange,
             onSelect,

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -50,7 +50,7 @@ export function useGoogleAutocomplete({
     const [autoComplete, setAutoComplete] = useState<string>('off');
     const newGooglePlacesApiServiceRef = useRef<NewGooglePlacesApiService>();
     const googleAutocompleteServiceRef = useRef<GoogleAutocompleteService>();
-    const latestNewApiInputRef = useRef<string>();
+    const newApiInputRef = useRef<string>();
 
     if (!newGooglePlacesApiServiceRef.current) {
         newGooglePlacesApiServiceRef.current = new NewGooglePlacesApiService(apiKey);
@@ -82,7 +82,9 @@ export function useGoogleAutocomplete({
         fetchSuggestions: (input: string): void => {
             const service = googleAutocompleteServiceRef.current;
 
-            if (!service) return;
+            if (!service) {
+                return;
+            }
 
             service.getAutocompleteService().then((autocompleteService) => {
                 autocompleteService.getPlacePredictions(
@@ -96,7 +98,9 @@ export function useGoogleAutocomplete({
         select: (item: AutocompleteItem): void => {
             const service = googleAutocompleteServiceRef.current;
 
-            if (!service) return;
+            if (!service) {
+                return;
+            }
 
             service.getPlacesServices().then((placesService) => {
                 placesService.getDetails(
@@ -113,14 +117,16 @@ export function useGoogleAutocomplete({
         fetchSuggestions: (input: string): void => {
             const service = newGooglePlacesApiServiceRef.current;
 
-            if (!service) return;
+            if (!service) {
+                return;
+            }
 
-            latestNewApiInputRef.current = input;
+            newApiInputRef.current = input;
 
             service
                 .getSuggestions(input, types, componentRestrictions)
                 .then((results) => {
-                    if (latestNewApiInputRef.current === input) {
+                    if (newApiInputRef.current === input) {
                         setItems(results);
                     }
                 })
@@ -128,14 +134,14 @@ export function useGoogleAutocomplete({
                     if (isNewPlacesApiPermissionDenied(error)) {
                         newGooglePlacesApiState.isUnavailable = true;
 
-                        if (latestNewApiInputRef.current === input) {
+                        if (newApiInputRef.current === input) {
                             legacyApi.fetchSuggestions(input);
                         }
 
                         return;
                     }
 
-                    if (latestNewApiInputRef.current === input) {
+                    if (newApiInputRef.current === input) {
                         setItems([]);
                     }
                 });
@@ -143,7 +149,9 @@ export function useGoogleAutocomplete({
         select: (item: AutocompleteItem): void => {
             const service = newGooglePlacesApiServiceRef.current;
 
-            if (!service) return;
+            if (!service) {
+                return;
+            }
 
             service
                 .getPlaceDetails(item.id, fields)

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -110,7 +110,10 @@ export function useGoogleAutocomplete({
             .catch((error) => {
                 if (isNewPlacesApiPermissionDenied(error)) {
                     newGooglePlacesApiState.isUnavailable = true;
-                    fetchSuggestionsWithLegacyApi(input);
+
+                    if (latestNewApiInputRef.current === input) {
+                        fetchSuggestionsWithLegacyApi(input);
+                    }
 
                     return;
                 }

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -206,6 +206,7 @@ export function useGoogleAutocomplete({
         setAutocompleteValue(input);
 
         if (!input) {
+            newApiInputRef.current = input;
             setItems([]);
 
             return;

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -1,0 +1,205 @@
+import { useRef, useState } from 'react';
+
+import { type AutocompleteItem } from '@bigcommerce/checkout/ui';
+
+import GoogleAutocompleteService from './GoogleAutocompleteService';
+import { type GoogleAutocompleteOptionTypes } from './googleAutocompleteTypes';
+import { NewGooglePlacesApiService } from './newGooglePlacesApi';
+import { getNewGooglePlacesApiScriptLoader } from './newGooglePlacesApi/getNewGooglePlacesApiScriptLoader';
+import { isNewPlacesApiPermissionDenied } from './newGooglePlacesApi/utils';
+import { toAutocompleteItems } from './utils';
+
+export interface UseGoogleAutocompleteProps {
+    apiKey: string;
+    fields?: string[];
+    nextElement?: HTMLElement;
+    isAutocompleteEnabled?: boolean;
+    isNewPlacesApiEnabled: boolean;
+    types?: GoogleAutocompleteOptionTypes[];
+    componentRestrictions?: google.maps.places.ComponentRestrictions;
+    onSelect(place: google.maps.places.PlaceResult | null, item: AutocompleteItem): void;
+    onChange(value: string, isOpen: boolean): void;
+}
+
+export interface UseGoogleAutocompleteResult {
+    items: AutocompleteItem[];
+    autoComplete: string;
+    handleSelect(item: AutocompleteItem): void;
+    handleChange(input: string): void;
+}
+
+// module-scoped because we want to persist across all checkout steps
+const newGooglePlacesApiState = { isUnavailable: false };
+
+export function resetNewGooglePlacesApiState(): void {
+    newGooglePlacesApiState.isUnavailable = false;
+}
+
+export function useGoogleAutocomplete({
+    apiKey,
+    fields,
+    nextElement,
+    isAutocompleteEnabled,
+    isNewPlacesApiEnabled,
+    types,
+    componentRestrictions,
+    onSelect,
+    onChange,
+}: UseGoogleAutocompleteProps): UseGoogleAutocompleteResult {
+    const [items, setItems] = useState<AutocompleteItem[]>([]);
+    const [autoComplete, setAutoComplete] = useState<string>('off');
+    const newGooglePlacesApiServiceRef = useRef<NewGooglePlacesApiService>();
+    const googleAutocompleteServiceRef = useRef<GoogleAutocompleteService>();
+    const latestNewApiInputRef = useRef<string>();
+
+    if (!newGooglePlacesApiServiceRef.current) {
+        newGooglePlacesApiServiceRef.current = new NewGooglePlacesApiService(apiKey);
+    }
+
+    if (!googleAutocompleteServiceRef.current) {
+        // When the new Places API is enabled, the legacy service must share the same script-loader instance.
+        // Otherwise Maps JS API that they depend on will be loaded twice and that breaks both services
+        googleAutocompleteServiceRef.current = new GoogleAutocompleteService(
+            apiKey,
+            isNewPlacesApiEnabled ? getNewGooglePlacesApiScriptLoader() : undefined,
+        );
+    }
+
+    const isUsingLegacyApi = () => !isNewPlacesApiEnabled || newGooglePlacesApiState.isUnavailable;
+
+    const finalizeSelection = (
+        place: google.maps.places.PlaceResult | null,
+        item: AutocompleteItem,
+    ) => {
+        if (nextElement) {
+            nextElement.focus();
+        }
+
+        onSelect(place, item);
+    };
+
+    const fetchSuggestionsWithLegacyApi = (input: string): void => {
+        const service = googleAutocompleteServiceRef.current;
+
+        if (!service) return;
+
+        service.getAutocompleteService().then((autocompleteService) => {
+            autocompleteService.getPlacePredictions(
+                { input, types: types || ['geocode'], componentRestrictions },
+                (results) => {
+                    setItems(toAutocompleteItems(results ?? undefined));
+                },
+            );
+        });
+    };
+
+    const fetchSuggestionsWithNewApi = (input: string): void => {
+        const service = newGooglePlacesApiServiceRef.current;
+
+        if (!service) return;
+
+        latestNewApiInputRef.current = input;
+
+        service
+            .getSuggestions(input, types, componentRestrictions)
+            .then((results) => {
+                if (latestNewApiInputRef.current === input) {
+                    setItems(results);
+                }
+            })
+            .catch((error) => {
+                if (isNewPlacesApiPermissionDenied(error)) {
+                    newGooglePlacesApiState.isUnavailable = true;
+                    fetchSuggestionsWithLegacyApi(input);
+
+                    return;
+                }
+
+                if (latestNewApiInputRef.current === input) {
+                    setItems([]);
+                }
+            });
+    };
+
+    const selectWithLegacyApi = (item: AutocompleteItem): void => {
+        const service = googleAutocompleteServiceRef.current;
+
+        if (!service) return;
+
+        service.getPlacesServices().then((placesService) => {
+            placesService.getDetails(
+                { placeId: item.id, fields: fields || ['address_components', 'name'] },
+                (result) => {
+                    finalizeSelection(result, item);
+                },
+            );
+        });
+    };
+
+    const selectWithNewApi = (item: AutocompleteItem): void => {
+        const service = newGooglePlacesApiServiceRef.current;
+
+        if (!service) return;
+
+        service
+            .getPlaceDetails(item.id, fields)
+            .then((result) => finalizeSelection(result, item))
+            .catch((error) => {
+                if (isNewPlacesApiPermissionDenied(error)) {
+                    newGooglePlacesApiState.isUnavailable = true;
+                    selectWithLegacyApi(item);
+                }
+            });
+    };
+
+    const handleSelect = (item: AutocompleteItem) => {
+        if (isUsingLegacyApi()) {
+            selectWithLegacyApi(item);
+
+            return;
+        }
+
+        selectWithNewApi(item);
+    };
+
+    const resetAutocomplete = (): void => {
+        setItems([]);
+        setAutoComplete('off');
+    };
+
+    const setAutocompleteValue = (input: string): void => {
+        setAutoComplete(input && input.length ? 'nope' : 'off');
+    };
+
+    const fetchSuggestions = (input: string): void => {
+        if (isUsingLegacyApi()) {
+            fetchSuggestionsWithLegacyApi(input);
+
+            return;
+        }
+
+        fetchSuggestionsWithNewApi(input);
+    };
+
+    const handleChange = (input: string) => {
+        onChange(input, false);
+
+        if (!isAutocompleteEnabled) {
+            resetAutocomplete();
+
+            return;
+        }
+
+        setAutocompleteValue(input);
+
+        if (!input) {
+            setItems([]);
+
+            return;
+        }
+
+        fetchSuggestions(input);
+    };
+
+    return { items, autoComplete, handleSelect, handleChange };
+}

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -78,91 +78,93 @@ export function useGoogleAutocomplete({
         onSelect(place, item);
     };
 
-    const fetchSuggestionsWithLegacyApi = (input: string): void => {
-        const service = googleAutocompleteServiceRef.current;
+    const legacyApi = {
+        fetchSuggestions: (input: string): void => {
+            const service = googleAutocompleteServiceRef.current;
 
-        if (!service) return;
+            if (!service) return;
 
-        service.getAutocompleteService().then((autocompleteService) => {
-            autocompleteService.getPlacePredictions(
-                { input, types: types || ['geocode'], componentRestrictions },
-                (results) => {
-                    setItems(toAutocompleteItems(results ?? undefined));
-                },
-            );
-        });
+            service.getAutocompleteService().then((autocompleteService) => {
+                autocompleteService.getPlacePredictions(
+                    { input, types: types || ['geocode'], componentRestrictions },
+                    (results) => {
+                        setItems(toAutocompleteItems(results ?? undefined));
+                    },
+                );
+            });
+        },
+        select: (item: AutocompleteItem): void => {
+            const service = googleAutocompleteServiceRef.current;
+
+            if (!service) return;
+
+            service.getPlacesServices().then((placesService) => {
+                placesService.getDetails(
+                    { placeId: item.id, fields: fields || ['address_components', 'name'] },
+                    (result) => {
+                        finalizeSelection(result, item);
+                    },
+                );
+            });
+        },
     };
 
-    const fetchSuggestionsWithNewApi = (input: string): void => {
-        const service = newGooglePlacesApiServiceRef.current;
+    const newApi = {
+        fetchSuggestions: (input: string): void => {
+            const service = newGooglePlacesApiServiceRef.current;
 
-        if (!service) return;
+            if (!service) return;
 
-        latestNewApiInputRef.current = input;
+            latestNewApiInputRef.current = input;
 
-        service
-            .getSuggestions(input, types, componentRestrictions)
-            .then((results) => {
-                if (latestNewApiInputRef.current === input) {
-                    setItems(results);
-                }
-            })
-            .catch((error) => {
-                if (isNewPlacesApiPermissionDenied(error)) {
-                    newGooglePlacesApiState.isUnavailable = true;
-
+            service
+                .getSuggestions(input, types, componentRestrictions)
+                .then((results) => {
                     if (latestNewApiInputRef.current === input) {
-                        fetchSuggestionsWithLegacyApi(input);
+                        setItems(results);
+                    }
+                })
+                .catch((error) => {
+                    if (isNewPlacesApiPermissionDenied(error)) {
+                        newGooglePlacesApiState.isUnavailable = true;
+
+                        if (latestNewApiInputRef.current === input) {
+                            legacyApi.fetchSuggestions(input);
+                        }
+
+                        return;
                     }
 
-                    return;
-                }
+                    if (latestNewApiInputRef.current === input) {
+                        setItems([]);
+                    }
+                });
+        },
+        select: (item: AutocompleteItem): void => {
+            const service = newGooglePlacesApiServiceRef.current;
 
-                if (latestNewApiInputRef.current === input) {
-                    setItems([]);
-                }
-            });
-    };
+            if (!service) return;
 
-    const selectWithLegacyApi = (item: AutocompleteItem): void => {
-        const service = googleAutocompleteServiceRef.current;
-
-        if (!service) return;
-
-        service.getPlacesServices().then((placesService) => {
-            placesService.getDetails(
-                { placeId: item.id, fields: fields || ['address_components', 'name'] },
-                (result) => {
-                    finalizeSelection(result, item);
-                },
-            );
-        });
-    };
-
-    const selectWithNewApi = (item: AutocompleteItem): void => {
-        const service = newGooglePlacesApiServiceRef.current;
-
-        if (!service) return;
-
-        service
-            .getPlaceDetails(item.id, fields)
-            .then((result) => finalizeSelection(result, item))
-            .catch((error) => {
-                if (isNewPlacesApiPermissionDenied(error)) {
-                    newGooglePlacesApiState.isUnavailable = true;
-                    selectWithLegacyApi(item);
-                }
-            });
+            service
+                .getPlaceDetails(item.id, fields)
+                .then((result) => finalizeSelection(result, item))
+                .catch((error) => {
+                    if (isNewPlacesApiPermissionDenied(error)) {
+                        newGooglePlacesApiState.isUnavailable = true;
+                        legacyApi.select(item);
+                    }
+                });
+        },
     };
 
     const handleSelect = (item: AutocompleteItem) => {
         if (isUsingLegacyApi()) {
-            selectWithLegacyApi(item);
+            legacyApi.select(item);
 
             return;
         }
 
-        selectWithNewApi(item);
+        newApi.select(item);
     };
 
     const resetAutocomplete = (): void => {
@@ -176,12 +178,12 @@ export function useGoogleAutocomplete({
 
     const fetchSuggestions = (input: string): void => {
         if (isUsingLegacyApi()) {
-            fetchSuggestionsWithLegacyApi(input);
+            legacyApi.fetchSuggestions(input);
 
             return;
         }
 
-        fetchSuggestionsWithNewApi(input);
+        newApi.fetchSuggestions(input);
     };
 
     const handleChange = (input: string) => {

--- a/packages/core/src/app/address/googleAutocomplete/utils.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.ts
@@ -1,0 +1,12 @@
+import { type AutocompleteItem } from '@bigcommerce/checkout/ui';
+
+export const toAutocompleteItems = (
+    results?: google.maps.places.AutocompletePrediction[],
+): AutocompleteItem[] => {
+    return (results || []).map((result) => ({
+        label: result.description,
+        value: result.structured_formatting.main_text,
+        highlightedSlices: result.matched_substrings,
+        id: result.place_id,
+    }));
+};


### PR DESCRIPTION
## What/Why?

This is part II of this change: https://github.com/bigcommerce/checkout-js/pull/3135, where I actually wire up this new Places API service to production, but hide new functionality behind a feature flag.

When the [CHECKOUT-10026.new_google_places_api](https://app.launchdarkly.com/projects/default/flags/CHECKOUT-10026.new_google_places_api) experiment is on, address autocomplete uses Google's new Places API (session-token based, AutocompleteSuggestion/Place classes) instead of the legacy API service. If the new API is denied due to permissions error (`gRPC PERMISSION_DENIED`), we assume that the service is not enabled for the store and silently fall back to the legacy API for the rest of the session. No visible errors for users and no visible change between old and new service - this is an infrastructure swap behind a feature flag.

NOTE: when the flag is off, there will be no change for end users, However, the code won't be byte-to-byte identical: we initialize `newGooglePlacesApiServiceRef.current` with `new NewGooglePlacesApiService(apiKey)` unconditionally on mount, even when the flag is off. It has no side effects though (no network call, no script load - the script loader inside of it is lazy), so this is just a trivial extra allocation without any functional change for end users.

[CHECKOUT-10026.new_google_places_api](https://app.launchdarkly.com/projects/default/flags/CHECKOUT-10026.new_google_places_api) is currently set to `true` in integration and staging and `false` for everyone in production.

## Rollout/Rollback

Set [CHECKOUT-10026.new_google_places_api](https://app.launchdarkly.com/projects/default/flags/CHECKOUT-10026.new_google_places_api) experiment to false if the store where we rolled out the feature is affected. For issues with other stores revert the PR.

## Testing

New CI tests + manual testing.

If you want to test yourself you can use these API keys in https://console.cloud.google.com/apis/credentials?project=bc-hackathon-env:
1. **Google Maps API Key test** - our old API key that still has access to **old Places API** and has no access to new Places API. Represents old users.
2. **Maxs Places API Key Test** - our new API key that has access to **new Places API** and no access to old Places API. Represents new users.

My tests are below:

### With experiment set to false (same as current production)

Existing customers with old API keys:

https://github.com/user-attachments/assets/47e3a4c0-b98c-43b0-b35c-37bafd7816c8

New customers with new API keys (doesn't work):

https://github.com/user-attachments/assets/d4a50153-7a1a-4e94-8046-307d195ff895


### With experiment set to true

Existing customers with old API keys (Initial 403, then fallback to the old service. Billing step will remember that we fallback and skips new api):

https://github.com/user-attachments/assets/6215bf66-7765-40be-81de-5b93e4ae9530

New customers with new API keys (just works):

https://github.com/user-attachments/assets/bc6aea36-d54d-426b-a606-73cd271ad79b




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core checkout address capture and external Google API behavior; rollout is flag-gated with legacy fallback, but wrong fallback rules could break autocomplete for some API key configurations.
> 
> **Overview**
> Checkout address line 1 autocomplete can use Google's **new Places API** when experiment `CHECKOUT-10026.new_google_places_api` is on, passed from `AddressForm` through `GoogleAutocompleteFormField` as `isNewPlacesApiEnabled`.
> 
> Autocomplete logic moves into **`useGoogleAutocomplete`**, which prefers the new API for suggestions and place details and **falls back to the legacy Maps Places service** only on permission-denied (`gRPC` code 7). That denial **latches for the session** (module state) so later keystrokes skip the new API; transient errors clear suggestions or skip `onSelect` without latching. With the flag off, only legacy runs. Legacy shares the new API's script loader when the flag is on to avoid double-loading Maps JS.
> 
> `GoogleAutocomplete` is thinned to the hook plus UI; legacy prediction mapping lives in `utils.ts`. A broad **`GoogleAutocomplete.test.tsx`** suite covers happy path, fallback, latch, and flag-off behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a61c18b576c3b1a579c85fd06bc3959c26fca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->