### PR TITLE
chore(checkout): CHECKOUT-10249 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.943.0",
+        "@bigcommerce/checkout-sdk": "^1.943.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.943.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.0.tgz",
-      "integrity": "sha512-QM38Yy8MfOQwp/lKh6LcQ6Rzj755ohDjfVXYTswreKSEWqOck9WSQYHrC52IuRtCVkIXlsNgvy9ueFO/V1lj7w==",
+      "version": "1.943.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.1.tgz",
+      "integrity": "sha512-ChFXiMrK/hX0eM9UYnc9XCcb3sMUQQ7lkvE9rwNYGTT/GQnK4gizJ5YidOH9+HAG8PoUZa1yxAqsx6nvoSBNjQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29814,9 +29814,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.943.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.0.tgz",
-      "integrity": "sha512-QM38Yy8MfOQwp/lKh6LcQ6Rzj755ohDjfVXYTswreKSEWqOck9WSQYHrC52IuRtCVkIXlsNgvy9ueFO/V1lj7w==",
+      "version": "1.943.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.1.tgz",
+      "integrity": "sha512-ChFXiMrK/hX0eM9UYnc9XCcb3sMUQQ7lkvE9rwNYGTT/GQnK4gizJ5YidOH9+HAG8PoUZa1yxAqsx6nvoSBNjQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.943.0",
+    "@bigcommerce/checkout-sdk": "^1.943.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
Jira: [CHECKOUT-10249](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10249)

## What/Why?

Bump `@bigcommerce/checkout-sdk` from 1.943.0 to 1.943.1. 
- https://github.com/bigcommerce/checkout-sdk-js/pull/3322

## Rollout/Rollback

Revert.

## Testing

CI.

[CHECKOUT-10249]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout SDK upgrades can affect payment and checkout behavior at runtime even without local code edits; risk depends on what changed in SDK 1.943.1.
> 
> **Overview**
> Updates the **`@bigcommerce/checkout-sdk`** dependency from **1.943.0** to **1.943.1** in `package.json` and `package-lock.json` (CHECKOUT-10249), pulling in changes from [checkout-sdk-js#3322](https://github.com/bigcommerce/checkout-sdk-js/pull/3322). There are **no first-party source changes** in this repo—only the resolved SDK version and integrity hash in the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c2e4a84a45e664566ad50172a421ccbb0208de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->