### PR TITLE
feat(checkout): CHECKOUT-10208 Accessibility - payment radio buttons keyboard operable

### DIFF
--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -110,6 +110,16 @@ describe('PaymentForm', () => {
         expect(screen.getByTestId('providers-section-on-top-of-payments-list')).toBeInTheDocument();
     });
 
+    it('keeps payment method radios keyboard-operable while a payment method is initializing', () => {
+        render(<PaymentFormTest {...defaultProps} isInitializingPayment={true} />);
+
+        const radios = screen.getAllByRole('radio');
+
+        expect(radios).toHaveLength(2);
+        radios.forEach((radio) => expect(radio).toBeEnabled());
+        expect(screen.getByTestId('loading-overlay')).toBeInTheDocument();
+    });
+
     it('renders terms and conditions field if copy is provided', () => {
         const textAcceptTerms = 'Accept terms';
 

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -120,6 +120,24 @@ describe('PaymentForm', () => {
         expect(screen.getByTestId('loading-overlay')).toBeInTheDocument();
     });
 
+    it('does not trigger payment method selection when a radio is activated while a payment method is initializing', () => {
+        const onMethodSelect = jest.fn();
+
+        render(
+            <PaymentFormTest
+                {...defaultProps}
+                isInitializingPayment={true}
+                onMethodSelect={onMethodSelect}
+            />,
+        );
+
+        const radios = screen.getAllByRole('radio');
+
+        fireEvent.click(radios[1]);
+
+        expect(onMethodSelect).not.toHaveBeenCalled();
+    });
+
     it('renders terms and conditions field if copy is provided', () => {
         const textAcceptTerms = 'Accept terms';
 

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -120,7 +120,7 @@ describe('PaymentForm', () => {
         expect(screen.getByTestId('loading-overlay')).toBeInTheDocument();
     });
 
-    it('does not trigger payment method selection when a radio is activated while a payment method is initializing', () => {
+    it('does not change the selected payment method when a radio is activated while a payment method is initializing', () => {
         const onMethodSelect = jest.fn();
 
         render(
@@ -133,9 +133,12 @@ describe('PaymentForm', () => {
 
         const radios = screen.getAllByRole('radio');
 
+        expect(radios[1]).not.toBeChecked();
+
         fireEvent.click(radios[1]);
 
         expect(onMethodSelect).not.toHaveBeenCalled();
+        expect(radios[1]).not.toBeChecked();
     });
 
     it('renders terms and conditions field if copy is provided', () => {

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -3,7 +3,7 @@ import { find, get, noop } from 'lodash';
 import React, { type FunctionComponent, memo, useCallback, useMemo } from 'react';
 
 import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
-import { Checklist, ChecklistItem } from '@bigcommerce/checkout/ui';
+import { Checklist, ChecklistItem, LoadingOverlay } from '@bigcommerce/checkout/ui';
 
 import { connectFormik, type ConnectFormikProps } from '../../common/form';
 import { isMobile } from '../../common/utility';
@@ -87,47 +87,46 @@ const PaymentMethodList: FunctionComponent<
             <div aria-live="assertive" className="is-srOnly" role="status">
                 {titleText}
             </div>
-            <Checklist
-                defaultSelectedItemId={values.paymentProviderRadio}
-                isDisabled={isInitializingPayment}
-                name="paymentProviderRadio"
-                onSelect={handleSelect}
-            >
-                {methods.map((method) => {
-                    const value = getUniquePaymentMethodId(method.id, method.gateway);
-                    const showOnlyOnMobileDevices = get(
-                        method,
-                        'initializationData.showOnlyOnMobileDevices',
-                        false,
-                    );
+            <LoadingOverlay isLoading={Boolean(isInitializingPayment)}>
+                <Checklist
+                    defaultSelectedItemId={values.paymentProviderRadio}
+                    name="paymentProviderRadio"
+                    onSelect={handleSelect}
+                >
+                    {methods.map((method) => {
+                        const value = getUniquePaymentMethodId(method.id, method.gateway);
+                        const showOnlyOnMobileDevices = get(
+                            method,
+                            'initializationData.showOnlyOnMobileDevices',
+                            false,
+                        );
 
-                    if (showOnlyOnMobileDevices && !isMobile()) {
-                        return;
-                    }
+                        if (showOnlyOnMobileDevices && !isMobile()) {
+                            return;
+                        }
 
-                    return (
-                        <PaymentMethodListItem
-                            disabledReason={
-                                method === chequeMethod ? chequeDisabledReason : undefined
-                            }
-                            isDisabled={isInitializingPayment}
-                            isEmbedded={isEmbedded}
-                            isUsingMultiShipping={isUsingMultiShipping}
-                            key={value}
-                            method={method}
-                            onUnhandledError={onUnhandledError}
-                            value={value}
-                        />
-                    );
-                })}
-            </Checklist>
+                        return (
+                            <PaymentMethodListItem
+                                disabledReason={
+                                    method === chequeMethod ? chequeDisabledReason : undefined
+                                }
+                                isEmbedded={isEmbedded}
+                                isUsingMultiShipping={isUsingMultiShipping}
+                                key={value}
+                                method={method}
+                                onUnhandledError={onUnhandledError}
+                                value={value}
+                            />
+                        );
+                    })}
+                </Checklist>
+            </LoadingOverlay>
         </>
     );
 };
 
 interface PaymentMethodListItemProps {
     disabledReason?: PoDisabledReason;
-    isDisabled?: boolean;
     isEmbedded?: boolean;
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
@@ -137,7 +136,6 @@ interface PaymentMethodListItemProps {
 
 const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     disabledReason,
-    isDisabled,
     isEmbedded,
     isUsingMultiShipping,
     method,
@@ -175,7 +173,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
         <ChecklistItem
             content={renderPaymentMethod}
             htmlId={`radio-${value}`}
-            isDisabled={isDisabled || Boolean(disabledReason)}
+            isDisabled={Boolean(disabledReason)}
             label={renderPaymentMethodTitle}
             value={value}
         />

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -77,13 +77,9 @@ const PaymentMethodList: FunctionComponent<
 
     const handleSelect = useCallback(
         (value: string) => {
-            if (isInitializingPayment) {
-                return;
-            }
-
             onSelect(getPaymentMethodFromListValue(methods, value));
         },
-        [isInitializingPayment, methods, onSelect],
+        [methods, onSelect],
     );
 
     return (
@@ -115,6 +111,7 @@ const PaymentMethodList: FunctionComponent<
                                     method === chequeMethod ? chequeDisabledReason : undefined
                                 }
                                 isEmbedded={isEmbedded}
+                                isInitializingPayment={isInitializingPayment}
                                 isUsingMultiShipping={isUsingMultiShipping}
                                 key={value}
                                 method={method}
@@ -132,6 +129,7 @@ const PaymentMethodList: FunctionComponent<
 interface PaymentMethodListItemProps {
     disabledReason?: PoDisabledReason;
     isEmbedded?: boolean;
+    isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     method: PaymentMethod;
     value: string;
@@ -141,6 +139,7 @@ interface PaymentMethodListItemProps {
 const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
     disabledReason,
     isEmbedded,
+    isInitializingPayment,
     isUsingMultiShipping,
     method,
     onUnhandledError,
@@ -178,6 +177,7 @@ const PaymentMethodListItem: FunctionComponent<PaymentMethodListItemProps> = ({
             content={renderPaymentMethod}
             htmlId={`radio-${value}`}
             isDisabled={Boolean(disabledReason)}
+            isReadOnly={isInitializingPayment}
             label={renderPaymentMethodTitle}
             value={value}
         />

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -77,9 +77,13 @@ const PaymentMethodList: FunctionComponent<
 
     const handleSelect = useCallback(
         (value: string) => {
+            if (isInitializingPayment) {
+                return;
+            }
+
             onSelect(getPaymentMethodFromListValue(methods, value));
         },
-        [methods, onSelect],
+        [isInitializingPayment, methods, onSelect],
     );
 
     return (

--- a/packages/ui/src/form/ChecklistItem/ChecklistItem.test.tsx
+++ b/packages/ui/src/form/ChecklistItem/ChecklistItem.test.tsx
@@ -2,7 +2,7 @@ import { Formik } from 'formik';
 import { noop } from 'lodash';
 import React from 'react';
 
-import { render, screen } from '@bigcommerce/checkout/test-utils';
+import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
 
 import AccordionContext from '../../accordion/AccordionContext';
 import { ChecklistContext } from '../Checklist/Checklist';
@@ -35,5 +35,19 @@ describe('ChecklistItem', () => {
         renderChecklistItem({ isDisabled: true });
 
         expect(screen.getByRole('radio')).toBeDisabled();
+    });
+
+    it('keeps the radio input focusable but ignores selection when isReadOnly is true', () => {
+        renderChecklistItem({ isReadOnly: true });
+
+        const radio = screen.getByRole('radio');
+
+        expect(radio).toBeEnabled();
+        expect(radio).toHaveAttribute('aria-disabled', 'true');
+        expect(radio).not.toBeChecked();
+
+        fireEvent.click(radio);
+
+        expect(radio).not.toBeChecked();
     });
 });

--- a/packages/ui/src/form/ChecklistItem/ChecklistItem.tsx
+++ b/packages/ui/src/form/ChecklistItem/ChecklistItem.tsx
@@ -1,6 +1,6 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 import { type FieldProps } from 'formik';
-import { kebabCase } from 'lodash';
+import { kebabCase, noop } from 'lodash';
 import React, {
     type FunctionComponent,
     memo,
@@ -18,12 +18,15 @@ export interface ChecklistItemProps {
     content?: ReactNode;
     htmlId?: string;
     isDisabled?: boolean;
+    // Unlike isDisabled, keeps the input focusable while blocking selection.
+    isReadOnly?: boolean;
     label: ReactNode | ((isSelected: boolean) => ReactNode);
     value: string;
 }
 
 const ChecklistItem: FunctionComponent<ChecklistItemProps> = ({
     isDisabled,
+    isReadOnly,
     value,
     content,
     htmlId = kebabCase(value),
@@ -37,15 +40,17 @@ const ChecklistItem: FunctionComponent<ChecklistItemProps> = ({
         memoizeOne((isSelected: boolean) => ({ field }: FieldProps) => (
             <ChecklistItemInput
                 {...field}
+                aria-disabled={isReadOnly || undefined}
                 disabled={isDisabled}
                 id={htmlId}
                 isSelected={field.value === value}
+                onChange={isReadOnly ? noop : field.onChange}
                 value={value}
             >
                 {label instanceof Function ? label(isSelected) : label}
             </ChecklistItemInput>
         )),
-        [htmlId, isDisabled, label, value],
+        [htmlId, isDisabled, isReadOnly, label, value],
     );
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui/src/form/ChecklistItem/ChecklistItem.tsx
+++ b/packages/ui/src/form/ChecklistItem/ChecklistItem.tsx
@@ -18,7 +18,6 @@ export interface ChecklistItemProps {
     content?: ReactNode;
     htmlId?: string;
     isDisabled?: boolean;
-    // Unlike isDisabled, keeps the input focusable while blocking selection.
     isReadOnly?: boolean;
     label: ReactNode | ((isSelected: boolean) => ReactNode);
     value: string;


### PR DESCRIPTION
## What/Why?

### What
Allows the payment method radio buttons on checkout to be accessible using the keyboard's up/down arrow keys.

- Wraps the `Checklist` in a `LoadingOverlay` to communicate the loading state visually, instead of disabling the controls.
- Keeps the payment method radios **enabled and keyboard-operable** during initialisation, so keyboard/assistive technology users retain access.
- Adds a new `isReadOnly` prop to the shared `ChecklistItem` component (`packages/ui`): it overrides the input's `onChange` with a no-op and sets `aria-disabled`, keeping the radio focusable while preventing it from being toggled — unlike `isDisabled`, which uses the native `disabled` attribute and removes it from the tab order.
- `PaymentMethodList` threads `isInitializingPayment` down to each item as `isReadOnly`, so selection is blocked while a method is initializing, without affecting keyboard reachability.

### Why?
Restores keyboard and screen-reader access to the payment method selector during initialisation, while still signalling the section is loading and preventing a method from being changed mid-initialization.

**Problem:** the original disabled-radio approach removed items from the tab order, breaking keyboard/AT access. An earlier attempt at fixing this only blocked the `onMethodSelect` callback, but testing showed Formik's own field `onChange` (wired directly to the radio input) still changed `paymentProviderRadio` and the visually selected item — silently desyncing the selected method from what was actually being initialized/validated/submitted. The `isReadOnly` prop closes that gap at the source, by intercepting the input's `onChange` directly rather than relying on a downstream guard.
## Rollout/Rollback
Revert the PR.

## Testing
- Added `ChecklistItem.test.tsx` coverage: with `isReadOnly`, the radio stays focusable/enabled but doesn't get checked when clicked.
- Added `PaymentForm.test.tsx` coverage: clicking a different payment method radio during `isInitializingPayment` does not change which radio is checked, and does not call `onMethodSelect`.

### Before
Shoppers can't tab into the payment method radio button group, and can't select an option using the up/down arrow keys.

**Theme v2**
https://github.com/user-attachments/assets/73763df5-52a1-48b5-a1df-b857dcfb5d8b

**Theme v1**
https://github.com/user-attachments/assets/84f743f4-8eab-4d28-92b7-f9a5f79ce474


### After
Shoppers can tab into the payment method radio button group, and select an option using the up/down arrow keys.

**Theme v2**
https://github.com/user-attachments/assets/4b146e15-ad55-4fbf-b4d0-1b172442c207

**Theme v1**
https://github.com/user-attachments/assets/a37e5b5a-bc10-4d34-bce0-4a473113bc20



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the checkout payment selection path and Formik wiring; behavior is constrained by tests and only applies during payment initialization, but regressions could affect which method is submitted.
> 
> **Overview**
> Fixes checkout payment method selection during initialization so keyboard and assistive-tech users can still reach the radio group, while blocking actual method changes until init finishes.
> 
> **Payment method list:** The checklist is no longer disabled during `isInitializingPayment`. A `LoadingOverlay` shows loading instead. Each `ChecklistItem` gets `isReadOnly` while initializing (cheque/PO disable reasons still use `isDisabled` only).
> 
> **Shared `ChecklistItem`:** New optional `isReadOnly` sets `aria-disabled` and swaps the radio’s `onChange` for a no-op so Formik’s field value does not update on click—unlike `disabled`, which removes radios from the tab order.
> 
> Tests cover read-only checklist behavior and that `PaymentForm` does not call `onMethodSelect` or change the checked radio when initializing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7354d561a1b0cecad9de0da38fe759491da8113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->