### PR TITLE
fix(payment): CHECKOUT-9045 Show error with timeout if hosted form fails to load

### DIFF
--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.test.tsx
@@ -171,6 +171,56 @@ describe('HostedCreditCardComponent', () => {
         expect(initializePayment.mock.calls[0][0]).toHaveProperty('creditCard');
     });
 
+    it('rejects with a timeout error when initializePayment never settles', async () => {
+        jest.useFakeTimers();
+
+        const initializePayment = jest.fn().mockReturnValue(new Promise(() => undefined));
+
+        renderWithoutWrapper(
+            <HostedCreditCardComponent
+                {...getDefaultProps({
+                    checkoutService: { initializePayment, deinitializePayment: jest.fn() },
+                })}
+            />,
+        );
+
+        const wrappedInitializePayment = (
+            jest.requireMock('@bigcommerce/checkout/credit-card-integration')
+                .CreditCardPaymentMethodComponent as jest.Mock
+        ).mock.calls.slice(-1)[0][0].initializePayment;
+
+        const assertion = expect(wrappedInitializePayment({}, undefined)).rejects.toThrow(
+            'payment.payment_method_unavailable_error',
+        );
+
+        await jest.advanceTimersByTimeAsync(30_000);
+        await assertion;
+
+        jest.useRealTimers();
+    });
+
+    it('does not leave a pending timer once initializePayment resolves', async () => {
+        jest.useFakeTimers();
+
+        const initializePayment = jest.fn().mockResolvedValue(undefined);
+
+        renderWithoutWrapper(
+            <HostedCreditCardComponent
+                {...getDefaultProps({
+                    checkoutService: { initializePayment, deinitializePayment: jest.fn() },
+                })}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('init-btn'));
+
+        await jest.runOnlyPendingTimersAsync();
+
+        expect(jest.getTimerCount()).toBe(0);
+
+        jest.useRealTimers();
+    });
+
     it('passes correct validation schemas to CreditCardPaymentMethodComponent', () => {
         renderWithoutWrapper(<HostedCreditCardComponent {...getDefaultProps()} />);
 

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -33,6 +33,18 @@ export interface HostedCreditCardComponentProps extends PaymentMethodProps {
     initializePayment?: CheckoutService['initializePayment'];
 }
 
+const HOSTED_FIELD_INIT_TIMEOUT_MS = 30000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, timeoutError: Error): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>;
+
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(timeoutError), ms);
+    });
+
+    return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer));
+}
+
 const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProps> = ({
     method,
     checkoutService,
@@ -258,7 +270,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     const initializeHostedCreditCardPayment: CreditCardPaymentMethodProps['initializePayment'] =
         useCallback(
             async (options, selectedInstrument) => {
-                return initializePayment({
+                const initializeOptions = {
                     ...options,
                     integrations: [
                         createCreditCardPaymentStrategy,
@@ -273,13 +285,24 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                             bigpayToken: selectedInstrument?.bigpayToken,
                         },
                     }),
-                });
+                };
+
+                if (!isHostedFormEnabled) {
+                    return initializePayment(initializeOptions);
+                }
+
+                return withTimeout(
+                    initializePayment(initializeOptions),
+                    HOSTED_FIELD_INIT_TIMEOUT_MS,
+                    new Error(language.translate('payment.payment_method_unavailable_error')),
+                );
             },
             [
                 getHostedFormOptions,
                 initializePayment,
                 isHostedFormEnabled,
                 isCBAMPGSResolverEnabled,
+                language,
             ],
         );
 


### PR DESCRIPTION
## What/Why?
Show error after a timeout if hosted form fails to load.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hosted credit card payment init path; behavior change is limited to slow/hung init with an existing user-facing error string and timer cleanup on success.
> 
> **Overview**
> When the hosted credit card form is enabled, **`initializePayment`** is now raced against a **30s** timeout so checkout does not hang indefinitely if the hosted fields never finish loading.
> 
> On timeout, initialization rejects with the existing **`payment.payment_method_unavailable_error`** message. The timeout is cleared when initialization succeeds or fails. Non-hosted flows are unchanged and still call **`initializePayment`** without the wrapper.
> 
> Tests cover timeout rejection (fake timers) and that no timer remains after a successful init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c159d4f349530036a31d6efa82a296e081f0492e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->