### PR TITLE
fix(checkout): CHECKOUT-10067 show loading skeleton during persisting b2b meta data

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -103,6 +103,7 @@ export interface WithCheckoutProps {
     isGuestEnabled: boolean;
     isLoadingCheckout: boolean;
     isPending: boolean;
+    isPersistingB2BMetadata: boolean;
     isPriceHiddenFromGuests: boolean;
     isShowingWalletButtonsOnTop: boolean;
     isShippingDiscountDisplayEnabled: boolean;
@@ -144,6 +145,7 @@ const Checkout = ({
     language,
     cartUrl,
     isPending,
+    isPersistingB2BMetadata,
     isPriceHiddenFromGuests,
     containerId,
     embeddedStylesheet,
@@ -703,7 +705,9 @@ const Checkout = ({
         };
     }, []);
 
-    if (state.isRedirecting) {
+    // The payment step unmounts once the order is placed, so show the confirmation skeleton
+    // while B2B metadata persists to avoid a blank page.
+    if (state.isRedirecting || isPersistingB2BMetadata) {
         return <OrderConfirmationPageSkeleton />;
     }
 

--- a/packages/core/src/app/checkout/mapToCheckoutProps.ts
+++ b/packages/core/src/app/checkout/mapToCheckoutProps.ts
@@ -56,6 +56,7 @@ export default function mapToCheckoutProps({
         isLoadingCheckout: statuses.isLoadingCheckout(),
         isShippingDiscountDisplayEnabled,
         isPending: statuses.isPending(),
+        isPersistingB2BMetadata: statuses.isPersistingB2BMetadata(),
         isPriceHiddenFromGuests,
         isShowingWalletButtonsOnTop: walletButtonsOnTopFlag,
         loadCheckout: checkoutService.loadCheckout,


### PR DESCRIPTION
## What/Why?

- Show a loading skeleton when persisting B2B meta data post order.
- Because previously the payment step would display empty because the order was complete.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing


**BEFORE**

https://github.com/user-attachments/assets/2cd29a28-19e0-4526-8600-5796bbd88419



**AFTER**

https://github.com/user-attachments/assets/b9419e91-b449-4240-8f92-a5a39d933230


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading state tied to an existing checkout status flag; no changes to order submission or B2B persistence logic.
> 
> **Overview**
> Fixes a **blank checkout screen** after B2B orders complete: the payment step unmounts as soon as the order is placed, but post-order **B2B metadata persistence** can still be running.
> 
> The checkout page now reads **`isPersistingB2BMetadata`** from checkout store statuses (via `mapToCheckoutProps`) and treats it like an in-flight redirect—rendering **`OrderConfirmationPageSkeleton`** until persistence finishes, not only when `isRedirecting` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10c18937c0a237e84192253fa1b7283ec8002c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->