### PR TITLE
feat(payment): Migrate CyberSource v2 to Resolver Configuration

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -44,6 +44,11 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
         'PI-4748.cba_resolver_configuration',
         false,
     );
+    const isCyberSourceResolverEnabled = isExperimentEnabled(
+        config?.checkoutSettings,
+        'PI-4749.cyber_source_resolver_configuration',
+        false,
+    );
 
     const initializeHostedCreditCardPayment: CreditCardPaymentMethodProps['initializePayment'] =
         useCallback(
@@ -53,8 +58,9 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                     integrations: [
                         ...(options.integrations ?? []),
                         createCreditCardPaymentStrategy,
-                        createCyberSourcePaymentStrategy,
-                        createCyberSourceV2PaymentStrategy,
+                        ...(!isCyberSourceResolverEnabled
+                            ? [createCyberSourcePaymentStrategy, createCyberSourceV2PaymentStrategy]
+                            : []),
                         createSagePayPaymentStrategy,
                         ...(!isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
                     ],
@@ -63,7 +69,12 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                     },
                 });
             },
-            [getHostedFormOptions, initializePayment, isCBAMPGSResolverEnabled],
+            [
+                getHostedFormOptions,
+                initializePayment,
+                isCBAMPGSResolverEnabled,
+                isCyberSourceResolverEnabled,
+            ],
         );
 
     return (

--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -49,6 +49,11 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
         'PI-4754.sage_pay_resolver_configuration',
         false,
     );
+    const isCyberSourceResolverEnabled = isExperimentEnabled(
+        config?.checkoutSettings,
+        'PI-4749.cyber_source_resolver_configuration',
+        false,
+    );
 
     const initializeHostedCreditCardPayment: CreditCardPaymentMethodProps['initializePayment'] =
         useCallback(
@@ -58,8 +63,9 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                     integrations: [
                         ...(options.integrations ?? []),
                         createCreditCardPaymentStrategy,
-                        createCyberSourcePaymentStrategy,
-                        createCyberSourceV2PaymentStrategy,
+                        ...(!isCyberSourceResolverEnabled
+                            ? [createCyberSourcePaymentStrategy, createCyberSourceV2PaymentStrategy]
+                            : []),
                         ...(!isSagePayResolverEnabled ? [createSagePayPaymentStrategy] : []),
                         ...(!isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
                     ],
@@ -73,6 +79,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                 initializePayment,
                 isCBAMPGSResolverEnabled,
                 isSagePayResolverEnabled,
+                isCyberSourceResolverEnabled,
             ],
         );
 

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -40,5 +40,8 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
 
         { id: 'tdonlinemart' },
         { id: 'cba_mpgs', experiment: 'PI-4748_cba_resolver_configuration' },
+        { id: 'cybersource', experiment: 'PI-4749_cyber_source_resolver_configuration' },
+        { id: 'cybersourcev2', experiment: 'PI-4749_cyber_source_resolver_configuration' },
+        { id: 'bnz', experiment: 'PI-4749_cyber_source_resolver_configuration' },
     ],
 );

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -44,5 +44,8 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
             id: 'sagepay',
             experiment: 'PI-4754_sage_pay_resolver_configuration',
         },
+        { id: 'cybersource', experiment: 'PI-4749_cyber_source_resolver_configuration' },
+        { id: 'cybersourcev2', experiment: 'PI-4749_cyber_source_resolver_configuration' },
+        { id: 'bnz', experiment: 'PI-4749_cyber_source_resolver_configuration' },
     ],
 );

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -7,6 +7,10 @@ import { createBlueSnapDirectCreditCardPaymentStrategy } from '@bigcommerce/chec
 import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
+import {
+    createCyberSourcePaymentStrategy,
+    createCyberSourceV2PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
 import { compact, forIn } from 'lodash';
 import React, { type FunctionComponent, type ReactNode, useCallback, useState } from 'react';
@@ -47,6 +51,11 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     const isCBAMPGSResolverEnabled =
         checkoutState.data.getConfig()?.checkoutSettings.features?.[
             'PI-4748.cba_resolver_configuration'
+        ] ?? false;
+
+    const isCyberSourceResolverEnabled =
+        checkoutState.data.getConfig()?.checkoutSettings.features?.[
+            'PI-4749.cyber_source_resolver_configuration'
         ] ?? false;
 
     const { setFieldTouched, setFieldValue, setSubmitted, submitForm } = paymentForm;
@@ -264,6 +273,9 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                         createCreditCardPaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
                         ...(isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
+                        ...(isCyberSourceResolverEnabled
+                            ? [createCyberSourcePaymentStrategy, createCyberSourceV2PaymentStrategy]
+                            : []),
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,
                     ],
@@ -280,6 +292,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                 initializePayment,
                 isHostedFormEnabled,
                 isCBAMPGSResolverEnabled,
+                isCyberSourceResolverEnabled,
             ],
         );
 

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -8,6 +8,10 @@ import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrat
 import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
+import {
+    createCyberSourcePaymentStrategy,
+    createCyberSourceV2PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/cybersource';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
 import { compact, forIn } from 'lodash';
 import React, { type FunctionComponent, type ReactNode, useCallback, useState } from 'react';
@@ -64,6 +68,11 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     const isSagePayResolverEnabled =
         checkoutState.data.getConfig()?.checkoutSettings.features?.[
             'PI-4754.sage_pay_resolver_configuration'
+        ] ?? false;
+
+    const isCyberSourceResolverEnabled =
+        checkoutState.data.getConfig()?.checkoutSettings.features?.[
+            'PI-4749.cyber_source_resolver_configuration'
         ] ?? false;
 
     const { setFieldTouched, setFieldValue, setSubmitted, submitForm } = paymentForm;
@@ -282,6 +291,9 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                         createBlueSnapDirectCreditCardPaymentStrategy,
                         ...(isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
                         ...(isSagePayResolverEnabled ? [createSagePayPaymentStrategy] : []),
+                        ...(isCyberSourceResolverEnabled
+                            ? [createCyberSourcePaymentStrategy, createCyberSourceV2PaymentStrategy]
+                            : []),
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,
                     ],
@@ -310,6 +322,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                 isCBAMPGSResolverEnabled,
                 isSagePayResolverEnabled,
                 language,
+                isCyberSourceResolverEnabled,
             ],
         );
 


### PR DESCRIPTION
## What/Why?

Migrates the cybersource payment method to the new resolver-based architecture by registering it in the HostedCreditCardPaymentMethod component resolver (packages/hosted-credit-card-integration).

## Rollout/Rollback
turn of PI-4749.cyber_source_resolver_configuration
roll back this commit

## Testing

<img width="1246" height="1586" alt="image" src="https://github.com/user-attachments/assets/3a14828d-bffb-4400-9666-5c30ff26fc87" />
<img width="575" height="350" alt="image" src="https://github.com/user-attachments/assets/9f11ba55-1778-424b-9dad-a93cc5218c86" />
<img width="555" height="525" alt="image" src="https://github.com/user-attachments/assets/50d68467-0458-4a78-b81c-15b4a5f9e4d0" />


<img width="1487" height="267" alt="image" src="https://github.com/user-attachments/assets/b48bd46f-a13f-4b28-9a73-204a76e4bf47" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which code path initializes CyberSource/BNZ card payments at checkout; risk is mitigated by a feature flag but misconfiguration could break those payment methods.
> 
> **Overview**
> CyberSource hosted credit card checkout is moved behind **`PI-4749.cyber_source_resolver_configuration`**, following the same pattern as CBA MPGS and SagePay.
> 
> When the flag is **on**, **`cybersource`**, **`cybersourcev2`**, and **`bnz`** resolve through **`hosted-credit-card-integration`** (with CyberSource payment strategies registered in **`HostedCreditCardComponent`**). When it is **off**, **`HostedCreditCardPaymentMethod`** in core still wires **`createCyberSourcePaymentStrategy`** and **`createCyberSourceV2PaymentStrategy`** during payment initialization.
> 
> Rollout is controlled by toggling the experiment; disabling it restores the prior core integration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb08fc412cb1986f3495f85c9b9857d8af1a4ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->