### PR TITLE
fix(checkout): CHECKOUT-10247 Update shouldSaveAddress

### DIFF
--- a/packages/core/src/app/address/getShouldSaveAddress.test.ts
+++ b/packages/core/src/app/address/getShouldSaveAddress.test.ts
@@ -1,0 +1,40 @@
+import { type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+import { getAddress } from './address.mock';
+import getShouldSaveAddress from './getShouldSaveAddress';
+
+describe('getShouldSaveAddress', () => {
+    it('returns true when no address is provided', () => {
+        expect(getShouldSaveAddress()).toBe(true);
+    });
+
+    it('returns true when the address has no shouldSaveAddress value', () => {
+        expect(getShouldSaveAddress(getAddress())).toBe(true);
+    });
+
+    it('returns the explicit shouldSaveAddress value of a checkout address', () => {
+        expect(getShouldSaveAddress({ ...getAddress(), shouldSaveAddress: false })).toBe(false);
+        expect(getShouldSaveAddress({ ...getAddress(), shouldSaveAddress: true })).toBe(true);
+    });
+
+    it('returns false for a saved customer address', () => {
+        const customerAddress: CustomerAddress = {
+            ...getAddress(),
+            id: 1,
+            type: 'residential',
+        };
+
+        expect(getShouldSaveAddress(customerAddress)).toBe(false);
+    });
+
+    it('returns false for a saved customer address even when it carries shouldSaveAddress', () => {
+        const customerAddress: CustomerAddress = {
+            ...getAddress(),
+            id: 1,
+            type: 'residential',
+            shouldSaveAddress: true,
+        };
+
+        expect(getShouldSaveAddress(customerAddress)).toBe(false);
+    });
+});

--- a/packages/core/src/app/address/getShouldSaveAddress.ts
+++ b/packages/core/src/app/address/getShouldSaveAddress.ts
@@ -1,0 +1,13 @@
+import { type Address, type CustomerAddress } from '@bigcommerce/checkout-sdk';
+
+export default function getShouldSaveAddress(address?: Address | CustomerAddress): boolean {
+    if (address && isCustomerAddress(address)) {
+        return false;
+    }
+
+    return address?.shouldSaveAddress ?? true;
+}
+
+function isCustomerAddress(address: Address | CustomerAddress): address is CustomerAddress {
+    return 'id' in address && 'type' in address;
+}

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -12,6 +12,7 @@ export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';
 export { default as setDefaultAddress } from './setDefaultAddress';
+export { default as getShouldSaveAddress } from './getShouldSaveAddress';
 export { reorderAddressFormFields } from './reorderAddressFormFields';
 export {
     default as getAddressFormFieldsValidationSchema,

--- a/packages/core/src/app/address/mapAddressToFormValues.test.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.test.ts
@@ -1,5 +1,6 @@
-import { type Address, type FormField } from '@bigcommerce/checkout-sdk';
+import { type Address, type CustomerAddress, type FormField } from '@bigcommerce/checkout-sdk';
 
+import { getAddress, getCustomerAddressB2B } from './address.mock';
 import { getFormFields } from './formField.mock';
 import mapAddressToFormValues from './mapAddressToFormValues';
 
@@ -145,6 +146,52 @@ describe('mapAddressToFormValues', () => {
             const result = mapAddressToFormValues(fields, address);
 
             expect(result.extraFields?.b2bExtraField_100).toBe('Default Corp');
+        });
+
+        it('reads extra field values from b2b.extraFields for a company address', () => {
+            const fields: FormField[] = [...getFormFields(), extraField];
+
+            const address: CustomerAddress = {
+                ...getAddress(),
+                id: 1,
+                type: 'residential',
+                b2b: getCustomerAddressB2B({
+                    extraFields: [{ fieldId: '100', fieldValue: 'Company Corp' }],
+                }),
+            };
+
+            const result = mapAddressToFormValues(fields, address);
+
+            expect(result.extraFields?.b2bExtraField_100).toBe('Company Corp');
+        });
+    });
+
+    describe('shouldSaveAddress', () => {
+        it('defaults to true when no address is provided', () => {
+            const result = mapAddressToFormValues(getFormFields());
+
+            expect(result.shouldSaveAddress).toBe(true);
+        });
+
+        it('keeps the explicit shouldSaveAddress value of a checkout address', () => {
+            const result = mapAddressToFormValues(getFormFields(), {
+                ...getAddress(),
+                shouldSaveAddress: false,
+            });
+
+            expect(result.shouldSaveAddress).toBe(false);
+        });
+
+        it('seeds false for a saved customer address', () => {
+            const address: CustomerAddress = {
+                ...getAddress(),
+                id: 1,
+                type: 'residential',
+            };
+
+            const result = mapAddressToFormValues(getFormFields(), address);
+
+            expect(result.shouldSaveAddress).toBe(false);
         });
     });
 });

--- a/packages/core/src/app/address/mapAddressToFormValues.ts
+++ b/packages/core/src/app/address/mapAddressToFormValues.ts
@@ -9,6 +9,7 @@ import {
 import { DynamicFormFieldType } from '@bigcommerce/checkout/ui';
 
 import getAddressExtraFields from './getAddressExtraFields';
+import getShouldSaveAddress from './getShouldSaveAddress';
 
 export type AddressFormValues = Pick<
     Address,
@@ -77,8 +78,7 @@ export default function mapAddressToFormValues(
         }, {} as AddressFormValues),
     };
 
-    values.shouldSaveAddress =
-        address && address.shouldSaveAddress !== undefined ? address.shouldSaveAddress : true;
+    values.shouldSaveAddress = getShouldSaveAddress(address);
 
     if (address?.label !== undefined) {
         values.label = address.label;

--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -384,6 +384,59 @@ describe('Shipping step', () => {
             ).toBeInTheDocument();
         });
 
+        it('does not flag a saved customer address to be saved again when completing the shipping step', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithMultiShippingCart);
+
+            jest.spyOn(checkoutService, 'updateShippingAddress');
+            jest.spyOn(checkoutService, 'updateBillingAddress');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            checkout.updateCheckout(
+                'post',
+                '/checkouts/xxxxxxxxxx-xxxx-xxax-xxxx-xxxxxx/consignments',
+                {
+                    ...checkoutWithBillingEmail,
+                    consignments: [
+                        {
+                            ...consignment,
+                            selectedShippingOption: undefined,
+                        },
+                    ],
+                },
+            );
+            checkout.updateCheckout(
+                'put',
+                '/checkouts/xxxxxxxxxx-xxxx-xxax-xxxx-xxxxxx/consignments/consignment-1',
+                {
+                    ...checkoutWithShipping,
+                },
+            );
+            checkout.updateCheckout(
+                'put',
+                '/checkouts/xxxxxxxxxx-xxxx-xxax-xxxx-xxxxxx/billing-address/billing-address-id*',
+                {
+                    ...checkoutWithShippingAndBilling,
+                },
+            );
+
+            await userEvent.click(screen.getByTestId('address-select-button'));
+            await userEvent.click(screen.getByText(/111 Testing Rd/i));
+
+            await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+            await checkout.waitForPaymentStep();
+
+            expect(checkoutService.updateShippingAddress).not.toHaveBeenCalledWith(
+                expect.objectContaining({ shouldSaveAddress: true }),
+            );
+            expect(checkoutService.updateBillingAddress).toHaveBeenCalledWith(
+                expect.objectContaining({ shouldSaveAddress: false }),
+            );
+        });
+
         it('enters new address for the customer with saved address and completes the shipping step', async () => {
             const config = {
                 ...checkoutSettings,

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -8,6 +8,7 @@ import { AddressFormSkeleton, ConfirmationModal } from '@bigcommerce/checkout/ui
 
 import {
     AddressType,
+    getShouldSaveAddress,
     isEqualAddress,
     mapAddressFromFormValues,
     setDefaultAddress,
@@ -157,7 +158,7 @@ function Shipping({
 
         if (
             !isEqualAddress(updatedShippingAddress, shippingAddress) ||
-            shippingAddress?.shouldSaveAddress !== updatedShippingAddress?.shouldSaveAddress
+            getShouldSaveAddress(shippingAddress) !== getShouldSaveAddress(updatedShippingAddress)
         ) {
             promises.push(updateShippingAddress(updatedShippingAddress || {}));
         }


### PR DESCRIPTION
## What/Why?

Introduce `getShouldSaveAddress` to compare addresses in a consistent way.

Ensure `checkout-js` does not flag a saved customer address to be saved again.

## Rollout/Rollback

Revert.

## Testing
<img width="1512" height="949" alt="Screenshot 2026-07-22 at 13 41 36" src="https://github.com/user-attachments/assets/09842be3-bf1c-4314-8ec1-ced12c964326" />
<img width="1512" height="949" alt="Screenshot 2026-07-22 at 13 42 24" src="https://github.com/user-attachments/assets/6b50ad83-c140-4357-a6b1-baf86bac794f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped checkout address-save behavior with unit and shipping integration tests; no auth or payment changes.
> 
> **Overview**
> Fixes checkout treating **saved customer addresses** as needing to be saved again by centralizing **`shouldSaveAddress`** logic in **`getShouldSaveAddress`**.
> 
> **`getShouldSaveAddress`** returns **`false`** for addresses identified as saved customer records (`id` + `type`), even when the API still sets **`shouldSaveAddress: true`**; other addresses keep explicit flags or default to **`true`**. **`mapAddressToFormValues`** and single-shipping submit in **`Shipping`** now use this helper so form seeding and “did the save flag change?” comparisons stay consistent.
> 
> Tests cover the helper, form mapping (including **`shouldSaveAddress`** and B2B **`extraFields`** on company addresses), and an integration case where completing shipping with a selected saved address does not call **`updateShippingAddress`** with **`shouldSaveAddress: true`** while billing uses **`shouldSaveAddress: false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd4d516b3d595dded9e4fb922a4102b47f42e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->