### PR TITLE
fix(checkout): CHECKOUT-10026 Use debounce with google autocomplete

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
@@ -100,6 +100,30 @@ describe('GoogleAutocomplete', () => {
             expect(mockGetLegacyApiSuggestions).not.toHaveBeenCalled();
         });
 
+        it('debounces suggestion requests into a single call while typing', async () => {
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            await userEvent.type(screen.getByRole('textbox'), '123');
+
+            await screen.findByText('123 New API Ave');
+            expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1);
+            expect(mockGetNewApiSuggestions).toHaveBeenCalledWith('123', undefined, undefined);
+        });
+
+        it('does not request suggestions when the input is cleared before the debounce elapses', async () => {
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            const input = screen.getByRole('textbox');
+
+            await userEvent.type(input, '123');
+            await userEvent.clear(input);
+
+            await new Promise((resolve) => setTimeout(resolve, 400));
+
+            expect(mockGetNewApiSuggestions).not.toHaveBeenCalled();
+            expect(screen.queryByText('123 New API Ave')).not.toBeInTheDocument();
+        });
+
         it('calls onSelect with the new API place result when a suggestion is picked', async () => {
             render(<GoogleAutocomplete {...defaultProps} />);
 

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, { act } from 'react';
 
 import { render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 
@@ -122,6 +122,37 @@ describe('GoogleAutocomplete', () => {
 
             expect(mockGetNewApiSuggestions).not.toHaveBeenCalled();
             expect(screen.queryByText('123 New API Ave')).not.toBeInTheDocument();
+        });
+
+        it('cancels a pending suggestions request when a suggestion is picked before the debounce elapses', async () => {
+            jest.useFakeTimers();
+
+            const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+            try {
+                render(<GoogleAutocomplete {...defaultProps} />);
+
+                const input = screen.getByRole('textbox');
+
+                await user.type(input, '123');
+                await screen.findByText('123 New API Ave');
+                expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1);
+
+                // Schedule one more API call after getting suggestions
+                await user.type(input, '4');
+                await user.click(screen.getByText('123 New API Ave'));
+
+                await waitFor(() => expect(defaultProps.onSelect).toHaveBeenCalled());
+
+                act(() => {
+                    jest.advanceTimersByTime(400);
+                });
+
+                // Make sure second suggestions call is cancelled
+                expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1);
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         it('calls onSelect with the new API place result when a suggestion is picked', async () => {

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
@@ -194,6 +194,33 @@ describe('GoogleAutocomplete', () => {
             expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1);
         });
 
+        it('debounces suggestions into a single legacy call after falling back', async () => {
+            mockGetNewApiSuggestions.mockRejectedValue(gRpcPermissionDeniedErrorMock);
+
+            render(<GoogleAutocomplete {...defaultProps} />);
+
+            const input = screen.getByRole('textbox');
+
+            // First request is denied by the new API and falls back to legacy with the same input.
+            await userEvent.type(input, '1');
+            await screen.findByText('123 Legacy St, New York');
+            expect(mockGetLegacyApiSuggestions).toHaveBeenCalledTimes(1);
+            expect(mockGetLegacyApiSuggestions).toHaveBeenCalledWith(
+                expect.objectContaining({ input: '1' }),
+                expect.any(Function),
+            );
+
+            // Subsequent keystrokes collapse into one more legacy request with the final input.
+            await userEvent.type(input, '234');
+
+            await waitFor(() => expect(mockGetLegacyApiSuggestions).toHaveBeenCalledTimes(2));
+            expect(mockGetLegacyApiSuggestions).toHaveBeenLastCalledWith(
+                expect.objectContaining({ input: '1234' }),
+                expect.any(Function),
+            );
+            expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(1);
+        });
+
         it('keeps retrying the new API on later input after a transient failure, without falling back', async () => {
             mockGetNewApiSuggestions.mockRejectedValue(gRpcSomeOtherErrorMock);
 

--- a/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
+++ b/packages/core/src/app/address/googleAutocomplete/GoogleAutocomplete.test.tsx
@@ -155,6 +155,58 @@ describe('GoogleAutocomplete', () => {
             }
         });
 
+        it('drops an in-flight suggestions response that resolves after a suggestion is picked', async () => {
+            jest.useFakeTimers();
+
+            const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+            const staleSuggestions = [
+                { id: 'stale-place', label: '123 Stale St', value: '123 Stale St' },
+            ];
+
+            let resolveSecondFetch: ((value: unknown) => void) | undefined;
+
+            mockGetNewApiSuggestions
+                .mockImplementationOnce(() => Promise.resolve(newApiSuggestions))
+                .mockImplementationOnce(
+                    () =>
+                        new Promise((resolve) => {
+                            resolveSecondFetch = resolve;
+                        }),
+                );
+
+            try {
+                render(<GoogleAutocomplete {...defaultProps} />);
+
+                const input = screen.getByRole('textbox');
+
+                await user.type(input, '123');
+                await screen.findByText('123 New API Ave');
+
+                // The next keystroke starts a second fetch that stays in flight
+                await user.type(input, '4');
+
+                act(() => {
+                    jest.advanceTimersByTime(300);
+                });
+
+                expect(mockGetNewApiSuggestions).toHaveBeenCalledTimes(2);
+
+                await user.click(screen.getByText('123 New API Ave'));
+                await waitFor(() => expect(defaultProps.onSelect).toHaveBeenCalled());
+
+                // The in-flight response must not repopulate the dropdown after selection
+                await act(async () => {
+                    resolveSecondFetch?.(staleSuggestions);
+                });
+
+                // a new request should give a new suggestion list
+                await user.type(input, '5');
+                expect(screen.queryByText('123 Stale St')).not.toBeInTheDocument();
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
         it('calls onSelect with the new API place result when a suggestion is picked', async () => {
             render(<GoogleAutocomplete {...defaultProps} />);
 

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -1,4 +1,5 @@
-import { useRef, useState } from 'react';
+import { debounce } from 'lodash';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { type AutocompleteItem } from '@bigcommerce/checkout/ui';
 
@@ -7,7 +8,7 @@ import { type GoogleAutocompleteOptionTypes } from './googleAutocompleteTypes';
 import { NewGooglePlacesApiService } from './newGooglePlacesApi';
 import { getNewGooglePlacesApiScriptLoader } from './newGooglePlacesApi/getNewGooglePlacesApiScriptLoader';
 import { isNewPlacesApiPermissionDenied } from './newGooglePlacesApi/utils';
-import { toAutocompleteItems } from './utils';
+import { FETCH_SUGGESTIONS_DEBOUNCE_WAIT, toAutocompleteItems } from './utils';
 
 export interface UseGoogleAutocompleteProps {
     apiKey: string;
@@ -194,10 +195,26 @@ export function useGoogleAutocomplete({
         newApi.fetchSuggestions(input);
     };
 
+    const fetchSuggestionsRef = useRef(fetchSuggestions);
+
+    fetchSuggestionsRef.current = fetchSuggestions;
+
+    const debouncedFetchSuggestions = useMemo(
+        () =>
+            debounce(
+                (input: string) => fetchSuggestionsRef.current(input),
+                FETCH_SUGGESTIONS_DEBOUNCE_WAIT,
+            ),
+        [],
+    );
+
+    useEffect(() => () => debouncedFetchSuggestions.cancel(), [debouncedFetchSuggestions]);
+
     const handleChange = (input: string) => {
         onChange(input, false);
 
         if (!isAutocompleteEnabled) {
+            debouncedFetchSuggestions.cancel();
             resetAutocomplete();
 
             return;
@@ -206,13 +223,14 @@ export function useGoogleAutocomplete({
         setAutocompleteValue(input);
 
         if (!input) {
+            debouncedFetchSuggestions.cancel();
             newApiInputRef.current = input;
             setItems([]);
 
             return;
         }
 
-        fetchSuggestions(input);
+        debouncedFetchSuggestions(input);
     };
 
     return { items, autoComplete, handleSelect, handleChange };

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -166,16 +166,6 @@ export function useGoogleAutocomplete({
         },
     };
 
-    const handleSelect = (item: AutocompleteItem) => {
-        if (isUsingLegacyApi()) {
-            legacyApi.select(item);
-
-            return;
-        }
-
-        newApi.select(item);
-    };
-
     const resetAutocomplete = (): void => {
         setItems([]);
         setAutoComplete('off');
@@ -213,6 +203,18 @@ export function useGoogleAutocomplete({
             debouncedFetchSuggestions.cancel();
         };
     }, [debouncedFetchSuggestions]);
+
+    const handleSelect = (item: AutocompleteItem) => {
+        debouncedFetchSuggestions.cancel();
+
+        if (isUsingLegacyApi()) {
+            legacyApi.select(item);
+
+            return;
+        }
+
+        newApi.select(item);
+    };
 
     const handleChange = (input: string) => {
         onChange(input, false);

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -208,7 +208,11 @@ export function useGoogleAutocomplete({
         [],
     );
 
-    useEffect(() => () => debouncedFetchSuggestions.cancel(), [debouncedFetchSuggestions]);
+    useEffect(() => {
+        return () => {
+            debouncedFetchSuggestions.cancel();
+        };
+    }, [debouncedFetchSuggestions]);
 
     const handleChange = (input: string) => {
         onChange(input, false);

--- a/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
+++ b/packages/core/src/app/address/googleAutocomplete/useGoogleAutocomplete.ts
@@ -122,8 +122,6 @@ export function useGoogleAutocomplete({
                 return;
             }
 
-            newApiInputRef.current = input;
-
             service
                 .getSuggestions(input, types, componentRestrictions)
                 .then((results) => {
@@ -206,6 +204,7 @@ export function useGoogleAutocomplete({
 
     const handleSelect = (item: AutocompleteItem) => {
         debouncedFetchSuggestions.cancel();
+        newApiInputRef.current = undefined;
 
         if (isUsingLegacyApi()) {
             legacyApi.select(item);
@@ -228,9 +227,10 @@ export function useGoogleAutocomplete({
 
         setAutocompleteValue(input);
 
+        newApiInputRef.current = input;
+
         if (!input) {
             debouncedFetchSuggestions.cancel();
-            newApiInputRef.current = input;
             setItems([]);
 
             return;

--- a/packages/core/src/app/address/googleAutocomplete/utils.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.ts
@@ -1,5 +1,7 @@
 import { type AutocompleteItem } from '@bigcommerce/checkout/ui';
 
+export const FETCH_SUGGESTIONS_DEBOUNCE_WAIT = 300;
+
 export const toAutocompleteItems = (
     results?: google.maps.places.AutocompletePrediction[],
 ): AutocompleteItem[] => {


### PR DESCRIPTION
## What/Why?

Based on this pattern: https://www.epicreact.dev/the-latest-ref-pattern-in-react.
We currently fire google autocomplete api on every keystroke which is both expensive for merchants (they are charged per request) but also can lead to rate limiting issues.
I use standard 300ms debounce to improve it and fire api calls less frequently.

## Rollout/Rollback

Revert the PR.

## Testing

CI + manual testing.
New API (fallback not needed):

https://github.com/user-attachments/assets/edbb9a86-38cb-415f-af4f-039dd198b9da

Old API (with fallback):

https://github.com/user-attachments/assets/a83dbdfc-ad5c-4418-9478-f9f00bb037fa



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkout address autocomplete timing and API routing (new vs legacy); wrong cancel/debounce behavior could delay or drop suggestions, but changes are localized to the hook.
> 
> **Overview**
> Reduces **per-keystroke** Google Places autocomplete calls by debouncing suggestion fetches (**300ms**) in `useGoogleAutocomplete`, using the latest-ref pattern so each debounced invocation still uses the current new-vs-legacy fetch path.
> 
> Pending debounced work is **cancelled** when the user picks a suggestion, clears the field, disables autocomplete, or the hook unmounts, so stray requests don’t run after those actions.
> 
> Tests cover collapsed new-API calls while typing, no fetch after fast clear, cancel on selection before debounce fires, and the same debouncing after legacy fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ff21110c11a285f6710b6f132c27dc918dbca4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->