### PR TITLE
feat(checkout): CHECKOUT-10223 Delete Invoice Checkout

### DIFF
--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -44,7 +44,9 @@ import Checkout, { type CheckoutProps } from './Checkout';
 
 describe('Checkout', () => {
     let checkout: CheckoutPageNodeObject;
-    let CheckoutTest: FunctionComponent<CheckoutProps>;
+    let CheckoutTest: FunctionComponent<
+        CheckoutProps & { capabilities?: typeof defaultCapabilities }
+    >;
     let checkoutService: CheckoutService;
     let extensionService: ExtensionServiceInterface;
     let defaultProps: CheckoutProps & AnalyticsContextProps;
@@ -101,7 +103,7 @@ describe('Checkout', () => {
 
         jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
 
-        CheckoutTest = (props) => (
+        CheckoutTest = ({ capabilities, ...props }) => (
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleProvider
                     checkoutService={checkoutService}
@@ -110,7 +112,13 @@ describe('Checkout', () => {
                     <AnalyticsProviderMock>
                         <ExtensionProvider extensionService={extensionService}>
                             <ThemeProvider>
-                                <Checkout {...props} />
+                                {capabilities ? (
+                                    <CapabilitiesContext.Provider value={capabilities}>
+                                        <Checkout {...props} />
+                                    </CapabilitiesContext.Provider>
+                                ) : (
+                                    <Checkout {...props} />
+                                )}
                             </ThemeProvider>
                         </ExtensionProvider>
                     </AnalyticsProviderMock>
@@ -635,28 +643,9 @@ describe('Checkout', () => {
                     },
                 };
 
-                const CheckoutWithInvoiceRedirect: FunctionComponent<CheckoutProps> = (props) => (
-                    <CheckoutProvider checkoutService={checkoutService}>
-                        <LocaleProvider
-                            checkoutService={checkoutService}
-                            languageService={getLanguageService()}
-                        >
-                            <AnalyticsProviderMock>
-                                <ExtensionProvider extensionService={extensionService}>
-                                    <ThemeProvider>
-                                        <CapabilitiesContext.Provider
-                                            value={invoiceRedirectCapabilities}
-                                        >
-                                            <Checkout {...props} />
-                                        </CapabilitiesContext.Provider>
-                                    </ThemeProvider>
-                                </ExtensionProvider>
-                            </AnalyticsProviderMock>
-                        </LocaleProvider>
-                    </CheckoutProvider>
+                render(
+                    <CheckoutTest {...defaultProps} capabilities={invoiceRedirectCapabilities} />,
                 );
-
-                render(<CheckoutWithInvoiceRedirect {...defaultProps} />);
 
                 await checkout.waitForPaymentStep();
 
@@ -674,6 +663,64 @@ describe('Checkout', () => {
                     writable: true,
                 });
             }
+        });
+    });
+
+    describe('cart deletion on exit', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutService, 'deleteCheckout').mockResolvedValue({} as any);
+        });
+
+        it('deletes cart on page exit when invoiceRedirect capability is enabled', async () => {
+            render(
+                <CheckoutTest
+                    {...defaultProps}
+                    capabilities={{
+                        ...defaultCapabilities,
+                        orderConfirmation: {
+                            ...defaultCapabilities.orderConfirmation,
+                            invoiceRedirect: true,
+                        },
+                    }}
+                />,
+            );
+
+            await checkout.waitForCustomerStep();
+
+            window.dispatchEvent(new Event('beforeunload'));
+
+            expect(checkoutService.deleteCheckout).toHaveBeenCalled();
+        });
+
+        it('deletes cart on page exit when quote config is present', async () => {
+            render(
+                <CheckoutTest
+                    {...defaultProps}
+                    capabilities={{
+                        ...defaultCapabilities,
+                        userJourney: {
+                            ...defaultCapabilities.userJourney,
+                            quoteConfig: { id: 1 },
+                        },
+                    }}
+                />,
+            );
+
+            await checkout.waitForCustomerStep();
+
+            window.dispatchEvent(new Event('beforeunload'));
+
+            expect(checkoutService.deleteCheckout).toHaveBeenCalled();
+        });
+
+        it('does not delete cart on page exit when neither quote config nor invoiceRedirect is enabled', async () => {
+            render(<CheckoutTest {...defaultProps} capabilities={defaultCapabilities} />);
+
+            await checkout.waitForCustomerStep();
+
+            window.dispatchEvent(new Event('beforeunload'));
+
+            expect(checkoutService.deleteCheckout).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -167,7 +167,7 @@ const Checkout = ({
     });
 
     useEffect(() => {
-        if (quoteConfig?.id) {
+        if (quoteConfig?.id || invoiceRedirect) {
             return deleteCartOnExit(checkoutService);
         }
     }, []);


### PR DESCRIPTION
## What/Why?

We should delete invoice cart upon exiting checkout as a product decision.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends exit-time cart deletion to invoice flows; mistaken triggers could delete carts shoppers did not intend to abandon, though behavior mirrors existing quote checkout.
> 
> **Overview**
> **Invoice checkout carts are now removed when the shopper leaves checkout**, matching the existing quote-checkout behavior.
> 
> `CheckoutPage` registers `deleteCartOnExit` when **`orderConfirmation.invoiceRedirect`** is enabled, not only when a **quote config** is present. That hook calls `checkoutService.deleteCheckout` on `beforeunload` / `pagehide` (unless an order was placed or is submitting).
> 
> Tests pass capabilities through an updated **`CheckoutTest`** helper and add coverage for invoice redirect, quote config, and the case where neither flag is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3ac7fd29c2a183a1efad8f4e5cf434d9e0af9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->