### PR TITLE
fix(checkout): CHECKOUT-10206 Clear phone number internal state

### DIFF
--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
@@ -12,6 +12,7 @@ import { PhoneFormField, type PhoneFormFieldProps } from './PhoneFormField';
 
 const mockIsValidNumber = jest.fn();
 const mockSetCountry = jest.fn();
+const mockSetNumber = jest.fn();
 const mockGetSelectedCountryData = jest.fn();
 
 jest.mock('@intl-tel-input/react', () => ({
@@ -29,6 +30,7 @@ jest.mock('@intl-tel-input/react', () => ({
                 getSelectedCountryData: mockGetSelectedCountryData,
                 isValidNumber: mockIsValidNumber,
                 setCountry: mockSetCountry,
+                setNumber: mockSetNumber,
             }),
         }));
 
@@ -88,6 +90,7 @@ describe('PhoneFormField', () => {
         mockGetSelectedCountryData.mockClear();
         mockIsValidNumber.mockClear();
         mockSetCountry.mockClear();
+        mockSetNumber.mockClear();
     });
 
     it('renders IntlTelInput', () => {
@@ -100,6 +103,17 @@ describe('PhoneFormField', () => {
         renderPhoneFormField({ selectedCountry: 'US' });
 
         expect(mockSetCountry).toHaveBeenCalledWith('us');
+    });
+
+    it('clears any stale number before auto-setting the country', () => {
+        renderPhoneFormField({ selectedCountry: 'US' });
+
+        expect(mockSetNumber).toHaveBeenCalledWith('');
+
+        const setNumberOrder = mockSetNumber.mock.invocationCallOrder[0];
+        const setCountryOrder = mockSetCountry.mock.invocationCallOrder[0];
+
+        expect(setNumberOrder).toBeLessThan(setCountryOrder);
     });
 
     it('does not auto-set country when selectedCountry is not provided', () => {

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -50,6 +50,8 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
             const intlTelInputInstance = intlTelInputRef.current?.getInstance();
 
             if (intlTelInputInstance) {
+                // library's internal instance can have stale digits in edge cases (bug on their side)
+                intlTelInputInstance.setNumber('');
                 intlTelInputInstance.setCountry(selectedCountryInIsoFormat);
                 isPhoneCountryAutoSetRef.current = true;
             }


### PR DESCRIPTION
## What/Why?

I found some edge case where internal library state isn't updated on time and that contributed to the FastLane hanging bug. Better to fix it in case it affects anything else.

## Rollout/Rollback

Revert the PR. Only affects the code that is hidden behind CHECKOUT-9019.use_new_phone_number_validation (currently off in prod).

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line guard around existing auto-country logic in checkout phone UI, behind `CHECKOUT-9019.use_new_phone_number_validation` (off in prod); no auth or data-path changes.
> 
> **Overview**
> When checkout auto-applies `selectedCountry` on an empty phone field, **`PhoneInput` now calls `setNumber('')` on the intl-tel-input instance before `setCountry`**, so stale digits in the library’s internal state cannot linger.
> 
> This is a defensive fix for an upstream intl-tel-input edge case that contributed to **FastLane hanging**; Formik’s value was already empty when this path runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e712da6013655bc8d9154d5ee2da9c1950e28a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->