### PR TITLE
feat(paymnet): Migrate SagePay to Resolver Configuration

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/HostedCreditCardPaymentMethod.tsx
@@ -44,6 +44,11 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
         'PI-4748.cba_resolver_configuration',
         false,
     );
+    const isSagePayResolverEnabled = isExperimentEnabled(
+        config?.checkoutSettings,
+        'PI-4754.sage_pay_resolver_configuration',
+        false,
+    );
 
     const initializeHostedCreditCardPayment: CreditCardPaymentMethodProps['initializePayment'] =
         useCallback(
@@ -55,7 +60,7 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                         createCreditCardPaymentStrategy,
                         createCyberSourcePaymentStrategy,
                         createCyberSourceV2PaymentStrategy,
-                        createSagePayPaymentStrategy,
+                        ...(!isSagePayResolverEnabled ? [createSagePayPaymentStrategy] : []),
                         ...(!isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
                     ],
                     creditCard: getHostedFormOptions && {
@@ -63,7 +68,12 @@ const HostedCreditCardPaymentMethod: FunctionComponent<
                     },
                 });
             },
-            [getHostedFormOptions, initializePayment, isCBAMPGSResolverEnabled],
+            [
+                getHostedFormOptions,
+                initializePayment,
+                isCBAMPGSResolverEnabled,
+                isSagePayResolverEnabled,
+            ],
         );
 
     return (

--- a/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
+++ b/packages/hosted-credit-card-integration/src/HostedCreditCardPaymentMethod.tsx
@@ -40,5 +40,9 @@ export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>
 
         { id: 'tdonlinemart' },
         { id: 'cba_mpgs', experiment: 'PI-4748_cba_resolver_configuration' },
+        {
+            id: 'sagepay',
+            experiment: 'PI-4754_sage_pay_resolver_configuration',
+        },
     ],
 );

--- a/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
+++ b/packages/hosted-credit-card-integration/src/components/HostedCreditCardComponent.tsx
@@ -7,6 +7,7 @@ import { createBlueSnapDirectCreditCardPaymentStrategy } from '@bigcommerce/chec
 import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
 import { createCheckoutComCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createCreditCardPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/credit-card';
+import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import { createTDOnlineMartPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/td-bank';
 import { compact, forIn } from 'lodash';
 import React, { type FunctionComponent, type ReactNode, useCallback, useState } from 'react';
@@ -59,6 +60,10 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
     const isCBAMPGSResolverEnabled =
         checkoutState.data.getConfig()?.checkoutSettings.features?.[
             'PI-4748.cba_resolver_configuration'
+        ] ?? false;
+    const isSagePayResolverEnabled =
+        checkoutState.data.getConfig()?.checkoutSettings.features?.[
+            'PI-4754.sage_pay_resolver_configuration'
         ] ?? false;
 
     const { setFieldTouched, setFieldValue, setSubmitted, submitForm } = paymentForm;
@@ -276,6 +281,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                         createCreditCardPaymentStrategy,
                         createBlueSnapDirectCreditCardPaymentStrategy,
                         ...(isCBAMPGSResolverEnabled ? [createCBAMPGSPaymentStrategy] : []),
+                        ...(isSagePayResolverEnabled ? [createSagePayPaymentStrategy] : []),
                         createTDOnlineMartPaymentStrategy,
                         createCheckoutComCreditCardPaymentStrategy,
                     ],
@@ -302,6 +308,7 @@ const HostedCreditCardComponent: FunctionComponent<HostedCreditCardComponentProp
                 initializePayment,
                 isHostedFormEnabled,
                 isCBAMPGSResolverEnabled,
+                isSagePayResolverEnabled,
                 language,
             ],
         );


### PR DESCRIPTION
## What/Why?

Migrates the SagePay payment method to the new resolver-based architecture by registering it in the HostedCreditCardPaymentMethod component resolver (packages/hosted-credit-card-integration).
## Rollout/Rollback

rollback this commit

## Testing

hosted fields off

https://github.com/user-attachments/assets/22f90f23-5ec9-4acb-bd12-989092c7fb23

hosted fields on

https://github.com/user-attachments/assets/200ea179-00ad-4305-87b8-06703542929a

<img width="786" height="682" alt="image" src="https://github.com/user-attachments/assets/4e30ae15-717e-436e-b6d5-1506c231b3bb" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment method resolution and strategy registration for SagePay; incorrect flag handling could break SagePay checkout, but rollout is feature-flagged and mirrors an existing CBA MPGS migration.
> 
> **Overview**
> SagePay checkout routing now follows the same **experiment-gated resolver pattern** as CBA MPGS (`PI-4754.sage_pay_resolver_configuration`).
> 
> When the flag is **on**, `sagepay` is resolved through `hosted-credit-card-integration` and `createSagePayPaymentStrategy` is registered during payment init in `HostedCreditCardComponent`. When the flag is **off**, the core `HostedCreditCardPaymentMethod` path still registers SagePay so existing behavior remains until rollout completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f569e41163e50c835d6069a6ff7e63dfe0eb7ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->