### PR TITLE
chore(checkout): CHECKOUT-10250 Clean up experiments

### DIFF
--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -201,11 +201,7 @@ const getShippingStepStatus = createSelector(
     },
     ({ data }: CheckoutSelectors) => data.getConfig(),
     (shippingAddress, consignments, cart, shippingAddressFields, config) => {
-        const validateMaxLength = isExperimentEnabled(
-            config?.checkoutSettings,
-            'CHECKOUT-9768.form_fields_max_length_validation',
-            false,
-        );
+        const validateMaxLength = true;
         const hasAddress = shippingAddress
             ? isValidAddress(shippingAddress, shippingAddressFields, validateMaxLength)
             : false;

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.ts
@@ -201,9 +201,8 @@ const getShippingStepStatus = createSelector(
     },
     ({ data }: CheckoutSelectors) => data.getConfig(),
     (shippingAddress, consignments, cart, shippingAddressFields, config) => {
-        const validateMaxLength = true;
         const hasAddress = shippingAddress
-            ? isValidAddress(shippingAddress, shippingAddressFields, validateMaxLength)
+            ? isValidAddress(shippingAddress, shippingAddressFields, true)
             : false;
         const hasOptions = consignments ? hasSelectedShippingOptions(consignments) : false;
         const hasUnassignedItems =

--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -37,31 +37,6 @@ describe('OrderSummaryItems', () => {
         );
     };
 
-    const enableBundleExperiment = () => {
-        const config = getStoreConfig();
-
-        jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
-            ...config,
-            checkoutSettings: {
-                ...config.checkoutSettings,
-                features: {
-                    ...config.checkoutSettings.features,
-                    'BACK-425.update_bundle_item_ux': true,
-                },
-            },
-            inventorySettings: {
-                showQuantityOnBackorder: true,
-                showBackorderMessage: true,
-                showQuantityOnHand: false,
-                showBackorderAvailabilityPrompt: false,
-                backorderAvailabilityPrompt: null,
-                showDefaultShippingExpectationPrompt: false,
-                defaultShippingExpectationPrompt: null,
-                shouldDisplayBackorderMessagesOnStorefront: true,
-            },
-        });
-    };
-
     beforeEach(() => {
         checkoutService = createCheckoutService();
         localeContext = createLocaleContext(getStoreConfig());
@@ -189,7 +164,7 @@ describe('OrderSummaryItems', () => {
         });
     });
 
-    describe('backorder details toggle gating (mobile vs desktop) and persistence', () => {
+    describe('backorder details toggle on mobile and desktop, and persistence', () => {
         const backorderItems = {
             customItems: [],
             physicalItems: [
@@ -202,24 +177,7 @@ describe('OrderSummaryItems', () => {
             giftCertificates: [],
         };
 
-        // A bundle parent whose only backordered line is its child. With the experiment off the
-        // child is stripped from display, so the backorder toggle would have nothing to show.
-        const hiddenBundleChildBackordered = {
-            customItems: [],
-            physicalItems: [
-                { ...getPhysicalItem(), id: '666' },
-                {
-                    ...getPhysicalItem(),
-                    id: '777',
-                    parentId: '666',
-                    stockPosition: { quantityBackordered: 2 },
-                },
-            ],
-            digitalItems: [],
-            giftCertificates: [],
-        };
-
-        it('renders the toggle on desktop when the bundle experiment is off', () => {
+        it('renders the toggle on desktop', () => {
             renderOrderSummaryItems({
                 displayLineItemsCount: true,
                 items: backorderItems,
@@ -228,33 +186,9 @@ describe('OrderSummaryItems', () => {
             expect(screen.getByTestId('cart-backorder-link')).toBeInTheDocument();
         });
 
-        it('hides the toggle on the mobile cart modal when the bundle experiment is off', () => {
+        it('renders the toggle on the mobile cart modal', () => {
             renderOrderSummaryItems({
                 displayLineItemsCount: false,
-                isMobileCartModal: true,
-                items: backorderItems,
-            });
-
-            expect(screen.queryByTestId('cart-backorder-link')).not.toBeInTheDocument();
-            expect(screen.queryByTestId('cart-count-total')).not.toBeInTheDocument();
-        });
-
-        it('hides the toggle on the mobile cart modal when only hidden bundle children are backordered (experiment off)', () => {
-            renderOrderSummaryItems({
-                displayLineItemsCount: false,
-                isMobileCartModal: true,
-                items: hiddenBundleChildBackordered,
-            });
-
-            expect(screen.queryByTestId('cart-backorder-link')).not.toBeInTheDocument();
-        });
-
-        it('renders the toggle on the mobile cart modal when the bundle experiment is on', () => {
-            enableBundleExperiment();
-
-            renderOrderSummaryItems({
-                displayLineItemsCount: false,
-                isMobileCartModal: true,
                 items: backorderItems,
             });
 
@@ -272,9 +206,6 @@ describe('OrderSummaryItems', () => {
         });
 
         it('persists the selection when the component is remounted across the breakpoint', async () => {
-            // The mobile re-mount only shows the toggle while the bundle experiment is on.
-            enableBundleExperiment();
-
             const { unmount } = renderOrderSummaryItems({
                 displayLineItemsCount: true,
                 items: backorderItems,
@@ -290,41 +221,14 @@ describe('OrderSummaryItems', () => {
 
             renderOrderSummaryItems({
                 displayLineItemsCount: false,
-                isMobileCartModal: true,
                 items: backorderItems,
             });
 
             expect(screen.getByRole('switch')).toBeChecked();
         });
-
-        it('keeps line item details collapsed on the gated mobile modal even if previously expanded', async () => {
-            // Turn the toggle on where it is available (desktop) so the module-scoped selection
-            // persists as expanded.
-            const { unmount } = renderOrderSummaryItems({
-                displayLineItemsCount: true,
-                items: backorderItems,
-            });
-
-            await userEvent.click(screen.getByRole('switch'));
-
-            expect(screen.getByTestId('cart-item-backorder-qty')).toBeInTheDocument();
-
-            unmount();
-
-            // Mobile cart modal with the experiment off: the toggle is gated away, so the persisted
-            // selection must NOT expand the line item details.
-            renderOrderSummaryItems({
-                displayLineItemsCount: false,
-                isMobileCartModal: true,
-                items: backorderItems,
-            });
-
-            expect(screen.queryByTestId('cart-backorder-link')).not.toBeInTheDocument();
-            expect(screen.queryByTestId('cart-item-backorder-qty')).not.toBeInTheDocument();
-        });
     });
 
-    describe('backorder details for bundle items (pick-list experiment enabled)', () => {
+    describe('backorder details for bundle items', () => {
         const bundleProps: OrderSummaryItemsProps = {
             displayLineItemsCount: true,
             items: {
@@ -363,8 +267,6 @@ describe('OrderSummaryItems', () => {
         };
 
         it('renders the parent item and hides the bundle child as a separate line item', () => {
-            enableBundleExperiment();
-
             renderOrderSummaryItems(bundleProps);
 
             expect(
@@ -376,8 +278,6 @@ describe('OrderSummaryItems', () => {
         });
 
         it('shows the bundled child backorder details when the toggle is turned on', async () => {
-            enableBundleExperiment();
-
             renderOrderSummaryItems(bundleProps);
 
             // Collapsed by default — the backorder line is not mounted yet.

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -19,7 +19,6 @@ import {
     isSmallScreen,
     Switch,
 } from '@bigcommerce/checkout/ui';
-import { isExperimentEnabled } from '@bigcommerce/checkout/utility';
 
 import getBackorderCount from './getBackorderCount';
 import getItemsCount from './getItemsCount';
@@ -28,11 +27,7 @@ import mapFromDigital from './mapFromDigital';
 import mapFromGiftCertificate from './mapFromGiftCertificate';
 import mapFromPhysical from './mapFromPhysical';
 import OrderSummaryItem from './OrderSummaryItem';
-import {
-    buildBundleItemsMapFromOrder,
-    removeAndBundleItemsTogether,
-    removeBundledItems,
-} from './removeBundledItems';
+import { buildBundleItemsMapFromOrder, removeAndBundleItemsTogether } from './removeBundledItems';
 
 // Module-scoped to survive the responsive remount. Safe as MobileView mounts only one instance at a time.
 let backorderDetailsExpanded = false;
@@ -77,7 +72,6 @@ const COLLAPSED_ITEMS_LIMIT_SMALL_SCREEN = 3;
 export interface OrderSummaryItemsProps {
     displayLineItemsCount: boolean;
     items: LineItemMap;
-    isMobileCartModal?: boolean;
 }
 
 const SummaryHeading = ({
@@ -126,25 +120,23 @@ const ProductList = ({
     collapsedLimit,
     showBackorderDetails,
     bundleItemsMap,
-    pickListExperimentEnabled,
 }: {
     items: LineItemMap;
     isExpanded: boolean;
     collapsedLimit: number;
     showBackorderDetails: boolean;
     bundleItemsMap?: Map<string | number, Array<PhysicalItem | DigitalItem>>;
-    pickListExperimentEnabled?: boolean;
 }): ReactElement => {
     const summaryItems = [
         ...items.physicalItems
             .slice()
             .sort((item) => item.variantId)
-            .map((item) => mapFromPhysical(item, bundleItemsMap, pickListExperimentEnabled)),
+            .map((item) => mapFromPhysical(item, bundleItemsMap)),
         ...items.giftCertificates.slice().map(mapFromGiftCertificate),
         ...items.digitalItems
             .slice()
             .sort((item) => item.variantId)
-            .map((item) => mapFromDigital(item, bundleItemsMap, pickListExperimentEnabled)),
+            .map((item) => mapFromDigital(item, bundleItemsMap)),
         ...(items.customItems || []).map(mapFromCustom),
     ].slice(0, isExpanded ? undefined : collapsedLimit);
 
@@ -193,7 +185,6 @@ const CartActions = ({
 const OrderSummaryItems = ({
     displayLineItemsCount = true,
     items,
-    isMobileCartModal = false,
 }: OrderSummaryItemsProps): ReactElement => {
     const [isExpanded, setIsExpanded] = useState(false);
     const [showBackorderDetails, setShowBackorderDetails] = useState(getBackorderDetailsExpanded);
@@ -219,28 +210,13 @@ const OrderSummaryItems = ({
         !!config?.inventorySettings?.shouldDisplayBackorderMessagesOnStorefront &&
         (!!config?.inventorySettings?.showQuantityOnBackorder ||
             !!config?.inventorySettings?.showBackorderMessage);
-    const pickListExperimentEnabled = config
-        ? isExperimentEnabled(config.checkoutSettings, 'BACK-425.update_bundle_item_ux', false)
-        : false;
+    const showBackorderSwitch = shouldDisplayBackorderDetails && backorderCount > 0;
 
-    // On the mobile cart modal, bundle children are not rendered while the bundle experiment is
-    // off, so gate the backorder toggle behind the experiment there to stop it appearing when
-    // only hidden bundle children are backordered.
-    const showBackorderSwitch =
-        shouldDisplayBackorderDetails &&
-        backorderCount > 0 &&
-        (!isMobileCartModal || pickListExperimentEnabled);
-
-    // Only expand line-item backorder details when the toggle is actually available; otherwise the
-    // persisted (module-scoped) selection could expand details on a surface where the toggle is
-    // hidden (e.g. the mobile cart modal with the bundle experiment off).
     const expandBackorderDetails = showBackorderSwitch && showBackorderDetails;
 
-    const { nonBundledItems, bundleItemsMap } = pickListExperimentEnabled
-        ? order?.bundledItems
-            ? buildBundleItemsMapFromOrder(items, order.bundledItems)
-            : removeAndBundleItemsTogether(items)
-        : { nonBundledItems: removeBundledItems(items), bundleItemsMap: undefined };
+    const { nonBundledItems, bundleItemsMap } = order?.bundledItems
+        ? buildBundleItemsMapFromOrder(items, order.bundledItems)
+        : removeAndBundleItemsTogether(items);
 
     const collapsedLimit = isSmallScreen()
         ? COLLAPSED_ITEMS_LIMIT_SMALL_SCREEN
@@ -272,7 +248,6 @@ const OrderSummaryItems = ({
                 collapsedLimit={collapsedLimit}
                 isExpanded={isExpanded}
                 items={nonBundledItems}
-                pickListExperimentEnabled={pickListExperimentEnabled}
                 showBackorderDetails={expandBackorderDetails}
             />
 

--- a/packages/core/src/app/order/OrderSummaryModal.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.test.tsx
@@ -88,7 +88,7 @@ describe('OrderSummaryModal', () => {
         });
     });
 
-    describe('when the bundle pick-list experiment is enabled', () => {
+    describe('bundle pick-list rendering', () => {
         const localeContext = createLocaleContext(getStoreConfig());
 
         // Raw line items, exactly as the mobile drawer now passes them through: a bundle
@@ -121,13 +121,6 @@ describe('OrderSummaryModal', () => {
 
             jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
                 ...config,
-                checkoutSettings: {
-                    ...config.checkoutSettings,
-                    features: {
-                        ...config.checkoutSettings.features,
-                        'BACK-425.update_bundle_item_ux': true,
-                    },
-                },
                 inventorySettings: {
                     showQuantityOnBackorder: true,
                     showBackorderMessage: true,
@@ -168,29 +161,6 @@ describe('OrderSummaryModal', () => {
         it('does not render the bundle child as a separate top-level line item', () => {
             renderModal();
 
-            expect(
-                screen.queryByRole('heading', { name: '1 x Bundled Hat' }),
-            ).not.toBeInTheDocument();
-        });
-
-        it('keeps the bundle child hidden when the experiment is disabled (gating intact)', () => {
-            const config = getStoreConfig();
-
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
-                ...config,
-                checkoutSettings: {
-                    ...config.checkoutSettings,
-                    features: {
-                        ...config.checkoutSettings.features,
-                        'BACK-425.update_bundle_item_ux': false,
-                    },
-                },
-            });
-
-            renderModal();
-
-            // Experiment off: the child must neither nest nor appear as its own line item.
-            expect(screen.queryByTestId('cart-item-bundled-item-name')).not.toBeInTheDocument();
             expect(
                 screen.queryByRole('heading', { name: '1 x Bundled Hat' }),
             ).not.toBeInTheDocument();

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -136,7 +136,7 @@ const OrderSummaryModal: FunctionComponent<
             onRequestClose={onRequestClose}
         >
             <OrderSummarySection>
-                <OrderSummaryItems displayLineItemsCount={false} isMobileCartModal items={items} />
+                <OrderSummaryItems displayLineItemsCount={false} items={items} />
             </OrderSummarySection>
             {isMultiCouponEnabledForCheckout || isMultiCouponEnabledForOrder ? (
                 <NewOrderSummarySubtotals

--- a/packages/core/src/app/order/mapFromDigital.test.tsx
+++ b/packages/core/src/app/order/mapFromDigital.test.tsx
@@ -27,7 +27,7 @@ describe('mapFromDigital()', () => {
         expect(productOptions[0].content).toMatchSnapshot();
     });
 
-    describe('with pickListExperimentEnabled', () => {
+    describe('with bundleItemsMap', () => {
         it('marks pick-list option as isMainBundledItem true with stockPosition', () => {
             const bundledChild = {
                 ...getPhysicalItem(),
@@ -68,7 +68,7 @@ describe('mapFromDigital()', () => {
                 ['667', [bundledChild]],
             ]);
 
-            const { productOptions = [] } = mapFromDigital(item, bundleItemsMap, true);
+            const { productOptions = [] } = mapFromDigital(item, bundleItemsMap);
             const itemOptions = productOptions.filter(
                 (o) => o.testId === 'cart-item-product-option',
             );
@@ -87,7 +87,7 @@ describe('mapFromDigital()', () => {
             expect(colorOption?.stockPosition).toBeUndefined();
         });
 
-        it('preserves options without attributeId when experiment is enabled', () => {
+        it('preserves options without attributeId', () => {
             const item = {
                 ...getDigitalItem(),
                 id: '667',
@@ -98,7 +98,7 @@ describe('mapFromDigital()', () => {
 
             const bundleItemsMap = new Map<string | number, PhysicalItem[]>();
 
-            const { productOptions = [] } = mapFromDigital(item, bundleItemsMap, true);
+            const { productOptions = [] } = mapFromDigital(item, bundleItemsMap);
             const itemOptions = productOptions.filter(
                 (o) => o.testId === 'cart-item-product-option',
             );
@@ -121,50 +121,7 @@ describe('mapFromDigital()', () => {
                 ['667', [bundledChild]],
             ]);
 
-            const { bundledItems } = mapFromDigital(item, bundleItemsMap, true);
-
-            expect(bundledItems).toBeUndefined();
-        });
-    });
-
-    describe('without pickListExperimentEnabled', () => {
-        it('maps all options without colon separator and does not set name/value', () => {
-            const item = {
-                ...getDigitalItem(),
-                options: [
-                    {
-                        name: 'Pick List Option',
-                        nameId: 11,
-                        value: 'Item A',
-                        valueId: 2,
-                        attributeId: 'attr-picklist',
-                    },
-                ] as LineItemOption[],
-            };
-
-            const { productOptions = [] } = mapFromDigital(item, undefined, false);
-            const itemOption = productOptions.find((o) => o.testId === 'cart-item-product-option');
-
-            expect(itemOption?.content).toBe('Pick List Option Item A');
-            expect(itemOption?.name).toBeUndefined();
-            expect(itemOption?.value).toBeUndefined();
-        });
-
-        it('returns no bundledItems even when map has children', () => {
-            const bundledChild = {
-                ...getPhysicalItem(),
-                id: '777',
-                parentId: '667',
-                addedByAttributeId: 'attr-picklist',
-            } as unknown as PhysicalItem;
-
-            const item = { ...getDigitalItem(), id: '667', options: [] as LineItemOption[] };
-
-            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([
-                ['667', [bundledChild]],
-            ]);
-
-            const { bundledItems } = mapFromDigital(item, bundleItemsMap, false);
+            const { bundledItems } = mapFromDigital(item, bundleItemsMap);
 
             expect(bundledItems).toBeUndefined();
         });

--- a/packages/core/src/app/order/mapFromDigital.tsx
+++ b/packages/core/src/app/order/mapFromDigital.tsx
@@ -10,46 +10,36 @@ import { type OrderItemType, type OrderSummaryItemOption } from './OrderSummaryI
 function mapFromDigital(
     item: DigitalItem,
     bundleItemsMap?: Map<string | number, Array<PhysicalItem | DigitalItem>>,
-    pickListExperimentEnabled?: boolean,
 ): OrderItemType {
     const bundledItems = bundleItemsMap?.get(String(item.id));
     const bundledItemsAddedByAttributeIds = bundledItems?.flatMap(({ addedByAttributeId }) =>
         addedByAttributeId ? [addedByAttributeId] : [],
     );
 
-    const mappedOptions = pickListExperimentEnabled
-        ? item.options?.map((option) => {
-              if (
-                  option.attributeId &&
-                  bundledItemsAddedByAttributeIds?.includes(option.attributeId)
-              ) {
-                  const bundledItem = bundledItems?.find(
-                      ({ addedByAttributeId }) => addedByAttributeId === option.attributeId,
-                  );
+    const mappedOptions = item.options?.map((option) => {
+        if (option.attributeId && bundledItemsAddedByAttributeIds?.includes(option.attributeId)) {
+            const bundledItem = bundledItems?.find(
+                ({ addedByAttributeId }) => addedByAttributeId === option.attributeId,
+            );
 
-                  return {
-                      testId: 'cart-item-product-option',
-                      content: `${option.name}: ${option.value}`,
-                      name: `${option.name}:`,
-                      value: option.value,
-                      isMainBundledItem: true,
-                      stockPosition: bundledItem ? mapBackorderDetails(bundledItem) : undefined,
-                  };
-              }
+            return {
+                testId: 'cart-item-product-option',
+                content: `${option.name}: ${option.value}`,
+                name: `${option.name}:`,
+                value: option.value,
+                isMainBundledItem: true,
+                stockPosition: bundledItem ? mapBackorderDetails(bundledItem) : undefined,
+            };
+        }
 
-              return {
-                  testId: 'cart-item-product-option',
-                  content: `${option.name}: ${option.value}`,
-                  name: `${option.name}:`,
-                  value: option.value,
-                  isMainBundledItem: false,
-              };
-          })
-        : item.options?.map((option) => ({
-              testId: 'cart-item-product-option',
-              content: `${option.name} ${option.value}`,
-              isMainBundledItem: false,
-          }));
+        return {
+            testId: 'cart-item-product-option',
+            content: `${option.name}: ${option.value}`,
+            name: `${option.name}:`,
+            value: option.value,
+            isMainBundledItem: false,
+        };
+    });
 
     return {
         id: item.id,

--- a/packages/core/src/app/order/mapFromPhysical.test.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.test.tsx
@@ -5,7 +5,7 @@ import { getPhysicalItem } from '../cart/lineItem.mock';
 import mapFromPhysical from './mapFromPhysical';
 
 describe('mapFromPhysical()', () => {
-    describe('without bundleItemsMap (legacy path)', () => {
+    describe('without bundleItemsMap', () => {
         it('maps basic item fields', () => {
             const item = getPhysicalItem();
             const result = mapFromPhysical(item);
@@ -15,13 +15,11 @@ describe('mapFromPhysical()', () => {
             expect(result.quantity).toBe(item.quantity);
         });
 
-        it('formats options without colon separator and does not set name/value', () => {
+        it('formats options with colon separator', () => {
             const item = getPhysicalItem();
             const result = mapFromPhysical(item);
 
-            expect(result.productOptions![0].content).toBe('n v');
-            expect(result.productOptions![0].name).toBeUndefined();
-            expect(result.productOptions![0].value).toBeUndefined();
+            expect(result.productOptions![0].content).toBe('n: v');
         });
 
         it('returns no bundledItems', () => {
@@ -31,7 +29,7 @@ describe('mapFromPhysical()', () => {
         });
     });
 
-    describe('with pickListExperimentEnabled', () => {
+    describe('with bundleItemsMap', () => {
         it('formats options with colon separator', () => {
             const item = {
                 ...getPhysicalItem(),
@@ -45,7 +43,7 @@ describe('mapFromPhysical()', () => {
                     },
                 ] as LineItemOption[],
             };
-            const result = mapFromPhysical(item, undefined, true);
+            const result = mapFromPhysical(item);
 
             expect(result.productOptions![0].content).toBe('Color: Red');
         });
@@ -81,7 +79,7 @@ describe('mapFromPhysical()', () => {
 
             const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
-            const result = mapFromPhysical(parent, bundleItemsMap, true);
+            const result = mapFromPhysical(parent, bundleItemsMap);
 
             expect(result.productOptions).toHaveLength(2);
 
@@ -123,7 +121,7 @@ describe('mapFromPhysical()', () => {
 
             const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
-            const result = mapFromPhysical(parent, bundleItemsMap, true);
+            const result = mapFromPhysical(parent, bundleItemsMap);
             const pickListOption = result.productOptions!.find((o) => o.name === 'Pick List:');
 
             expect(pickListOption?.isMainBundledItem).toBe(true);
@@ -150,47 +148,15 @@ describe('mapFromPhysical()', () => {
 
             const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
 
-            const result = mapFromPhysical(parent, bundleItemsMap, true);
+            const result = mapFromPhysical(parent, bundleItemsMap);
 
             expect(result.productOptions).toHaveLength(1);
             expect(result.productOptions![0].isMainBundledItem).toBe(false);
         });
 
         it('returns no bundledItems when the item has no children', () => {
-            const result = mapFromPhysical(getPhysicalItem(), new Map(), true);
+            const result = mapFromPhysical(getPhysicalItem(), new Map());
 
-            expect(result.bundledItems).toBeUndefined();
-        });
-    });
-
-    describe('without pickListExperimentEnabled', () => {
-        it('does not filter options and returns no bundledItems even when map has children', () => {
-            const child = {
-                ...getPhysicalItem(),
-                id: '777',
-                parentId: '666',
-                addedByAttributeId: 'attr-picklist',
-            } as unknown as PhysicalItem;
-
-            const parent = {
-                ...getPhysicalItem(),
-                id: '666',
-                options: [
-                    {
-                        name: 'Pick List',
-                        nameId: 11,
-                        value: 'Item A',
-                        valueId: 2,
-                        attributeId: 'attr-picklist',
-                    },
-                ] as LineItemOption[],
-            };
-
-            const bundleItemsMap = new Map<string | number, PhysicalItem[]>([['666', [child]]]);
-
-            const result = mapFromPhysical(parent, bundleItemsMap, false);
-
-            expect(result.productOptions).toHaveLength(1);
             expect(result.bundledItems).toBeUndefined();
         });
     });

--- a/packages/core/src/app/order/mapFromPhysical.tsx
+++ b/packages/core/src/app/order/mapFromPhysical.tsx
@@ -7,7 +7,6 @@ import { type OrderItemType } from './OrderSummaryItem';
 function mapFromPhysical(
     item: PhysicalItem,
     bundleItemsMap?: Map<string | number, Array<PhysicalItem | DigitalItem>>,
-    pickListExperimentEnabled?: boolean,
 ): OrderItemType {
     const bundledItems = bundleItemsMap?.get(String(item.id));
 
@@ -15,43 +14,30 @@ function mapFromPhysical(
         addedByAttributeId ? [addedByAttributeId] : [],
     );
 
-    const options = pickListExperimentEnabled
-        ? item.options?.map((option) => {
-              if (
-                  option.attributeId &&
-                  bundledItemsAddedByAttributeIds?.includes(option.attributeId)
-              ) {
-                  const bundledItem = bundledItems?.find(
-                      ({ addedByAttributeId }) => addedByAttributeId === option.attributeId,
-                  );
+    const options = item.options?.map((option) => {
+        if (option.attributeId && bundledItemsAddedByAttributeIds?.includes(option.attributeId)) {
+            const bundledItem = bundledItems?.find(
+                ({ addedByAttributeId }) => addedByAttributeId === option.attributeId,
+            );
 
-                  return {
-                      testId: 'cart-item-product-option',
-                      content: pickListExperimentEnabled
-                          ? `${option.name}: ${option.value}`
-                          : `${option.name} ${option.value}`,
-                      name: `${option.name}:`,
-                      value: option.value,
-                      isMainBundledItem: true,
-                      stockPosition: bundledItem ? mapBackorderDetails(bundledItem) : undefined,
-                  };
-              }
+            return {
+                testId: 'cart-item-product-option',
+                content: `${option.name}: ${option.value}`,
+                name: `${option.name}:`,
+                value: option.value,
+                isMainBundledItem: true,
+                stockPosition: bundledItem ? mapBackorderDetails(bundledItem) : undefined,
+            };
+        }
 
-              return {
-                  testId: 'cart-item-product-option',
-                  content: pickListExperimentEnabled
-                      ? `${option.name}: ${option.value}`
-                      : `${option.name} ${option.value}`,
-                  name: `${option.name}:`,
-                  value: option.value,
-                  isMainBundledItem: false,
-              };
-          })
-        : item.options?.map((option) => ({
-              testId: 'cart-item-product-option',
-              content: `${option.name} ${option.value}`,
-              isMainBundledItem: false,
-          }));
+        return {
+            testId: 'cart-item-product-option',
+            content: `${option.name}: ${option.value}`,
+            name: `${option.name}:`,
+            value: option.value,
+            isMainBundledItem: false,
+        };
+    });
 
     return {
         id: item.id,

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -26,7 +26,7 @@ import { createOffsitePaymentStrategy } from '@bigcommerce/checkout-sdk/integrat
 import { createPaypalExpressPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/paypal-express';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
 import { memoizeOne } from '@bigcommerce/memoize';
-import { isEmpty, noop } from 'lodash';
+import { noop } from 'lodash';
 import React, {
     type MutableRefObject,
     type ReactElement,
@@ -48,7 +48,7 @@ import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
 import { ChecklistSkeleton } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage, isExperimentEnabled } from '@bigcommerce/checkout/utility';
+import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { withAnalytics } from '../analytics';
 import { withCheckout } from '../checkout';
@@ -117,7 +117,6 @@ interface WithCheckoutPaymentProps {
     orderId?: number;
     shouldExecuteSpamCheck: boolean;
     shouldLocaliseErrorMessages: boolean;
-    shouldShowSubmitPaymentButton: boolean;
     submitOrderError?: Error;
     termsConditionsText?: string;
     termsConditionsUrl?: string;
@@ -761,8 +760,6 @@ const Payment = (
     const { selectedMethod = props.defaultMethod } = state;
     const uniqueSelectedMethodId =
         selectedMethod && getUniquePaymentMethodId(selectedMethod.id, selectedMethod.gateway);
-    const shouldShowPaymentForm =
-        props.shouldShowSubmitPaymentButton || (!isEmpty(props.methods) && props.defaultMethod);
     // themeV2 embeds the billing form in the payment step. Disable "Place Order"
     // while its billing address is loading or being persisted (initialization,
     // address-book change, or the pre-submit save), so a click can't silently
@@ -777,52 +774,50 @@ const Payment = (
     return (
         <PaymentContext.Provider value={getContextValue()}>
             <ChecklistSkeleton isLoading={!state.isReady}>
-                {shouldShowPaymentForm && (
-                    <PaymentForm
-                        additionalField={props.capabilities.payment.additionalField}
-                        availableStoreCredit={props.availableStoreCredit}
-                        defaultGatewayId={props.defaultMethod?.gateway}
-                        defaultMethodId={props.defaultMethod?.id || ''}
-                        didExceedSpamLimit={state.didExceedSpamLimit}
-                        disableStoreCredit={disableStoreCredit}
-                        isBillingSameAsShipping={props.isBillingSameAsShipping}
-                        isEmbedded={props.isEmbedded}
-                        isInitializingPayment={props.isInitializingPayment}
-                        isPaymentDataRequired={props.isPaymentDataRequired}
-                        isStoreCreditApplied={props.isStoreCreditApplied}
-                        isTermsConditionsRequired={props.isTermsConditionsRequired}
-                        isUsingMultiShipping={props.isUsingMultiShipping}
-                        methods={props.methods}
-                        onBillingSameAsShippingChange={props.onBillingSameAsShippingChange}
-                        onMethodSelect={setSelectedMethod}
-                        onStoreCreditChange={handleStoreCreditChange}
-                        onSubmit={handleSubmit}
-                        onUnhandledError={handleError}
-                        orderExtraFields={props.orderExtraFields}
-                        selectedMethod={state.selectedMethod || props.defaultMethod}
-                        shouldDisableSubmit={
-                            (uniqueSelectedMethodId &&
-                                state.shouldDisableSubmit[uniqueSelectedMethodId]) ||
-                            isBillingFormBusy ||
-                            undefined
-                        }
-                        shouldExecuteSpamCheck={props.shouldExecuteSpamCheck}
-                        shouldHidePaymentSubmitButton={
-                            (uniqueSelectedMethodId &&
-                                props.isPaymentDataRequired() &&
-                                state.shouldHidePaymentSubmitButton[uniqueSelectedMethodId]) ||
-                            undefined
-                        }
-                        termsConditionsText={props.termsConditionsText}
-                        termsConditionsUrl={props.termsConditionsUrl}
-                        usableStoreCredit={props.usableStoreCredit}
-                        validationSchema={
-                            (uniqueSelectedMethodId &&
-                                validationSchemasRef.current[uniqueSelectedMethodId]) ||
-                            undefined
-                        }
-                    />
-                )}
+                <PaymentForm
+                    additionalField={props.capabilities.payment.additionalField}
+                    availableStoreCredit={props.availableStoreCredit}
+                    defaultGatewayId={props.defaultMethod?.gateway}
+                    defaultMethodId={props.defaultMethod?.id || ''}
+                    didExceedSpamLimit={state.didExceedSpamLimit}
+                    disableStoreCredit={disableStoreCredit}
+                    isBillingSameAsShipping={props.isBillingSameAsShipping}
+                    isEmbedded={props.isEmbedded}
+                    isInitializingPayment={props.isInitializingPayment}
+                    isPaymentDataRequired={props.isPaymentDataRequired}
+                    isStoreCreditApplied={props.isStoreCreditApplied}
+                    isTermsConditionsRequired={props.isTermsConditionsRequired}
+                    isUsingMultiShipping={props.isUsingMultiShipping}
+                    methods={props.methods}
+                    onBillingSameAsShippingChange={props.onBillingSameAsShippingChange}
+                    onMethodSelect={setSelectedMethod}
+                    onStoreCreditChange={handleStoreCreditChange}
+                    onSubmit={handleSubmit}
+                    onUnhandledError={handleError}
+                    orderExtraFields={props.orderExtraFields}
+                    selectedMethod={state.selectedMethod || props.defaultMethod}
+                    shouldDisableSubmit={
+                        (uniqueSelectedMethodId &&
+                            state.shouldDisableSubmit[uniqueSelectedMethodId]) ||
+                        isBillingFormBusy ||
+                        undefined
+                    }
+                    shouldExecuteSpamCheck={props.shouldExecuteSpamCheck}
+                    shouldHidePaymentSubmitButton={
+                        (uniqueSelectedMethodId &&
+                            props.isPaymentDataRequired() &&
+                            state.shouldHidePaymentSubmitButton[uniqueSelectedMethodId]) ||
+                        undefined
+                    }
+                    termsConditionsText={props.termsConditionsText}
+                    termsConditionsUrl={props.termsConditionsUrl}
+                    usableStoreCredit={props.usableStoreCredit}
+                    validationSchema={
+                        (uniqueSelectedMethodId &&
+                            validationSchemasRef.current[uniqueSelectedMethodId]) ||
+                        undefined
+                    }
+                />
             </ChecklistSkeleton>
 
             {renderOrderErrorModal()}
@@ -936,11 +931,6 @@ export function mapToPaymentProps(
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,
         shouldLocaliseErrorMessages:
             features['PAYMENTS-6799.localise_checkout_payment_error_messages'],
-        shouldShowSubmitPaymentButton: isExperimentEnabled(
-            checkoutSettings,
-            'CHECKOUT-9729.show_submit_button_when_payment_not_required',
-            false,
-        ),
         submitOrder: checkoutService.submitOrder,
         submitOrderError: getSubmitOrderError(),
         checkoutServiceSubscribe: checkoutService.subscribe,

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -18,7 +18,7 @@ import {
 } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
 import { Fieldset, Form, FormContext, Legend } from '@bigcommerce/checkout/ui';
-import { B2BSessionStorage, isExperimentEnabled } from '@bigcommerce/checkout/utility';
+import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { getTranslateAddressError } from '../address';
 import { isFloatingLabelEnabled } from '../common/utility';
@@ -149,16 +149,8 @@ const PaymentForm: FunctionComponent<
         : false;
     const poMethodDisabledReason = usePoMethodDisabledReason(selectedMethod);
     const isSubmitDisabled = shouldDisableSubmit || Boolean(poMethodDisabledReason);
-    const shouldShowSubmitButtonWhenPaymentNotRequired = isExperimentEnabled(
-        checkoutSettings,
-        'CHECKOUT-9729.show_submit_button_when_payment_not_required',
-        false,
-    );
     const hideSubmitPaymentButton =
-        shouldHidePaymentSubmitButton ||
-        (shouldShowSubmitButtonWhenPaymentNotRequired &&
-            isPaymentDataRequired() &&
-            isEmpty(methods));
+        shouldHidePaymentSubmitButton || (isPaymentDataRequired() && isEmpty(methods));
 
     if (shouldExecuteSpamCheck) {
         return (
@@ -181,8 +173,7 @@ const PaymentForm: FunctionComponent<
                 />
             )}
 
-            {shouldShowSubmitButtonWhenPaymentNotRequired &&
-                isEmpty(methods) &&
+            {isEmpty(methods) &&
                 (isPaymentDataRequired() ? (
                     <NoPaymentMethods
                         message={
@@ -195,7 +186,7 @@ const PaymentForm: FunctionComponent<
                     />
                 ))}
 
-            {(!shouldShowSubmitButtonWhenPaymentNotRequired || !isEmpty(methods)) && (
+            {!isEmpty(methods) && (
                 <PaymentMethodListFieldset
                     isEmbedded={isEmbedded}
                     isInitializingPayment={isInitializingPayment}

--- a/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
+++ b/packages/core/src/app/shipping/ConsignmentAddressSelector.tsx
@@ -51,7 +51,6 @@ const ConsignmentAddressSelector = ({
         updateConsignment,
         createCustomerAddress,
         customer,
-        validateMaxLength,
         getConsignments: getPreviousConsignments,
     } = useShipping();
 
@@ -61,7 +60,7 @@ const ConsignmentAddressSelector = ({
     const isGuest = customer.isGuest;
 
     const handleSelectAddress = async (address: Address) => {
-        if (!isValidAddress(address, getFields(address.countryCode), validateMaxLength)) {
+        if (!isValidAddress(address, getFields(address.countryCode), true)) {
             return onUnhandledError(new AssignItemInvalidAddressError());
         }
 

--- a/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.test.tsx
+++ b/packages/core/src/app/shipping/PayPalFastlaneShippingAddress.test.tsx
@@ -104,7 +104,6 @@ describe('PayPalFastlaneShippingAddress', () => {
                     ],
                 },
             ],
-            validateMaxLength: false,
         };
 
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());

--- a/packages/core/src/app/shipping/ShippingAddress.tsx
+++ b/packages/core/src/app/shipping/ShippingAddress.tsx
@@ -23,7 +23,6 @@ export interface ShippingAddressProps {
     methodId?: string;
     shippingAddress?: Address;
     hasRequestedShippingOptions: boolean;
-    validateMaxLength: boolean;
     deinitialize(options: ShippingRequestOptions): Promise<CheckoutSelectors>;
     initialize(options: ShippingInitializeOptions): Promise<CheckoutSelectors>;
     onAddressSelect(address: Address): void;
@@ -40,7 +39,6 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
         onAddressSelect,
         onFieldChange,
         onUseNewAddress,
-        validateMaxLength,
         isLoading,
         shippingAddress,
         hasRequestedShippingOptions,
@@ -80,7 +78,7 @@ const ShippingAddress: FunctionComponent<ShippingAddressProps> = (props) => {
             onAddressSelect={onAddressSelect}
             onFieldChange={handleFieldChange}
             onUseNewAddress={onUseNewAddress}
-            validateMaxLength={validateMaxLength}
+            validateMaxLength
         />
     );
 };

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -43,7 +43,6 @@ const ShippingForm = ({
         isNoCountriesErrorOnCheckoutEnabled,
         methodId,
         shippingAddress,
-        validateMaxLength,
     } = useShipping();
     const {
         extensionState: { shippingFormRenderTimestamp },
@@ -107,7 +106,6 @@ const ShippingForm = ({
             onUnhandledError={onUnhandledError}
             shippingAddress={shippingAddress}
             shippingFormRenderTimestamp={shippingFormRenderTimestamp}
-            validateMaxLength={validateMaxLength}
         />
     );
 };

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -46,7 +46,6 @@ describe('SingleShippingForm', () => {
         onSubmit: jest.fn(),
         getFields: jest.fn(() => addressFormFields),
         onUnhandledError: jest.fn(),
-        validateMaxLength: false,
     };
 
     const shippingAutosaveDelay = 500;

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -41,7 +41,6 @@ export interface SingleShippingFormProps {
     shippingAutosaveDelay?: number;
     isInitialValueLoaded: boolean;
     shippingFormRenderTimestamp?: number;
-    validateMaxLength: boolean;
     getFields(countryCode?: string): FormField[];
     onSubmit(values: SingleShippingFormValues): void;
     onUnhandledError?(error: Error): void;
@@ -82,7 +81,6 @@ const SingleShippingForm: React.FC<
     shippingAddress,
     shippingAutosaveDelay = SHIPPING_AUTOSAVE_DELAY,
     shippingFormRenderTimestamp,
-    validateMaxLength,
     values,
 }) => {
     const {
@@ -300,7 +298,6 @@ const SingleShippingForm: React.FC<
                     onUnhandledError={onUnhandledError}
                     onUseNewAddress={handleUseNewAddress}
                     shippingAddress={shippingAddress}
-                    validateMaxLength={validateMaxLength}
                 />
                 {shouldShowBillingSameAsShipping && (
                     <div className="form-body">
@@ -347,7 +344,6 @@ export default withLanguage(
             language,
             getFields,
             methodId,
-            validateMaxLength,
         }: SingleShippingFormProps & WithLanguageProps) =>
             shouldHaveCustomValidation(methodId)
                 ? object({
@@ -371,7 +367,7 @@ export default withLanguage(
                           getAddressFormFieldsValidationSchema({
                               language,
                               formFields: getFields(formValues?.countryCode),
-                              validateMaxLength,
+                              validateMaxLength: true,
                           }),
                       ),
                   }),

--- a/packages/core/src/app/shipping/hooks/useShipping.mock.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.mock.ts
@@ -43,5 +43,4 @@ export const getUseShippingTestMock: () => ReturnType<typeof useShipping> = () =
     updateCheckout: jest.fn(),
     updateConsignment: jest.fn(),
     updateShippingAddress: jest.fn(),
-    validateMaxLength: true,
 });

--- a/packages/core/src/app/shipping/hooks/useShipping.mock.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.mock.ts
@@ -43,5 +43,5 @@ export const getUseShippingTestMock: () => ReturnType<typeof useShipping> = () =
     updateCheckout: jest.fn(),
     updateConsignment: jest.fn(),
     updateShippingAddress: jest.fn(),
-    validateMaxLength: false,
+    validateMaxLength: true,
 });

--- a/packages/core/src/app/shipping/hooks/useShipping.test.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.test.ts
@@ -85,7 +85,6 @@ describe('useShipping', () => {
         expect(result.current.customer).toEqual(getCustomer());
         expect(result.current.shouldShowOrderComments).toBe(true);
         expect(result.current.shouldShowMultiShipping).toBe(false);
-        expect(result.current.validateMaxLength).toBe(true);
     });
 
     describe('shouldShowMultiShipping', () => {
@@ -159,14 +158,6 @@ describe('useShipping', () => {
             const { result } = renderHook(() => useShipping());
 
             expect(result.current.shouldShowMultiShipping).toBe(false);
-        });
-    });
-
-    describe('validateMaxLength', () => {
-        it('is always true', () => {
-            const { result } = renderHook(() => useShipping());
-
-            expect(result.current.validateMaxLength).toBe(true);
         });
     });
 

--- a/packages/core/src/app/shipping/hooks/useShipping.test.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.test.ts
@@ -85,7 +85,7 @@ describe('useShipping', () => {
         expect(result.current.customer).toEqual(getCustomer());
         expect(result.current.shouldShowOrderComments).toBe(true);
         expect(result.current.shouldShowMultiShipping).toBe(false);
-        expect(result.current.validateMaxLength).toBe(false);
+        expect(result.current.validateMaxLength).toBe(true);
     });
 
     describe('shouldShowMultiShipping', () => {
@@ -100,16 +100,6 @@ describe('useShipping', () => {
                             quantity: 2,
                         },
                     ],
-                },
-            });
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
-                ...getStoreConfig(),
-                checkoutSettings: {
-                    ...getStoreConfig().checkoutSettings,
-                    features: {
-                        ...getStoreConfig().checkoutSettings?.features,
-                        'CHECKOUT-9768.form_fields_max_length_validation': true,
-                    },
                 },
             });
         });
@@ -173,26 +163,7 @@ describe('useShipping', () => {
     });
 
     describe('validateMaxLength', () => {
-        it('is false when experiment is not enabled', () => {
-            const { result } = renderHook(() => useShipping());
-
-            expect(result.current.validateMaxLength).toBe(false);
-        });
-
-        it('is true when CHECKOUT-9768.form_fields_max_length_validation experiment is enabled', () => {
-            const config = getStoreConfig();
-
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
-                ...config,
-                checkoutSettings: {
-                    ...config.checkoutSettings,
-                    features: {
-                        ...config.checkoutSettings.features,
-                        'CHECKOUT-9768.form_fields_max_length_validation': true,
-                    },
-                },
-            });
-
+        it('is always true', () => {
             const { result } = renderHook(() => useShipping());
 
             expect(result.current.validateMaxLength).toBe(true);

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -227,6 +227,5 @@ export const useShipping = () => {
         shouldRenderStripeForm:
             providerWithCustomCheckout === PaymentMethodId.StripeUPE &&
             shouldUseStripeLinkByMinimumAmount(cart),
-        validateMaxLength: true,
     };
 };

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -227,10 +227,6 @@ export const useShipping = () => {
         shouldRenderStripeForm:
             providerWithCustomCheckout === PaymentMethodId.StripeUPE &&
             shouldUseStripeLinkByMinimumAmount(cart),
-        validateMaxLength: isExperimentEnabled(
-            config.checkoutSettings,
-            'CHECKOUT-9768.form_fields_max_length_validation',
-            false,
-        ),
+        validateMaxLength: true,
     };
 };


### PR DESCRIPTION
## What/Why?
Clean up rolled out experiments.
- CHECKOUT-9768.form_fields_max_length_validation
- CHECKOUT-9729.show_submit_button_when_payment_not_required
- BACK-425.update_bundle_item_ux

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default behavior for address max-length validation, payment step when no methods exist, and cart line-item/bundle display across checkout and mobile modal—areas shoppers interact with directly, though this codifies already-rolled-out experiment behavior.
> 
> **Overview**
> Removes three feature flags and makes their **on** behavior the only path.
> 
> **`CHECKOUT-9768.form_fields_max_length_validation`** — Shipping and consignment address checks always pass `validateMaxLength: true` into `isValidAddress` and Yup schemas. The `validateMaxLength` value is no longer read from config or threaded through `useShipping` and shipping form props.
> 
> **`CHECKOUT-9729.show_submit_button_when_payment_not_required`** — `Payment` always mounts `PaymentForm`. When there are no payment methods, the “payment not required” / unavailable messaging and submit behavior no longer depend on an experiment; submit hiding uses `isPaymentDataRequired() && isEmpty(methods)` only.
> 
> **`BACK-425.update_bundle_item_ux`** — Order summary always groups bundle children (pick-list UX): `removeAndBundleItemsTogether` / `buildBundleItemsMapFromOrder`, colon-separated options in `mapFromPhysical` / `mapFromDigital`, backorder toggle on mobile cart modal without bundle-experiment gating, and `isMobileCartModal` removed from `OrderSummaryItems`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50bef97c57954bad46dcb4a149769c7974dd0c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->