### PR TITLE
chore(payment): PI-5495 Remove migs from payment provider mocks

### DIFF
--- a/packages/core/src/app/config/config.mock.ts
+++ b/packages/core/src/app/config/config.mock.ts
@@ -73,7 +73,6 @@ export function getStoreConfig(): StoreConfig {
         paymentSettings: {
             bigpayBaseUrl: 'https://bigpay.integration.zone',
             clientSidePaymentProviders: [
-                'migs',
                 'eway',
                 'securenet',
                 'usaepay',

--- a/packages/test-mocks/src/config.mock.ts
+++ b/packages/test-mocks/src/config.mock.ts
@@ -70,7 +70,6 @@ export function getStoreConfig(): StoreConfig {
         paymentSettings: {
             bigpayBaseUrl: 'https://bigpay.integration.zone',
             clientSidePaymentProviders: [
-                'migs',
                 'eway',
                 'securenet',
                 'usaepay',


### PR DESCRIPTION
## What/Why?

BigCommerce is decommissioning the MIGS (Mastercard Internet Gateway Service) payment provider. The backend removal is complete in BigPay; this PR removes the now-stale `'migs'` entry from the `clientSidePaymentProviders` arrays in the test config mocks so the fixtures stay in sync with the supported providers.

Files changed (test mocks only):
- `packages/core/src/app/config/config.mock.ts`
- `packages/test-mocks/src/config.mock.ts`

No functional change.

Jira: [PI-5495](https://bigcommercecloud.atlassian.net/browse/PI-5495)

## Rollout/Rollback

No runtime impact — the change only touches test mock fixtures, not production code. No experiments or database migrations are involved. Rollback is a straight revert of this PR.

## Testing

- Case-insensitive, whole-word `migs` grep across the repo (excluding lockfiles/dist/node_modules) returns no remaining references after the change.
- Confirmed no test asserts on the length of `clientSidePaymentProviders` or on the `'migs'` value specifically, so removing the entry does not break existing assertions.
- Structurally validated each edited `clientSidePaymentProviders` array still parses as a valid string array (18 entries, no `migs`).


[PI-5495]: https://bigcommercecloud.atlassian.net/browse/PI-5495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7e745b22e78cfda5ddbeb4a44b82b740969eed42. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->