### PR TITLE
fix(checkout): CHECKOUT-10225 Enable Floating Fields for Extra Fields

### DIFF
--- a/packages/cheque-payment-integration/src/ChequePaymentMethod.tsx
+++ b/packages/cheque-payment-integration/src/ChequePaymentMethod.tsx
@@ -12,6 +12,7 @@ import PoNumber from './PoNumber';
 const ChequePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     method,
     checkoutService,
+    checkoutState,
     onUnhandledError,
     paymentForm,
     language,
@@ -19,6 +20,10 @@ const ChequePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const {
         payment: { poConfig },
     } = useCapabilities();
+    const isFloatingLabelEnabled = Boolean(
+        checkoutState.data.getConfig()?.checkoutSettings.checkoutUserExperienceSettings
+            .floatingLabelEnabled,
+    );
 
     useEffect(() => {
         const initializePayment = async () => {
@@ -58,6 +63,7 @@ const ChequePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     if (poConfig?.field) {
         return (
             <PoNumber
+                isFloatingLabelEnabled={isFloatingLabelEnabled}
                 isRequired={poConfig.field.required}
                 label={poConfig.field.label}
                 language={language}

--- a/packages/cheque-payment-integration/src/PoNumber.tsx
+++ b/packages/cheque-payment-integration/src/PoNumber.tsx
@@ -14,6 +14,7 @@ import './PoNumber.scss';
 export interface PoNumberProps {
     label: string;
     isRequired: boolean;
+    isFloatingLabelEnabled?: boolean;
     method: PaymentMethod;
     language: LanguageService;
     paymentForm: PaymentFormService;
@@ -24,6 +25,7 @@ export const PO_NUMBER_FIELD_NAME = 'poNumber';
 const PoNumber: FunctionComponent<PoNumberProps> = ({
     label,
     isRequired,
+    isFloatingLabelEnabled,
     method,
     language,
     paymentForm: { setFieldValue, setValidationSchema },
@@ -43,8 +45,10 @@ const PoNumber: FunctionComponent<PoNumberProps> = ({
                 {...field}
                 aria-labelledby={`${PO_NUMBER_FIELD_NAME}-label ${PO_NUMBER_FIELD_NAME}-field-error-message`}
                 id={PO_NUMBER_FIELD_NAME}
+                isFloatingLabelEnabled={isFloatingLabelEnabled}
             />
         ),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [],
     );
 
@@ -52,22 +56,40 @@ const PoNumber: FunctionComponent<PoNumberProps> = ({
         <div className="po-number-container">
             <FormField
                 input={renderInput}
+                isFloatingLabelEnabled={isFloatingLabelEnabled}
                 label={
-                    <Legend>
-                        <label
-                            className="po-number-label"
-                            htmlFor={PO_NUMBER_FIELD_NAME}
-                            id={`${PO_NUMBER_FIELD_NAME}-label`}
-                        >
-                            <span>{label}</span>
+                    isFloatingLabelEnabled ? undefined : (
+                        <Legend>
+                            <label
+                                className="po-number-label"
+                                htmlFor={PO_NUMBER_FIELD_NAME}
+                                id={`${PO_NUMBER_FIELD_NAME}-label`}
+                            >
+                                <span>{label}</span>
+                                {!isRequired && (
+                                    <span>
+                                        {' '}
+                                        <TranslatedString id="common.optional_text" />
+                                    </span>
+                                )}
+                            </label>
+                        </Legend>
+                    )
+                }
+                labelContent={
+                    isFloatingLabelEnabled ? (
+                        <>
+                            {label}
                             {!isRequired && (
-                                <span>
+                                <>
                                     {' '}
-                                    <TranslatedString id="common.optional_text" />
-                                </span>
+                                    <small>
+                                        <TranslatedString id="common.optional_text" />
+                                    </small>
+                                </>
                             )}
-                        </label>
-                    </Legend>
+                        </>
+                    ) : undefined
                 }
                 name={PO_NUMBER_FIELD_NAME}
             />

--- a/packages/core/src/app/payment/AdditionalPaymentField.tsx
+++ b/packages/core/src/app/payment/AdditionalPaymentField.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { type FieldProps } from 'formik';
 import React, { type FunctionComponent, useCallback } from 'react';
 
@@ -7,17 +8,20 @@ import { FormField, TextInput } from '@bigcommerce/checkout/ui';
 interface AdditionalPaymentFieldProps {
     label: string;
     isRequired: boolean;
+    isFloatingLabelEnabled?: boolean;
 }
 
 const AdditionalPaymentField: FunctionComponent<AdditionalPaymentFieldProps> = ({
     label,
     isRequired,
+    isFloatingLabelEnabled,
 }) => {
     const renderInput = useCallback(
         ({ field }: FieldProps<string>) => (
             <TextInput
                 {...field}
                 id="additionalPaymentField"
+                isFloatingLabelEnabled={isFloatingLabelEnabled}
                 testId="additionalPaymentField-input"
             />
         ),
@@ -25,10 +29,15 @@ const AdditionalPaymentField: FunctionComponent<AdditionalPaymentFieldProps> = (
     );
 
     return (
-        <div className="dynamic-form-field">
+        <div
+            className={classNames('dynamic-form-field', {
+                'floating-form-field': isFloatingLabelEnabled,
+            })}
+        >
             <FormField
                 id="additionalPaymentField"
                 input={renderInput}
+                isFloatingLabelEnabled={isFloatingLabelEnabled}
                 labelContent={
                     <>
                         {label}

--- a/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
+++ b/packages/core/src/app/payment/InvoicePaymentCommentField.tsx
@@ -1,15 +1,23 @@
+import classNames from 'classnames';
 import { type FieldProps } from 'formik';
 import React, { type FunctionComponent, useCallback } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { FormField, TextArea } from '@bigcommerce/checkout/ui';
 
-const InvoicePaymentCommentField: FunctionComponent = () => {
+interface InvoicePaymentCommentFieldProps {
+    isFloatingLabelEnabled?: boolean;
+}
+
+const InvoicePaymentCommentField: FunctionComponent<InvoicePaymentCommentFieldProps> = ({
+    isFloatingLabelEnabled,
+}) => {
     const renderInput = useCallback(
         ({ field }: FieldProps<string>) => (
             <TextArea
                 {...field}
                 id="invoicePaymentComment"
+                isFloatingLabelEnabled={isFloatingLabelEnabled}
                 rows={4}
                 testId="invoicePaymentComment-input"
             />
@@ -18,10 +26,15 @@ const InvoicePaymentCommentField: FunctionComponent = () => {
     );
 
     return (
-        <div className="dynamic-form-field">
+        <div
+            className={classNames('dynamic-form-field', {
+                'floating-form-field': isFloatingLabelEnabled,
+            })}
+        >
             <FormField
                 id="invoicePaymentComment"
                 input={renderInput}
+                isFloatingLabelEnabled={isFloatingLabelEnabled}
                 labelContent={<TranslatedString id="payment.invoice_payment_comment_label" />}
                 name="invoicePaymentComment"
             />

--- a/packages/core/src/app/payment/PaymentForm.scss
+++ b/packages/core/src/app/payment/PaymentForm.scss
@@ -1,0 +1,7 @@
+@import "../../scss/Base";
+
+.checkout-step--payment {
+    .dynamic-form-field.floating-form-field {
+        margin-bottom: $floating-form-field-spacing;
+    }
+}

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -21,7 +21,7 @@ import { Fieldset, Form, FormContext, Legend } from '@bigcommerce/checkout/ui';
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { getTranslateAddressError } from '../address';
-import { isExperimentEnabled } from '../common/utility';
+import { isExperimentEnabled, isFloatingLabelEnabled } from '../common/utility';
 import { getOrderExtraFieldsValidationSchema } from '../formFields';
 import { TermsConditions } from '../termsConditions';
 
@@ -43,6 +43,8 @@ import PaymentSubmitButton from './PaymentSubmitButton';
 import { ProvidersSectionOnTopOfPaymentsList } from './ProvidersSectionOnTopOfPaymentsList';
 import SpamProtectionField from './SpamProtectionField';
 import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
+
+import './PaymentForm.scss';
 
 export interface PaymentFormProps {
     additionalField?: Capabilities['payment']['additionalField'];
@@ -138,6 +140,9 @@ const PaymentForm: FunctionComponent<
         payment: { invoicePaymentComment },
     } = useCapabilities();
     const { checkoutSettings } = config ?? {};
+    const isFloatingLabelEnabledValue = checkoutSettings
+        ? isFloatingLabelEnabled(checkoutSettings)
+        : false;
     const poMethodDisabledReason = usePoMethodDisabledReason(selectedMethod);
     const isSubmitDisabled = shouldDisableSubmit || Boolean(poMethodDisabledReason);
     const shouldShowSubmitButtonWhenPaymentNotRequired = isExperimentEnabled(
@@ -211,6 +216,7 @@ const PaymentForm: FunctionComponent<
 
             {additionalField && (
                 <AdditionalPaymentField
+                    isFloatingLabelEnabled={isFloatingLabelEnabledValue}
                     isRequired={additionalField.required}
                     label={additionalField.label}
                 />
@@ -224,10 +230,15 @@ const PaymentForm: FunctionComponent<
             )}
 
             {orderExtraFields && orderExtraFields.length > 0 && (
-                <OrderExtraFieldsFieldset formFields={orderExtraFields} />
+                <OrderExtraFieldsFieldset
+                    formFields={orderExtraFields}
+                    isFloatingLabelEnabled={isFloatingLabelEnabledValue}
+                />
             )}
 
-            {invoicePaymentComment && <InvoicePaymentCommentField />}
+            {invoicePaymentComment && (
+                <InvoicePaymentCommentField isFloatingLabelEnabled={isFloatingLabelEnabledValue} />
+            )}
 
             <div className="form-actions">
                 {hideSubmitPaymentButton ? (

--- a/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.tsx
+++ b/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.tsx
@@ -5,10 +5,12 @@ import { DynamicFormField } from '@bigcommerce/checkout/ui';
 
 interface OrderExtraFieldsFieldsetProps {
     formFields: FormField[];
+    isFloatingLabelEnabled?: boolean;
 }
 
 const OrderExtraFieldsFieldset: FunctionComponent<OrderExtraFieldsFieldsetProps> = ({
     formFields,
+    isFloatingLabelEnabled,
 }) => {
     const extraFields = formFields.filter((field) => isExtraField(field));
 
@@ -21,6 +23,7 @@ const OrderExtraFieldsFieldset: FunctionComponent<OrderExtraFieldsFieldsetProps>
             {extraFields.map((field) => (
                 <DynamicFormField
                     field={field}
+                    isFloatingLabelEnabled={isFloatingLabelEnabled}
                     key={`${field.id}-${field.name}`}
                     label={field.label}
                     parentFieldName="orderExtraFields"


### PR DESCRIPTION
## What/Why?

Enable floating labels setting for order extra field, reference number, and payment comment in the payment step.

## Rollout/Rollback

Revert.

## Testing
### When floating label setting is on
<img width="715" height="765" alt="image" src="https://github.com/user-attachments/assets/48a748c2-ddd1-444d-ad59-8a09b2a0db31" />

### When floating label setting is off
<img width="715" height="794" alt="image" src="https://github.com/user-attachments/assets/47f49c00-8265-4dde-8c6d-03c088671a0f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes gated by an existing checkout UX flag; no payment or validation logic changes.
> 
> **Overview**
> When **floating labels** are enabled in checkout settings, the payment step now uses the same floating-label pattern for fields that were still on the legacy layout: **PO / reference number** (cheque), **additional payment field**, **invoice payment comment**, and **order extra fields**.
> 
> `PaymentForm` reads the setting via `isFloatingLabelEnabled` and passes it into those components; cheque integration reads it from `checkoutState` for `PoNumber`. Each field forwards `isFloatingLabelEnabled` to `FormField` / inputs and, where needed, switches between `Legend`+label vs `labelContent`, optional text in `<small>`, and a `floating-form-field` wrapper. **PaymentForm.scss** adds spacing for floating dynamic fields on the payment step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601fb7a140c87139180cd405ddc9b1d5ffc1d1b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->