### PR TITLE
feat(checkout): CHECKOUT-10142 Update Session Storage

### DIFF
--- a/packages/cheque-payment-integration/src/PoNumber.tsx
+++ b/packages/cheque-payment-integration/src/PoNumber.tsx
@@ -29,10 +29,7 @@ const PoNumber: FunctionComponent<PoNumberProps> = ({
     paymentForm: { setFieldValue, setValidationSchema },
 }) => {
     useEffect(() => {
-        setFieldValue(
-            PO_NUMBER_FIELD_NAME,
-            B2BSessionStorage.getValue(B2BSessionStorage.poNumberKey),
-        );
+        setFieldValue(PO_NUMBER_FIELD_NAME, B2BSessionStorage.getPaymentValues()?.poNumber ?? '');
         setValidationSchema(method, getPoNumberValidationSchema(language, isRequired, label));
 
         return () => {
@@ -50,10 +47,6 @@ const PoNumber: FunctionComponent<PoNumberProps> = ({
         ),
         [],
     );
-
-    const handleChange = useCallback((value: string) => {
-        B2BSessionStorage.set(B2BSessionStorage.poNumberKey, value.trim());
-    }, []);
 
     return (
         <div className="po-number-container">
@@ -77,7 +70,6 @@ const PoNumber: FunctionComponent<PoNumberProps> = ({
                     </Legend>
                 }
                 name={PO_NUMBER_FIELD_NAME}
-                onChange={handleChange}
             />
         </div>
     );

--- a/packages/core/src/app/address/AddressFormModal.tsx
+++ b/packages/core/src/app/address/AddressFormModal.tsx
@@ -33,7 +33,6 @@ export interface AddressFormProps {
     isLoading: boolean;
     shouldShowSaveAddress?: boolean;
     defaultCountryCode?: string;
-    storageKey?: string;
     getFields(countryCode?: string): FormField[];
     onSaveAddress(address: AddressFormValues): void;
     onRequestClose?(): void;
@@ -75,11 +74,10 @@ const SaveAddressForm = withLanguage(
         handleSubmit: (values, { props: { onSaveAddress } }) => {
             onSaveAddress(values);
         },
-        mapPropsToValues: ({ getFields, selectedAddress, storageKey }) =>
+        mapPropsToValues: ({ getFields, selectedAddress }) =>
             mapAddressToFormValues(
                 getFields(selectedAddress && selectedAddress.countryCode),
                 selectedAddress,
-                storageKey,
             ),
         validationSchema: ({ language, getFields }: AddressFormProps & WithLanguageProps) =>
             lazy<Partial<AddressFormValues>>((values) =>

--- a/packages/core/src/app/address/mapAddressFromFormValues.ts
+++ b/packages/core/src/app/address/mapAddressFromFormValues.ts
@@ -1,7 +1,5 @@
 import { type Address } from '@bigcommerce/checkout-sdk';
 
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
-
 import {
     mapAddressExtraFieldsFromFormValues,
     mapCustomFormFieldsFromFormValues,
@@ -9,20 +7,8 @@ import {
 
 import { type AddressFormValues } from './mapAddressToFormValues';
 
-export default function mapAddressFromFormValues(
-    formValues: AddressFormValues,
-    storageKey?: string,
-): Address {
+export default function mapAddressFromFormValues(formValues: AddressFormValues): Address {
     const { customFields, extraFields, shouldSaveAddress, ...address } = formValues;
-
-    if (storageKey && extraFields && Object.keys(extraFields).length > 0) {
-        const fieldsToStore = {
-            ...extraFields,
-            shouldSaveAddress,
-        };
-
-        B2BSessionStorage.set(storageKey, fieldsToStore as Record<string, unknown>);
-    }
 
     return {
         ...address,

--- a/packages/core/src/app/address/mapAddressToFormValues.test.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.test.ts
@@ -1,7 +1,5 @@
 import { type Address, type FormField } from '@bigcommerce/checkout-sdk';
 
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
-
 import { getFormFields } from './formField.mock';
 import mapAddressToFormValues from './mapAddressToFormValues';
 
@@ -113,9 +111,7 @@ describe('mapAddressToFormValues', () => {
         expect(result.extraFields?.b2bExtraField_100).toBe('');
     });
 
-    describe('session storage precedence', () => {
-        const storageKey = 'test_storage_key';
-
+    describe('extra field value precedence', () => {
         const extraField: FormField = {
             custom: false,
             default: 'Default Corp',
@@ -125,42 +121,30 @@ describe('mapAddressToFormValues', () => {
             required: false,
         };
 
-        afterEach(() => {
-            B2BSessionStorage.remove(storageKey);
-        });
-
-        it('prefers extra field value from address over session storage', () => {
+        it('prefers the extra field value from the address over the field default', () => {
             const fields: FormField[] = [...getFormFields(), extraField];
-
-            B2BSessionStorage.set(storageKey, {
-                b2bExtraField_100: 'Stored Corp',
-            });
 
             const address = {
                 firstName: 'John',
                 extraFields: [{ fieldId: '100', fieldValue: 'Address Corp' }],
             } as Address;
 
-            const result = mapAddressToFormValues(fields, address, storageKey);
+            const result = mapAddressToFormValues(fields, address);
 
             expect(result.extraFields?.b2bExtraField_100).toBe('Address Corp');
         });
 
-        it('falls back to session storage when address has no value for the extra field', () => {
+        it('falls back to the field default when the address has no value for the extra field', () => {
             const fields: FormField[] = [...getFormFields(), extraField];
-
-            B2BSessionStorage.set(storageKey, {
-                b2bExtraField_100: 'Stored Corp',
-            });
 
             const address = {
                 firstName: 'John',
                 extraFields: [],
             } as unknown as Address;
 
-            const result = mapAddressToFormValues(fields, address, storageKey);
+            const result = mapAddressToFormValues(fields, address);
 
-            expect(result.extraFields?.b2bExtraField_100).toBe('Stored Corp');
+            expect(result.extraFields?.b2bExtraField_100).toBe('Default Corp');
         });
     });
 });

--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -7,7 +7,6 @@ import {
 } from '@bigcommerce/checkout-sdk/essential';
 
 import { DynamicFormFieldType } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 export type AddressFormValues = Pick<
     Address,
@@ -20,10 +19,7 @@ export type AddressFormValues = Pick<
 export default function mapAddressToFormValues(
     fields: FormField[],
     address?: Address,
-    storageKey?: string,
 ): AddressFormValues {
-    const storedExtraFields = storageKey ? B2BSessionStorage.get(storageKey) : undefined;
-
     const values = {
         ...fields.reduce((addressFormValues, field) => {
             const { name, custom, fieldType, default: defaultValue } = field;
@@ -42,8 +38,7 @@ export default function mapAddressToFormValues(
                     ({ fieldId }) => fieldId === rawFieldId,
                 )?.fieldValue;
 
-                addressFormValues.extraFields[name] =
-                    extraFieldValue ?? storedExtraFields?.[name] ?? defaultValue ?? '';
+                addressFormValues.extraFields[name] = extraFieldValue ?? defaultValue ?? '';
 
                 return addressFormValues;
             }

--- a/packages/core/src/app/address/setDefaultAddress.spec.ts
+++ b/packages/core/src/app/address/setDefaultAddress.spec.ts
@@ -1,15 +1,10 @@
 import { type CustomerAddress } from '@bigcommerce/checkout-sdk';
 
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
-
 import { getAddress, getCustomerAddressB2B } from './address.mock';
 import AddressType from './AddressType';
 import setDefaultAddress from './setDefaultAddress';
 
 describe('setDefaultAddress', () => {
-    const shippingIdKey = B2BSessionStorage.shippingAddressIdKey;
-    const billingIdKey = B2BSessionStorage.billingAddressIdKey;
-
     const getCustomerAddress = (overrides: Partial<CustomerAddress> = {}): CustomerAddress => ({
         ...getAddress(),
         id: 1,
@@ -21,12 +16,11 @@ describe('setDefaultAddress', () => {
     let updateAddress: jest.Mock;
 
     beforeEach(() => {
-        sessionStorage.clear();
         updateAddress = jest.fn().mockResolvedValue(undefined);
     });
 
     describe('when there is no current address', () => {
-        it('applies the default address and stores its id', async () => {
+        it('applies the default address', async () => {
             const defaultAddress = getCustomerAddress({
                 id: 7,
                 b2b: getCustomerAddressB2B({ isShipping: true, isDefaultShipping: true }),
@@ -40,24 +34,6 @@ describe('setDefaultAddress', () => {
             });
 
             expect(updateAddress).toHaveBeenCalledWith(defaultAddress);
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBe(7);
-        });
-
-        it('applies the default address but does not store an id when it has none', async () => {
-            const defaultAddress = getCustomerAddress({
-                id: undefined as unknown as number,
-                b2b: getCustomerAddressB2B({ isShipping: true, isDefaultShipping: true }),
-            });
-
-            await setDefaultAddress({
-                type: AddressType.Shipping,
-                currentAddress: undefined,
-                addresses: [defaultAddress],
-                updateAddress,
-            });
-
-            expect(updateAddress).toHaveBeenCalledWith(defaultAddress);
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
         });
 
         it('does nothing when there is no default address', async () => {
@@ -69,10 +45,9 @@ describe('setDefaultAddress', () => {
             });
 
             expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
         });
 
-        it('does not store an id when applying the default address fails', async () => {
+        it('swallows the error when applying the default address fails', async () => {
             updateAddress.mockRejectedValue(new Error('update failed'));
 
             const defaultAddress = getCustomerAddress({
@@ -80,147 +55,55 @@ describe('setDefaultAddress', () => {
                 b2b: getCustomerAddressB2B({ isShipping: true, isDefaultShipping: true }),
             });
 
+            await expect(
+                setDefaultAddress({
+                    type: AddressType.Shipping,
+                    currentAddress: undefined,
+                    addresses: [defaultAddress],
+                    updateAddress,
+                }),
+            ).resolves.toBeUndefined();
+        });
+
+        it('only considers default addresses of the requested type', async () => {
+            const billingOnlyDefault = getCustomerAddress({
+                id: 50,
+                b2b: getCustomerAddressB2B({ isBilling: true, isDefaultBilling: true }),
+            });
+            const shippingDefault = getCustomerAddress({
+                id: 42,
+                b2b: getCustomerAddressB2B({ isShipping: true, isDefaultShipping: true }),
+            });
+
             await setDefaultAddress({
                 type: AddressType.Shipping,
                 currentAddress: undefined,
-                addresses: [defaultAddress],
+                addresses: [billingOnlyDefault, shippingDefault],
                 updateAddress,
             });
 
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
+            expect(updateAddress).toHaveBeenCalledWith(shippingDefault);
         });
     });
 
     describe('when there is a pre-existing address', () => {
-        it('recovers the book id by matching the current address', async () => {
-            const currentAddress = getAddress();
-            const matchingAddress = getCustomerAddress({ id: 42 });
-
+        it('does not overwrite it with the default address', async () => {
             await setDefaultAddress({
                 type: AddressType.Shipping,
-                currentAddress,
+                currentAddress: getAddress(),
                 addresses: [
-                    getCustomerAddress({ id: 3, address1: 'Somewhere else' }),
-                    matchingAddress,
+                    getCustomerAddress({
+                        id: 7,
+                        b2b: getCustomerAddressB2B({
+                            isShipping: true,
+                            isDefaultShipping: true,
+                        }),
+                    }),
                 ],
                 updateAddress,
             });
 
             expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBe(42);
-        });
-
-        it('does nothing when no book address matches', async () => {
-            await setDefaultAddress({
-                type: AddressType.Shipping,
-                currentAddress: getAddress(),
-                addresses: [getCustomerAddress({ id: 3, address1: 'Somewhere else' })],
-                updateAddress,
-            });
-
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
-        });
-
-        it('clears a stale stored id when no book address matches', async () => {
-            B2BSessionStorage.set(shippingIdKey, 99);
-
-            await setDefaultAddress({
-                type: AddressType.Shipping,
-                currentAddress: getAddress(),
-                addresses: [getCustomerAddress({ id: 3, address1: 'Somewhere else' })],
-                updateAddress,
-            });
-
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
-        });
-
-        it('keeps the stored id when it still matches the current address', async () => {
-            B2BSessionStorage.set(shippingIdKey, 42);
-
-            await setDefaultAddress({
-                type: AddressType.Shipping,
-                currentAddress: getAddress(),
-                addresses: [getCustomerAddress({ id: 42 })],
-                updateAddress,
-            });
-
-            expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBe(42);
-        });
-
-        it('replaces a stale stored id when the current address matches a different entry', async () => {
-            B2BSessionStorage.set(shippingIdKey, 99);
-
-            await setDefaultAddress({
-                type: AddressType.Shipping,
-                currentAddress: getAddress(),
-                addresses: [
-                    getCustomerAddress({ id: 3, address1: 'Somewhere else' }),
-                    getCustomerAddress({ id: 42 }),
-                ],
-                updateAddress,
-            });
-
-            expect(updateAddress).not.toHaveBeenCalled();
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBe(42);
-        });
-    });
-
-    describe('when company rows duplicate fields across types', () => {
-        it('matches a shipping row over a content-identical billing-only row for the shipping key', async () => {
-            const billingOnly = getCustomerAddress({
-                id: 50,
-                b2b: getCustomerAddressB2B({ isBilling: true }),
-            });
-            const shippingRow = getCustomerAddress({
-                id: 42,
-                b2b: getCustomerAddressB2B({ isShipping: true }),
-            });
-
-            await setDefaultAddress({
-                type: AddressType.Shipping,
-                currentAddress: getAddress(),
-                addresses: [billingOnly, shippingRow],
-                updateAddress,
-            });
-
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBe(42);
-        });
-
-        it('does not store a billing-only row id under the shipping key', async () => {
-            const billingOnly = getCustomerAddress({
-                id: 50,
-                b2b: getCustomerAddressB2B({ isBilling: true }),
-            });
-
-            await setDefaultAddress({
-                type: AddressType.Shipping,
-                currentAddress: getAddress(),
-                addresses: [billingOnly],
-                updateAddress,
-            });
-
-            expect(B2BSessionStorage.getAddressId(shippingIdKey)).toBeUndefined();
-        });
-
-        it('matches a billing row over a content-identical shipping-only row for the billing key', async () => {
-            const shippingOnly = getCustomerAddress({
-                id: 60,
-                b2b: getCustomerAddressB2B({ isShipping: true }),
-            });
-            const billingRow = getCustomerAddress({
-                id: 24,
-                b2b: getCustomerAddressB2B({ isBilling: true }),
-            });
-
-            await setDefaultAddress({
-                type: AddressType.Billing,
-                currentAddress: getAddress(),
-                addresses: [shippingOnly, billingRow],
-                updateAddress,
-            });
-
-            expect(B2BSessionStorage.getAddressId(billingIdKey)).toBe(24);
         });
     });
 });

--- a/packages/core/src/app/address/setDefaultAddress.ts
+++ b/packages/core/src/app/address/setDefaultAddress.ts
@@ -1,9 +1,6 @@
 import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
 
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
-
 import AddressType from './AddressType';
-import isEqualAddress from './isEqualAddress';
 
 interface SetDefaultAddressOptions {
     type: AddressType;
@@ -18,54 +15,24 @@ export default async function setDefaultAddress({
     addresses,
     updateAddress,
 }: SetDefaultAddressOptions): Promise<void> {
+    if (currentAddress?.address1) {
+        return;
+    }
+
     const isShipping = type === AddressType.Shipping;
-    const addressIdKey = isShipping
-        ? B2BSessionStorage.shippingAddressIdKey
-        : B2BSessionStorage.billingAddressIdKey;
+    const defaultAddress = addresses
+        ?.filter((address) => (isShipping ? address.b2b?.isShipping : address.b2b?.isBilling))
+        .find((address) =>
+            isShipping ? address.b2b?.isDefaultShipping : address.b2b?.isDefaultBilling,
+        );
 
-    const filteredAddresses = addresses?.filter((address) =>
-        isShipping ? address.b2b?.isShipping : address.b2b?.isBilling,
-    );
-    const defaultAddress = filteredAddresses?.find((address) =>
-        isShipping ? address.b2b?.isDefaultShipping : address.b2b?.isDefaultBilling,
-    );
-
-    if (!currentAddress?.address1) {
-        if (!defaultAddress) {
-            return;
-        }
-
-        try {
-            await updateAddress(defaultAddress);
-
-            if (defaultAddress.id) {
-                B2BSessionStorage.set(addressIdKey, defaultAddress.id);
-            }
-        } catch {
-            /* Do nothing: we should not block shoppers from buying. */
-        }
-
+    if (!defaultAddress) {
         return;
     }
 
-    const storedAddressId = B2BSessionStorage.getAddressId(addressIdKey);
-    const storedIdStillMatches = filteredAddresses?.some(
-        (address) => address.id === storedAddressId && isEqualAddress(address, currentAddress),
-    );
-
-    if (storedAddressId && storedIdStillMatches) {
-        return;
-    }
-
-    // Pre-existing address (e.g. resumed checkout): recover its book ID by matching,
-    // or clear a stale ID when the address no longer corresponds to a book entry.
-    const matchedAddress = filteredAddresses?.find((address) =>
-        isEqualAddress(address, currentAddress),
-    );
-
-    if (matchedAddress?.id) {
-        B2BSessionStorage.set(addressIdKey, matchedAddress.id);
-    } else {
-        B2BSessionStorage.remove(addressIdKey);
+    try {
+        await updateAddress(defaultAddress);
+    } catch {
+        /* Do nothing: we should not block shoppers from buying. */
     }
 }

--- a/packages/core/src/app/address/setDefaultAddress.ts
+++ b/packages/core/src/app/address/setDefaultAddress.ts
@@ -20,11 +20,11 @@ export default async function setDefaultAddress({
     }
 
     const isShipping = type === AddressType.Shipping;
-    const defaultAddress = addresses
-        ?.filter((address) => (isShipping ? address.b2b?.isShipping : address.b2b?.isBilling))
-        .find((address) =>
-            isShipping ? address.b2b?.isDefaultShipping : address.b2b?.isDefaultBilling,
-        );
+    const defaultAddress = addresses?.find(({ b2b }) =>
+        isShipping
+            ? b2b?.isShipping && b2b.isDefaultShipping
+            : b2b?.isBilling && b2b.isDefaultBilling,
+    );
 
     if (!defaultAddress) {
         return;

--- a/packages/core/src/app/billing/Billing.test.tsx
+++ b/packages/core/src/app/billing/Billing.test.tsx
@@ -40,13 +40,7 @@ import {
     shippingAddress2,
     shippingAddress3,
 } from '@bigcommerce/checkout/test-framework';
-import {
-    act,
-    renderWithoutWrapper as render,
-    screen,
-    waitFor,
-} from '@bigcommerce/checkout/test-utils';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
+import { act, renderWithoutWrapper as render, screen } from '@bigcommerce/checkout/test-utils';
 
 import { getCustomerAddressB2B } from '../address/address.mock';
 import Checkout from '../checkout/Checkout';
@@ -616,14 +610,14 @@ describe('Billing step', () => {
             customer: customerWithCompanyBillingAddress,
         };
 
-        it('stores the selected billing address id when hasCompanyAddressBook is enabled', async () => {
+        it('updates the billing address when a company address is selected', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
                 checkout: checkoutWithCompanyBillingAddress,
             });
 
-            jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
-                checkoutService.getState(),
-            );
+            const updateBillingAddressSpy = jest
+                .spyOn(checkoutService, 'updateBillingAddress')
+                .mockResolvedValue(checkoutService.getState());
 
             render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
 
@@ -634,31 +628,9 @@ describe('Billing step', () => {
                 await userEvent.click(screen.getByTestId('address-select-option-action'));
             });
 
-            expect(B2BSessionStorage.getAddressId(B2BSessionStorage.billingAddressIdKey)).toBe(3);
-        });
-
-        it('does not store the billing address id when hasCompanyAddressBook is disabled', async () => {
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping, {
-                checkout: checkoutWithCustomer,
-            });
-
-            jest.spyOn(checkoutService, 'updateBillingAddress').mockResolvedValue(
-                checkoutService.getState(),
+            expect(updateBillingAddressSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ id: 3 }),
             );
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForBillingStep();
-
-            await act(async () => {
-                await userEvent.click(screen.getByTestId('address-select-button'));
-                // shippingAddress3 is the customer's saved address with id 3.
-                await userEvent.click(screen.getByText(shippingAddress3.address1));
-            });
-
-            expect(
-                B2BSessionStorage.getAddressId(B2BSessionStorage.billingAddressIdKey),
-            ).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -4,7 +4,6 @@ import React, { type ReactElement, useCallback, useEffect, useState } from 'reac
 import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, Legend } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import {
     AddressType,
@@ -99,10 +98,7 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
     }: BillingFormValues): Promise<void> => {
         const billingAddress = getBillingAddress();
         const promises: Array<Promise<CheckoutSelectors>> = [];
-        const address = mapAddressFromFormValues(
-            addressValues,
-            B2BSessionStorage.billingExtraFieldsKey,
-        );
+        const address = mapAddressFromFormValues(addressValues);
 
         if (address && !isEqualAddress(address, billingAddress)) {
             promises.push(checkoutService.updateBillingAddress(address));

--- a/packages/core/src/app/billing/BillingForm.tsx
+++ b/packages/core/src/app/billing/BillingForm.tsx
@@ -1,11 +1,6 @@
-import {
-    type Address,
-    type CustomerAddress,
-    type FormField,
-    isExtraField,
-} from '@bigcommerce/checkout-sdk/essential';
+import { type Address, type FormField, isExtraField } from '@bigcommerce/checkout-sdk/essential';
 import { type FormikProps, withFormik } from 'formik';
-import React, { type RefObject, useEffect, useRef, useState } from 'react';
+import React, { type RefObject, useRef, useState } from 'react';
 import { lazy } from 'yup';
 
 import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
@@ -23,7 +18,6 @@ import {
     Form,
     LoadingOverlay,
 } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import {
     AddressForm,
@@ -80,7 +74,6 @@ const BillingForm = ({
     }));
     const {
         billing: { hideSaveToAddressBookCheck, restrictManualAddressEntry },
-        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
     } = useCapabilities();
 
     if (!config || !customer || !cart) {
@@ -112,31 +105,11 @@ const BillingForm = ({
     const shouldShowOrderComments = enableOrderComments && getShippableItemsCount(cart) < 1;
     const shouldShowSaveAddress = !hideSaveToAddressBookCheck && !isGuest;
 
-    // Once the address form opens (selected address is invalid or no longer matches a
-    // book entry), the stored book id can't faithfully represent it, so drop it.
-    useEffect(() => {
-        if (
-            hasCompanyAddressBook &&
-            !hasValidCustomerAddress &&
-            B2BSessionStorage.getAddressId(B2BSessionStorage.billingAddressIdKey)
-        ) {
-            B2BSessionStorage.remove(B2BSessionStorage.billingAddressIdKey);
-        }
-    }, [hasCompanyAddressBook, hasValidCustomerAddress]);
-
     const handleSelectAddress = async (address: Partial<Address>) => {
         setIsResettingAddress(true);
 
         try {
             await checkoutService.updateBillingAddress(address);
-
-            B2BSessionStorage.remove(B2BSessionStorage.billingAddressIdKey);
-
-            const selectedAddressId = (address as CustomerAddress).id;
-
-            if (hasCompanyAddressBook && selectedAddressId) {
-                B2BSessionStorage.set(B2BSessionStorage.billingAddressIdKey, selectedAddressId);
-            }
         } catch (error) {
             if (error instanceof Error) {
                 onUnhandledError(error);
@@ -147,10 +120,6 @@ const BillingForm = ({
     };
 
     const handleUseNewAddress = () => {
-        if (hasAddressExtraFields) {
-            B2BSessionStorage.remove(B2BSessionStorage.billingExtraFieldsKey);
-        }
-
         void handleSelectAddress({});
     };
 
@@ -219,7 +188,6 @@ export default withLanguage(
             ...mapAddressToFormValues(
                 getFields(billingAddress && billingAddress.countryCode),
                 billingAddress,
-                B2BSessionStorage.billingExtraFieldsKey,
             ),
             orderComment: customerMessage,
         }),

--- a/packages/core/src/app/payment/AdditionalPaymentField.test.tsx
+++ b/packages/core/src/app/payment/AdditionalPaymentField.test.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { getStoreConfig } from '../config/config.mock';
 
@@ -25,10 +24,6 @@ describe('AdditionalPaymentField', () => {
                 </Formik>
             </LocaleContext.Provider>,
         );
-
-    beforeEach(() => {
-        sessionStorage.clear();
-    });
 
     it('renders the provided label and an input', () => {
         renderField({ label: 'Delivery instructions' });
@@ -53,26 +48,13 @@ describe('AdditionalPaymentField', () => {
         ).not.toBeInTheDocument();
     });
 
-    it('writes the typed value to session storage on change', () => {
+    it('updates the field value on change', () => {
         renderField();
 
         fireEvent.change(screen.getByTestId('additionalPaymentField-input'), {
             target: { value: 'leave at front door' },
         });
 
-        expect(B2BSessionStorage.getValue(B2BSessionStorage.additionalPaymentFieldKey)).toBe(
-            'leave at front door',
-        );
-    });
-
-    it('stores an empty value when the field is cleared', () => {
-        B2BSessionStorage.set(B2BSessionStorage.additionalPaymentFieldKey, 'existing');
-        renderField({}, 'existing');
-
-        fireEvent.change(screen.getByTestId('additionalPaymentField-input'), {
-            target: { value: '' },
-        });
-
-        expect(B2BSessionStorage.getValue(B2BSessionStorage.additionalPaymentFieldKey)).toBe('');
+        expect(screen.getByDisplayValue('leave at front door')).toBeInTheDocument();
     });
 });

--- a/packages/core/src/app/payment/AdditionalPaymentField.tsx
+++ b/packages/core/src/app/payment/AdditionalPaymentField.tsx
@@ -3,7 +3,6 @@ import React, { type FunctionComponent, useCallback } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { FormField, TextInput } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 interface AdditionalPaymentFieldProps {
     label: string;
@@ -19,13 +18,6 @@ const AdditionalPaymentField: FunctionComponent<AdditionalPaymentFieldProps> = (
             <TextInput
                 {...field}
                 id="additionalPaymentField"
-                onChange={(event) => {
-                    field.onChange(event);
-                    B2BSessionStorage.set(
-                        B2BSessionStorage.additionalPaymentFieldKey,
-                        event.target.value,
-                    );
-                }}
                 testId="additionalPaymentField-input"
             />
         ),

--- a/packages/core/src/app/payment/InvoicePaymentCommentField.test.tsx
+++ b/packages/core/src/app/payment/InvoicePaymentCommentField.test.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { getStoreConfig } from '../config/config.mock';
 
@@ -23,10 +22,6 @@ describe('InvoicePaymentCommentField', () => {
             </LocaleContext.Provider>,
         );
 
-    beforeEach(() => {
-        sessionStorage.clear();
-    });
-
     it('renders a textarea labeled "Payment comment"', () => {
         renderField();
 
@@ -34,24 +29,13 @@ describe('InvoicePaymentCommentField', () => {
         expect(screen.getByTestId('invoicePaymentComment-input')).toBeInTheDocument();
     });
 
-    it('writes the typed value to session storage on change', () => {
+    it('updates the field value on change', () => {
         renderField();
 
         fireEvent.change(screen.getByTestId('invoicePaymentComment-input'), {
             target: { value: 'hello world' },
         });
 
-        expect(B2BSessionStorage.getValue(B2BSessionStorage.invoiceCommentKey)).toBe('hello world');
-    });
-
-    it('stores an empty value when the field is cleared', () => {
-        B2BSessionStorage.set(B2BSessionStorage.invoiceCommentKey, 'existing');
-        renderField('existing');
-
-        fireEvent.change(screen.getByTestId('invoicePaymentComment-input'), {
-            target: { value: '' },
-        });
-
-        expect(B2BSessionStorage.getValue(B2BSessionStorage.invoiceCommentKey)).toBe('');
+        expect(screen.getByDisplayValue('hello world')).toBeInTheDocument();
     });
 });

--- a/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
+++ b/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
@@ -3,7 +3,6 @@ import React, { type FunctionComponent, useCallback } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { FormField, TextArea } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 const InvoicePaymentCommentField: FunctionComponent = () => {
     const renderInput = useCallback(
@@ -11,10 +10,6 @@ const InvoicePaymentCommentField: FunctionComponent = () => {
             <TextArea
                 {...field}
                 id="invoicePaymentComment"
-                onChange={(event) => {
-                    field.onChange(event);
-                    B2BSessionStorage.set(B2BSessionStorage.invoiceCommentKey, event.target.value);
-                }}
                 rows={4}
                 testId="invoicePaymentComment-input"
             />

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -32,7 +32,8 @@ import {
     orderResponse,
     payments,
 } from '@bigcommerce/checkout/test-framework';
-import { renderWithoutWrapper as render, screen } from '@bigcommerce/checkout/test-utils';
+import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
@@ -739,6 +740,328 @@ describe('Payment step', () => {
             await act(async () => userEvent.click(screen.getByText('Place Order')));
 
             expect(submitOrderSpy).not.toHaveBeenCalled();
+        });
+
+        it('persists B2B metadata after finalizing the order on mount when persistB2BMetadata capability is enabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith({
+                    isInvoice: false,
+                    invoiceComment: undefined,
+                    poNumber: undefined,
+                    referenceNumber: undefined,
+                    extraFields: [],
+                    extraInfo: {},
+                }),
+            );
+        });
+
+        it('persists the address extra fields from the checkout object after finalizing on mount', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            const { billingAddress } = checkoutWithShippingAndBilling;
+            const [consignment] = checkoutWithShippingAndBilling.consignments;
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                    billingAddress: billingAddress && {
+                        ...billingAddress,
+                        extraFields: [{ fieldId: '30', fieldValue: 'Finance' }],
+                    },
+                    consignments: [
+                        {
+                            ...consignment,
+                            shippingAddress: {
+                                ...consignment.shippingAddress,
+                                extraFields: [{ fieldId: '31', fieldValue: 'B7' }],
+                            },
+                        },
+                    ],
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: '30', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [{ fieldName: '31', fieldValue: 'B7' }],
+                            },
+                        },
+                    }),
+                ),
+            );
+        });
+
+        it('stores the address IDs returned by the order endpoint, persists them and clears them afterwards', async () => {
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(
+                        ctx.json({
+                            ...orderResponse,
+                            data: {
+                                ...orderResponse.data,
+                                b2bContext: { billingAddressId: 111, shippingAddressId: 222 },
+                            },
+                        }),
+                    ),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+            );
+
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        extraInfo: {
+                            billingAddressId: 111,
+                            shipppingAddressId: 222,
+                        },
+                    }),
+                ),
+            );
+
+            await waitFor(() =>
+                expect(B2BSessionStorage.getAddressIds()).toEqual({
+                    billingAddressId: undefined,
+                    shippingAddressId: undefined,
+                }),
+            );
+        });
+
+        it('persists B2B metadata with isInvoice true and the captured form values when the invoiceRedirect capability is enabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            B2BSessionStorage.setPaymentValues({ invoicePaymentComment: 'Invoice me' });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: {
+                    ...checkoutSettings,
+                    storeConfig: {
+                        ...checkoutSettings.storeConfig,
+                        checkoutSettings: {
+                            ...checkoutSettings.storeConfig.checkoutSettings,
+                            capabilities: {
+                                ...defaultCapabilities,
+                                orderConfirmation: {
+                                    ...defaultCapabilities.orderConfirmation,
+                                    persistB2BMetadata: true,
+                                    invoiceRedirect: true,
+                                },
+                            },
+                        },
+                    },
+                },
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        isInvoice: true,
+                        invoiceComment: 'Invoice me',
+                    }),
+                ),
+            );
+        });
+
+        it('does not clear B2B sessionStorage when persisting metadata fails', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            B2BSessionStorage.setAddressIds({ billingAddressId: 111, shippingAddressId: 222 });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockRejectedValue(new Error('Persist failed'));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() => expect(persistSpy).toHaveBeenCalled());
+
+            expect(B2BSessionStorage.getAddressIds()).toEqual({
+                billingAddressId: 111,
+                shippingAddressId: 222,
+            });
+        });
+
+        it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            const finalizeSpy = jest
+                .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+                .mockResolvedValue(checkoutService.getState());
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() => expect(finalizeSpy).toHaveBeenCalled());
+
+            expect(persistSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -986,7 +986,7 @@ describe('Payment step', () => {
             );
         });
 
-        it('does not clear B2B sessionStorage when persisting metadata fails', async () => {
+        it('clears B2B sessionStorage even when persisting metadata fails', async () => {
             const location = window.location;
 
             Object.defineProperty(window, 'location', {
@@ -1024,10 +1024,12 @@ describe('Payment step', () => {
 
             await waitFor(() => expect(persistSpy).toHaveBeenCalled());
 
-            expect(B2BSessionStorage.getAddressIds()).toEqual({
-                billingAddressId: 111,
-                shippingAddressId: 222,
-            });
+            await waitFor(() =>
+                expect(B2BSessionStorage.getAddressIds()).toEqual({
+                    billingAddressId: undefined,
+                    shippingAddressId: undefined,
+                }),
+            );
         });
 
         it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -1,4 +1,5 @@
 import {
+    type Address,
     type Capabilities,
     type Cart,
     type CartStockPositionsChangedError,
@@ -45,6 +46,7 @@ import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
 import { ChecklistSkeleton } from '@bigcommerce/checkout/ui';
+import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { withAnalytics } from '../analytics';
 import { withCheckout } from '../checkout';
@@ -58,6 +60,12 @@ import {
 import { EMPTY_ARRAY, isExperimentEnabled } from '../common/utility';
 import { TermsConditionsType } from '../termsConditions';
 
+import {
+    type B2BPaymentFormValues,
+    buildB2BMetadataOptions,
+    clearB2BMetadataStorage,
+    storeB2BPaymentValues,
+} from './b2bMetadata';
 import CartStockPositionsChangedModal from './CartStockPositionsChangedModal';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
@@ -85,8 +93,10 @@ interface WithCheckoutPaymentProps {
     addressExtraFields?: FormField[];
     availableStoreCredit: number;
     b2bToken?: string;
+    billingAddress?: Address;
     cart?: Cart;
     consignments?: Consignment[];
+    shippingAddress?: Address;
     cartUrl: string;
     defaultMethod?: PaymentMethod;
     finalizeOrderError?: Error;
@@ -111,6 +121,7 @@ interface WithCheckoutPaymentProps {
     loadCheckout(): Promise<CheckoutSelectors>;
     loadPaymentMethods(): Promise<CheckoutSelectors>;
     refreshB2BPaymentMethods: CheckoutService['refreshB2BPaymentMethods'];
+    submitB2BMetadata: CheckoutService['persistB2BMetadata'];
     submitOrder(values: OrderRequestBody): Promise<CheckoutSelectors>;
     checkoutServiceSubscribe: CheckoutService['subscribe'];
 }
@@ -143,11 +154,12 @@ const Payment = (
 
     const isReadyRef = useRef(state.isReady);
     const grandTotalChangeUnsubscribe = useRef<() => void>();
+    const b2bContextChangeUnsubscribe = useRef<() => void>();
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
 
     const {
-        orderConfirmation: { persistB2BMetadata },
+        orderConfirmation: { persistB2BMetadata, invoiceRedirect },
         userJourney: { disableStoreCredit },
     } = useCapabilities();
 
@@ -386,6 +398,32 @@ const Payment = (
             });
     };
 
+    const persistB2BMetadataIfNeeded = async (values?: B2BPaymentFormValues): Promise<void> => {
+        const {
+            addressExtraFields,
+            billingAddress,
+            orderExtraFields,
+            shippingAddress,
+            submitB2BMetadata,
+        } = props;
+
+        if (!persistB2BMetadata) {
+            return;
+        }
+
+        const metadataPayload = buildB2BMetadataOptions(invoiceRedirect, {
+            formValues: values,
+            billingAddress,
+            shippingAddress,
+            orderExtraFields,
+            addressExtraFields,
+        });
+
+        await submitB2BMetadata(metadataPayload);
+
+        clearB2BMetadataStorage();
+    };
+
     const handleSubmit = useCallback(
         async (values: PaymentFormValues) => {
             const {
@@ -404,6 +442,24 @@ const Payment = (
 
             analyticsTracker.clickPayButton({ shouldCreateAccount: values.shouldCreateAccount });
 
+            const {
+                additionalPaymentField,
+                invoicePaymentComment,
+                orderExtraFields,
+                ...orderValues
+            } = values;
+            const b2bPaymentValues: B2BPaymentFormValues = {
+                poNumber: values.poNumber,
+                invoicePaymentComment,
+                additionalPaymentField,
+                orderExtraFields,
+            };
+
+            if (persistB2BMetadata) {
+                clearB2BMetadataStorage();
+                storeB2BPaymentValues(b2bPaymentValues);
+            }
+
             const customSubmit =
                 selectedMethod &&
                 submitFunctions[
@@ -411,7 +467,7 @@ const Payment = (
                 ];
 
             if (customSubmit) {
-                return customSubmit(values);
+                return customSubmit(orderValues);
             }
 
             try {
@@ -420,9 +476,11 @@ const Payment = (
                 }
 
                 const state = await submitOrder(
-                    mapToOrderRequestBody(values, isPaymentDataRequired()),
+                    mapToOrderRequestBody(orderValues, isPaymentDataRequired()),
                 );
                 const order = state.data.getOrder();
+
+                await persistB2BMetadataIfNeeded(b2bPaymentValues);
 
                 analyticsTracker.paymentComplete();
 
@@ -580,6 +638,24 @@ const Payment = (
 
             await loadPaymentMethodsOrThrow();
 
+            if (persistB2BMetadata) {
+                // The order endpoint responds with the ids of the company addresses
+                // created during order submission. Off-site payment methods redirect
+                // away immediately afterwards, so mirror the ids into sessionStorage
+                // as soon as they land in checkout state — the post-redirect persist
+                // call reads them back from there.
+                b2bContextChangeUnsubscribe.current = checkoutServiceSubscribe(
+                    ({ data }) => {
+                        const b2bContext = data.getB2BContext();
+
+                        if (b2bContext?.billingAddressId || b2bContext?.shippingAddressId) {
+                            B2BSessionStorage.setAddressIds(b2bContext);
+                        }
+                    },
+                    ({ data }) => data.getB2BContext(),
+                );
+            }
+
             if (persistB2BMetadata && orderId) {
                 try {
                     await refreshB2BPaymentMethods();
@@ -609,6 +685,8 @@ const Payment = (
                 });
                 const order = state.data.getOrder();
 
+                await persistB2BMetadataIfNeeded();
+
                 onFinalize(order?.orderId);
             } catch (error) {
                 if (isErrorWithType(error) && error.type !== 'order_finalization_not_required') {
@@ -634,6 +712,11 @@ const Payment = (
                 if (grandTotalChangeUnsubscribe.current) {
                     grandTotalChangeUnsubscribe.current();
                     grandTotalChangeUnsubscribe.current = undefined;
+                }
+
+                if (b2bContextChangeUnsubscribe.current) {
+                    b2bContextChangeUnsubscribe.current();
+                    b2bContextChangeUnsubscribe.current = undefined;
                 }
 
                 window.removeEventListener('beforeunload', handleBeforeUnload);
@@ -716,6 +799,7 @@ export function mapToPaymentProps(
     const {
         data: {
             getAddressExtraFields,
+            getBillingAddress,
             getCart,
             getCheckout,
             getConfig,
@@ -725,6 +809,7 @@ export function mapToPaymentProps(
             getOrderExtraFields,
             getPaymentMethod,
             getPaymentMethods,
+            getShippingAddress,
             isPaymentDataRequired,
             getPaymentProviderCustomer,
         },
@@ -779,8 +864,10 @@ export function mapToPaymentProps(
         availableStoreCredit: customer.storeCredit,
         addressExtraFields,
         b2bToken: checkoutState.data.getB2BToken(),
+        billingAddress: getBillingAddress(),
         cart: getCart(),
         consignments,
+        shippingAddress: getShippingAddress(),
         cartUrl: config.links.cartLink,
         clearError: checkoutService.clearError,
         defaultMethod,
@@ -797,6 +884,7 @@ export function mapToPaymentProps(
         orderExtraFields,
         orderId: checkout.orderId,
         refreshB2BPaymentMethods: checkoutService.refreshB2BPaymentMethods,
+        submitB2BMetadata: checkoutService.persistB2BMetadata,
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,
         shouldLocaliseErrorMessages:
             features['PAYMENTS-6799.localise_checkout_payment_error_messages'],

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -418,9 +418,13 @@ const Payment = (
             addressExtraFields,
         });
 
-        await submitB2BMetadata(metadataPayload);
-
-        clearB2BMetadataStorage();
+        try {
+            await submitB2BMetadata(metadataPayload);
+        } catch {
+            /* Do nothing: failing to persist B2B metadata should not fail the checkout flow. */
+        } finally {
+            clearB2BMetadataStorage();
+        }
     };
 
     const handleSubmit = useCallback(

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -154,7 +154,6 @@ const Payment = (
 
     const isReadyRef = useRef(state.isReady);
     const grandTotalChangeUnsubscribe = useRef<() => void>();
-    const b2bContextChangeUnsubscribe = useRef<() => void>();
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
 
@@ -429,6 +428,7 @@ const Payment = (
             const {
                 defaultMethod,
                 loadPaymentMethods,
+                checkoutServiceSubscribe,
                 isPaymentDataRequired,
                 onCartChangedError = noop,
                 onSubmit = noop,
@@ -475,9 +475,23 @@ const Payment = (
                     await refreshB2BPaymentMethods();
                 }
 
+                const unsubscribeB2BContext = persistB2BMetadata
+                    ? checkoutServiceSubscribe(
+                          ({ data }) => {
+                              const b2bContext = data.getB2BContext();
+
+                              if (b2bContext?.billingAddressId || b2bContext?.shippingAddressId) {
+                                  B2BSessionStorage.setAddressIds(b2bContext);
+                              }
+                          },
+                          ({ data }) => data.getB2BContext(),
+                      )
+                    : noop;
+
                 const state = await submitOrder(
                     mapToOrderRequestBody(orderValues, isPaymentDataRequired()),
-                );
+                ).finally(unsubscribeB2BContext);
+
                 const order = state.data.getOrder();
 
                 await persistB2BMetadataIfNeeded(b2bPaymentValues);
@@ -638,24 +652,6 @@ const Payment = (
 
             await loadPaymentMethodsOrThrow();
 
-            if (persistB2BMetadata) {
-                // The order endpoint responds with the ids of the company addresses
-                // created during order submission. Off-site payment methods redirect
-                // away immediately afterwards, so mirror the ids into sessionStorage
-                // as soon as they land in checkout state — the post-redirect persist
-                // call reads them back from there.
-                b2bContextChangeUnsubscribe.current = checkoutServiceSubscribe(
-                    ({ data }) => {
-                        const b2bContext = data.getB2BContext();
-
-                        if (b2bContext?.billingAddressId || b2bContext?.shippingAddressId) {
-                            B2BSessionStorage.setAddressIds(b2bContext);
-                        }
-                    },
-                    ({ data }) => data.getB2BContext(),
-                );
-            }
-
             if (persistB2BMetadata && orderId) {
                 try {
                     await refreshB2BPaymentMethods();
@@ -712,11 +708,6 @@ const Payment = (
                 if (grandTotalChangeUnsubscribe.current) {
                     grandTotalChangeUnsubscribe.current();
                     grandTotalChangeUnsubscribe.current = undefined;
-                }
-
-                if (b2bContextChangeUnsubscribe.current) {
-                    b2bContextChangeUnsubscribe.current();
-                    b2bContextChangeUnsubscribe.current = undefined;
                 }
 
                 window.removeEventListener('beforeunload', handleBeforeUnload);

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -62,10 +62,11 @@ import { TermsConditionsType } from '../termsConditions';
 
 import {
     type B2BPaymentFormValues,
-    buildB2BMetadataOptions,
     clearB2BMetadataStorage,
     storeB2BPaymentValues,
 } from './b2bMetadata';
+import { getB2BMetadataPayload } from './b2bMetadataForPostOrder';
+import { mapToB2BOrderRequestBody } from './b2bMetadataForSubmitOrder';
 import CartStockPositionsChangedModal from './CartStockPositionsChangedModal';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
@@ -410,7 +411,7 @@ const Payment = (
             return;
         }
 
-        const metadataPayload = buildB2BMetadataOptions(invoiceRedirect, {
+        const metadataPayload = getB2BMetadataPayload(invoiceRedirect, {
             formValues: values,
             billingAddress,
             shippingAddress,
@@ -492,9 +493,10 @@ const Payment = (
                       )
                     : noop;
 
-                const state = await submitOrder(
-                    mapToOrderRequestBody(orderValues, isPaymentDataRequired()),
-                ).finally(unsubscribeB2BContext);
+                const state = await submitOrder({
+                    ...mapToOrderRequestBody(orderValues, isPaymentDataRequired()),
+                    ...(persistB2BMetadata ? mapToB2BOrderRequestBody(b2bPaymentValues) : {}),
+                }).finally(unsubscribeB2BContext);
 
                 const order = state.data.getOrder();
 

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -265,9 +265,15 @@ describe('PaymentForm', () => {
             sessionStorage.clear();
         });
 
-        it('seeds inputs from session storage when stored values exist', () => {
-            B2BSessionStorage.set(B2BSessionStorage.orderExtraFieldsKey, {
-                b2bExtraField_500: 'restored value',
+        it('seeds inputs with the field default value', () => {
+            render(<PaymentFormTest {...defaultProps} orderExtraFields={orderExtraFields} />);
+
+            expect(screen.getByDisplayValue('default value')).toBeInTheDocument();
+        });
+
+        it('restores inputs from the values captured at submit time', () => {
+            B2BSessionStorage.setPaymentValues({
+                orderExtraFields: { b2bExtraField_500: 'restored value' },
             });
 
             render(<PaymentFormTest {...defaultProps} orderExtraFields={orderExtraFields} />);
@@ -275,15 +281,9 @@ describe('PaymentForm', () => {
             expect(screen.getByDisplayValue('restored value')).toBeInTheDocument();
         });
 
-        it('uses field default when session storage is empty', () => {
-            render(<PaymentFormTest {...defaultProps} orderExtraFields={orderExtraFields} />);
-
-            expect(screen.getByDisplayValue('default value')).toBeInTheDocument();
-        });
-
-        it('falls back to default when stored value has an unexpected type', () => {
-            B2BSessionStorage.set(B2BSessionStorage.orderExtraFieldsKey, {
-                b2bExtraField_500: { tampered: true },
+        it('falls back to the default when a captured value has an unexpected type', () => {
+            B2BSessionStorage.setPaymentValues({
+                orderExtraFields: { b2bExtraField_500: { tampered: true } },
             });
 
             render(<PaymentFormTest {...defaultProps} orderExtraFields={orderExtraFields} />);
@@ -352,16 +352,16 @@ describe('PaymentForm', () => {
             expect(screen.queryByTestId('invoicePaymentComment-input')).not.toBeInTheDocument();
         });
 
-        it('seeds the textarea from session storage when a value is stored', () => {
+        it('restores the textarea from the value captured at submit time', () => {
             enableCapability();
-            B2BSessionStorage.set(B2BSessionStorage.invoiceCommentKey, 'restored comment');
+            B2BSessionStorage.setPaymentValues({ invoicePaymentComment: 'restored comment' });
 
             render(<PaymentFormTest {...defaultProps} />);
 
             expect(screen.getByDisplayValue('restored comment')).toBeInTheDocument();
         });
 
-        it('writes typed values to session storage and strips them from the submit payload', async () => {
+        it('includes the typed value in the submit payload', async () => {
             enableCapability();
 
             const onSubmit = jest.fn();
@@ -372,16 +372,12 @@ describe('PaymentForm', () => {
                 target: { value: 'note for invoice' },
             });
 
-            expect(B2BSessionStorage.getValue(B2BSessionStorage.invoiceCommentKey)).toBe(
-                'note for invoice',
-            );
-
             fireEvent.submit(screen.getByTestId('payment-form'));
 
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(onSubmit).toHaveBeenCalledWith(
-                expect.not.objectContaining({ invoicePaymentComment: expect.anything() }),
+                expect.objectContaining({ invoicePaymentComment: 'note for invoice' }),
             );
         });
     });
@@ -425,8 +421,8 @@ describe('PaymentForm', () => {
             ).not.toBeInTheDocument();
         });
 
-        it('seeds the field from session storage when a value is stored', () => {
-            B2BSessionStorage.set(B2BSessionStorage.additionalPaymentFieldKey, 'restored note');
+        it('restores the field from the value captured at submit time', () => {
+            B2BSessionStorage.setPaymentValues({ additionalPaymentField: 'restored note' });
 
             render(
                 <PaymentFormTest
@@ -438,7 +434,7 @@ describe('PaymentForm', () => {
             expect(screen.getByDisplayValue('restored note')).toBeInTheDocument();
         });
 
-        it('writes typed values to session storage and strips them from the submit payload', async () => {
+        it('includes the typed value in the submit payload', async () => {
             const onSubmit = jest.fn();
 
             render(
@@ -453,16 +449,12 @@ describe('PaymentForm', () => {
                 target: { value: 'special handling' },
             });
 
-            expect(B2BSessionStorage.getValue(B2BSessionStorage.additionalPaymentFieldKey)).toBe(
-                'special handling',
-            );
-
             fireEvent.submit(screen.getByTestId('payment-form'));
 
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(onSubmit).toHaveBeenCalledWith(
-                expect.not.objectContaining({ additionalPaymentField: expect.anything() }),
+                expect.objectContaining({ additionalPaymentField: 'special handling' }),
             );
         });
 

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -331,9 +331,9 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
 const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, PaymentFormValues> =
     {
         mapPropsToValues: ({ defaultGatewayId, defaultMethodId, orderExtraFields }) => {
-            const storedOrderExtraFields = B2BSessionStorage.get(
-                B2BSessionStorage.orderExtraFieldsKey,
-            );
+            // Restores the B2B values captured at submit time when the shopper
+            // comes back from an off-site payment redirect.
+            const storedPaymentValues = B2BSessionStorage.getPaymentValues();
 
             return {
                 ccCustomerCode: '',
@@ -364,35 +364,19 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
                 routingNumber: '',
                 orderExtraFields: getInitialOrderExtraFieldsValues(
                     orderExtraFields,
-                    storedOrderExtraFields,
+                    storedPaymentValues?.orderExtraFields,
                 ),
-                invoicePaymentComment: B2BSessionStorage.getValue(
-                    B2BSessionStorage.invoiceCommentKey,
-                ),
-                additionalPaymentField: B2BSessionStorage.getValue(
-                    B2BSessionStorage.additionalPaymentFieldKey,
-                ),
+                invoicePaymentComment: storedPaymentValues?.invoicePaymentComment ?? '',
+                additionalPaymentField: storedPaymentValues?.additionalPaymentField ?? '',
             };
         },
 
         handleSubmit: (values, { props: { onSubmit = noop } }) => {
-            const {
-                orderExtraFields,
-                invoicePaymentComment: _invoicePaymentComment,
-                additionalPaymentField: _additionalPaymentField,
-                ...rest
-            } = values as PaymentFormValues & {
-                orderExtraFields?: Record<string, unknown>;
-                invoicePaymentComment?: string;
-                additionalPaymentField?: string;
-            };
-
-            if (orderExtraFields && Object.keys(orderExtraFields).length > 0) {
-                B2BSessionStorage.set(B2BSessionStorage.orderExtraFieldsKey, orderExtraFields);
-            }
-
             onSubmit(
-                omitBy(rest, (value, key) => isNil(value) || value === '' || key === 'hostedForm'),
+                omitBy(
+                    values,
+                    (value, key) => isNil(value) || value === '' || key === 'hostedForm',
+                ),
             );
         },
 

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -5,7 +5,7 @@ import {
     type PaymentMethod,
 } from '@bigcommerce/checkout-sdk/essential';
 import { type FormikProps, type FormikState, withFormik, type WithFormikConfig } from 'formik';
-import { isEmpty, isNil, noop, omitBy } from 'lodash';
+import { isEmpty, noop, omitBy } from 'lodash';
 import React, { type FunctionComponent, memo, useCallback, useContext, useMemo } from 'react';
 import { object, type ObjectSchema, string } from 'yup';
 
@@ -375,7 +375,7 @@ const paymentFormConfig: WithFormikConfig<PaymentFormProps & WithLanguageProps, 
             onSubmit(
                 omitBy(
                     values,
-                    (value, key) => isNil(value) || value === '' || key === 'hostedForm',
+                    (value, key) => value == null || value === '' || key === 'hostedForm',
                 ),
             );
         },

--- a/packages/core/src/app/payment/b2bMetadata.test.ts
+++ b/packages/core/src/app/payment/b2bMetadata.test.ts
@@ -1,151 +1,52 @@
-import { type Address, B2B_EXTRA_FIELD_PREFIX, type FormField } from '@bigcommerce/checkout-sdk';
-
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
-import {
-    type B2BPaymentFormValues,
-    buildAddressExtraFields,
-    buildAddressExtraInfo,
-    buildB2BMetadataOptions,
-    buildExtraFields,
-    storeB2BPaymentValues,
-} from './b2bMetadata';
+import { clearB2BMetadataStorage, storeB2BPaymentValues } from './b2bMetadata';
 
 describe('b2bMetadata', () => {
     beforeEach(() => {
         sessionStorage.clear();
     });
 
-    describe('buildExtraFields', () => {
-        const orderExtraFields = [
-            { name: 'field_25', label: 'Cost Centre' },
-            { name: 'field_26', label: 'Department' },
-        ] as FormField[];
+    describe('storeB2BPaymentValues', () => {
+        it('stores the captured payment form values', () => {
+            storeB2BPaymentValues({
+                poNumber: 'PO-123',
+                invoicePaymentComment: 'Please rush this order',
+                additionalPaymentField: 'REF-456',
+                orderExtraFields: { costCentre: 'Engineering' },
+            });
 
-        it('maps each form field name to its label from the field definitions', () => {
-            expect(buildExtraFields({ field_25: 'Engineering' }, orderExtraFields)).toEqual([
-                { fieldName: 'Cost Centre', fieldValue: 'Engineering' },
-            ]);
-        });
-
-        it('falls back to the form field name when no matching definition is found', () => {
-            expect(buildExtraFields({ field_99: 'value' }, orderExtraFields)).toEqual([
-                { fieldName: 'field_99', fieldValue: 'value' },
-            ]);
-        });
-
-        it('falls back to the form field name when no definitions are provided', () => {
-            expect(buildExtraFields({ field_25: 'Engineering' })).toEqual([
-                { fieldName: 'field_25', fieldValue: 'Engineering' },
-            ]);
-        });
-
-        it('returns an empty array when there are no form values', () => {
-            expect(buildExtraFields(undefined, orderExtraFields)).toEqual([]);
-        });
-    });
-
-    describe('buildAddressExtraFields', () => {
-        const addressExtraFields = [
-            { name: `${B2B_EXTRA_FIELD_PREFIX}30`, label: 'Floor' },
-            { name: `${B2B_EXTRA_FIELD_PREFIX}31`, label: 'Dock' },
-        ] as FormField[];
-
-        it('maps each raw field id to the label of its prefixed field definition', () => {
-            expect(
-                buildAddressExtraFields([{ fieldId: '30', fieldValue: '3' }], addressExtraFields),
-            ).toEqual([{ fieldName: 'Floor', fieldValue: '3' }]);
-        });
-
-        it('falls back to the raw field id when no matching definition is found', () => {
-            expect(buildAddressExtraFields([{ fieldId: '99', fieldValue: 'value' }])).toEqual([
-                { fieldName: '99', fieldValue: 'value' },
-            ]);
-        });
-
-        it('returns an empty array when the address has no extra fields', () => {
-            expect(buildAddressExtraFields(undefined, addressExtraFields)).toEqual([]);
-        });
-    });
-
-    describe('buildAddressExtraInfo', () => {
-        const addressExtraFields = [
-            { name: `${B2B_EXTRA_FIELD_PREFIX}30`, label: 'Floor' },
-            { name: `${B2B_EXTRA_FIELD_PREFIX}31`, label: 'Dock' },
-        ] as FormField[];
-
-        const buildAddress = (extraFields: Address['extraFields']): Address =>
-            ({ extraFields }) as Address;
-
-        it('maps billing and shipping address extra fields to their labels', () => {
-            expect(
-                buildAddressExtraInfo(
-                    buildAddress([{ fieldId: '30', fieldValue: '3' }]),
-                    buildAddress([{ fieldId: '31', fieldValue: 'B7' }]),
-                    addressExtraFields,
-                ),
-            ).toEqual({
-                addressExtraFields: {
-                    billingAddressExtraFields: [{ fieldName: 'Floor', fieldValue: '3' }],
-                    shippingAddressExtraFields: [{ fieldName: 'Dock', fieldValue: 'B7' }],
-                },
+            expect(B2BSessionStorage.getPaymentValues()).toEqual({
+                poNumber: 'PO-123',
+                invoicePaymentComment: 'Please rush this order',
+                additionalPaymentField: 'REF-456',
+                orderExtraFields: { costCentre: 'Engineering' },
             });
         });
 
-        it('omits the address extra fields when neither address has any', () => {
-            expect(buildAddressExtraInfo(buildAddress([]), buildAddress(undefined))).toEqual({});
-        });
+        it('drops values that do not have the expected type', () => {
+            storeB2BPaymentValues({
+                poNumber: 123,
+                invoicePaymentComment: { nested: true },
+                additionalPaymentField: undefined,
+                orderExtraFields: 'not-a-record',
+            });
 
-        it('includes the stored billing and shipping address ids', () => {
+            expect(B2BSessionStorage.getPaymentValues()).toEqual({});
+        });
+    });
+
+    describe('clearB2BMetadataStorage', () => {
+        it('clears every stored B2B value', () => {
+            storeB2BPaymentValues({ poNumber: 'PO-123' });
             B2BSessionStorage.setAddressIds({ billingAddressId: 11, shippingAddressId: 22 });
 
-            expect(buildAddressExtraInfo()).toEqual({
-                billingAddressId: 11,
-                shipppingAddressId: 22,
-            });
-        });
-    });
+            clearB2BMetadataStorage();
 
-    describe('buildB2BMetadataOptions', () => {
-        const formValues: B2BPaymentFormValues = {
-            poNumber: 'PO-123',
-            invoicePaymentComment: 'Please rush this order',
-            additionalPaymentField: 'REF-456',
-            orderExtraFields: { costCentre: 'Engineering' },
-        };
-
-        it('builds the payload from the payment form values when they are available', () => {
-            expect(buildB2BMetadataOptions(true, { formValues })).toEqual({
-                isInvoice: true,
-                invoiceComment: 'Please rush this order',
-                poNumber: 'PO-123',
-                referenceNumber: 'REF-456',
-                extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
-                extraInfo: {},
-            });
-        });
-
-        it('falls back to the values captured at submit time when the form state is gone', () => {
-            storeB2BPaymentValues(formValues);
-
-            expect(buildB2BMetadataOptions(false)).toEqual({
-                isInvoice: false,
-                invoiceComment: 'Please rush this order',
-                poNumber: 'PO-123',
-                referenceNumber: 'REF-456',
-                extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
-                extraInfo: {},
-            });
-        });
-
-        it('builds an empty payload when there are neither form values nor captured values', () => {
-            expect(buildB2BMetadataOptions(false)).toEqual({
-                isInvoice: false,
-                invoiceComment: undefined,
-                poNumber: undefined,
-                referenceNumber: undefined,
-                extraFields: [],
-                extraInfo: {},
+            expect(B2BSessionStorage.getPaymentValues()).toBeUndefined();
+            expect(B2BSessionStorage.getAddressIds()).toEqual({
+                billingAddressId: undefined,
+                shippingAddressId: undefined,
             });
         });
     });

--- a/packages/core/src/app/payment/b2bMetadata.test.ts
+++ b/packages/core/src/app/payment/b2bMetadata.test.ts
@@ -1,0 +1,152 @@
+import { type Address, B2B_EXTRA_FIELD_PREFIX, type FormField } from '@bigcommerce/checkout-sdk';
+
+import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
+
+import {
+    type B2BPaymentFormValues,
+    buildAddressExtraFields,
+    buildAddressExtraInfo,
+    buildB2BMetadataOptions,
+    buildExtraFields,
+    storeB2BPaymentValues,
+} from './b2bMetadata';
+
+describe('b2bMetadata', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    describe('buildExtraFields', () => {
+        const orderExtraFields = [
+            { name: 'field_25', label: 'Cost Centre' },
+            { name: 'field_26', label: 'Department' },
+        ] as FormField[];
+
+        it('maps each form field name to its label from the field definitions', () => {
+            expect(buildExtraFields({ field_25: 'Engineering' }, orderExtraFields)).toEqual([
+                { fieldName: 'Cost Centre', fieldValue: 'Engineering' },
+            ]);
+        });
+
+        it('falls back to the form field name when no matching definition is found', () => {
+            expect(buildExtraFields({ field_99: 'value' }, orderExtraFields)).toEqual([
+                { fieldName: 'field_99', fieldValue: 'value' },
+            ]);
+        });
+
+        it('falls back to the form field name when no definitions are provided', () => {
+            expect(buildExtraFields({ field_25: 'Engineering' })).toEqual([
+                { fieldName: 'field_25', fieldValue: 'Engineering' },
+            ]);
+        });
+
+        it('returns an empty array when there are no form values', () => {
+            expect(buildExtraFields(undefined, orderExtraFields)).toEqual([]);
+        });
+    });
+
+    describe('buildAddressExtraFields', () => {
+        const addressExtraFields = [
+            { name: `${B2B_EXTRA_FIELD_PREFIX}30`, label: 'Floor' },
+            { name: `${B2B_EXTRA_FIELD_PREFIX}31`, label: 'Dock' },
+        ] as FormField[];
+
+        it('maps each raw field id to the label of its prefixed field definition', () => {
+            expect(
+                buildAddressExtraFields([{ fieldId: '30', fieldValue: '3' }], addressExtraFields),
+            ).toEqual([{ fieldName: 'Floor', fieldValue: '3' }]);
+        });
+
+        it('falls back to the raw field id when no matching definition is found', () => {
+            expect(buildAddressExtraFields([{ fieldId: '99', fieldValue: 'value' }])).toEqual([
+                { fieldName: '99', fieldValue: 'value' },
+            ]);
+        });
+
+        it('returns an empty array when the address has no extra fields', () => {
+            expect(buildAddressExtraFields(undefined, addressExtraFields)).toEqual([]);
+        });
+    });
+
+    describe('buildAddressExtraInfo', () => {
+        const addressExtraFields = [
+            { name: `${B2B_EXTRA_FIELD_PREFIX}30`, label: 'Floor' },
+            { name: `${B2B_EXTRA_FIELD_PREFIX}31`, label: 'Dock' },
+        ] as FormField[];
+
+        const buildAddress = (extraFields: Address['extraFields']): Address =>
+            ({ extraFields }) as Address;
+
+        it('maps billing and shipping address extra fields to their labels', () => {
+            expect(
+                buildAddressExtraInfo(
+                    buildAddress([{ fieldId: '30', fieldValue: '3' }]),
+                    buildAddress([{ fieldId: '31', fieldValue: 'B7' }]),
+                    addressExtraFields,
+                ),
+            ).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'Floor', fieldValue: '3' }],
+                    shippingAddressExtraFields: [{ fieldName: 'Dock', fieldValue: 'B7' }],
+                },
+            });
+        });
+
+        it('omits the address extra fields when neither address has any', () => {
+            expect(buildAddressExtraInfo(buildAddress([]), buildAddress(undefined))).toEqual({});
+        });
+
+        it('includes the stored billing and shipping address ids', () => {
+            B2BSessionStorage.setAddressIds({ billingAddressId: 11, shippingAddressId: 22 });
+
+            expect(buildAddressExtraInfo()).toEqual({
+                billingAddressId: 11,
+                shipppingAddressId: 22,
+            });
+        });
+    });
+
+    describe('buildB2BMetadataOptions', () => {
+        const formValues: B2BPaymentFormValues = {
+            poNumber: 'PO-123',
+            invoicePaymentComment: 'Please rush this order',
+            additionalPaymentField: 'REF-456',
+            orderExtraFields: { costCentre: 'Engineering' },
+        };
+
+        it('builds the payload from the payment form values when they are available', () => {
+            expect(buildB2BMetadataOptions(true, { formValues })).toEqual({
+                isInvoice: true,
+                invoiceComment: 'Please rush this order',
+                poNumber: 'PO-123',
+                referenceNumber: 'REF-456',
+                extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                extraInfo: {},
+            });
+        });
+
+        it('falls back to the values captured at submit time when the form state is gone', () => {
+            storeB2BPaymentValues(formValues);
+
+            expect(buildB2BMetadataOptions(false)).toEqual({
+                isInvoice: false,
+                invoiceComment: 'Please rush this order',
+                poNumber: 'PO-123',
+                referenceNumber: 'REF-456',
+                extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                extraInfo: {},
+            });
+        });
+
+        it('builds an empty payload when there are neither form values nor captured values', () => {
+            expect(buildB2BMetadataOptions(false)).toEqual({
+                isInvoice: false,
+                invoiceComment: undefined,
+                poNumber: undefined,
+                referenceNumber: undefined,
+                extraFields: [],
+                extraInfo: {},
+            });
+        });
+    });
+});

--- a/packages/core/src/app/payment/b2bMetadata.test.ts
+++ b/packages/core/src/app/payment/b2bMetadata.test.ts
@@ -34,6 +34,21 @@ describe('b2bMetadata', () => {
 
             expect(B2BSessionStorage.getPaymentValues()).toEqual({});
         });
+
+        it('drops an array orderExtraFields without losing the other stored values', () => {
+            storeB2BPaymentValues({
+                poNumber: 'PO-123',
+                invoicePaymentComment: 'Please rush this order',
+                additionalPaymentField: 'REF-456',
+                orderExtraFields: ['not', 'a', 'record'],
+            });
+
+            expect(B2BSessionStorage.getPaymentValues()).toEqual({
+                poNumber: 'PO-123',
+                invoicePaymentComment: 'Please rush this order',
+                additionalPaymentField: 'REF-456',
+            });
+        });
     });
 
     describe('clearB2BMetadataStorage', () => {

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -11,7 +11,9 @@ export const getStringValue = (value: unknown): string | undefined =>
     typeof value === 'string' ? value : undefined;
 
 export const getRecordValue = (value: unknown): Record<string, unknown> | undefined =>
-    typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : undefined;
 
 export const storeB2BPaymentValues = ({
     poNumber,

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -15,6 +15,14 @@ export const getRecordValue = (value: unknown): Record<string, unknown> | undefi
         ? (value as Record<string, unknown>)
         : undefined;
 
+export const hasNonEmptyExtraFieldValue = (
+    entry: [string, unknown],
+): entry is [string, string | number] => {
+    const value = entry[1];
+
+    return typeof value === 'number' || (typeof value === 'string' && value !== '');
+};
+
 export const storeB2BPaymentValues = ({
     poNumber,
     invoicePaymentComment,

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -1,14 +1,4 @@
-import {
-    type Address,
-    B2B_EXTRA_FIELD_PREFIX,
-    type FormField,
-    type PersistB2BMetadataOptions,
-} from '@bigcommerce/checkout-sdk/essential';
-
-import { B2BSessionStorage, type B2BStoredPaymentValues } from '@bigcommerce/checkout/utility';
-
-type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
-type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
+import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 export interface B2BPaymentFormValues {
     poNumber?: unknown;
@@ -17,15 +7,12 @@ export interface B2BPaymentFormValues {
     orderExtraFields?: unknown;
 }
 
-const getStringValue = (value: unknown): string | undefined =>
+export const getStringValue = (value: unknown): string | undefined =>
     typeof value === 'string' ? value : undefined;
 
-const getOrderExtraFieldValues = (value: unknown): Record<string, unknown> | undefined =>
-    // The payment form types its values loosely; this is the single assertion that types them.
+export const getRecordValue = (value: unknown): Record<string, unknown> | undefined =>
     typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
 
-// Captures the B2B fields of the payment form when the shopper submits the
-// order, so they survive an off-site payment redirect.
 export const storeB2BPaymentValues = ({
     poNumber,
     invoicePaymentComment,
@@ -36,101 +23,8 @@ export const storeB2BPaymentValues = ({
         poNumber: getStringValue(poNumber),
         invoicePaymentComment: getStringValue(invoicePaymentComment),
         additionalPaymentField: getStringValue(additionalPaymentField),
-        orderExtraFields: getOrderExtraFieldValues(orderExtraFields),
+        orderExtraFields: getRecordValue(orderExtraFields),
     });
-};
-
-export const buildExtraFields = (
-    formExtraFields?: Record<string, unknown>,
-    fields?: FormField[],
-): B2BMetadataExtraField[] =>
-    formExtraFields
-        ? Object.entries(formExtraFields).map(([fieldName, fieldValue]) => ({
-              // The API expects the field label, but form values are keyed by field name (id).
-              fieldName: fields?.find((field) => field.name === fieldName)?.label ?? fieldName,
-              fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
-          }))
-        : [];
-
-// Address extra-field values come from the checkout object keyed by raw field id,
-// while the field definitions are named with the `B2B_EXTRA_FIELD_PREFIX`.
-export const buildAddressExtraFields = (
-    extraFieldValues?: Address['extraFields'],
-    fields?: FormField[],
-): B2BMetadataExtraField[] =>
-    (extraFieldValues ?? []).map(({ fieldId, fieldValue }) => ({
-        fieldName:
-            fields?.find((field) => field.name === `${B2B_EXTRA_FIELD_PREFIX}${fieldId}`)?.label ??
-            fieldId,
-        fieldValue,
-    }));
-
-export const buildAddressExtraInfo = (
-    billingAddress?: Address,
-    shippingAddress?: Address,
-    addressExtraFields?: FormField[],
-): B2BMetadataExtraInfo => {
-    const extraInfo: B2BMetadataExtraInfo = {};
-
-    if (billingAddress?.extraFields?.length || shippingAddress?.extraFields?.length) {
-        extraInfo.addressExtraFields = {
-            billingAddressExtraFields: buildAddressExtraFields(
-                billingAddress?.extraFields,
-                addressExtraFields,
-            ),
-            shippingAddressExtraFields: buildAddressExtraFields(
-                shippingAddress?.extraFields,
-                addressExtraFields,
-            ),
-        };
-    }
-
-    const { billingAddressId, shippingAddressId } = B2BSessionStorage.getAddressIds();
-
-    if (billingAddressId) {
-        extraInfo.billingAddressId = billingAddressId;
-    }
-
-    if (shippingAddressId) {
-        // The SDK field is spelled with a triple "p" (shipppingAddressId).
-        extraInfo.shipppingAddressId = shippingAddressId;
-    }
-
-    return extraInfo;
-};
-
-interface B2BMetadataSources {
-    formValues?: B2BPaymentFormValues;
-    billingAddress?: Address;
-    shippingAddress?: Address;
-    orderExtraFields?: FormField[];
-    addressExtraFields?: FormField[];
-}
-
-export const buildB2BMetadataOptions = (
-    isInvoice: PersistB2BMetadataOptions['isInvoice'],
-    {
-        formValues,
-        billingAddress,
-        shippingAddress,
-        orderExtraFields,
-        addressExtraFields,
-    }: B2BMetadataSources = {},
-): PersistB2BMetadataOptions => {
-    const sourceValues: B2BPaymentFormValues | B2BStoredPaymentValues | undefined =
-        formValues ?? B2BSessionStorage.getPaymentValues();
-
-    return {
-        isInvoice,
-        invoiceComment: getStringValue(sourceValues?.invoicePaymentComment),
-        poNumber: getStringValue(sourceValues?.poNumber),
-        referenceNumber: getStringValue(sourceValues?.additionalPaymentField),
-        extraFields: buildExtraFields(
-            getOrderExtraFieldValues(sourceValues?.orderExtraFields),
-            orderExtraFields,
-        ),
-        extraInfo: buildAddressExtraInfo(billingAddress, shippingAddress, addressExtraFields),
-    };
 };
 
 export const clearB2BMetadataStorage = (): void => {

--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -1,6 +1,138 @@
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
+import {
+    type Address,
+    B2B_EXTRA_FIELD_PREFIX,
+    type FormField,
+    type PersistB2BMetadataOptions,
+} from '@bigcommerce/checkout-sdk/essential';
 
-// Clear all B2B sessionStorage after a successful order.
+import { B2BSessionStorage, type B2BStoredPaymentValues } from '@bigcommerce/checkout/utility';
+
+type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
+type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
+
+export interface B2BPaymentFormValues {
+    poNumber?: unknown;
+    invoicePaymentComment?: unknown;
+    additionalPaymentField?: unknown;
+    orderExtraFields?: unknown;
+}
+
+const getStringValue = (value: unknown): string | undefined =>
+    typeof value === 'string' ? value : undefined;
+
+const getOrderExtraFieldValues = (value: unknown): Record<string, unknown> | undefined =>
+    // The payment form types its values loosely; this is the single assertion that types them.
+    typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+
+// Captures the B2B fields of the payment form when the shopper submits the
+// order, so they survive an off-site payment redirect.
+export const storeB2BPaymentValues = ({
+    poNumber,
+    invoicePaymentComment,
+    additionalPaymentField,
+    orderExtraFields,
+}: B2BPaymentFormValues): void => {
+    B2BSessionStorage.setPaymentValues({
+        poNumber: getStringValue(poNumber),
+        invoicePaymentComment: getStringValue(invoicePaymentComment),
+        additionalPaymentField: getStringValue(additionalPaymentField),
+        orderExtraFields: getOrderExtraFieldValues(orderExtraFields),
+    });
+};
+
+export const buildExtraFields = (
+    formExtraFields?: Record<string, unknown>,
+    fields?: FormField[],
+): B2BMetadataExtraField[] =>
+    formExtraFields
+        ? Object.entries(formExtraFields).map(([fieldName, fieldValue]) => ({
+              // The API expects the field label, but form values are keyed by field name (id).
+              fieldName: fields?.find((field) => field.name === fieldName)?.label ?? fieldName,
+              fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
+          }))
+        : [];
+
+// Address extra-field values come from the checkout object keyed by raw field id,
+// while the field definitions are named with the `B2B_EXTRA_FIELD_PREFIX`.
+export const buildAddressExtraFields = (
+    extraFieldValues?: Address['extraFields'],
+    fields?: FormField[],
+): B2BMetadataExtraField[] =>
+    (extraFieldValues ?? []).map(({ fieldId, fieldValue }) => ({
+        fieldName:
+            fields?.find((field) => field.name === `${B2B_EXTRA_FIELD_PREFIX}${fieldId}`)?.label ??
+            fieldId,
+        fieldValue,
+    }));
+
+export const buildAddressExtraInfo = (
+    billingAddress?: Address,
+    shippingAddress?: Address,
+    addressExtraFields?: FormField[],
+): B2BMetadataExtraInfo => {
+    const extraInfo: B2BMetadataExtraInfo = {};
+
+    if (billingAddress?.extraFields?.length || shippingAddress?.extraFields?.length) {
+        extraInfo.addressExtraFields = {
+            billingAddressExtraFields: buildAddressExtraFields(
+                billingAddress?.extraFields,
+                addressExtraFields,
+            ),
+            shippingAddressExtraFields: buildAddressExtraFields(
+                shippingAddress?.extraFields,
+                addressExtraFields,
+            ),
+        };
+    }
+
+    const { billingAddressId, shippingAddressId } = B2BSessionStorage.getAddressIds();
+
+    if (billingAddressId) {
+        extraInfo.billingAddressId = billingAddressId;
+    }
+
+    if (shippingAddressId) {
+        // The SDK field is spelled with a triple "p" (shipppingAddressId).
+        extraInfo.shipppingAddressId = shippingAddressId;
+    }
+
+    return extraInfo;
+};
+
+interface B2BMetadataSources {
+    formValues?: B2BPaymentFormValues;
+    billingAddress?: Address;
+    shippingAddress?: Address;
+    orderExtraFields?: FormField[];
+    addressExtraFields?: FormField[];
+}
+
+export const buildB2BMetadataOptions = (
+    isInvoice: PersistB2BMetadataOptions['isInvoice'],
+    {
+        formValues,
+        billingAddress,
+        shippingAddress,
+        orderExtraFields,
+        addressExtraFields,
+    }: B2BMetadataSources = {},
+): PersistB2BMetadataOptions => {
+    const sourceValues: B2BPaymentFormValues | B2BStoredPaymentValues | undefined =
+        formValues ?? B2BSessionStorage.getPaymentValues();
+
+    return {
+        isInvoice,
+        invoiceComment: getStringValue(sourceValues?.invoicePaymentComment),
+        poNumber: getStringValue(sourceValues?.poNumber),
+        referenceNumber: getStringValue(sourceValues?.additionalPaymentField),
+        extraFields: buildExtraFields(
+            getOrderExtraFieldValues(sourceValues?.orderExtraFields),
+            orderExtraFields,
+        ),
+        extraInfo: buildAddressExtraInfo(billingAddress, shippingAddress, addressExtraFields),
+    };
+};
+
 export const clearB2BMetadataStorage = (): void => {
     B2BSessionStorage.clearAll();
 };

--- a/packages/core/src/app/payment/b2bMetadataForPostOrder.test.ts
+++ b/packages/core/src/app/payment/b2bMetadataForPostOrder.test.ts
@@ -1,0 +1,133 @@
+import { type Address, B2B_EXTRA_FIELD_PREFIX, type FormField } from '@bigcommerce/checkout-sdk';
+
+import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
+
+import { type B2BPaymentFormValues, storeB2BPaymentValues } from './b2bMetadata';
+import {
+    getB2BMetadataPayload,
+    getExtraInfoValues,
+    getOrderExtraFieldsValues,
+} from './b2bMetadataForPostOrder';
+
+describe('b2bMetadataForPostOrder', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    describe('getOrderExtraFieldsValues', () => {
+        const orderExtraFields = [
+            { name: 'field_25', label: 'Cost Centre' },
+            { name: 'field_26', label: 'Department' },
+        ] as FormField[];
+
+        it('maps each form field name to its label from the field definitions', () => {
+            expect(
+                getOrderExtraFieldsValues({ field_25: 'Engineering' }, orderExtraFields),
+            ).toEqual([{ fieldName: 'Cost Centre', fieldValue: 'Engineering' }]);
+        });
+
+        it('falls back to the form field name when no matching definition is found', () => {
+            expect(getOrderExtraFieldsValues({ field_99: 'value' }, orderExtraFields)).toEqual([
+                { fieldName: 'field_99', fieldValue: 'value' },
+            ]);
+        });
+
+        it('falls back to the form field name when no definitions are provided', () => {
+            expect(getOrderExtraFieldsValues({ field_25: 'Engineering' })).toEqual([
+                { fieldName: 'field_25', fieldValue: 'Engineering' },
+            ]);
+        });
+
+        it('omits fields with empty values', () => {
+            expect(
+                getOrderExtraFieldsValues({ field_25: '', field_26: 'Finance' }, orderExtraFields),
+            ).toEqual([{ fieldName: 'Department', fieldValue: 'Finance' }]);
+        });
+
+        it('returns an empty array when there are no form values', () => {
+            expect(getOrderExtraFieldsValues(undefined, orderExtraFields)).toEqual([]);
+        });
+    });
+
+    describe('getExtraInfoValues', () => {
+        const addressExtraFields = [
+            { name: `${B2B_EXTRA_FIELD_PREFIX}30`, label: 'Floor' },
+            { name: `${B2B_EXTRA_FIELD_PREFIX}31`, label: 'Dock' },
+        ] as FormField[];
+
+        const buildAddress = (extraFields: Address['extraFields']): Address =>
+            ({ extraFields }) as Address;
+
+        it('maps billing and shipping address extra fields to their labels', () => {
+            expect(
+                getExtraInfoValues(
+                    buildAddress([{ fieldId: '30', fieldValue: '3' }]),
+                    buildAddress([{ fieldId: '31', fieldValue: 'B7' }]),
+                    addressExtraFields,
+                ),
+            ).toEqual({
+                addressExtraFields: {
+                    billingAddressExtraFields: [{ fieldName: 'Floor', fieldValue: '3' }],
+                    shippingAddressExtraFields: [{ fieldName: 'Dock', fieldValue: 'B7' }],
+                },
+            });
+        });
+
+        it('omits the address extra fields when neither address has any', () => {
+            expect(getExtraInfoValues(buildAddress([]), buildAddress(undefined))).toEqual({});
+        });
+
+        it('includes the stored billing and shipping address ids', () => {
+            B2BSessionStorage.setAddressIds({ billingAddressId: 11, shippingAddressId: 22 });
+
+            expect(getExtraInfoValues()).toEqual({
+                billingAddressId: 11,
+                shipppingAddressId: 22,
+            });
+        });
+    });
+
+    describe('getB2BMetadataPayload', () => {
+        const formValues: B2BPaymentFormValues = {
+            poNumber: 'PO-123',
+            invoicePaymentComment: 'Please rush this order',
+            additionalPaymentField: 'REF-456',
+            orderExtraFields: { costCentre: 'Engineering' },
+        };
+
+        it('builds the payload from the payment form values when they are available', () => {
+            expect(getB2BMetadataPayload(true, { formValues })).toEqual({
+                isInvoice: true,
+                invoiceComment: 'Please rush this order',
+                poNumber: 'PO-123',
+                referenceNumber: 'REF-456',
+                extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                extraInfo: {},
+            });
+        });
+
+        it('falls back to the values captured at submit time when the form state is gone', () => {
+            storeB2BPaymentValues(formValues);
+
+            expect(getB2BMetadataPayload(false)).toEqual({
+                isInvoice: false,
+                invoiceComment: 'Please rush this order',
+                poNumber: 'PO-123',
+                referenceNumber: 'REF-456',
+                extraFields: [{ fieldName: 'costCentre', fieldValue: 'Engineering' }],
+                extraInfo: {},
+            });
+        });
+
+        it('builds an empty payload when there are neither form values nor captured values', () => {
+            expect(getB2BMetadataPayload(false)).toEqual({
+                isInvoice: false,
+                invoiceComment: undefined,
+                poNumber: undefined,
+                referenceNumber: undefined,
+                extraFields: [],
+                extraInfo: {},
+            });
+        });
+    });
+});

--- a/packages/core/src/app/payment/b2bMetadataForPostOrder.ts
+++ b/packages/core/src/app/payment/b2bMetadataForPostOrder.ts
@@ -7,7 +7,12 @@ import {
 
 import { B2BSessionStorage, type B2BStoredPaymentValues } from '@bigcommerce/checkout/utility';
 
-import { type B2BPaymentFormValues, getRecordValue, getStringValue } from './b2bMetadata';
+import {
+    type B2BPaymentFormValues,
+    getRecordValue,
+    getStringValue,
+    hasNonEmptyExtraFieldValue,
+} from './b2bMetadata';
 
 type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
 type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
@@ -21,7 +26,6 @@ interface B2BMetadataSources {
     addressExtraFields?: FormField[];
 }
 
-const isNonEmptyExtraFieldValue = (value: unknown): boolean => value != null && value !== '';
 const getExtraFieldLabel = (
     fieldName: string,
     fieldLabels: FieldLabelLookup,
@@ -33,11 +37,11 @@ const mapOrderExtraFieldsValues = (
     fieldLabels: FieldLabelLookup,
 ): B2BMetadataExtraField[] =>
     Object.entries(formExtraFields)
-        .filter(([, fieldValue]) => isNonEmptyExtraFieldValue(fieldValue))
+        .filter(hasNonEmptyExtraFieldValue)
         .map(([fieldName, fieldValue]) => ({
             // The API expects the field label, but form values are keyed by field name (id).
             fieldName: getExtraFieldLabel(fieldName, fieldLabels),
-            fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
+            fieldValue,
         }));
 
 const createExtraFieldLabelLookup = (fields?: FormField[]): FieldLabelLookup =>

--- a/packages/core/src/app/payment/b2bMetadataForPostOrder.ts
+++ b/packages/core/src/app/payment/b2bMetadataForPostOrder.ts
@@ -1,0 +1,129 @@
+import {
+    type Address,
+    B2B_EXTRA_FIELD_PREFIX,
+    type FormField,
+    type PersistB2BMetadataOptions,
+} from '@bigcommerce/checkout-sdk/essential';
+
+import { B2BSessionStorage, type B2BStoredPaymentValues } from '@bigcommerce/checkout/utility';
+
+import { type B2BPaymentFormValues, getRecordValue, getStringValue } from './b2bMetadata';
+
+type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
+type B2BMetadataExtraInfo = NonNullable<PersistB2BMetadataOptions['extraInfo']>;
+type FieldLabelLookup = ReadonlyMap<string, string>;
+
+interface B2BMetadataSources {
+    formValues?: B2BPaymentFormValues;
+    billingAddress?: Address;
+    shippingAddress?: Address;
+    orderExtraFields?: FormField[];
+    addressExtraFields?: FormField[];
+}
+
+const isNonEmptyExtraFieldValue = (value: unknown): boolean => value != null && value !== '';
+const getExtraFieldLabel = (
+    fieldName: string,
+    fieldLabels: FieldLabelLookup,
+    fallback = fieldName,
+): string => fieldLabels.get(fieldName) ?? fallback;
+
+const mapOrderExtraFieldsValues = (
+    formExtraFields: Record<string, unknown>,
+    fieldLabels: FieldLabelLookup,
+): B2BMetadataExtraField[] =>
+    Object.entries(formExtraFields)
+        .filter(([, fieldValue]) => isNonEmptyExtraFieldValue(fieldValue))
+        .map(([fieldName, fieldValue]) => ({
+            // The API expects the field label, but form values are keyed by field name (id).
+            fieldName: getExtraFieldLabel(fieldName, fieldLabels),
+            fieldValue: fieldValue as B2BMetadataExtraField['fieldValue'],
+        }));
+
+const createExtraFieldLabelLookup = (fields?: FormField[]): FieldLabelLookup =>
+    new Map(fields?.map(({ name, label }) => [name, label]) ?? []);
+
+export const getOrderExtraFieldsValues = (
+    formExtraFields?: Record<string, unknown>,
+    fields?: FormField[],
+): B2BMetadataExtraField[] => {
+    if (!formExtraFields) {
+        return [];
+    }
+
+    return mapOrderExtraFieldsValues(formExtraFields, createExtraFieldLabelLookup(fields));
+};
+
+const mapAddressExtraFields = (
+    extraFieldValues: NonNullable<Address['extraFields']>,
+    fieldLabels: FieldLabelLookup,
+): B2BMetadataExtraField[] =>
+    extraFieldValues.map(({ fieldId, fieldValue }) => ({
+        fieldName: getExtraFieldLabel(`${B2B_EXTRA_FIELD_PREFIX}${fieldId}`, fieldLabels, fieldId),
+        fieldValue,
+    }));
+
+export const getExtraInfoValues = (
+    billingAddress?: Address,
+    shippingAddress?: Address,
+    addressExtraFields?: FormField[],
+): B2BMetadataExtraInfo => {
+    const extraInfo: B2BMetadataExtraInfo = {};
+    const fieldLabels = createExtraFieldLabelLookup(addressExtraFields);
+
+    const billingAddressExtraFields = mapAddressExtraFields(
+        billingAddress?.extraFields ?? [],
+        fieldLabels,
+    );
+
+    const shippingAddressExtraFields = mapAddressExtraFields(
+        shippingAddress?.extraFields ?? [],
+        fieldLabels,
+    );
+
+    if (billingAddressExtraFields.length > 0 || shippingAddressExtraFields.length > 0) {
+        extraInfo.addressExtraFields = {
+            billingAddressExtraFields,
+            shippingAddressExtraFields,
+        };
+    }
+
+    const { billingAddressId, shippingAddressId } = B2BSessionStorage.getAddressIds();
+
+    if (billingAddressId) {
+        extraInfo.billingAddressId = billingAddressId;
+    }
+
+    if (shippingAddressId) {
+        // The SDK field is spelled with a triple "p" (shipppingAddressId).
+        extraInfo.shipppingAddressId = shippingAddressId;
+    }
+
+    return extraInfo;
+};
+
+export const getB2BMetadataPayload = (
+    isInvoice: PersistB2BMetadataOptions['isInvoice'],
+    {
+        formValues,
+        billingAddress,
+        shippingAddress,
+        orderExtraFields,
+        addressExtraFields,
+    }: B2BMetadataSources = {},
+): PersistB2BMetadataOptions => {
+    const sourceValues: B2BPaymentFormValues | B2BStoredPaymentValues | undefined =
+        formValues ?? B2BSessionStorage.getPaymentValues();
+
+    return {
+        isInvoice,
+        invoiceComment: getStringValue(sourceValues?.invoicePaymentComment),
+        poNumber: getStringValue(sourceValues?.poNumber),
+        referenceNumber: getStringValue(sourceValues?.additionalPaymentField),
+        extraFields: getOrderExtraFieldsValues(
+            getRecordValue(sourceValues?.orderExtraFields),
+            orderExtraFields,
+        ),
+        extraInfo: getExtraInfoValues(billingAddress, shippingAddress, addressExtraFields),
+    };
+};

--- a/packages/core/src/app/payment/b2bMetadataForSubmitOrder.test.ts
+++ b/packages/core/src/app/payment/b2bMetadataForSubmitOrder.test.ts
@@ -1,0 +1,50 @@
+import { B2B_EXTRA_FIELD_PREFIX } from '@bigcommerce/checkout-sdk';
+
+import { mapToB2BOrderRequestBody } from './b2bMetadataForSubmitOrder';
+
+describe('b2bMetadataForSubmitOrder', () => {
+    describe('mapToB2BOrderRequestBody', () => {
+        it('maps the payment form values to the order request fields', () => {
+            expect(
+                mapToB2BOrderRequestBody({
+                    poNumber: 'PO-123',
+                    additionalPaymentField: 'REF-456',
+                    orderExtraFields: { [`${B2B_EXTRA_FIELD_PREFIX}500`]: 'Engineering' },
+                }),
+            ).toEqual({
+                poNumber: 'PO-123',
+                additionalText: 'REF-456',
+                orderExtraFields: [{ fieldId: '500', fieldValue: 'Engineering' }],
+            });
+        });
+
+        it('keeps the field name as the id when it has no B2B prefix', () => {
+            expect(mapToB2BOrderRequestBody({ orderExtraFields: { customField: 7 } })).toEqual({
+                orderExtraFields: [{ fieldId: 'customField', fieldValue: 7 }],
+            });
+        });
+
+        it('omits empty and non-scalar extra field values', () => {
+            expect(
+                mapToB2BOrderRequestBody({
+                    orderExtraFields: {
+                        empty: '',
+                        missing: undefined,
+                        tampered: { nested: true },
+                        filled: 'value',
+                    },
+                }),
+            ).toEqual({ orderExtraFields: [{ fieldId: 'filled', fieldValue: 'value' }] });
+        });
+
+        it('omits the keys when the values are empty or missing', () => {
+            expect(mapToB2BOrderRequestBody({ poNumber: '', orderExtraFields: {} })).toEqual({});
+        });
+
+        it('omits values that are not strings', () => {
+            expect(
+                mapToB2BOrderRequestBody({ poNumber: 123, additionalPaymentField: true }),
+            ).toEqual({});
+        });
+    });
+});

--- a/packages/core/src/app/payment/b2bMetadataForSubmitOrder.ts
+++ b/packages/core/src/app/payment/b2bMetadataForSubmitOrder.ts
@@ -1,0 +1,57 @@
+import { B2B_EXTRA_FIELD_PREFIX, type OrderRequestBody } from '@bigcommerce/checkout-sdk/essential';
+
+import { type B2BPaymentFormValues, getRecordValue, getStringValue } from './b2bMetadata';
+
+type B2BOrderRequestExtraField = NonNullable<OrderRequestBody['orderExtraFields']>[number];
+
+type B2BOrderRequestFields = Pick<
+    OrderRequestBody,
+    'additionalText' | 'orderExtraFields' | 'poNumber'
+>;
+
+const toRawExtraFieldId = (fieldName: string): string =>
+    fieldName.startsWith(B2B_EXTRA_FIELD_PREFIX)
+        ? fieldName.slice(B2B_EXTRA_FIELD_PREFIX.length)
+        : fieldName;
+
+const hasNonEmptyExtraFieldValue = (
+    entry: [string, unknown],
+): entry is [string, string | number] => {
+    const value = entry[1];
+
+    return typeof value === 'number' || (typeof value === 'string' && value !== '');
+};
+
+const getOrderExtraFieldValues = (value: unknown): B2BOrderRequestExtraField[] =>
+    Object.entries(getRecordValue(value) ?? {})
+        .filter(hasNonEmptyExtraFieldValue)
+        .map(([fieldName, fieldValue]) => ({
+            fieldId: toRawExtraFieldId(fieldName),
+            fieldValue,
+        }));
+
+export const mapToB2BOrderRequestBody = ({
+    poNumber,
+    additionalPaymentField,
+    orderExtraFields,
+}: B2BPaymentFormValues): B2BOrderRequestFields => {
+    const fields: B2BOrderRequestFields = {};
+
+    const poNumberValue = getStringValue(poNumber);
+    const additionalText = getStringValue(additionalPaymentField);
+    const orderExtraFieldValues = getOrderExtraFieldValues(orderExtraFields);
+
+    if (poNumberValue) {
+        fields.poNumber = poNumberValue;
+    }
+
+    if (additionalText) {
+        fields.additionalText = additionalText;
+    }
+
+    if (orderExtraFieldValues.length > 0) {
+        fields.orderExtraFields = orderExtraFieldValues;
+    }
+
+    return fields;
+};

--- a/packages/core/src/app/payment/b2bMetadataForSubmitOrder.ts
+++ b/packages/core/src/app/payment/b2bMetadataForSubmitOrder.ts
@@ -1,6 +1,11 @@
 import { B2B_EXTRA_FIELD_PREFIX, type OrderRequestBody } from '@bigcommerce/checkout-sdk/essential';
 
-import { type B2BPaymentFormValues, getRecordValue, getStringValue } from './b2bMetadata';
+import {
+    type B2BPaymentFormValues,
+    getRecordValue,
+    getStringValue,
+    hasNonEmptyExtraFieldValue,
+} from './b2bMetadata';
 
 type B2BOrderRequestExtraField = NonNullable<OrderRequestBody['orderExtraFields']>[number];
 
@@ -13,14 +18,6 @@ const toRawExtraFieldId = (fieldName: string): string =>
     fieldName.startsWith(B2B_EXTRA_FIELD_PREFIX)
         ? fieldName.slice(B2B_EXTRA_FIELD_PREFIX.length)
         : fieldName;
-
-const hasNonEmptyExtraFieldValue = (
-    entry: [string, unknown],
-): entry is [string, string | number] => {
-    const value = entry[1];
-
-    return typeof value === 'number' || (typeof value === 'string' && value !== '');
-};
 
 const getOrderExtraFieldValues = (value: unknown): B2BOrderRequestExtraField[] =>
     Object.entries(getRecordValue(value) ?? {})

--- a/packages/core/src/app/payment/orderExtraFields/getInitialOrderExtraFieldsValues.ts
+++ b/packages/core/src/app/payment/orderExtraFields/getInitialOrderExtraFieldsValues.ts
@@ -2,7 +2,7 @@ import { type FormField } from '@bigcommerce/checkout-sdk/essential';
 
 export default function getInitialOrderExtraFieldsValues(
     orderExtraFields: FormField[] | undefined,
-    storedOrderExtraFields: Record<string, unknown> | undefined,
+    storedOrderExtraFields?: Record<string, unknown>,
 ): Record<string, string | number> {
     return (orderExtraFields ?? []).reduce<Record<string, string | number>>((acc, field) => {
         const raw = storedOrderExtraFields?.[field.name];

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 
 import { useCapabilities } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import {
     AddressFormModal,
@@ -55,8 +54,6 @@ const ConsignmentAddressSelector = ({
         validateMaxLength,
         getConsignments: getPreviousConsignments,
     } = useShipping();
-
-    const storageKey = B2BSessionStorage.getConsignmentKey(consignment?.id ?? '');
 
     // TODO: add filter for addresses
     const addresses = customer.addresses || EMPTY_ARRAY;
@@ -116,7 +113,7 @@ const ConsignmentAddressSelector = ({
     };
 
     const handleSaveAddress = async (addressFormValues: AddressFormValues) => {
-        const address = mapAddressFromFormValues(addressFormValues, storageKey);
+        const address = mapAddressFromFormValues(addressFormValues);
 
         await handleSelectAddress(address);
 
@@ -160,7 +157,6 @@ const ConsignmentAddressSelector = ({
                 onSaveAddress={handleSaveAddress}
                 selectedAddress={isGuest ? selectedAddress : undefined}
                 shouldShowSaveAddress={hasCompanyAddressBook}
-                storageKey={storageKey}
             />
             {isGuest ? (
                 <GuestCustomerAddressSelector

--- a/packages/core/src/app/shipping/NewConsignment.tsx
+++ b/packages/core/src/app/shipping/NewConsignment.tsx
@@ -8,7 +8,6 @@ import React, { useMemo, useState } from 'react';
 
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { isErrorWithType } from '../common/error';
 
@@ -75,8 +74,6 @@ const NewConsignment = ({
 
         const previousConsignments = getPreviousConsignments() ?? [];
 
-        const previousConsignmentIds = new Set(previousConsignments.map((c) => c.id));
-
         try {
             const {
                 data: { getConsignments },
@@ -86,14 +83,6 @@ const NewConsignment = ({
             });
 
             currentConsignments = getConsignments();
-
-            const newConsignment = currentConsignments?.find(
-                (c) => !previousConsignmentIds.has(c.id),
-            );
-
-            if (newConsignment) {
-                B2BSessionStorage.reassignConsignmentKey(newConsignment.id);
-            }
         } catch (error) {
             if (error instanceof AssignItemFailedError) {
                 onUnhandledError(error);

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -43,7 +43,6 @@ import {
     waitFor,
     within,
 } from '@bigcommerce/checkout/test-utils';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { getCustomerAddressB2B } from '../address/address.mock';
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
@@ -1096,7 +1095,7 @@ describe('Shipping step', () => {
             </CheckoutProvider>
         );
 
-        it('stores the selected shipping address id when hasCompanyAddressBook is enabled', async () => {
+        it('updates the shipping address when a company address is selected', async () => {
             // The searchable address book only lists addresses flagged for shipping.
             const checkoutWithCompanyShippingAddress = {
                 ...checkoutWithMultiShippingCart,
@@ -1116,9 +1115,9 @@ describe('Shipping step', () => {
                 checkout: checkoutWithCompanyShippingAddress,
             });
 
-            jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
-                checkoutService.getState(),
-            );
+            const updateShippingAddressSpy = jest
+                .spyOn(checkoutService, 'updateShippingAddress')
+                .mockResolvedValue(checkoutService.getState());
 
             render(<CheckoutWithCompanyAddressBook {...defaultProps} />);
 
@@ -1127,7 +1126,9 @@ describe('Shipping step', () => {
             await userEvent.click(screen.getByTestId('address-select-button'));
             await userEvent.click(screen.getByTestId('address-select-option-action'));
 
-            expect(B2BSessionStorage.getAddressId(B2BSessionStorage.shippingAddressIdKey)).toBe(1);
+            expect(updateShippingAddressSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ id: 1 }),
+            );
         });
 
         it('shows save address checkbox in multi-shipping new address modal when hasCompanyAddressBook is true', async () => {
@@ -1192,26 +1193,6 @@ describe('Shipping step', () => {
             await waitFor(() =>
                 expect(checkoutService.createCustomerAddress).not.toHaveBeenCalled(),
             );
-        });
-
-        it('does not store the shipping address id when hasCompanyAddressBook is disabled', async () => {
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
-
-            jest.spyOn(checkoutService, 'updateShippingAddress').mockResolvedValue(
-                checkoutService.getState(),
-            );
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForShippingStep();
-
-            await userEvent.click(screen.getByTestId('address-select-button'));
-            // 111 Testing Rd is the customer's saved address with id 1.
-            await userEvent.click(screen.getByText(/111 Testing Rd/i));
-
-            expect(
-                B2BSessionStorage.getAddressId(B2BSessionStorage.shippingAddressIdKey),
-            ).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -5,7 +5,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useCapabilities } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, ConfirmationModal } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import {
     AddressType,
@@ -148,11 +147,7 @@ function Shipping({
 
     const handleSingleShippingSubmit = async (values: SingleShippingFormValues) => {
         const updatedShippingAddress =
-            values.shippingAddress &&
-            mapAddressFromFormValues(
-                values.shippingAddress,
-                B2BSessionStorage.shippingExtraFieldsKey,
-            );
+            values.shippingAddress && mapAddressFromFormValues(values.shippingAddress);
         const promises: Array<Promise<CheckoutSelectors>> = [];
         const hasRemoteBilling = hasRemoteBillingFn(methodId);
 
@@ -164,8 +159,6 @@ function Shipping({
         }
 
         if (values.billingSameAsShipping && updatedShippingAddress && !hasRemoteBilling) {
-            B2BSessionStorage.copyShippingToBilling();
-
             if (!isEqualAddress(updatedShippingAddress, billingAddress)) {
                 promises.push(updateBillingAddress(updatedShippingAddress));
             }

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -1,4 +1,4 @@
-import { type Address, type CustomerAddress, type FormField } from '@bigcommerce/checkout-sdk';
+import { type Address, type FormField } from '@bigcommerce/checkout-sdk';
 import { type FormikProps } from 'formik';
 import { debounce, type DebouncedFunc, isEqual, noop } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -7,14 +7,12 @@ import { lazy, object } from 'yup';
 import { useCapabilities } from '@bigcommerce/checkout/contexts';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { Fieldset, Form } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import {
     type AddressFormValues,
     getAddressFormFieldsValidationSchema,
     getTranslateAddressError,
     isEqualAddress,
-    isValidCustomerAddress,
     mapAddressFromFormValues,
     mapAddressToFormValues,
 } from '../address';
@@ -89,11 +87,9 @@ const SingleShippingForm: React.FC<
 }) => {
     const {
         shipping: { hideBillingSameAsShippingCheck },
-        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
     } = useCapabilities();
     const {
         consignments,
-        customer,
         deinitializeShippingMethod: deinitialize,
         deleteConsignments,
         initializeShippingMethod: initialize,
@@ -103,13 +99,6 @@ const SingleShippingForm: React.FC<
         shouldShowOrderComments,
         updateShippingAddress: updateAddress,
     } = useShipping();
-
-    const hasValidShippingCustomerAddress = isValidCustomerAddress(
-        shippingAddress,
-        customer.addresses,
-        getFields(shippingAddress?.countryCode),
-        validateMaxLength,
-    );
 
     const propsRef = useRef({ values, shippingAddress, isValid });
     const debouncedUpdateAddressRef = useRef<
@@ -122,18 +111,6 @@ const SingleShippingForm: React.FC<
     const [isResettingAddress, setIsResettingAddress] = useState(false);
     const [isUpdatingShippingData, setIsUpdatingShippingData] = useState(false);
     const [hasRequestedShippingOptions, setHasRequestedShippingOptions] = useState(false);
-
-    // Once the address form opens (selected address is invalid or no longer matches a
-    // book entry), the stored book id can't faithfully represent it, so drop it.
-    useEffect(() => {
-        if (
-            hasCompanyAddressBook &&
-            !hasValidShippingCustomerAddress &&
-            B2BSessionStorage.getAddressId(B2BSessionStorage.shippingAddressIdKey)
-        ) {
-            B2BSessionStorage.remove(B2BSessionStorage.shippingAddressIdKey);
-        }
-    }, [hasCompanyAddressBook, hasValidShippingCustomerAddress]);
 
     const stateOrProvinceCodeFormField = useMemo(() => {
         return getFields(values.shippingAddress?.countryCode).find(
@@ -204,7 +181,6 @@ const SingleShippingForm: React.FC<
                 shippingAddress: mapAddressToFormValues(
                     getFields(shippingAddress?.countryCode),
                     shippingAddress,
-                    B2BSessionStorage.shippingExtraFieldsKey,
                 ),
             });
         }
@@ -260,14 +236,6 @@ const SingleShippingForm: React.FC<
         try {
             await updateAddress(address);
 
-            B2BSessionStorage.remove(B2BSessionStorage.shippingAddressIdKey);
-
-            const selectedAddressId = (address as CustomerAddress).id;
-
-            if (hasCompanyAddressBook && selectedAddressId) {
-                B2BSessionStorage.set(B2BSessionStorage.shippingAddressIdKey, selectedAddressId);
-            }
-
             setValues({
                 ...propsRef.current.values,
                 shippingAddress: mapAddressToFormValues(getFields(address.countryCode), address),
@@ -284,12 +252,6 @@ const SingleShippingForm: React.FC<
 
         try {
             const address = await deleteConsignments();
-
-            if (hasAddressExtraFields) {
-                B2BSessionStorage.remove(B2BSessionStorage.shippingExtraFieldsKey);
-            }
-
-            B2BSessionStorage.remove(B2BSessionStorage.shippingAddressIdKey);
 
             setValues({
                 ...propsRef.current.values,
@@ -376,7 +338,6 @@ export default withLanguage(
             shippingAddress: mapAddressToFormValues(
                 getFields(shippingAddress?.countryCode),
                 shippingAddress,
-                B2BSessionStorage.shippingExtraFieldsKey,
             ),
         }),
         validateOnMount: true,

--- a/packages/utility/src/index.ts
+++ b/packages/utility/src/index.ts
@@ -2,4 +2,8 @@ export { default as isBuyNowCart } from './isBuyNowCart';
 export { default as navigateToOrderConfirmation } from './navigateToOrderConfirmation';
 export { default as isErrorWithTranslationKey } from './is-error-with-translation-key';
 export { default as hideEditCartLink } from './hideEditCartLink';
-export { B2BSessionStorage, type B2BStoredMetadata } from './storage/B2BSessionStorage';
+export {
+    B2BSessionStorage,
+    type B2BStoredAddressIds,
+    type B2BStoredPaymentValues,
+} from './storage/B2BSessionStorage';

--- a/packages/utility/src/storage/B2BSessionStorage.test.ts
+++ b/packages/utility/src/storage/B2BSessionStorage.test.ts
@@ -5,175 +5,90 @@ describe('B2BSessionStorage', () => {
         sessionStorage.clear();
     });
 
-    describe('get / set / remove', () => {
-        it('returns undefined for a missing key', () => {
-            expect(B2BSessionStorage.get(B2BSessionStorage.orderExtraFieldsKey)).toBeUndefined();
-        });
-
-        it('round-trips an object through base64-encoded JSON', () => {
-            const fields = { costCentre: 'Acme Corp' };
-
-            B2BSessionStorage.set(B2BSessionStorage.billingExtraFieldsKey, fields);
-
-            expect(sessionStorage.getItem(B2BSessionStorage.billingExtraFieldsKey)).toBe(
-                btoa(encodeURIComponent(JSON.stringify(fields))),
-            );
-            expect(B2BSessionStorage.get(B2BSessionStorage.billingExtraFieldsKey)).toEqual(fields);
-        });
-
-        it('round-trips a string and defaults to empty via getValue', () => {
-            B2BSessionStorage.set(B2BSessionStorage.poNumberKey, 'PO-123');
-
-            expect(B2BSessionStorage.getValue(B2BSessionStorage.poNumberKey)).toBe('PO-123');
-            expect(B2BSessionStorage.getValue(B2BSessionStorage.invoiceCommentKey)).toBe('');
-        });
-
-        it('round-trips a numeric address id via getAddressId', () => {
-            B2BSessionStorage.set(B2BSessionStorage.billingAddressIdKey, 42);
-
-            expect(sessionStorage.getItem(B2BSessionStorage.billingAddressIdKey)).toBe(
-                btoa(encodeURIComponent(JSON.stringify(42))),
-            );
-            expect(B2BSessionStorage.getAddressId(B2BSessionStorage.billingAddressIdKey)).toBe(42);
-        });
-
-        it('returns undefined for malformed stored data', () => {
-            sessionStorage.setItem(B2BSessionStorage.orderExtraFieldsKey, 'not-base64-json');
-
-            expect(B2BSessionStorage.get(B2BSessionStorage.orderExtraFieldsKey)).toBeUndefined();
-        });
-
-        it('removes a stored key', () => {
-            B2BSessionStorage.set(B2BSessionStorage.orderExtraFieldsKey, { a: 1 });
-
-            B2BSessionStorage.remove(B2BSessionStorage.orderExtraFieldsKey);
-
-            expect(B2BSessionStorage.get(B2BSessionStorage.orderExtraFieldsKey)).toBeUndefined();
-        });
-    });
-
-    describe('getAll', () => {
-        it('returns string defaults and undefined fields when nothing is stored', () => {
-            expect(B2BSessionStorage.getAll()).toEqual({
-                poNumber: '',
-                additionalPaymentField: '',
-                invoiceComment: '',
-                orderExtraFields: undefined,
-                billingExtraFields: undefined,
-                shippingExtraFields: undefined,
+    describe('setAddressIds / getAddressIds', () => {
+        it('returns undefined ids when nothing is stored', () => {
+            expect(B2BSessionStorage.getAddressIds()).toEqual({
                 billingAddressId: undefined,
                 shippingAddressId: undefined,
             });
         });
 
-        it('reads every stored value with the right type', () => {
-            B2BSessionStorage.set(B2BSessionStorage.poNumberKey, 'PO-123');
-            B2BSessionStorage.set(B2BSessionStorage.additionalPaymentFieldKey, 'REF-456');
-            B2BSessionStorage.set(B2BSessionStorage.invoiceCommentKey, 'note');
-            B2BSessionStorage.set(B2BSessionStorage.orderExtraFieldsKey, { costCentre: 'Eng' });
-            B2BSessionStorage.set(B2BSessionStorage.billingExtraFieldsKey, { department: 'Fin' });
-            B2BSessionStorage.set(B2BSessionStorage.shippingExtraFieldsKey, { dock: 'B7' });
-            B2BSessionStorage.set(B2BSessionStorage.billingAddressIdKey, 11);
-            B2BSessionStorage.set(B2BSessionStorage.shippingAddressIdKey, 22);
+        it('round-trips both ids through base64-encoded JSON', () => {
+            B2BSessionStorage.setAddressIds({ billingAddressId: 11, shippingAddressId: 22 });
 
-            expect(B2BSessionStorage.getAll()).toEqual({
-                poNumber: 'PO-123',
-                additionalPaymentField: 'REF-456',
-                invoiceComment: 'note',
-                orderExtraFields: { costCentre: 'Eng' },
-                billingExtraFields: { department: 'Fin' },
-                shippingExtraFields: { dock: 'B7' },
+            expect(sessionStorage.getItem(B2BSessionStorage.billingAddressIdKey)).toBe(
+                btoa(encodeURIComponent(JSON.stringify(11))),
+            );
+            expect(B2BSessionStorage.getAddressIds()).toEqual({
                 billingAddressId: 11,
                 shippingAddressId: 22,
             });
         });
+
+        it('removes a previously stored id when the new value is missing', () => {
+            B2BSessionStorage.setAddressIds({ billingAddressId: 11, shippingAddressId: 22 });
+
+            B2BSessionStorage.setAddressIds({ shippingAddressId: 33 });
+
+            expect(B2BSessionStorage.getAddressIds()).toEqual({
+                billingAddressId: undefined,
+                shippingAddressId: 33,
+            });
+        });
+
+        it('returns undefined for malformed stored data', () => {
+            sessionStorage.setItem(B2BSessionStorage.billingAddressIdKey, 'not-base64-json');
+
+            expect(B2BSessionStorage.getAddressIds().billingAddressId).toBeUndefined();
+        });
+
+        it('returns undefined for stored data that is not a number', () => {
+            sessionStorage.setItem(
+                B2BSessionStorage.shippingAddressIdKey,
+                btoa(encodeURIComponent(JSON.stringify('not-a-number'))),
+            );
+
+            expect(B2BSessionStorage.getAddressIds().shippingAddressId).toBeUndefined();
+        });
+    });
+
+    describe('setPaymentValues / getPaymentValues', () => {
+        it('returns undefined when nothing is stored', () => {
+            expect(B2BSessionStorage.getPaymentValues()).toBeUndefined();
+        });
+
+        it('round-trips the captured payment form values', () => {
+            const values = {
+                poNumber: 'PO-123',
+                invoicePaymentComment: 'Please rush this order',
+                additionalPaymentField: 'REF-456',
+                orderExtraFields: { costCentre: 'Engineering' },
+            };
+
+            B2BSessionStorage.setPaymentValues(values);
+
+            expect(B2BSessionStorage.getPaymentValues()).toEqual(values);
+        });
+
+        it('returns undefined for malformed stored data', () => {
+            sessionStorage.setItem(B2BSessionStorage.paymentValuesKey, 'not-base64-json');
+
+            expect(B2BSessionStorage.getPaymentValues()).toBeUndefined();
+        });
     });
 
     describe('clearAll', () => {
-        it('removes every b2b key (including consignment keys), leaving unrelated keys', () => {
-            B2BSessionStorage.set(B2BSessionStorage.poNumberKey, 'PO-123');
-            B2BSessionStorage.set(B2BSessionStorage.invoiceCommentKey, 'note');
-            B2BSessionStorage.set(B2BSessionStorage.orderExtraFieldsKey, { a: 1 });
-            B2BSessionStorage.set(B2BSessionStorage.billingExtraFieldsKey, { b: 2 });
-            B2BSessionStorage.set(B2BSessionStorage.shippingExtraFieldsKey, { c: 3 });
-            B2BSessionStorage.set(B2BSessionStorage.billingAddressIdKey, 11);
-            B2BSessionStorage.set(B2BSessionStorage.shippingAddressIdKey, 22);
-            B2BSessionStorage.set(B2BSessionStorage.getConsignmentKey('123'), { d: 4 });
+        it('removes every b2b key, leaving unrelated keys', () => {
+            B2BSessionStorage.setAddressIds({ billingAddressId: 11, shippingAddressId: 22 });
+            B2BSessionStorage.setPaymentValues({ poNumber: 'PO-123' });
             sessionStorage.setItem('unrelatedKey', 'keep-me');
 
             B2BSessionStorage.clearAll();
 
-            [
-                B2BSessionStorage.poNumberKey,
-                B2BSessionStorage.invoiceCommentKey,
-                B2BSessionStorage.orderExtraFieldsKey,
-                B2BSessionStorage.billingExtraFieldsKey,
-                B2BSessionStorage.shippingExtraFieldsKey,
-                B2BSessionStorage.billingAddressIdKey,
-                B2BSessionStorage.shippingAddressIdKey,
-                B2BSessionStorage.getConsignmentKey('123'),
-            ].forEach((key) => expect(sessionStorage.getItem(key)).toBeNull());
-
+            expect(sessionStorage.getItem(B2BSessionStorage.billingAddressIdKey)).toBeNull();
+            expect(sessionStorage.getItem(B2BSessionStorage.shippingAddressIdKey)).toBeNull();
+            expect(sessionStorage.getItem(B2BSessionStorage.paymentValuesKey)).toBeNull();
             expect(sessionStorage.getItem('unrelatedKey')).toBe('keep-me');
-        });
-    });
-
-    describe('copyShippingToBilling', () => {
-        it('copies shipping fields and address id to billing', () => {
-            const fields = { costCentre: 'Acme Corp' };
-
-            B2BSessionStorage.set(B2BSessionStorage.shippingExtraFieldsKey, fields);
-            B2BSessionStorage.set(B2BSessionStorage.shippingAddressIdKey, 42);
-
-            B2BSessionStorage.copyShippingToBilling();
-
-            expect(B2BSessionStorage.get(B2BSessionStorage.billingExtraFieldsKey)).toEqual(fields);
-            expect(B2BSessionStorage.getAddressId(B2BSessionStorage.billingAddressIdKey)).toBe(42);
-        });
-
-        it('removes the billing address id when shipping has none', () => {
-            B2BSessionStorage.set(B2BSessionStorage.billingAddressIdKey, 99);
-
-            B2BSessionStorage.copyShippingToBilling();
-
-            expect(
-                B2BSessionStorage.getAddressId(B2BSessionStorage.billingAddressIdKey),
-            ).toBeUndefined();
-        });
-
-        it('leaves billing fields untouched when shipping has no fields', () => {
-            const billingFields = { department: 'Existing' };
-
-            B2BSessionStorage.set(B2BSessionStorage.billingExtraFieldsKey, billingFields);
-
-            B2BSessionStorage.copyShippingToBilling();
-
-            expect(B2BSessionStorage.get(B2BSessionStorage.billingExtraFieldsKey)).toEqual(
-                billingFields,
-            );
-        });
-    });
-
-    describe('reassignConsignmentKey', () => {
-        it('moves fields from the temp key to the real consignment key', () => {
-            const fields = { costCentre: 'Acme Corp' };
-
-            B2BSessionStorage.set(B2BSessionStorage.getConsignmentKey(''), fields);
-
-            B2BSessionStorage.reassignConsignmentKey('consignment-123');
-
-            expect(
-                B2BSessionStorage.get(B2BSessionStorage.getConsignmentKey('consignment-123')),
-            ).toEqual(fields);
-            expect(B2BSessionStorage.get(B2BSessionStorage.getConsignmentKey(''))).toBeUndefined();
-        });
-
-        it('does nothing when the temp key has no data', () => {
-            B2BSessionStorage.reassignConsignmentKey('consignment-123');
-
-            expect(
-                B2BSessionStorage.get(B2BSessionStorage.getConsignmentKey('consignment-123')),
-            ).toBeUndefined();
         });
     });
 });

--- a/packages/utility/src/storage/B2BSessionStorage.ts
+++ b/packages/utility/src/storage/B2BSessionStorage.ts
@@ -10,6 +10,33 @@ export interface B2BStoredPaymentValues {
     orderExtraFields?: Record<string, unknown>;
 }
 
+function isStringValue(value: unknown): value is string | undefined {
+    return value === undefined || typeof value === 'string';
+}
+
+function isB2BStoredPaymentValues(value: unknown): value is B2BStoredPaymentValues {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    const poNumber = 'poNumber' in value ? value.poNumber : undefined;
+    const invoicePaymentComment =
+        'invoicePaymentComment' in value ? value.invoicePaymentComment : undefined;
+    const additionalPaymentField =
+        'additionalPaymentField' in value ? value.additionalPaymentField : undefined;
+    const orderExtraFields = 'orderExtraFields' in value ? value.orderExtraFields : undefined;
+
+    return (
+        isStringValue(poNumber) &&
+        isStringValue(invoicePaymentComment) &&
+        isStringValue(additionalPaymentField) &&
+        (orderExtraFields === undefined ||
+            (typeof orderExtraFields === 'object' &&
+                orderExtraFields !== null &&
+                !Array.isArray(orderExtraFields)))
+    );
+}
+
 export class B2BSessionStorage {
     static readonly keyPrefix = 'checkout_js_b2b';
     static readonly billingAddressIdKey = `${this.keyPrefix}_billingAddressId`;
@@ -37,10 +64,7 @@ export class B2BSessionStorage {
     static getPaymentValues(): B2BStoredPaymentValues | undefined {
         const value = this.decode(this.paymentValuesKey);
 
-        return typeof value === 'object' && value !== null
-            ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-              (value as B2BStoredPaymentValues)
-            : undefined;
+        return isB2BStoredPaymentValues(value) ? value : undefined;
     }
 
     static clearAll(): void {

--- a/packages/utility/src/storage/B2BSessionStorage.ts
+++ b/packages/utility/src/storage/B2BSessionStorage.ts
@@ -1,37 +1,59 @@
-export interface B2BStoredMetadata {
-    poNumber: string;
-    additionalPaymentField: string;
-    invoiceComment: string;
-    orderExtraFields?: Record<string, unknown>;
-    billingExtraFields?: Record<string, unknown>;
-    shippingExtraFields?: Record<string, unknown>;
+export interface B2BStoredAddressIds {
     billingAddressId?: number;
     shippingAddressId?: number;
 }
 
+export interface B2BStoredPaymentValues {
+    poNumber?: string;
+    invoicePaymentComment?: string;
+    additionalPaymentField?: string;
+    orderExtraFields?: Record<string, unknown>;
+}
+
 export class B2BSessionStorage {
-    static readonly keyPrefix = 'b2b';
-    // payment fields
-    static readonly poNumberKey = `${this.keyPrefix}_poNumber`;
-    static readonly additionalPaymentFieldKey = `${this.keyPrefix}_additionalPaymentField`;
-    static readonly invoiceCommentKey = `${this.keyPrefix}_invoiceComment`;
-    // address / order extra fields
-    static readonly billingExtraFieldsKey = `${this.keyPrefix}_addressExtraFields_billing`;
-    static readonly shippingExtraFieldsKey = `${this.keyPrefix}_addressExtraFields_shipping`;
-    static readonly consignmentExtraFieldsKeyPrefix = `${this.keyPrefix}_addressExtraFields_consignment_`;
-    static readonly orderExtraFieldsKey = `${this.keyPrefix}_orderExtraFields`;
+    static readonly keyPrefix = 'checkout_js_b2b';
     static readonly billingAddressIdKey = `${this.keyPrefix}_billingAddressId`;
     static readonly shippingAddressIdKey = `${this.keyPrefix}_shippingAddressId`;
+    static readonly paymentValuesKey = `${this.keyPrefix}_paymentValues`;
 
-    static getConsignmentKey(consignmentId: string): string {
-        return `${this.consignmentExtraFieldsKeyPrefix}${consignmentId}`;
+    // Overwrites both keys so ids from a previous order submission can never
+    // outlive the order they belong to.
+    static setAddressIds({ billingAddressId, shippingAddressId }: B2BStoredAddressIds): void {
+        this.setOrRemove(this.billingAddressIdKey, billingAddressId);
+        this.setOrRemove(this.shippingAddressIdKey, shippingAddressId);
     }
 
-    static set(key: string, value: unknown): void {
-        sessionStorage.setItem(key, btoa(encodeURIComponent(JSON.stringify(value))));
+    static getAddressIds(): B2BStoredAddressIds {
+        return {
+            billingAddressId: this.getNumber(this.billingAddressIdKey),
+            shippingAddressId: this.getNumber(this.shippingAddressIdKey),
+        };
     }
 
-    static get<T = Record<string, unknown>>(key: string): T | undefined {
+    static setPaymentValues(values: B2BStoredPaymentValues): void {
+        sessionStorage.setItem(this.paymentValuesKey, this.encode(values));
+    }
+
+    static getPaymentValues(): B2BStoredPaymentValues | undefined {
+        const value = this.decode(this.paymentValuesKey);
+
+        return typeof value === 'object' && value !== null
+            ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              (value as B2BStoredPaymentValues)
+            : undefined;
+    }
+
+    static clearAll(): void {
+        Object.keys(sessionStorage)
+            .filter((key) => key.startsWith(this.keyPrefix))
+            .forEach((key) => sessionStorage.removeItem(key));
+    }
+
+    private static encode(value: unknown): string {
+        return btoa(encodeURIComponent(JSON.stringify(value)));
+    }
+
+    private static decode(key: string): unknown {
         const raw = sessionStorage.getItem(key);
 
         if (!raw) {
@@ -41,69 +63,23 @@ export class B2BSessionStorage {
         try {
             // JSON.parse is typed `any`; this is the single assertion that types the decoded value.
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            return JSON.parse(decodeURIComponent(atob(raw))) as T;
+            return JSON.parse(decodeURIComponent(atob(raw))) as unknown;
         } catch {
             return undefined;
         }
     }
 
-    // Typed convenience so address-id reads stay cast-free.
-    static getAddressId(key: string): number | undefined {
-        return this.get<number>(key);
-    }
-
-    // String fields default to '' so form inputs stay controlled and the payload shape is unchanged.
-    static getValue(key: string): string {
-        return this.get<string>(key) ?? '';
-    }
-
-    // Reads every stored B2B value at once so consumers can destructure instead of passing keys.
-    static getAll(): B2BStoredMetadata {
-        return {
-            poNumber: this.getValue(this.poNumberKey),
-            additionalPaymentField: this.getValue(this.additionalPaymentFieldKey),
-            invoiceComment: this.getValue(this.invoiceCommentKey),
-            orderExtraFields: this.get(this.orderExtraFieldsKey),
-            billingExtraFields: this.get(this.billingExtraFieldsKey),
-            shippingExtraFields: this.get(this.shippingExtraFieldsKey),
-            billingAddressId: this.getAddressId(this.billingAddressIdKey),
-            shippingAddressId: this.getAddressId(this.shippingAddressIdKey),
-        };
-    }
-
-    static remove(key: string): void {
-        sessionStorage.removeItem(key);
-    }
-
-    static clearAll(): void {
-        Object.keys(sessionStorage)
-            .filter((key) => key.startsWith(this.keyPrefix))
-            .forEach((key) => sessionStorage.removeItem(key));
-    }
-
-    static copyShippingToBilling(): void {
-        const shippingFields = this.get(this.shippingExtraFieldsKey);
-
-        if (shippingFields) {
-            this.set(this.billingExtraFieldsKey, shippingFields);
-        }
-
-        const shippingAddressId = this.getAddressId(this.shippingAddressIdKey);
-
-        if (shippingAddressId) {
-            this.set(this.billingAddressIdKey, shippingAddressId);
+    private static setOrRemove(key: string, value: number | undefined): void {
+        if (value === undefined) {
+            sessionStorage.removeItem(key);
         } else {
-            this.remove(this.billingAddressIdKey);
+            sessionStorage.setItem(key, this.encode(value));
         }
     }
 
-    static reassignConsignmentKey(consignmentId: string): void {
-        const tempKey = this.getConsignmentKey('');
-        const fields = this.get(tempKey);
+    private static getNumber(key: string): number | undefined {
+        const value = this.decode(key);
 
-        if (fields) {
-            this.set(this.getConsignmentKey(consignmentId), fields);
-            this.remove(tempKey);
-        }
+        return typeof value === 'number' ? value : undefined;
     }
 }


### PR DESCRIPTION
## What/Why?

- Session storage is now used for off-site payment flow, saving only 4 values(`poNumber`, `invoicePaymentComment`, `additionalPaymentField`, `orderExtraFields`).
   - the company address ids returned by the order endpoint.
   - the B2B payment form values captured at submit.
- Address extra fields are read from the checkout object now.
   - the SDK now round-trips them through the API (CHECKOUT-10176), so billing/shipping steps stop writing to storage.
- Reflect the API changes on the order endpoint(update props of `submitOrder()` .

The following changes are not included in this PR as the SDK side is still pending:
- ~the addition of `b2b?: CustomerAddressB2B;` to the address object.~ Not needed any more.

## Rollout/Rollback

Revert.

## Testing

### Manual testing

https://github.com/user-attachments/assets/367d3cbd-8571-4459-a8cc-e64661d7505e

<img width="1112" height="936" alt="image" src="https://github.com/user-attachments/assets/08f6d965-d2bf-4f19-9ffb-c3b500d5836e" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes B2B order submission, post-order metadata persistence, and address/default-address behavior; regressions could lose PO/extra-field data on redirect or mis-associate company address IDs.
> 
> **Overview**
> **B2B session storage** is narrowed to off-site payment recovery: only **payment form snapshots** (`poNumber`, invoice comment, additional field, order extra fields) and **billing/shipping address IDs** from the order response. Per-field writes during typing, address extra-field keys, consignment keys, and shipping→billing copy are removed; the storage key prefix changes to `checkout_js_b2b`.
> 
> **Address flows** no longer pass `storageKey` or read/write extra fields from session storage—extra fields come from the **checkout address** (and field defaults) and are sent via `mapAddressFromFormValues`. **Billing/shipping** stop persisting company address book IDs on select; **`setDefaultAddress`** only applies a default when there is no current address (no ID recovery/matching).
> 
> **Payment** when `persistB2BMetadata` is on: captures B2B values at submit, merges **`mapToB2BOrderRequestBody`** into `submitOrder`, subscribes to **`getB2BContext`** to stash address IDs, then calls **`persistB2BMetadata`** after submit/finalize (with payload from checkout addresses + stored values) and **clears** storage in a `finally` block. Payment fields stay on the Formik submit payload instead of being stripped after writing to storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a14012e19598f1b91a019f33d8aa4b1785fe59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->