### PR TITLE
fix(checkout): CHECKOUT-10240 Show "Select an address"

### DIFF
--- a/packages/core/src/app/address/AddressSelect.test.tsx
+++ b/packages/core/src/app/address/AddressSelect.test.tsx
@@ -55,6 +55,55 @@ describe('AddressSelect component', () => {
         expect(screen.getByText('Enter a new address')).toBeInTheDocument();
     });
 
+    it('renders `Select an address` when there is no selected address and manual address entry is restricted', () => {
+        const storeConfig = getStoreConfig();
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+            ...storeConfig,
+            checkoutSettings: {
+                ...storeConfig.checkoutSettings,
+                capabilities: {
+                    ...defaultCapabilities,
+                    billing: {
+                        ...defaultCapabilities.billing,
+                        restrictManualAddressEntry: true,
+                    },
+                },
+            },
+        });
+
+        renderAddressSelect({ type: AddressType.Billing });
+
+        expect(screen.getByTestId('address-select-placeholder')).toHaveTextContent(
+            'Select an address',
+        );
+        expect(screen.queryByText('Enter a new address')).not.toBeInTheDocument();
+    });
+
+    it('renders `Enter Address` when manual address entry is only restricted for the other address type', () => {
+        const storeConfig = getStoreConfig();
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+            ...storeConfig,
+            checkoutSettings: {
+                ...storeConfig.checkoutSettings,
+                capabilities: {
+                    ...defaultCapabilities,
+                    shipping: {
+                        ...defaultCapabilities.shipping,
+                        restrictManualAddressEntry: true,
+                    },
+                },
+            },
+        });
+
+        renderAddressSelect({ type: AddressType.Billing });
+
+        expect(screen.getByTestId('address-select-placeholder')).toHaveTextContent(
+            'Enter a new address',
+        );
+    });
+
     it('renders static address when there is a selected address', () => {
         const selectedAddress = getAddress();
 

--- a/packages/core/src/app/address/AddressSelectButton.tsx
+++ b/packages/core/src/app/address/AddressSelectButton.tsx
@@ -10,6 +10,7 @@ import {
 import { type AddressSelectProps } from './AddressSelect';
 import SingleLineStaticAddress from './SingleLineStaticAddress';
 import StaticAddress from './StaticAddress';
+import { useRestrictManualAddressEntry } from './useRestrictManualAddressEntry';
 
 type AddressSelectButtonProps = Pick<
     AddressSelectProps,
@@ -24,12 +25,21 @@ const AddressSelectButton: FunctionComponent<AddressSelectButtonProps & WithLang
     placeholderText,
 }) => {
     const [ariaExpanded, setAriaExpanded] = useState(false);
+    const restrictManualAddressEntry = useRestrictManualAddressEntry(type);
 
     const SelectedAddress = () => {
         if (!selectedAddress) {
             return (
                 <span className="body-regular" data-test="address-select-placeholder">
-                    {placeholderText ?? <TranslatedString id="address.enter_address_action" />}
+                    {placeholderText ?? (
+                        <TranslatedString
+                            id={
+                                restrictManualAddressEntry
+                                    ? 'address.select_address_action'
+                                    : 'address.enter_address_action'
+                            }
+                        />
+                    )}
                 </span>
             );
         }

--- a/packages/core/src/app/address/SearchableAddressSelectComponent.tsx
+++ b/packages/core/src/app/address/SearchableAddressSelectComponent.tsx
@@ -1,7 +1,7 @@
 import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
 import React, { type ChangeEvent, type FunctionComponent, useMemo, useState } from 'react';
 
-import { useCapabilities, useLocale } from '@bigcommerce/checkout/contexts';
+import { useLocale } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { TextInput } from '@bigcommerce/checkout/ui';
@@ -9,6 +9,7 @@ import { TextInput } from '@bigcommerce/checkout/ui';
 import AddressType from './AddressType';
 import { searchingAddresses } from './searchingAddresses';
 import StaticAddress from './StaticAddress';
+import { useRestrictManualAddressEntry } from './useRestrictManualAddressEntry';
 
 export interface SearchableAddressSelectProps {
     addresses: CustomerAddress[];
@@ -28,14 +29,7 @@ export const SearchableAddressSelectComponent: FunctionComponent<SearchableAddre
     const [searchQuery, setSearchQuery] = useState('');
 
     const { language } = useLocale();
-    const {
-        shipping: { restrictManualAddressEntry: restrictManualAddressEntryForShipping },
-        billing: { restrictManualAddressEntry: restrictManualAddressEntryForBilling },
-    } = useCapabilities();
-    const restrictManualAddressEntry =
-        type === AddressType.Shipping
-            ? restrictManualAddressEntryForShipping
-            : restrictManualAddressEntryForBilling;
+    const restrictManualAddressEntry = useRestrictManualAddressEntry(type);
 
     const filteredAddresses = useMemo(() => {
         const addressesByType = addresses.filter((address) =>

--- a/packages/core/src/app/address/useRestrictManualAddressEntry.ts
+++ b/packages/core/src/app/address/useRestrictManualAddressEntry.ts
@@ -1,0 +1,14 @@
+import { useCapabilities } from '@bigcommerce/checkout/contexts';
+
+import AddressType from './AddressType';
+
+export const useRestrictManualAddressEntry = (type: AddressType): boolean => {
+    const {
+        shipping: { restrictManualAddressEntry: restrictManualAddressEntryForShipping },
+        billing: { restrictManualAddressEntry: restrictManualAddressEntryForBilling },
+    } = useCapabilities();
+
+    return type === AddressType.Shipping
+        ? restrictManualAddressEntryForShipping
+        : restrictManualAddressEntryForBilling;
+};

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -25,6 +25,7 @@
             "custom_valid_error": "{label} is not valid",
             "edit_address_action": "Edit address",
             "enter_address_action": "Enter a new address",
+            "select_address_action": "Select an address",
             "enter_or_select_address_action": "Enter or select a different address",
             "add_address_heading": "Add Address",
             "save_address_action": "Save Address",


### PR DESCRIPTION
## What/Why?

Show "Select an address" when creating a new address is disabled.

## Rollout/Rollback

Revert.

## Testing

### Before
<img width="564" height="486" alt="image" src="https://github.com/user-attachments/assets/4cf29714-bdff-468d-87f5-70e09d4e64d7" />

<img width="564" height="466" alt="image" src="https://github.com/user-attachments/assets/420d029d-2f27-4c1e-a3d7-ae4bcc39f285" />

### After
<img width="564" height="191" alt="Screenshot 2026-07-17 at 14 58 49" src="https://github.com/user-attachments/assets/98deaaa3-067b-4855-8437-ffe96929e6d2" />
<img width="582" height="225" alt="Screenshot 2026-07-17 at 14 58 24" src="https://github.com/user-attachments/assets/7916ff41-1637-4c6f-8fdb-2568d592b654" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and placeholder logic only in checkout address UI; behavior is gated on existing store capabilities with new tests.
> 
> **Overview**
> When **manual address entry** is disabled for billing or shipping, the address select control no longer shows **"Enter a new address"** with no selection—it shows **"Select an address"** instead, matching the fact that users can only pick from saved addresses.
> 
> `AddressSelectButton` picks between `address.select_address_action` and `address.enter_address_action` using a new **`useRestrictManualAddressEntry(type)`** hook (shared with the searchable dropdown, which already hid the add-new row). English copy adds **`select_address_action`**. Tests cover billing vs shipping capability scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f476f49c7420c4c2f66a2d550ffc6708005fbe02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->