### PR TITLE
feat(checkout): CHECKOUT-10185 Remove checkout step subheaders for themeV2

### DIFF
--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -289,6 +289,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     values,
 }) => {
     const { setSubmitted } = useContext(FormContext);
+    const { themeV2 } = useThemeContext();
 
     const handlePaymentMethodSelect = useCallback(
         (method: PaymentMethod) => {
@@ -318,7 +319,7 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     return (
         <Fieldset
             legend={
-                <Legend>
+                <Legend hidden={themeV2}>
                     <TranslatedString id="payment.payment_methods_text" />
                 </Legend>
             }

--- a/packages/core/src/app/shipping/ShippingHeader.tsx
+++ b/packages/core/src/app/shipping/ShippingHeader.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import React, { type FunctionComponent, memo, useState } from 'react';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
+import { useThemeContext } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { ConfirmationModal, Legend } from '@bigcommerce/checkout/ui';
@@ -26,6 +27,9 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
         useState(false);
     const [isMultiShippingUnavailableModalOpen, setIsMultiShippingUnavailableModalOpen] =
         useState(false);
+    const { themeV2 } = useThemeContext();
+
+    const isSubheaderHidden = themeV2 && !isMultiShippingMode;
 
     const handleShipToSingleConfirmation = () => {
         setIsSingleShippingConfirmationModalOpen(false);
@@ -40,7 +44,7 @@ const ShippingHeader: FunctionComponent<ShippingHeaderProps> = ({
         <>
             <Extension region={ExtensionRegion.ShippingShippingAddressFormBefore} />
             <div className={classNames(['form-legend-container', 'shipping-header'])}>
-                <Legend testId="shipping-address-heading">
+                <Legend hidden={isSubheaderHidden} testId="shipping-address-heading">
                     <TranslatedString
                         id={
                             isMultiShippingMode

--- a/packages/core/src/app/shipping/StaticConsignmentV2.tsx
+++ b/packages/core/src/app/shipping/StaticConsignmentV2.tsx
@@ -2,8 +2,6 @@ import { type Consignment } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import React, { type FunctionComponent, memo } from 'react';
 
-import { useThemeContext } from '@bigcommerce/checkout/contexts';
-import { TranslatedString } from '@bigcommerce/checkout/locale';
 import {
     isPayPalFastlaneAddress,
     PoweredByPayPalFastlaneLabel,
@@ -27,7 +25,6 @@ const StaticConsignmentV2: FunctionComponent<StaticConsignmentV2Props> = ({
     isShippingDiscountDisplayEnabled,
 }) => {
     const { paypalFastlaneAddresses } = usePayPalFastlaneAddress();
-    const { themeV2 } = useThemeContext();
     const isMobile = isMobileView();
 
     const {
@@ -49,22 +46,12 @@ const StaticConsignmentV2: FunctionComponent<StaticConsignmentV2Props> = ({
             )}
         >
             <div className="flex-column shipping-address-container">
-                {!themeV2 && (
-                    <p className="title">
-                        <TranslatedString id="shipping.shipping_address_heading" />
-                    </p>
-                )}
                 <StaticAddress address={address} type={AddressType.Shipping} />
                 {showPayPalFastlaneAddressLabel && <PoweredByPayPalFastlaneLabel />}
             </div>
 
             {selectedShippingOption && (
                 <div className="flex-column shipping-method">
-                    {!themeV2 && (
-                        <p className="title">
-                            <TranslatedString id="shipping.shipping_method_label" />
-                        </p>
-                    )}
                     <div className="shippingOption shippingOption--alt shippingOption--selected">
                         <StaticShippingOption
                             displayAdditionalInformation={false}

--- a/packages/core/src/app/shipping/StaticConsignmentV2.tsx
+++ b/packages/core/src/app/shipping/StaticConsignmentV2.tsx
@@ -2,6 +2,7 @@ import { type Consignment } from '@bigcommerce/checkout-sdk';
 import classNames from 'classnames';
 import React, { type FunctionComponent, memo } from 'react';
 
+import { useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import {
     isPayPalFastlaneAddress,
@@ -26,6 +27,7 @@ const StaticConsignmentV2: FunctionComponent<StaticConsignmentV2Props> = ({
     isShippingDiscountDisplayEnabled,
 }) => {
     const { paypalFastlaneAddresses } = usePayPalFastlaneAddress();
+    const { themeV2 } = useThemeContext();
     const isMobile = isMobileView();
 
     const {
@@ -47,18 +49,22 @@ const StaticConsignmentV2: FunctionComponent<StaticConsignmentV2Props> = ({
             )}
         >
             <div className="flex-column shipping-address-container">
-                <p className="title">
-                    <TranslatedString id="shipping.shipping_address_heading" />
-                </p>
+                {!themeV2 && (
+                    <p className="title">
+                        <TranslatedString id="shipping.shipping_address_heading" />
+                    </p>
+                )}
                 <StaticAddress address={address} type={AddressType.Shipping} />
                 {showPayPalFastlaneAddressLabel && <PoweredByPayPalFastlaneLabel />}
             </div>
 
             {selectedShippingOption && (
                 <div className="flex-column shipping-method">
-                    <p className="title">
-                        <TranslatedString id="shipping.shipping_method_label" />
-                    </p>
+                    {!themeV2 && (
+                        <p className="title">
+                            <TranslatedString id="shipping.shipping_method_label" />
+                        </p>
+                    )}
                     <div className="shippingOption shippingOption--alt shippingOption--selected">
                         <StaticShippingOption
                             displayAdditionalInformation={false}

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -28,6 +28,14 @@
             margin: spacing("single") 0;
         }
         
+        // :not(:last-child) keeps collapsed steps unaffected
+        .checkout-step--shipping,
+        .checkout-step--payment {
+            .checkout-view-header:not(:last-child) {
+                margin-bottom: spacing("half");
+            }
+        }
+
         .stepHeader {
             flex-wrap: wrap;
             padding: 0;

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -36,6 +36,10 @@
             }
         }
 
+        .shipping-header:not(:has(> :not(.is-srOnly))) {
+            padding-bottom: 0;
+        }
+
         .stepHeader {
             flex-wrap: wrap;
             padding: 0;

--- a/packages/core/src/scss/themeV2/components/checkout/_staticConsignment.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_staticConsignment.scss
@@ -6,6 +6,8 @@
     }
 
     @include themeV2 {
+        padding-top: spacing("quarter");
+
         .shippingOption {
             border: 0;
             margin-top: 0;
@@ -14,12 +16,6 @@
 
         .shipping-address-container {
             width: 60%;
-        }
-
-        .title {
-            font-size: fontSize("base");
-            font-weight: fontWeight("bold");
-            margin-bottom: spacing("quarter");
         }
     }
 }


### PR DESCRIPTION
## What/Why?

Removes subheaders from Shipping and Payment steps. We want to remove these headings to make checkout feel less text-heavy.

## Rollout/Rollback

Revert the PR. The change only affects themeV2. themeV1 is unaffected.

## Testing

Manual testing with themeV2 store.

Before:
<img width="982" height="769" alt="Screenshot 2026-07-23 at 10 05 24 AM" src="https://github.com/user-attachments/assets/098209b5-4cce-4784-9acf-d550d14bf324" />

<img width="980" height="776" alt="Screenshot 2026-07-23 at 10 06 43 AM" src="https://github.com/user-attachments/assets/ce1a42ae-ce71-41ad-b207-93d50fca0057" />

After:
<img width="980" height="768" alt="Screenshot 2026-07-23 at 11 09 43 AM" src="https://github.com/user-attachments/assets/ebbc3d2f-2dc8-49a7-ada5-2be939b28562" />

<img width="980" height="768" alt="Screenshot 2026-07-23 at 11 40 57 AM" src="https://github.com/user-attachments/assets/d92bddaa-dfb8-47a7-b686-14c1e4430c0f" />

NOTE:
Ship to multiple addresses looks a bit off now, but we have a separate ticket to fix this: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10184 (it will be moved to another area)
<img width="980" height="768" alt="Screenshot 2026-07-23 at 11 27 38 AM" src="https://github.com/user-attachments/assets/422a3330-5cb2-4b41-b11f-aa8c64427687" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes gated on themeV2; themeV1 behavior is unchanged and fieldset legends remain for accessibility.
> 
> **Overview**
> For **themeV2** only, shipping and payment steps show less redundant heading text so the flow feels lighter.
> 
> **Payment** hides the “Payment methods” fieldset legend via `Legend hidden={themeV2}` while keeping it available for assistive tech (`is-srOnly`). **Shipping** hides the shipping-address legend when themeV2 and single-address mode; the multiship heading stays visible. **Static consignment (V2)** drops the extra “Shipping address” and “Shipping method” title lines above the summary content.
> 
> **themeV2 SCSS** tightens layout: smaller gap under shipping/payment view headers (without affecting collapsed steps), zero bottom padding on `.shipping-header` when only screen-reader content remains, and adjusted static-consignment top spacing after removing the titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603457a7ebd413a720adf4f6e73893da4b409899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->