### PR TITLE
fix(checkout): CHECKOUT-10187 Reduce order summary gap and payment margin for themeV2

### DIFF
--- a/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
@@ -62,6 +62,7 @@
 
     @include themeV2-desktop {
         width: grid-calc(5, $total-columns);
+        padding-left: remCalc(30px);
         padding-right: spacing("single");
         position: sticky;
         right: auto;

--- a/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
@@ -72,7 +72,7 @@
         order: 0; // Reset order on large screens and above
 
         .cart {
-            margin: spacing("double") 0 spacing("single");
+            margin: 2rem 0 spacing("single");
         }
     }
 

--- a/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
@@ -40,6 +40,16 @@
     }
 }
 
+.form-checklist-body {
+    @include themeV2 {
+        margin-left: $checklist-pip-spacing--small;
+
+        @include breakpoint("small") {
+            margin-left: $checklist-pip-spacing;
+        }
+    }
+}
+
 .form-checklist-checkbox {
     @include themeV2 {
         &:focus ~ .form-label {

--- a/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
@@ -43,15 +43,25 @@
 .form-checklist-body {
     @include themeV2 {
         margin-left: $checklist-pip-spacing--small;
+        margin-right: $checklist-pip-spacing--small;
 
         @include breakpoint("small") {
             margin-left: $checklist-pip-spacing;
+            margin-right: $checklist-pip-spacing;
         }
     }
 }
 
 .form-checklist-checkbox {
     @include themeV2 {
+        & ~ .form-label {
+            padding-right: $checklist-pip-spacing--small;
+
+            @include breakpoint("small") {
+                padding-right: $checklist-pip-spacing;
+            }
+        }
+
         &:focus ~ .form-label {
             box-shadow: $checklist-focus-boxShadow;
         }

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -83,13 +83,17 @@
 
         .layout-main {
             width: grid-calc(7, $total-columns);
+            padding-right: remCalc(30px);
+        }
+
+        .checkout-steps {
+            padding-right: 0;
         }
     }
 
     @include themeV2-widescreen {
         .layout-main {
             width: grid-calc(8, $total-columns);
-            padding-right: spacing("single");
         }
     }
 }

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -21,6 +21,10 @@
             margin-top: #{spacing('base') + spacing('base')};
         }
 
+        .discountBanner {
+            margin-top: 2rem;
+        }
+
         .checkout-step {
             background-color: $color-white;
             border-bottom: none;


### PR DESCRIPTION
## What/Why?

Reduce the gap to exactly 60px as per new designs. Reduce the gap between payment details and left border as well (see screenshots in comments for reference).

## Rollout/Rollback

Revert the PR. This only impacts theme V2. Theme V1 is unaffected by the change.

## Testing

Manual visual testing on a theme v2 store.

Before:

https://github.com/user-attachments/assets/c197677f-dc1a-4798-861f-f620f342ad15

After:

https://github.com/user-attachments/assets/06fa7421-ab86-46b4-a60b-3e4677295d18


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only SCSS for theme V2 checkout layout; theme V1 is untouched and rollback is a simple revert.
> 
> **Overview**
> **Theme V2 checkout layout** is adjusted on desktop so the main column and order summary sit with a **60px** gutter: `layout-main` gets `padding-right: remCalc(30px)` and `layout-cart` gets matching `padding-left`, and widescreen no longer adds extra right padding on the main column. **Order summary** top spacing uses **2rem** instead of the double spacing token.
> 
> **Discount banner** spacing is increased with **2rem** top margin. **Payment/shipping checklist** items get horizontal inset on `.form-checklist-body` and right padding on labels via the existing **checklist-pip-spacing** variables so content aligns with the radio pip and the left border gap matches design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf67830a23f0a5f7140f71e9ec3a629b6ad704d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->