### PR TITLE
fix(checkout): CHECKOUT-10206 Do not pass value unconditionally to phone input

### DIFF
--- a/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
@@ -27,9 +27,13 @@ jest.mock('@intl-tel-input/react', () => ({
     >(({ inputProps, onChangeNumber, value }, ref) => {
         useImperativeHandle(ref, () => ({
             getInstance: () => ({
+                getNumber: () => '',
                 getSelectedCountryData: mockGetSelectedCountryData,
+                isActive: () => true,
                 isValidNumber: mockIsValidNumber,
+                promise: Promise.resolve(),
                 setCountry: mockSetCountry,
+                setNumber: jest.fn(),
             }),
         }));
 

--- a/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneFormField.test.tsx
@@ -14,6 +14,7 @@ const mockIsValidNumber = jest.fn();
 const mockSetCountry = jest.fn();
 const mockSetNumber = jest.fn();
 const mockGetSelectedCountryData = jest.fn();
+const mockGetNumber = jest.fn(() => '');
 
 jest.mock('@intl-tel-input/react', () => ({
     __esModule: true,
@@ -27,8 +28,11 @@ jest.mock('@intl-tel-input/react', () => ({
     >(({ inputProps, onChangeNumber, value }, ref) => {
         useImperativeHandle(ref, () => ({
             getInstance: () => ({
+                getNumber: mockGetNumber,
                 getSelectedCountryData: mockGetSelectedCountryData,
+                isActive: () => true,
                 isValidNumber: mockIsValidNumber,
+                promise: Promise.resolve(),
                 setCountry: mockSetCountry,
                 setNumber: mockSetNumber,
             }),
@@ -87,6 +91,7 @@ describe('PhoneFormField', () => {
     );
 
     beforeEach(() => {
+        mockGetNumber.mockClear();
         mockGetSelectedCountryData.mockClear();
         mockIsValidNumber.mockClear();
         mockSetCountry.mockClear();
@@ -103,17 +108,6 @@ describe('PhoneFormField', () => {
         renderPhoneFormField({ selectedCountry: 'US' });
 
         expect(mockSetCountry).toHaveBeenCalledWith('us');
-    });
-
-    it('clears any stale number before auto-setting the country', () => {
-        renderPhoneFormField({ selectedCountry: 'US' });
-
-        expect(mockSetNumber).toHaveBeenCalledWith('');
-
-        const setNumberOrder = mockSetNumber.mock.invocationCallOrder[0];
-        const setCountryOrder = mockSetCountry.mock.invocationCallOrder[0];
-
-        expect(setNumberOrder).toBeLessThan(setCountryOrder);
     });
 
     it('does not auto-set country when selectedCountry is not provided', () => {

--- a/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
+++ b/packages/ui/src/form/PhoneFormField/PhoneInput.tsx
@@ -2,6 +2,7 @@ import IntlTelInput, { type IntlTelInputRef } from '@intl-tel-input/react';
 import 'intl-tel-input/styles';
 import classNames from 'classnames';
 import { type FieldProps } from 'formik';
+import { noop } from 'lodash';
 import React, {
     type FunctionComponent,
     type RefObject,
@@ -35,6 +36,32 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
 
     const currentValue = value ? String(value) : '';
 
+    const currentValueRef = useRef(currentValue);
+
+    currentValueRef.current = currentValue;
+
+    // sync initial Formik value ourselves
+    // the library's value prop has a bug with stale values that caused an infinite loop
+    // see #incident-20260711-2475 for details
+    useEffect(() => {
+        const intlTelInputInstance = intlTelInputRef.current?.getInstance();
+
+        if (!intlTelInputInstance) {
+            return;
+        }
+
+        void intlTelInputInstance.promise
+            .then(() => {
+                const latestValue = currentValueRef.current;
+
+                if (intlTelInputInstance.getNumber() !== latestValue) {
+                    intlTelInputInstance.setNumber(latestValue);
+                }
+            })
+            .catch(noop);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentValue]);
+
     useEffect(() => {
         if (!selectedCountry || value || isPhoneCountryAutoSetRef.current) {
             return;
@@ -50,8 +77,6 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
             const intlTelInputInstance = intlTelInputRef.current?.getInstance();
 
             if (intlTelInputInstance) {
-                // library's internal instance can have stale digits in edge cases (bug on their side)
-                intlTelInputInstance.setNumber('');
                 intlTelInputInstance.setCountry(selectedCountryInIsoFormat);
                 isPhoneCountryAutoSetRef.current = true;
             }
@@ -65,13 +90,13 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
     const handleChangeNumber = useCallback(
         (newPhoneNumber: string) => {
             // Ignore no-op emissions fired by the library itself
-            if (newPhoneNumber === currentValue) {
+            if (newPhoneNumber === currentValueRef.current) {
                 return;
             }
 
             void setFieldValue(name, newPhoneNumber);
         },
-        [name, setFieldValue, currentValue],
+        [name, setFieldValue],
     );
 
     return (
@@ -101,7 +126,6 @@ export const PhoneInput: FunctionComponent<PhoneInputProps> = ({
                 ref={intlTelInputRef}
                 separateDialCode={false}
                 strictRejectAnimation={false}
-                value={currentValue}
             />
         </span>
     );


### PR DESCRIPTION
## What/Why?

This fix: https://github.com/bigcommerce/checkout-js/pull/3165 did not resolve the issue. I have investigated further with Claude and found out that passing a value and excessively re-rendering this component (which is what happens during Fastlane path load) causes an internal IntlTelInput library bug: when the phone value changes twice in quick succession, it gets stuck re-applying the two values back and forth, locking up the page.

I stopped relying on this third-party component logic for value-handling and moved it to our wrapper component instead. This way we are in control and make sure that things are stable by using refs. Everything shoppers see and do is unchanged - typing a phone number, validation, auto-saving, and pre-filling saved numbers should work exactly as before.

## Rollout/Rollback

Revert this PR. Practically this is a no-op, as the change is isolated to the phone input component, which is at the moment hidden for all production stores behind CHECKOUT-9019.use_new_phone_number_validation.

## Testing

CI tests + ensuring all functional tests still pass + manual testing:


https://github.com/user-attachments/assets/24881d95-80e9-4824-8a81-b08fb75ae145



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout phone field integration with a third-party widget; behavior is meant to stay the same but timing of value/country sync changed, with rollout gated behind an experiment flag per the PR description.
> 
> **Overview**
> Fixes checkout freezes when the phone field re-renders quickly (e.g. Fastlane load) by **stopping use of the IntlTelInput `value` prop**, which could oscillate between two values and lock the page.
> 
> **`PhoneInput`** now keeps Formik as source of truth: after the widget’s `promise` resolves, it compares `getNumber()` to the latest Formik value (via a ref) and calls `setNumber` only when they differ. Change handlers ignore library no-op updates using the same ref. Auto country selection no longer clears the number with `setNumber('')` before `setCountry`.
> 
> Test mocks for `@intl-tel-input/react` were extended with `getNumber`, `promise`, `isActive`, and `setNumber`; the test that asserted clearing the number before auto-setting country was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195d0f4c598bd5354916af08a4c02daaebd6b53e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->