### PR TITLE
fix(checkout): CHECKOUT-10227 Decouple new phone component from fastlane

### DIFF
--- a/packages/core/src/app/address/AddressForm.test.tsx
+++ b/packages/core/src/app/address/AddressForm.test.tsx
@@ -23,6 +23,19 @@ import { getStoreConfig } from '../config/config.mock';
 import AddressForm, { type AddressFormProps } from './AddressForm';
 import { getFormFields } from './formField.mock';
 
+jest.mock('@intl-tel-input/react', () => {
+    const MockReact = jest.requireActual<typeof React>('react');
+
+    return {
+        __esModule: true,
+        default: ({ inputProps }: { inputProps?: Record<string, unknown> }) =>
+            MockReact.createElement('input', {
+                ...inputProps,
+                'data-test': 'intl-tel-input-mock',
+            }),
+    };
+});
+
 describe('AddressForm Component', () => {
     let checkoutService: CheckoutService;
     let localeContext: LocaleContextType;
@@ -132,5 +145,53 @@ describe('AddressForm Component', () => {
         await userEvent.keyboard(fieldValue);
 
         expect(onChange).toHaveBeenCalledWith(fieldId, fieldValue);
+    });
+
+    describe('new phone number validation experiment', () => {
+        const phoneFormFieldMock = {
+            fieldType: 'text',
+            id: 'phone',
+            name: 'phone',
+        } as FormField;
+
+        const getConfigMockWithPhoneExperimentTrue = (
+            providerWithCustomCheckout: string | null = null,
+        ) => {
+            const config = getStoreConfig();
+
+            return {
+                ...config,
+                checkoutSettings: {
+                    ...config.checkoutSettings,
+                    features: {
+                        ...config.checkoutSettings.features,
+                        'CHECKOUT-9019.use_new_phone_number_validation': true,
+                    },
+                    providerWithCustomCheckout,
+                },
+            };
+        };
+
+        it('renders legacy phone field when PayPal Fastlane powers custom checkout', () => {
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(
+                getConfigMockWithPhoneExperimentTrue('bigcommerce_payments_fastlane'),
+            );
+
+            renderAddressFormComponent({ formFields: [...formFields, phoneFormFieldMock] });
+
+            expect(screen.queryByTestId('intl-tel-input-mock')).not.toBeInTheDocument();
+            expect(screen.getByTestId('phoneInput-text')).toBeInTheDocument();
+        });
+
+        it('renders new phone number field when custom checkout provider is not PayPal Fastlane', () => {
+            jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(
+                getConfigMockWithPhoneExperimentTrue('100%_definitely_not_fastlane'),
+            );
+
+            renderAddressFormComponent({ formFields: [...formFields, phoneFormFieldMock] });
+
+            expect(screen.getByTestId('intl-tel-input-mock')).toBeInTheDocument();
+            expect(screen.queryByTestId('phoneInput-text')).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/core/src/app/address/AddressForm.tsx
+++ b/packages/core/src/app/address/AddressForm.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 
 import { useCapabilities, useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { isPayPalFastlaneMethod } from '@bigcommerce/checkout/paypal-fastlane-integration';
 import {
     type AutocompleteItem,
     CheckboxFormField,
@@ -14,6 +15,7 @@ import {
 import { isExperimentEnabled } from '@bigcommerce/checkout/utility';
 
 import { EMPTY_ARRAY, isFloatingLabelEnabled } from '../common/utility';
+import getProviderWithCustomCheckout from '../payment/getProviderWithCustomCheckout';
 
 import {
     type AddressFormProps,
@@ -57,11 +59,17 @@ const AddressForm: React.FC<AddressFormProps> = ({
     const isFloatingLabelEnabledValue = config
         ? isFloatingLabelEnabled(config.checkoutSettings)
         : false;
-    const isNewPhoneValidationExperimentEnabled = isExperimentEnabled(
-        config?.checkoutSettings,
-        'CHECKOUT-9019.use_new_phone_number_validation',
-        false,
+    const isPayPalFastlaneEnabled = isPayPalFastlaneMethod(
+        getProviderWithCustomCheckout(config?.checkoutSettings.providerWithCustomCheckout),
     );
+    // PayPal Fastlane stores keep the legacy phone input for now, due to incident
+    const isNewPhoneValidationExperimentEnabled =
+        !isPayPalFastlaneEnabled &&
+        isExperimentEnabled(
+            config?.checkoutSettings,
+            'CHECKOUT-9019.use_new_phone_number_validation',
+            false,
+        );
     const isNewGooglePlacesApiEnabled = isExperimentEnabled(
         config?.checkoutSettings,
         'CHECKOUT-10026.new_google_places_api',


### PR DESCRIPTION
## What/Why?

Since we had an incident related to this combination of phone input component and Fastlane: [#incident-20260711-2475](https://commerce-group.enterprise.slack.com/archives/C0BGMHC81FF) we decided to exclude Fastlane stores from rollout at this time.

## Rollout/Rollback

Revert the PR.

## Testing

New CI tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to address-form phone UI gating with an explicit Fastlane carve-out; no auth or payment processing changes.
> 
> **Overview**
> **Address form phone input** now treats PayPal Fastlane custom checkout as an exception to the `CHECKOUT-9019.use_new_phone_number_validation` experiment: when Fastlane powers custom checkout, address forms keep the **legacy** phone field even if the experiment is on; all other stores still get the **intl-tel-input** path when the flag is enabled.
> 
> `AddressForm` resolves the custom checkout provider via `getProviderWithCustomCheckout` and `isPayPalFastlaneMethod`, then sets `isNewPhoneValidationExperimentEnabled` to the experiment flag **and** `!isPayPalFastlaneEnabled` (comment references a prior incident).
> 
> Tests mock `@intl-tel-input/react` and assert Fastlane (`bigcommerce_payments_fastlane`) shows `phoneInput-text` while a non-Fastlane provider shows the mock intl component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cdba6d6504e243e1ca29b25fee357e1af97be92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->