### PR TITLE
feat(checkout): CHECKOUT-10152 add new useBilling hook 

### DIFF
--- a/packages/core/src/app/billing/Billing.tsx
+++ b/packages/core/src/app/billing/Billing.tsx
@@ -1,19 +1,13 @@
-import type { CheckoutSelectors, FormField } from '@bigcommerce/checkout-sdk';
-import React, { type ReactElement, useCallback, useEffect, useState } from 'react';
+import type { CheckoutSelectors } from '@bigcommerce/checkout-sdk';
+import React, { type ReactElement } from 'react';
 
-import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, Legend } from '@bigcommerce/checkout/ui';
 
-import {
-    AddressType,
-    isEqualAddress,
-    mapAddressFromFormValues,
-    setDefaultAddress,
-} from '../address';
+import { isEqualAddress, mapAddressFromFormValues } from '../address';
 
 import BillingForm, { type BillingFormValues } from './BillingForm';
-import getBillingMethodId from './getBillingMethodId';
+import { useBilling } from './hooks/useBilling';
 
 export interface BillingProps {
     navigateNextStep(): void;
@@ -21,76 +15,18 @@ export interface BillingProps {
     onUnhandledError(error: Error): void;
 }
 
-const getFieldsWithExtraFields = (
-    getBillingAddressFields: (countryCode: string) => FormField[],
-    hasAddressExtraFields: boolean,
-    getAddressExtraFields: () => FormField[],
-    countryCode?: string,
-) => {
-    const addressFields = getBillingAddressFields(countryCode || '');
-
-    if (!hasAddressExtraFields) {
-        return addressFields;
-    }
-
-    const addressExtraFields = getAddressExtraFields();
-
-    return [...addressFields, ...addressExtraFields];
-};
-
 const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps): ReactElement => {
     const {
-        selectedState: {
-            checkout,
-            config,
-            cart,
-            customer,
-            isLoadingBillingCountries,
-            getBillingAddressFields,
-            getAddressExtraFields,
-        },
-        // using getBillingAddress function to guarantee latest state inside of async function in useEffect
-        checkoutState: {
-            data: { getBillingAddress },
-        },
-        checkoutService,
-    } = useCheckout(({ data, statuses }) => ({
-        checkout: data.getCheckout(),
-        config: data.getConfig(),
-        cart: data.getCart(),
-        customer: data.getCustomer(),
-        billingAddress: data.getBillingAddress(),
-        isLoadingBillingCountries: statuses.isLoadingBillingCountries(),
-        getBillingAddressFields: data.getBillingAddressFields,
-        getAddressExtraFields: data.getAddressExtraFields,
-    }));
-    const {
-        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
-        billing: { restrictManualAddressEntry },
-    } = useCapabilities();
-
-    if (!config || !customer || !checkout || !cart) {
-        throw new Error('Unable to access checkout data');
-    }
-
-    const [isApplyingDefaultAddress, setIsApplyingDefaultAddress] = useState(true);
-    const isInitializing = isLoadingBillingCountries || isApplyingDefaultAddress;
-
-    // Below constants are for <BillingForm />'s HOC props
-    const customerMessage = checkout.customerMessage;
-    const methodId = getBillingMethodId(checkout);
-    const billingAddress = getBillingAddress();
-
-    const getFields = useCallback(
-        (countryCode?: string) =>
-            getFieldsWithExtraFields(
-                getBillingAddressFields,
-                hasAddressExtraFields,
-                getAddressExtraFields,
-                countryCode,
-            ),
-        [getBillingAddressFields, hasAddressExtraFields, getAddressExtraFields],
-    );
+        billingAddress,
+        customerMessage,
+        getBillingAddress,
+        getFields,
+        isInitializing,
+        methodId,
+        showNoAddressesWarning,
+        updateBillingAddress,
+        updateCheckout,
+    } = useBilling({ onReady, onUnhandledError });
 
     const handleSubmit = async ({
         orderComment,
@@ -101,11 +37,11 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
         const address = mapAddressFromFormValues(addressValues);
 
         if (address && !isEqualAddress(address, billingAddress)) {
-            promises.push(checkoutService.updateBillingAddress(address));
+            promises.push(updateBillingAddress(address));
         }
 
         if (customerMessage !== orderComment) {
-            promises.push(checkoutService.updateCheckout({ customerMessage: orderComment }));
+            promises.push(updateCheckout({ customerMessage: orderComment }));
         }
 
         try {
@@ -119,38 +55,7 @@ const Billing = ({ navigateNextStep, onReady, onUnhandledError }: BillingProps):
         }
     };
 
-    useEffect(() => {
-        const init = async () => {
-            try {
-                await checkoutService.loadBillingAddressFields();
-
-                if (hasCompanyAddressBook) {
-                    await setDefaultAddress({
-                        type: AddressType.Billing,
-                        currentAddress: getBillingAddress(),
-                        addresses: customer.addresses,
-                        updateAddress: checkoutService.updateBillingAddress,
-                    });
-                }
-
-                onReady();
-            } catch (error) {
-                if (error instanceof Error) {
-                    onUnhandledError(error);
-                }
-            } finally {
-                setIsApplyingDefaultAddress(false);
-            }
-        };
-
-        void init();
-    }, []);
-
-    // Show warning message when restrictManualAddressEntry is true and no addresses are available
-    const hasAddresses = customer?.addresses && customer.addresses.length > 0;
-    const showWarningMessage = restrictManualAddressEntry && !hasAddresses;
-
-    if (showWarningMessage) {
+    if (showNoAddressesWarning) {
         return (
             <div className="no-addresses-warning body-regular">
                 <TranslatedString id="billing.no_billing_addresses_warning" />

--- a/packages/core/src/app/billing/hooks/useBilling.ts
+++ b/packages/core/src/app/billing/hooks/useBilling.ts
@@ -1,0 +1,123 @@
+import { type FormField } from '@bigcommerce/checkout-sdk';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
+
+import { AddressType, setDefaultAddress } from '../../address';
+import getBillingMethodId from '../getBillingMethodId';
+
+const getFieldsWithExtraFields = (
+    getBillingAddressFields: (countryCode: string) => FormField[],
+    hasAddressExtraFields: boolean,
+    getAddressExtraFields: () => FormField[],
+    countryCode?: string,
+) => {
+    const addressFields = getBillingAddressFields(countryCode || '');
+
+    if (!hasAddressExtraFields) {
+        return addressFields;
+    }
+
+    const addressExtraFields = getAddressExtraFields();
+
+    return [...addressFields, ...addressExtraFields];
+};
+
+export interface UseBillingOptions {
+    onReady?(): void;
+    onUnhandledError(error: Error): void;
+}
+
+export const useBilling = ({ onReady, onUnhandledError }: UseBillingOptions) => {
+    const {
+        selectedState: {
+            checkout,
+            config,
+            customer,
+            isLoadingBillingCountries,
+            getBillingAddressFields,
+            getAddressExtraFields,
+        },
+        // using getBillingAddress function to guarantee latest state inside of async functions
+        checkoutState: {
+            data: { getBillingAddress, getShippingAddress },
+        },
+        checkoutService,
+    } = useCheckout(({ data, statuses }) => ({
+        checkout: data.getCheckout(),
+        config: data.getConfig(),
+        customer: data.getCustomer(),
+        isLoadingBillingCountries: statuses.isLoadingBillingCountries(),
+        getBillingAddressFields: data.getBillingAddressFields,
+        getAddressExtraFields: data.getAddressExtraFields,
+    }));
+    const {
+        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
+        billing: { restrictManualAddressEntry },
+    } = useCapabilities();
+
+    if (!config || !customer || !checkout) {
+        throw new Error('Unable to access checkout data');
+    }
+
+    const [isApplyingDefaultAddress, setIsApplyingDefaultAddress] = useState(true);
+    const isInitializing = isLoadingBillingCountries || isApplyingDefaultAddress;
+
+    const customerMessage = checkout.customerMessage;
+    const billingAddress = getBillingAddress();
+    const methodId = getBillingMethodId(checkout);
+
+    const hasAddresses = Boolean(customer.addresses && customer.addresses.length > 0);
+    const showNoAddressesWarning = restrictManualAddressEntry && !hasAddresses;
+
+    const getFields = useCallback(
+        (countryCode?: string) =>
+            getFieldsWithExtraFields(
+                getBillingAddressFields,
+                hasAddressExtraFields,
+                getAddressExtraFields,
+                countryCode,
+            ),
+        [getBillingAddressFields, hasAddressExtraFields, getAddressExtraFields],
+    );
+
+    useEffect(() => {
+        const init = async () => {
+            try {
+                await checkoutService.loadBillingAddressFields();
+
+                if (hasCompanyAddressBook) {
+                    await setDefaultAddress({
+                        type: AddressType.Billing,
+                        currentAddress: getBillingAddress(),
+                        addresses: customer.addresses,
+                        updateAddress: checkoutService.updateBillingAddress,
+                    });
+                }
+
+                onReady?.();
+            } catch (error) {
+                if (error instanceof Error) {
+                    onUnhandledError(error);
+                }
+            } finally {
+                setIsApplyingDefaultAddress(false);
+            }
+        };
+
+        void init();
+    }, []);
+
+    return {
+        billingAddress,
+        customerMessage,
+        getBillingAddress,
+        getFields,
+        getShippingAddress,
+        isInitializing,
+        methodId,
+        showNoAddressesWarning,
+        updateBillingAddress: checkoutService.updateBillingAddress,
+        updateCheckout: checkoutService.updateCheckout,
+    };
+};

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -1,17 +1,12 @@
-import type { CheckoutSelectors, FormField } from '@bigcommerce/checkout-sdk';
-import React, { type FunctionComponent, useCallback, useEffect, useState } from 'react';
+import type { CheckoutSelectors } from '@bigcommerce/checkout-sdk';
+import React, { type FunctionComponent } from 'react';
 
-import { useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, Legend } from '@bigcommerce/checkout/ui';
 
-import {
-    AddressType,
-    isEqualAddress,
-    mapAddressFromFormValues,
-    setDefaultAddress,
-} from '../../address';
+import { isEqualAddress, mapAddressFromFormValues } from '../../address';
 import { type BillingFormValues } from '../../billing/billingFormConfig';
+import { useBilling } from '../../billing/hooks/useBilling';
 
 import { PaymentBillingForm } from './PaymentBillingForm';
 
@@ -25,23 +20,6 @@ export interface PaymentBillingBlockProps {
     onUnhandledError(error: Error): void;
 }
 
-const getFieldsWithExtraFields = (
-    getBillingAddressFields: (countryCode: string) => FormField[],
-    hasAddressExtraFields: boolean,
-    getAddressExtraFields: () => FormField[],
-    countryCode?: string,
-) => {
-    const addressFields = getBillingAddressFields(countryCode || '');
-
-    if (!hasAddressExtraFields) {
-        return addressFields;
-    }
-
-    const addressExtraFields = getAddressExtraFields();
-
-    return [...addressFields, ...addressExtraFields];
-};
-
 export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = ({
     methodId,
     isBillingSameAsShipping,
@@ -49,43 +27,16 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
     onUnhandledError,
 }) => {
     const {
-        selectedState: {
-            checkout,
-            config,
-            customer,
-            isLoadingBillingCountries,
-            getBillingAddressFields,
-            getAddressExtraFields,
-        },
-        checkoutState: {
-            data: { getBillingAddress, getShippingAddress },
-        },
-        checkoutService,
-    } = useCheckout(({ data, statuses }) => ({
-        checkout: data.getCheckout(),
-        config: data.getConfig(),
-        customer: data.getCustomer(),
-        isLoadingBillingCountries: statuses.isLoadingBillingCountries(),
-        getBillingAddressFields: data.getBillingAddressFields,
-        getAddressExtraFields: data.getAddressExtraFields,
-    }));
-    const {
-        billing: { restrictManualAddressEntry },
-        userJourney: { hasAddressExtraFields, hasCompanyAddressBook },
-    } = useCapabilities();
-
-    if (!config || !customer || !checkout) {
-        throw new Error('Unable to access checkout data');
-    }
-
-    const [isApplyingDefaultAddress, setIsApplyingDefaultAddress] = useState(true);
-    const isInitializing = isLoadingBillingCountries || isApplyingDefaultAddress;
-
-    const hasAddresses = Boolean(customer.addresses && customer.addresses.length > 0);
-    const showNoAddressesWarning = restrictManualAddressEntry && !hasAddresses;
-
-    const customerMessage = checkout.customerMessage;
-    const billingAddress = getBillingAddress();
+        billingAddress,
+        customerMessage,
+        getBillingAddress,
+        getFields,
+        getShippingAddress,
+        isInitializing,
+        showNoAddressesWarning,
+        updateBillingAddress,
+        updateCheckout,
+    } = useBilling({ onUnhandledError });
 
     const handleBillingSameAsShippingChange = (checked: boolean) => {
         onBillingSameAsShippingChange(checked);
@@ -97,7 +48,7 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
         const shippingAddress = getShippingAddress();
 
         if (shippingAddress && !isEqualAddress(shippingAddress, getBillingAddress())) {
-            checkoutService.updateBillingAddress(shippingAddress).catch((error) => {
+            updateBillingAddress(shippingAddress).catch((error) => {
                 onBillingSameAsShippingChange(false);
 
                 if (error instanceof Error) {
@@ -106,17 +57,6 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
             });
         }
     };
-
-    const getFields = useCallback(
-        (countryCode?: string) =>
-            getFieldsWithExtraFields(
-                getBillingAddressFields,
-                hasAddressExtraFields,
-                getAddressExtraFields,
-                countryCode,
-            ),
-        [getBillingAddressFields, hasAddressExtraFields, getAddressExtraFields],
-    );
 
     // Persist without navigating — the payment step's "Place Order" is the only
     // submit. Called by PaymentBillingForm's pre-submit save;
@@ -129,40 +69,15 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
         const address = mapAddressFromFormValues(addressValues);
 
         if (address && !isEqualAddress(address, currentBillingAddress)) {
-            promises.push(checkoutService.updateBillingAddress(address));
+            promises.push(updateBillingAddress(address));
         }
 
         if (customerMessage !== orderComment) {
-            promises.push(checkoutService.updateCheckout({ customerMessage: orderComment }));
+            promises.push(updateCheckout({ customerMessage: orderComment }));
         }
 
         await Promise.all(promises);
     };
-
-    useEffect(() => {
-        const init = async () => {
-            try {
-                await checkoutService.loadBillingAddressFields();
-
-                if (hasCompanyAddressBook) {
-                    await setDefaultAddress({
-                        type: AddressType.Billing,
-                        currentAddress: getBillingAddress(),
-                        addresses: customer.addresses,
-                        updateAddress: checkoutService.updateBillingAddress,
-                    });
-                }
-            } catch (error) {
-                if (error instanceof Error) {
-                    onUnhandledError(error);
-                }
-            } finally {
-                setIsApplyingDefaultAddress(false);
-            }
-        };
-
-        void init();
-    }, []);
 
     if (showNoAddressesWarning) {
         return (


### PR DESCRIPTION

## What/Why?

- Add new useBilling hook to manage common logic between 2 billing components.
- Now that we have 2 billing components, one in standalone step and another in Payment step, its better to have common logic live in a separate hook and can be reused.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout billing address updates and initialization on both billing and payment steps; behavior should be equivalent but regressions could affect address defaults, warnings, and same-as-shipping sync.
> 
> **Overview**
> Introduces **`useBilling`** to centralize billing checkout wiring that was duplicated in the standalone **`Billing`** step and **`PaymentBillingBlock`**.
> 
> The hook owns field merging (billing + extra address fields), initialization (`loadBillingAddressFields`, optional company default billing address), the **restrict manual entry / no addresses** warning, and exposes **`updateBillingAddress`** / **`updateCheckout`** plus **`getShippingAddress`** for payment-step “same as shipping” sync. **`Billing`** and **`PaymentBillingBlock`** now only handle step-specific submit/persist and UI.
> 
> **`onReady`** is optional and still invoked from init only when the standalone billing step passes it; the payment billing block does not. The shared guard no longer requires **`cart`** (it was unused in the extracted logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1984594f6159e67b463b922b9c52aaa37d86ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->