### PR TITLE
fix(checkout): CHECKOUT-10206 Stabilise the phone input component so it handles unmount and remount better

### DIFF
--- a/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.tsx
+++ b/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.tsx
@@ -115,7 +115,7 @@ export const PayPalFastlaneShippingAddress: FC<PayPalFastlaneShippingAddressProp
                     address={shippingAddress}
                     consignments={props.consignments}
                     formFields={formFields}
-                    isLoading={isLoadingStrategy}
+                    isLoading={isLoadingStrategy || isLoading}
                     onAddressSelect={onAddressSelect}
                     onFieldChange={handleFieldChange}
                     onUseNewAddress={props.onUseNewAddress}

--- a/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.tsx
+++ b/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.tsx
@@ -115,7 +115,7 @@ export const PayPalFastlaneShippingAddress: FC<PayPalFastlaneShippingAddressProp
                     address={shippingAddress}
                     consignments={props.consignments}
                     formFields={formFields}
-                    isLoading={isLoadingStrategy || isLoading}
+                    isLoading={isLoadingStrategy}
                     onAddressSelect={onAddressSelect}
                     onFieldChange={handleFieldChange}
                     onUseNewAddress={props.onUseNewAddress}

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
@@ -69,6 +69,21 @@ describe('PhoneFormField', () => {
             </LocaleContext.Provider>,
         );
 
+    const renderWithSelectedCountry = (selectedCountry: string) => (
+        <LocaleContext.Provider value={localeContextMock}>
+            <Formik initialValues={{ phone: '' }} onSubmit={jest.fn()}>
+                <FormProvider initialIsSubmitted>
+                    <PhoneFormField
+                        id="phone"
+                        label="Phone Number"
+                        name="phone"
+                        selectedCountry={selectedCountry}
+                    />
+                </FormProvider>
+            </Formik>
+        </LocaleContext.Provider>
+    );
+
     beforeEach(() => {
         mockGetSelectedCountryData.mockClear();
         mockIsValidNumber.mockClear();
@@ -110,6 +125,32 @@ describe('PhoneFormField', () => {
         );
 
         expect(mockSetCountry).not.toHaveBeenCalled();
+    });
+
+    it('retries auto-set country on a later selectedCountry change if setCountry previously threw', () => {
+        mockSetCountry.mockImplementationOnce(() => {
+            throw new Error('Invalid iso2 code');
+        });
+
+        const { rerender } = render(renderWithSelectedCountry('US'));
+
+        expect(mockSetCountry).toHaveBeenCalledTimes(1);
+
+        rerender(renderWithSelectedCountry('CA'));
+
+        expect(mockSetCountry).toHaveBeenCalledTimes(2);
+        expect(mockSetCountry).toHaveBeenLastCalledWith('ca');
+        expect(screen.getByTestId('phone-text')).toBeInTheDocument();
+    });
+
+    it('does not re-apply auto-set country on a later selectedCountry change once it already succeeded', () => {
+        const { rerender } = render(renderWithSelectedCountry('US'));
+
+        expect(mockSetCountry).toHaveBeenCalledTimes(1);
+
+        rerender(renderWithSelectedCountry('CA'));
+
+        expect(mockSetCountry).toHaveBeenCalledTimes(1);
     });
 
     it('shows a validation error when the phone number is invalid', async () => {

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -33,7 +33,7 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
 }) => {
     const isPhoneCountryAutoSetRef = useRef(false);
 
-    const currentValue = value ? String(value) : '';
+    const currentValue = `${value}`;
 
     useEffect(() => {
         if (!selectedCountry || value || isPhoneCountryAutoSetRef.current) {

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -33,7 +33,7 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
 }) => {
     const isPhoneCountryAutoSetRef = useRef(false);
 
-    const currentValue = `${value}`;
+    const currentValue = value ? String(value) : '';
 
     useEffect(() => {
         if (!selectedCountry || value || isPhoneCountryAutoSetRef.current) {

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -2,7 +2,13 @@ import IntlTelInput, { type IntlTelInputRef } from '@intl-tel-input/react';
 import 'intl-tel-input/styles';
 import classNames from 'classnames';
 import { type FieldProps } from 'formik';
-import React, { type FunctionComponent, type RefObject, useCallback, useEffect } from 'react';
+import React, {
+    type FunctionComponent,
+    type RefObject,
+    useCallback,
+    useEffect,
+    useRef,
+} from 'react';
 
 import { isIso2 } from '../../utils';
 
@@ -25,24 +31,42 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
     selectedCountry,
     intlTelInputRef,
 }) => {
+    const isPhoneCountryAutoSetRef = useRef(false);
+
+    const currentValue = value ? String(value) : '';
+
     useEffect(() => {
-        if (!selectedCountry || value) {
+        if (!selectedCountry || value || isPhoneCountryAutoSetRef.current) {
             return;
         }
 
         const selectedCountryInIsoFormat = selectedCountry.toLowerCase();
 
-        if (isIso2(selectedCountryInIsoFormat)) {
+        if (!isIso2(selectedCountryInIsoFormat)) {
+            return;
+        }
+
+        isPhoneCountryAutoSetRef.current = true;
+
+        try {
             intlTelInputRef.current?.getInstance()?.setCountry(selectedCountryInIsoFormat);
+        } catch {
+            // Defensive: the underlying library throws for unrecognized iso2 codes.
+            // A mismatch here shouldn't be able to break the form.
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedCountry]);
 
     const handleChangeNumber = useCallback(
         (newPhoneNumber: string) => {
+            // Ignore no-op emissions fired by the library itself
+            if (newPhoneNumber === currentValue) {
+                return;
+            }
+
             void setFieldValue(name, newPhoneNumber);
         },
-        [name, setFieldValue],
+        [name, setFieldValue, currentValue],
     );
 
     return (
@@ -72,7 +96,7 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
                 ref={intlTelInputRef}
                 separateDialCode={false}
                 strictRejectAnimation={false}
-                value={value ? String(value) : ''}
+                value={currentValue}
             />
         </span>
     );

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -46,13 +46,16 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
             return;
         }
 
-        isPhoneCountryAutoSetRef.current = true;
-
         try {
-            intlTelInputRef.current?.getInstance()?.setCountry(selectedCountryInIsoFormat);
+            const intlTelInputInstance = intlTelInputRef.current?.getInstance();
+
+            if (intlTelInputInstance) {
+                intlTelInputInstance.setCountry(selectedCountryInIsoFormat);
+                isPhoneCountryAutoSetRef.current = true;
+            }
         } catch {
             // Defensive: the underlying library throws for unrecognized iso2 codes.
-            // A mismatch here shouldn't be able to break the form.
+            // Ref stays unset so a later, different selectedCountry can still be applied.
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedCountry]);


### PR DESCRIPTION
## What/Why?

Addresses the issue that caused [#incident-20260711-2475](https://commerce-group.enterprise.slack.com/archives/C0BGMHC81FF)

**Bug:** Checkout would hang in an infinite loop when PayPal Fastlane is enabled and a logged-in customer with a saved address clicks "Enter a new address". This is only an issue when `CHECKOUT-9019.use_new_phone_number_validation` experiment is on.

The main issue is that the PayPal Fastlane path has many "if" conditions in rendering path including `shippingAddress`. So in some scenarios the address form repeatedly mounts and unmounts with many renders which is further amplified by phone input component. The phone input component library internally is calling handleChangeNumber function on first render which writes to Formik state and in certain conditions this Formik - Phone library instability gets stuck in a loop.

I added safeguards to Input so that it would avoid updating formik if the values are the same (newPhoneNumber === currentValue), which should avoid the loop. I also added additional stability to useEffect that's in PhoneInput component. I stabilized it using a ref to ensure it only runs once and does not cause additional re-renders.

The issue is reproducible on this store: https://sklormp.duckybucko.com/checkout with OOPC enabled. You need to:
1. Log in with existing user
2. Make sure you have an address saved
3. Instead of using this address, click on new address when check out

However, it is not reproducible locally. When you switch to Custom checkout and serve the local auto-loader-dev.js from master branch it works fine even for this store. So the bug only exists in production builds.


If you want to read about exact rendering loop (according to Claude), here it is:
1. Shopper is logged in with a saved address, PayPal Fastlane, CHECKOUT-9019.use_new_phone_number_validation experiment ON.
7. Shopper clicks "Enter a new address" → SingleShippingForm.handleUseNewAddress (SingleShippingForm.tsx:282) sets isResettingAddress(true) and calls await deleteConsignments().
8. deleteConsignments() (useShipping.ts:19-30) deletes every consignment via the checkout SDK. Once those resolve, the checkout state has zero consignments.
9. useShipping()'s shippingAddress selector (useShipping.ts:150) recomputes to undefined (no consignments to derive an address from).
10. ShippingAddress.tsx's branch condition (methodId && isPayPalFastlaneMethod(methodId) && shippingAddress, ShippingAddress.tsx:59) flips to false → React unmounts PayPalFastlaneShippingAddress (and everything inside it, including PhoneInput) and mounts the plain fallback ShippingAddressForm instead.
11. handleUseNewAddress finishes: setValues({ ..., shippingAddress: mapAddressToFormValues(...) }) resets the address form to blank/default values (empty phone field), then isResettingAddress(false).
12. The freshly mounted PhoneInput runs its mount effect. selectedCountry is truthy (store default) and value is empty, so it unconditionally calls intlTelInputRef.current?.getInstance()?.setCountry(...). **This is now fixed by this PR**
13. This new IntlTelInput instance's loadUtils() dynamic import (intl-tel-input/utils) is still in flight — real CDN/network latency in production. The library's internal lastEmittedNumberRef hasn't been seeded from the real value yet.
14. setCountry() dispatches a native input CustomEvent on the underlying <input> (intlTelInput.js:4663-4684), which the React wrapper's onInput: update handler picks up.
15. Because the library's internal state wasn't seeded correctly yet (step 8), update()'s comparison disagrees with the actual current value and calls onChangeNumber(num) even though nothing meaningful changed.
16. handleChangeNumber unconditionally calls setFieldValue(name, newPhoneNumber), writing to Formik. **This is now fixed by this PR**
17. BasicFormField's InnerFieldInput effect (BasicFormField.tsx:38-49) detects the Formik value changed and fires its onChange callback, bubbling through AddressForm up to SingleShippingForm.handleFieldChange('phone', value).
18. phone isn't in SHIPPING_ADDRESS_FIELDS, but hasRequestedShippingOptions is still false this early in the reset, so handleFieldChange still calls updateAddressWithFormData(true) (SingleShippingForm.tsx:254).
19. After the debounce (SHIPPING_AUTOSAVE_DELAY ≈ 1700ms), this calls checkoutService.updateShippingAddress() — a real network call that creates/updates a consignment with the (mostly blank) address.
20. That mutation changes consignments/shippingAddress in useShipping() again — shippingAddress becomes truthy (a consignment exists again).
21. ShippingAddress.tsx's branch flips back to PayPalFastlaneShippingAddress → unmounts the fallback form and remounts PayPalFastlaneShippingAddress (and a brand-new PhoneInput).
22. Back to step 7 — the new mount repeats the exact same race, indefinitely. 

**Why does it happen in production but not locally?** Locally, that chunk loads over localhost almost instantly, so the library's internal state is usually already seeded correctly by the time setCountry() runs, and no spurious onChangeNumber fires. Real network/CDN latency in production (plus the real deleteConsignment API round-trips in steps 2-3) makes the unlucky interleaving far more likely and cause the loop.

## Rollout/Rollback

Revert the PR.

## Testing

CI + we need to check that it resolves the loop in https://sklormp.duckybucko.com/checkout. Safe to merge right now because this component is hidden behind an experiment in production, and enabled in staging and integration, so existing tests should catch any component regression.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared checkout phone/Formik wiring; behavior change is narrow but shipping address autosave depends on phone updates firing only for real edits.
> 
> **Overview**
> Hardens **`PhoneInput`** so intl-tel-input mount/remount cycles (e.g. PayPal Fastlane + “Enter a new address”) don’t spin Formik into an infinite update loop.
> 
> **Auto-set country** now runs at most once per mount via a ref, wraps `setCountry` in try/catch (failed attempts don’t block a later `selectedCountry`), and still skips when the field already has a value.
> 
> **Change handler** ignores `onChangeNumber` callbacks when the new value matches the current Formik value, blocking spurious writes from the library during `setCountry` / utils load races.
> 
> Tests add **`renderWithSelectedCountry`** and cover retry-after-throw vs no re-apply after success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92112e1566aecd28f4195d72e1684adaaac6c869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->