### PR TITLE
feat(checkout): CHECKOUT-10150 add billing same as shipping toggle

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -430,6 +430,17 @@ const Checkout = ({
         [navigateToNextIncompleteStep, navigateToStep],
     );
 
+    // themeV2 embeds the billing form in the payment step, so the same-as-shipping
+    // toggle lives there instead of on shipping. Keep the checkout-wide value in
+    // sync so returning to shipping doesn't re-copy shipping over a billing address
+    // the shopper set on payment. Unlike handleShippingNextStep this never navigates.
+    const handleBillingSameAsShippingChange = useCallback(
+        (isBillingSameAsShipping: boolean): void => {
+            setState((prev) => ({ ...prev, isBillingSameAsShipping }));
+        },
+        [],
+    );
+
     const handleShippingSignIn = useCallback((): void => {
         setCustomerViewType(CustomerViewType.Login);
     }, [setCustomerViewType]);
@@ -533,12 +544,14 @@ const Checkout = ({
                         checkEmbeddedSupport={checkEmbeddedSupport}
                         consignments={consignments}
                         errorLogger={errorLogger}
+                        isBillingSameAsShipping={isBillingSameAsShipping}
                         isEmbedded={isEmbedded()}
                         isUsingMultiShipping={
                             cart && consignments
                                 ? isUsingMultiShipping(consignments, cart.lineItems)
                                 : false
                         }
+                        onBillingSameAsShippingChange={handleBillingSameAsShippingChange}
                         onCartChangedError={handleCartChangedError}
                         onEdit={handleEditStep}
                         onExpanded={handleExpanded}

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -430,10 +430,6 @@ const Checkout = ({
         [navigateToNextIncompleteStep, navigateToStep],
     );
 
-    // themeV2 embeds the billing form in the payment step, so the same-as-shipping
-    // toggle lives there instead of on shipping. Keep the checkout-wide value in
-    // sync so returning to shipping doesn't re-copy shipping over a billing address
-    // the shopper set on payment. Unlike handleShippingNextStep this never navigates.
     const handleBillingSameAsShippingChange = useCallback(
         (isBillingSameAsShipping: boolean): void => {
             setState((prev) => ({ ...prev, isBillingSameAsShipping }));

--- a/packages/core/src/app/checkout/components/PaymentStep.tsx
+++ b/packages/core/src/app/checkout/components/PaymentStep.tsx
@@ -38,6 +38,8 @@ const PaymentStep = ({
     capabilities,
     consignments,
     errorLogger,
+    isBillingSameAsShipping,
+    onBillingSameAsShippingChange,
     onEdit,
     onExpanded,
     checkEmbeddedSupport,
@@ -60,12 +62,14 @@ const PaymentStep = ({
                 capabilities={capabilities}
                 checkEmbeddedSupport={checkEmbeddedSupport}
                 errorLogger={errorLogger}
+                isBillingSameAsShipping={isBillingSameAsShipping}
                 isEmbedded={isEmbedded()}
                 isUsingMultiShipping={
                     cart && consignments
                         ? isUsingMultiShipping(consignments, cart.lineItems)
                         : false
                 }
+                onBillingSameAsShippingChange={onBillingSameAsShippingChange}
                 onCartChangedError={onCartChangedError}
                 onFinalize={onFinalize}
                 onReady={onReady}

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -80,9 +80,11 @@ import { getFilteredPaymentMethodsWithDefault } from './paymentMethodFilters';
 export interface PaymentProps {
     capabilities: Capabilities;
     errorLogger: ErrorLogger;
+    isBillingSameAsShipping?: boolean;
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     checkEmbeddedSupport?(methodIds: string[]): void; // TODO: We're currently doing this check in multiple places, perhaps we should move it up so this check get be done in a single place instead.
+    onBillingSameAsShippingChange?(isBillingSameAsShipping: boolean): void;
     onCartChangedError?(): void;
     onFinalize?(): void;
     onFinalizeError?(error: Error): void;
@@ -783,6 +785,7 @@ const Payment = (
                         defaultMethodId={props.defaultMethod?.id || ''}
                         didExceedSpamLimit={state.didExceedSpamLimit}
                         disableStoreCredit={disableStoreCredit}
+                        isBillingSameAsShipping={props.isBillingSameAsShipping}
                         isEmbedded={props.isEmbedded}
                         isInitializingPayment={props.isInitializingPayment}
                         isPaymentDataRequired={props.isPaymentDataRequired}
@@ -790,6 +793,7 @@ const Payment = (
                         isTermsConditionsRequired={props.isTermsConditionsRequired}
                         isUsingMultiShipping={props.isUsingMultiShipping}
                         methods={props.methods}
+                        onBillingSameAsShippingChange={props.onBillingSameAsShippingChange}
                         onMethodSelect={setSelectedMethod}
                         onStoreCreditChange={handleStoreCreditChange}
                         onSubmit={handleSubmit}

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -51,6 +51,7 @@ export interface PaymentFormProps {
     defaultGatewayId?: string;
     defaultMethodId: string;
     didExceedSpamLimit?: boolean;
+    isBillingSameAsShipping?: boolean;
     isEmbedded?: boolean;
     isInitializingPayment?: boolean;
     isTermsConditionsRequired?: boolean;
@@ -68,6 +69,7 @@ export interface PaymentFormProps {
     usableStoreCredit?: number;
     validationSchema?: ObjectSchema<Partial<PaymentFormValues>>;
     isPaymentDataRequired(): boolean;
+    onBillingSameAsShippingChange?(isBillingSameAsShipping: boolean): void;
     onMethodSelect?(method: PaymentMethod): void;
     onStoreCreditChange?(useStoreCredit?: boolean): void;
     onSubmit?(values: PaymentFormValues): void;
@@ -81,6 +83,7 @@ const PaymentForm: FunctionComponent<
     availableStoreCredit = 0,
     disableStoreCredit = false,
     didExceedSpamLimit,
+    isBillingSameAsShipping,
     isEmbedded,
     isInitializingPayment,
     isPaymentDataRequired,
@@ -89,6 +92,7 @@ const PaymentForm: FunctionComponent<
     isUsingMultiShipping,
     language,
     methods,
+    onBillingSameAsShippingChange,
     onMethodSelect,
     onStoreCreditChange,
     onUnhandledError,
@@ -202,7 +206,9 @@ const PaymentForm: FunctionComponent<
 
             {themeV2 && (
                 <PaymentBillingBlock
+                    isBillingSameAsShipping={isBillingSameAsShipping ?? true}
                     methodId={selectedMethod?.id}
+                    onBillingSameAsShippingChange={onBillingSameAsShippingChange ?? noop}
                     onUnhandledError={onUnhandledError ?? noop}
                 />
             )}

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -159,6 +159,24 @@ describe('PaymentBillingBlock', () => {
         expect(checkoutService.updateBillingAddress).toHaveBeenCalledWith(getShippingAddress());
     });
 
+    it('reverts the toggle and reports the error when copying shipping to billing fails', async () => {
+        const error = new Error('update failed');
+
+        jest.spyOn(checkoutService, 'updateBillingAddress').mockRejectedValue(error);
+
+        render(<PaymentBillingBlockTest />);
+
+        await screen.findByTestId('trigger-persist');
+
+        act(() => {
+            mockCapturedProps.onBillingSameAsShippingChange(true);
+        });
+
+        await waitFor(() => expect(mockCapturedProps.isBillingSameAsShipping).toBe(false));
+
+        expect(onUnhandledError).toHaveBeenCalledWith(error);
+    });
+
     it('does not copy shipping to billing when the toggle is unchecked', async () => {
         render(<PaymentBillingBlockTest />);
 

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -83,18 +83,29 @@ describe('PaymentBillingBlock', () => {
         jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(undefined);
         jest.spyOn(checkoutState.data, 'getShippingAddress').mockReturnValue(getShippingAddress());
 
-        PaymentBillingBlockTest = ({ methodId }) => (
-            <CheckoutProvider checkoutService={checkoutService}>
-                <LocaleContext.Provider value={localeContext}>
-                    <CapabilitiesContext.Provider value={defaultCapabilities}>
-                        <PaymentBillingBlock
-                            methodId={methodId}
-                            onUnhandledError={onUnhandledError}
-                        />
-                    </CapabilitiesContext.Provider>
-                </LocaleContext.Provider>
-            </CheckoutProvider>
-        );
+        // "Billing same as shipping" is now checkout-wide state owned by
+        // CheckoutPage. Stand in for that here so the block reflects the value and
+        // reports the shopper's choice back up, matching the real wiring.
+        PaymentBillingBlockTest = ({ methodId }) => {
+            const [isBillingSameAsShipping, setIsBillingSameAsShipping] = React.useState(
+                getStoreConfig().checkoutSettings.checkoutBillingSameAsShippingEnabled ?? true,
+            );
+
+            return (
+                <CheckoutProvider checkoutService={checkoutService}>
+                    <LocaleContext.Provider value={localeContext}>
+                        <CapabilitiesContext.Provider value={defaultCapabilities}>
+                            <PaymentBillingBlock
+                                isBillingSameAsShipping={isBillingSameAsShipping}
+                                methodId={methodId}
+                                onBillingSameAsShippingChange={setIsBillingSameAsShipping}
+                                onUnhandledError={onUnhandledError}
+                            />
+                        </CapabilitiesContext.Provider>
+                    </LocaleContext.Provider>
+                </CheckoutProvider>
+            );
+        };
     });
 
     it('renders the billing address heading', async () => {
@@ -139,7 +150,9 @@ describe('PaymentBillingBlock', () => {
 
         await screen.findByTestId('trigger-persist');
 
-        mockCapturedProps.onBillingSameAsShippingChange(true);
+        act(() => {
+            mockCapturedProps.onBillingSameAsShippingChange(true);
+        });
 
         await new Promise((resolve) => process.nextTick(resolve));
 
@@ -151,7 +164,9 @@ describe('PaymentBillingBlock', () => {
 
         await screen.findByTestId('trigger-persist');
 
-        mockCapturedProps.onBillingSameAsShippingChange(false);
+        act(() => {
+            mockCapturedProps.onBillingSameAsShippingChange(false);
+        });
 
         await new Promise((resolve) => process.nextTick(resolve));
 
@@ -190,7 +205,11 @@ describe('PaymentBillingBlock', () => {
                             },
                         }}
                     >
-                        <PaymentBillingBlock onUnhandledError={onUnhandledError} />
+                        <PaymentBillingBlock
+                            isBillingSameAsShipping={true}
+                            onBillingSameAsShippingChange={jest.fn()}
+                            onUnhandledError={onUnhandledError}
+                        />
                     </CapabilitiesContext.Provider>
                 </LocaleContext.Provider>
             </CheckoutProvider>,

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -4,7 +4,7 @@ import {
     type CheckoutService,
     createCheckoutService,
 } from '@bigcommerce/checkout-sdk';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { type FunctionComponent } from 'react';
 
 import {
@@ -23,6 +23,7 @@ import { type BillingFormValues } from '../../billing/billingFormConfig';
 import { getCheckout } from '../../checkout/checkouts.mock';
 import { getStoreConfig } from '../../config/config.mock';
 import { getCustomer } from '../../customer/customers.mock';
+import { getShippingAddress } from '../../shipping/shipping-addresses.mock';
 
 import { PaymentBillingBlock } from './PaymentBillingBlock';
 import { type PaymentBillingFormProps } from './PaymentBillingForm';
@@ -80,6 +81,7 @@ describe('PaymentBillingBlock', () => {
         jest.spyOn(checkoutState.data, 'getBillingAddressFields').mockReturnValue(formFields);
         jest.spyOn(checkoutState.data, 'getAddressExtraFields').mockReturnValue([]);
         jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(undefined);
+        jest.spyOn(checkoutState.data, 'getShippingAddress').mockReturnValue(getShippingAddress());
 
         PaymentBillingBlockTest = ({ methodId }) => (
             <CheckoutProvider checkoutService={checkoutService}>
@@ -122,6 +124,52 @@ describe('PaymentBillingBlock', () => {
         await screen.findByTestId('trigger-persist');
 
         expect(mockCapturedProps.methodId).toBe('amazonpay');
+    });
+
+    it('defaults the same-as-shipping toggle from checkout settings', async () => {
+        render(<PaymentBillingBlockTest />);
+
+        await screen.findByTestId('trigger-persist');
+
+        expect(mockCapturedProps.isBillingSameAsShipping).toBe(true);
+    });
+
+    it('copies the shipping address to billing when the toggle is checked', async () => {
+        render(<PaymentBillingBlockTest />);
+
+        await screen.findByTestId('trigger-persist');
+
+        mockCapturedProps.onBillingSameAsShippingChange(true);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(checkoutService.updateBillingAddress).toHaveBeenCalledWith(getShippingAddress());
+    });
+
+    it('does not copy shipping to billing when the toggle is unchecked', async () => {
+        render(<PaymentBillingBlockTest />);
+
+        await screen.findByTestId('trigger-persist');
+
+        mockCapturedProps.onBillingSameAsShippingChange(false);
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(checkoutService.updateBillingAddress).not.toHaveBeenCalled();
+    });
+
+    it('remembers the shopper unchecking the toggle across re-renders', async () => {
+        render(<PaymentBillingBlockTest />);
+
+        await screen.findByTestId('trigger-persist');
+
+        expect(mockCapturedProps.isBillingSameAsShipping).toBe(true);
+
+        act(() => {
+            mockCapturedProps.onBillingSameAsShippingChange(false);
+        });
+
+        await waitFor(() => expect(mockCapturedProps.isBillingSameAsShipping).toBe(false));
     });
 
     it('shows a warning instead of the form when manual entry is restricted and there are no saved addresses', async () => {

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -32,9 +32,6 @@ let mockCapturedProps: PaymentBillingFormProps;
 
 let mockPersistValues: BillingFormValues;
 
-// Stand in for PaymentBillingForm: capture the props the container passes and
-// expose a button that invokes onPersist, so we can test the container's
-// persistence wiring without driving the real address form.
 jest.mock('./PaymentBillingForm', () => ({
     PaymentBillingForm: (props: PaymentBillingFormProps) => {
         mockCapturedProps = props;
@@ -83,9 +80,6 @@ describe('PaymentBillingBlock', () => {
         jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(undefined);
         jest.spyOn(checkoutState.data, 'getShippingAddress').mockReturnValue(getShippingAddress());
 
-        // "Billing same as shipping" is now checkout-wide state owned by
-        // CheckoutPage. Stand in for that here so the block reflects the value and
-        // reports the shopper's choice back up, matching the real wiring.
         PaymentBillingBlockTest = ({ methodId }) => {
             const [isBillingSameAsShipping, setIsBillingSameAsShipping] = React.useState(
                 getStoreConfig().checkoutSettings.checkoutBillingSameAsShippingEnabled ?? true,

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -53,9 +53,10 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
             getBillingAddressFields,
             getAddressExtraFields,
         },
-        // getBillingAddress guarantees the latest state inside async callbacks
+        // getBillingAddress / getShippingAddress guarantee the latest state inside
+        // async callbacks
         checkoutState: {
-            data: { getBillingAddress },
+            data: { getBillingAddress, getShippingAddress },
         },
         checkoutService,
     } = useCheckout(({ data, statuses }) => ({
@@ -83,6 +84,28 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
 
     const customerMessage = checkout.customerMessage;
     const billingAddress = getBillingAddress();
+
+    const [isBillingSameAsShipping, setIsBillingSameAsShipping] = useState(
+        config.checkoutSettings.checkoutBillingSameAsShippingEnabled ?? true,
+    );
+
+    const handleBillingSameAsShippingChange = (checked: boolean) => {
+        setIsBillingSameAsShipping(checked);
+
+        if (!checked) {
+            return;
+        }
+
+        const shippingAddress = getShippingAddress();
+
+        if (shippingAddress && !isEqualAddress(shippingAddress, getBillingAddress())) {
+            checkoutService.updateBillingAddress(shippingAddress).catch((error) => {
+                if (error instanceof Error) {
+                    onUnhandledError(error);
+                }
+            });
+        }
+    };
 
     const getFields = useCallback(
         (countryCode?: string) =>
@@ -163,8 +186,10 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
                     billingAddress={billingAddress}
                     customerMessage={customerMessage}
                     getFields={getFields}
+                    isBillingSameAsShipping={isBillingSameAsShipping}
                     isLoading={isInitializing}
                     methodId={methodId}
+                    onBillingSameAsShippingChange={handleBillingSameAsShippingChange}
                     onPersist={handlePersist}
                     onUnhandledError={onUnhandledError}
                 />

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -100,6 +100,8 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
 
         if (shippingAddress && !isEqualAddress(shippingAddress, getBillingAddress())) {
             checkoutService.updateBillingAddress(shippingAddress).catch((error) => {
+                onBillingSameAsShippingChange(false);
+
                 if (error instanceof Error) {
                     onUnhandledError(error);
                 }

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -57,8 +57,6 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
             getBillingAddressFields,
             getAddressExtraFields,
         },
-        // getBillingAddress / getShippingAddress guarantee the latest state inside
-        // async callbacks
         checkoutState: {
             data: { getBillingAddress, getShippingAddress },
         },
@@ -121,9 +119,7 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
     );
 
     // Persist without navigating — the payment step's "Place Order" is the only
-    // submit. Called by PaymentBillingForm's pre-submit save; the isEqualAddress
-    // guard prevents a redundant updateBillingAddress when nothing changed. Errors
-    // propagate so the pre-submit save can block the order.
+    // submit. Called by PaymentBillingForm's pre-submit save;
     const handlePersist = async ({
         orderComment,
         ...addressValues

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -20,6 +20,8 @@ export interface PaymentBillingBlockProps {
     // billing form's method-specific behaviour (e.g. Amazon Pay's static address
     // + reduced schema). Must reflect the live selection, not checkout.payments.
     methodId?: string;
+    isBillingSameAsShipping: boolean;
+    onBillingSameAsShippingChange(isBillingSameAsShipping: boolean): void;
     onUnhandledError(error: Error): void;
 }
 
@@ -42,6 +44,8 @@ const getFieldsWithExtraFields = (
 
 export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = ({
     methodId,
+    isBillingSameAsShipping,
+    onBillingSameAsShippingChange,
     onUnhandledError,
 }) => {
     const {
@@ -85,12 +89,8 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
     const customerMessage = checkout.customerMessage;
     const billingAddress = getBillingAddress();
 
-    const [isBillingSameAsShipping, setIsBillingSameAsShipping] = useState(
-        config.checkoutSettings.checkoutBillingSameAsShippingEnabled ?? true,
-    );
-
     const handleBillingSameAsShippingChange = (checked: boolean) => {
-        setIsBillingSameAsShipping(checked);
+        onBillingSameAsShippingChange(checked);
 
         if (!checked) {
             return;

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
@@ -4,7 +4,7 @@ import {
     createCheckoutService,
 } from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
-import React from 'react';
+import React, { type FunctionComponent } from 'react';
 
 import {
     CapabilitiesContext,
@@ -35,26 +35,28 @@ describe('PaymentBillingForm', () => {
     let setEnsureBillingAddressSaved: jest.Mock;
     let defaultProps: PaymentBillingFormProps;
 
+    const PaymentBillingFormTest: FunctionComponent<PaymentBillingFormProps> = (props) => (
+        <CheckoutProvider checkoutService={checkoutService}>
+            <LocaleContext.Provider value={localeContext}>
+                <CapabilitiesContext.Provider value={defaultCapabilities}>
+                    <PaymentContext.Provider
+                        value={{
+                            setEnsureBillingAddressSaved,
+                            disableSubmit: jest.fn(),
+                            setSubmit: jest.fn(),
+                            setValidationSchema: jest.fn(),
+                            hidePaymentSubmitButton: jest.fn(),
+                        }}
+                    >
+                        <PaymentBillingForm {...props} />
+                    </PaymentContext.Provider>
+                </CapabilitiesContext.Provider>
+            </LocaleContext.Provider>
+        </CheckoutProvider>
+    );
+
     const renderForm = (props: PaymentBillingFormProps) =>
-        render(
-            <CheckoutProvider checkoutService={checkoutService}>
-                <LocaleContext.Provider value={localeContext}>
-                    <CapabilitiesContext.Provider value={defaultCapabilities}>
-                        <PaymentContext.Provider
-                            value={{
-                                setEnsureBillingAddressSaved,
-                                disableSubmit: jest.fn(),
-                                setSubmit: jest.fn(),
-                                setValidationSchema: jest.fn(),
-                                hidePaymentSubmitButton: jest.fn(),
-                            }}
-                        >
-                            <PaymentBillingForm {...props} />
-                        </PaymentContext.Provider>
-                    </CapabilitiesContext.Provider>
-                </LocaleContext.Provider>
-            </CheckoutProvider>,
-        );
+        render(<PaymentBillingFormTest {...props} />);
 
     beforeEach(() => {
         checkoutService = createCheckoutService();
@@ -81,7 +83,9 @@ describe('PaymentBillingForm', () => {
             billingAddress: getBillingAddress(),
             customerMessage: '',
             getFields: () => getFormFields(),
+            isBillingSameAsShipping: false,
             isLoading: false,
+            onBillingSameAsShippingChange: jest.fn(),
             onPersist,
             onUnhandledError: noop,
         };
@@ -168,6 +172,20 @@ describe('PaymentBillingForm', () => {
         expect(onPersist).not.toHaveBeenCalled();
     });
 
+    it('does not include the same-as-shipping flag in the persisted billing values', async () => {
+        renderForm(defaultProps);
+
+        await waitFor(() =>
+            expect(capturedEnsureBillingAddressSaved).toEqual(expect.any(Function)),
+        );
+
+        await capturedEnsureBillingAddressSaved?.();
+
+        expect(onPersist).toHaveBeenCalledWith(
+            expect.not.objectContaining({ billingSameAsShipping: expect.anything() }),
+        );
+    });
+
     it('reports a persist failure via onUnhandledError and resolves false without throwing', async () => {
         const error = new Error('failed to save billing address');
         const onUnhandledError = jest.fn();
@@ -182,5 +200,79 @@ describe('PaymentBillingForm', () => {
 
         await expect(capturedEnsureBillingAddressSaved?.()).resolves.toBe(false);
         expect(onUnhandledError).toHaveBeenCalledWith(error);
+    });
+
+    describe('billing same as shipping toggle', () => {
+        it('renders the toggle with the payment-step label', () => {
+            renderForm(defaultProps);
+
+            expect(screen.getByTestId('billingSameAsShipping')).toBeInTheDocument();
+            expect(screen.getByText('Same as shipping address')).toBeInTheDocument();
+        });
+
+        it('collapses the billing address fields when checked', () => {
+            renderForm({ ...defaultProps, isBillingSameAsShipping: true });
+
+            expect(screen.getByTestId('billingSameAsShipping')).toBeInTheDocument();
+            expect(screen.queryByText('First Name')).not.toBeInTheDocument();
+        });
+
+        it('shows the billing address fields when unchecked', () => {
+            renderForm({ ...defaultProps, isBillingSameAsShipping: false });
+
+            expect(screen.getByText('First Name')).toBeInTheDocument();
+        });
+
+        it('resolves true without persisting when checked (billing mirrors shipping)', async () => {
+            renderForm({ ...defaultProps, isBillingSameAsShipping: true });
+
+            await waitFor(() =>
+                expect(capturedEnsureBillingAddressSaved).toEqual(expect.any(Function)),
+            );
+
+            await expect(capturedEnsureBillingAddressSaved?.()).resolves.toBe(true);
+            expect(onPersist).not.toHaveBeenCalled();
+        });
+
+        it('hides the toggle for static-address methods (e.g. Amazon Pay)', () => {
+            renderForm({ ...defaultProps, methodId: 'amazonpay' });
+
+            expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
+        });
+
+        it('stays unchecked and does not re-fire on a billing address reinitialize', async () => {
+            const onBillingSameAsShippingChange = jest.fn();
+            const props = {
+                ...defaultProps,
+                isBillingSameAsShipping: false,
+                billingAddress: getBillingAddress(),
+                onBillingSameAsShippingChange,
+            };
+
+            const { rerender } = renderForm(props);
+
+            expect(screen.getByText('First Name')).toBeInTheDocument();
+
+            rerender(
+                <PaymentBillingFormTest {...props} billingAddress={getEmptyBillingAddress()} />,
+            );
+
+            expect(await screen.findByText('First Name')).toBeInTheDocument();
+            expect(onBillingSameAsShippingChange).not.toHaveBeenCalledWith(true);
+        });
+
+        it('notifies onBillingSameAsShippingChange when the shopper checks it', async () => {
+            const onBillingSameAsShippingChange = jest.fn();
+
+            renderForm({
+                ...defaultProps,
+                isBillingSameAsShipping: false,
+                onBillingSameAsShippingChange,
+            });
+
+            fireEvent.click(screen.getByTestId('billingSameAsShipping'));
+
+            await waitFor(() => expect(onBillingSameAsShippingChange).toHaveBeenCalledWith(true));
+        });
     });
 });

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
@@ -78,6 +78,7 @@ describe('PaymentBillingForm', () => {
             isGuest: true,
             addresses: [],
         });
+        jest.spyOn(checkoutState.statuses, 'isUpdatingBillingAddress').mockReturnValue(false);
 
         defaultProps = {
             billingAddress: getBillingAddress(),
@@ -208,6 +209,14 @@ describe('PaymentBillingForm', () => {
 
             expect(screen.getByTestId('billingSameAsShipping')).toBeInTheDocument();
             expect(screen.getByText('Same as shipping address')).toBeInTheDocument();
+        });
+
+        it('disables the toggle while a billing address update is in flight', () => {
+            jest.spyOn(checkoutState.statuses, 'isUpdatingBillingAddress').mockReturnValue(true);
+
+            renderForm(defaultProps);
+
+            expect(screen.getByTestId('billingSameAsShipping')).toBeDisabled();
         });
 
         it('collapses the billing address fields when checked', () => {

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -26,7 +26,6 @@ export interface PaymentBillingFormProps {
     billingAddress?: Address;
     customerMessage: string;
     isLoading: boolean;
-    // Default for the "billing same as shipping" toggle (from checkout settings).
     isBillingSameAsShipping: boolean;
     getFields(countryCode?: string): FormField[];
     // Persists the billing address (updateBillingAddress). Must throw on failure
@@ -55,11 +54,12 @@ const PaymentBillingFormComponent = ({
 
     const {
         checkoutService,
-        selectedState: { customer, config, cart },
-    } = useCheckout(({ data }) => ({
+        selectedState: { customer, config, cart, isUpdatingBillingAddress },
+    } = useCheckout(({ data, statuses }) => ({
         customer: data.getCustomer(),
         config: data.getConfig(),
         cart: data.getCart(),
+        isUpdatingBillingAddress: statuses.isUpdatingBillingAddress(),
     }));
     const {
         billing: { hideSaveToAddressBookCheck, restrictManualAddressEntry },
@@ -98,20 +98,12 @@ const PaymentBillingFormComponent = ({
     const isBillingAddressCollapsed =
         shouldShowBillingSameAsShipping && values.billingSameAsShipping;
 
-    // Ensure a pending edit is saved before the payment step places the order:
-    // block while still loading, otherwise validate (surfacing errors + blocking
-    // on invalid) and persist. A persist failure is reported through the billing
-    // error channel and blocks the order — it must not surface as a payment
-    // failure, so this never throws.
     const ensureBillingAddressSaved = useCallback(async (): Promise<boolean> => {
         if (isLoading || isResettingAddress) {
             return false;
         }
 
-        // Collapsed "same as shipping": billing already mirrors the shipping
-        // address (copied on toggle + on shipping-continue), so nothing to
-        // validate or persist here. Only when the toggle is actually shown —
-        // static-address methods (e.g. Amazon Pay) hide it and must still persist.
+        // A checked, visible toggle is trusted as proof billing already mirrors shipping.
         if (shouldShowBillingSameAsShipping && values.billingSameAsShipping) {
             return true;
         }
@@ -184,6 +176,7 @@ const PaymentBillingFormComponent = ({
         <div className="checkout-billing-form" data-test="checkout-billing-form">
             {shouldShowBillingSameAsShipping && (
                 <BillingSameAsShippingField
+                    disabled={isUpdatingBillingAddress}
                     labelStringId="billing.same_as_shipping_label"
                     onChange={onBillingSameAsShippingChange}
                 />

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -16,17 +16,25 @@ import {
 import StaticBillingAddress from '../../billing/StaticBillingAddress';
 import { OrderComments } from '../../orderComments';
 import { getShippableItemsCount } from '../../shipping';
+import BillingSameAsShippingField from '../../shipping/BillingSameAsShippingField';
 import PaymentContext from '../PaymentContext';
+
+// The payment-step billing form adds the "billing same as shipping" toggle on
+// top of the shared billing values.
+export type PaymentBillingFormValues = BillingFormValues & { billingSameAsShipping: boolean };
 
 export interface PaymentBillingFormProps {
     methodId?: string;
     billingAddress?: Address;
     customerMessage: string;
     isLoading: boolean;
+    // Default for the "billing same as shipping" toggle (from checkout settings).
+    isBillingSameAsShipping: boolean;
     getFields(countryCode?: string): FormField[];
     // Persists the billing address (updateBillingAddress). Must throw on failure
     // so the pre-submit ensureBillingAddressSaved can block the order.
     onPersist(values: BillingFormValues): Promise<void>;
+    onBillingSameAsShippingChange(isBillingSameAsShipping: boolean): void;
     onUnhandledError(error: Error): void;
 }
 
@@ -40,8 +48,9 @@ const PaymentBillingFormComponent = ({
     validateForm,
     values,
     onPersist,
+    onBillingSameAsShippingChange,
     onUnhandledError,
-}: PaymentBillingFormProps & WithLanguageProps & FormikProps<BillingFormValues>) => {
+}: PaymentBillingFormProps & WithLanguageProps & FormikProps<PaymentBillingFormValues>) => {
     const [isResettingAddress, setIsResettingAddress] = useState(false);
     const { isPayPalFastlaneEnabled, paypalFastlaneAddresses } = usePayPalFastlaneAddress();
     const paymentContext = useContext(PaymentContext);
@@ -85,6 +94,9 @@ const PaymentBillingFormComponent = ({
     const { enableOrderComments } = config.checkoutSettings;
     const shouldShowOrderComments = enableOrderComments && getShippableItemsCount(cart) < 1;
     const shouldShowSaveAddress = !hideSaveToAddressBookCheck && !isGuest;
+    const shouldShowBillingSameAsShipping = !shouldRenderStaticAddress;
+    const isBillingAddressCollapsed =
+        shouldShowBillingSameAsShipping && values.billingSameAsShipping;
 
     // Ensure a pending edit is saved before the payment step places the order:
     // block while still loading, otherwise validate (surfacing errors + blocking
@@ -96,6 +108,14 @@ const PaymentBillingFormComponent = ({
             return false;
         }
 
+        // Collapsed "same as shipping": billing already mirrors the shipping
+        // address (copied on toggle + on shipping-continue), so nothing to
+        // validate or persist here. Only when the toggle is actually shown —
+        // static-address methods (e.g. Amazon Pay) hide it and must still persist.
+        if (shouldShowBillingSameAsShipping && values.billingSameAsShipping) {
+            return true;
+        }
+
         const errors = await validateForm();
 
         if (Object.keys(errors).length > 0) {
@@ -105,7 +125,9 @@ const PaymentBillingFormComponent = ({
         }
 
         try {
-            await onPersist(values);
+            const { billingSameAsShipping: _billingSameAsShipping, ...billingValues } = values;
+
+            await onPersist(billingValues);
         } catch (error) {
             if (error instanceof Error) {
                 onUnhandledError(error);
@@ -118,6 +140,7 @@ const PaymentBillingFormComponent = ({
     }, [
         isLoading,
         isResettingAddress,
+        shouldShowBillingSameAsShipping,
         validateForm,
         setTouched,
         onPersist,
@@ -159,53 +182,72 @@ const PaymentBillingFormComponent = ({
 
     return (
         <div className="checkout-billing-form" data-test="checkout-billing-form">
-            {shouldRenderStaticAddress && billingAddress && (
-                <div className="form-fieldset">
-                    <StaticBillingAddress address={billingAddress} />
-                </div>
+            {shouldShowBillingSameAsShipping && (
+                <BillingSameAsShippingField
+                    labelStringId="billing.same_as_shipping_label"
+                    onChange={onBillingSameAsShippingChange}
+                />
             )}
 
-            <Fieldset id="checkoutBillingAddress">
-                {hasAddresses && !shouldRenderStaticAddress && (
-                    <Fieldset id="billingAddresses">
-                        <LoadingOverlay isLoading={isResettingAddress}>
-                            <AddressSelect
-                                addresses={billingAddresses}
-                                onSelectAddress={handleSelectAddress}
-                                onUseNewAddress={handleUseNewAddress}
-                                selectedAddress={
-                                    hasValidCustomerAddress ? billingAddress : undefined
-                                }
-                                type={AddressType.Billing}
-                            />
-                        </LoadingOverlay>
+            {/* Collapse the billing address when it mirrors shipping. */}
+            {!isBillingAddressCollapsed && (
+                <>
+                    {shouldRenderStaticAddress && billingAddress && (
+                        <div className="form-fieldset">
+                            <StaticBillingAddress address={billingAddress} />
+                        </div>
+                    )}
+
+                    <Fieldset id="checkoutBillingAddress">
+                        {hasAddresses && !shouldRenderStaticAddress && (
+                            <Fieldset id="billingAddresses">
+                                <LoadingOverlay isLoading={isResettingAddress}>
+                                    <AddressSelect
+                                        addresses={billingAddresses}
+                                        onSelectAddress={handleSelectAddress}
+                                        onUseNewAddress={handleUseNewAddress}
+                                        selectedAddress={
+                                            hasValidCustomerAddress ? billingAddress : undefined
+                                        }
+                                        type={AddressType.Billing}
+                                    />
+                                </LoadingOverlay>
+                            </Fieldset>
+                        )}
+
+                        {!restrictManualAddressEntry && !hasValidCustomerAddress && (
+                            <AddressFormSkeleton isLoading={isResettingAddress}>
+                                <AddressForm
+                                    countryCode={values.countryCode}
+                                    formFields={editableFormFields}
+                                    setFieldValue={setFieldValue}
+                                    shouldShowSaveAddress={shouldShowSaveAddress}
+                                    type={AddressType.Billing}
+                                />
+                            </AddressFormSkeleton>
+                        )}
                     </Fieldset>
-                )}
 
-                {!restrictManualAddressEntry && !hasValidCustomerAddress && (
-                    <AddressFormSkeleton isLoading={isResettingAddress}>
-                        <AddressForm
-                            countryCode={values.countryCode}
-                            formFields={editableFormFields}
-                            setFieldValue={setFieldValue}
-                            shouldShowSaveAddress={shouldShowSaveAddress}
-                            type={AddressType.Billing}
-                        />
-                    </AddressFormSkeleton>
-                )}
-            </Fieldset>
-
-            {shouldShowOrderComments && <OrderComments />}
+                    {shouldShowOrderComments && <OrderComments />}
+                </>
+            )}
         </div>
     );
 };
 
 export const PaymentBillingForm = withLanguage(
-    withFormik<PaymentBillingFormProps & WithLanguageProps, BillingFormValues>({
+    withFormik<PaymentBillingFormProps & WithLanguageProps, PaymentBillingFormValues>({
         // No submit button — persistence happens via ensureBillingAddressSaved.
         handleSubmit: () => undefined,
-        mapPropsToValues: ({ getFields, customerMessage, billingAddress }) =>
-            getBillingFormInitialValues(getFields, billingAddress, customerMessage),
+        mapPropsToValues: ({
+            getFields,
+            customerMessage,
+            billingAddress,
+            isBillingSameAsShipping,
+        }) => ({
+            ...getBillingFormInitialValues(getFields, billingAddress, customerMessage),
+            billingSameAsShipping: isBillingSameAsShipping,
+        }),
         validateOnMount: true,
         validationSchema: ({
             language,

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -65,6 +65,7 @@ const PaymentBillingFormComponent = ({
     }));
     const {
         billing: { hideSaveToAddressBookCheck, restrictManualAddressEntry },
+        shipping: { hideBillingSameAsShippingCheck },
     } = useCapabilities();
 
     if (!config || !customer || !cart) {
@@ -94,7 +95,8 @@ const PaymentBillingFormComponent = ({
     const { enableOrderComments } = config.checkoutSettings;
     const shouldShowOrderComments = enableOrderComments && getShippableItemsCount(cart) < 1;
     const shouldShowSaveAddress = !hideSaveToAddressBookCheck && !isGuest;
-    const shouldShowBillingSameAsShipping = !shouldRenderStaticAddress;
+    const shouldShowBillingSameAsShipping =
+        !shouldRenderStaticAddress && !hideBillingSameAsShippingCheck;
     const isBillingAddressCollapsed =
         shouldShowBillingSameAsShipping && values.billingSameAsShipping;
 

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -19,9 +19,7 @@ import { getShippableItemsCount } from '../../shipping';
 import BillingSameAsShippingField from '../../shipping/BillingSameAsShippingField';
 import PaymentContext from '../PaymentContext';
 
-// The payment-step billing form adds the "billing same as shipping" toggle on
-// top of the shared billing values.
-export type PaymentBillingFormValues = BillingFormValues & { billingSameAsShipping: boolean };
+type PaymentBillingFormValues = BillingFormValues & { billingSameAsShipping: boolean };
 
 export interface PaymentBillingFormProps {
     methodId?: string;
@@ -191,7 +189,6 @@ const PaymentBillingFormComponent = ({
                 />
             )}
 
-            {/* Collapse the billing address when it mirrors shipping. */}
             {!isBillingAddressCollapsed && (
                 <>
                     {shouldRenderStaticAddress && billingAddress && (

--- a/packages/core/src/app/shipping/BillingSameAsShippingField.tsx
+++ b/packages/core/src/app/shipping/BillingSameAsShippingField.tsx
@@ -4,11 +4,13 @@ import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CheckboxFormField } from '@bigcommerce/checkout/ui';
 
 export interface BillingSameAsShippingFieldProps {
+    disabled?: boolean;
     labelStringId?: string;
     onChange?(isChecked: boolean): void;
 }
 
 const BillingSameAsShippingField: FunctionComponent<BillingSameAsShippingFieldProps> = ({
+    disabled,
     labelStringId = 'billing.use_shipping_address_label',
     onChange,
 }) => {
@@ -16,6 +18,7 @@ const BillingSameAsShippingField: FunctionComponent<BillingSameAsShippingFieldPr
 
     return (
         <CheckboxFormField
+            disabled={disabled}
             id="sameAsBilling"
             labelContent={labelContent}
             name="billingSameAsShipping"

--- a/packages/core/src/app/shipping/BillingSameAsShippingField.tsx
+++ b/packages/core/src/app/shipping/BillingSameAsShippingField.tsx
@@ -4,16 +4,15 @@ import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { CheckboxFormField } from '@bigcommerce/checkout/ui';
 
 export interface BillingSameAsShippingFieldProps {
+    labelStringId?: string;
     onChange?(isChecked: boolean): void;
 }
 
 const BillingSameAsShippingField: FunctionComponent<BillingSameAsShippingFieldProps> = ({
+    labelStringId = 'billing.use_shipping_address_label',
     onChange,
 }) => {
-    const labelContent = useMemo(
-        () => <TranslatedString id="billing.use_shipping_address_label" />,
-        [],
-    );
+    const labelContent = useMemo(() => <TranslatedString id={labelStringId} />, [labelStringId]);
 
     return (
         <CheckboxFormField

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -3,7 +3,12 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
+import {
+    CheckoutProvider,
+    ExtensionProvider,
+    LocaleContext,
+    ThemeContext,
+} from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
@@ -339,6 +344,17 @@ describe('SingleShippingForm', () => {
 
     it('does not render billing same as shipping checkbox for amazon pay', async () => {
         renderSingleShippingFormComponent({ methodId: 'amazonpay' });
+
+        expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
+    });
+
+    it('does not render billing same as shipping checkbox under themeV2', async () => {
+        // Under themeV2 the toggle moves to the payment step's billing block.
+        render(
+            <ThemeContext.Provider value={{ themeV2: true }}>
+                {createSingleShippingFormComponent()}
+            </ThemeContext.Provider>,
+        );
 
         expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
     });

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -4,7 +4,7 @@ import { debounce, type DebouncedFunc, isEqual, noop } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { lazy, object } from 'yup';
 
-import { useCapabilities } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { Fieldset, Form } from '@bigcommerce/checkout/ui';
 
@@ -88,6 +88,7 @@ const SingleShippingForm: React.FC<
     const {
         shipping: { hideBillingSameAsShippingCheck },
     } = useCapabilities();
+    const { themeV2 } = useThemeContext();
     const {
         consignments,
         deinitializeShippingMethod: deinitialize,
@@ -279,6 +280,7 @@ const SingleShippingForm: React.FC<
 
     const shouldShowBillingSameAsShipping =
         !hideBillingSameAsShippingCheck &&
+        !themeV2 &&
         !PAYMENT_METHOD_VALID.some((method) => method === methodId);
 
     return (

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -54,7 +54,8 @@
             "no_billing_addresses_warning": "Sorry, you have no billing address to choose from, please go to your address book to create an address or contact your site admin.",
             "save_billing_address_error": "An error occurred while saving the billing address to your price quote. Please try again.",
             "billing_address_amazonpay": "Managed by Amazon Pay",
-            "use_shipping_address_label": "My billing address is the same as my shipping address."
+            "use_shipping_address_label": "My billing address is the same as my shipping address.",
+            "same_as_shipping_label": "Same as shipping address"
         },
         "cart": {
             "billed_amount_text": "*You will be charged and invoiced {total} ({code}) for this order.",


### PR DESCRIPTION
## What/Why?

- Add "same as shipping" toggle in payment step for themeV2.
- Hide the toggle from Shipping step when themeV2 is enabled.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

https://github.com/user-attachments/assets/dc6a8e21-2627-44e2-bfe5-d6d0bb171245





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing address persistence and order-submit gating on the payment step; incorrect toggle or copy-to-billing behavior could place orders with wrong billing data.
> 
> **Overview**
> For **themeV2**, the **“same as shipping address”** control moves from the shipping step into the **payment step billing block**, with checkout-level state wired through `CheckoutPage` → payment components.
> 
> When the toggle is **on**, billing fields collapse, place-order pre-save **skips** manual billing persistence, and checking the box **copies the shipping address** to billing (with **revert + error** if `updateBillingAddress` fails). The shared checkbox supports a **payment-specific label**, can be **disabled** while billing updates, and stays **hidden** for Amazon Pay and when capabilities hide it.
> 
> **Shipping** no longer shows the checkbox under themeV2. A new locale string supports the shorter payment-step label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18f5ab4a9bdff1d322e14ae6f85ca341dd3f4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->