### PR TITLE
fix(payment): CHECKOUT-10244 Hide hidden order extra fields in checkout UI

### DIFF
--- a/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.test.tsx
+++ b/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.test.tsx
@@ -64,6 +64,18 @@ describe('OrderExtraFieldsFieldset', () => {
         },
     } as FormField;
 
+    const hiddenExtraField: FormField = {
+        custom: false,
+        default: '',
+        hidden: true,
+        id: 'b2bExtraField_400',
+        label: 'Internal Reference',
+        name: 'b2bExtraField_400',
+        required: true,
+        fieldType: 'text',
+        type: 'string',
+    } as FormField;
+
     const renderFieldset = (formFields: FormField[]) =>
         render(
             <LocaleContext.Provider value={localeContext}>
@@ -90,6 +102,19 @@ describe('OrderExtraFieldsFieldset', () => {
 
     it('returns null when no extra fields are provided', () => {
         renderFieldset([nonExtraField]);
+
+        expect(screen.queryByTestId('order-extra-fields')).not.toBeInTheDocument();
+    });
+
+    it('filters out hidden extra fields', () => {
+        renderFieldset([extraField, hiddenExtraField]);
+
+        expect(screen.getByText('PO Number')).toBeInTheDocument();
+        expect(screen.queryByText('Internal Reference')).not.toBeInTheDocument();
+    });
+
+    it('returns null when all extra fields are hidden', () => {
+        renderFieldset([hiddenExtraField]);
 
         expect(screen.queryByTestId('order-extra-fields')).not.toBeInTheDocument();
     });

--- a/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.tsx
+++ b/packages/core/src/app/payment/orderExtraFields/OrderExtraFieldsFieldset.tsx
@@ -14,7 +14,7 @@ const OrderExtraFieldsFieldset: FunctionComponent<OrderExtraFieldsFieldsetProps>
     isFloatingLabelEnabled,
 }) => {
     const { language } = useLocale();
-    const extraFields = formFields.filter((field) => isExtraField(field));
+    const extraFields = formFields.filter((field) => isExtraField(field) && !field.hidden);
 
     if (extraFields.length === 0) {
         return null;


### PR DESCRIPTION
## What/Why?
Hide hidden order extra fields in checkout UI

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-layer filter on checkout form fields; no auth, payment, or submission logic changes.
> 
> **Overview**
> Checkout **order extra fields** with `hidden: true` are no longer shown in the payment UI.
> 
> `OrderExtraFieldsFieldset` now excludes hidden fields when building the list to render; if every extra field is hidden, the fieldset still returns **null** (same as when there are no extra fields). Tests cover mixed visible/hidden fields and the all-hidden case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7bb335368a2edf6f56838b86ccb2d29379be23d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->