### PR TITLE
feat(payment): PAYPAL-6795 fixed payment submit button behavior

### DIFF
--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -1,9 +1,9 @@
 import {
-  type CheckoutService,
-  createCheckoutService,
-  createEmbeddedCheckoutMessenger,
-  type EmbeddedCheckoutMessenger,
-  PaymentMethod,
+    type CheckoutService,
+    createCheckoutService,
+    createEmbeddedCheckoutMessenger,
+    type EmbeddedCheckoutMessenger,
+    type PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
@@ -42,7 +42,8 @@ import {
     createEmbeddedCheckoutStylesheet,
     createEmbeddedCheckoutSupport,
 } from '../embeddedCheckout';
-import { PaymentContextProps } from './PaymentContext';
+
+import { type PaymentContextProps } from './PaymentContext';
 
 // Controllable billing save for the themeV2 pre-submit gate. Other tests keep
 // themeV2 off, so the block never renders and this stays unused there.
@@ -70,1166 +71,1190 @@ jest.mock('./billingForm', () => {
 let mockPaymentContextEffect: ((context: PaymentContextProps) => void) | undefined;
 
 jest.mock('./PaymentRedeemables', () => {
-  const ReactActual = require('react');
+    const ReactActual = require('react');
 
-  const { default: PaymentContextActual } = require('./PaymentContext');
+    const { default: PaymentContextActual } = require('./PaymentContext');
 
-  const PaymentRedeemablesMock = () => {
-    const context = ReactActual.useContext(PaymentContextActual);
+    const PaymentRedeemablesMock = () => {
+        const context = ReactActual.useContext(PaymentContextActual);
 
-    ReactActual.useEffect(() => {
-      mockPaymentContextEffect?.(context);
-    }, []);
+        ReactActual.useEffect(() => {
+            mockPaymentContextEffect?.(context);
+        }, []);
 
-    return null;
-  };
+        return null;
+    };
 
-  return {
-    __esModule: true,
-    default: PaymentRedeemablesMock,
-  };
+    return {
+        __esModule: true,
+        default: PaymentRedeemablesMock,
+    };
 });
 
 describe('Payment step', () => {
-  let checkout: CheckoutPageNodeObject;
-  let CheckoutTest: FunctionComponent<CheckoutProps>;
-  let checkoutService: CheckoutService;
-  let extensionService: ExtensionServiceInterface;
-  let defaultProps: CheckoutProps;
-  let embeddedMessengerMock: EmbeddedCheckoutMessenger;
-  let analyticsTracker: Partial<AnalyticsEvents>;
+    let checkout: CheckoutPageNodeObject;
+    let CheckoutTest: FunctionComponent<CheckoutProps>;
+    let checkoutService: CheckoutService;
+    let extensionService: ExtensionServiceInterface;
+    let defaultProps: CheckoutProps;
+    let embeddedMessengerMock: EmbeddedCheckoutMessenger;
+    let analyticsTracker: Partial<AnalyticsEvents>;
 
-  beforeAll(() => {
-    checkout = new CheckoutPageNodeObject();
-    checkout.goto();
-  });
-
-  afterEach(() => {
-    checkout.resetHandlers();
-    sessionStorage.clear();
-    mockPaymentContextEffect = undefined;
-  });
-
-  afterAll(() => {
-    checkout.close();
-  });
-
-  beforeEach(() => {
-    window.scrollTo = jest.fn();
-
-    checkoutService = createCheckoutService();
-    extensionService = new ExtensionService(checkoutService, createErrorLogger());
-    embeddedMessengerMock = createEmbeddedCheckoutMessenger({
-      parentOrigin: 'https://store.url',
-    });
-    defaultProps = {
-      checkoutId: checkoutWithBillingEmail.id,
-      containerId: CHECKOUT_ROOT_NODE_ID,
-      createEmbeddedMessenger: () => embeddedMessengerMock,
-      embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
-      embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
-      errorLogger: createErrorLogger(),
-    };
-
-    jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
-    analyticsTracker = {
-      selectedPaymentMethod: jest.fn(),
-    };
-
-    CheckoutTest = (props) => (
-      <CheckoutProvider checkoutService={checkoutService}>
-        <LocaleProvider checkoutService={checkoutService} languageService={getLanguageService()}>
-          <AnalyticsProviderMock analyticsTracker={analyticsTracker}>
-            <ExtensionProvider extensionService={extensionService}>
-              <ThemeProvider>
-                <Checkout {...props} />
-              </ThemeProvider>
-            </ExtensionProvider>
-          </AnalyticsProviderMock>
-        </LocaleProvider>
-      </CheckoutProvider>
-    );
-  });
-
-  it('renders payment step with 2 offline payment methods', async () => {
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio', { name: 'Pay in Store' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: 'Cash on Delivery' })).toBeInTheDocument();
-  });
-
-  it('tracks selected payment method on initial load', async () => {
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledWith('Pay in Store', 'instore');
-    expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
-  });
-
-  it('selects another payment method and places the order successfully', async () => {
-    checkout.setRequestHandler(
-      rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
-    );
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-    );
-
-    const location = window.location;
-
-    Object.defineProperty(window, 'location', {
-      value: {
-        // eslint-disable-next-line @typescript-eslint/no-misused-spread
-        ...location,
-        replace: jest.fn(),
-      },
-      writable: true,
+    beforeAll(() => {
+        checkout = new CheckoutPageNodeObject();
+        checkout.goto();
     });
 
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio', { name: 'Pay in Store', checked: true })).toBeInTheDocument();
-
-    await act(async () => userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })));
-
-    expect(
-      await screen.findByRole('radio', { name: 'Cash on Delivery', checked: true }),
-    ).toBeInTheDocument();
-
-    await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-    expect(window.location.replace).toHaveBeenCalledWith('/order-confirmation');
-  });
-
-  it('does not place the order when embedded billing (themeV2) is invalid', async () => {
-    const themeV2Config = {
-      ...checkoutSettings,
-      storeConfig: {
-        ...checkoutSettings.storeConfig,
-        checkoutSettings: {
-          ...checkoutSettings.storeConfig.checkoutSettings,
-          checkoutUserExperienceSettings: {
-            ...checkoutSettings.storeConfig.checkoutSettings.checkoutUserExperienceSettings,
-            checkoutV2Theme: true,
-          },
-        },
-      },
-    };
-
-    mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(false);
-
-    const location = window.location;
-
-    Object.defineProperty(window, 'location', {
-      value: {
-        // eslint-disable-next-line @typescript-eslint/no-misused-spread
-        ...location,
-        replace: jest.fn(),
-      },
-      writable: true,
+    afterEach(() => {
+        checkout.resetHandlers();
+        sessionStorage.clear();
+        mockPaymentContextEffect = undefined;
     });
 
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-      config: themeV2Config,
+    afterAll(() => {
+        checkout.close();
     });
 
-    const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+    beforeEach(() => {
+        window.scrollTo = jest.fn();
 
-    render(<CheckoutTest {...defaultProps} />);
+        checkoutService = createCheckoutService();
+        extensionService = new ExtensionService(checkoutService, createErrorLogger());
+        embeddedMessengerMock = createEmbeddedCheckoutMessenger({
+            parentOrigin: 'https://store.url',
+        });
+        defaultProps = {
+            checkoutId: checkoutWithBillingEmail.id,
+            containerId: CHECKOUT_ROOT_NODE_ID,
+            createEmbeddedMessenger: () => embeddedMessengerMock,
+            embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
+            embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
+            errorLogger: createErrorLogger(),
+        };
 
-    await checkout.waitForPaymentStep();
+        jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
+        analyticsTracker = {
+            selectedPaymentMethod: jest.fn(),
+        };
 
-    await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-    expect(mockEnsureBillingAddressSaved).toHaveBeenCalled();
-    expect(submitOrderSpy).not.toHaveBeenCalled();
-    expect(window.location.replace).not.toHaveBeenCalled();
-  });
-
-  it('disables Place Order while the embedded billing (themeV2) address is being persisted', async () => {
-    const themeV2Config = {
-      ...checkoutSettings,
-      storeConfig: {
-        ...checkoutSettings.storeConfig,
-        checkoutSettings: {
-          ...checkoutSettings.storeConfig.checkoutSettings,
-          checkoutUserExperienceSettings: {
-            ...checkoutSettings.storeConfig.checkoutSettings.checkoutUserExperienceSettings,
-            checkoutV2Theme: true,
-          },
-        },
-      },
-    };
-
-    mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-      config: themeV2Config,
+        CheckoutTest = (props) => (
+            <CheckoutProvider checkoutService={checkoutService}>
+                <LocaleProvider
+                    checkoutService={checkoutService}
+                    languageService={getLanguageService()}
+                >
+                    <AnalyticsProviderMock analyticsTracker={analyticsTracker}>
+                        <ExtensionProvider extensionService={extensionService}>
+                            <ThemeProvider>
+                                <Checkout {...props} />
+                            </ThemeProvider>
+                        </ExtensionProvider>
+                    </AnalyticsProviderMock>
+                </LocaleProvider>
+            </CheckoutProvider>
+        );
     });
 
-    // Keep the billing-address update in flight so isUpdatingBillingAddress
-    // stays true while we assert the submit button is disabled.
-    checkout.setRequestHandler(
-      rest.put(
-        '/api/storefront/checkouts/*/billing-address/*',
-        () => new Promise<never>(() => undefined),
-      ),
-    );
+    it('renders payment step with 2 offline payment methods', async () => {
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
 
-    render(<CheckoutTest {...defaultProps} />);
+        render(<CheckoutTest {...defaultProps} />);
 
-    await checkout.waitForPaymentStep();
+        await checkout.waitForPaymentStep();
 
-    await act(async () => {
-      void checkoutService.updateBillingAddress({});
+        expect(screen.getByRole('radio', { name: 'Pay in Store' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'Cash on Delivery' })).toBeInTheDocument();
     });
 
-    await waitFor(() =>
-      // eslint-disable-next-line jest-dom/prefer-to-have-attribute
-      expect(
-        screen.getByRole('button', { name: /place order/i }).hasAttribute('disabled'),
-      ).toBeTruthy(),
-    );
-  });
+    it('tracks selected payment method on initial load', async () => {
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
 
-  it('does not submit the order when disableSubmit is called for another method right after the selected one', async () => {
-    const paypal = {
-      ...payments[0],
-      id: 'paypal',
-      config: { ...payments[0].config, displayName: 'PayPal' },
-    };
-    const stripe = {
-      ...payments[0],
-      id: 'stripe',
-      config: { ...payments[0].config, displayName: 'Stripe' },
-    };
+        render(<CheckoutTest {...defaultProps} />);
 
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([paypal, stripe]))),
-    );
+        await checkout.waitForPaymentStep();
 
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    // PayPal is first in the list above, so it's selected by default.
-    // disableSubmit only reads id/gateway, so minimal stand-ins are enough.
-    // Calling disableSubmit for a second, different method straight after it
-    // used to wipe out the first method's disabled state before Payment
-    // re-rendered.
-    const paypalMethod = { id: 'paypal', gateway: null } as unknown as PaymentMethod;
-    const stripeMethod = { id: 'stripe', gateway: null } as unknown as PaymentMethod;
-
-    mockPaymentContextEffect = (context) => {
-      context.disableSubmit(paypalMethod, true);
-      context.disableSubmit(stripeMethod, true);
-    };
-
-    const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    await userEvent.click(screen.getByText('Place Order'));
-
-    expect(submitOrderSpy).not.toHaveBeenCalled();
-  });
-
-  it('goes back to billing step after unmounting the component', async () => {
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    await userEvent.click(screen.getByRole('radio', { name: 'Pay in Store' }));
-    await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[2]);
-
-    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
-    expect(screen.queryByText('Pay in Store')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
-  });
-
-  it('applies store credit automatically', async () => {
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-      checkout: {
-        ...checkoutWithShippingAndBilling,
-        customer: {
-          ...customer,
-          storeCredit: 1000,
-        },
-      },
+        expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledWith(
+            'Pay in Store',
+            'instore',
+        );
+        expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
     });
 
-    checkout.setRequestHandler(
-      rest.post('api/storefront/checkouts/*/store-credit', (_, res, ctx) =>
-        res(
-          ctx.json({
-            ...checkoutWithShippingAndBilling,
-            isStoreCreditApplied: true,
-            outstandingBalance: 0,
-            customer: {
-              ...customer,
-              storeCredit: 1000,
+    it('selects another payment method and places the order successfully', async () => {
+        checkout.setRequestHandler(
+            rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                res(ctx.json(orderResponse)),
+            ),
+        );
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+        );
+
+        const location = window.location;
+
+        Object.defineProperty(window, 'location', {
+            value: {
+                // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                ...location,
+                replace: jest.fn(),
             },
-          }),
-        ),
-      ),
-    );
+            writable: true,
+        });
 
-    render(<CheckoutTest {...defaultProps} />);
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
 
-    await checkout.waitForPaymentStep();
+        render(<CheckoutTest {...defaultProps} />);
 
-    expect(screen.getByText(/Payment is not required/)).toBeInTheDocument();
-  });
+        await checkout.waitForPaymentStep();
 
-  it('does not apply store credit automatically when disableStoreCredit is true', async () => {
-    const configWithDisableStoreCredit = {
-      ...checkoutSettings,
-      storeConfig: {
-        ...checkoutSettings.storeConfig,
-        checkoutSettings: {
-          ...checkoutSettings.storeConfig.checkoutSettings,
-          capabilities: {
-            ...defaultCapabilities,
-            userJourney: {
-              ...defaultCapabilities.userJourney,
-              disableStoreCredit: true,
-            },
-          },
-        },
-      },
-    };
+        expect(
+            screen.getByRole('radio', { name: 'Pay in Store', checked: true }),
+        ).toBeInTheDocument();
 
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-      config: configWithDisableStoreCredit,
-      checkout: {
-        ...checkoutWithShippingAndBilling,
-        isStoreCreditApplied: false,
-        customer: {
-          ...customer,
-          storeCredit: 1000,
-        },
-      },
+        await act(async () =>
+            userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
+        );
+
+        expect(
+            await screen.findByRole('radio', { name: 'Cash on Delivery', checked: true }),
+        ).toBeInTheDocument();
+
+        await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+        expect(window.location.replace).toHaveBeenCalledWith('/order-confirmation');
     });
 
-    const applyStoreCreditSpy = jest.spyOn(checkoutService, 'applyStoreCredit');
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(applyStoreCreditSpy).not.toHaveBeenCalledWith(true);
-  });
-
-  it('does not render amazon if multi-shipping', async () => {
-    const amazonPay = {
-      ...payments[0],
-      id: 'amazonpay',
-      config: {
-        ...payments[0].config,
-        displayName: 'Amazon Pay',
-      },
-    };
-
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) =>
-        res(ctx.json([payments[0], amazonPay])),
-      ),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio')).toBeInTheDocument();
-    expect(screen.queryByText('Amazon Pay')).not.toBeInTheDocument();
-  });
-
-  it('does not render bolt if showInCheckout is false', async () => {
-    const bolt = {
-      ...payments[0],
-      id: 'bolt',
-      initializationData: { showInCheckout: false },
-      config: {
-        ...payments[0].config,
-        displayName: 'Bolt',
-      },
-    };
-
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([payments[0], bolt]))),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio')).toBeInTheDocument();
-    expect(screen.queryByText('Bolt')).not.toBeInTheDocument();
-  });
-
-  it('does not render methods with braintreelocalmethods id', async () => {
-    const braintree = {
-      ...payments[0],
-      id: 'braintreelocalmethods',
-      config: {
-        ...payments[0].config,
-        displayName: 'BrainTree Local Methods',
-      },
-    };
-
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) =>
-        res(ctx.json([payments[0], braintree])),
-      ),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio')).toBeInTheDocument();
-    expect(screen.queryByText(/BrainTree/)).not.toBeInTheDocument();
-  });
-
-  it('groups payment methods that match configured prefix when PAYMENTS-5142 experiment is enabled', async () => {
-    const facilypay3 = {
-      ...payments[0],
-      id: 'facilypay_3',
-      config: {
-        ...payments[0].config,
-        displayName: '3x Oney',
-      },
-    };
-    const facilypay6 = {
-      ...payments[0],
-      id: 'facilypay_6',
-      config: {
-        ...payments[0].config,
-        displayName: '6x Oney',
-      },
-    };
-    const card = {
-      ...payments[0],
-      id: 'card',
-      config: {
-        ...payments[0].config,
-        displayName: 'Card',
-      },
-    };
-
-    const configWithGroupingExperiment = {
-      ...checkoutSettings,
-      storeConfig: {
-        ...checkoutSettings.storeConfig,
-        checkoutSettings: {
-          ...checkoutSettings.storeConfig.checkoutSettings,
-          features: {
-            ...checkoutSettings.storeConfig.checkoutSettings.features,
-            'PAYMENTS-5142.payment_method_grouping': true,
-          },
-        },
-      },
-    };
-
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) =>
-        res(ctx.json([card, facilypay6, facilypay3])),
-      ),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-      config: configWithGroupingExperiment,
-    });
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio', { name: 'Oney' })).toBeInTheDocument();
-    expect(screen.queryByRole('radio', { name: '3x Oney' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('radio', { name: '6x Oney' })).not.toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: 'Card' })).toBeInTheDocument();
-  });
-
-  it('does not group prefixed payment methods when PAYMENTS-5142 experiment is disabled', async () => {
-    const facilypay3 = {
-      ...payments[0],
-      id: 'facilypay_3',
-      config: {
-        ...payments[0].config,
-        displayName: '3x Oney',
-      },
-    };
-    const facilypay6 = {
-      ...payments[0],
-      id: 'facilypay_6',
-      config: {
-        ...payments[0].config,
-        displayName: '6x Oney',
-      },
-    };
-
-    const configWithoutGroupingExperiment = {
-      ...checkoutSettings,
-      storeConfig: {
-        ...checkoutSettings.storeConfig,
-        checkoutSettings: {
-          ...checkoutSettings.storeConfig.checkoutSettings,
-          features: {
-            ...checkoutSettings.storeConfig.checkoutSettings.features,
-            'PAYMENTS-5142.payment_method_grouping': false,
-          },
-        },
-      },
-    };
-
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) =>
-        res(ctx.json([facilypay6, facilypay3])),
-      ),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-      config: configWithoutGroupingExperiment,
-    });
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio', { name: '3x Oney' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: '6x Oney' })).toBeInTheDocument();
-    expect(screen.queryByRole('radio', { name: 'Oney' })).not.toBeInTheDocument();
-  });
-
-  it('does not group payment methods when no configured prefix matches', async () => {
-    const installments3 = {
-      ...payments[0],
-      id: 'installments_3',
-      config: {
-        ...payments[0].config,
-        displayName: '3x Installments',
-      },
-    };
-    const installments6 = {
-      ...payments[0],
-      id: 'installments_6',
-      config: {
-        ...payments[0].config,
-        displayName: '6x Installments',
-      },
-    };
-
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) =>
-        res(ctx.json([installments3, installments6])),
-      ),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-
-    expect(screen.getByRole('radio', { name: '3x Installments' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: '6x Installments' })).toBeInTheDocument();
-  });
-
-  it('does not render payment form if there are no methods', async () => {
-    checkout.setRequestHandler(
-      rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([]))),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    expect(await screen.findByText('Payment')).toBeInTheDocument();
-    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
-  });
-
-  it('renders error modal if there is error when submitting order', async () => {
-    checkout.setRequestHandler(
-      rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-        res(
-          ctx.status(500),
-          ctx.json({
-            title: 'The tax provider is unavailable.',
-            type: 'order_error',
-          }),
-        ),
-      ),
-    );
-
-    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-    render(<CheckoutTest {...defaultProps} />);
-
-    await checkout.waitForPaymentStep();
-    await userEvent.click(screen.getByText('Place Order'));
-
-    expect(screen.getByText("Something's gone wrong")).toBeInTheDocument();
-
-    await userEvent.click(screen.getByText('Ok'));
-
-    expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
-  });
-
-  describe('B2B payment methods refresh', () => {
-    const createConfigWithPersistB2BMetadata = () => ({
-      ...checkoutSettings,
-      storeConfig: {
-        ...checkoutSettings.storeConfig,
-        checkoutSettings: {
-          ...checkoutSettings.storeConfig.checkoutSettings,
-          capabilities: {
-            ...defaultCapabilities,
-            orderConfirmation: {
-              ...defaultCapabilities.orderConfirmation,
-              persistB2BMetadata: true,
-            },
-          },
-        },
-      },
-    });
-
-    it('refreshes B2B payment methods on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-          orderId: 12345,
-        },
-      });
-
-      const refreshSpy = jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      expect(refreshSpy).toHaveBeenCalled();
-    });
-
-    it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-        },
-      });
-
-      const refreshSpy = jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      expect(refreshSpy).not.toHaveBeenCalled();
-    });
-
-    it('does not refresh B2B payment methods on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          orderId: 12345,
-        },
-      });
-
-      const refreshSpy = jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      expect(refreshSpy).not.toHaveBeenCalled();
-    });
-
-    it('refreshes B2B payment methods before submitting order when persistB2BMetadata capability is enabled', async () => {
-      checkout.setRequestHandler(
-        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
-      );
-      checkout.setRequestHandler(
-        rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-      );
-
-      const location = window.location;
-
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
-
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-        },
-      });
-
-      const refreshSpy = jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-      const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      refreshSpy.mockClear();
-
-      await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
-      expect(submitOrderSpy).toHaveBeenCalledTimes(1);
-
-      const refreshCallOrder = refreshSpy.mock.invocationCallOrder[0];
-      const submitOrderCallOrder = submitOrderSpy.mock.invocationCallOrder[0];
-
-      expect(refreshCallOrder).toBeLessThan(submitOrderCallOrder);
-    });
-
-    it('does not refresh B2B payment methods before submitting order when persistB2BMetadata capability is disabled', async () => {
-      checkout.setRequestHandler(
-        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
-      );
-      checkout.setRequestHandler(
-        rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-      );
-
-      const location = window.location;
-
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
-
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-      const refreshSpy = jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-      expect(refreshSpy).not.toHaveBeenCalled();
-    });
-
-    it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-          orderId: 12345,
-        },
-      });
-
-      jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockRejectedValue(new Error('B2B payments refresh failed'));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      expect(screen.getByText(/place order/i)).toBeInTheDocument();
-    });
-
-    it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
-      checkout.setRequestHandler(
-        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
-      );
-
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-        },
-      });
-
-      jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockRejectedValue(new Error('B2B payments refresh failed'));
-
-      const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-      expect(submitOrderSpy).not.toHaveBeenCalled();
-    });
-
-    it('persists B2B metadata after finalizing the order on mount when persistB2BMetadata capability is enabled', async () => {
-      const location = window.location;
-
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
-
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-          orderId: 12345,
-        },
-      });
-
-      jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-      jest
-        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
-        .mockResolvedValue(checkoutService.getState());
-
-      const persistSpy = jest
-        .spyOn(checkoutService, 'persistB2BMetadata')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await waitFor(() =>
-        expect(persistSpy).toHaveBeenCalledWith({
-          isInvoice: false,
-          invoiceComment: undefined,
-          poNumber: undefined,
-          referenceNumber: undefined,
-          extraFields: [],
-          extraInfo: {},
-        }),
-      );
-    });
-
-    it('persists the address extra fields from the checkout object after finalizing on mount', async () => {
-      const location = window.location;
-
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
-
-      const { billingAddress } = checkoutWithShippingAndBilling;
-      const [consignment] = checkoutWithShippingAndBilling.consignments;
-
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-          orderId: 12345,
-          billingAddress: billingAddress && {
-            ...billingAddress,
-            extraFields: [{ fieldId: '30', fieldValue: 'Finance' }],
-          },
-          consignments: [
-            {
-              ...consignment,
-              shippingAddress: {
-                ...consignment.shippingAddress,
-                extraFields: [{ fieldId: '31', fieldValue: 'B7' }],
-              },
-            },
-          ],
-        },
-      });
-
-      jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-      jest
-        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
-        .mockResolvedValue(checkoutService.getState());
-
-      const persistSpy = jest
-        .spyOn(checkoutService, 'persistB2BMetadata')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await waitFor(() =>
-        expect(persistSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            extraInfo: {
-              addressExtraFields: {
-                billingAddressExtraFields: [{ fieldName: '30', fieldValue: 'Finance' }],
-                shippingAddressExtraFields: [{ fieldName: '31', fieldValue: 'B7' }],
-              },
-            },
-          }),
-        ),
-      );
-    });
-
-    it('stores the address IDs returned by the order endpoint, persists them and clears them afterwards', async () => {
-      checkout.setRequestHandler(
-        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-          res(
-            ctx.json({
-              ...orderResponse,
-              data: {
-                ...orderResponse.data,
-                order: {
-                  ...orderResponse.data.order,
-                  b2bMetadata: {
-                    billingAddressId: 111,
-                    shippingAddressId: 222,
-                  },
+    it('does not place the order when embedded billing (themeV2) is invalid', async () => {
+        const themeV2Config = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    checkoutUserExperienceSettings: {
+                        ...checkoutSettings.storeConfig.checkoutSettings
+                            .checkoutUserExperienceSettings,
+                        checkoutV2Theme: true,
+                    },
                 },
-              },
-            }),
-          ),
-        ),
-      );
-      checkout.setRequestHandler(
-        rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-      );
-
-      const location = window.location;
-
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
-
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-        },
-      });
-
-      jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      const persistSpy = jest
-        .spyOn(checkoutService, 'persistB2BMetadata')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-      render(<CheckoutTest {...defaultProps} />);
-
-      await checkout.waitForPaymentStep();
-
-      await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-      await waitFor(() =>
-        expect(persistSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            extraInfo: {
-              billingAddressId: 111,
-              shipppingAddressId: 222,
             },
-          }),
-        ),
-      );
+        };
 
-      await waitFor(() =>
-        expect(B2BSessionStorage.getAddressIds()).toEqual({
-          billingAddressId: undefined,
-          shippingAddressId: undefined,
-        }),
-      );
+        mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(false);
+
+        const location = window.location;
+
+        Object.defineProperty(window, 'location', {
+            value: {
+                // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                ...location,
+                replace: jest.fn(),
+            },
+            writable: true,
+        });
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: themeV2Config,
+        });
+
+        const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+        expect(mockEnsureBillingAddressSaved).toHaveBeenCalled();
+        expect(submitOrderSpy).not.toHaveBeenCalled();
+        expect(window.location.replace).not.toHaveBeenCalled();
     });
 
-    it('persists B2B metadata with isInvoice true and the captured form values when the invoiceRedirect capability is enabled', async () => {
-      const location = window.location;
-
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
-
-      B2BSessionStorage.setPaymentValues({ invoicePaymentComment: 'Invoice me' });
-
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: {
-          ...checkoutSettings,
-          storeConfig: {
-            ...checkoutSettings.storeConfig,
-            checkoutSettings: {
-              ...checkoutSettings.storeConfig.checkoutSettings,
-              capabilities: {
-                ...defaultCapabilities,
-                orderConfirmation: {
-                  ...defaultCapabilities.orderConfirmation,
-                  persistB2BMetadata: true,
-                  invoiceRedirect: true,
+    it('disables Place Order while the embedded billing (themeV2) address is being persisted', async () => {
+        const themeV2Config = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    checkoutUserExperienceSettings: {
+                        ...checkoutSettings.storeConfig.checkoutSettings
+                            .checkoutUserExperienceSettings,
+                        checkoutV2Theme: true,
+                    },
                 },
-              },
             },
-          },
-        },
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-          orderId: 12345,
-        },
-      });
+        };
 
-      jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-      jest
-        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
-        .mockResolvedValue(checkoutService.getState());
+        mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
 
-      const persistSpy = jest
-        .spyOn(checkoutService, 'persistB2BMetadata')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: themeV2Config,
+        });
 
-      render(<CheckoutTest {...defaultProps} />);
+        // Keep the billing-address update in flight so isUpdatingBillingAddress
+        // stays true while we assert the submit button is disabled.
+        checkout.setRequestHandler(
+            rest.put(
+                '/api/storefront/checkouts/*/billing-address/*',
+                () => new Promise<never>(() => undefined),
+            ),
+        );
 
-      await waitFor(() =>
-        expect(persistSpy).toHaveBeenCalledWith(
-          expect.objectContaining({
-            isInvoice: true,
-            invoiceComment: 'Invoice me',
-          }),
-        ),
-      );
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        await act(async () => {
+            void checkoutService.updateBillingAddress({});
+        });
+
+        await waitFor(() =>
+            // eslint-disable-next-line jest-dom/prefer-to-have-attribute
+            expect(
+                screen.getByRole('button', { name: /place order/i }).hasAttribute('disabled'),
+            ).toBeTruthy(),
+        );
     });
 
-    it('clears B2B sessionStorage even when persisting metadata fails', async () => {
-      const location = window.location;
+    it('does not submit the order when disableSubmit is called for another method right after the selected one', async () => {
+        const paypal = {
+            ...payments[0],
+            id: 'paypal',
+            config: { ...payments[0].config, displayName: 'PayPal' },
+        };
+        const stripe = {
+            ...payments[0],
+            id: 'stripe',
+            config: { ...payments[0].config, displayName: 'Stripe' },
+        };
 
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([paypal, stripe]))),
+        );
 
-      B2BSessionStorage.setAddressIds({ billingAddressId: 111, shippingAddressId: 222 });
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
 
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        config: createConfigWithPersistB2BMetadata(),
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-          orderId: 12345,
-        },
-      });
+        // PayPal is first in the list above, so it's selected by default.
+        // disableSubmit only reads id/gateway, so minimal stand-ins are enough.
+        // Calling disableSubmit for a second, different method straight after it
+        // used to wipe out the first method's disabled state before Payment
+        // re-rendered.
+        const paypalMethod = { id: 'paypal', gateway: null } as unknown as PaymentMethod;
+        const stripeMethod = { id: 'stripe', gateway: null } as unknown as PaymentMethod;
 
-      jest
-        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-      jest
-        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
-        .mockResolvedValue(checkoutService.getState());
+        mockPaymentContextEffect = (context) => {
+            context.disableSubmit(paypalMethod, true);
+            context.disableSubmit(stripeMethod, true);
+        };
 
-      const persistSpy = jest
-        .spyOn(checkoutService, 'persistB2BMetadata')
-        .mockRejectedValue(new Error('Persist failed'));
+        const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
 
-      render(<CheckoutTest {...defaultProps} />);
+        render(<CheckoutTest {...defaultProps} />);
 
-      await waitFor(() => expect(persistSpy).toHaveBeenCalled());
+        await checkout.waitForPaymentStep();
 
-      await waitFor(() =>
-        expect(B2BSessionStorage.getAddressIds()).toEqual({
-          billingAddressId: undefined,
-          shippingAddressId: undefined,
-        }),
-      );
+        await userEvent.click(screen.getByText('Place Order'));
+
+        expect(submitOrderSpy).not.toHaveBeenCalled();
     });
 
-    it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {
-      const location = window.location;
+    it('goes back to billing step after unmounting the component', async () => {
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
 
-      Object.defineProperty(window, 'location', {
-        value: {
-          // eslint-disable-next-line @typescript-eslint/no-misused-spread
-          ...location,
-          replace: jest.fn(),
-        },
-        writable: true,
-      });
+        render(<CheckoutTest {...defaultProps} />);
 
-      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-        checkout: {
-          ...checkoutWithShippingAndBilling,
-          customer,
-          orderId: 12345,
-        },
-      });
+        await checkout.waitForPaymentStep();
 
-      const finalizeSpy = jest
-        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
-        .mockResolvedValue(checkoutService.getState());
-      const persistSpy = jest
-        .spyOn(checkoutService, 'persistB2BMetadata')
-        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+        await userEvent.click(screen.getByRole('radio', { name: 'Pay in Store' }));
+        await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[2]);
 
-      render(<CheckoutTest {...defaultProps} />);
-
-      await waitFor(() => expect(finalizeSpy).toHaveBeenCalled());
-
-      expect(persistSpy).not.toHaveBeenCalled();
+        expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+        expect(screen.queryByText('Pay in Store')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
     });
-  });
+
+    it('applies store credit automatically', async () => {
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            checkout: {
+                ...checkoutWithShippingAndBilling,
+                customer: {
+                    ...customer,
+                    storeCredit: 1000,
+                },
+            },
+        });
+
+        checkout.setRequestHandler(
+            rest.post('api/storefront/checkouts/*/store-credit', (_, res, ctx) =>
+                res(
+                    ctx.json({
+                        ...checkoutWithShippingAndBilling,
+                        isStoreCreditApplied: true,
+                        outstandingBalance: 0,
+                        customer: {
+                            ...customer,
+                            storeCredit: 1000,
+                        },
+                    }),
+                ),
+            ),
+        );
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByText(/Payment is not required/)).toBeInTheDocument();
+    });
+
+    it('does not apply store credit automatically when disableStoreCredit is true', async () => {
+        const configWithDisableStoreCredit = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    capabilities: {
+                        ...defaultCapabilities,
+                        userJourney: {
+                            ...defaultCapabilities.userJourney,
+                            disableStoreCredit: true,
+                        },
+                    },
+                },
+            },
+        };
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: configWithDisableStoreCredit,
+            checkout: {
+                ...checkoutWithShippingAndBilling,
+                isStoreCreditApplied: false,
+                customer: {
+                    ...customer,
+                    storeCredit: 1000,
+                },
+            },
+        });
+
+        const applyStoreCreditSpy = jest.spyOn(checkoutService, 'applyStoreCredit');
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(applyStoreCreditSpy).not.toHaveBeenCalledWith(true);
+    });
+
+    it('does not render amazon if multi-shipping', async () => {
+        const amazonPay = {
+            ...payments[0],
+            id: 'amazonpay',
+            config: {
+                ...payments[0].config,
+                displayName: 'Amazon Pay',
+            },
+        };
+
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) =>
+                res(ctx.json([payments[0], amazonPay])),
+            ),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingAndBilling);
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio')).toBeInTheDocument();
+        expect(screen.queryByText('Amazon Pay')).not.toBeInTheDocument();
+    });
+
+    it('does not render bolt if showInCheckout is false', async () => {
+        const bolt = {
+            ...payments[0],
+            id: 'bolt',
+            initializationData: { showInCheckout: false },
+            config: {
+                ...payments[0].config,
+                displayName: 'Bolt',
+            },
+        };
+
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) =>
+                res(ctx.json([payments[0], bolt])),
+            ),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio')).toBeInTheDocument();
+        expect(screen.queryByText('Bolt')).not.toBeInTheDocument();
+    });
+
+    it('does not render methods with braintreelocalmethods id', async () => {
+        const braintree = {
+            ...payments[0],
+            id: 'braintreelocalmethods',
+            config: {
+                ...payments[0].config,
+                displayName: 'BrainTree Local Methods',
+            },
+        };
+
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) =>
+                res(ctx.json([payments[0], braintree])),
+            ),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio')).toBeInTheDocument();
+        expect(screen.queryByText(/BrainTree/)).not.toBeInTheDocument();
+    });
+
+    it('groups payment methods that match configured prefix when PAYMENTS-5142 experiment is enabled', async () => {
+        const facilypay3 = {
+            ...payments[0],
+            id: 'facilypay_3',
+            config: {
+                ...payments[0].config,
+                displayName: '3x Oney',
+            },
+        };
+        const facilypay6 = {
+            ...payments[0],
+            id: 'facilypay_6',
+            config: {
+                ...payments[0].config,
+                displayName: '6x Oney',
+            },
+        };
+        const card = {
+            ...payments[0],
+            id: 'card',
+            config: {
+                ...payments[0].config,
+                displayName: 'Card',
+            },
+        };
+
+        const configWithGroupingExperiment = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    features: {
+                        ...checkoutSettings.storeConfig.checkoutSettings.features,
+                        'PAYMENTS-5142.payment_method_grouping': true,
+                    },
+                },
+            },
+        };
+
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) =>
+                res(ctx.json([card, facilypay6, facilypay3])),
+            ),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: configWithGroupingExperiment,
+        });
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio', { name: 'Oney' })).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: '3x Oney' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: '6x Oney' })).not.toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: 'Card' })).toBeInTheDocument();
+    });
+
+    it('does not group prefixed payment methods when PAYMENTS-5142 experiment is disabled', async () => {
+        const facilypay3 = {
+            ...payments[0],
+            id: 'facilypay_3',
+            config: {
+                ...payments[0].config,
+                displayName: '3x Oney',
+            },
+        };
+        const facilypay6 = {
+            ...payments[0],
+            id: 'facilypay_6',
+            config: {
+                ...payments[0].config,
+                displayName: '6x Oney',
+            },
+        };
+
+        const configWithoutGroupingExperiment = {
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    features: {
+                        ...checkoutSettings.storeConfig.checkoutSettings.features,
+                        'PAYMENTS-5142.payment_method_grouping': false,
+                    },
+                },
+            },
+        };
+
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) =>
+                res(ctx.json([facilypay6, facilypay3])),
+            ),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+            config: configWithoutGroupingExperiment,
+        });
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio', { name: '3x Oney' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: '6x Oney' })).toBeInTheDocument();
+        expect(screen.queryByRole('radio', { name: 'Oney' })).not.toBeInTheDocument();
+    });
+
+    it('does not group payment methods when no configured prefix matches', async () => {
+        const installments3 = {
+            ...payments[0],
+            id: 'installments_3',
+            config: {
+                ...payments[0].config,
+                displayName: '3x Installments',
+            },
+        };
+        const installments6 = {
+            ...payments[0],
+            id: 'installments_6',
+            config: {
+                ...payments[0].config,
+                displayName: '6x Installments',
+            },
+        };
+
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) =>
+                res(ctx.json([installments3, installments6])),
+            ),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+
+        expect(screen.getByRole('radio', { name: '3x Installments' })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: '6x Installments' })).toBeInTheDocument();
+    });
+
+    it('does not render payment form if there are no methods', async () => {
+        checkout.setRequestHandler(
+            rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([]))),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        expect(await screen.findByText('Payment')).toBeInTheDocument();
+        expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    });
+
+    it('renders error modal if there is error when submitting order', async () => {
+        checkout.setRequestHandler(
+            rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                res(
+                    ctx.status(500),
+                    ctx.json({
+                        title: 'The tax provider is unavailable.',
+                        type: 'order_error',
+                    }),
+                ),
+            ),
+        );
+
+        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+        render(<CheckoutTest {...defaultProps} />);
+
+        await checkout.waitForPaymentStep();
+        await userEvent.click(screen.getByText('Place Order'));
+
+        expect(screen.getByText("Something's gone wrong")).toBeInTheDocument();
+
+        await userEvent.click(screen.getByText('Ok'));
+
+        expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
+    });
+
+    describe('B2B payment methods refresh', () => {
+        const createConfigWithPersistB2BMetadata = () => ({
+            ...checkoutSettings,
+            storeConfig: {
+                ...checkoutSettings.storeConfig,
+                checkoutSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings,
+                    capabilities: {
+                        ...defaultCapabilities,
+                        orderConfirmation: {
+                            ...defaultCapabilities.orderConfirmation,
+                            persistB2BMetadata: true,
+                        },
+                    },
+                },
+            },
+        });
+
+        it('refreshes B2B payment methods on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(refreshSpy).toHaveBeenCalled();
+        });
+
+        it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(refreshSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not refresh B2B payment methods on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    orderId: 12345,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(refreshSpy).not.toHaveBeenCalled();
+        });
+
+        it('refreshes B2B payment methods before submitting order when persistB2BMetadata capability is enabled', async () => {
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(ctx.json(orderResponse)),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+            );
+
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+            const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            refreshSpy.mockClear();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            expect(refreshSpy).toHaveBeenCalledTimes(1);
+            expect(submitOrderSpy).toHaveBeenCalledTimes(1);
+
+            const refreshCallOrder = refreshSpy.mock.invocationCallOrder[0];
+            const submitOrderCallOrder = submitOrderSpy.mock.invocationCallOrder[0];
+
+            expect(refreshCallOrder).toBeLessThan(submitOrderCallOrder);
+        });
+
+        it('does not refresh B2B payment methods before submitting order when persistB2BMetadata capability is disabled', async () => {
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(ctx.json(orderResponse)),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+            );
+
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+            const refreshSpy = jest
+                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            expect(refreshSpy).not.toHaveBeenCalled();
+        });
+
+        it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
+                new Error('B2B payments refresh failed'),
+            );
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(screen.getByText(/place order/i)).toBeInTheDocument();
+        });
+
+        it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(ctx.json(orderResponse)),
+                ),
+            );
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
+                new Error('B2B payments refresh failed'),
+            );
+
+            const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            expect(submitOrderSpy).not.toHaveBeenCalled();
+        });
+
+        it('persists B2B metadata after finalizing the order on mount when persistB2BMetadata capability is enabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith({
+                    isInvoice: false,
+                    invoiceComment: undefined,
+                    poNumber: undefined,
+                    referenceNumber: undefined,
+                    extraFields: [],
+                    extraInfo: {},
+                }),
+            );
+        });
+
+        it('persists the address extra fields from the checkout object after finalizing on mount', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            const { billingAddress } = checkoutWithShippingAndBilling;
+            const [consignment] = checkoutWithShippingAndBilling.consignments;
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                    billingAddress: billingAddress && {
+                        ...billingAddress,
+                        extraFields: [{ fieldId: '30', fieldValue: 'Finance' }],
+                    },
+                    consignments: [
+                        {
+                            ...consignment,
+                            shippingAddress: {
+                                ...consignment.shippingAddress,
+                                extraFields: [{ fieldId: '31', fieldValue: 'B7' }],
+                            },
+                        },
+                    ],
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        extraInfo: {
+                            addressExtraFields: {
+                                billingAddressExtraFields: [
+                                    { fieldName: '30', fieldValue: 'Finance' },
+                                ],
+                                shippingAddressExtraFields: [{ fieldName: '31', fieldValue: 'B7' }],
+                            },
+                        },
+                    }),
+                ),
+            );
+        });
+
+        it('stores the address IDs returned by the order endpoint, persists them and clears them afterwards', async () => {
+            checkout.setRequestHandler(
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(
+                        ctx.json({
+                            ...orderResponse,
+                            data: {
+                                ...orderResponse.data,
+                                order: {
+                                    ...orderResponse.data.order,
+                                    b2bMetadata: {
+                                        billingAddressId: 111,
+                                        shippingAddressId: 222,
+                                    },
+                                },
+                            },
+                        }),
+                    ),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+            );
+
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        extraInfo: {
+                            billingAddressId: 111,
+                            shipppingAddressId: 222,
+                        },
+                    }),
+                ),
+            );
+
+            await waitFor(() =>
+                expect(B2BSessionStorage.getAddressIds()).toEqual({
+                    billingAddressId: undefined,
+                    shippingAddressId: undefined,
+                }),
+            );
+        });
+
+        it('persists B2B metadata with isInvoice true and the captured form values when the invoiceRedirect capability is enabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            B2BSessionStorage.setPaymentValues({ invoicePaymentComment: 'Invoice me' });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: {
+                    ...checkoutSettings,
+                    storeConfig: {
+                        ...checkoutSettings.storeConfig,
+                        checkoutSettings: {
+                            ...checkoutSettings.storeConfig.checkoutSettings,
+                            capabilities: {
+                                ...defaultCapabilities,
+                                orderConfirmation: {
+                                    ...defaultCapabilities.orderConfirmation,
+                                    persistB2BMetadata: true,
+                                    invoiceRedirect: true,
+                                },
+                            },
+                        },
+                    },
+                },
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() =>
+                expect(persistSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        isInvoice: true,
+                        invoiceComment: 'Invoice me',
+                    }),
+                ),
+            );
+        });
+
+        it('clears B2B sessionStorage even when persisting metadata fails', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            B2BSessionStorage.setAddressIds({ billingAddressId: 111, shippingAddressId: 222 });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: createConfigWithPersistB2BMetadata(),
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
+                Promise.resolve(checkoutService.getState()),
+            );
+            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
+                checkoutService.getState(),
+            );
+
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockRejectedValue(new Error('Persist failed'));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() => expect(persistSpy).toHaveBeenCalled());
+
+            await waitFor(() =>
+                expect(B2BSessionStorage.getAddressIds()).toEqual({
+                    billingAddressId: undefined,
+                    shippingAddressId: undefined,
+                }),
+            );
+        });
+
+        it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {
+            const location = window.location;
+
+            Object.defineProperty(window, 'location', {
+                value: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
+                    ...location,
+                    replace: jest.fn(),
+                },
+                writable: true,
+            });
+
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    customer,
+                    orderId: 12345,
+                },
+            });
+
+            const finalizeSpy = jest
+                .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+                .mockResolvedValue(checkoutService.getState());
+            const persistSpy = jest
+                .spyOn(checkoutService, 'persistB2BMetadata')
+                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await waitFor(() => expect(finalizeSpy).toHaveBeenCalled());
+
+            expect(persistSpy).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -1,8 +1,9 @@
 import {
-    type CheckoutService,
-    createCheckoutService,
-    createEmbeddedCheckoutMessenger,
-    type EmbeddedCheckoutMessenger,
+  type CheckoutService,
+  createCheckoutService,
+  createEmbeddedCheckoutMessenger,
+  type EmbeddedCheckoutMessenger,
+  PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
@@ -41,6 +42,7 @@ import {
     createEmbeddedCheckoutStylesheet,
     createEmbeddedCheckoutSupport,
 } from '../embeddedCheckout';
+import { PaymentContextProps } from './PaymentContext';
 
 // Controllable billing save for the themeV2 pre-submit gate. Other tests keep
 // themeV2 off, so the block never renders and this stays unused there.
@@ -65,1127 +67,1169 @@ jest.mock('./billingForm', () => {
     };
 });
 
+let mockPaymentContextEffect: ((context: PaymentContextProps) => void) | undefined;
+
+jest.mock('./PaymentRedeemables', () => {
+  const ReactActual = require('react');
+
+  const { default: PaymentContextActual } = require('./PaymentContext');
+
+  const PaymentRedeemablesMock = () => {
+    const context = ReactActual.useContext(PaymentContextActual);
+
+    ReactActual.useEffect(() => {
+      mockPaymentContextEffect?.(context);
+    }, []);
+
+    return null;
+  };
+
+  return {
+    __esModule: true,
+    default: PaymentRedeemablesMock,
+  };
+});
+
 describe('Payment step', () => {
-    let checkout: CheckoutPageNodeObject;
-    let CheckoutTest: FunctionComponent<CheckoutProps>;
-    let checkoutService: CheckoutService;
-    let extensionService: ExtensionServiceInterface;
-    let defaultProps: CheckoutProps;
-    let embeddedMessengerMock: EmbeddedCheckoutMessenger;
-    let analyticsTracker: Partial<AnalyticsEvents>;
+  let checkout: CheckoutPageNodeObject;
+  let CheckoutTest: FunctionComponent<CheckoutProps>;
+  let checkoutService: CheckoutService;
+  let extensionService: ExtensionServiceInterface;
+  let defaultProps: CheckoutProps;
+  let embeddedMessengerMock: EmbeddedCheckoutMessenger;
+  let analyticsTracker: Partial<AnalyticsEvents>;
 
-    beforeAll(() => {
-        checkout = new CheckoutPageNodeObject();
-        checkout.goto();
+  beforeAll(() => {
+    checkout = new CheckoutPageNodeObject();
+    checkout.goto();
+  });
+
+  afterEach(() => {
+    checkout.resetHandlers();
+    sessionStorage.clear();
+    mockPaymentContextEffect = undefined;
+  });
+
+  afterAll(() => {
+    checkout.close();
+  });
+
+  beforeEach(() => {
+    window.scrollTo = jest.fn();
+
+    checkoutService = createCheckoutService();
+    extensionService = new ExtensionService(checkoutService, createErrorLogger());
+    embeddedMessengerMock = createEmbeddedCheckoutMessenger({
+      parentOrigin: 'https://store.url',
+    });
+    defaultProps = {
+      checkoutId: checkoutWithBillingEmail.id,
+      containerId: CHECKOUT_ROOT_NODE_ID,
+      createEmbeddedMessenger: () => embeddedMessengerMock,
+      embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
+      embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
+      errorLogger: createErrorLogger(),
+    };
+
+    jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
+    analyticsTracker = {
+      selectedPaymentMethod: jest.fn(),
+    };
+
+    CheckoutTest = (props) => (
+      <CheckoutProvider checkoutService={checkoutService}>
+        <LocaleProvider checkoutService={checkoutService} languageService={getLanguageService()}>
+          <AnalyticsProviderMock analyticsTracker={analyticsTracker}>
+            <ExtensionProvider extensionService={extensionService}>
+              <ThemeProvider>
+                <Checkout {...props} />
+              </ThemeProvider>
+            </ExtensionProvider>
+          </AnalyticsProviderMock>
+        </LocaleProvider>
+      </CheckoutProvider>
+    );
+  });
+
+  it('renders payment step with 2 offline payment methods', async () => {
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    expect(screen.getByRole('radio', { name: 'Pay in Store' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Cash on Delivery' })).toBeInTheDocument();
+  });
+
+  it('tracks selected payment method on initial load', async () => {
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledWith('Pay in Store', 'instore');
+    expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects another payment method and places the order successfully', async () => {
+    checkout.setRequestHandler(
+      rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
+    );
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+    );
+
+    const location = window.location;
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        // eslint-disable-next-line @typescript-eslint/no-misused-spread
+        ...location,
+        replace: jest.fn(),
+      },
+      writable: true,
     });
 
-    afterEach(() => {
-        checkout.resetHandlers();
-        sessionStorage.clear();
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    expect(screen.getByRole('radio', { name: 'Pay in Store', checked: true })).toBeInTheDocument();
+
+    await act(async () => userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })));
+
+    expect(
+      await screen.findByRole('radio', { name: 'Cash on Delivery', checked: true }),
+    ).toBeInTheDocument();
+
+    await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+    expect(window.location.replace).toHaveBeenCalledWith('/order-confirmation');
+  });
+
+  it('does not place the order when embedded billing (themeV2) is invalid', async () => {
+    const themeV2Config = {
+      ...checkoutSettings,
+      storeConfig: {
+        ...checkoutSettings.storeConfig,
+        checkoutSettings: {
+          ...checkoutSettings.storeConfig.checkoutSettings,
+          checkoutUserExperienceSettings: {
+            ...checkoutSettings.storeConfig.checkoutSettings.checkoutUserExperienceSettings,
+            checkoutV2Theme: true,
+          },
+        },
+      },
+    };
+
+    mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(false);
+
+    const location = window.location;
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        // eslint-disable-next-line @typescript-eslint/no-misused-spread
+        ...location,
+        replace: jest.fn(),
+      },
+      writable: true,
     });
 
-    afterAll(() => {
-        checkout.close();
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+      config: themeV2Config,
     });
 
-    beforeEach(() => {
-        window.scrollTo = jest.fn();
+    const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
 
-        checkoutService = createCheckoutService();
-        extensionService = new ExtensionService(checkoutService, createErrorLogger());
-        embeddedMessengerMock = createEmbeddedCheckoutMessenger({
-            parentOrigin: 'https://store.url',
-        });
-        defaultProps = {
-            checkoutId: checkoutWithBillingEmail.id,
-            containerId: CHECKOUT_ROOT_NODE_ID,
-            createEmbeddedMessenger: () => embeddedMessengerMock,
-            embeddedStylesheet: createEmbeddedCheckoutStylesheet(),
-            embeddedSupport: createEmbeddedCheckoutSupport(getLanguageService()),
-            errorLogger: createErrorLogger(),
-        };
+    render(<CheckoutTest {...defaultProps} />);
 
-        jest.spyOn(defaultProps.errorLogger, 'log').mockImplementation(noop);
-        analyticsTracker = {
-            selectedPaymentMethod: jest.fn(),
-        };
+    await checkout.waitForPaymentStep();
 
-        CheckoutTest = (props) => (
-            <CheckoutProvider checkoutService={checkoutService}>
-                <LocaleProvider
-                    checkoutService={checkoutService}
-                    languageService={getLanguageService()}
-                >
-                    <AnalyticsProviderMock analyticsTracker={analyticsTracker}>
-                        <ExtensionProvider extensionService={extensionService}>
-                            <ThemeProvider>
-                                <Checkout {...props} />
-                            </ThemeProvider>
-                        </ExtensionProvider>
-                    </AnalyticsProviderMock>
-                </LocaleProvider>
-            </CheckoutProvider>
-        );
+    await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+    expect(mockEnsureBillingAddressSaved).toHaveBeenCalled();
+    expect(submitOrderSpy).not.toHaveBeenCalled();
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it('disables Place Order while the embedded billing (themeV2) address is being persisted', async () => {
+    const themeV2Config = {
+      ...checkoutSettings,
+      storeConfig: {
+        ...checkoutSettings.storeConfig,
+        checkoutSettings: {
+          ...checkoutSettings.storeConfig.checkoutSettings,
+          checkoutUserExperienceSettings: {
+            ...checkoutSettings.storeConfig.checkoutSettings.checkoutUserExperienceSettings,
+            checkoutV2Theme: true,
+          },
+        },
+      },
+    };
+
+    mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
+
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+      config: themeV2Config,
     });
 
-    it('renders payment step with 2 offline payment methods', async () => {
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+    // Keep the billing-address update in flight so isUpdatingBillingAddress
+    // stays true while we assert the submit button is disabled.
+    checkout.setRequestHandler(
+      rest.put(
+        '/api/storefront/checkouts/*/billing-address/*',
+        () => new Promise<never>(() => undefined),
+      ),
+    );
 
-        render(<CheckoutTest {...defaultProps} />);
+    render(<CheckoutTest {...defaultProps} />);
 
-        await checkout.waitForPaymentStep();
+    await checkout.waitForPaymentStep();
 
-        expect(screen.getByRole('radio', { name: 'Pay in Store' })).toBeInTheDocument();
-        expect(screen.getByRole('radio', { name: 'Cash on Delivery' })).toBeInTheDocument();
+    await act(async () => {
+      void checkoutService.updateBillingAddress({});
     });
 
-    it('tracks selected payment method on initial load', async () => {
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+    await waitFor(() =>
+      // eslint-disable-next-line jest-dom/prefer-to-have-attribute
+      expect(
+        screen.getByRole('button', { name: /place order/i }).hasAttribute('disabled'),
+      ).toBeTruthy(),
+    );
+  });
 
-        render(<CheckoutTest {...defaultProps} />);
+  it('does not submit the order when disableSubmit is called for another method right after the selected one', async () => {
+    const paypal = {
+      ...payments[0],
+      id: 'paypal',
+      config: { ...payments[0].config, displayName: 'PayPal' },
+    };
+    const stripe = {
+      ...payments[0],
+      id: 'stripe',
+      config: { ...payments[0].config, displayName: 'Stripe' },
+    };
 
-        await checkout.waitForPaymentStep();
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([paypal, stripe]))),
+    );
 
-        expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledWith(
-            'Pay in Store',
-            'instore',
-        );
-        expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    // PayPal is first in the list above, so it's selected by default.
+    // disableSubmit only reads id/gateway, so minimal stand-ins are enough.
+    // Calling disableSubmit for a second, different method straight after it
+    // used to wipe out the first method's disabled state before Payment
+    // re-rendered.
+    const paypalMethod = { id: 'paypal', gateway: null } as unknown as PaymentMethod;
+    const stripeMethod = { id: 'stripe', gateway: null } as unknown as PaymentMethod;
+
+    mockPaymentContextEffect = (context) => {
+      context.disableSubmit(paypalMethod, true);
+      context.disableSubmit(stripeMethod, true);
+    };
+
+    const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    await userEvent.click(screen.getByText('Place Order'));
+
+    expect(submitOrderSpy).not.toHaveBeenCalled();
+  });
+
+  it('goes back to billing step after unmounting the component', async () => {
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Pay in Store' }));
+    await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[2]);
+
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pay in Store')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+  });
+
+  it('applies store credit automatically', async () => {
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+      checkout: {
+        ...checkoutWithShippingAndBilling,
+        customer: {
+          ...customer,
+          storeCredit: 1000,
+        },
+      },
     });
 
-    it('selects another payment method and places the order successfully', async () => {
-        checkout.setRequestHandler(
-            rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-                res(ctx.json(orderResponse)),
-            ),
-        );
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-        );
-
-        const location = window.location;
-
-        Object.defineProperty(window, 'location', {
-            value: {
-                // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                ...location,
-                replace: jest.fn(),
+    checkout.setRequestHandler(
+      rest.post('api/storefront/checkouts/*/store-credit', (_, res, ctx) =>
+        res(
+          ctx.json({
+            ...checkoutWithShippingAndBilling,
+            isStoreCreditApplied: true,
+            outstandingBalance: 0,
+            customer: {
+              ...customer,
+              storeCredit: 1000,
             },
-            writable: true,
-        });
+          }),
+        ),
+      ),
+    );
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+    render(<CheckoutTest {...defaultProps} />);
 
-        render(<CheckoutTest {...defaultProps} />);
+    await checkout.waitForPaymentStep();
 
-        await checkout.waitForPaymentStep();
+    expect(screen.getByText(/Payment is not required/)).toBeInTheDocument();
+  });
 
-        expect(
-            screen.getByRole('radio', { name: 'Pay in Store', checked: true }),
-        ).toBeInTheDocument();
+  it('does not apply store credit automatically when disableStoreCredit is true', async () => {
+    const configWithDisableStoreCredit = {
+      ...checkoutSettings,
+      storeConfig: {
+        ...checkoutSettings.storeConfig,
+        checkoutSettings: {
+          ...checkoutSettings.storeConfig.checkoutSettings,
+          capabilities: {
+            ...defaultCapabilities,
+            userJourney: {
+              ...defaultCapabilities.userJourney,
+              disableStoreCredit: true,
+            },
+          },
+        },
+      },
+    };
 
-        await act(async () =>
-            userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
-        );
-
-        expect(
-            await screen.findByRole('radio', { name: 'Cash on Delivery', checked: true }),
-        ).toBeInTheDocument();
-
-        await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-        expect(window.location.replace).toHaveBeenCalledWith('/order-confirmation');
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+      config: configWithDisableStoreCredit,
+      checkout: {
+        ...checkoutWithShippingAndBilling,
+        isStoreCreditApplied: false,
+        customer: {
+          ...customer,
+          storeCredit: 1000,
+        },
+      },
     });
 
-    it('does not place the order when embedded billing (themeV2) is invalid', async () => {
-        const themeV2Config = {
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    checkoutUserExperienceSettings: {
-                        ...checkoutSettings.storeConfig.checkoutSettings
-                            .checkoutUserExperienceSettings,
-                        checkoutV2Theme: true,
-                    },
-                },
-            },
-        };
+    const applyStoreCreditSpy = jest.spyOn(checkoutService, 'applyStoreCredit');
 
-        mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(false);
+    render(<CheckoutTest {...defaultProps} />);
 
-        const location = window.location;
+    await checkout.waitForPaymentStep();
 
-        Object.defineProperty(window, 'location', {
-            value: {
-                // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                ...location,
-                replace: jest.fn(),
-            },
-            writable: true,
-        });
+    expect(applyStoreCreditSpy).not.toHaveBeenCalledWith(true);
+  });
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-            config: themeV2Config,
-        });
+  it('does not render amazon if multi-shipping', async () => {
+    const amazonPay = {
+      ...payments[0],
+      id: 'amazonpay',
+      config: {
+        ...payments[0].config,
+        displayName: 'Amazon Pay',
+      },
+    };
 
-        const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) =>
+        res(ctx.json([payments[0], amazonPay])),
+      ),
+    );
 
-        render(<CheckoutTest {...defaultProps} />);
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingAndBilling);
 
-        await checkout.waitForPaymentStep();
+    render(<CheckoutTest {...defaultProps} />);
 
-        await act(async () => userEvent.click(screen.getByText('Place Order')));
+    await checkout.waitForPaymentStep();
 
-        expect(mockEnsureBillingAddressSaved).toHaveBeenCalled();
-        expect(submitOrderSpy).not.toHaveBeenCalled();
-        expect(window.location.replace).not.toHaveBeenCalled();
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+    expect(screen.queryByText('Amazon Pay')).not.toBeInTheDocument();
+  });
+
+  it('does not render bolt if showInCheckout is false', async () => {
+    const bolt = {
+      ...payments[0],
+      id: 'bolt',
+      initializationData: { showInCheckout: false },
+      config: {
+        ...payments[0].config,
+        displayName: 'Bolt',
+      },
+    };
+
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([payments[0], bolt]))),
+    );
+
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+    expect(screen.queryByText('Bolt')).not.toBeInTheDocument();
+  });
+
+  it('does not render methods with braintreelocalmethods id', async () => {
+    const braintree = {
+      ...payments[0],
+      id: 'braintreelocalmethods',
+      config: {
+        ...payments[0].config,
+        displayName: 'BrainTree Local Methods',
+      },
+    };
+
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) =>
+        res(ctx.json([payments[0], braintree])),
+      ),
+    );
+
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+    expect(screen.queryByText(/BrainTree/)).not.toBeInTheDocument();
+  });
+
+  it('groups payment methods that match configured prefix when PAYMENTS-5142 experiment is enabled', async () => {
+    const facilypay3 = {
+      ...payments[0],
+      id: 'facilypay_3',
+      config: {
+        ...payments[0].config,
+        displayName: '3x Oney',
+      },
+    };
+    const facilypay6 = {
+      ...payments[0],
+      id: 'facilypay_6',
+      config: {
+        ...payments[0].config,
+        displayName: '6x Oney',
+      },
+    };
+    const card = {
+      ...payments[0],
+      id: 'card',
+      config: {
+        ...payments[0].config,
+        displayName: 'Card',
+      },
+    };
+
+    const configWithGroupingExperiment = {
+      ...checkoutSettings,
+      storeConfig: {
+        ...checkoutSettings.storeConfig,
+        checkoutSettings: {
+          ...checkoutSettings.storeConfig.checkoutSettings,
+          features: {
+            ...checkoutSettings.storeConfig.checkoutSettings.features,
+            'PAYMENTS-5142.payment_method_grouping': true,
+          },
+        },
+      },
+    };
+
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) =>
+        res(ctx.json([card, facilypay6, facilypay3])),
+      ),
+    );
+
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+      config: configWithGroupingExperiment,
     });
 
-    it('disables Place Order while the embedded billing (themeV2) address is being persisted', async () => {
-        const themeV2Config = {
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    checkoutUserExperienceSettings: {
-                        ...checkoutSettings.storeConfig.checkoutSettings
-                            .checkoutUserExperienceSettings,
-                        checkoutV2Theme: true,
-                    },
-                },
-            },
-        };
+    render(<CheckoutTest {...defaultProps} />);
 
-        mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
+    await checkout.waitForPaymentStep();
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-            config: themeV2Config,
-        });
+    expect(screen.getByRole('radio', { name: 'Oney' })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: '3x Oney' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: '6x Oney' })).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Card' })).toBeInTheDocument();
+  });
 
-        // Keep the billing-address update in flight so isUpdatingBillingAddress
-        // stays true while we assert the submit button is disabled.
-        checkout.setRequestHandler(
-            rest.put(
-                '/api/storefront/checkouts/*/billing-address/*',
-                () => new Promise<never>(() => undefined),
-            ),
-        );
+  it('does not group prefixed payment methods when PAYMENTS-5142 experiment is disabled', async () => {
+    const facilypay3 = {
+      ...payments[0],
+      id: 'facilypay_3',
+      config: {
+        ...payments[0].config,
+        displayName: '3x Oney',
+      },
+    };
+    const facilypay6 = {
+      ...payments[0],
+      id: 'facilypay_6',
+      config: {
+        ...payments[0].config,
+        displayName: '6x Oney',
+      },
+    };
 
-        render(<CheckoutTest {...defaultProps} />);
+    const configWithoutGroupingExperiment = {
+      ...checkoutSettings,
+      storeConfig: {
+        ...checkoutSettings.storeConfig,
+        checkoutSettings: {
+          ...checkoutSettings.storeConfig.checkoutSettings,
+          features: {
+            ...checkoutSettings.storeConfig.checkoutSettings.features,
+            'PAYMENTS-5142.payment_method_grouping': false,
+          },
+        },
+      },
+    };
 
-        await checkout.waitForPaymentStep();
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) =>
+        res(ctx.json([facilypay6, facilypay3])),
+      ),
+    );
 
-        await act(async () => {
-            void checkoutService.updateBillingAddress({});
-        });
-
-        await waitFor(() =>
-            // eslint-disable-next-line jest-dom/prefer-to-have-attribute
-            expect(
-                screen.getByRole('button', { name: /place order/i }).hasAttribute('disabled'),
-            ).toBeTruthy(),
-        );
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+      config: configWithoutGroupingExperiment,
     });
 
-    it('goes back to billing step after unmounting the component', async () => {
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+    render(<CheckoutTest {...defaultProps} />);
 
-        render(<CheckoutTest {...defaultProps} />);
+    await checkout.waitForPaymentStep();
 
-        await checkout.waitForPaymentStep();
+    expect(screen.getByRole('radio', { name: '3x Oney' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '6x Oney' })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Oney' })).not.toBeInTheDocument();
+  });
 
-        await userEvent.click(screen.getByRole('radio', { name: 'Pay in Store' }));
-        await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[2]);
+  it('does not group payment methods when no configured prefix matches', async () => {
+    const installments3 = {
+      ...payments[0],
+      id: 'installments_3',
+      config: {
+        ...payments[0].config,
+        displayName: '3x Installments',
+      },
+    };
+    const installments6 = {
+      ...payments[0],
+      id: 'installments_6',
+      config: {
+        ...payments[0].config,
+        displayName: '6x Installments',
+      },
+    };
 
-        expect(screen.queryByRole('radio')).not.toBeInTheDocument();
-        expect(screen.queryByText('Pay in Store')).not.toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument();
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) =>
+        res(ctx.json([installments3, installments6])),
+      ),
+    );
+
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+
+    expect(screen.getByRole('radio', { name: '3x Installments' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '6x Installments' })).toBeInTheDocument();
+  });
+
+  it('does not render payment form if there are no methods', async () => {
+    checkout.setRequestHandler(
+      rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([]))),
+    );
+
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    expect(await screen.findByText('Payment')).toBeInTheDocument();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+
+  it('renders error modal if there is error when submitting order', async () => {
+    checkout.setRequestHandler(
+      rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+        res(
+          ctx.status(500),
+          ctx.json({
+            title: 'The tax provider is unavailable.',
+            type: 'order_error',
+          }),
+        ),
+      ),
+    );
+
+    checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+    render(<CheckoutTest {...defaultProps} />);
+
+    await checkout.waitForPaymentStep();
+    await userEvent.click(screen.getByText('Place Order'));
+
+    expect(screen.getByText("Something's gone wrong")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Ok'));
+
+    expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
+  });
+
+  describe('B2B payment methods refresh', () => {
+    const createConfigWithPersistB2BMetadata = () => ({
+      ...checkoutSettings,
+      storeConfig: {
+        ...checkoutSettings.storeConfig,
+        checkoutSettings: {
+          ...checkoutSettings.storeConfig.checkoutSettings,
+          capabilities: {
+            ...defaultCapabilities,
+            orderConfirmation: {
+              ...defaultCapabilities.orderConfirmation,
+              persistB2BMetadata: true,
+            },
+          },
+        },
+      },
     });
 
-    it('applies store credit automatically', async () => {
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-            checkout: {
-                ...checkoutWithShippingAndBilling,
-                customer: {
-                    ...customer,
-                    storeCredit: 1000,
-                },
-            },
-        });
+    it('refreshes B2B payment methods on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+          orderId: 12345,
+        },
+      });
 
-        checkout.setRequestHandler(
-            rest.post('api/storefront/checkouts/*/store-credit', (_, res, ctx) =>
-                res(
-                    ctx.json({
-                        ...checkoutWithShippingAndBilling,
-                        isStoreCreditApplied: true,
-                        outstandingBalance: 0,
-                        customer: {
-                            ...customer,
-                            storeCredit: 1000,
-                        },
-                    }),
-                ),
-            ),
-        );
+      const refreshSpy = jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
-        render(<CheckoutTest {...defaultProps} />);
+      render(<CheckoutTest {...defaultProps} />);
 
-        await checkout.waitForPaymentStep();
+      await checkout.waitForPaymentStep();
 
-        expect(screen.getByText(/Payment is not required/)).toBeInTheDocument();
+      expect(refreshSpy).toHaveBeenCalled();
     });
 
-    it('does not apply store credit automatically when disableStoreCredit is true', async () => {
-        const configWithDisableStoreCredit = {
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    capabilities: {
-                        ...defaultCapabilities,
-                        userJourney: {
-                            ...defaultCapabilities.userJourney,
-                            disableStoreCredit: true,
-                        },
-                    },
-                },
-            },
-        };
+    it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+        },
+      });
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-            config: configWithDisableStoreCredit,
-            checkout: {
-                ...checkoutWithShippingAndBilling,
-                isStoreCreditApplied: false,
-                customer: {
-                    ...customer,
-                    storeCredit: 1000,
-                },
-            },
-        });
+      const refreshSpy = jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
-        const applyStoreCreditSpy = jest.spyOn(checkoutService, 'applyStoreCredit');
+      render(<CheckoutTest {...defaultProps} />);
 
-        render(<CheckoutTest {...defaultProps} />);
+      await checkout.waitForPaymentStep();
 
-        await checkout.waitForPaymentStep();
-
-        expect(applyStoreCreditSpy).not.toHaveBeenCalledWith(true);
+      expect(refreshSpy).not.toHaveBeenCalled();
     });
 
-    it('does not render amazon if multi-shipping', async () => {
-        const amazonPay = {
-            ...payments[0],
-            id: 'amazonpay',
-            config: {
-                ...payments[0].config,
-                displayName: 'Amazon Pay',
-            },
-        };
+    it('does not refresh B2B payment methods on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          orderId: 12345,
+        },
+      });
 
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/payments', (_, res, ctx) =>
-                res(ctx.json([payments[0], amazonPay])),
-            ),
-        );
+      const refreshSpy = jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingAndBilling);
+      render(<CheckoutTest {...defaultProps} />);
 
-        render(<CheckoutTest {...defaultProps} />);
+      await checkout.waitForPaymentStep();
 
-        await checkout.waitForPaymentStep();
-
-        expect(screen.getByRole('radio')).toBeInTheDocument();
-        expect(screen.queryByText('Amazon Pay')).not.toBeInTheDocument();
+      expect(refreshSpy).not.toHaveBeenCalled();
     });
 
-    it('does not render bolt if showInCheckout is false', async () => {
-        const bolt = {
-            ...payments[0],
-            id: 'bolt',
-            initializationData: { showInCheckout: false },
-            config: {
-                ...payments[0].config,
-                displayName: 'Bolt',
-            },
-        };
+    it('refreshes B2B payment methods before submitting order when persistB2BMetadata capability is enabled', async () => {
+      checkout.setRequestHandler(
+        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
+      );
+      checkout.setRequestHandler(
+        rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+      );
 
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/payments', (_, res, ctx) =>
-                res(ctx.json([payments[0], bolt])),
-            ),
-        );
+      const location = window.location;
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
 
-        render(<CheckoutTest {...defaultProps} />);
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+        },
+      });
 
-        await checkout.waitForPaymentStep();
+      const refreshSpy = jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+      const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
 
-        expect(screen.getByRole('radio')).toBeInTheDocument();
-        expect(screen.queryByText('Bolt')).not.toBeInTheDocument();
+      render(<CheckoutTest {...defaultProps} />);
+
+      await checkout.waitForPaymentStep();
+
+      refreshSpy.mockClear();
+
+      await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+      expect(submitOrderSpy).toHaveBeenCalledTimes(1);
+
+      const refreshCallOrder = refreshSpy.mock.invocationCallOrder[0];
+      const submitOrderCallOrder = submitOrderSpy.mock.invocationCallOrder[0];
+
+      expect(refreshCallOrder).toBeLessThan(submitOrderCallOrder);
     });
 
-    it('does not render methods with braintreelocalmethods id', async () => {
-        const braintree = {
-            ...payments[0],
-            id: 'braintreelocalmethods',
-            config: {
-                ...payments[0].config,
-                displayName: 'BrainTree Local Methods',
-            },
-        };
+    it('does not refresh B2B payment methods before submitting order when persistB2BMetadata capability is disabled', async () => {
+      checkout.setRequestHandler(
+        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
+      );
+      checkout.setRequestHandler(
+        rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+      );
 
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/payments', (_, res, ctx) =>
-                res(ctx.json([payments[0], braintree])),
-            ),
-        );
+      const location = window.location;
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
 
-        render(<CheckoutTest {...defaultProps} />);
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
 
-        await checkout.waitForPaymentStep();
+      const refreshSpy = jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
 
-        expect(screen.getByRole('radio')).toBeInTheDocument();
-        expect(screen.queryByText(/BrainTree/)).not.toBeInTheDocument();
+      render(<CheckoutTest {...defaultProps} />);
+
+      await checkout.waitForPaymentStep();
+
+      await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+      expect(refreshSpy).not.toHaveBeenCalled();
     });
 
-    it('groups payment methods that match configured prefix when PAYMENTS-5142 experiment is enabled', async () => {
-        const facilypay3 = {
-            ...payments[0],
-            id: 'facilypay_3',
-            config: {
-                ...payments[0].config,
-                displayName: '3x Oney',
-            },
-        };
-        const facilypay6 = {
-            ...payments[0],
-            id: 'facilypay_6',
-            config: {
-                ...payments[0].config,
-                displayName: '6x Oney',
-            },
-        };
-        const card = {
-            ...payments[0],
-            id: 'card',
-            config: {
-                ...payments[0].config,
-                displayName: 'Card',
-            },
-        };
+    it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+          orderId: 12345,
+        },
+      });
 
-        const configWithGroupingExperiment = {
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    features: {
-                        ...checkoutSettings.storeConfig.checkoutSettings.features,
-                        'PAYMENTS-5142.payment_method_grouping': true,
-                    },
-                },
-            },
-        };
+      jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockRejectedValue(new Error('B2B payments refresh failed'));
 
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/payments', (_, res, ctx) =>
-                res(ctx.json([card, facilypay6, facilypay3])),
-            ),
-        );
+      render(<CheckoutTest {...defaultProps} />);
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-            config: configWithGroupingExperiment,
-        });
+      await checkout.waitForPaymentStep();
 
-        render(<CheckoutTest {...defaultProps} />);
-
-        await checkout.waitForPaymentStep();
-
-        expect(screen.getByRole('radio', { name: 'Oney' })).toBeInTheDocument();
-        expect(screen.queryByRole('radio', { name: '3x Oney' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('radio', { name: '6x Oney' })).not.toBeInTheDocument();
-        expect(screen.getByRole('radio', { name: 'Card' })).toBeInTheDocument();
+      expect(screen.getByText(/place order/i)).toBeInTheDocument();
     });
 
-    it('does not group prefixed payment methods when PAYMENTS-5142 experiment is disabled', async () => {
-        const facilypay3 = {
-            ...payments[0],
-            id: 'facilypay_3',
-            config: {
-                ...payments[0].config,
-                displayName: '3x Oney',
-            },
-        };
-        const facilypay6 = {
-            ...payments[0],
-            id: 'facilypay_6',
-            config: {
-                ...payments[0].config,
-                displayName: '6x Oney',
-            },
-        };
+    it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
+      checkout.setRequestHandler(
+        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) => res(ctx.json(orderResponse))),
+      );
 
-        const configWithoutGroupingExperiment = {
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    features: {
-                        ...checkoutSettings.storeConfig.checkoutSettings.features,
-                        'PAYMENTS-5142.payment_method_grouping': false,
-                    },
-                },
-            },
-        };
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+        },
+      });
 
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/payments', (_, res, ctx) =>
-                res(ctx.json([facilypay6, facilypay3])),
-            ),
-        );
+      jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockRejectedValue(new Error('B2B payments refresh failed'));
 
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-            config: configWithoutGroupingExperiment,
-        });
+      const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
 
-        render(<CheckoutTest {...defaultProps} />);
+      render(<CheckoutTest {...defaultProps} />);
 
-        await checkout.waitForPaymentStep();
+      await checkout.waitForPaymentStep();
 
-        expect(screen.getByRole('radio', { name: '3x Oney' })).toBeInTheDocument();
-        expect(screen.getByRole('radio', { name: '6x Oney' })).toBeInTheDocument();
-        expect(screen.queryByRole('radio', { name: 'Oney' })).not.toBeInTheDocument();
+      await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+      expect(submitOrderSpy).not.toHaveBeenCalled();
     });
 
-    it('does not group payment methods when no configured prefix matches', async () => {
-        const installments3 = {
-            ...payments[0],
-            id: 'installments_3',
-            config: {
-                ...payments[0].config,
-                displayName: '3x Installments',
+    it('persists B2B metadata after finalizing the order on mount when persistB2BMetadata capability is enabled', async () => {
+      const location = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
+
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+          orderId: 12345,
+        },
+      });
+
+      jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+      jest
+        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+        .mockResolvedValue(checkoutService.getState());
+
+      const persistSpy = jest
+        .spyOn(checkoutService, 'persistB2BMetadata')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+      render(<CheckoutTest {...defaultProps} />);
+
+      await waitFor(() =>
+        expect(persistSpy).toHaveBeenCalledWith({
+          isInvoice: false,
+          invoiceComment: undefined,
+          poNumber: undefined,
+          referenceNumber: undefined,
+          extraFields: [],
+          extraInfo: {},
+        }),
+      );
+    });
+
+    it('persists the address extra fields from the checkout object after finalizing on mount', async () => {
+      const location = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
+
+      const { billingAddress } = checkoutWithShippingAndBilling;
+      const [consignment] = checkoutWithShippingAndBilling.consignments;
+
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+          orderId: 12345,
+          billingAddress: billingAddress && {
+            ...billingAddress,
+            extraFields: [{ fieldId: '30', fieldValue: 'Finance' }],
+          },
+          consignments: [
+            {
+              ...consignment,
+              shippingAddress: {
+                ...consignment.shippingAddress,
+                extraFields: [{ fieldId: '31', fieldValue: 'B7' }],
+              },
             },
-        };
-        const installments6 = {
-            ...payments[0],
-            id: 'installments_6',
-            config: {
-                ...payments[0].config,
-                displayName: '6x Installments',
+          ],
+        },
+      });
+
+      jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+      jest
+        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+        .mockResolvedValue(checkoutService.getState());
+
+      const persistSpy = jest
+        .spyOn(checkoutService, 'persistB2BMetadata')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+      render(<CheckoutTest {...defaultProps} />);
+
+      await waitFor(() =>
+        expect(persistSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            extraInfo: {
+              addressExtraFields: {
+                billingAddressExtraFields: [{ fieldName: '30', fieldValue: 'Finance' }],
+                shippingAddressExtraFields: [{ fieldName: '31', fieldValue: 'B7' }],
+              },
             },
-        };
-
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/payments', (_, res, ctx) =>
-                res(ctx.json([installments3, installments6])),
-            ),
-        );
-
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-        render(<CheckoutTest {...defaultProps} />);
-
-        await checkout.waitForPaymentStep();
-
-        expect(screen.getByRole('radio', { name: '3x Installments' })).toBeInTheDocument();
-        expect(screen.getByRole('radio', { name: '6x Installments' })).toBeInTheDocument();
+          }),
+        ),
+      );
     });
 
-    it('does not render payment form if there are no methods', async () => {
-        checkout.setRequestHandler(
-            rest.get('/api/storefront/payments', (_, res, ctx) => res(ctx.json([]))),
-        );
-
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-        render(<CheckoutTest {...defaultProps} />);
-
-        expect(await screen.findByText('Payment')).toBeInTheDocument();
-        expect(screen.queryByRole('radio')).not.toBeInTheDocument();
-    });
-
-    it('renders error modal if there is error when submitting order', async () => {
-        checkout.setRequestHandler(
-            rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-                res(
-                    ctx.status(500),
-                    ctx.json({
-                        title: 'The tax provider is unavailable.',
-                        type: 'order_error',
-                    }),
-                ),
-            ),
-        );
-
-        checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-        render(<CheckoutTest {...defaultProps} />);
-
-        await checkout.waitForPaymentStep();
-        await userEvent.click(screen.getByText('Place Order'));
-
-        expect(screen.getByText("Something's gone wrong")).toBeInTheDocument();
-
-        await userEvent.click(screen.getByText('Ok'));
-
-        expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
-    });
-
-    describe('B2B payment methods refresh', () => {
-        const createConfigWithPersistB2BMetadata = () => ({
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    capabilities: {
-                        ...defaultCapabilities,
-                        orderConfirmation: {
-                            ...defaultCapabilities.orderConfirmation,
-                            persistB2BMetadata: true,
-                        },
-                    },
+    it('stores the address IDs returned by the order endpoint, persists them and clears them afterwards', async () => {
+      checkout.setRequestHandler(
+        rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+          res(
+            ctx.json({
+              ...orderResponse,
+              data: {
+                ...orderResponse.data,
+                order: {
+                  ...orderResponse.data.order,
+                  b2bMetadata: {
+                    billingAddressId: 111,
+                    shippingAddressId: 222,
+                  },
                 },
+              },
+            }),
+          ),
+        ),
+      );
+      checkout.setRequestHandler(
+        rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
+      );
+
+      const location = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
+
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+        },
+      });
+
+      jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+      const persistSpy = jest
+        .spyOn(checkoutService, 'persistB2BMetadata')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+      render(<CheckoutTest {...defaultProps} />);
+
+      await checkout.waitForPaymentStep();
+
+      await act(async () => userEvent.click(screen.getByText('Place Order')));
+
+      await waitFor(() =>
+        expect(persistSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            extraInfo: {
+              billingAddressId: 111,
+              shipppingAddressId: 222,
             },
-        });
-
-        it('refreshes B2B payment methods on mount when persistB2BMetadata capability is enabled and orderId is present on checkout', async () => {
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                },
-            });
-
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            expect(refreshSpy).toHaveBeenCalled();
-        });
-
-        it('does not refresh B2B payment methods on mount when checkout has no orderId', async () => {
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                },
-            });
-
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            expect(refreshSpy).not.toHaveBeenCalled();
-        });
-
-        it('does not refresh B2B payment methods on mount when persistB2BMetadata capability is disabled even when orderId is present', async () => {
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    orderId: 12345,
-                },
-            });
-
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            expect(refreshSpy).not.toHaveBeenCalled();
-        });
-
-        it('refreshes B2B payment methods before submitting order when persistB2BMetadata capability is enabled', async () => {
-            checkout.setRequestHandler(
-                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-                    res(ctx.json(orderResponse)),
-                ),
-            );
-            checkout.setRequestHandler(
-                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-            );
-
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                },
-            });
-
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-            const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            refreshSpy.mockClear();
-
-            await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-            expect(refreshSpy).toHaveBeenCalledTimes(1);
-            expect(submitOrderSpy).toHaveBeenCalledTimes(1);
-
-            const refreshCallOrder = refreshSpy.mock.invocationCallOrder[0];
-            const submitOrderCallOrder = submitOrderSpy.mock.invocationCallOrder[0];
-
-            expect(refreshCallOrder).toBeLessThan(submitOrderCallOrder);
-        });
-
-        it('does not refresh B2B payment methods before submitting order when persistB2BMetadata capability is disabled', async () => {
-            checkout.setRequestHandler(
-                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-                    res(ctx.json(orderResponse)),
-                ),
-            );
-            checkout.setRequestHandler(
-                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-            );
-
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
-
-            const refreshSpy = jest
-                .spyOn(checkoutService, 'refreshB2BPaymentMethods')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-            expect(refreshSpy).not.toHaveBeenCalled();
-        });
-
-        it('completes initialization and renders the payment step when mount-time B2B refresh fails', async () => {
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
-                new Error('B2B payments refresh failed'),
-            );
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            expect(screen.getByText(/place order/i)).toBeInTheDocument();
-        });
-
-        it('does not submit the order when B2B payment methods refresh fails before submit', async () => {
-            checkout.setRequestHandler(
-                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-                    res(ctx.json(orderResponse)),
-                ),
-            );
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockRejectedValue(
-                new Error('B2B payments refresh failed'),
-            );
-
-            const submitOrderSpy = jest.spyOn(checkoutService, 'submitOrder');
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-            expect(submitOrderSpy).not.toHaveBeenCalled();
-        });
-
-        it('persists B2B metadata after finalizing the order on mount when persistB2BMetadata capability is enabled', async () => {
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
-            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
-                checkoutService.getState(),
-            );
-
-            const persistSpy = jest
-                .spyOn(checkoutService, 'persistB2BMetadata')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await waitFor(() =>
-                expect(persistSpy).toHaveBeenCalledWith({
-                    isInvoice: false,
-                    invoiceComment: undefined,
-                    poNumber: undefined,
-                    referenceNumber: undefined,
-                    extraFields: [],
-                    extraInfo: {},
-                }),
-            );
-        });
-
-        it('persists the address extra fields from the checkout object after finalizing on mount', async () => {
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            const { billingAddress } = checkoutWithShippingAndBilling;
-            const [consignment] = checkoutWithShippingAndBilling.consignments;
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                    billingAddress: billingAddress && {
-                        ...billingAddress,
-                        extraFields: [{ fieldId: '30', fieldValue: 'Finance' }],
-                    },
-                    consignments: [
-                        {
-                            ...consignment,
-                            shippingAddress: {
-                                ...consignment.shippingAddress,
-                                extraFields: [{ fieldId: '31', fieldValue: 'B7' }],
-                            },
-                        },
-                    ],
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
-            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
-                checkoutService.getState(),
-            );
-
-            const persistSpy = jest
-                .spyOn(checkoutService, 'persistB2BMetadata')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await waitFor(() =>
-                expect(persistSpy).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        extraInfo: {
-                            addressExtraFields: {
-                                billingAddressExtraFields: [
-                                    { fieldName: '30', fieldValue: 'Finance' },
-                                ],
-                                shippingAddressExtraFields: [{ fieldName: '31', fieldValue: 'B7' }],
-                            },
-                        },
-                    }),
-                ),
-            );
-        });
-
-        it('stores the address IDs returned by the order endpoint, persists them and clears them afterwards', async () => {
-            checkout.setRequestHandler(
-                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
-                    res(
-                        ctx.json({
-                            ...orderResponse,
-                            data: {
-                                ...orderResponse.data,
-                                order: {
-                                    ...orderResponse.data.order,
-                                    b2bMetadata: {
-                                        billingAddressId: 111,
-                                        shippingAddressId: 222,
-                                    },
-                                },
-                            },
-                        }),
-                    ),
-                ),
-            );
-            checkout.setRequestHandler(
-                rest.get('/api/storefront/orders/*', (_, res, ctx) => res(ctx.json(orderResponse))),
-            );
-
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
-
-            const persistSpy = jest
-                .spyOn(checkoutService, 'persistB2BMetadata')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForPaymentStep();
-
-            await act(async () => userEvent.click(screen.getByText('Place Order')));
-
-            await waitFor(() =>
-                expect(persistSpy).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        extraInfo: {
-                            billingAddressId: 111,
-                            shipppingAddressId: 222,
-                        },
-                    }),
-                ),
-            );
-
-            await waitFor(() =>
-                expect(B2BSessionStorage.getAddressIds()).toEqual({
-                    billingAddressId: undefined,
-                    shippingAddressId: undefined,
-                }),
-            );
-        });
-
-        it('persists B2B metadata with isInvoice true and the captured form values when the invoiceRedirect capability is enabled', async () => {
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            B2BSessionStorage.setPaymentValues({ invoicePaymentComment: 'Invoice me' });
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: {
-                    ...checkoutSettings,
-                    storeConfig: {
-                        ...checkoutSettings.storeConfig,
-                        checkoutSettings: {
-                            ...checkoutSettings.storeConfig.checkoutSettings,
-                            capabilities: {
-                                ...defaultCapabilities,
-                                orderConfirmation: {
-                                    ...defaultCapabilities.orderConfirmation,
-                                    persistB2BMetadata: true,
-                                    invoiceRedirect: true,
-                                },
-                            },
-                        },
-                    },
-                },
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
-            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
-                checkoutService.getState(),
-            );
-
-            const persistSpy = jest
-                .spyOn(checkoutService, 'persistB2BMetadata')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await waitFor(() =>
-                expect(persistSpy).toHaveBeenCalledWith(
-                    expect.objectContaining({
-                        isInvoice: true,
-                        invoiceComment: 'Invoice me',
-                    }),
-                ),
-            );
-        });
-
-        it('clears B2B sessionStorage even when persisting metadata fails', async () => {
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            B2BSessionStorage.setAddressIds({ billingAddressId: 111, shippingAddressId: 222 });
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: createConfigWithPersistB2BMetadata(),
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                },
-            });
-
-            jest.spyOn(checkoutService, 'refreshB2BPaymentMethods').mockImplementation(() =>
-                Promise.resolve(checkoutService.getState()),
-            );
-            jest.spyOn(checkoutService, 'finalizeOrderIfNeeded').mockResolvedValue(
-                checkoutService.getState(),
-            );
-
-            const persistSpy = jest
-                .spyOn(checkoutService, 'persistB2BMetadata')
-                .mockRejectedValue(new Error('Persist failed'));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await waitFor(() => expect(persistSpy).toHaveBeenCalled());
-
-            await waitFor(() =>
-                expect(B2BSessionStorage.getAddressIds()).toEqual({
-                    billingAddressId: undefined,
-                    shippingAddressId: undefined,
-                }),
-            );
-        });
-
-        it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {
-            const location = window.location;
-
-            Object.defineProperty(window, 'location', {
-                value: {
-                    // eslint-disable-next-line @typescript-eslint/no-misused-spread
-                    ...location,
-                    replace: jest.fn(),
-                },
-                writable: true,
-            });
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                checkout: {
-                    ...checkoutWithShippingAndBilling,
-                    customer,
-                    orderId: 12345,
-                },
-            });
-
-            const finalizeSpy = jest
-                .spyOn(checkoutService, 'finalizeOrderIfNeeded')
-                .mockResolvedValue(checkoutService.getState());
-            const persistSpy = jest
-                .spyOn(checkoutService, 'persistB2BMetadata')
-                .mockImplementation(() => Promise.resolve(checkoutService.getState()));
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await waitFor(() => expect(finalizeSpy).toHaveBeenCalled());
-
-            expect(persistSpy).not.toHaveBeenCalled();
-        });
+          }),
+        ),
+      );
+
+      await waitFor(() =>
+        expect(B2BSessionStorage.getAddressIds()).toEqual({
+          billingAddressId: undefined,
+          shippingAddressId: undefined,
+        }),
+      );
     });
+
+    it('persists B2B metadata with isInvoice true and the captured form values when the invoiceRedirect capability is enabled', async () => {
+      const location = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
+
+      B2BSessionStorage.setPaymentValues({ invoicePaymentComment: 'Invoice me' });
+
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: {
+          ...checkoutSettings,
+          storeConfig: {
+            ...checkoutSettings.storeConfig,
+            checkoutSettings: {
+              ...checkoutSettings.storeConfig.checkoutSettings,
+              capabilities: {
+                ...defaultCapabilities,
+                orderConfirmation: {
+                  ...defaultCapabilities.orderConfirmation,
+                  persistB2BMetadata: true,
+                  invoiceRedirect: true,
+                },
+              },
+            },
+          },
+        },
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+          orderId: 12345,
+        },
+      });
+
+      jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+      jest
+        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+        .mockResolvedValue(checkoutService.getState());
+
+      const persistSpy = jest
+        .spyOn(checkoutService, 'persistB2BMetadata')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+      render(<CheckoutTest {...defaultProps} />);
+
+      await waitFor(() =>
+        expect(persistSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isInvoice: true,
+            invoiceComment: 'Invoice me',
+          }),
+        ),
+      );
+    });
+
+    it('clears B2B sessionStorage even when persisting metadata fails', async () => {
+      const location = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
+
+      B2BSessionStorage.setAddressIds({ billingAddressId: 111, shippingAddressId: 222 });
+
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        config: createConfigWithPersistB2BMetadata(),
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+          orderId: 12345,
+        },
+      });
+
+      jest
+        .spyOn(checkoutService, 'refreshB2BPaymentMethods')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+      jest
+        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+        .mockResolvedValue(checkoutService.getState());
+
+      const persistSpy = jest
+        .spyOn(checkoutService, 'persistB2BMetadata')
+        .mockRejectedValue(new Error('Persist failed'));
+
+      render(<CheckoutTest {...defaultProps} />);
+
+      await waitFor(() => expect(persistSpy).toHaveBeenCalled());
+
+      await waitFor(() =>
+        expect(B2BSessionStorage.getAddressIds()).toEqual({
+          billingAddressId: undefined,
+          shippingAddressId: undefined,
+        }),
+      );
+    });
+
+    it('does not persist B2B metadata after finalizing the order on mount when persistB2BMetadata capability is disabled', async () => {
+      const location = window.location;
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-spread
+          ...location,
+          replace: jest.fn(),
+        },
+        writable: true,
+      });
+
+      checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+        checkout: {
+          ...checkoutWithShippingAndBilling,
+          customer,
+          orderId: 12345,
+        },
+      });
+
+      const finalizeSpy = jest
+        .spyOn(checkoutService, 'finalizeOrderIfNeeded')
+        .mockResolvedValue(checkoutService.getState());
+      const persistSpy = jest
+        .spyOn(checkoutService, 'persistB2BMetadata')
+        .mockImplementation(() => Promise.resolve(checkoutService.getState()));
+
+      render(<CheckoutTest {...defaultProps} />);
+
+      await waitFor(() => expect(finalizeSpy).toHaveBeenCalled());
+
+      expect(persistSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -267,41 +267,41 @@ const Payment = (
         return null;
     };
 
-  const disableSubmit = (method: PaymentMethod, disabled = true): void => {
-    const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
+    const disableSubmit = (method: PaymentMethod, disabled = true): void => {
+        const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
 
-    setState((prevState) => {
-      if (prevState.shouldDisableSubmit[uniqueId] === disabled) {
-        return prevState;
-      }
+        setState((prevState) => {
+            if (prevState.shouldDisableSubmit[uniqueId] === disabled) {
+                return prevState;
+            }
 
-      return {
-        ...prevState,
-        shouldDisableSubmit: {
-          ...prevState.shouldDisableSubmit,
-          [uniqueId]: disabled,
-        },
-      };
-    });
-  };
+            return {
+                ...prevState,
+                shouldDisableSubmit: {
+                    ...prevState.shouldDisableSubmit,
+                    [uniqueId]: disabled,
+                },
+            };
+        });
+    };
 
-  const hidePaymentSubmitButton = (method: PaymentMethod, disabled = true): void => {
-    const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
+    const hidePaymentSubmitButton = (method: PaymentMethod, disabled = true): void => {
+        const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
 
-    setState((prevState) => {
-      if (prevState.shouldHidePaymentSubmitButton[uniqueId] === disabled) {
-        return prevState;
-      }
+        setState((prevState) => {
+            if (prevState.shouldHidePaymentSubmitButton[uniqueId] === disabled) {
+                return prevState;
+            }
 
-      return {
-        ...prevState,
-        shouldHidePaymentSubmitButton: {
-          ...prevState.shouldHidePaymentSubmitButton,
-          [uniqueId]: disabled,
-        },
-      };
-    });
-  };
+            return {
+                ...prevState,
+                shouldHidePaymentSubmitButton: {
+                    ...prevState.shouldHidePaymentSubmitButton,
+                    [uniqueId]: disabled,
+                },
+            };
+        });
+    };
 
     const handleBeforeUnload = (event: BeforeUnloadEvent): string | undefined => {
         const { defaultMethod, isSubmittingOrder, language } = props;

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -267,39 +267,41 @@ const Payment = (
         return null;
     };
 
-    const disableSubmit = (method: PaymentMethod, disabled = true): void => {
-        const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
-        const { shouldDisableSubmit } = state;
+  const disableSubmit = (method: PaymentMethod, disabled = true): void => {
+    const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
 
-        if (shouldDisableSubmit[uniqueId] === disabled) {
-            return;
-        }
+    setState((prevState) => {
+      if (prevState.shouldDisableSubmit[uniqueId] === disabled) {
+        return prevState;
+      }
 
-        setState((prevState) => ({
-            ...prevState,
-            shouldDisableSubmit: {
-                ...shouldDisableSubmit,
-                [uniqueId]: disabled,
-            },
-        }));
-    };
+      return {
+        ...prevState,
+        shouldDisableSubmit: {
+          ...prevState.shouldDisableSubmit,
+          [uniqueId]: disabled,
+        },
+      };
+    });
+  };
 
-    const hidePaymentSubmitButton = (method: PaymentMethod, disabled = true): void => {
-        const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
-        const { shouldHidePaymentSubmitButton } = state;
+  const hidePaymentSubmitButton = (method: PaymentMethod, disabled = true): void => {
+    const uniqueId = getUniquePaymentMethodId(method.id, method.gateway);
 
-        if (shouldHidePaymentSubmitButton[uniqueId] === disabled) {
-            return;
-        }
+    setState((prevState) => {
+      if (prevState.shouldHidePaymentSubmitButton[uniqueId] === disabled) {
+        return prevState;
+      }
 
-        setState((prevState) => ({
-            ...prevState,
-            shouldHidePaymentSubmitButton: {
-                ...shouldHidePaymentSubmitButton,
-                [uniqueId]: disabled,
-            },
-        }));
-    };
+      return {
+        ...prevState,
+        shouldHidePaymentSubmitButton: {
+          ...prevState.shouldHidePaymentSubmitButton,
+          [uniqueId]: disabled,
+        },
+      };
+    });
+  };
 
     const handleBeforeUnload = (event: BeforeUnloadEvent): string | undefined => {
         const { defaultMethod, isSubmittingOrder, language } = props;


### PR DESCRIPTION
## What/Why?

Fixed payment submit button behavior on checkout page.

The reason it happens is that Payment.tsx's hidePaymentSubmitButton and disableSubmit built their state update from a closure-captured snapshot instead of prevState. When Stripe fired its callback later, the update replaced the entire shared per-method map with its stale snapshot and its own key, even though PayPal was still the selected method. Stripe triggers this because its checklist item mounts unconditionally, regardless of selection.



## Rollout/Rollback
Revert this PR

## Testing

**Before**

https://github.com/user-attachments/assets/8ec909c5-9a77-4e38-9daa-20ded3ef371e

**After**

https://github.com/user-attachments/assets/70775dc1-a0c0-46cb-9763-40128ae6867c


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core checkout payment submit gating; the change is small and targeted but affects order placement behavior for all payment methods.
> 
> **Overview**
> Fixes checkout **Place Order** staying enabled (or submitting when it should not) when multiple payment integrations call `disableSubmit` or `hidePaymentSubmitButton` in quick succession—for example PayPal selected while Stripe’s UI still mounts and toggles its own flag.
> 
> In `Payment.tsx`, both helpers now update their per-method maps inside functional `setState`, spreading **`prevState`** instead of a closure snapshot of `shouldDisableSubmit` / `shouldHidePaymentSubmitButton`. No-op checks run inside that updater so concurrent calls no longer overwrite another method’s entry.
> 
> Adds a payment-step test that mocks `PaymentRedeemables` to call `disableSubmit` for two methods back-to-back and asserts **`submitOrder`** is not invoked when the user clicks Place Order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bd422ec5962300e6fc5815e2a5b153a0f0b686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->