### PR TITLE
feat(checkout): CHECKOUT-10152 skip the standalone billing step for themeV2

### DIFF
--- a/packages/contexts/src/index.ts
+++ b/packages/contexts/src/index.ts
@@ -1,4 +1,4 @@
-export { useThemeContext, ThemeContext, ThemeProvider } from './theme';
+export { useThemeContext, ThemeContext, ThemeProvider, isThemeV2Enabled } from './theme';
 export {
     AnalyticsContext,
     AnalyticsProvider,

--- a/packages/contexts/src/theme/ThemeProvider.tsx
+++ b/packages/contexts/src/theme/ThemeProvider.tsx
@@ -2,6 +2,7 @@ import React, { type ReactNode } from 'react';
 
 import { useCheckout } from '../checkout';
 
+import { isThemeV2Enabled } from './isThemeV2Enabled';
 import ThemeContext from './ThemeContext';
 
 export interface ThemeProviderProps {
@@ -11,19 +12,7 @@ export interface ThemeProviderProps {
 export const ThemeProvider = ({ children }: ThemeProviderProps) => {
     const { selectedState: config } = useCheckout((state) => state.data.getConfig());
 
-    let themeV2 = false;
-
-    if (config?.checkoutSettings) {
-        const newThemeExperimentEnabled = Boolean(
-            config.checkoutSettings.features['CHECKOUT-7962.update_font_style_on_checkout_page'] ??
-                true,
-        );
-        const newThemeSettingEnabled = Boolean(
-            config.checkoutSettings.checkoutUserExperienceSettings.checkoutV2Theme ?? false,
-        );
-
-        themeV2 = newThemeSettingEnabled && newThemeExperimentEnabled;
-    }
+    const themeV2 = isThemeV2Enabled(config);
 
     return <ThemeContext.Provider value={{ themeV2 }}>{children}</ThemeContext.Provider>;
 };

--- a/packages/contexts/src/theme/index.ts
+++ b/packages/contexts/src/theme/index.ts
@@ -1,2 +1,3 @@
 export { default as ThemeContext, useThemeContext } from './ThemeContext';
 export { ThemeProvider } from './ThemeProvider';
+export { isThemeV2Enabled } from './isThemeV2Enabled';

--- a/packages/contexts/src/theme/isThemeV2Enabled.ts
+++ b/packages/contexts/src/theme/isThemeV2Enabled.ts
@@ -1,0 +1,17 @@
+import { type StoreConfig } from '@bigcommerce/checkout-sdk/essential';
+
+export const isThemeV2Enabled = (config?: StoreConfig): boolean => {
+    if (!config?.checkoutSettings) {
+        return false;
+    }
+
+    const newThemeExperimentEnabled = Boolean(
+        config.checkoutSettings.features['CHECKOUT-7962.update_font_style_on_checkout_page'] ??
+            true,
+    );
+    const newThemeSettingEnabled = Boolean(
+        config.checkoutSettings.checkoutUserExperienceSettings.checkoutV2Theme ?? false,
+    );
+
+    return newThemeSettingEnabled && newThemeExperimentEnabled;
+};

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -421,13 +421,13 @@ const Checkout = ({
         (isBillingSameAsShipping: boolean): void => {
             setState((prev) => ({ ...prev, isBillingSameAsShipping }));
 
-            if (isBillingSameAsShipping) {
+            if (isBillingSameAsShipping || themeV2) {
                 navigateToNextIncompleteStep();
             } else {
                 navigateToStep(CheckoutStepType.Billing);
             }
         },
-        [navigateToNextIncompleteStep, navigateToStep],
+        [navigateToNextIncompleteStep, navigateToStep, themeV2],
     );
 
     const handleBillingSameAsShippingChange = useCallback(

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.test.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.test.ts
@@ -480,6 +480,49 @@ describe('getCheckoutStepStatuses()', () => {
         ]);
     });
 
+    describe('themeV2 (billing captured on the payment step)', () => {
+        const getThemeV2Config = () => ({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                features: {
+                    ...getStoreConfig().checkoutSettings.features,
+                    'CHECKOUT-7962.update_font_style_on_checkout_page': true,
+                },
+                checkoutUserExperienceSettings: {
+                    ...getStoreConfig().checkoutSettings.checkoutUserExperienceSettings,
+                    checkoutV2Theme: true,
+                },
+            },
+        });
+
+        beforeEach(() => {
+            jest.spyOn(state.data, 'getConfig').mockReturnValue(getThemeV2Config());
+        });
+
+        it('omits the standalone billing step', () => {
+            expect(
+                find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Billing }),
+            ).toBeUndefined();
+        });
+
+        it('returns the remaining steps in order without billing', () => {
+            expect(getCheckoutStepStatuses(state).map((step) => step.type)).toEqual([
+                CheckoutStepType.Customer,
+                CheckoutStepType.Shipping,
+                CheckoutStepType.Payment,
+            ]);
+        });
+
+        it('still omits the billing step when a wallet payment (e.g. Amazon Pay) is present', () => {
+            jest.spyOn(state.data, 'getCheckout').mockReturnValue(getCheckoutWithPayments());
+
+            expect(
+                find(getCheckoutStepStatuses(state), { type: CheckoutStepType.Billing }),
+            ).toBeUndefined();
+        });
+    });
+
     it('marks latter steps as non-editable if earlier steps are incomplete', () => {
         jest.spyOn(state.data, 'getShippingAddress').mockReturnValue(undefined);
 

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -2,6 +2,7 @@ import { type CheckoutPayment, type CheckoutSelectors } from '@bigcommerce/check
 import { compact } from 'lodash';
 import { createSelector } from 'reselect';
 
+import { isThemeV2Enabled } from '@bigcommerce/checkout/contexts';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 
 import { isValidAddress } from '../address';
@@ -96,7 +97,11 @@ const getBillingStepStatus = createSelector(
             : EMPTY_ARRAY;
     },
     ({ data }: CheckoutSelectors) => data.getConfig(),
-    (checkout, billingAddress, billingAddressFields) => {
+    (checkout, billingAddress, billingAddressFields, config) => {
+        if (isThemeV2Enabled(config)) {
+            return undefined;
+        }
+
         const hasAddress = billingAddress
             ? isValidAddress(billingAddress, billingAddressFields)
             : false;


### PR DESCRIPTION
## What/Why?

For enhanced checkout theme, skip the standalone billing step since for themV2 the billing step stays in Payment block.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**Enhanced theme setting OFF**

https://github.com/user-attachments/assets/256c5f80-5bc4-4386-be3d-893b5e7d285e



**Enhanced theme setting ON**

https://github.com/user-attachments/assets/7ab03a7a-12fb-4b32-b6da-24cab9d7bb1b



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core checkout step order and post-shipping navigation; mis-gating themeV2 could skip billing or show the wrong flow for some stores.
> 
> **Overview**
> For **themeV2** checkouts, billing is collected on the payment step instead of a separate step. This PR wires that into step configuration and navigation.
> 
> **`isThemeV2Enabled`** is extracted from `ThemeProvider` into a shared helper (same experiment + `checkoutV2Theme` flags) and exported from `@bigcommerce/checkout/contexts`. **`getCheckoutStepStatuses`** uses it so the billing step is omitted when themeV2 is on, including with wallet payments. **`CheckoutPage`** advances past shipping straight to the next incomplete step when `themeV2` is true, even if billing is not “same as shipping.” Tests cover the shortened step list (Customer → Shipping → Payment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1349cefac6e082f56a5a23a081d3128332bfcbae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->