### PR TITLE
chore(checkout): CHECKOUT-10197 Remove caching from dev:server

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit -p ./tsconfig.base.json",
     "dev": "npm-run-all nx:dev",
     "dev:vm": "WEBPACK_DONE='rsync -rvc --progress --delete --compress-level=9 build store.bcdev:/opt/bigcommerce_app/vagrant_code/vendor/bower_components/checkout-js/' npm run dev",
-    "dev:server": "http-server build --cors",
+    "dev:server": "http-server build --cors -c-1",
     "e2e": "npm run build && npx playwright install && PORT=5005 MODE=REPLAY npx playwright test",
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:alpha": "npm run lint && npm run test -- --coverage && npm run nx:prerelease-build && npm run release:version",


### PR DESCRIPTION
## What/Why?

Running `npm run dev:server` and making changes doesn't reflect in stores with custom checkout on refresh consistently even with a hard refresh. This is because http-server defaults to 1 hour caching (Cache-Control: max-age=3600), so the browser keeps serving stale build output regardless.

I added -c-1 to the dev:server script, which disables http-server's cache-control header and changes are now reflected consistently on page refresh during local development.

## Rollout/Rollback

Revert the PR.

## Testing

Manual testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line dev script change only; no production build or runtime behavior is affected.
> 
> **Overview**
> Updates the **`dev:server`** npm script so **`http-server`** no longer sends a default **1-hour** `Cache-Control` header on the local **`build`** output.
> 
> The script now passes **`-c-1`**, which turns off that caching behavior so refreshes (including hard refresh) pick up the latest assets while developing against a store’s custom checkout URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a03af74ed8355931e9b0600a03d41412cd2a2c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->