### PR TITLE
fix(checkout): CHECKOUT-10190 Fix StylelintWebpackPlugin linting files outside packages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,6 +140,7 @@ function appConfig(options, argv) {
                     enabled: isProduction,
                 }),
                 new StyleLintPlugin({
+                    files: 'packages/**/*.scss',
                     fix: !isProduction,
                     cache: true,
                     cacheLocation: join(process.cwd(), 'node_modules/.cache/'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,7 +140,7 @@ function appConfig(options, argv) {
                     enabled: isProduction,
                 }),
                 new StyleLintPlugin({
-                    files: 'packages/**/*.scss',
+                    files: 'packages/**/*.{scss,sass,css}',
                     fix: !isProduction,
                     cache: true,
                     cacheLocation: join(process.cwd(), 'node_modules/.cache/'),


### PR DESCRIPTION
## What/Why?

Whenever I run `npm run dev`, it causes unrelated file changes to show up in git. Specifically `dist/*.css` files (e.g. `checkout-*.css`, `vendor-async-*.css`) getting modified even though running `dev` only supposed to build into `build/`:


### Root cause

<img width="690" height="139" alt="Screenshot 2026-07-08 at 10 09 21 AM" src="https://github.com/user-attachments/assets/ec1af525-9dd1-4831-b676-cb9dddfc1372" />

`StylelintWebpackPlugin` was configured without a `files` option, so it defaulted to linting every `.css`/`.scss`/`.sass` file in the whole repo (its default `files` glob resolves to the webpack context root and does not exclude `dist`). Stylelint's autofix rewrote leftover compiled CSS sitting in `dist/` from a previous production build, making it look like `npm run dev` was randomly editing tracked files.

### Fix
Scoped the plugin to our actual code that lives in /packages:

```js
new StyleLintPlugin({
    files: 'packages/**/*.{scss,sass,css}',
    ...
})
```

This restricts linting/autofix to `packages/`, so that it can no longer match anything under `dist/`, `build/`, or any other generated output folder.

## Rollout/Rollback

Revert the PR.

## Testing

- Ran `npm run dev`, confirmed no changes appear under `dist/`.
- Confirmed `.scss` lint/autofix still runs on save for files under `packages/`:


https://github.com/user-attachments/assets/8219a9e5-3cbb-4c02-8f72-03ec4ac81b28



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single webpack plugin glob change with no auth, data, or runtime logic impact; only narrows which files Stylelint processes.
> 
> **Overview**
> **Fixes spurious git diffs during `npm run dev`** caused by Stylelint autofix touching compiled CSS in `dist/` from prior production builds.
> 
> The webpack `StyleLintPlugin` config now sets **`files: 'packages/**/*.{scss,sass,css}'`**, so lint/autofix runs only on source under `packages/` and skips `dist/`, `build/`, and other generated output. Development behavior for package styles is unchanged; production still emits errors via `emitErrors: isProduction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ece34a26b2f7b838071b3d8d8bf56ddd11b90618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->