### PR TITLE
fix(checkout): CHECKOUT-10180 Initialize checklist formik with correct value

### DIFF
--- a/packages/ui/src/form/Checklist/Checklist.test.tsx
+++ b/packages/ui/src/form/Checklist/Checklist.test.tsx
@@ -1,14 +1,25 @@
-import { Formik } from 'formik';
+import { Formik, useFormikContext } from 'formik';
 import React from 'react';
 
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
 import { Checklist } from './Checklist';
 
-const renderChecklist = (children?: React.ReactNode) =>
+const FormikValue = ({ name }: { name: string }) => {
+    const { values } = useFormikContext<Record<string, string>>();
+
+    return <span data-test="formik-value">{values[name]}</span>;
+};
+
+const renderChecklist = (children?: React.ReactNode, defaultSelectedItemId?: string) =>
     render(
-        <Formik initialValues={{ payment: '' }} onSubmit={jest.fn()}>
-            <Checklist name="payment">{children}</Checklist>
+        <Formik initialValues={{ shippingOptionId: '' }} onSubmit={jest.fn()}>
+            <>
+                <Checklist defaultSelectedItemId={defaultSelectedItemId} name="shippingOptionId">
+                    {children}
+                </Checklist>
+                <FormikValue name="shippingOptionId" />
+            </>
         </Formik>,
     );
 
@@ -26,5 +37,17 @@ describe('Checklist', () => {
 
         expect(accordion).toHaveClass('form-checklist');
         expect(accordion).toHaveClass('optimizedCheckout-form-checklist');
+    });
+
+    it('initializes the formik field with the default selected item id', () => {
+        renderChecklist(undefined, 'standard-shipping');
+
+        expect(screen.getByTestId('formik-value')).toHaveTextContent('standard-shipping');
+    });
+
+    it('leaves the formik field empty when no default selected item id is provided', () => {
+        renderChecklist();
+
+        expect(screen.getByTestId('formik-value')).toBeEmptyDOMElement();
     });
 });

--- a/packages/ui/src/form/Checklist/Checklist.tsx
+++ b/packages/ui/src/form/Checklist/Checklist.tsx
@@ -27,6 +27,7 @@ export interface ChecklistContextProps {
 export const ChecklistContext = createContext<ChecklistContextProps | undefined>(undefined);
 
 export const Checklist: FunctionComponent<ChecklistProps> = ({
+    defaultSelectedItemId,
     name,
     onSelect = noop,
     ...props
@@ -34,6 +35,10 @@ export const Checklist: FunctionComponent<ChecklistProps> = ({
     const { setFieldValue } = useFormikContext();
 
     useEffect(() => {
+        if (defaultSelectedItemId) {
+            void setFieldValue(name, defaultSelectedItemId);
+        }
+
         return () => {
             void setFieldValue(name, '');
         };
@@ -55,6 +60,7 @@ export const Checklist: FunctionComponent<ChecklistProps> = ({
             <Accordion
                 {...props}
                 className="form-checklist optimizedCheckout-form-checklist"
+                defaultSelectedItemId={defaultSelectedItemId}
                 onSelect={handleSelect}
             />
         </ChecklistContext.Provider>


### PR DESCRIPTION
## What/Why?

This PR fixes the issue when a checkout page is rendered without pre-selected shipping method even though it comes as selected through our initial state.

The issue is that Checklist forwards `defaultSelectedItemId` to Accordion for visual pre-selection, but never syncs that value into its own Formik field.

Fix: the existing useEffect that runs on mount and unmount now also seeds the Formik field with `defaultSelectedItemId` on mount, if present.

This Checklist component is also used by Payment method selection, but this PR should not make any difference there. In Payment method selection `defaultSelectedItemId` comes from Formik, so setting it on mount will be a no-op.

Added tests covering both the seeded and empty-default cases.

## Rollout/Rollback

Revert the PR.

## Testing

New CI tests + manual testing:

### Before

https://github.com/user-attachments/assets/e67aaf74-589d-45a6-b6e6-2b1c03a77c5b

### After

https://github.com/user-attachments/assets/68703b27-f104-4810-8ab9-0caf4d7f529b


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI form sync change in a shared component; payment paths are expected to be no-ops when the value already comes from Formik.
> 
> **Overview**
> Fixes checkout shipping (and similar checklist UIs) where the **accordion looked pre-selected** but the **Formlist/Formik field stayed empty** because `defaultSelectedItemId` was only passed to `Accordion`, not written into Formik.
> 
> On mount, the existing cleanup `useEffect` now also calls `setFieldValue(name, defaultSelectedItemId)` when that prop is set, so initial server/checkout state matches the form value. Unmount still clears the field. Payment flows that already derive the default from Formik should behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e2487f11ff014197a4a54c1a5c61816e2e6aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->