### PR TITLE
chore(checkout): CHECKOUT-10142 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.936.2",
+        "@bigcommerce/checkout-sdk": "^1.939.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.936.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.2.tgz",
-      "integrity": "sha512-XsC/pqRaSVVNPIm4M3p21b/ERD+eVT+43JiC85JMifqeDrTuEx12QZYpjAum3PPjEr5n3hDFbby/Pd9ML82NDw==",
+      "version": "1.939.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.939.0.tgz",
+      "integrity": "sha512-78RKEfBwt/oQaQJBkFdqNJwJTTKY26WIDcb6oTayAP9Tl9FI9M3awl6CQCFqTJX4JR24xP3n51M5GpKdTxF8Dg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29823,9 +29823,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.936.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.936.2.tgz",
-      "integrity": "sha512-XsC/pqRaSVVNPIm4M3p21b/ERD+eVT+43JiC85JMifqeDrTuEx12QZYpjAum3PPjEr5n3hDFbby/Pd9ML82NDw==",
+      "version": "1.939.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.939.0.tgz",
+      "integrity": "sha512-78RKEfBwt/oQaQJBkFdqNJwJTTKY26WIDcb6oTayAP9Tl9FI9M3awl6CQCFqTJX4JR24xP3n51M5GpKdTxF8Dg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.936.2",
+    "@bigcommerce/checkout-sdk": "^1.939.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/address/SearchableAddressSelectComponent.test.tsx
+++ b/packages/core/src/app/address/SearchableAddressSelectComponent.test.tsx
@@ -99,7 +99,7 @@ describe('SearchableAddressSelectComponent', () => {
     it('calls onSelectAddress with selected address when an address option is clicked', () => {
         const onSelectAddress = jest.fn();
         const addresses = getB2BCustomer().addresses;
-        const billingAddresses = addresses.filter((address) => address.isBilling);
+        const billingAddresses = addresses.filter((address) => address.b2b?.isBilling);
 
         renderComponent({ onSelectAddress, addresses });
 
@@ -128,7 +128,7 @@ describe('SearchableAddressSelectComponent', () => {
 
     it('renders only billing addresses on the billing step', () => {
         const addresses = getB2BCustomer().addresses;
-        const billingAddresses = addresses.filter((address) => address.isBilling);
+        const billingAddresses = addresses.filter((address) => address.b2b?.isBilling);
 
         renderComponent({ addresses, type: AddressType.Billing });
 
@@ -141,7 +141,7 @@ describe('SearchableAddressSelectComponent', () => {
 
     it('renders only shipping addresses on the shipping step', () => {
         const addresses = getB2BCustomer().addresses;
-        const shippingAddresses = addresses.filter((address) => address.isShipping);
+        const shippingAddresses = addresses.filter((address) => address.b2b?.isShipping);
 
         renderComponent({ addresses, type: AddressType.Shipping });
 

--- a/packages/core/src/app/address/SearchableAddressSelectComponent.tsx
+++ b/packages/core/src/app/address/SearchableAddressSelectComponent.tsx
@@ -39,7 +39,7 @@ export const SearchableAddressSelectComponent: FunctionComponent<SearchableAddre
 
     const filteredAddresses = useMemo(() => {
         const addressesByType = addresses.filter((address) =>
-            type === AddressType.Shipping ? address.isShipping : address.isBilling,
+            type === AddressType.Shipping ? address.b2b?.isShipping : address.b2b?.isBilling,
         );
 
         return searchingAddresses(addressesByType, searchQuery);

--- a/packages/core/src/app/address/address.mock.ts
+++ b/packages/core/src/app/address/address.mock.ts
@@ -1,4 +1,20 @@
-import { type Address } from '@bigcommerce/checkout-sdk';
+import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+type CustomerAddressB2B = NonNullable<CustomerAddress['b2b']>;
+
+export function getCustomerAddressB2B(
+    overrides: Partial<CustomerAddressB2B> = {},
+): CustomerAddressB2B {
+    return {
+        isShipping: false,
+        isBilling: false,
+        isDefaultShipping: false,
+        isDefaultBilling: false,
+        label: '',
+        extraFields: [],
+        ...overrides,
+    };
+}
 
 export function getAddress(): Address {
     return {

--- a/packages/core/src/app/address/getAddressWithLabel.ts
+++ b/packages/core/src/app/address/getAddressWithLabel.ts
@@ -20,5 +20,7 @@ export default function getAddressWithLabel<T extends Address>(
         isEqualAddress(address, customerAddress),
     );
 
-    return match?.label ? { ...address, label: match.label } : address;
+    const label = match?.b2b?.label ?? match?.label;
+
+    return label ? { ...address, label } : address;
 }

--- a/packages/core/src/app/address/getAddressWithLabel.ts
+++ b/packages/core/src/app/address/getAddressWithLabel.ts
@@ -20,7 +20,7 @@ export default function getAddressWithLabel<T extends Address>(
         isEqualAddress(address, customerAddress),
     );
 
-    const label = match?.b2b?.label ?? match?.label;
+    const label = match?.b2b?.label;
 
     return label ? { ...address, label } : address;
 }

--- a/packages/core/src/app/address/isEqualAddress.ts
+++ b/packages/core/src/app/address/isEqualAddress.ts
@@ -50,22 +50,22 @@ function normalizeAddress(address: ComparableAddress) {
         'type',
         'email',
         'country',
-        'isShipping',
-        'isBilling',
-        'isDefaultShipping',
-        'isDefaultBilling',
+        'b2b',
         'label',
     ];
+
+    const b2bExtraFields = 'b2b' in address ? address.b2b?.extraFields : undefined;
 
     return omit(
         {
             ...address,
             customFields: (address.customFields || []).filter(({ fieldValue }) => !!fieldValue),
             // Normalize `extraFields` so an unchanged address compares equal instead of
-            // refiring update calls. Guards against any future path where one side has `[]`
-            // and the other omits it (e.g. backend behavior flips again, or a saved/customer
-            // address arrives with `[]`).
-            extraFields: address.extraFields || [],
+            // refiring update calls. Company addresses carry them nested under `b2b`, so
+            // lift those for comparison. Guards against any future path where one side has
+            // `[]` and the other omits it (e.g. backend behavior flips again, or a
+            // saved/customer address arrives with `[]`).
+            extraFields: b2bExtraFields ?? address.extraFields ?? [],
         },
         ignoredFields,
     );

--- a/packages/core/src/app/address/searchingAddresses.test.ts
+++ b/packages/core/src/app/address/searchingAddresses.test.ts
@@ -1,5 +1,6 @@
 import { type CustomerAddress } from '@bigcommerce/checkout-sdk';
 
+import { getCustomerAddressB2B } from './address.mock';
 import { searchingAddresses } from './searchingAddresses';
 
 const baseAddress: CustomerAddress = {
@@ -68,7 +69,9 @@ describe('searchingAddresses', () => {
     it('matches on extraFields string value', () => {
         const address: CustomerAddress = {
             ...baseAddress,
-            extraFields: [{ fieldId: 'ef_1', fieldValue: 'extra-value' }],
+            b2b: getCustomerAddressB2B({
+                extraFields: [{ fieldId: 'ef_1', fieldValue: 'extra-value' }],
+            }),
         };
 
         expect(searchingAddresses([address], 'extra-value')).toEqual([address]);
@@ -78,7 +81,9 @@ describe('searchingAddresses', () => {
     it('matches on extraFields numeric value', () => {
         const address: CustomerAddress = {
             ...baseAddress,
-            extraFields: [{ fieldId: 'ef_2', fieldValue: 99 }],
+            b2b: getCustomerAddressB2B({
+                extraFields: [{ fieldId: 'ef_2', fieldValue: 99 }],
+            }),
         };
 
         expect(searchingAddresses([address], '99')).toEqual([address]);

--- a/packages/core/src/app/address/searchingAddresses.ts
+++ b/packages/core/src/app/address/searchingAddresses.ts
@@ -22,7 +22,9 @@ export function searchingAddresses(addresses: CustomerAddress[], query: string):
             ...(address.customFields ?? []).map(({ fieldValue }) =>
                 Array.isArray(fieldValue) ? fieldValue.join(' ') : String(fieldValue),
             ),
-            ...(address.extraFields ?? []).map(({ fieldValue }) => String(fieldValue)),
+            ...(address.b2b?.extraFields ?? address.extraFields ?? []).map(({ fieldValue }) =>
+                String(fieldValue),
+            ),
         ]
             .filter(Boolean)
             .join(' ')

--- a/packages/core/src/app/address/searchingAddresses.ts
+++ b/packages/core/src/app/address/searchingAddresses.ts
@@ -22,9 +22,7 @@ export function searchingAddresses(addresses: CustomerAddress[], query: string):
             ...(address.customFields ?? []).map(({ fieldValue }) =>
                 Array.isArray(fieldValue) ? fieldValue.join(' ') : String(fieldValue),
             ),
-            ...(address.b2b?.extraFields ?? address.extraFields ?? []).map(({ fieldValue }) =>
-                String(fieldValue),
-            ),
+            ...(address.b2b?.extraFields ?? []).map(({ fieldValue }) => String(fieldValue)),
         ]
             .filter(Boolean)
             .join(' ')

--- a/packages/core/src/app/address/setDefaultAddress.spec.ts
+++ b/packages/core/src/app/address/setDefaultAddress.spec.ts
@@ -2,7 +2,7 @@ import { type CustomerAddress } from '@bigcommerce/checkout-sdk';
 
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
-import { getAddress } from './address.mock';
+import { getAddress, getCustomerAddressB2B } from './address.mock';
 import AddressType from './AddressType';
 import setDefaultAddress from './setDefaultAddress';
 
@@ -14,8 +14,7 @@ describe('setDefaultAddress', () => {
         ...getAddress(),
         id: 1,
         type: 'residential',
-        isShipping: true,
-        isBilling: true,
+        b2b: getCustomerAddressB2B({ isShipping: true, isBilling: true }),
         ...overrides,
     });
 
@@ -28,7 +27,10 @@ describe('setDefaultAddress', () => {
 
     describe('when there is no current address', () => {
         it('applies the default address and stores its id', async () => {
-            const defaultAddress = getCustomerAddress({ id: 7, isDefaultShipping: true });
+            const defaultAddress = getCustomerAddress({
+                id: 7,
+                b2b: getCustomerAddressB2B({ isShipping: true, isDefaultShipping: true }),
+            });
 
             await setDefaultAddress({
                 type: AddressType.Shipping,
@@ -44,7 +46,7 @@ describe('setDefaultAddress', () => {
         it('applies the default address but does not store an id when it has none', async () => {
             const defaultAddress = getCustomerAddress({
                 id: undefined as unknown as number,
-                isDefaultShipping: true,
+                b2b: getCustomerAddressB2B({ isShipping: true, isDefaultShipping: true }),
             });
 
             await setDefaultAddress({
@@ -73,7 +75,10 @@ describe('setDefaultAddress', () => {
         it('does not store an id when applying the default address fails', async () => {
             updateAddress.mockRejectedValue(new Error('update failed'));
 
-            const defaultAddress = getCustomerAddress({ id: 7, isDefaultShipping: true });
+            const defaultAddress = getCustomerAddress({
+                id: 7,
+                b2b: getCustomerAddressB2B({ isShipping: true, isDefaultShipping: true }),
+            });
 
             await setDefaultAddress({
                 type: AddressType.Shipping,
@@ -163,8 +168,14 @@ describe('setDefaultAddress', () => {
 
     describe('when company rows duplicate fields across types', () => {
         it('matches a shipping row over a content-identical billing-only row for the shipping key', async () => {
-            const billingOnly = getCustomerAddress({ id: 50, isShipping: false, isBilling: true });
-            const shippingRow = getCustomerAddress({ id: 42, isShipping: true, isBilling: false });
+            const billingOnly = getCustomerAddress({
+                id: 50,
+                b2b: getCustomerAddressB2B({ isBilling: true }),
+            });
+            const shippingRow = getCustomerAddress({
+                id: 42,
+                b2b: getCustomerAddressB2B({ isShipping: true }),
+            });
 
             await setDefaultAddress({
                 type: AddressType.Shipping,
@@ -177,7 +188,10 @@ describe('setDefaultAddress', () => {
         });
 
         it('does not store a billing-only row id under the shipping key', async () => {
-            const billingOnly = getCustomerAddress({ id: 50, isShipping: false, isBilling: true });
+            const billingOnly = getCustomerAddress({
+                id: 50,
+                b2b: getCustomerAddressB2B({ isBilling: true }),
+            });
 
             await setDefaultAddress({
                 type: AddressType.Shipping,
@@ -190,8 +204,14 @@ describe('setDefaultAddress', () => {
         });
 
         it('matches a billing row over a content-identical shipping-only row for the billing key', async () => {
-            const shippingOnly = getCustomerAddress({ id: 60, isShipping: true, isBilling: false });
-            const billingRow = getCustomerAddress({ id: 24, isShipping: false, isBilling: true });
+            const shippingOnly = getCustomerAddress({
+                id: 60,
+                b2b: getCustomerAddressB2B({ isShipping: true }),
+            });
+            const billingRow = getCustomerAddress({
+                id: 24,
+                b2b: getCustomerAddressB2B({ isBilling: true }),
+            });
 
             await setDefaultAddress({
                 type: AddressType.Billing,

--- a/packages/core/src/app/address/setDefaultAddress.ts
+++ b/packages/core/src/app/address/setDefaultAddress.ts
@@ -24,10 +24,10 @@ export default async function setDefaultAddress({
         : B2BSessionStorage.billingAddressIdKey;
 
     const filteredAddresses = addresses?.filter((address) =>
-        isShipping ? address.isShipping : address.isBilling,
+        isShipping ? address.b2b?.isShipping : address.b2b?.isBilling,
     );
     const defaultAddress = filteredAddresses?.find((address) =>
-        isShipping ? address.isDefaultShipping : address.isDefaultBilling,
+        isShipping ? address.b2b?.isDefaultShipping : address.b2b?.isDefaultBilling,
     );
 
     if (!currentAddress?.address1) {

--- a/packages/core/src/app/billing/Billing.test.tsx
+++ b/packages/core/src/app/billing/Billing.test.tsx
@@ -48,6 +48,7 @@ import {
 } from '@bigcommerce/checkout/test-utils';
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
+import { getCustomerAddressB2B } from '../address/address.mock';
 import Checkout from '../checkout/Checkout';
 import { type CheckoutInitializerProps } from '../checkout/CheckoutInitializer';
 import { getCheckoutPayment } from '../checkout/checkouts.mock';
@@ -606,7 +607,9 @@ describe('Billing step', () => {
         // lists addresses flagged for billing. shippingAddress3 is given id 3 and isBilling.
         const customerWithCompanyBillingAddress = {
             ...customer,
-            addresses: [{ ...shippingAddress3, id: 3, isBilling: true }],
+            addresses: [
+                { ...shippingAddress3, id: 3, b2b: getCustomerAddressB2B({ isBilling: true }) },
+            ],
         };
         const checkoutWithCompanyBillingAddress = {
             ...checkoutWithShipping,

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -614,13 +614,14 @@ describe('Checkout', () => {
                 jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockResolvedValue(
                     {} as any,
                 );
+                jest.spyOn(checkoutService, 'persistB2BMetadata').mockResolvedValue({} as any);
 
                 const getState = checkoutService.getState.bind(checkoutService);
 
                 jest.spyOn(checkoutService, 'getState').mockImplementation(() => {
                     const state = getState();
 
-                    state.data.getB2BReceiptId = () => 123;
+                    state.data.getB2BContext = () => ({ receiptId: '123' });
 
                     return state;
                 });

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -255,12 +255,12 @@ const Checkout = ({
 
         setState((prevState) => ({ ...prevState, isRedirecting: true }));
 
-        const receiptId = checkoutService.getState().data.getB2BReceiptId();
+        const b2bContext = checkoutService.getState().data.getB2BContext();
 
-        if (invoiceRedirect && receiptId) {
+        if (invoiceRedirect && b2bContext?.receiptId) {
             const { links: { siteLink = '' } = {} } = data.getConfig() || {};
 
-            window.location.replace(`${siteLink}/#/invoice?receiptId=${receiptId}`);
+            window.location.replace(`${siteLink}/#/invoice?receiptId=${b2bContext.receiptId}`);
 
             return;
         }

--- a/packages/core/src/app/customer/customers.mock.ts
+++ b/packages/core/src/app/customer/customers.mock.ts
@@ -1,5 +1,6 @@
 import { type Customer } from '@bigcommerce/checkout-sdk';
 
+import { getCustomerAddressB2B } from '../address/address.mock';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 
 // TODO: Consider exporting mock objects from SDK
@@ -73,24 +74,21 @@ export function getB2BCustomer(): Customer {
                 ...getShippingAddress(),
                 id: 9,
                 type: 'commercial',
-                isShipping: true,
-                isBilling: true,
+                b2b: getCustomerAddressB2B({ isShipping: true, isBilling: true }),
             },
             {
                 ...getShippingAddress(),
                 id: 10,
                 type: 'commercial',
                 address1: 'Shipping Only Way',
-                isShipping: true,
-                isBilling: false,
+                b2b: getCustomerAddressB2B({ isShipping: true }),
             },
             {
                 ...getShippingAddress(),
                 id: 11,
                 type: 'commercial',
                 address1: 'Billing Only Way',
-                isShipping: false,
-                isBilling: true,
+                b2b: getCustomerAddressB2B({ isBilling: true }),
             },
             {
                 ...getShippingAddress(),
@@ -99,8 +97,7 @@ export function getB2BCustomer(): Customer {
                 address1: 'Invalid B2B Way',
                 firstName: 'Invalid Address',
                 lastName: '',
-                isShipping: true,
-                isBilling: true,
+                b2b: getCustomerAddressB2B({ isShipping: true, isBilling: true }),
             },
         ],
         isGuest: false,

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -45,6 +45,7 @@ import {
 } from '@bigcommerce/checkout/test-utils';
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
+import { getCustomerAddressB2B } from '../address/address.mock';
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
 import { createErrorLogger } from '../common/error';
 import {
@@ -1101,7 +1102,13 @@ describe('Shipping step', () => {
                 ...checkoutWithMultiShippingCart,
                 customer: {
                     ...customer,
-                    addresses: [{ ...shippingAddress, id: 1, isShipping: true }],
+                    addresses: [
+                        {
+                            ...shippingAddress,
+                            id: 1,
+                            b2b: getCustomerAddressB2B({ isShipping: true }),
+                        },
+                    ],
                 },
             };
 


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk version 1.936.2 → 1.939.0

- `getB2BReceiptId()` replaced by `getB2BContext()`

- `CustomerAddress` B2B metadata moved into an optional nested `b2b` object (`isShipping`, `isBilling`, `isDefaultShipping`, `isDefaultBilling`, `label`, `extraFields`) 
   - no more direct top-level fields on customer addresses. Returned only with the `customer.addresses.b2b` include, which the SDK auto-requests when the store has `hasCompanyAddressBook`. 

- Updated `persistB2BMetadata()` checkout service method.

## Rollout/Rollback

Revert.

## Testing

### Manual testing
`b2b`is loaded as part of an address.

<img width="1646" height="868" alt="image" src="https://github.com/user-attachments/assets/6b285171-fae8-4f2b-99cc-31e058f8d7f7" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect B2B shipping/billing address filtering, defaults, search, and invoice redirect; regressions would mis-route B2B buyers or skip wrong addresses, but scope is mostly adapter + test updates aligned to the SDK bump.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from `^1.936.2` to **`^1.939.0`** and updates checkout-js to match the SDK’s reshaped B2B customer-address model.
> 
> **Company address book behavior** now reads shipping/billing flags, defaults, labels, and searchable **extra fields** from **`address.b2b`** (e.g. `b2b.isShipping`, `b2b.label`, `b2b.extraFields`) instead of top-level address properties. That touches address filtering in the searchable picker, default-address selection/session storage, address search, label resolution, and equality checks (with `extraFields` lifted from `b2b` for comparison).
> 
> **Post-order B2B invoice redirect** uses **`getB2BContext()?.receiptId`** instead of **`getB2BReceiptId()`** when building the buyer-portal invoice URL.
> 
> Tests and mocks add **`getCustomerAddressB2B`** and align B2B scenarios with the nested shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487c2e28bebe2750869c2a94624c93a52bcdf8df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->