### PR TITLE
fix(checkout): CHECKOUT-10153 Always render billing step for digital items in themeV2

### DIFF
--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
@@ -248,6 +248,20 @@ describe('PaymentBillingForm', () => {
             expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
         });
 
+        it('hides the toggle and shows the address fields for a digital-only cart', () => {
+            const cart = getCart();
+
+            jest.spyOn(checkoutState.data, 'getCart').mockReturnValue({
+                ...cart,
+                lineItems: { ...cart.lineItems, physicalItems: [] },
+            });
+
+            renderForm({ ...defaultProps, isBillingSameAsShipping: true });
+
+            expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
+            expect(screen.getByText('First Name')).toBeInTheDocument();
+        });
+
         it('stays unchecked and does not re-fire on a billing address reinitialize', async () => {
             const onBillingSameAsShippingChange = jest.fn();
             const props = {

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -106,8 +106,6 @@ const PaymentBillingFormComponent = ({
     const hasShippableItems = getShippableItemsCount(cart) > 0;
     const shouldShowOrderComments = enableOrderComments && !hasShippableItems;
     const shouldShowSaveAddress = !hideSaveToAddressBookCheck && !isGuest;
-    // With no shippable items there is no shipping address to mirror, so the
-    // toggle is hidden and the billing form renders expanded.
     const shouldShowBillingSameAsShipping =
         !shouldRenderStaticAddress && !hideBillingSameAsShippingCheck && hasShippableItems;
     const isBillingAddressCollapsed =

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -103,10 +103,13 @@ const PaymentBillingFormComponent = ({
             getFields(billingAddress.countryCode),
         );
     const { enableOrderComments } = config.checkoutSettings;
-    const shouldShowOrderComments = enableOrderComments && getShippableItemsCount(cart) < 1;
+    const hasShippableItems = getShippableItemsCount(cart) > 0;
+    const shouldShowOrderComments = enableOrderComments && !hasShippableItems;
     const shouldShowSaveAddress = !hideSaveToAddressBookCheck && !isGuest;
+    // With no shippable items there is no shipping address to mirror, so the
+    // toggle is hidden and the billing form renders expanded.
     const shouldShowBillingSameAsShipping =
-        !shouldRenderStaticAddress && !hideBillingSameAsShippingCheck;
+        !shouldRenderStaticAddress && !hideBillingSameAsShippingCheck && hasShippableItems;
     const isBillingAddressCollapsed =
         shouldShowBillingSameAsShipping && values.billingSameAsShipping;
 


### PR DESCRIPTION
## What/Why?

When our cart only consists of digital items render billing step expanded. There is no shipping step in this case so it makes sense to remove the toggle and just render the billing form.

## Rollout/Rollback

Revert the PR. Only affects functionality in themeV2. ThemeV1 is unaffected.

## Testing

Manual on a themeV2 store.

### Before:

https://github.com/user-attachments/assets/14684f99-a21e-4e15-8db9-ccba9113f69d

### After:

https://github.com/user-attachments/assets/5b9bd854-1040-40bc-b2a8-f0d95c7484af

Keep existing behavior for physical items or mixed carts:

https://github.com/user-attachments/assets/8cd5c8e2-76a2-436a-87a1-1b2b89bd15fb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ThemeV2 payment billing UI only; physical and mixed carts keep the existing toggle behavior.
> 
> **Overview**
> For **digital-only carts** (no physical line items), checkout payment billing no longer shows the **“Same as shipping address”** toggle and keeps the billing address fields visible, since there is no shipping step to mirror.
> 
> `PaymentBillingForm` gates `shouldShowBillingSameAsShipping` on `hasShippableItems` (`getShippableItemsCount(cart) > 0`). Order-comments visibility for non-shippable carts is unchanged in behavior, expressed via the same `hasShippableItems` flag. A unit test covers the digital-only case (toggle hidden, **First Name** shown even when `isBillingSameAsShipping` is true).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 357e64a6c707445faa1e2b7a108db04c214ed383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->