### PR TITLE
feat(checkout): CHECKOUT-10226 Show Placeholder for Extra Dropdown Field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.939.0",
+        "@bigcommerce/checkout-sdk": "^1.942.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.939.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.939.0.tgz",
-      "integrity": "sha512-78RKEfBwt/oQaQJBkFdqNJwJTTKY26WIDcb6oTayAP9Tl9FI9M3awl6CQCFqTJX4JR24xP3n51M5GpKdTxF8Dg==",
+      "version": "1.942.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.2.tgz",
+      "integrity": "sha512-YKR5qtIddKF2yxYtZlHFj09n79plUmasRVJMxW33HzBYUDW6aVSYKsnFRn17acFS4NSgTusEwovKqR2yzhr1qg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29814,9 +29814,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.939.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.939.0.tgz",
-      "integrity": "sha512-78RKEfBwt/oQaQJBkFdqNJwJTTKY26WIDcb6oTayAP9Tl9FI9M3awl6CQCFqTJX4JR24xP3n51M5GpKdTxF8Dg==",
+      "version": "1.942.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.2.tgz",
+      "integrity": "sha512-YKR5qtIddKF2yxYtZlHFj09n79plUmasRVJMxW33HzBYUDW6aVSYKsnFRn17acFS4NSgTusEwovKqR2yzhr1qg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.939.0",
+    "@bigcommerce/checkout-sdk": "^1.942.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/address/AddressForm.test.tsx
+++ b/packages/core/src/app/address/AddressForm.test.tsx
@@ -92,6 +92,42 @@ describe('AddressForm Component', () => {
         expect(screen.getByTestId('google-autocomplete-form-field')).toBeInTheDocument();
     });
 
+    it('renders translated placeholder as first option of extra dropdown field', () => {
+        const extraDropdownField = {
+            custom: false,
+            default: '',
+            id: 'b2bExtraField_1',
+            label: 'Extra Dropdown Field',
+            name: 'b2bExtraField_1',
+            required: false,
+            fieldType: 'dropdown',
+            type: 'string',
+            options: {
+                items: [
+                    { value: 'option1', label: 'Option 1' },
+                    { value: 'option2', label: 'Option 2' },
+                ],
+            },
+        } as FormField;
+
+        renderAddressFormComponent({
+            formFields: [...formFields, extraDropdownField],
+        });
+
+        const placeholderOption = screen.getByRole('option', { name: 'Please Select' });
+
+        expect(placeholderOption).toBeInTheDocument();
+        expect(placeholderOption).toHaveValue('');
+        expect(screen.getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+    });
+
+    it('does not render placeholder for custom dropdown field', () => {
+        renderAddressFormComponent({ formFields });
+
+        expect(screen.getByText('Custom dropdown')).toBeInTheDocument();
+        expect(screen.queryByText('Please Select')).not.toBeInTheDocument();
+    });
+
     it('updates field with new value', async () => {
         const onChange = jest.fn();
         const fieldValue = 'test';

--- a/packages/core/src/app/address/AddressForm.test.tsx
+++ b/packages/core/src/app/address/AddressForm.test.tsx
@@ -121,13 +121,6 @@ describe('AddressForm Component', () => {
         expect(screen.getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
     });
 
-    it('does not render placeholder for custom dropdown field', () => {
-        renderAddressFormComponent({ formFields });
-
-        expect(screen.getByText('Custom dropdown')).toBeInTheDocument();
-        expect(screen.queryByText('Please Select')).not.toBeInTheDocument();
-    });
-
     it('updates field with new value', async () => {
         const onChange = jest.fn();
         const fieldValue = 'test';

--- a/packages/core/src/app/address/AddressForm.tsx
+++ b/packages/core/src/app/address/AddressForm.tsx
@@ -141,6 +141,10 @@ const AddressForm: React.FC<AddressFormProps> = ({
                 return field.default;
             }
 
+            if (isExtraField(field) && field.fieldType === DynamicFormFieldType.DROPDOWN) {
+                return language.translate('common.please_select_text');
+            }
+
             return translatedPlaceholderId && language.translate(translatedPlaceholderId);
         },
         [language],

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -978,7 +978,13 @@ describe('Payment step', () => {
                             ...orderResponse,
                             data: {
                                 ...orderResponse.data,
-                                b2bContext: { billingAddressId: 111, shippingAddressId: 222 },
+                                order: {
+                                    ...orderResponse.data.order,
+                                    b2bMetadata: {
+                                        billingAddressId: 111,
+                                        shippingAddressId: 222,
+                                    },
+                                },
                             },
                         }),
                     ),

--- a/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.test.tsx
+++ b/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.test.tsx
@@ -1,15 +1,18 @@
-import { createLanguageService, type FormField } from '@bigcommerce/checkout-sdk';
+import { type FormField } from '@bigcommerce/checkout-sdk';
 import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
 
 import { LocaleContext, type LocaleContextType } from '@bigcommerce/checkout/contexts';
+import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
+
+import { getStoreConfig } from '../../config/config.mock';
 
 import OrderExtraFieldsFieldset from './OrderExtraFieldsFieldset';
 
 describe('OrderExtraFieldsFieldset', () => {
-    const localeContext: LocaleContextType = { language: createLanguageService() };
+    const localeContext: LocaleContextType = createLocaleContext(getStoreConfig());
 
     const extraField: FormField = {
         custom: false,
@@ -42,6 +45,23 @@ describe('OrderExtraFieldsFieldset', () => {
         required: true,
         fieldType: 'text',
         type: 'string',
+    } as FormField;
+
+    const dropdownExtraField: FormField = {
+        custom: false,
+        default: '',
+        id: 'b2bExtraField_300',
+        label: 'Shipping Priority',
+        name: 'b2bExtraField_300',
+        required: true,
+        fieldType: 'dropdown',
+        type: 'string',
+        options: {
+            items: [
+                { value: 'high', label: 'High' },
+                { value: 'low', label: 'Low' },
+            ],
+        },
     } as FormField;
 
     const renderFieldset = (formFields: FormField[]) =>
@@ -78,5 +98,21 @@ describe('OrderExtraFieldsFieldset', () => {
         renderFieldset([]);
 
         expect(screen.queryByTestId('order-extra-fields')).not.toBeInTheDocument();
+    });
+
+    it('renders translated placeholder as first option of dropdown extra field', () => {
+        renderFieldset([dropdownExtraField]);
+
+        const options = screen.getAllByRole('option');
+
+        expect(options[0]).toHaveTextContent('Please Select');
+        expect(options[0]).toHaveValue('');
+        expect(options).toHaveLength(3);
+    });
+
+    it('does not render placeholder for non-dropdown extra fields', () => {
+        renderFieldset([extraField]);
+
+        expect(screen.queryByText('Please Select')).not.toBeInTheDocument();
     });
 });

--- a/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.tsx
+++ b/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.tsx
@@ -1,7 +1,8 @@
 import { type FormField, isExtraField } from '@bigcommerce/checkout-sdk/essential';
 import React, { type FunctionComponent } from 'react';
 
-import { DynamicFormField } from '@bigcommerce/checkout/ui';
+import { useLocale } from '@bigcommerce/checkout/contexts';
+import { DynamicFormField, DynamicFormFieldType } from '@bigcommerce/checkout/ui';
 
 interface OrderExtraFieldsFieldsetProps {
     formFields: FormField[];
@@ -12,6 +13,7 @@ const OrderExtraFieldsFieldset: FunctionComponent<OrderExtraFieldsFieldsetProps>
     formFields,
     isFloatingLabelEnabled,
 }) => {
+    const { language } = useLocale();
     const extraFields = formFields.filter((field) => isExtraField(field));
 
     if (extraFields.length === 0) {
@@ -27,6 +29,11 @@ const OrderExtraFieldsFieldset: FunctionComponent<OrderExtraFieldsFieldsetProps>
                     key={`${field.id}-${field.name}`}
                     label={field.label}
                     parentFieldName="orderExtraFields"
+                    placeholder={
+                        field.fieldType === DynamicFormFieldType.DROPDOWN
+                            ? language.translate('common.please_select_text')
+                            : undefined
+                    }
                 />
             ))}
         </div>

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -120,6 +120,7 @@
             "error_code": "Error code:",
             "request_id": "Request ID:",
             "optional_text": "(Optional)",
+            "please_select_text": "Please Select",
             "unavailable_error": "Checkout is temporarily unavailable. Please try again later.",
             "unavailable_heading": "Checkout is temporarily unavailable",
             "unstable_network_error": "It looks like the server is taking too long to respond, this can be caused by either poor connectivity or an error with our servers. Please try again in a while.",


### PR DESCRIPTION
## What/Why?

Add a clear placeholder to help users select an option from the extra-field dropdown.

## Rollout/Rollback

Revert.

## Testing

### Existing B2B checkout
<img width="499" height="66" alt="Screenshot 2026-07-16 at 14 54 49" src="https://github.com/user-attachments/assets/260ae73a-abf7-44b3-abda-1c8a5cdb47b4" />

### New Extra Dropdown Field on OOPC
#### Address
<img width="542" height="382" alt="Screenshot 2026-07-16 at 15 15 16" src="https://github.com/user-attachments/assets/2192f126-b781-4940-8471-28d68ea3a1db" />

#### Order
<img width="519" height="153" alt="Screenshot 2026-07-16 at 14 59 09" src="https://github.com/user-attachments/assets/615df4f5-1770-4460-a262-f8e8cb373db2" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only placeholder behavior for B2B dropdowns plus a dependency bump; the payment test change aligns with SDK response shape and does not alter production payment logic in this diff.
> 
> **Overview**
> Adds a localized **"Please Select"** first option for B2B **extra-field dropdowns** on address forms and order extra fields at payment, via `common.please_select_text` and `DynamicFormField` placeholders in `AddressForm` and `OrderExtraFieldsFieldset`.
> 
> Bumps **`@bigcommerce/checkout-sdk`** to `^1.942.2` and updates a payment integration test mock so order-submit responses expose B2B address IDs under **`order.b2bMetadata`** instead of **`b2bContext`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b78e2066496fab56c3cf2db1ee72af01b0598771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->