### PR TITLE
feat(payment): add shipping options filtering callback for Stripe Link V2

### DIFF
--- a/packages/stripe-integration/src/stripe-ocs/StripeLinkV2Button.tsx
+++ b/packages/stripe-integration/src/stripe-ocs/StripeLinkV2Button.tsx
@@ -8,10 +8,19 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 import { navigateToOrderConfirmation } from '@bigcommerce/checkout/utility';
+import { ShippingOption } from '@bigcommerce/checkout-sdk';
 
 const StripeLinkV2Button: FunctionComponent<CheckoutButtonProps> = (props) => {
+    const filterAvailableShippingOptions = (shippingOptions: ShippingOption[]) => {
+        // INFO: filter function can return a Promise or a value
+        return new Promise((resolve) => {
+            resolve(shippingOptions.filter((option) => option.type !== "shipping_pickupinstore"));
+        });
+        // return shippingOptions.filter((option) => option.type !== "shipping_pickupinstore");
+    };
     const additionalInitializationOptions = {
         onComplete: navigateToOrderConfirmation,
+        filterAvailableShippingOptions,
         loadingContainerId: 'checkout-app',
         methodId: 'optimized_checkout',
         gatewayId: 'stripeocs',


### PR DESCRIPTION
## What/Why?

Adds an optional `filterAvailableShippingOptions` callback to `StripeOCSCustomerInitializeOptions`, consumed by both Stripe Link V2 strategies (customer and button). This lets a checkout implementation filter which shipping options are shown in the Stripe Link / Express Checkout payment sheet, e.g. to hide rates that shouldn't be offered for this payment flow:

```ts
checkoutService.initializeCustomer({
    methodId: 'stripeocs',
    stripeocs: {
        // ...
        filterAvailableShippingOptions: async (shippingOptions) =>
            shippingOptions.filter((option) => option.description !== 'Freight'),
    },
});
```

Behavior:

- The callback receives the consignment's full availableShippingOptions and returns the subset to display; it runs in _getAvailableShippingOptions before options are mapped to Stripe shipping rates.
- If the callback rejects or throws, the strategy logs the error and falls back to the unfiltered options, so the shipping-address-change event always resolves and the payment sheet never hangs.
- If the currently selected shipping option is filtered out, it is treated as unselected and the recommended (or first remaining) option is re-selected via selectShippingOption, keeping BigCommerce consignment state in sync with what the Stripe sheet displays.
- When the callback is not provided, behavior is unchanged.

## Rollout/Rollback
Rollback this PR

## Testing
Without filtering:

https://github.com/user-attachments/assets/602ddc1b-2893-4d5b-8993-4cc5380a85f1

With custom filtration

https://github.com/user-attachments/assets/d615a4fa-fa93-417e-b59f-e86fe2e5d53a



<!-- CURSOR_SUMMARY -->