### PR TITLE
chore(checkout): CHECKOUT-10262 Bump checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.943.1",
+        "@bigcommerce/checkout-sdk": "^1.945.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.943.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.1.tgz",
-      "integrity": "sha512-ChFXiMrK/hX0eM9UYnc9XCcb3sMUQQ7lkvE9rwNYGTT/GQnK4gizJ5YidOH9+HAG8PoUZa1yxAqsx6nvoSBNjQ==",
+      "version": "1.945.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.945.0.tgz",
+      "integrity": "sha512-vXqE/W6RU1pQlIi/le0auaZ4gzHh/yWJNGXLwzRhq9eepgDYHg6/+vOsPQ4N3XtAGGhlLOTBox4K3STw1pycBw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29814,9 +29814,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.943.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.943.1.tgz",
-      "integrity": "sha512-ChFXiMrK/hX0eM9UYnc9XCcb3sMUQQ7lkvE9rwNYGTT/GQnK4gizJ5YidOH9+HAG8PoUZa1yxAqsx6nvoSBNjQ==",
+      "version": "1.945.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.945.0.tgz",
+      "integrity": "sha512-vXqE/W6RU1pQlIi/le0auaZ4gzHh/yWJNGXLwzRhq9eepgDYHg6/+vOsPQ4N3XtAGGhlLOTBox4K3STw1pycBw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.943.1",
+    "@bigcommerce/checkout-sdk": "^1.945.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/e2e/__har__/Shipping-with-Guest-checkout_658786807/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-Guest-checkout_658786807/recording.har
@@ -474,7 +474,7 @@
         }
       },
       {
-        "_id": "62b7af24b64ea3e0cc6ddc24ed8eb099",
+        "_id": "a053135c591a60529d8e2d0217ae6f52",
         "_order": 0,
         "cache": {},
         "request": {
@@ -496,7 +496,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"email\":\"test@example.com\"}"
+            "text": "{\"email\":\"test@example.com\",\"shouldSaveAddress\":false}"
           },
           "queryString": [
             {

--- a/packages/core/e2e/__har__/Shipping-with-different-billing-address_981343935/recording.har
+++ b/packages/core/e2e/__har__/Shipping-with-different-billing-address_981343935/recording.har
@@ -474,7 +474,7 @@
         }
       },
       {
-        "_id": "490957108292fad64964030b50b56019",
+        "_id": "0a4c9ec83f27a9d02506c6a6607ee955",
         "_order": 0,
         "cache": {},
         "request": {
@@ -496,7 +496,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"email\":\"test@example.com\"}"
+            "text": "{\"email\":\"test@example.com\",\"shouldSaveAddress\":false}"
           },
           "queryString": [
             {

--- a/packages/test-framework/project.json
+++ b/packages/test-framework/project.json
@@ -9,7 +9,7 @@
       "outputs": ["{options.outputFile}"]
     },
     "regenerate-har": {
-      "executor": "@nx/workspace:run-commands",
+      "executor": "nx:run-commands",
       "options": {
         "commands": ["node packages/test-framework/scripts/polly/regenerateHar.js"]
       }


### PR DESCRIPTION
## What/Why?

- SDK version bump to release:
  - https://github.com/bigcommerce/checkout-sdk-js/pull/3326
 - Update e2e tests HAR files to reflect the changes.
 - Fix `npm run regenerate-har` command.

## Rollout/Rollback

Revert.

## Testing
### Manually tested having `shouldSaveAddress: false` as part of guest checkout flow
<img width="1362" height="421" alt="Screenshot 2026-07-28 at 12 38 43" src="https://github.com/user-attachments/assets/2c26d471-1c65-437a-babd-587f6d05602e" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The SDK upgrade changes guest checkout billing-address API payloads (`shouldSaveAddress`), which can affect whether guest addresses are persisted; rollback is a dependency revert plus HAR refresh.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **1.943.1** to **1.945.0** (lockfile included), picking up the SDK release tied to guest-checkout billing-address behavior.
> 
> E2E **HAR** fixtures for guest shipping flows now record billing-address requests with **`shouldSaveAddress: false`** alongside the email (instead of email-only payloads), so replay tests match what the updated SDK sends.
> 
> The **test-framework** `regenerate-har` Nx target switches from the deprecated **`@nx/workspace:run-commands`** executor to **`nx:run-commands`**, restoring **`npm run regenerate-har`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a71aee7b9763d0b0514f115da161be5d1586c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->