### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.936.2",
+        "@bigcommerce/checkout-sdk": "^1.938.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.936.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.2.tgz",
-      "integrity": "sha512-XsC/pqRaSVVNPIm4M3p21b/ERD+eVT+43JiC85JMifqeDrTuEx12QZYpjAum3PPjEr5n3hDFbby/Pd9ML82NDw==",
+      "version": "1.938.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.938.0.tgz",
+      "integrity": "sha512-cW3Ljja5dnnAaUuOhr+zFRYPkd2jM99vi+5B0y5GUph6Xl519LKTcmne+L1G9zBMaOn5pZkT7xKcUX0SWCSCdQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.936.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.2.tgz",
-      "integrity": "sha512-XsC/pqRaSVVNPIm4M3p21b/ERD+eVT+43JiC85JMifqeDrTuEx12QZYpjAum3PPjEr5n3hDFbby/Pd9ML82NDw==",
+      "version": "1.938.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.938.0.tgz",
+      "integrity": "sha512-cW3Ljja5dnnAaUuOhr+zFRYPkd2jM99vi+5B0y5GUph6Xl519LKTcmne+L1G9zBMaOn5pZkT7xKcUX0SWCSCdQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.936.2",
+    "@bigcommerce/checkout-sdk": "^1.938.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-js version
to deploy PR:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3306](https://github.com/bigcommerce/checkout-sdk-js/pull/3306)

## Rollout/Rollback
Rollback this PR and all related

## Testing
In checkout-sdk PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout and payment flows depend on the SDK; risk follows the SDK release (auth/payment logic lives there), though this PR only changes the version pin.
> 
> **Overview**
> Bumps the **`@bigcommerce/checkout-sdk`** dependency from **^1.936.2** to **^1.938.0** in `package.json` and `package-lock.json`. There are **no application source changes** in this repo—the update pulls in whatever payment/checkout behavior shipped in checkout-sdk-js (see linked SDK PR **#3306**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec9479ef558816b80548c49d663ffd11aef1ccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->