### PR TITLE
CHECKOUT-10184: Move sign-in and multi-shipping CTAs to step header row

### DIFF
--- a/packages/contexts/src/checkoutStepHeaderAction/CheckoutStepHeaderActionContext.tsx
+++ b/packages/contexts/src/checkoutStepHeaderAction/CheckoutStepHeaderActionContext.tsx
@@ -1,8 +1,7 @@
+import { noop } from 'lodash';
 import { createContext, type ReactNode, useContext } from 'react';
 
 type SetCheckoutStepHeaderAction = (action: ReactNode) => void;
-
-const noop: SetCheckoutStepHeaderAction = () => {};
 
 export const CheckoutStepHeaderActionContext = createContext<SetCheckoutStepHeaderAction>(noop);
 

--- a/packages/contexts/src/checkoutStepHeaderAction/index.ts
+++ b/packages/contexts/src/checkoutStepHeaderAction/index.ts
@@ -1,0 +1,4 @@
+export {
+    CheckoutStepHeaderActionContext,
+    useSetCheckoutStepHeaderAction,
+} from './CheckoutStepHeaderActionContext';

--- a/packages/contexts/src/index.ts
+++ b/packages/contexts/src/index.ts
@@ -15,6 +15,10 @@ export {
     useCapabilities,
 } from './capabilities';
 export { PaymentFormContext, usePaymentFormContext, PaymentFormProvider } from './paymentForm';
+export {
+    CheckoutStepHeaderActionContext,
+    useSetCheckoutStepHeaderAction,
+} from './checkoutStepHeaderAction';
 
 export type { AnalyticsContextProps, AnalyticsEvents } from './analytics/AnalyticsContext';
 export type { ExtensionAction, ExtensionServiceInterface } from './extension/ExtensionType';

--- a/packages/core/src/app/checkout/CheckoutStep.tsx
+++ b/packages/core/src/app/checkout/CheckoutStep.tsx
@@ -10,10 +10,10 @@ import React, {
 } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
+import { CheckoutStepHeaderActionContext } from '@bigcommerce/checkout/contexts';
 import { isMobileView, MobileView } from '@bigcommerce/checkout/ui';
 
 import CheckoutStepHeader from './CheckoutStepHeader';
-import { CheckoutStepHeaderActionContext } from './CheckoutStepHeaderActionContext';
 import type CheckoutStepType from './CheckoutStepType';
 
 export interface CheckoutStepProps {

--- a/packages/core/src/app/checkout/CheckoutStep.tsx
+++ b/packages/core/src/app/checkout/CheckoutStep.tsx
@@ -13,11 +13,13 @@ import { CSSTransition } from 'react-transition-group';
 import { isMobileView, MobileView } from '@bigcommerce/checkout/ui';
 
 import CheckoutStepHeader from './CheckoutStepHeader';
+import { CheckoutStepHeaderActionContext } from './CheckoutStepHeaderActionContext';
 import type CheckoutStepType from './CheckoutStepType';
 
 export interface CheckoutStepProps {
     children?: ReactNode;
     heading?: ReactNode;
+    headerAction?: ReactNode;
     isActive?: boolean;
     isBusy: boolean;
     isComplete?: boolean;
@@ -32,6 +34,7 @@ export interface CheckoutStepProps {
 const CheckoutStep = ({
     children,
     heading,
+    headerAction,
     isActive,
     isBusy,
     isComplete,
@@ -43,6 +46,7 @@ const CheckoutStep = ({
     onExpanded = noop,
 }: CheckoutStepProps): ReactElement => {
     const [isClosed, setIsClosed] = useState(true);
+    const [contextHeaderAction, setContextHeaderAction] = useState<ReactNode>(null);
 
     const containerRef = useRef<HTMLLIElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
@@ -157,6 +161,8 @@ const CheckoutStep = ({
         }
     }, [isActive]);
 
+    const shouldShowSuggestion = suggestion && isClosed && !isActive;
+
     return (
         <li
             className={classNames('checkout-step', 'optimizedCheckout-checkoutStep', {
@@ -164,43 +170,50 @@ const CheckoutStep = ({
             })}
             ref={containerRef}
         >
-            <div className="checkout-view-header">
-                <CheckoutStepHeader
-                    heading={heading}
-                    isActive={isActive}
-                    isComplete={isComplete}
-                    isEditable={isEditable}
-                    onEdit={onEdit}
-                    summary={summary}
-                    type={type}
-                />
-            </div>
-
-            {suggestion && isClosed && !isActive && (
-                <div className="checkout-suggestion" data-test="step-suggestion">
-                    {suggestion}
+            <CheckoutStepHeaderActionContext.Provider value={setContextHeaderAction}>
+                <div className="checkout-view-header">
+                    <CheckoutStepHeader
+                        headerAction={contextHeaderAction ?? headerAction}
+                        heading={heading}
+                        isActive={isActive}
+                        isComplete={isComplete}
+                        isEditable={isEditable}
+                        onEdit={onEdit}
+                        summary={summary}
+                        type={type}
+                    />
                 </div>
-            )}
 
-            <MobileView>
-                {(matched) => (
-                    <CSSTransition
-                        addEndListener={handleTransitionEnd}
-                        classNames="checkout-view-content"
-                        enter={!matched}
-                        exit={!matched}
-                        in={isActive}
-                        mountOnEnter
-                        onExited={onAnimationEnd}
-                        timeout={{}}
-                        unmountOnExit
-                    >
-                        <div aria-busy={isBusy} className="checkout-view-content" ref={contentRef}>
-                            {isActive ? children : null}
-                        </div>
-                    </CSSTransition>
+                {shouldShowSuggestion && (
+                    <div className="checkout-suggestion" data-test="step-suggestion">
+                        {suggestion}
+                    </div>
                 )}
-            </MobileView>
+
+                <MobileView>
+                    {(matched) => (
+                        <CSSTransition
+                            addEndListener={handleTransitionEnd}
+                            classNames="checkout-view-content"
+                            enter={!matched}
+                            exit={!matched}
+                            in={isActive}
+                            mountOnEnter
+                            onExited={onAnimationEnd}
+                            timeout={{}}
+                            unmountOnExit
+                        >
+                            <div
+                                aria-busy={isBusy}
+                                className="checkout-view-content"
+                                ref={contentRef}
+                            >
+                                {isActive ? children : null}
+                            </div>
+                        </CSSTransition>
+                    )}
+                </MobileView>
+            </CheckoutStepHeaderActionContext.Provider>
         </li>
     );
 };

--- a/packages/core/src/app/checkout/CheckoutStepHeader.test.tsx
+++ b/packages/core/src/app/checkout/CheckoutStepHeader.test.tsx
@@ -83,4 +83,16 @@ describe('CheckoutStepHeader', () => {
 
         expect(screen.queryByTestId('step-complete-icon')).not.toBeInTheDocument();
     });
+
+    it('renders headerAction if step is active', () => {
+        render(<CheckoutStepHeader {...defaultProps} headerAction="Sign in now" isActive />);
+
+        expect(screen.getByTestId('step-header-action')).toHaveTextContent('Sign in now');
+    });
+
+    it('does not render headerAction if step is not active', () => {
+        render(<CheckoutStepHeader {...defaultProps} headerAction="Sign in now" />);
+
+        expect(screen.queryByTestId('step-header-action')).not.toBeInTheDocument();
+    });
 });

--- a/packages/core/src/app/checkout/CheckoutStepHeader.tsx
+++ b/packages/core/src/app/checkout/CheckoutStepHeader.tsx
@@ -11,6 +11,7 @@ import type CheckoutStepType from './CheckoutStepType';
 
 export interface CheckoutStepHeaderProps {
     heading: ReactNode;
+    headerAction?: ReactNode;
     isActive?: boolean;
     isComplete?: boolean;
     isEditable?: boolean;
@@ -21,6 +22,7 @@ export interface CheckoutStepHeaderProps {
 
 const CheckoutStepHeader: FunctionComponent<CheckoutStepHeaderProps> = ({
     heading,
+    headerAction,
     isActive,
     isComplete,
     isEditable,
@@ -87,6 +89,15 @@ const CheckoutStepHeader: FunctionComponent<CheckoutStepHeaderProps> = ({
                     >
                         <TranslatedString id="common.edit_action" />
                     </Button>
+                </div>
+            )}
+
+            {isActive && headerAction && (
+                <div
+                    className="stepHeader-actions stepHeader-actions--cta stepHeader-column"
+                    data-test="step-header-action"
+                >
+                    {headerAction}
                 </div>
             )}
         </div>

--- a/packages/core/src/app/checkout/CheckoutStepHeaderActionContext.tsx
+++ b/packages/core/src/app/checkout/CheckoutStepHeaderActionContext.tsx
@@ -1,0 +1,11 @@
+import { createContext, type ReactNode, useContext } from 'react';
+
+type SetCheckoutStepHeaderAction = (action: ReactNode) => void;
+
+const noop: SetCheckoutStepHeaderAction = () => {};
+
+export const CheckoutStepHeaderActionContext = createContext<SetCheckoutStepHeaderAction>(noop);
+
+export function useSetCheckoutStepHeaderAction(): SetCheckoutStepHeaderAction {
+    return useContext(CheckoutStepHeaderActionContext);
+}

--- a/packages/core/src/app/checkout/components/CustomerStep.tsx
+++ b/packages/core/src/app/checkout/components/CustomerStep.tsx
@@ -1,5 +1,6 @@
 import React, { lazy } from 'react';
 
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { LazyContainer } from '@bigcommerce/checkout/ui';
 
@@ -9,7 +10,9 @@ import {
     CustomerInfo,
     type CustomerProps,
     type CustomerSignOutEvent,
+    CustomerViewType,
 } from '../../customer';
+import { attemptStorefrontLoginRedirect } from '../../customer/attemptStorefrontLoginRedirect';
 import { isEmbedded } from '../../embeddedCheckout';
 import CheckoutStep from '../CheckoutStep';
 import type CheckoutStepType from '../CheckoutStepType';
@@ -52,9 +55,53 @@ const CustomerStep: React.FC<CustomerStepProps> = ({
     onUnhandledError,
     onWalletButtonClick,
 }) => {
+    const { themeV2 } = useThemeContext();
+    const {
+        selectedState: {
+            config,
+            isContinuingAsGuest,
+            isExecutingPaymentMethodCheckout,
+            isInitializingCustomer,
+        },
+    } = useCheckout(({ data, statuses }) => ({
+        config: data.getConfig(),
+        isContinuingAsGuest: statuses.isContinuingAsGuest(),
+        isExecutingPaymentMethodCheckout: statuses.isExecutingPaymentMethodCheckout(),
+        isInitializingCustomer: statuses.isInitializingCustomer(),
+    }));
+
+    const handleShowLogin = () => {
+        if (attemptStorefrontLoginRedirect(config)) {
+            return;
+        }
+
+        onChangeViewType?.(CustomerViewType.Login);
+    };
+
+    const isCustomerBusy =
+        isContinuingAsGuest || isExecutingPaymentMethodCheckout || isInitializingCustomer;
+    const shouldShowHeaderAction =
+        themeV2 && viewType === CustomerViewType.Guest && !isCustomerBusy;
+
+    const headerAction = shouldShowHeaderAction ? (
+        <span className="body-regular">
+            <TranslatedString id="customer.login_text" />{' '}
+            <a
+                data-test="customer-continue-button"
+                id="checkout-customer-login"
+                onClick={handleShowLogin}
+                role="button"
+                tabIndex={0}
+            >
+                <TranslatedString id="customer.login_action" />
+            </a>
+        </span>
+    ) : null;
+
     return (
         <CheckoutStep
             {...step}
+            headerAction={headerAction}
             heading={<TranslatedString id="customer.customer_heading" />}
             key={step.type}
             onEdit={onEdit}

--- a/packages/core/src/app/checkout/components/ShippingStep.tsx
+++ b/packages/core/src/app/checkout/components/ShippingStep.tsx
@@ -1,11 +1,13 @@
 import type { Cart, Consignment } from '@bigcommerce/checkout-sdk/essential';
 import React, { lazy } from 'react';
 
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, LazyContainer } from '@bigcommerce/checkout/ui';
 
 import { retry } from '../../common/utility';
 import { type ShippingProps, ShippingSummary } from '../../shipping';
+import { shouldShowMultiShippingToggle } from '../../shipping/utils';
 import CheckoutStep from '../CheckoutStep';
 import type CheckoutStepType from '../CheckoutStepType';
 
@@ -45,13 +47,33 @@ const ShippingStep: React.FC<ShippingStepProps> = ({
     onUnhandledError,
     setIsMultishippingMode,
 }) => {
+    const { themeV2 } = useThemeContext();
+    const {
+        selectedState: { checkout, config },
+    } = useCheckout(({ data }) => ({
+        checkout: data.getCheckout(),
+        config: data.getConfig(),
+    }));
+
     if (!cart) {
         return null;
     }
 
+    const shouldShowHeaderAction =
+        themeV2 && checkout && config && shouldShowMultiShippingToggle(checkout, config, cart);
+
+    const headerAction = shouldShowHeaderAction ? (
+        <span className="body-cta" data-test="shipping-mode-toggle">
+            <TranslatedString
+                id={isMultiShippingMode ? 'shipping.ship_to_single' : 'shipping.ship_to_multi'}
+            />
+        </span>
+    ) : null;
+
     return (
         <CheckoutStep
             {...step}
+            headerAction={headerAction}
             heading={<TranslatedString id="shipping.shipping_heading" />}
             key={step.type}
             onEdit={onEdit}

--- a/packages/core/src/app/customer/GuestForm.tsx
+++ b/packages/core/src/app/customer/GuestForm.tsx
@@ -21,6 +21,7 @@ import {
 
 import { getPrivacyPolicyValidationSchema, PrivacyPolicyField } from '../privacyPolicy';
 
+import { attemptStorefrontLoginRedirect } from './attemptStorefrontLoginRedirect';
 import EmailField from './EmailField';
 import SubscribeField from './SubscribeField';
 import { SubscribeSessionStorage } from './SubscribeSessionStorage';
@@ -96,15 +97,8 @@ const GuestForm: FunctionComponent<
         return null;
     }
 
-    const {
-        checkoutSettings: { shouldRedirectToStorefrontForAuth },
-        links: { checkoutLink, loginLink },
-    } = config;
-
     const handleLogin: () => void = () => {
-        if (shouldRedirectToStorefrontForAuth) {
-            window.location.assign(`${loginLink}?redirectTo=${checkoutLink}`);
-
+        if (attemptStorefrontLoginRedirect(config)) {
             return;
         }
 
@@ -124,21 +118,6 @@ const GuestForm: FunctionComponent<
                     </Legend>
                 }
             >
-                {themeV2 && !isLoading && (
-                    <p className="customer-login-link body-regular">
-                        <TranslatedString id="customer.login_text" />{' '}
-                        <a
-                            data-test="customer-continue-button"
-                            id="checkout-customer-login"
-                            onClick={handleLogin}
-                            role="button"
-                            tabIndex={0}
-                        >
-                            <TranslatedString id="customer.login_action" />
-                        </a>
-                    </p>
-                )}
-
                 <div className="customerEmail-container">
                     <div className="customerEmail-body">
                         <EmailField
@@ -151,6 +130,13 @@ const GuestForm: FunctionComponent<
                         {(canSubscribe || requiresMarketingConsent) && (
                             <BasicFormField name="shouldSubscribe" render={renderField} />
                         )}
+
+                        {themeV2 && privacyPolicyUrl && (
+                            <PrivacyPolicyField
+                                isExpressPrivacyPolicy={isExpressPrivacyPolicy}
+                                url={privacyPolicyUrl}
+                            />
+                        )}
                     </div>
 
                     <div
@@ -159,7 +145,9 @@ const GuestForm: FunctionComponent<
                         })}
                     >
                         <Button
-                            className="customerEmail-button body-bold"
+                            className={classNames('body-bold', {
+                                'customerEmail-button': !themeV2,
+                            })}
                             id="checkout-customer-continue"
                             isLoading={isLoading}
                             testId="customer-continue-as-guest-button"
@@ -171,7 +159,7 @@ const GuestForm: FunctionComponent<
                     </div>
                 </div>
 
-                {privacyPolicyUrl && (
+                {!themeV2 && privacyPolicyUrl && (
                     <PrivacyPolicyField
                         isExpressPrivacyPolicy={isExpressPrivacyPolicy}
                         url={privacyPolicyUrl}

--- a/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
+++ b/packages/core/src/app/customer/RedirectToStorefrontLogin.tsx
@@ -4,6 +4,8 @@ import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { Button, ButtonVariant } from '@bigcommerce/checkout/ui';
 
+import { attemptStorefrontLoginRedirect } from './attemptStorefrontLoginRedirect';
+
 interface RedirectToStorefrontLoginProps {
     isDisabled: boolean;
     isLoading: boolean;
@@ -19,10 +21,8 @@ export const RedirectToStorefrontLogin: React.FC<RedirectToStorefrontLoginProps>
         return null;
     }
 
-    const { checkoutLink, loginLink } = config.links;
-
     const handleRedirect = () => {
-        return window.location.assign(`${loginLink}?redirectTo=${checkoutLink}`);
+        attemptStorefrontLoginRedirect(config);
     };
 
     return (

--- a/packages/core/src/app/customer/StripeGuestForm.tsx
+++ b/packages/core/src/app/customer/StripeGuestForm.tsx
@@ -3,6 +3,7 @@ import {
     type CustomerRequestOptions,
 } from '@bigcommerce/checkout-sdk';
 import { createStripeUPECustomerStrategy } from '@bigcommerce/checkout-sdk/integrations/stripe';
+import classNames from 'classnames';
 import { type FieldProps, type FormikProps, withFormik } from 'formik';
 import React, {
     type FunctionComponent,
@@ -227,21 +228,6 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                             )
                         }
                     >
-                        {themeV2 && !isLoading && (
-                            <p className="customer-login-link body-regular">
-                                <TranslatedString id="customer.login_text" />{' '}
-                                <a
-                                    data-test="customer-continue-button"
-                                    id="checkout-customer-login"
-                                    onClick={onShowLogin}
-                                    role="button"
-                                    tabIndex={0}
-                                >
-                                    <TranslatedString id="customer.login_action" />
-                                </a>
-                            </p>
-                        )}
-
                         <div className="customerEmail-container">
                             <div className="customerEmail-body">
                                 <div id="stripeupeLink" />
@@ -249,12 +235,21 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                                 {(canSubscribe || requiresMarketingConsent) && (
                                     <BasicFormField name="shouldSubscribe" render={renderField} />
                                 )}
+
+                                {themeV2 && privacyPolicyUrl && (
+                                    <PrivacyPolicyField
+                                        isExpressPrivacyPolicy={isExpressPrivacyPolicy}
+                                        url={privacyPolicyUrl}
+                                    />
+                                )}
                             </div>
 
                             <div className="form-actions customerEmail-action">
                                 {(!authentication || (authentication && !isNewAuth)) && (
                                     <Button
-                                        className="stripeCustomerEmail-button"
+                                        className={classNames({
+                                            'stripeCustomerEmail-button': !themeV2,
+                                        })}
                                         disabled={continueAsAGuestButton}
                                         id="stripe-checkout-customer-continue"
                                         isLoading={isLoading}
@@ -268,7 +263,7 @@ const StripeGuestForm: FunctionComponent<StripeGuestFormProps & FormikProps<Gues
                             </div>
                         </div>
 
-                        {privacyPolicyUrl && (
+                        {!themeV2 && privacyPolicyUrl && (
                             <PrivacyPolicyField
                                 isExpressPrivacyPolicy={isExpressPrivacyPolicy}
                                 url={privacyPolicyUrl}

--- a/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
+++ b/packages/core/src/app/customer/__snapshots__/StripeGuestForm.test.tsx.snap
@@ -295,20 +295,6 @@ exports[`StripeGuestForm matches snapshot with theme v2 1`] = `
               <div
                 class="form-body"
               >
-                <p
-                  class="customer-login-link body-regular"
-                >
-                  Already have an account?
-                   
-                  <a
-                    data-test="customer-continue-button"
-                    id="checkout-customer-login"
-                    role="button"
-                    tabindex="0"
-                  >
-                    Sign in now
-                  </a>
-                </p>
                 <div
                   class="customerEmail-container"
                 >
@@ -344,7 +330,7 @@ exports[`StripeGuestForm matches snapshot with theme v2 1`] = `
                     class="form-actions customerEmail-action"
                   >
                     <button
-                      class="button stripeCustomerEmail-button button--primary optimizedCheckout-buttonPrimary"
+                      class="button button--primary optimizedCheckout-buttonPrimary"
                       data-test="stripe-customer-continue-as-guest-button"
                       disabled=""
                       id="stripe-checkout-customer-continue"
@@ -402,20 +388,6 @@ exports[`StripeGuestForm matches snapshot with theme v2 1`] = `
             <div
               class="form-body"
             >
-              <p
-                class="customer-login-link body-regular"
-              >
-                Already have an account?
-                 
-                <a
-                  data-test="customer-continue-button"
-                  id="checkout-customer-login"
-                  role="button"
-                  tabindex="0"
-                >
-                  Sign in now
-                </a>
-              </p>
               <div
                 class="customerEmail-container"
               >
@@ -451,7 +423,7 @@ exports[`StripeGuestForm matches snapshot with theme v2 1`] = `
                   class="form-actions customerEmail-action"
                 >
                   <button
-                    class="button stripeCustomerEmail-button button--primary optimizedCheckout-buttonPrimary"
+                    class="button button--primary optimizedCheckout-buttonPrimary"
                     data-test="stripe-customer-continue-as-guest-button"
                     disabled=""
                     id="stripe-checkout-customer-continue"

--- a/packages/core/src/app/customer/attemptStorefrontLoginRedirect.test.ts
+++ b/packages/core/src/app/customer/attemptStorefrontLoginRedirect.test.ts
@@ -1,0 +1,46 @@
+import { getStoreConfig } from '../config/config.mock';
+
+import { attemptStorefrontLoginRedirect } from './attemptStorefrontLoginRedirect';
+
+describe('attemptStorefrontLoginRedirect()', () => {
+    const { assign } = window.location;
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            value: { assign: jest.fn() },
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            value: { assign },
+            writable: true,
+        });
+    });
+
+    it('returns false and does not redirect if config is not provided', () => {
+        expect(attemptStorefrontLoginRedirect(undefined)).toBe(false);
+        expect(window.location.assign).not.toHaveBeenCalled();
+    });
+
+    it('returns false and does not redirect if shouldRedirectToStorefrontForAuth is false', () => {
+        const config = getStoreConfig();
+
+        config.checkoutSettings.shouldRedirectToStorefrontForAuth = false;
+
+        expect(attemptStorefrontLoginRedirect(config)).toBe(false);
+        expect(window.location.assign).not.toHaveBeenCalled();
+    });
+
+    it('returns true and redirects to the login link when shouldRedirectToStorefrontForAuth is true', () => {
+        const config = getStoreConfig();
+
+        config.checkoutSettings.shouldRedirectToStorefrontForAuth = true;
+
+        expect(attemptStorefrontLoginRedirect(config)).toBe(true);
+        expect(window.location.assign).toHaveBeenCalledWith(
+            `${config.links.loginLink}?redirectTo=${config.links.checkoutLink}`,
+        );
+    });
+});

--- a/packages/core/src/app/customer/attemptStorefrontLoginRedirect.ts
+++ b/packages/core/src/app/customer/attemptStorefrontLoginRedirect.ts
@@ -1,0 +1,11 @@
+import { type StoreConfig } from '@bigcommerce/checkout-sdk';
+
+export function attemptStorefrontLoginRedirect(config?: StoreConfig): boolean {
+    if (!config?.checkoutSettings.shouldRedirectToStorefrontForAuth) {
+        return false;
+    }
+
+    window.location.assign(`${config.links.loginLink}?redirectTo=${config.links.checkoutLink}`);
+
+    return true;
+}

--- a/packages/core/src/app/shipping/Shipping.tsx
+++ b/packages/core/src/app/shipping/Shipping.tsx
@@ -115,7 +115,7 @@ function Shipping({
         void initializeShipping();
     }, []);
 
-    const handleMultiShippingModeSwitch = async () => {
+    const handleMultiShippingModeSwitch = useCallback(async () => {
         try {
             setIsInitializing(true);
 
@@ -143,7 +143,17 @@ function Shipping({
         }
 
         onToggleMultiShipping();
-    };
+    }, [
+        isMultiShippingMode,
+        consignments,
+        hasCompanyAddressBook,
+        customer,
+        decode,
+        updateShippingAddress,
+        deleteConsignments,
+        onUnhandledError,
+        onToggleMultiShipping,
+    ]);
 
     const handleSwitchToSingleShipping = useCallback(async () => {
         setIsMultiShippingUnavailableModalOpen(false);

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -1,12 +1,14 @@
 import { ExtensionRegion } from '@bigcommerce/checkout-sdk/essential';
 import classNames from 'classnames';
-import React, { type FunctionComponent, memo, useState } from 'react';
+import React, { type FunctionComponent, memo, useEffect, useMemo, useState } from 'react';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
 import { useThemeContext } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { ConfirmationModal, Legend } from '@bigcommerce/checkout/ui';
+
+import { useSetCheckoutStepHeaderAction } from '../checkout/CheckoutStepHeaderActionContext';
 
 import './ShippingHeader.scss';
 
@@ -28,6 +30,7 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
     const [isMultiShippingUnavailableModalOpen, setIsMultiShippingUnavailableModalOpen] =
         useState(false);
     const { themeV2 } = useThemeContext();
+    const setHeaderAction = useSetCheckoutStepHeaderAction();
 
     const isSubheaderHidden = themeV2 && !isMultiShippingMode;
 
@@ -39,6 +42,73 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
     const showConfirmationModal = shouldShowMultiShipping && isMultiShippingMode;
     const showMultiShippingUnavailableModal =
         shouldShowMultiShipping && !isMultiShippingMode && cartHasPromotionalItems;
+
+    const modeToggleLink = useMemo(() => {
+        if (showConfirmationModal) {
+            return (
+                <a
+                    className="body-cta"
+                    data-test="shipping-mode-toggle"
+                    href="#"
+                    onClick={preventDefault(() => setIsSingleShippingConfirmationModalOpen(true))}
+                >
+                    <TranslatedString id="shipping.ship_to_single" />
+                </a>
+            );
+        }
+
+        if (showMultiShippingUnavailableModal) {
+            return (
+                <a
+                    className="body-cta"
+                    data-test="shipping-mode-toggle"
+                    href="#"
+                    onClick={preventDefault(() => setIsMultiShippingUnavailableModalOpen(true))}
+                >
+                    <TranslatedString id="shipping.ship_to_multi" />
+                </a>
+            );
+        }
+
+        if (shouldShowMultiShipping) {
+            return (
+                <a
+                    className="body-cta"
+                    data-test="shipping-mode-toggle"
+                    href="#"
+                    onClick={preventDefault(onMultiShippingChange)}
+                >
+                    <TranslatedString
+                        id={
+                            isMultiShippingMode
+                                ? 'shipping.ship_to_single'
+                                : 'shipping.ship_to_multi'
+                        }
+                    />
+                </a>
+            );
+        }
+
+        return null;
+    }, [
+        showConfirmationModal,
+        showMultiShippingUnavailableModal,
+        shouldShowMultiShipping,
+        isMultiShippingMode,
+        onMultiShippingChange,
+    ]);
+
+    useEffect(() => {
+        if (!themeV2) {
+            setHeaderAction(null);
+
+            return;
+        }
+
+        setHeaderAction(modeToggleLink);
+
+        return () => setHeaderAction(null);
+    }, [themeV2, modeToggleLink, setHeaderAction]);
 
     return (
         <>
@@ -54,69 +124,29 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
                     />
                 </Legend>
 
-                {showConfirmationModal && (
-                    <>
-                        <ConfirmationModal
-                            action={handleShipToSingleConfirmation}
-                            actionButtonLabel={<TranslatedString id="common.proceed_action" />}
-                            headerId="shipping.ship_to_single_action"
-                            isModalOpen={isSingleShippingConfirmationModalOpen}
-                            messageId="shipping.ship_to_single_message"
-                            onRequestClose={() => setIsSingleShippingConfirmationModalOpen(false)}
-                        />
-                        <a
-                            className="body-cta"
-                            data-test="shipping-mode-toggle"
-                            href="#"
-                            onClick={preventDefault(() =>
-                                setIsSingleShippingConfirmationModalOpen(true),
-                            )}
-                        >
-                            <TranslatedString id="shipping.ship_to_single" />
-                        </a>
-                    </>
-                )}
-                {showMultiShippingUnavailableModal && (
-                    <>
-                        <ConfirmationModal
-                            action={() => setIsMultiShippingUnavailableModalOpen(false)}
-                            actionButtonLabel={<TranslatedString id="common.back_action" />}
-                            headerId="shipping.multishipping_unavailable_action"
-                            isModalOpen={isMultiShippingUnavailableModalOpen}
-                            messageId="shipping.multishipping_unavailable_message"
-                            onRequestClose={() => setIsMultiShippingUnavailableModalOpen(false)}
-                        />
-                        <a
-                            className="body-cta"
-                            data-test="shipping-mode-toggle"
-                            href="#"
-                            onClick={preventDefault(() =>
-                                setIsMultiShippingUnavailableModalOpen(true),
-                            )}
-                        >
-                            <TranslatedString id="shipping.ship_to_multi" />
-                        </a>
-                    </>
-                )}
-                {!showConfirmationModal &&
-                    !showMultiShippingUnavailableModal &&
-                    shouldShowMultiShipping && (
-                        <a
-                            className="body-cta"
-                            data-test="shipping-mode-toggle"
-                            href="#"
-                            onClick={preventDefault(onMultiShippingChange)}
-                        >
-                            <TranslatedString
-                                id={
-                                    isMultiShippingMode
-                                        ? 'shipping.ship_to_single'
-                                        : 'shipping.ship_to_multi'
-                                }
-                            />
-                        </a>
-                    )}
+                {!themeV2 && modeToggleLink}
             </div>
+
+            {showConfirmationModal && (
+                <ConfirmationModal
+                    action={handleShipToSingleConfirmation}
+                    actionButtonLabel={<TranslatedString id="common.proceed_action" />}
+                    headerId="shipping.ship_to_single_action"
+                    isModalOpen={isSingleShippingConfirmationModalOpen}
+                    messageId="shipping.ship_to_single_message"
+                    onRequestClose={() => setIsSingleShippingConfirmationModalOpen(false)}
+                />
+            )}
+            {showMultiShippingUnavailableModal && (
+                <ConfirmationModal
+                    action={() => setIsMultiShippingUnavailableModalOpen(false)}
+                    actionButtonLabel={<TranslatedString id="common.back_action" />}
+                    headerId="shipping.multishipping_unavailable_action"
+                    isModalOpen={isMultiShippingUnavailableModalOpen}
+                    messageId="shipping.multishipping_unavailable_message"
+                    onRequestClose={() => setIsMultiShippingUnavailableModalOpen(false)}
+                />
+            )}
         </>
     );
 };

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -48,11 +48,19 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
             return null;
         }
 
-        const handleClick = showConfirmationModal
-            ? () => setIsSingleShippingConfirmationModalOpen(true)
-            : showMultiShippingUnavailableModal
-              ? () => setIsMultiShippingUnavailableModalOpen(true)
-              : onMultiShippingChange;
+        const getHandleClick = () => {
+            if (showConfirmationModal) {
+                return () => setIsSingleShippingConfirmationModalOpen(true);
+            }
+
+            if (showMultiShippingUnavailableModal) {
+                return () => setIsMultiShippingUnavailableModalOpen(true);
+            }
+
+            return onMultiShippingChange;
+        };
+
+        const handleClick = getHandleClick();
 
         return (
             <a

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -44,52 +44,28 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
         shouldShowMultiShipping && !isMultiShippingMode && cartHasPromotionalItems;
 
     const modeToggleLink = useMemo(() => {
-        if (showConfirmationModal) {
-            return (
-                <a
-                    className="body-cta"
-                    data-test="shipping-mode-toggle"
-                    href="#"
-                    onClick={preventDefault(() => setIsSingleShippingConfirmationModalOpen(true))}
-                >
-                    <TranslatedString id="shipping.ship_to_single" />
-                </a>
-            );
+        if (!shouldShowMultiShipping) {
+            return null;
         }
 
-        if (showMultiShippingUnavailableModal) {
-            return (
-                <a
-                    className="body-cta"
-                    data-test="shipping-mode-toggle"
-                    href="#"
-                    onClick={preventDefault(() => setIsMultiShippingUnavailableModalOpen(true))}
-                >
-                    <TranslatedString id="shipping.ship_to_multi" />
-                </a>
-            );
-        }
+        const handleClick = showConfirmationModal
+            ? () => setIsSingleShippingConfirmationModalOpen(true)
+            : showMultiShippingUnavailableModal
+              ? () => setIsMultiShippingUnavailableModalOpen(true)
+              : onMultiShippingChange;
 
-        if (shouldShowMultiShipping) {
-            return (
-                <a
-                    className="body-cta"
-                    data-test="shipping-mode-toggle"
-                    href="#"
-                    onClick={preventDefault(onMultiShippingChange)}
-                >
-                    <TranslatedString
-                        id={
-                            isMultiShippingMode
-                                ? 'shipping.ship_to_single'
-                                : 'shipping.ship_to_multi'
-                        }
-                    />
-                </a>
-            );
-        }
-
-        return null;
+        return (
+            <a
+                className="body-cta"
+                data-test="shipping-mode-toggle"
+                href="#"
+                onClick={preventDefault(handleClick)}
+            >
+                <TranslatedString
+                    id={isMultiShippingMode ? 'shipping.ship_to_single' : 'shipping.ship_to_multi'}
+                />
+            </a>
+        );
     }, [
         showConfirmationModal,
         showMultiShippingUnavailableModal,

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -3,12 +3,10 @@ import classNames from 'classnames';
 import React, { type FunctionComponent, memo, useEffect, useMemo, useState } from 'react';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
-import { useThemeContext } from '@bigcommerce/checkout/contexts';
+import { useSetCheckoutStepHeaderAction, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { ConfirmationModal, Legend } from '@bigcommerce/checkout/ui';
-
-import { useSetCheckoutStepHeaderAction } from '../checkout/CheckoutStepHeaderActionContext';
 
 import './ShippingHeader.scss';
 

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -15,9 +15,9 @@ import { encodeAddressForWrite } from '../../address';
 import { EMPTY_ARRAY } from '../../common/utility';
 import getBackorderCount from '../../order/getBackorderCount';
 import getProviderWithCustomCheckout from '../../payment/getProviderWithCustomCheckout';
-import getShippableItemsCount from '../getShippableItemsCount';
 import getShippingMethodId from '../getShippingMethodId';
 import hasPromotionalItems from '../hasPromotionalItems';
+import { shouldShowMultiShippingToggle } from '../utils';
 
 const deleteConsignmentsSelector = createSelector(
     ({ checkoutService: { deleteConsignment } }: CheckoutContextProps) => deleteConsignment,
@@ -147,8 +147,7 @@ export const useShipping = () => {
         isDeletingConsignment() ||
         isLoadingCheckout();
 
-    const shippableItemsCount = getShippableItemsCount(cart);
-    const shouldShowMultiShipping = hasMultiShippingEnabled && !methodId && shippableItemsCount > 1;
+    const shouldShowMultiShipping = shouldShowMultiShippingToggle(checkout, config, cart);
 
     const shippingAddress =
         !shouldShowMultiShipping && consignments.length > 1 ? undefined : getShippingAddress();

--- a/packages/core/src/app/shipping/utils/index.ts
+++ b/packages/core/src/app/shipping/utils/index.ts
@@ -1,3 +1,4 @@
 export { generateItemHash } from './generateItemHash';
 export { getShippingOptionIds } from './getShippingOptionIds';
 export { setRecommendedOrMissingShippingOption } from './setRecommendedOrMissingShippingOption';
+export { shouldShowMultiShippingToggle } from './shouldShowMultiShippingToggle';

--- a/packages/core/src/app/shipping/utils/shouldShowMultiShippingToggle.test.ts
+++ b/packages/core/src/app/shipping/utils/shouldShowMultiShippingToggle.test.ts
@@ -1,0 +1,50 @@
+import { getCart } from '../../cart/carts.mock';
+import { getPhysicalItem } from '../../cart/lineItem.mock';
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { getStoreConfig } from '../../config/config.mock';
+
+import { shouldShowMultiShippingToggle } from './shouldShowMultiShippingToggle';
+
+describe('shouldShowMultiShippingToggle()', () => {
+    it('returns false if hasMultiShippingEnabled is false', () => {
+        const checkout = getCheckout();
+        const config = getStoreConfig();
+        const cart = {
+            ...getCart(),
+            lineItems: {
+                ...getCart().lineItems,
+                physicalItems: [getPhysicalItem(), getPhysicalItem()],
+            },
+        };
+
+        config.checkoutSettings.hasMultiShippingEnabled = false;
+
+        expect(shouldShowMultiShippingToggle(checkout, config, cart)).toBe(false);
+    });
+
+    it('returns false if there is one or fewer shippable items', () => {
+        const checkout = getCheckout();
+        const config = getStoreConfig();
+        const cart = getCart();
+
+        config.checkoutSettings.hasMultiShippingEnabled = true;
+
+        expect(shouldShowMultiShippingToggle(checkout, config, cart)).toBe(false);
+    });
+
+    it('returns true if multi-shipping is enabled and there is more than one shippable item', () => {
+        const checkout = getCheckout();
+        const config = getStoreConfig();
+        const cart = {
+            ...getCart(),
+            lineItems: {
+                ...getCart().lineItems,
+                physicalItems: [getPhysicalItem(), getPhysicalItem()],
+            },
+        };
+
+        config.checkoutSettings.hasMultiShippingEnabled = true;
+
+        expect(shouldShowMultiShippingToggle(checkout, config, cart)).toBe(true);
+    });
+});

--- a/packages/core/src/app/shipping/utils/shouldShowMultiShippingToggle.ts
+++ b/packages/core/src/app/shipping/utils/shouldShowMultiShippingToggle.ts
@@ -1,0 +1,16 @@
+import { type Cart, type Checkout, type StoreConfig } from '@bigcommerce/checkout-sdk';
+
+import getShippableItemsCount from '../getShippableItemsCount';
+import getShippingMethodId from '../getShippingMethodId';
+
+export function shouldShowMultiShippingToggle(
+    checkout: Checkout,
+    config: StoreConfig,
+    cart: Cart,
+): boolean {
+    return (
+        config.checkoutSettings.hasMultiShippingEnabled &&
+        !getShippingMethodId(checkout, config) &&
+        getShippableItemsCount(cart) > 1
+    );
+}

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -46,7 +46,7 @@
 
         .stepHeader {
             flex-wrap: wrap;
-            padding: 0;
+            padding: 0 0 spacing("single");
 
             .stepHeader-body {
                 order: 3;
@@ -58,6 +58,17 @@
             .stepHeader-actions {
                 margin-left: auto;
                 align-self: flex-start;
+            }
+
+            .stepHeader-actions--cta {
+                align-self: center;
+
+                .body-regular,
+                .body-cta {
+                    font-family: $fontFamily-montserrat;
+                    font-size: $fontSize-smallest;
+                    font-weight: $fontWeight-medium;
+                }
             }
 
             .stepHeader-figure {

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -62,12 +62,19 @@
 
             .stepHeader-actions--cta {
                 align-self: center;
+                margin-left: 0;
+                width: 100%;
 
                 .body-regular,
                 .body-cta {
                     font-family: $fontFamily-montserrat;
                     font-size: $fontSize-smallest;
                     font-weight: $fontWeight-medium;
+                }
+
+                @include breakpoint("small") {
+                    margin-left: auto;
+                    width: auto;
                 }
             }
 

--- a/packages/core/src/scss/themeV2/components/checkout/_customer-step.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_customer-step.scss
@@ -5,20 +5,19 @@
         }
     }
 
-    .customer-login-link {
-        @include themeV2 {
-            margin-top: #{spacing("half") + spacing("third")};
-        }
-    }
-
-    @include themeV2-desktop {
-        .customerEmail-container {
-            display: flex;
-            flex-direction: row;
-        }
-
+    @include themeV2-mobile {
         .customerEmail-body {
-            width: 80%;
+            width: 100%;
+
+            > *:last-child {
+                margin-bottom: spacing("single");
+            }
+        }
+
+        .customerEmail-action {
+            margin: 0;
+            padding-left: 0;
+            width: 100%;
         }
     }
 }

--- a/packages/core/src/scss/themeV2/font/_font.scss
+++ b/packages/core/src/scss/themeV2/font/_font.scss
@@ -3,7 +3,7 @@
     .header, .header-secondary, .sub-header {
         color: $color-black;
         font-family: $fontFamily-montserrat;
-        font-size: $fontSize-small;
+        font-size: $fontSize-large;
         font-weight: $fontWeight-bold;
     }
 


### PR DESCRIPTION
## What/Why?

Ticket: CHECKOUT-10184

Tightens spacing/density on the checkout page by:
- Relocating "Already have an account? Sign in now" (Customer step) onto the same row as the "Customer" step heading.
- Relocating "Ship to multiple addresses" (Shipping step) onto the same row as the "Shipping" step heading.
- Moving the Customer step's Continue button to the bottom-left (previously full-width, paired beside the email field).

This is gated behind the existing "enhanced checkout experience" theme setting (`checkoutUserExperienceSettings.checkoutV2Theme`, exposed via `useThemeContext().themeV2`) rather than a new feature flag — `GuestForm`/`StripeGuestForm` already branch on this same flag for related layout differences, so this reuses that pattern. Legacy (`!themeV2`) checkouts are visually unaffected.

## Rollout/Rollback

No new flag — rides the existing `checkoutV2Theme` setting already used for other enhanced-checkout-experience differences. Rollback is a straight revert; no migrations involved.

## Testing

- [x] manual test
<img width="2430" height="1532" alt="image" src="https://github.com/user-attachments/assets/e392a8c6-2aa0-43d7-8962-3f65fb328168" />
<img width="1602" height="1214" alt="image" src="https://github.com/user-attachments/assets/3ef77912-3fce-4ba1-90d3-8bf0d6a0c12d" />
<img width="1542" height="1286" alt="image" src="https://github.com/user-attachments/assets/4b9a47d4-adf6-4d13-b510-ffaeac494658" />
<img width="2500" height="1764" alt="image" src="https://github.com/user-attachments/assets/20506fe2-df6c-4d78-9aa4-a9b55edce741" />
<img width="2406" height="2238" alt="image" src="https://github.com/user-attachments/assets/92335010-ef3b-4b50-9200-37b29a685a05" />
<img width="2436" height="1920" alt="image" src="https://github.com/user-attachments/assets/18a1cea2-053b-4004-9d2c-28e11c5180ee" />


Mobile
<img width="796" height="1350" alt="image" src="https://github.com/user-attachments/assets/0138c50f-ba1b-49e0-8b7f-02b2fd4f3f76" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes customer login redirect paths and shipping mode toggle placement behind themeV2, but legacy checkout UI is preserved and tests cover redirect and header behavior; shipping relies on context overriding the step prop for the real click handler.
> 
> **Overview**
> For **themeV2** checkouts, this tightens step layout by surfacing CTAs on the same row as the step title and adjusting guest-form layout.
> 
> **Checkout step headers** gain an optional `headerAction` slot (active step only), plus `CheckoutStepHeaderActionContext` so deep children (e.g. shipping) can register an interactive CTA. Customer shows “Already have an account? Sign in now” from `CustomerStep` (removed from `GuestForm` / `StripeGuestForm` under themeV2); shipping’s multi-address toggle is pushed via context from `ShippingHeader` (with confirmation modals) while `ShippingStep` still supplies static label text when context is unset.
> 
> **Guest forms** under themeV2 move privacy policy into the email column, drop side-by-side continue styling (`customerEmail-button` / `stripeCustomerEmail-button` only when `!themeV2`), and centralize storefront auth redirect in `attemptStorefrontLoginRedirect` (used by guest forms, customer step, and `RedirectToStorefrontLogin`).
> 
> **Shared logic:** `shouldShowMultiShippingToggle` replaces inlined checks in `useShipping` and `ShippingStep`.
> 
> **SCSS:** themeV2 step header padding, `stepHeader-actions--cta` responsive layout, customer-step mobile full-width email/continue, and larger primary heading font size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0368fe7cda27395e542098ecc05cc31a7c875bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->