### PR TITLE
feat(checkout): CHECKOUT-10115 Prevent loading dynamic chunks without crossorigin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
         "@bigcommerce/request-sender": "^1.2.4",
-        "@bigcommerce/script-loader": "^2.2.2",
+        "@bigcommerce/script-loader": "^2.3.0",
         "@intl-tel-input/react": "^28.1.0",
         "@sentry/browser": "^9.40.0",
         "@types/card-validator": "^4.1.0",
@@ -2485,9 +2485,9 @@
       }
     },
     "node_modules/@bigcommerce/script-loader": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.2.5.tgz",
-      "integrity": "sha512-rohoDnjowfsrbwA4ipq8s5xs/Y1sW+GUvckaR/Q75ABPxTjqMdeiMfcIV0+lQOsuINgYlyX7rq2MefiGVh6Svw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.3.0.tgz",
+      "integrity": "sha512-+3TieZhnIlip6iKLnUOso98YWMlJFvuxt8r8Y3JhgQUGwD1FBmnKMqGeUH+TWdiqeeZeYSfOTBpdEDIyzD9v4A==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/request-sender": "^1.1.0",
@@ -29992,9 +29992,9 @@
       }
     },
     "@bigcommerce/script-loader": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.2.5.tgz",
-      "integrity": "sha512-rohoDnjowfsrbwA4ipq8s5xs/Y1sW+GUvckaR/Q75ABPxTjqMdeiMfcIV0+lQOsuINgYlyX7rq2MefiGVh6Svw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.3.0.tgz",
+      "integrity": "sha512-+3TieZhnIlip6iKLnUOso98YWMlJFvuxt8r8Y3JhgQUGwD1FBmnKMqGeUH+TWdiqeeZeYSfOTBpdEDIyzD9v4A==",
       "requires": {
         "@bigcommerce/request-sender": "^1.1.0",
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",
     "@bigcommerce/request-sender": "^1.2.4",
-    "@bigcommerce/script-loader": "^2.2.2",
+    "@bigcommerce/script-loader": "^2.3.0",
     "@intl-tel-input/react": "^28.1.0",
     "@sentry/browser": "^9.40.0",
     "@types/card-validator": "^4.1.0",

--- a/packages/core/src/app/auto-loader.ts
+++ b/packages/core/src/app/auto-loader.ts
@@ -31,41 +31,22 @@ function isCustomCheckoutWindow(window: Window): window is CustomCheckoutWindow 
         throw new Error('Checkout config is missing.');
     }
 
-    const isConsistentCrossOriginFixEnabled = Boolean(
-        window.checkoutConfig.isConsistentCrossOriginFixEnabled,
-    );
+    const { renderOrderConfirmation, renderCheckout } = await loadFiles({
+        isConsistentCrossOriginFixEnabled: Boolean(
+            window.checkoutConfig.isConsistentCrossOriginFixEnabled,
+        ),
+    });
 
-    const bootstrap = async (customCheckoutWindow: CustomCheckoutWindow): Promise<void> => {
-        const { renderOrderConfirmation, renderCheckout } = await loadFiles({
-            isConsistentCrossOriginFixEnabled,
-        });
+    const {
+        orderId,
+        checkoutId,
+        isConsistentCrossOriginFixEnabled: _isConsistentCrossOriginFixEnabled,
+        ...appProps
+    } = window.checkoutConfig;
 
-        const {
-            orderId,
-            checkoutId,
-            isConsistentCrossOriginFixEnabled: _isConsistentCrossOriginFixEnabled,
-            ...appProps
-        } = customCheckoutWindow.checkoutConfig;
-
-        if (orderId) {
-            renderOrderConfirmation({ ...appProps, orderId });
-        } else if (checkoutId) {
-            renderCheckout({ ...appProps, checkoutId });
-        }
-    };
-
-    if (!isConsistentCrossOriginFixEnabled) {
-        await bootstrap(window);
-
-        return;
-    }
-
-    try {
-        await bootstrap(window);
-    } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('[checkout-js] Checkout failed to bootstrap:', error);
-
-        throw error;
+    if (orderId) {
+        renderOrderConfirmation({ ...appProps, orderId });
+    } else if (checkoutId) {
+        renderCheckout({ ...appProps, checkoutId });
     }
 })();

--- a/packages/core/src/app/auto-loader.ts
+++ b/packages/core/src/app/auto-loader.ts
@@ -65,5 +65,7 @@ function isCustomCheckoutWindow(window: Window): window is CustomCheckoutWindow 
     } catch (error) {
         // eslint-disable-next-line no-console
         console.error('[checkout-js] Checkout failed to bootstrap:', error);
+
+        throw error;
     }
 })();

--- a/packages/core/src/app/auto-loader.ts
+++ b/packages/core/src/app/auto-loader.ts
@@ -16,6 +16,7 @@ export interface CustomCheckoutWindow extends Window {
         publicPath?: string;
         sentryConfig?: BrowserOptions;
         permalinkStatus?: OrderPermalinkStatus | null;
+        isSafePrefetchEnabled?: boolean;
     };
 }
 
@@ -30,13 +31,41 @@ function isCustomCheckoutWindow(window: Window): window is CustomCheckoutWindow 
         throw new Error('Checkout config is missing.');
     }
 
-    const { renderOrderConfirmation, renderCheckout } = await loadFiles();
+    const isSafePrefetchEnabled = Boolean(window.checkoutConfig.isSafePrefetchEnabled);
 
-    const { orderId, checkoutId, ...appProps } = window.checkoutConfig;
+    const bootstrap = async (customCheckoutWindow: CustomCheckoutWindow): Promise<void> => {
+        const { renderOrderConfirmation, renderCheckout } = await loadFiles({
+            isSafePrefetchEnabled,
+        });
 
-    if (orderId) {
-        renderOrderConfirmation({ ...appProps, orderId });
-    } else if (checkoutId) {
-        renderCheckout({ ...appProps, checkoutId });
+        const {
+            orderId,
+            checkoutId,
+            isSafePrefetchEnabled: _isSafePrefetchEnabled,
+            ...appProps
+        } = customCheckoutWindow.checkoutConfig;
+
+        if (orderId) {
+            renderOrderConfirmation({ ...appProps, orderId });
+        } else if (checkoutId) {
+            renderCheckout({ ...appProps, checkoutId });
+        }
+    };
+
+    // Gated behind the same flag as the crossorigin/SRI prefetch fix: existing stores
+    // (flag off) get the exact same fire-and-forget bootstrap as before this diagnostics
+    // work existed -- a failure is a silent unhandled rejection, same as always. Only
+    // flag-on stores get it caught and logged.
+    if (!isSafePrefetchEnabled) {
+        await bootstrap(window);
+
+        return;
+    }
+
+    try {
+        await bootstrap(window);
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('[checkout-js] Checkout failed to bootstrap:', error);
     }
 })();

--- a/packages/core/src/app/auto-loader.ts
+++ b/packages/core/src/app/auto-loader.ts
@@ -16,7 +16,7 @@ export interface CustomCheckoutWindow extends Window {
         publicPath?: string;
         sentryConfig?: BrowserOptions;
         permalinkStatus?: OrderPermalinkStatus | null;
-        isSafePrefetchEnabled?: boolean;
+        isConsistentCrossOriginFixEnabled?: boolean;
     };
 }
 
@@ -31,17 +31,19 @@ function isCustomCheckoutWindow(window: Window): window is CustomCheckoutWindow 
         throw new Error('Checkout config is missing.');
     }
 
-    const isSafePrefetchEnabled = Boolean(window.checkoutConfig.isSafePrefetchEnabled);
+    const isConsistentCrossOriginFixEnabled = Boolean(
+        window.checkoutConfig.isConsistentCrossOriginFixEnabled,
+    );
 
     const bootstrap = async (customCheckoutWindow: CustomCheckoutWindow): Promise<void> => {
         const { renderOrderConfirmation, renderCheckout } = await loadFiles({
-            isSafePrefetchEnabled,
+            isConsistentCrossOriginFixEnabled,
         });
 
         const {
             orderId,
             checkoutId,
-            isSafePrefetchEnabled: _isSafePrefetchEnabled,
+            isConsistentCrossOriginFixEnabled: _isConsistentCrossOriginFixEnabled,
             ...appProps
         } = customCheckoutWindow.checkoutConfig;
 
@@ -52,11 +54,7 @@ function isCustomCheckoutWindow(window: Window): window is CustomCheckoutWindow 
         }
     };
 
-    // Gated behind the same flag as the crossorigin/SRI prefetch fix: existing stores
-    // (flag off) get the exact same fire-and-forget bootstrap as before this diagnostics
-    // work existed -- a failure is a silent unhandled rejection, same as always. Only
-    // flag-on stores get it caught and logged.
-    if (!isSafePrefetchEnabled) {
+    if (!isConsistentCrossOriginFixEnabled) {
         await bootstrap(window);
 
         return;

--- a/packages/core/src/app/loader.test.ts
+++ b/packages/core/src/app/loader.test.ts
@@ -1,7 +1,6 @@
+import { CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration-api';
 import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
 import { noop } from 'lodash';
-
-import { CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration-api';
 
 import type AppExport from './AppExport';
 import { type AssetManifest, loadFiles, type LoadFilesOptions } from './loader';
@@ -25,6 +24,8 @@ describe('loadFiles', () => {
     let appExports: AppExport;
 
     beforeEach(() => {
+        jest.clearAllMocks();
+
         options = {
             publicPath: 'https://cdn.foo.bar/',
         };
@@ -133,6 +134,53 @@ describe('loadFiles', () => {
         );
     });
 
+    describe('when isSafePrefetchEnabled is true', () => {
+        afterEach(() => {
+            document.head.querySelectorAll('link[rel="prefetch"]').forEach((link) => {
+                link.remove();
+            });
+        });
+
+        it('does not use script-loader to prefetch dynamic JS or CSS chunks', async () => {
+            await loadFiles({ ...options, isSafePrefetchEnabled: true });
+
+            expect(getScriptLoader().preloadScripts).not.toHaveBeenCalled();
+            expect(getStylesheetLoader().preloadStylesheets).not.toHaveBeenCalled();
+        });
+
+        it('prefetches dynamic JS chunks with matching crossorigin and integrity attributes', async () => {
+            await loadFiles({ ...options, isSafePrefetchEnabled: true });
+
+            const links = document.head.querySelectorAll<HTMLLinkElement>(
+                'link[rel="prefetch"][as="script"]',
+            );
+
+            expect(links).toHaveLength(2);
+            expect(links[0]).toHaveAttribute('href', 'https://cdn.foo.bar/step-a.js');
+            expect(links[0]).toHaveAttribute('crossorigin', 'anonymous');
+            expect(links[0]).toHaveAttribute('integrity', 'hash-step-a-js');
+            expect(links[1]).toHaveAttribute('href', 'https://cdn.foo.bar/step-b.js');
+            expect(links[1]).toHaveAttribute('crossorigin', 'anonymous');
+            expect(links[1]).toHaveAttribute('integrity', 'hash-step-b-js');
+        });
+
+        it('prefetches dynamic CSS chunks with matching crossorigin and integrity attributes', async () => {
+            await loadFiles({ ...options, isSafePrefetchEnabled: true });
+
+            const links = document.head.querySelectorAll<HTMLLinkElement>(
+                'link[rel="prefetch"][as="style"]',
+            );
+
+            expect(links).toHaveLength(2);
+            expect(links[0]).toHaveAttribute('href', 'https://cdn.foo.bar/step-a.css');
+            expect(links[0]).toHaveAttribute('crossorigin', 'anonymous');
+            expect(links[0]).toHaveAttribute('integrity', 'hash-step-a-css');
+            expect(links[1]).toHaveAttribute('href', 'https://cdn.foo.bar/step-b.css');
+            expect(links[1]).toHaveAttribute('crossorigin', 'anonymous');
+            expect(links[1]).toHaveAttribute('integrity', 'hash-step-b-css');
+        });
+    });
+
     it('resolves with app version', async () => {
         const result = await loadFiles(options);
 
@@ -189,6 +237,47 @@ describe('loadFiles', () => {
             locale: expect.any(String),
             locales: expect.any(Object),
             translations: expect.any(Object),
+        });
+    });
+
+    describe('bootstrap diagnostics', () => {
+        it('does not log anything when isSafePrefetchEnabled is off, preserving existing behavior', async () => {
+            const consoleErrorSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined);
+            const bootstrapError = new Error('vendor.js failed to load');
+
+            jest.spyOn(getScriptLoader(), 'loadScript').mockImplementation((src: string) =>
+                src.includes('vendor.js') ? Promise.reject(bootstrapError) : Promise.resolve(),
+            );
+
+            await expect(loadFiles(options)).rejects.toThrow(bootstrapError);
+
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+            consoleErrorSpy.mockRestore();
+        });
+
+        it('logs a clear, greppable message and still rejects if bootstrapping fails when isSafePrefetchEnabled is on', async () => {
+            const consoleErrorSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined);
+            const bootstrapError = new Error('vendor.js failed to load');
+
+            jest.spyOn(getScriptLoader(), 'loadScript').mockImplementation((src: string) =>
+                src.includes('vendor.js') ? Promise.reject(bootstrapError) : Promise.resolve(),
+            );
+
+            await expect(loadFiles({ ...options, isSafePrefetchEnabled: true })).rejects.toThrow(
+                bootstrapError,
+            );
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '[checkout-js] Failed to bootstrap checkout:',
+                bootstrapError,
+            );
+
+            consoleErrorSpy.mockRestore();
         });
     });
 });

--- a/packages/core/src/app/loader.test.ts
+++ b/packages/core/src/app/loader.test.ts
@@ -58,6 +58,8 @@ describe('loadFiles', () => {
             renderOrderConfirmation: jest.fn(),
             initializeLanguageService: jest.fn(),
         };
+        (global as any).PRELOAD_ASSETS = ['step-a.js', 'step-b.js', 'step-a.css', 'step-b.css'];
+
         (global as any).scheduler = {
             yield() {
                 return new Promise((resolve) => process.nextTick(resolve));

--- a/packages/core/src/app/loader.test.ts
+++ b/packages/core/src/app/loader.test.ts
@@ -135,7 +135,7 @@ describe('loadFiles', () => {
         );
     });
 
-    describe('when isSafePrefetchEnabled is true', () => {
+    describe('when isConsistentCrossOriginFixEnabled is true', () => {
         afterEach(() => {
             document.head.querySelectorAll('link[rel="prefetch"]').forEach((link) => {
                 link.remove();
@@ -179,6 +179,35 @@ describe('loadFiles', () => {
             expect(links[1]).toHaveAttribute('href', 'https://cdn.foo.bar/step-b.css');
             expect(links[1]).toHaveAttribute('crossorigin', 'anonymous');
             expect(links[1]).toHaveAttribute('integrity', 'hash-step-b-css');
+        });
+
+        it('logs a failure tied to the specific prefetch link that failed, without a page-wide listener', async () => {
+            const consoleErrorSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined);
+            const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
+
+            expect(addEventListenerSpy).not.toHaveBeenCalledWith('error', expect.anything());
+            expect(addEventListenerSpy).not.toHaveBeenCalledWith(
+                'unhandledrejection',
+                expect.anything(),
+            );
+
+            const [failingLink] = document.head.querySelectorAll<HTMLLinkElement>(
+                'link[rel="prefetch"][as="script"]',
+            );
+
+            failingLink.dispatchEvent(new Event('error'));
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '[checkout-js] Failed to prefetch (load or integrity check failed):',
+                'https://cdn.foo.bar/step-a.js',
+            );
+
+            addEventListenerSpy.mockRestore();
+            consoleErrorSpy.mockRestore();
         });
     });
 
@@ -242,7 +271,7 @@ describe('loadFiles', () => {
     });
 
     describe('bootstrap diagnostics', () => {
-        it('does not log anything when isSafePrefetchEnabled is off, preserving existing behavior', async () => {
+        it('does not log anything when isConsistentCrossOriginFixEnabled is off, preserving existing behavior', async () => {
             const consoleErrorSpy = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => undefined);
@@ -259,7 +288,7 @@ describe('loadFiles', () => {
             consoleErrorSpy.mockRestore();
         });
 
-        it('logs a clear, greppable message and still rejects if bootstrapping fails when isSafePrefetchEnabled is on', async () => {
+        it('logs a clear, greppable message and still rejects if bootstrapping fails when isConsistentCrossOriginFixEnabled is on', async () => {
             const consoleErrorSpy = jest
                 .spyOn(console, 'error')
                 .mockImplementation(() => undefined);

--- a/packages/core/src/app/loader.test.ts
+++ b/packages/core/src/app/loader.test.ts
@@ -70,10 +70,6 @@ describe('loadFiles', () => {
     afterEach(() => {
         jest.restoreAllMocks();
 
-        document.head.querySelectorAll('link[rel="prefetch"]').forEach((link) => {
-            link.remove();
-        });
-
         delete (global as any).MANIFEST_JSON;
         delete (global as any).LIBRARY_NAME;
         delete (global as any).checkout;
@@ -142,75 +138,21 @@ describe('loadFiles', () => {
     });
 
     describe('when isConsistentCrossOriginFixEnabled is true', () => {
-        it('does not use script-loader to prefetch dynamic JS or CSS chunks', async () => {
-            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
-
-            expect(getScriptLoader().preloadScripts).not.toHaveBeenCalled();
-            expect(getStylesheetLoader().preloadStylesheets).not.toHaveBeenCalled();
-        });
-
         it('prefetches dynamic JS chunks with crossorigin matching the real chunk requests', async () => {
             await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
-            const links = document.head.querySelectorAll<HTMLLinkElement>(
-                'link[rel="prefetch"][as="script"]',
+            expect(getScriptLoader().preloadScripts).toHaveBeenCalledWith(
+                ['https://cdn.foo.bar/step-a.js', 'https://cdn.foo.bar/step-b.js'],
+                { prefetch: true, crossOrigin: 'anonymous' },
             );
-
-            expect(links).toHaveLength(2);
-            expect(links[0]).toHaveAttribute('href', 'https://cdn.foo.bar/step-a.js');
-            expect(links[0]).toHaveAttribute('crossorigin', 'anonymous');
-            expect(links[1]).toHaveAttribute('href', 'https://cdn.foo.bar/step-b.js');
-            expect(links[1]).toHaveAttribute('crossorigin', 'anonymous');
         });
 
         it('prefetches dynamic CSS chunks with crossorigin matching the real chunk requests', async () => {
             await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
-            const links = document.head.querySelectorAll<HTMLLinkElement>(
-                'link[rel="prefetch"][as="style"]',
-            );
-
-            expect(links).toHaveLength(2);
-            expect(links[0]).toHaveAttribute('href', 'https://cdn.foo.bar/step-a.css');
-            expect(links[0]).toHaveAttribute('crossorigin', 'anonymous');
-            expect(links[1]).toHaveAttribute('href', 'https://cdn.foo.bar/step-b.css');
-            expect(links[1]).toHaveAttribute('crossorigin', 'anonymous');
-        });
-
-        it('omits integrity from prefetch links since browsers ignore it and SRI is checked on the real chunk requests', async () => {
-            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
-
-            const links = document.head.querySelectorAll<HTMLLinkElement>('link[rel="prefetch"]');
-
-            expect(links).toHaveLength(4);
-            links.forEach((link) => {
-                expect(link).not.toHaveAttribute('integrity');
-            });
-        });
-
-        it('logs a failure tied to the specific prefetch link that failed, without a page-wide listener', async () => {
-            const consoleErrorSpy = jest
-                .spyOn(console, 'error')
-                .mockImplementation(() => undefined);
-            const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
-
-            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
-
-            expect(addEventListenerSpy).not.toHaveBeenCalledWith('error', expect.anything());
-            expect(addEventListenerSpy).not.toHaveBeenCalledWith(
-                'unhandledrejection',
-                expect.anything(),
-            );
-
-            const [failingLink] = document.head.querySelectorAll<HTMLLinkElement>(
-                'link[rel="prefetch"][as="script"]',
-            );
-
-            failingLink.dispatchEvent(new Event('error'));
-
-            expect(consoleErrorSpy).toHaveBeenCalledWith(
-                '[checkout-js] Failed to prefetch:',
-                'https://cdn.foo.bar/step-a.js',
+            expect(getStylesheetLoader().preloadStylesheets).toHaveBeenCalledWith(
+                ['https://cdn.foo.bar/step-a.css', 'https://cdn.foo.bar/step-b.css'],
+                { prefetch: true, crossOrigin: 'anonymous' },
             );
         });
     });
@@ -271,43 +213,6 @@ describe('loadFiles', () => {
             locale: expect.any(String),
             locales: expect.any(Object),
             translations: expect.any(Object),
-        });
-    });
-
-    describe('bootstrap diagnostics', () => {
-        it('does not log anything when isConsistentCrossOriginFixEnabled is off, preserving existing behavior', async () => {
-            const consoleErrorSpy = jest
-                .spyOn(console, 'error')
-                .mockImplementation(() => undefined);
-            const bootstrapError = new Error('vendor.js failed to load');
-
-            jest.spyOn(getScriptLoader(), 'loadScript').mockImplementation((src: string) =>
-                src.includes('vendor.js') ? Promise.reject(bootstrapError) : Promise.resolve(),
-            );
-
-            await expect(loadFiles(options)).rejects.toThrow(bootstrapError);
-
-            expect(consoleErrorSpy).not.toHaveBeenCalled();
-        });
-
-        it('logs a clear, greppable message and still rejects if bootstrapping fails when isConsistentCrossOriginFixEnabled is on', async () => {
-            const consoleErrorSpy = jest
-                .spyOn(console, 'error')
-                .mockImplementation(() => undefined);
-            const bootstrapError = new Error('vendor.js failed to load');
-
-            jest.spyOn(getScriptLoader(), 'loadScript').mockImplementation((src: string) =>
-                src.includes('vendor.js') ? Promise.reject(bootstrapError) : Promise.resolve(),
-            );
-
-            await expect(
-                loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true }),
-            ).rejects.toThrow(bootstrapError);
-
-            expect(consoleErrorSpy).toHaveBeenCalledWith(
-                '[checkout-js] Failed to bootstrap checkout:',
-                bootstrapError,
-            );
         });
     });
 });

--- a/packages/core/src/app/loader.test.ts
+++ b/packages/core/src/app/loader.test.ts
@@ -1,6 +1,7 @@
-import { CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration-api';
 import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
 import { noop } from 'lodash';
+
+import { CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration-api';
 
 import type AppExport from './AppExport';
 import { type AssetManifest, loadFiles, type LoadFilesOptions } from './loader';
@@ -142,14 +143,14 @@ describe('loadFiles', () => {
         });
 
         it('does not use script-loader to prefetch dynamic JS or CSS chunks', async () => {
-            await loadFiles({ ...options, isSafePrefetchEnabled: true });
+            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
             expect(getScriptLoader().preloadScripts).not.toHaveBeenCalled();
             expect(getStylesheetLoader().preloadStylesheets).not.toHaveBeenCalled();
         });
 
         it('prefetches dynamic JS chunks with matching crossorigin and integrity attributes', async () => {
-            await loadFiles({ ...options, isSafePrefetchEnabled: true });
+            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
             const links = document.head.querySelectorAll<HTMLLinkElement>(
                 'link[rel="prefetch"][as="script"]',
@@ -165,7 +166,7 @@ describe('loadFiles', () => {
         });
 
         it('prefetches dynamic CSS chunks with matching crossorigin and integrity attributes', async () => {
-            await loadFiles({ ...options, isSafePrefetchEnabled: true });
+            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
             const links = document.head.querySelectorAll<HTMLLinkElement>(
                 'link[rel="prefetch"][as="style"]',
@@ -268,9 +269,9 @@ describe('loadFiles', () => {
                 src.includes('vendor.js') ? Promise.reject(bootstrapError) : Promise.resolve(),
             );
 
-            await expect(loadFiles({ ...options, isSafePrefetchEnabled: true })).rejects.toThrow(
-                bootstrapError,
-            );
+            await expect(
+                loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true }),
+            ).rejects.toThrow(bootstrapError);
 
             expect(consoleErrorSpy).toHaveBeenCalledWith(
                 '[checkout-js] Failed to bootstrap checkout:',

--- a/packages/core/src/app/loader.test.ts
+++ b/packages/core/src/app/loader.test.ts
@@ -58,8 +58,6 @@ describe('loadFiles', () => {
             renderOrderConfirmation: jest.fn(),
             initializeLanguageService: jest.fn(),
         };
-        (global as any).PRELOAD_ASSETS = ['step-a.js', 'step-b.js', 'step-a.css', 'step-b.css'];
-
         (global as any).scheduler = {
             yield() {
                 return new Promise((resolve) => process.nextTick(resolve));
@@ -68,6 +66,12 @@ describe('loadFiles', () => {
     });
 
     afterEach(() => {
+        jest.restoreAllMocks();
+
+        document.head.querySelectorAll('link[rel="prefetch"]').forEach((link) => {
+            link.remove();
+        });
+
         delete (global as any).MANIFEST_JSON;
         delete (global as any).LIBRARY_NAME;
         delete (global as any).checkout;
@@ -136,12 +140,6 @@ describe('loadFiles', () => {
     });
 
     describe('when isConsistentCrossOriginFixEnabled is true', () => {
-        afterEach(() => {
-            document.head.querySelectorAll('link[rel="prefetch"]').forEach((link) => {
-                link.remove();
-            });
-        });
-
         it('does not use script-loader to prefetch dynamic JS or CSS chunks', async () => {
             await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
@@ -149,7 +147,7 @@ describe('loadFiles', () => {
             expect(getStylesheetLoader().preloadStylesheets).not.toHaveBeenCalled();
         });
 
-        it('prefetches dynamic JS chunks with matching crossorigin and integrity attributes', async () => {
+        it('prefetches dynamic JS chunks with crossorigin matching the real chunk requests', async () => {
             await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
             const links = document.head.querySelectorAll<HTMLLinkElement>(
@@ -159,13 +157,11 @@ describe('loadFiles', () => {
             expect(links).toHaveLength(2);
             expect(links[0]).toHaveAttribute('href', 'https://cdn.foo.bar/step-a.js');
             expect(links[0]).toHaveAttribute('crossorigin', 'anonymous');
-            expect(links[0]).toHaveAttribute('integrity', 'hash-step-a-js');
             expect(links[1]).toHaveAttribute('href', 'https://cdn.foo.bar/step-b.js');
             expect(links[1]).toHaveAttribute('crossorigin', 'anonymous');
-            expect(links[1]).toHaveAttribute('integrity', 'hash-step-b-js');
         });
 
-        it('prefetches dynamic CSS chunks with matching crossorigin and integrity attributes', async () => {
+        it('prefetches dynamic CSS chunks with crossorigin matching the real chunk requests', async () => {
             await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
 
             const links = document.head.querySelectorAll<HTMLLinkElement>(
@@ -175,10 +171,19 @@ describe('loadFiles', () => {
             expect(links).toHaveLength(2);
             expect(links[0]).toHaveAttribute('href', 'https://cdn.foo.bar/step-a.css');
             expect(links[0]).toHaveAttribute('crossorigin', 'anonymous');
-            expect(links[0]).toHaveAttribute('integrity', 'hash-step-a-css');
             expect(links[1]).toHaveAttribute('href', 'https://cdn.foo.bar/step-b.css');
             expect(links[1]).toHaveAttribute('crossorigin', 'anonymous');
-            expect(links[1]).toHaveAttribute('integrity', 'hash-step-b-css');
+        });
+
+        it('omits integrity from prefetch links since browsers ignore it and SRI is checked on the real chunk requests', async () => {
+            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
+
+            const links = document.head.querySelectorAll<HTMLLinkElement>('link[rel="prefetch"]');
+
+            expect(links).toHaveLength(4);
+            links.forEach((link) => {
+                expect(link).not.toHaveAttribute('integrity');
+            });
         });
 
         it('logs a failure tied to the specific prefetch link that failed, without a page-wide listener', async () => {
@@ -202,12 +207,9 @@ describe('loadFiles', () => {
             failingLink.dispatchEvent(new Event('error'));
 
             expect(consoleErrorSpy).toHaveBeenCalledWith(
-                '[checkout-js] Failed to prefetch (load or integrity check failed):',
+                '[checkout-js] Failed to prefetch:',
                 'https://cdn.foo.bar/step-a.js',
             );
-
-            addEventListenerSpy.mockRestore();
-            consoleErrorSpy.mockRestore();
         });
     });
 
@@ -284,8 +286,6 @@ describe('loadFiles', () => {
             await expect(loadFiles(options)).rejects.toThrow(bootstrapError);
 
             expect(consoleErrorSpy).not.toHaveBeenCalled();
-
-            consoleErrorSpy.mockRestore();
         });
 
         it('logs a clear, greppable message and still rejects if bootstrapping fails when isConsistentCrossOriginFixEnabled is on', async () => {
@@ -306,8 +306,6 @@ describe('loadFiles', () => {
                 '[checkout-js] Failed to bootstrap checkout:',
                 bootstrapError,
             );
-
-            consoleErrorSpy.mockRestore();
         });
     });
 });

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -32,32 +32,6 @@ export interface LoadFilesResult {
 
 const DIAGNOSTIC_PREFIX = '[checkout-js]';
 
-let areBootstrapDiagnosticsInstalled = false;
-
-function installBootstrapDiagnostics(): void {
-    if (areBootstrapDiagnosticsInstalled || typeof window === 'undefined') {
-        return;
-    }
-
-    areBootstrapDiagnosticsInstalled = true;
-
-    window.addEventListener('error', (event) => {
-        // eslint-disable-next-line no-console
-        console.error(
-            `${DIAGNOSTIC_PREFIX} Uncaught error on the checkout page:`,
-            event.error || event.message,
-        );
-    });
-
-    window.addEventListener('unhandledrejection', (event) => {
-        // eslint-disable-next-line no-console
-        console.error(
-            `${DIAGNOSTIC_PREFIX} Unhandled promise rejection on the checkout page:`,
-            event.reason,
-        );
-    });
-}
-
 function preloadWithConsistentCrossOrigin(
     tags: Array<{ rel: string; as: string; href: string; integrity?: string }>,
 ): void {
@@ -73,6 +47,14 @@ function preloadWithConsistentCrossOrigin(
             link.setAttribute('integrity', integrity);
         }
 
+        link.addEventListener('error', () => {
+            // eslint-disable-next-line no-console
+            console.error(
+                `${DIAGNOSTIC_PREFIX} Failed to prefetch (load or integrity check failed):`,
+                href,
+            );
+        });
+
         document.head.appendChild(link);
     });
 }
@@ -80,11 +62,6 @@ function preloadWithConsistentCrossOrigin(
 export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> {
     const publicPath = configurePublicPath(options && options.publicPath);
     const isConsistentCrossOriginFixEnabled = Boolean(options?.isConsistentCrossOriginFixEnabled);
-
-    // diagnostics is also gated behind the same experiment
-    if (isConsistentCrossOriginFixEnabled) {
-        installBootstrapDiagnostics();
-    }
 
     const {
         appVersion,

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -30,28 +30,6 @@ export interface LoadFilesResult {
     renderOrderConfirmation(options: RenderOrderConfirmationOptions): void;
 }
 
-const DIAGNOSTIC_PREFIX = '[checkout-js]';
-
-function prefetchWithConsistentCrossOrigin(
-    tags: Array<{ as: 'script' | 'style'; href: string }>,
-): void {
-    tags.forEach(({ as, href }) => {
-        const link = document.createElement('link');
-
-        link.setAttribute('rel', 'prefetch');
-        link.setAttribute('as', as);
-        link.setAttribute('href', href);
-        link.setAttribute('crossorigin', 'anonymous');
-
-        link.addEventListener('error', () => {
-            // eslint-disable-next-line no-console
-            console.error(`${DIAGNOSTIC_PREFIX} Failed to prefetch:`, href);
-        });
-
-        document.head.appendChild(link);
-    });
-}
-
 export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> {
     const publicPath = configurePublicPath(options && options.publicPath);
     const isConsistentCrossOriginFixEnabled = Boolean(options?.isConsistentCrossOriginFixEnabled);
@@ -94,81 +72,58 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
         ),
     );
 
-    if (isConsistentCrossOriginFixEnabled) {
-        prefetchWithConsistentCrossOrigin(
-            jsDynamicChunks.map((path) => ({
-                as: 'script',
-                href: joinPaths(publicPath, path),
-            })),
-        );
+    const preloadOptions = {
+        prefetch: true,
+        ...(isConsistentCrossOriginFixEnabled && { crossOrigin: 'anonymous' as const }),
+    };
 
-        prefetchWithConsistentCrossOrigin(
-            cssDynamicChunks.map((path) => ({
-                as: 'style',
-                href: joinPaths(publicPath, path),
-            })),
-        );
-    } else {
-        getScriptLoader().preloadScripts(
-            jsDynamicChunks.map((path) => joinPaths(publicPath, path)),
-            { prefetch: true },
-        );
+    getScriptLoader().preloadScripts(
+        jsDynamicChunks.map((path) => joinPaths(publicPath, path)),
+        preloadOptions,
+    );
 
-        getStylesheetLoader().preloadStylesheets(
-            cssDynamicChunks.map((path) => joinPaths(publicPath, path)),
-            { prefetch: true },
-        );
-    }
+    getStylesheetLoader().preloadStylesheets(
+        cssDynamicChunks.map((path) => joinPaths(publicPath, path)),
+        preloadOptions,
+    );
 
     const languageConfig = isLanguageWindow(window)
         ? window.language
         : { locale: 'en', locales: {}, translations: {} };
 
-    const filesPromise: Promise<LoadFilesResult> = Promise.all([
-        getDefaultTranslations(languageConfig.locale),
-        scripts,
-        stylesheets,
-    ]).then(([defaultTranslations]) => {
-        if (!isRecordContainingKey(window, LIBRARY_NAME)) {
-            throw new Error(`'${LIBRARY_NAME}' property is not available in window.`);
-        }
+    return Promise.all([getDefaultTranslations(languageConfig.locale), scripts, stylesheets]).then(
+        ([defaultTranslations]) => {
+            if (!isRecordContainingKey(window, LIBRARY_NAME)) {
+                throw new Error(`'${LIBRARY_NAME}' property is not available in window.`);
+            }
 
-        const appExport = window[LIBRARY_NAME];
+            const appExport = window[LIBRARY_NAME];
 
-        if (!isAppExport(appExport)) {
-            throw new Error(
-                'The functions required to bootstrap the application are not available.',
-            );
-        }
+            if (!isAppExport(appExport)) {
+                throw new Error(
+                    'The functions required to bootstrap the application are not available.',
+                );
+            }
 
-        const { renderCheckout, renderOrderConfirmation, initializeLanguageService } = appExport;
+            const { renderCheckout, renderOrderConfirmation, initializeLanguageService } =
+                appExport;
 
-        initializeLanguageService({
-            ...languageConfig,
-            defaultTranslations,
-        });
+            initializeLanguageService({
+                ...languageConfig,
+                defaultTranslations,
+            });
 
-        return {
-            appVersion,
-            renderCheckout: async (renderOptions) => {
-                await yieldToMain();
-                renderCheckout({ publicPath, ...renderOptions });
-            },
-            renderOrderConfirmation: async (renderOptions) => {
-                await yieldToMain();
-                renderOrderConfirmation({ publicPath, ...renderOptions });
-            },
-        };
-    });
-
-    if (!isConsistentCrossOriginFixEnabled) {
-        return filesPromise;
-    }
-
-    return filesPromise.catch((error) => {
-        // eslint-disable-next-line no-console
-        console.error(`${DIAGNOSTIC_PREFIX} Failed to bootstrap checkout:`, error);
-
-        throw error;
-    });
+            return {
+                appVersion,
+                renderCheckout: async (renderOptions) => {
+                    await yieldToMain();
+                    renderCheckout({ publicPath, ...renderOptions });
+                },
+                renderOrderConfirmation: async (renderOptions) => {
+                    await yieldToMain();
+                    renderOrderConfirmation({ publicPath, ...renderOptions });
+                },
+            };
+        },
+    );
 }

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -1,5 +1,6 @@
-import { getDefaultTranslations, isLanguageWindow } from '@bigcommerce/checkout/locale';
 import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
+
+import { getDefaultTranslations, isLanguageWindow } from '@bigcommerce/checkout/locale';
 
 import { isAppExport } from './AppExport';
 import { type RenderCheckoutOptions } from './checkout';
@@ -20,7 +21,7 @@ export interface AssetManifest {
 
 export interface LoadFilesOptions {
     publicPath?: string;
-    isSafePrefetchEnabled?: boolean;
+    isConsistentCrossOriginFixEnabled?: boolean;
 }
 
 export interface LoadFilesResult {
@@ -33,17 +34,6 @@ const DIAGNOSTIC_PREFIX = '[checkout-js]';
 
 let areBootstrapDiagnosticsInstalled = false;
 
-/**
- * Bootstrap failures (a chunk that never loads, an uncaught exception thrown by
- * another script on the page, a rejected promise inside the loader itself) currently
- * have no error reporting: Sentry is only initialized once the checkout app has
- * rendered, which is exactly the thing that doesn't happen when bootstrap fails. These
- * listeners are a last-resort safety net so a failure at least leaves a clear,
- * greppable trace in the console instead of a silent, unexplained hang. They are
- * intentionally left installed for the lifetime of the page (not just the bootstrap
- * window), since we've also seen checkout go silent minutes after a successful initial
- * load (e.g. mid-way through the shipping step).
- */
 function installBootstrapDiagnostics(): void {
     if (areBootstrapDiagnosticsInstalled || typeof window === 'undefined') {
         return;
@@ -68,7 +58,7 @@ function installBootstrapDiagnostics(): void {
     });
 }
 
-function preloadWithCrossOrigin(
+function preloadWithConsistentCrossOrigin(
     tags: Array<{ rel: string; as: string; href: string; integrity?: string }>,
 ): void {
     tags.forEach(({ rel, as, href, integrity }) => {
@@ -89,13 +79,10 @@ function preloadWithCrossOrigin(
 
 export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> {
     const publicPath = configurePublicPath(options && options.publicPath);
-    const isSafePrefetchEnabled = Boolean(options?.isSafePrefetchEnabled);
+    const isConsistentCrossOriginFixEnabled = Boolean(options?.isConsistentCrossOriginFixEnabled);
 
-    // Gated behind the same flag as the crossorigin/SRI prefetch fix below: existing
-    // stores (flag off) get byte-for-byte the same behavior as before this diagnostics
-    // work existed. Only stores opted into the fix also get the extra error visibility
-    // while we validate the rollout.
-    if (isSafePrefetchEnabled) {
+    // diagnostics is also gated behind the same experiment
+    if (isConsistentCrossOriginFixEnabled) {
         installBootstrapDiagnostics();
     }
 
@@ -137,14 +124,8 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
         ),
     );
 
-    if (isSafePrefetchEnabled) {
-        // `@bigcommerce/script-loader`'s preloadScripts/preloadStylesheets create
-        // `<link rel="prefetch">` tags with no `crossorigin` attribute, while webpack's
-        // runtime later loads these same chunk URLs with `crossorigin="anonymous"` plus a
-        // Subresource Integrity hash. A browser can end up reusing the crossorigin-less
-        // prefetch response for the later CORS+SRI request, which silently fails to
-        // execute. Build the prefetch tags ourselves so the attributes match.
-        preloadWithCrossOrigin(
+    if (isConsistentCrossOriginFixEnabled) {
+        preloadWithConsistentCrossOrigin(
             jsDynamicChunks.map((path) => ({
                 rel: 'prefetch',
                 as: 'script',
@@ -153,7 +134,7 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
             })),
         );
 
-        preloadWithCrossOrigin(
+        preloadWithConsistentCrossOrigin(
             cssDynamicChunks.map((path) => ({
                 rel: 'prefetch',
                 as: 'style',
@@ -214,9 +195,7 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
         };
     });
 
-    // Same gating as above: don't attach a `.catch()` at all unless the flag is on, so
-    // existing stores get the exact same promise behavior as before this existed.
-    if (!isSafePrefetchEnabled) {
+    if (!isConsistentCrossOriginFixEnabled) {
         return filesPromise;
     }
 

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -1,6 +1,5 @@
-import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
-
 import { getDefaultTranslations, isLanguageWindow } from '@bigcommerce/checkout/locale';
+import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
 
 import { isAppExport } from './AppExport';
 import { type RenderCheckoutOptions } from './checkout';
@@ -21,6 +20,7 @@ export interface AssetManifest {
 
 export interface LoadFilesOptions {
     publicPath?: string;
+    isSafePrefetchEnabled?: boolean;
 }
 
 export interface LoadFilesResult {
@@ -29,8 +29,76 @@ export interface LoadFilesResult {
     renderOrderConfirmation(options: RenderOrderConfirmationOptions): void;
 }
 
+const DIAGNOSTIC_PREFIX = '[checkout-js]';
+
+let areBootstrapDiagnosticsInstalled = false;
+
+/**
+ * Bootstrap failures (a chunk that never loads, an uncaught exception thrown by
+ * another script on the page, a rejected promise inside the loader itself) currently
+ * have no error reporting: Sentry is only initialized once the checkout app has
+ * rendered, which is exactly the thing that doesn't happen when bootstrap fails. These
+ * listeners are a last-resort safety net so a failure at least leaves a clear,
+ * greppable trace in the console instead of a silent, unexplained hang. They are
+ * intentionally left installed for the lifetime of the page (not just the bootstrap
+ * window), since we've also seen checkout go silent minutes after a successful initial
+ * load (e.g. mid-way through the shipping step).
+ */
+function installBootstrapDiagnostics(): void {
+    if (areBootstrapDiagnosticsInstalled || typeof window === 'undefined') {
+        return;
+    }
+
+    areBootstrapDiagnosticsInstalled = true;
+
+    window.addEventListener('error', (event) => {
+        // eslint-disable-next-line no-console
+        console.error(
+            `${DIAGNOSTIC_PREFIX} Uncaught error on the checkout page:`,
+            event.error || event.message,
+        );
+    });
+
+    window.addEventListener('unhandledrejection', (event) => {
+        // eslint-disable-next-line no-console
+        console.error(
+            `${DIAGNOSTIC_PREFIX} Unhandled promise rejection on the checkout page:`,
+            event.reason,
+        );
+    });
+}
+
+function preloadWithCrossOrigin(
+    tags: Array<{ rel: string; as: string; href: string; integrity?: string }>,
+): void {
+    tags.forEach(({ rel, as, href, integrity }) => {
+        const link = document.createElement('link');
+
+        link.setAttribute('rel', rel);
+        link.setAttribute('as', as);
+        link.setAttribute('href', href);
+        link.setAttribute('crossorigin', 'anonymous');
+
+        if (integrity) {
+            link.setAttribute('integrity', integrity);
+        }
+
+        document.head.appendChild(link);
+    });
+}
+
 export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> {
     const publicPath = configurePublicPath(options && options.publicPath);
+    const isSafePrefetchEnabled = Boolean(options?.isSafePrefetchEnabled);
+
+    // Gated behind the same flag as the crossorigin/SRI prefetch fix below: existing
+    // stores (flag off) get byte-for-byte the same behavior as before this diagnostics
+    // work existed. Only stores opted into the fix also get the extra error visibility
+    // while we validate the rollout.
+    if (isSafePrefetchEnabled) {
+        installBootstrapDiagnostics();
+    }
+
     const {
         appVersion,
         css = [],
@@ -69,53 +137,93 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
         ),
     );
 
-    getScriptLoader().preloadScripts(
-        jsDynamicChunks.map((path) => joinPaths(publicPath, path)),
-        { prefetch: true },
-    );
+    if (isSafePrefetchEnabled) {
+        // `@bigcommerce/script-loader`'s preloadScripts/preloadStylesheets create
+        // `<link rel="prefetch">` tags with no `crossorigin` attribute, while webpack's
+        // runtime later loads these same chunk URLs with `crossorigin="anonymous"` plus a
+        // Subresource Integrity hash. A browser can end up reusing the crossorigin-less
+        // prefetch response for the later CORS+SRI request, which silently fails to
+        // execute. Build the prefetch tags ourselves so the attributes match.
+        preloadWithCrossOrigin(
+            jsDynamicChunks.map((path) => ({
+                rel: 'prefetch',
+                as: 'script',
+                href: joinPaths(publicPath, path),
+                integrity: integrity[path],
+            })),
+        );
 
-    getStylesheetLoader().preloadStylesheets(
-        cssDynamicChunks.map((path) => joinPaths(publicPath, path)),
-        { prefetch: true },
-    );
+        preloadWithCrossOrigin(
+            cssDynamicChunks.map((path) => ({
+                rel: 'prefetch',
+                as: 'style',
+                href: joinPaths(publicPath, path),
+                integrity: integrity[path],
+            })),
+        );
+    } else {
+        getScriptLoader().preloadScripts(
+            jsDynamicChunks.map((path) => joinPaths(publicPath, path)),
+            { prefetch: true },
+        );
+
+        getStylesheetLoader().preloadStylesheets(
+            cssDynamicChunks.map((path) => joinPaths(publicPath, path)),
+            { prefetch: true },
+        );
+    }
 
     const languageConfig = isLanguageWindow(window)
         ? window.language
         : { locale: 'en', locales: {}, translations: {} };
 
-    return Promise.all([getDefaultTranslations(languageConfig.locale), scripts, stylesheets]).then(
-        ([defaultTranslations]) => {
-            if (!isRecordContainingKey(window, LIBRARY_NAME)) {
-                throw new Error(`'${LIBRARY_NAME}' property is not available in window.`);
-            }
+    const filesPromise = Promise.all([
+        getDefaultTranslations(languageConfig.locale),
+        scripts,
+        stylesheets,
+    ]).then(([defaultTranslations]) => {
+        if (!isRecordContainingKey(window, LIBRARY_NAME)) {
+            throw new Error(`'${LIBRARY_NAME}' property is not available in window.`);
+        }
 
-            const appExport = window[LIBRARY_NAME];
+        const appExport = window[LIBRARY_NAME];
 
-            if (!isAppExport(appExport)) {
-                throw new Error(
-                    'The functions required to bootstrap the application are not available.',
-                );
-            }
+        if (!isAppExport(appExport)) {
+            throw new Error(
+                'The functions required to bootstrap the application are not available.',
+            );
+        }
 
-            const { renderCheckout, renderOrderConfirmation, initializeLanguageService } =
-                appExport;
+        const { renderCheckout, renderOrderConfirmation, initializeLanguageService } = appExport;
 
-            initializeLanguageService({
-                ...languageConfig,
-                defaultTranslations,
-            });
+        initializeLanguageService({
+            ...languageConfig,
+            defaultTranslations,
+        });
 
-            return {
-                appVersion,
-                renderCheckout: async (renderOptions) => {
-                    await yieldToMain();
-                    renderCheckout({ publicPath, ...renderOptions });
-                },
-                renderOrderConfirmation: async (renderOptions) => {
-                    await yieldToMain();
-                    renderOrderConfirmation({ publicPath, ...renderOptions });
-                },
-            };
-        },
-    );
+        return {
+            appVersion,
+            renderCheckout: async (renderOptions) => {
+                await yieldToMain();
+                renderCheckout({ publicPath, ...renderOptions });
+            },
+            renderOrderConfirmation: async (renderOptions) => {
+                await yieldToMain();
+                renderOrderConfirmation({ publicPath, ...renderOptions });
+            },
+        };
+    });
+
+    // Same gating as above: don't attach a `.catch()` at all unless the flag is on, so
+    // existing stores get the exact same promise behavior as before this existed.
+    if (!isSafePrefetchEnabled) {
+        return filesPromise;
+    }
+
+    return filesPromise.catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error(`${DIAGNOSTIC_PREFIX} Failed to bootstrap checkout:`, error);
+
+        throw error;
+    });
 }

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -32,27 +32,20 @@ export interface LoadFilesResult {
 
 const DIAGNOSTIC_PREFIX = '[checkout-js]';
 
-function preloadWithConsistentCrossOrigin(
-    tags: Array<{ rel: string; as: string; href: string; integrity?: string }>,
+function prefetchWithConsistentCrossOrigin(
+    tags: Array<{ as: 'script' | 'style'; href: string }>,
 ): void {
-    tags.forEach(({ rel, as, href, integrity }) => {
+    tags.forEach(({ as, href }) => {
         const link = document.createElement('link');
 
-        link.setAttribute('rel', rel);
+        link.setAttribute('rel', 'prefetch');
         link.setAttribute('as', as);
         link.setAttribute('href', href);
         link.setAttribute('crossorigin', 'anonymous');
 
-        if (integrity) {
-            link.setAttribute('integrity', integrity);
-        }
-
         link.addEventListener('error', () => {
             // eslint-disable-next-line no-console
-            console.error(
-                `${DIAGNOSTIC_PREFIX} Failed to prefetch (load or integrity check failed):`,
-                href,
-            );
+            console.error(`${DIAGNOSTIC_PREFIX} Failed to prefetch:`, href);
         });
 
         document.head.appendChild(link);
@@ -102,21 +95,17 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
     );
 
     if (isConsistentCrossOriginFixEnabled) {
-        preloadWithConsistentCrossOrigin(
+        prefetchWithConsistentCrossOrigin(
             jsDynamicChunks.map((path) => ({
-                rel: 'prefetch',
                 as: 'script',
                 href: joinPaths(publicPath, path),
-                integrity: integrity[path],
             })),
         );
 
-        preloadWithConsistentCrossOrigin(
+        prefetchWithConsistentCrossOrigin(
             cssDynamicChunks.map((path) => ({
-                rel: 'prefetch',
                 as: 'style',
                 href: joinPaths(publicPath, path),
-                integrity: integrity[path],
             })),
         );
     } else {
@@ -135,7 +124,7 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
         ? window.language
         : { locale: 'en', locales: {}, translations: {} };
 
-    const filesPromise = Promise.all([
+    const filesPromise: Promise<LoadFilesResult> = Promise.all([
         getDefaultTranslations(languageConfig.locale),
         scripts,
         stylesheets,


### PR DESCRIPTION
[CHECKOUT-10115](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10115)

## What/Why?

Checkout pre-downloads its billing, shipping, and payment step files so steps open instantly, but the prefetch requests are currently sent without a `crossorigin` attribute (plain no-CORS requests), while the actual loads use `crossorigin="anonymous"` with SRI integrity checks (CORS requests).

Because the two request modes don't share cache entries cleanly, every shopper downloaded those files twice and when a browser or CDN cached the no-CORS response (which lacks the Access-Control-Allow-Origin header), the later SRI-checked load was silently blocked and checkout could freeze at the shipping, billing, or payment step.

This change creates the prefetch <link> tags directly with the same `crossorigin="anonymous"` mode as the real loads. I couldn't reuse `@bigcommerce/script-loader` here because its `preloadScripts`/`preloadStylesheets` API doesn't support setting custom attributes like `crossorigin` on the links it creates. The result: the cached copy is always valid and reused, so no duplicate downloads and no freeze. 

It ships behind a `CHECKOUT-10115.consistent_crossorigin_prefetch_fix` feature flag (flag-off behavior is unchanged and test-covered) to minimize any risks.

## Rollout/Rollback

Revert or set `CHECKOUT-10115.consistent_crossorigin_prefetch_fix` to false.

## Testing

New CI tests + I deployed to integration (where the `CHECKOUT-10115.consistent_crossorigin_prefetch_fix` flag is set to true) and ran our checkout suite:

https://launchbay.bigcommerce.net/deployments/564600

All tests are passing except for the B2B test but this is known to fail at the moment:
<img width="1494" height="816" alt="image" src="https://github.com/user-attachments/assets/5301559f-bb08-4b59-ad5c-a3b7fada36fc" />

Confirming that the flag is true:

<img width="759" height="453" alt="image" src="https://github.com/user-attachments/assets/34aceb31-e49a-407a-89c5-fb41c9721ae4" />

The store if you want to test: https://tss-store-1784610142062125342.my-integration.zone/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout bootstrap and asset prefetch for all shoppers when the flag is on; behavior is gated and tests preserve flag-off semantics.
> 
> **Overview**
> Fixes duplicate downloads and checkout freezes on shipping/billing/payment when prefetch and real chunk loads used mismatched CORS modes.
> 
> **`loadFiles`** now accepts `isConsistentCrossOriginFixEnabled`. When enabled, dynamic JS/CSS prefetches pass `crossOrigin: 'anonymous'` (via upgraded **`@bigcommerce/script-loader` ^2.3.0**) so prefetch cache entries match integrity-checked loads. Flag off keeps prior prefetch behavior.
> 
> **`auto-loader`** reads `isConsistentCrossOriginFixEnabled` from `window.checkoutConfig`, forwards it to `loadFiles`, and omits it from props passed to render functions. Loader tests cover both flag states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972966473e653d6b28ae0ec3c51f8117f18ec2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[CHECKOUT-10115]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ