### PR TITLE
feat(payment): PI-5431 [SPIKE] [FE] Surcharging (Bluesnap, Adyen) - PoC [do not merge]

### DIFF
--- a/packages/core/src/app/cart/withRedeemable.tsx
+++ b/packages/core/src/app/cart/withRedeemable.tsx
@@ -43,6 +43,9 @@ export default function withRedeemable(
                 showHeader={showHeader}
                 storeCreditAmount={storeCreditAmount}
                 storeCurrency={storeCurrency}
+                // Surcharging: assumes the BE Fees API recomputes outstandingBalance to include
+                // the surcharge. Until that endpoint is implemented on the BE, no surcharge is
+                // applied, so this is just the normal total.
                 total={checkout.outstandingBalance}
             />
         );

--- a/packages/core/src/app/coupon/NewOrderSummarySubtotals.tsx
+++ b/packages/core/src/app/coupon/NewOrderSummarySubtotals.tsx
@@ -9,6 +9,13 @@ import { CollapseCSSTransition } from '@bigcommerce/checkout/ui';
 import { isOrderFee, OrderSummaryDiscount, OrderSummaryPrice } from '../order';
 
 import { AppliedGiftCertificates, CouponForm, Discounts } from './components';
+
+// Must match SURCHARGE_FEE_NAME in the SDK surcharge handler.
+const SURCHARGE_FEE_NAME = 'corporate_card_surcharge';
+
+const isSurchargeFee = (fee: Fee | OrderFee): boolean =>
+    'name' in fee && fee.name === SURCHARGE_FEE_NAME;
+
 import { useMultiCoupon } from './useMultiCoupon';
 import { getRedeemableLabelId } from './utils';
 
@@ -43,6 +50,12 @@ const NewOrderSummarySubtotals: FunctionComponent<MultiCouponProps> = ({
 
     const [isCouponFormVisible, setIsCouponFormVisible] = useState(!isCouponFormCollapsed);
     const couponFormRef = useRef<HTMLDivElement>(null);
+
+    // Shown as its own labelled row; other fees stay generic.
+    // NOTE: the surcharge fee comes from the BE Fees API (Checkout.fees). Until that endpoint
+    // is implemented on the BE, no surcharge fee is present, so this row simply won't render.
+    const surchargeFee = (fees ?? []).find(isSurchargeFee);
+    const otherFees = (fees ?? []).filter((fee) => !isSurchargeFee(fee)) as typeof fees;
 
     const toggleCouponForm = () => {
         setIsCouponFormVisible((prevState) => !prevState);
@@ -99,7 +112,16 @@ const NewOrderSummarySubtotals: FunctionComponent<MultiCouponProps> = ({
                     />
                 )}
 
-                {fees?.map((fee, index) => (
+                {/* Surcharge placeholder — shown once applied in-flight. */}
+                {!!surchargeFee && (
+                    <OrderSummaryPrice
+                        amount={surchargeFee.cost}
+                        label={<TranslatedString id="cart.surcharge_text" />}
+                        testId="cart-surcharge"
+                    />
+                )}
+
+                {otherFees?.map((fee, index) => (
                     <OrderSummaryPrice
                         amount={fee.cost}
                         key={index}

--- a/packages/core/src/app/order/OrderSummarySubtotals.tsx
+++ b/packages/core/src/app/order/OrderSummarySubtotals.tsx
@@ -13,6 +13,12 @@ import isOrderFee from './isOrderFee';
 import OrderSummaryDiscount from './OrderSummaryDiscount';
 import OrderSummaryPrice from './OrderSummaryPrice';
 
+// SMust match SURCHARGE_FEE_NAME in the SDK surcharge handler.
+const SURCHARGE_FEE_NAME = 'corporate_card_surcharge';
+
+const isSurchargeFee = (fee: Fee | OrderFee): boolean =>
+    'name' in fee && fee.name === SURCHARGE_FEE_NAME;
+
 export interface OrderSummarySubtotalsProps {
     coupons: Coupon[];
     giftCertificates?: GiftCertificate[];
@@ -46,6 +52,13 @@ const OrderSummarySubtotals: FunctionComponent<OrderSummarySubtotalsProps> = ({
     onRemovedGiftCertificate,
     onRemovedCoupon,
 }) => {
+    // Surcharging: render the surcharge as its own labelled row, alongside shipping /
+    // handling; keep other fees in the generic loop below.
+    // NOTE: the surcharge fee comes from the BE Fees API (Checkout.fees). Until that endpoint
+    // is implemented on the BE, no surcharge fee is present, so this row simply won't render.
+    const surchargeFee = (fees ?? []).find(isSurchargeFee);
+    const otherFees = (fees ?? []).filter((fee) => !isSurchargeFee(fee)) as typeof fees;
+
     return (
         <>
             <OrderSummaryPrice
@@ -110,7 +123,16 @@ const OrderSummarySubtotals: FunctionComponent<OrderSummarySubtotalsProps> = ({
                 />
             )}
 
-            {fees?.map((fee, index) => (
+            {/* Surcharge placeholder — shown once applied in-flight. */}
+            {!!surchargeFee && (
+                <OrderSummaryPrice
+                    amount={surchargeFee.cost}
+                    label={<TranslatedString id="cart.surcharge_text" />}
+                    testId="cart-surcharge"
+                />
+            )}
+
+            {otherFees?.map((fee, index) => (
                 <OrderSummaryPrice
                     amount={fee.cost}
                     key={index}

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -77,6 +77,9 @@ import PaymentForm from './PaymentForm';
 import { getUniquePaymentMethodId, PaymentMethodProviderType } from './paymentMethod';
 import { getFilteredPaymentMethodsWithDefault } from './paymentMethodFilters';
 
+// Must match SURCHARGE_FEE_NAME in the SDK surcharge handler.
+const SURCHARGE_FEE_NAME = 'corporate_card_surcharge';
+
 export interface PaymentProps {
     capabilities: Capabilities;
     errorLogger: ErrorLogger;
@@ -160,6 +163,7 @@ const Payment = (
 
     const isReadyRef = useRef(state.isReady);
     const grandTotalChangeUnsubscribe = useRef<() => void>();
+    const lastSurchargeTotalRef = useRef(0);
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
     // Set by the themeV2 billing form. Awaited before submitOrder so the order
@@ -637,10 +641,25 @@ const Payment = (
         }
     };
 
-    const handleCartTotalChange = async (): Promise<void> => {
+    const handleCartTotalChange = async (state?: CheckoutSelectors): Promise<void> => {
         const isReady = isReadyRef.current;
 
         if (!isReady) {
+            return;
+        }
+
+        // If the total change was caused by applying the
+        // surcharge fee, skip reloading payment methods. Reloading re-initialises the hosted
+        // (iframe) card fields and clears the card the shopper just entered. A real cart
+        // change (coupon/shipping) leaves the surcharge total unchanged and reloads as usual.
+        const checkout = state?.data.getCheckout();
+        const surchargeTotal = (checkout?.fees ?? [])
+            .filter((fee) => fee.name === SURCHARGE_FEE_NAME)
+            .reduce((sum, fee) => sum + fee.cost, 0);
+
+        if (surchargeTotal !== lastSurchargeTotalRef.current) {
+            lastSurchargeTotalRef.current = surchargeTotal;
+
             return;
         }
 
@@ -724,7 +743,11 @@ const Payment = (
             }
 
             grandTotalChangeUnsubscribe.current = checkoutServiceSubscribe(
-                () => handleCartTotalChange(),
+                // Pass state so we can detect a
+                // surcharge-driven total change and skip the payment-methods reload.
+                (state) => {
+                    void handleCartTotalChange(state);
+                },
                 ({ data }) => data.getCheckout()?.grandTotal,
                 ({ data }) => data.getCheckout()?.outstandingBalance,
             );

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -71,6 +71,7 @@
             "free_text": "Free",
             "gift_certificate_text": "Gift Certificate",
             "handling_text": "Handling",
+            "surcharge_text": "Surcharge",
             "item": "item",
             "items": "items",
             "item_count_text": "{count, plural, one{1 Item} other{# Items} }",


### PR DESCRIPTION
## What/Why?

Displays the card surcharge as a dedicated line in the order summary, and prevents the payment step from re-initialising the hosted (iframe) card fields when the surcharge changes the total - so the shopper's entered card is not cleared.

**Order summary** (OrderSummarySubtotals.tsx + coupon/NewOrderSummarySubtotals.tsx): render a dedicated "Surcharge" row (from Checkout.fees, detected by name 'corporate_card_surcharge'), alongside shipping/handling; other fees keep the existing generic loop.
**Payment.tsx**: handleCartTotalChange now receives checkout state and skips loadPaymentMethods when the total change is caused by the surcharge fee. This avoids re-initialising the Adyen/Bluesnap hosted fields (which would wipe the card). A real cart change (coupon/shipping) still reloads as before.
**Locale**: cart.surcharge_text ("Surcharge").

## Rollout/Rollback

This is just POC, do not merge

## Testing

https://github.com/user-attachments/assets/6196a766-9d87-4a3d-a309-ec6fc4bcc426


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment-step behavior on total changes is security- and conversion-sensitive; skipping payment-method reload when only surcharge fees change could miss updates if totals shift for other reasons at the same time, though the POC is gated on backend fees not yet shipped.
> 
> **Overview**
> **POC for corporate card surcharging** (Adyen/Bluesnap): surfaces the fee in the cart and stops payment from tearing down hosted card iframes when only the surcharge total moves.
> 
> Order summary components (`OrderSummarySubtotals`, `NewOrderSummarySubtotals`) now pull the fee named `corporate_card_surcharge` out of `Checkout.fees` and render a dedicated **Surcharge** row (`cart.surcharge_text`); remaining fees still use the generic fee loop. Comments note the row stays hidden until the backend Fees API supplies that fee and includes it in `outstandingBalance` (`withRedeemable` documents the same assumption).
> 
> On **Payment**, `handleCartTotalChange` receives checkout state from the grand-total subscription. If the aggregate surcharge fee amount changed, it updates a ref and **skips** `loadPaymentMethods` so Adyen/Bluesnap hosted fields are not re-initialized and the shopper’s card entry is preserved. Coupon/shipping-driven total changes still reload payment methods as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f96f5336e373624e56513124f0f730094217017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->