### PR TITLE
fix(checkout): CHECKOUT-10249 Bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.942.2",
+        "@bigcommerce/checkout-sdk": "^1.942.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.942.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.2.tgz",
-      "integrity": "sha512-YKR5qtIddKF2yxYtZlHFj09n79plUmasRVJMxW33HzBYUDW6aVSYKsnFRn17acFS4NSgTusEwovKqR2yzhr1qg==",
+      "version": "1.942.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.4.tgz",
+      "integrity": "sha512-WAXZlvoGYjV4lYTSnGOjepTf+C1LDxBLE5au59GSTrLqZ81eUCGRIVm6eDNUDnMtto9XFJLzxjCVscTc5cu/Nw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29814,9 +29814,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.942.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.2.tgz",
-      "integrity": "sha512-YKR5qtIddKF2yxYtZlHFj09n79plUmasRVJMxW33HzBYUDW6aVSYKsnFRn17acFS4NSgTusEwovKqR2yzhr1qg==",
+      "version": "1.942.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.4.tgz",
+      "integrity": "sha512-WAXZlvoGYjV4lYTSnGOjepTf+C1LDxBLE5au59GSTrLqZ81eUCGRIVm6eDNUDnMtto9XFJLzxjCVscTc5cu/Nw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.942.4",
+        "@bigcommerce/checkout-sdk": "^1.943.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.942.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.4.tgz",
-      "integrity": "sha512-WAXZlvoGYjV4lYTSnGOjepTf+C1LDxBLE5au59GSTrLqZ81eUCGRIVm6eDNUDnMtto9XFJLzxjCVscTc5cu/Nw==",
+      "version": "1.943.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.0.tgz",
+      "integrity": "sha512-QM38Yy8MfOQwp/lKh6LcQ6Rzj755ohDjfVXYTswreKSEWqOck9WSQYHrC52IuRtCVkIXlsNgvy9ueFO/V1lj7w==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29814,9 +29814,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.942.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.942.4.tgz",
-      "integrity": "sha512-WAXZlvoGYjV4lYTSnGOjepTf+C1LDxBLE5au59GSTrLqZ81eUCGRIVm6eDNUDnMtto9XFJLzxjCVscTc5cu/Nw==",
+      "version": "1.943.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.0.tgz",
+      "integrity": "sha512-QM38Yy8MfOQwp/lKh6LcQ6Rzj755ohDjfVXYTswreKSEWqOck9WSQYHrC52IuRtCVkIXlsNgvy9ueFO/V1lj7w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.942.4",
+    "@bigcommerce/checkout-sdk": "^1.943.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.942.2",
+    "@bigcommerce/checkout-sdk": "^1.942.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/cart/carts.mock.ts
+++ b/packages/core/src/app/cart/carts.mock.ts
@@ -8,6 +8,7 @@ export function getCart(): Cart {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
         companyId: 1,
+        companyName: null,
         currency: {
             name: 'US Dollar',
             code: 'USD',

--- a/packages/test-mocks/src/cart.mock.ts
+++ b/packages/test-mocks/src/cart.mock.ts
@@ -8,6 +8,7 @@ export function getCart(): Cart {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         customerId: 4,
         companyId: 1,
+        companyName: null,
         currency: {
             name: 'US Dollar',
             code: 'USD',


### PR DESCRIPTION
## What/Why?

Surface SDK changes:
- https://github.com/bigcommerce/checkout-sdk-js/pull/3320
- https://github.com/bigcommerce/checkout-sdk-js/pull/3321

No further change needed in `checkout-js`.

## Rollout/Rollback

Revert.

## Testing

CI.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump plus mock-only typing alignment; no production checkout behavior changed in this PR.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from `^1.942.2` to **`^1.943.0`** (with matching `package-lock.json` updates) to pick up upstream SDK changes referenced in CHECKOUT-10249.
> 
> Aligns test cart mocks in **`carts.mock.ts`** and **`cart.mock.ts`** with the updated SDK **`Cart`** shape by adding **`companyName: null`** alongside existing `companyId`. No checkout UI or runtime logic changes in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6538a3cfdcdde003157f87015dcfd9b33d4bbcd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->