### PR TITLE
refactor(checkout): CHECKOUT-10241 Add CannotCreatePersonalAccountSessionStorage

### DIFF
--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -32,6 +32,7 @@ import {
     consignmentCouponDiscount,
 } from '@bigcommerce/checkout/test-framework';
 import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+import { CannotCreatePersonalAccountSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { createErrorLogger } from '../common/error';
 import {
@@ -657,6 +658,58 @@ describe('Checkout', () => {
                     );
                 });
             } finally {
+                Object.defineProperty(window, 'location', {
+                    value: originalLocation,
+                    configurable: true,
+                    writable: true,
+                });
+            }
+        });
+
+        it('persists cannotCreatePersonalAccount to session storage when navigating to order confirmation', async () => {
+            const originalLocation = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...window.location,
+                    replace: jest.fn(),
+                },
+                configurable: true,
+                writable: true,
+            });
+
+            try {
+                checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+                jest.spyOn(checkoutService, 'submitOrder').mockResolvedValue({
+                    data: {
+                        getOrder: () => ({ orderId: 123 }) as any,
+                    },
+                } as any);
+
+                const capabilities = {
+                    ...defaultCapabilities,
+                    orderConfirmation: {
+                        ...defaultCapabilities.orderConfirmation,
+                        cannotCreatePersonalAccount: true,
+                    },
+                };
+
+                render(<CheckoutTest {...defaultProps} capabilities={capabilities} />);
+
+                await checkout.waitForPaymentStep();
+
+                await userEvent.click(screen.getByText(/place order/i));
+
+                await waitFor(() => {
+                    expect(
+                        CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount(),
+                    ).toBe(true);
+                });
+                expect(window.location.replace).toHaveBeenCalled();
+            } finally {
+                CannotCreatePersonalAccountSessionStorage.removeCannotCreatePersonalAccount();
                 Object.defineProperty(window, 'location', {
                     value: originalLocation,
                     configurable: true,

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -33,7 +33,10 @@ import {
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { OrderConfirmationPageSkeleton } from '@bigcommerce/checkout/ui';
-import { navigateToOrderConfirmation as navigateToOrderConfirmationUtility } from '@bigcommerce/checkout/utility';
+import {
+    CannotCreatePersonalAccountSessionStorage,
+    navigateToOrderConfirmation as navigateToOrderConfirmationUtility,
+} from '@bigcommerce/checkout/utility';
 
 import { withAnalytics } from '../analytics';
 import { EmptyCartMessage } from '../cart';
@@ -151,7 +154,7 @@ const Checkout = ({
     const capabilities = useCapabilities();
     const {
         userJourney: { requiresB2BToken, quoteConfig },
-        orderConfirmation: { invoiceRedirect },
+        orderConfirmation: { cannotCreatePersonalAccount, invoiceRedirect },
     } = capabilities;
     const { fetchB2BToken } = useB2BToken();
     const { checkoutService } = useCheckout(() => undefined);
@@ -264,6 +267,10 @@ const Checkout = ({
 
             return;
         }
+
+        CannotCreatePersonalAccountSessionStorage.setCannotCreatePersonalAccount(
+            cannotCreatePersonalAccount,
+        );
 
         void navigateToOrderConfirmationUtility(orderId);
     }, []);

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.test.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.test.tsx
@@ -15,7 +15,6 @@ import {
     type AnalyticsEvents,
     AnalyticsProviderMock,
     CheckoutProvider,
-    defaultCapabilities,
     ExtensionProvider,
     type ExtensionServiceInterface,
     type LocaleContextType,
@@ -24,6 +23,7 @@ import {
 } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext, getLanguageService } from '@bigcommerce/checkout/locale';
 import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+import { CannotCreatePersonalAccountSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { createErrorLogger } from '../../common/error';
 import { getStoreConfig } from '../../config/config.mock';
@@ -251,21 +251,30 @@ describe('OrderConfirmation', () => {
         );
     });
 
-    describe('when cannotCreatePersonalAccount capability is enabled', () => {
+    describe('when cannotCreatePersonalAccount is stored in session storage', () => {
         beforeEach(() => {
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
-                ...getStoreConfig(),
-                checkoutSettings: {
-                    ...getStoreConfig().checkoutSettings,
-                    capabilities: {
-                        ...defaultCapabilities,
-                        orderConfirmation: {
-                            ...defaultCapabilities.orderConfirmation,
-                            cannotCreatePersonalAccount: true,
-                        },
-                    },
-                },
+            CannotCreatePersonalAccountSessionStorage.setCannotCreatePersonalAccount(true);
+        });
+
+        afterEach(() => {
+            CannotCreatePersonalAccountSessionStorage.removeCannotCreatePersonalAccount();
+        });
+
+        it('removes the stored value after consuming it once', async () => {
+            render(<ComponentTest {...defaultProps} />);
+
+            await waitFor(() => {
+                expect(analyticsTracker.orderPurchased).toHaveBeenCalled();
             });
+
+            expect(
+                sessionStorage.getItem(CannotCreatePersonalAccountSessionStorage.key),
+            ).toBeNull();
+            expect(
+                screen.queryByText(
+                    localeContext.language.translate('customer.create_account_text'),
+                ),
+            ).not.toBeInTheDocument();
         });
 
         it('does not render the create account form', async () => {

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
@@ -5,10 +5,13 @@ import {
 import { createRequestSender } from '@bigcommerce/request-sender';
 import React, { type ReactElement, useEffect, useRef, useState } from 'react';
 
-import { useAnalytics, useCapabilities, useCheckout } from '@bigcommerce/checkout/contexts';
+import { useAnalytics, useCheckout } from '@bigcommerce/checkout/contexts';
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { OrderConfirmationPageSkeleton } from '@bigcommerce/checkout/ui';
-import { isExperimentEnabled } from '@bigcommerce/checkout/utility';
+import {
+    CannotCreatePersonalAccountSessionStorage,
+    isExperimentEnabled,
+} from '@bigcommerce/checkout/utility';
 
 import { type EmbeddedCheckoutStylesheet } from '../../embeddedCheckout';
 import { type CreatedCustomer, type SignUpFormValues } from '../../guestSignup';
@@ -64,9 +67,13 @@ export const OrderConfirmation = ({
         isLoadingOrder: statuses.isLoadingOrder(),
     }));
     const { analyticsTracker } = useAnalytics();
-    const {
-        orderConfirmation: { cannotCreatePersonalAccount },
-    } = useCapabilities();
+    const [cannotCreatePersonalAccount] = useState(() => {
+        const value = CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount();
+
+        CannotCreatePersonalAccountSessionStorage.removeCannotCreatePersonalAccount();
+
+        return value;
+    });
 
     const handleUnhandledError = (e: Error) => {
         setError(e);

--- a/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
+++ b/packages/core/src/app/order/OrderConfirmation/OrderConfirmation.tsx
@@ -67,13 +67,14 @@ export const OrderConfirmation = ({
         isLoadingOrder: statuses.isLoadingOrder(),
     }));
     const { analyticsTracker } = useAnalytics();
-    const [cannotCreatePersonalAccount] = useState(() => {
-        const value = CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount();
+    const [cannotCreatePersonalAccount, setCannotCreatePersonalAccount] = useState(false);
 
+    useEffect(() => {
+        setCannotCreatePersonalAccount(
+            CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount(),
+        );
         CannotCreatePersonalAccountSessionStorage.removeCannotCreatePersonalAccount();
-
-        return value;
-    });
+    }, []);
 
     const handleUnhandledError = (e: Error) => {
         setError(e);

--- a/packages/utility/src/index.ts
+++ b/packages/utility/src/index.ts
@@ -8,3 +8,4 @@ export {
     type B2BStoredAddressIds,
     type B2BStoredPaymentValues,
 } from './storage/B2BSessionStorage';
+export { CannotCreatePersonalAccountSessionStorage } from './storage/CannotCreatePersonalAccountSessionStorage';

--- a/packages/utility/src/storage/CannotCreatePersonalAccountSessionStorage.test.ts
+++ b/packages/utility/src/storage/CannotCreatePersonalAccountSessionStorage.test.ts
@@ -1,0 +1,42 @@
+import { CannotCreatePersonalAccountSessionStorage } from './CannotCreatePersonalAccountSessionStorage';
+
+describe('CannotCreatePersonalAccountSessionStorage', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('returns false when nothing is stored', () => {
+        expect(CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount()).toBe(
+            false,
+        );
+    });
+
+    it('round-trips a stored true value', () => {
+        CannotCreatePersonalAccountSessionStorage.setCannotCreatePersonalAccount(true);
+
+        expect(sessionStorage.getItem(CannotCreatePersonalAccountSessionStorage.key)).toBe('true');
+        expect(CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount()).toBe(
+            true,
+        );
+    });
+
+    it('round-trips a stored false value', () => {
+        CannotCreatePersonalAccountSessionStorage.setCannotCreatePersonalAccount(false);
+
+        expect(sessionStorage.getItem(CannotCreatePersonalAccountSessionStorage.key)).toBe('false');
+        expect(CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount()).toBe(
+            false,
+        );
+    });
+
+    it('removes the stored value', () => {
+        CannotCreatePersonalAccountSessionStorage.setCannotCreatePersonalAccount(true);
+
+        CannotCreatePersonalAccountSessionStorage.removeCannotCreatePersonalAccount();
+
+        expect(sessionStorage.getItem(CannotCreatePersonalAccountSessionStorage.key)).toBeNull();
+        expect(CannotCreatePersonalAccountSessionStorage.getCannotCreatePersonalAccount()).toBe(
+            false,
+        );
+    });
+});

--- a/packages/utility/src/storage/CannotCreatePersonalAccountSessionStorage.ts
+++ b/packages/utility/src/storage/CannotCreatePersonalAccountSessionStorage.ts
@@ -1,0 +1,15 @@
+export class CannotCreatePersonalAccountSessionStorage {
+    static readonly key = 'checkout_js_cannot_create_personal_account';
+
+    static setCannotCreatePersonalAccount(cannotCreatePersonalAccount: boolean): void {
+        sessionStorage.setItem(this.key, `${cannotCreatePersonalAccount}`);
+    }
+
+    static getCannotCreatePersonalAccount(): boolean {
+        return sessionStorage.getItem(this.key) === 'true';
+    }
+
+    static removeCannotCreatePersonalAccount(): void {
+        sessionStorage.removeItem(this.key);
+    }
+}


### PR DESCRIPTION
## What/Why?

Use session storage to:
- pass `cannotCreatePersonalAccount` from the checkout page to the order confirmation page.

Because the capability object is currently unavailable on the order confirmation page.

## Rollout/Rollback

Revert.

## Testing
### When `cannotCreatePersonalAccount` is `true`, sign-up form should be hidden.

https://github.com/user-attachments/assets/c07b64a6-5dfd-490a-80c9-fcc4f78d4e7e


### When `cannotCreatePersonalAccount` is `false`, sign-up form should be on display.

https://github.com/user-attachments/assets/eb5a039c-c8f2-4dcf-8d37-6f0535bcecf8


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to guest account UI on order confirmation; uses short-lived session storage with no auth or payment changes.
> 
> **Overview**
> **Order confirmation** no longer reads `cannotCreatePersonalAccount` from capabilities (unavailable on that page). The flag is written to **session storage** on checkout when redirecting after place order, then read once on order confirmation mount and cleared so the guest create-account / set-password UI still respects the capability.
> 
> Adds `CannotCreatePersonalAccountSessionStorage` in `@bigcommerce/checkout/utility` and wires **CheckoutPage** to persist the value before `navigateToOrderConfirmation`. **OrderConfirmation** drops `useCapabilities` for this flag in favor of the storage helper. Tests cover storage round-trip, checkout persistence on navigation, and one-time consumption on the confirmation page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b71b8f7e609a60e28e70522027fb8c52440f09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->