### PR TITLE
feat(payment): PI-5328 [Moneris][FE] Change the styling to match default BC fields

### DIFF
--- a/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
@@ -33,7 +33,10 @@ import {
 } from '@bigcommerce/checkout/test-mocks';
 import { act } from '@bigcommerce/checkout/test-utils';
 
+import getMonerisIframeStyles from './getMonerisIframeStyles';
 import MonerisPaymentMethod from './MonerisPaymentMethod';
+
+jest.mock('./getMonerisIframeStyles', () => jest.fn());
 
 describe('when using Moneris payment', () => {
     let method: PaymentMethod;
@@ -44,6 +47,15 @@ describe('when using Moneris payment', () => {
     let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
     let paymentForm: PaymentFormService;
 
+    const monerisIframeStyles = {
+        cssBody: 'font-family: "Open Sans", sans-serif;background: transparent;',
+        cssTextbox: 'border-radius: 4px;width: 100%;',
+        cssTextboxCardNumber: 'width: 100%;',
+        cssTextboxExpiryDate: 'width: 120px;',
+        cssTextboxCVV: 'width: 80px;',
+        cssInputLabel: 'font-weight: 500;',
+    };
+
     beforeEach(() => {
         paymentForm = getPaymentFormServiceMock();
 
@@ -51,6 +63,8 @@ describe('when using Moneris payment', () => {
         checkoutState = checkoutService.getState();
         localeContext = createLocaleContext(getStoreConfig());
         method = { ...getPaymentMethod(), id: PaymentMethodId.Moneris };
+
+        jest.mocked(getMonerisIframeStyles).mockResolvedValue(monerisIframeStyles);
 
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
 
@@ -88,34 +102,40 @@ describe('when using Moneris payment', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-        jest.resetAllMocks();
     });
 
-    it('renders as hosted widget method', () => {
+    it('renders as hosted widget method', async () => {
         render(<PaymentMethodTest {...defaultProps} />);
 
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith({
-            methodId: 'moneris',
-            integrations: [createMonerisPaymentStrategy],
-            moneris: {
-                containerId: 'moneris-iframe-container',
-                options: undefined,
-            },
+        await act(async () => {
+            await Promise.resolve();
         });
+
+        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+            expect.objectContaining({
+                methodId: 'moneris',
+                integrations: [createMonerisPaymentStrategy],
+                moneris: expect.objectContaining({
+                    containerId: 'moneris-iframe-container',
+                    style: monerisIframeStyles,
+                }),
+            }),
+        );
     });
 
-    it('initializes method with required config when no instruments', () => {
+    it('initializes method with required config when no instruments', async () => {
         jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue(undefined);
 
         render(<PaymentMethodTest {...defaultProps} />);
 
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith({
-            methodId: 'moneris',
-            integrations: [createMonerisPaymentStrategy],
-            moneris: {
-                containerId: 'moneris-iframe-container',
-                options: undefined,
-            },
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(getMonerisIframeStyles).toHaveBeenCalledWith({
+            cardNumberContainerId: 'moneris-ccNumber',
+            cardExpiryContainerId: 'moneris-ccExpiry',
+            cardCodeContainerId: 'moneris-ccCvv',
         });
     });
 
@@ -142,25 +162,28 @@ describe('when using Moneris payment', () => {
             await new Promise((resolve) => setTimeout(resolve, 0));
         });
 
-        expect(checkoutService.initializePayment).toHaveBeenCalledWith({
-            gatewayId: undefined,
-            methodId: 'moneris',
-            integrations: [createMonerisPaymentStrategy],
-            moneris: {
-                containerId: 'moneris-iframe-container',
-                form: {
-                    fields: {
-                        cardCodeVerification: undefined,
-                        cardNumberVerification: undefined,
+        expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+            expect.objectContaining({
+                gatewayId: undefined,
+                methodId: 'moneris',
+                integrations: [createMonerisPaymentStrategy],
+                moneris: expect.objectContaining({
+                    containerId: 'moneris-iframe-container',
+                    style: monerisIframeStyles,
+                    form: {
+                        fields: {
+                            cardCodeVerification: undefined,
+                            cardNumberVerification: undefined,
+                        },
+                        onBlur: expect.any(Function),
+                        onCardTypeChange: expect.any(Function),
+                        onEnter: expect.any(Function),
+                        onFocus: expect.any(Function),
+                        onValidate: expect.any(Function),
+                        styles: {},
                     },
-                    onBlur: expect.any(Function),
-                    onCardTypeChange: expect.any(Function),
-                    onEnter: expect.any(Function),
-                    onFocus: expect.any(Function),
-                    onValidate: expect.any(Function),
-                    styles: {},
-                },
-            },
-        });
+                }),
+            }),
+        );
     });
 });

--- a/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
@@ -134,6 +134,7 @@ describe('when using Moneris payment', () => {
 
         expect(getMonerisIframeStyles).toHaveBeenCalledWith({
             cardNumberContainerId: 'moneris-ccNumber',
+            onError: defaultProps.onUnhandledError,
         });
     });
 

--- a/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
@@ -138,6 +138,20 @@ describe('when using Moneris payment', () => {
         });
     });
 
+    it('calls onUnhandledError when payment initialization fails', async () => {
+        const error = new Error('Initialization failed');
+
+        jest.spyOn(checkoutService, 'initializePayment').mockRejectedValue(error);
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalledWith(error);
+    });
+
     it('initializes method with required config with vaulted instruments', async () => {
         jest.spyOn(checkoutState.data, 'getCustomer').mockReturnValue(getCustomer());
         jest.spyOn(checkoutState.data, 'getInstruments').mockReturnValue(getInstruments());

--- a/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
@@ -32,6 +32,7 @@ import {
     getStoreConfig,
 } from '@bigcommerce/checkout/test-mocks';
 import { act } from '@bigcommerce/checkout/test-utils';
+import { ErrorLevelType, type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 
 import getMonerisIframeStyles from './getMonerisIframeStyles';
 import MonerisPaymentMethod from './MonerisPaymentMethod';
@@ -46,6 +47,7 @@ describe('when using Moneris payment', () => {
     let localeContext: LocaleContextType;
     let PaymentMethodTest: FunctionComponent<PaymentMethodProps>;
     let paymentForm: PaymentFormService;
+    let errorLogger: ErrorLogger;
 
     const monerisIframeStyles = {
         cssBody: 'font-family: "Open Sans", sans-serif;background: transparent;',
@@ -78,6 +80,8 @@ describe('when using Moneris payment', () => {
 
         jest.spyOn(checkoutService, 'loadInstruments').mockResolvedValue(checkoutState);
 
+        errorLogger = { log: jest.fn() };
+
         defaultProps = {
             method,
             checkoutService,
@@ -88,7 +92,7 @@ describe('when using Moneris payment', () => {
         };
 
         PaymentMethodTest = (props) => (
-            <CheckoutProvider checkoutService={checkoutService}>
+            <CheckoutProvider checkoutService={checkoutService} errorLogger={errorLogger}>
                 <PaymentFormContext.Provider value={{ paymentForm }}>
                     <LocaleContext.Provider value={localeContext}>
                         <Formik initialValues={{}} onSubmit={noop}>
@@ -134,7 +138,35 @@ describe('when using Moneris payment', () => {
 
         expect(getMonerisIframeStyles).toHaveBeenCalledWith({
             cardNumberContainerId: 'moneris-ccNumber',
+            onMissingStyleContainer: expect.any(Function),
         });
+    });
+
+    it('logs missing style probe containers to errorLogger without interrupting checkout', async () => {
+        const styleProbeError = new Error(
+            'Unable to retrieve input styles as the provided container ID is not valid.',
+        );
+
+        jest.mocked(getMonerisIframeStyles).mockImplementation(({ onMissingStyleContainer }) => {
+            onMissingStyleContainer?.(styleProbeError);
+
+            return monerisIframeStyles;
+        });
+
+        render(<PaymentMethodTest {...defaultProps} />);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(errorLogger.log).toHaveBeenCalledWith(
+            styleProbeError,
+            { errorCode: 'monerisStyleProbe' },
+            ErrorLevelType.Warning,
+            { containerId: 'moneris-ccNumber' },
+        );
+        expect(defaultProps.onUnhandledError).not.toHaveBeenCalled();
+        expect(checkoutService.initializePayment).toHaveBeenCalled();
     });
 
     it('calls onUnhandledError when payment initialization fails', async () => {

--- a/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
@@ -134,7 +134,6 @@ describe('when using Moneris payment', () => {
 
         expect(getMonerisIframeStyles).toHaveBeenCalledWith({
             cardNumberContainerId: 'moneris-ccNumber',
-            onError: defaultProps.onUnhandledError,
         });
     });
 

--- a/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.test.tsx
@@ -64,7 +64,7 @@ describe('when using Moneris payment', () => {
         localeContext = createLocaleContext(getStoreConfig());
         method = { ...getPaymentMethod(), id: PaymentMethodId.Moneris };
 
-        jest.mocked(getMonerisIframeStyles).mockResolvedValue(monerisIframeStyles);
+        jest.mocked(getMonerisIframeStyles).mockReturnValue(monerisIframeStyles);
 
         jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
 
@@ -134,8 +134,6 @@ describe('when using Moneris payment', () => {
 
         expect(getMonerisIframeStyles).toHaveBeenCalledWith({
             cardNumberContainerId: 'moneris-ccNumber',
-            cardExpiryContainerId: 'moneris-ccExpiry',
-            cardCodeContainerId: 'moneris-ccCvv',
         });
     });
 

--- a/packages/moneris-integration/src/MonerisPaymentMethod.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.tsx
@@ -70,8 +70,6 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     );
 
     const cardNumberStyleContainerId = getHostedFieldId('ccNumber');
-    const cardExpiryStyleContainerId = getHostedFieldId('ccExpiry');
-    const cardCodeStyleContainerId = getHostedFieldId('ccCvv');
     const styleSamplerClassName = 'form-ccFields form-ccFields--without-card-name';
 
     const initializeMonerisPayment: HostedWidgetComponentProps['initializePayment'] = useCallback(
@@ -115,12 +113,6 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                     <div className="form-field form-field--ccNumber">
                         <div id={cardNumberStyleContainerId} />
                     </div>
-                    <div className="form-field form-field--ccExpiry">
-                        <div id={cardExpiryStyleContainerId} />
-                    </div>
-                    <div className="form-ccFields-field form-ccFields-field--ccCvv">
-                        <div id={cardCodeStyleContainerId} />
-                    </div>
                 </div>
             </div>
         );
@@ -145,6 +137,7 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                 isSignedIn={some(checkout?.payments, { providerId: method.id })}
                 loadInstruments={checkoutService.loadInstruments}
                 method={method}
+                onUnhandledError={onUnhandledError}
                 setFieldValue={setFieldValue}
                 setSubmit={setSubmit}
                 setValidationSchema={setValidationSchema}

--- a/packages/moneris-integration/src/MonerisPaymentMethod.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.tsx
@@ -29,6 +29,7 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     checkoutState,
     checkoutService,
     method,
+    onUnhandledError,
     ...rest
 }) => {
     const containerId = 'moneris-iframe-container';
@@ -77,6 +78,7 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         async (options: PaymentInitializeOptions, selectedInstrument) => {
             const style = getMonerisIframeStyles({
                 cardNumberContainerId: cardNumberStyleContainerId,
+                onError: onUnhandledError,
             });
 
             const paymentConfig = {
@@ -93,7 +95,13 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
             return checkoutService.initializePayment(paymentConfig);
         },
-        [cardNumberStyleContainerId, containerId, getHostedFormOptions, checkoutService],
+        [
+            cardNumberStyleContainerId,
+            containerId,
+            getHostedFormOptions,
+            checkoutService,
+            onUnhandledError,
+        ],
     );
 
     const validateInstrument = (_shouldShowNumber: boolean, selectedInstrument: CardInstrument) => {

--- a/packages/moneris-integration/src/MonerisPaymentMethod.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.tsx
@@ -93,12 +93,7 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
             return checkoutService.initializePayment(paymentConfig);
         },
-        [
-            cardNumberStyleContainerId,
-            containerId,
-            getHostedFormOptions,
-            checkoutService,
-        ],
+        [cardNumberStyleContainerId, containerId, getHostedFormOptions, checkoutService],
     );
 
     const validateInstrument = (_shouldShowNumber: boolean, selectedInstrument: CardInstrument) => {

--- a/packages/moneris-integration/src/MonerisPaymentMethod.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.tsx
@@ -71,15 +71,12 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const cardNumberStyleContainerId = getHostedFieldId('ccNumber');
     const cardExpiryStyleContainerId = getHostedFieldId('ccExpiry');
     const cardCodeStyleContainerId = getHostedFieldId('ccCvv');
-
     const styleSamplerClassName = 'form-ccFields form-ccFields--without-card-name';
 
     const initializeMonerisPayment: HostedWidgetComponentProps['initializePayment'] = useCallback(
         async (options: PaymentInitializeOptions, selectedInstrument) => {
-            const style = await getMonerisIframeStyles({
+            const style = getMonerisIframeStyles({
                 cardNumberContainerId: cardNumberStyleContainerId,
-                cardExpiryContainerId: cardExpiryStyleContainerId,
-                cardCodeContainerId: cardCodeStyleContainerId,
             });
 
             const paymentConfig = {
@@ -97,8 +94,6 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             return checkoutService.initializePayment(paymentConfig);
         },
         [
-            cardCodeStyleContainerId,
-            cardExpiryStyleContainerId,
             cardNumberStyleContainerId,
             containerId,
             getHostedFormOptions,

--- a/packages/moneris-integration/src/MonerisPaymentMethod.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.tsx
@@ -76,7 +76,6 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         async (options: PaymentInitializeOptions, selectedInstrument) => {
             const style = getMonerisIframeStyles({
                 cardNumberContainerId: cardNumberStyleContainerId,
-                onError: onUnhandledError,
             });
 
             const paymentConfig = {
@@ -93,13 +92,7 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
             return checkoutService.initializePayment(paymentConfig);
         },
-        [
-            cardNumberStyleContainerId,
-            containerId,
-            getHostedFormOptions,
-            checkoutService,
-            onUnhandledError,
-        ],
+        [cardNumberStyleContainerId, containerId, getHostedFormOptions, checkoutService],
     );
 
     const validateInstrument = (_shouldShowNumber: boolean, selectedInstrument: CardInstrument) => {

--- a/packages/moneris-integration/src/MonerisPaymentMethod.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.tsx
@@ -1,6 +1,6 @@
 import { type CardInstrument, type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { createMonerisPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/moneris';
-import { some } from 'lodash';
+import { compact, some } from 'lodash';
 import React, { type FunctionComponent, useCallback } from 'react';
 
 import {
@@ -21,6 +21,8 @@ import {
     toResolvableComponent,
 } from '@bigcommerce/checkout/payment-integration-api';
 
+import getMonerisIframeStyles from './getMonerisIframeStyles';
+
 const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     language,
     paymentForm,
@@ -29,7 +31,7 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     method,
     ...rest
 }) => {
-    const containerId = `moneris-iframe-container`;
+    const containerId = 'moneris-iframe-container';
 
     const { getHostedStoredCardValidationFieldset, getHostedFormOptions } = useHostedCreditCard({
         checkoutState,
@@ -61,13 +63,31 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const isInstrumentFeatureAvailable =
         !isGuestCustomer && Boolean(method.config.isVaultingEnabled);
 
+    const getHostedFieldId = useCallback(
+        (name: string) => `${compact([method.gateway, method.id]).join('-')}-${name}`,
+        [method],
+    );
+
+    const cardNumberStyleContainerId = getHostedFieldId('ccNumber');
+    const cardExpiryStyleContainerId = getHostedFieldId('ccExpiry');
+    const cardCodeStyleContainerId = getHostedFieldId('ccCvv');
+
+    const styleSamplerClassName = 'form-ccFields form-ccFields--without-card-name';
+
     const initializeMonerisPayment: HostedWidgetComponentProps['initializePayment'] = useCallback(
         async (options: PaymentInitializeOptions, selectedInstrument) => {
+            const style = await getMonerisIframeStyles({
+                cardNumberContainerId: cardNumberStyleContainerId,
+                cardExpiryContainerId: cardExpiryStyleContainerId,
+                cardCodeContainerId: cardCodeStyleContainerId,
+            });
+
             const paymentConfig = {
                 ...options,
                 integrations: [createMonerisPaymentStrategy],
                 moneris: {
                     containerId,
+                    style,
                     ...(selectedInstrument && {
                         form: await getHostedFormOptions(selectedInstrument),
                     }),
@@ -76,37 +96,67 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
             return checkoutService.initializePayment(paymentConfig);
         },
-        [containerId, getHostedFormOptions, checkoutService],
+        [
+            cardCodeStyleContainerId,
+            cardExpiryStyleContainerId,
+            cardNumberStyleContainerId,
+            containerId,
+            getHostedFormOptions,
+            checkoutService,
+        ],
     );
 
     const validateInstrument = (_shouldShowNumber: boolean, selectedInstrument: CardInstrument) => {
         return getHostedStoredCardValidationFieldset(selectedInstrument);
     };
 
+    const renderCheckoutThemeStylesForMoneris = () => {
+        return (
+            <div aria-hidden="true" className="u-hiddenVisually">
+                <div className={styleSamplerClassName}>
+                    <div className="form-field form-field--ccNumber">
+                        <div id={cardNumberStyleContainerId} />
+                    </div>
+                    <div className="form-field form-field--ccExpiry">
+                        <div id={cardExpiryStyleContainerId} />
+                    </div>
+                    <div className="form-ccFields-field form-ccFields-field--ccCvv">
+                        <div id={cardCodeStyleContainerId} />
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
     return (
-        <HostedWidgetPaymentComponent
-            containerId={containerId}
-            deinitializePayment={checkoutService.deinitializePayment}
-            disableSubmit={disableSubmit}
-            hidePaymentSubmitButton={hidePaymentSubmitButton}
-            initializePayment={initializeMonerisPayment}
-            instruments={instruments}
-            isInstrumentCardCodeRequired={isInstrumentCardCodeRequiredSelector(checkoutState)}
-            isInstrumentCardNumberRequired={isInstrumentCardNumberRequiredSelector(checkoutState)}
-            isInstrumentFeatureAvailable={isInstrumentFeatureAvailable}
-            isLoadingInstruments={isLoadingInstruments()}
-            isPaymentDataRequired={isPaymentDataRequired()}
-            isSignedIn={some(checkout?.payments, { providerId: method.id })}
-            loadInstruments={checkoutService.loadInstruments}
-            method={method}
-            setFieldValue={setFieldValue}
-            setSubmit={setSubmit}
-            setValidationSchema={setValidationSchema}
-            signOut={checkoutService.signOutCustomer}
-            storedCardValidationSchema={hostedStoredCardValidationSchema}
-            validateInstrument={validateInstrument}
-            {...rest}
-        />
+        <>
+            <HostedWidgetPaymentComponent
+                containerId={containerId}
+                deinitializePayment={checkoutService.deinitializePayment}
+                disableSubmit={disableSubmit}
+                hidePaymentSubmitButton={hidePaymentSubmitButton}
+                initializePayment={initializeMonerisPayment}
+                instruments={instruments}
+                isInstrumentCardCodeRequired={isInstrumentCardCodeRequiredSelector(checkoutState)}
+                isInstrumentCardNumberRequired={isInstrumentCardNumberRequiredSelector(
+                    checkoutState,
+                )}
+                isInstrumentFeatureAvailable={isInstrumentFeatureAvailable}
+                isLoadingInstruments={isLoadingInstruments()}
+                isPaymentDataRequired={isPaymentDataRequired()}
+                isSignedIn={some(checkout?.payments, { providerId: method.id })}
+                loadInstruments={checkoutService.loadInstruments}
+                method={method}
+                setFieldValue={setFieldValue}
+                setSubmit={setSubmit}
+                setValidationSchema={setValidationSchema}
+                signOut={checkoutService.signOutCustomer}
+                storedCardValidationSchema={hostedStoredCardValidationSchema}
+                validateInstrument={validateInstrument}
+                {...rest}
+            />
+            {renderCheckoutThemeStylesForMoneris()}
+        </>
     );
 };
 

--- a/packages/moneris-integration/src/MonerisPaymentMethod.tsx
+++ b/packages/moneris-integration/src/MonerisPaymentMethod.tsx
@@ -3,6 +3,8 @@ import { createMonerisPaymentStrategy } from '@bigcommerce/checkout-sdk/integrat
 import { compact, some } from 'lodash';
 import React, { type FunctionComponent, useCallback } from 'react';
 
+import { useCheckout } from '@bigcommerce/checkout/contexts';
+import { ErrorLevelType } from '@bigcommerce/checkout/error-handling-utils';
 import {
     getHostedInstrumentValidationSchema,
     useHostedCreditCard,
@@ -33,6 +35,7 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     ...rest
 }) => {
     const containerId = 'moneris-iframe-container';
+    const { errorLogger } = useCheckout();
 
     const { getHostedStoredCardValidationFieldset, getHostedFormOptions } = useHostedCreditCard({
         checkoutState,
@@ -72,10 +75,20 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const cardNumberStyleContainerId = getHostedFieldId('ccNumber');
     const styleSamplerClassName = 'form-ccFields form-ccFields--without-card-name';
 
+    const logMissingStyleContainer = useCallback(
+        (error: Error) => {
+            errorLogger?.log(error, { errorCode: 'monerisStyleProbe' }, ErrorLevelType.Warning, {
+                containerId: cardNumberStyleContainerId,
+            });
+        },
+        [cardNumberStyleContainerId, errorLogger],
+    );
+
     const initializeMonerisPayment: HostedWidgetComponentProps['initializePayment'] = useCallback(
         async (options: PaymentInitializeOptions, selectedInstrument) => {
             const style = getMonerisIframeStyles({
                 cardNumberContainerId: cardNumberStyleContainerId,
+                onMissingStyleContainer: logMissingStyleContainer,
             });
 
             const paymentConfig = {
@@ -92,7 +105,13 @@ const MonerisPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 
             return checkoutService.initializePayment(paymentConfig);
         },
-        [cardNumberStyleContainerId, containerId, getHostedFormOptions, checkoutService],
+        [
+            cardNumberStyleContainerId,
+            containerId,
+            getHostedFormOptions,
+            checkoutService,
+            logMissingStyleContainer,
+        ],
     );
 
     const validateInstrument = (_shouldShowNumber: boolean, selectedInstrument: CardInstrument) => {

--- a/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
@@ -17,7 +17,6 @@ describe('getMonerisIframeStyles', () => {
                 return {
                     color: 'rgb(95, 95, 95)',
                     fontFamily: '"Open Sans", sans-serif',
-                    fontSize: '13px',
                     fontWeight: '500',
                 };
             }
@@ -26,14 +25,16 @@ describe('getMonerisIframeStyles', () => {
                 const inputStyles: Record<string, string> = {
                     backgroundColor: 'rgb(255, 255, 255)',
                     border: '1px solid rgb(221, 221, 221)',
+                    borderColor: 'rgb(221, 221, 221)',
                     borderRadius: '4px',
+                    borderStyle: 'solid',
+                    borderWidth: '1px',
                     color: 'rgb(51, 51, 51)',
                     fontFamily: '"Open Sans", sans-serif',
                     fontSize: '13px',
                     fontWeight: '400',
                     height: '45px',
                     outline: '0',
-                    padding: '12px 16px',
                 };
 
                 if (inputStyles[property]) {
@@ -61,7 +62,7 @@ describe('getMonerisIframeStyles', () => {
         expect(styles.cssBody).toContain('background: transparent;');
 
         expect(styles.cssTextbox).toContain('justify-self: stretch;');
-        expect(styles.cssTextbox).toContain('padding-top: 1.3em;');
+        expect(styles.cssTextbox).toContain('padding: 0 12px;');
         expect(styles.cssTextbox).toContain('border-radius: 4px;');
         expect(styles.cssTextbox).not.toContain('padding: 12px 16px;');
 

--- a/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
@@ -82,12 +82,14 @@ describe('getMonerisIframeStyles', () => {
     });
 
     it('returns layout-only styles and logs when style probe elements are missing', () => {
+        const onMissingStyleContainer = jest.fn();
         const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
         document.body.innerHTML = '';
 
         const styles = getMonerisIframeStyles({
             cardNumberContainerId: 'moneris-cc-number',
+            onMissingStyleContainer,
         });
 
         expect(styles.cssBody).toContain('display: grid;');
@@ -100,8 +102,23 @@ describe('getMonerisIframeStyles', () => {
         expect(styles.cssInputLabel).toContain('font-size: 0.75rem;');
         expect(styles.cssInputLabel).not.toContain('font-weight:');
 
+        expect(onMissingStyleContainer).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message:
+                    'Unable to retrieve input styles as the provided container ID is not valid.',
+            }),
+        );
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+        getMonerisIframeStyles({
+            cardNumberContainerId: 'moneris-cc-number',
+        });
+
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'Unable to retrieve input styles as the provided container ID is not valid.',
+            expect.objectContaining({
+                message:
+                    'Unable to retrieve input styles as the provided container ID is not valid.',
+            }),
             { containerId: 'moneris-cc-number' },
         );
 

--- a/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
@@ -1,0 +1,76 @@
+import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
+import { getCreditCardInputStyles } from '@bigcommerce/checkout/instrument-utils';
+
+import getMonerisIframeStyles from './getMonerisIframeStyles';
+
+jest.mock('@bigcommerce/checkout/instrument-utils', () => ({
+    ...jest.requireActual<typeof import('@bigcommerce/checkout/instrument-utils')>(
+        '@bigcommerce/checkout/instrument-utils',
+    ),
+    getCreditCardInputStyles: jest.fn(),
+}));
+
+jest.mock('@bigcommerce/checkout/dom-utils', () => ({
+    getAppliedStyles: jest.fn(),
+}));
+
+describe('getMonerisIframeStyles', () => {
+    beforeEach(() => {
+        jest.mocked(getCreditCardInputStyles).mockImplementation((containerId: string) => {
+            if (containerId.includes('cc-expiry')) {
+                return Promise.resolve({ width: '120px' });
+            }
+
+            if (containerId.includes('cc-cvv') || containerId.includes('ccCvv')) {
+                return Promise.resolve({ width: '80px' });
+            }
+
+            return Promise.resolve({
+                backgroundColor: 'rgb(255, 255, 255)',
+                border: '1px solid rgb(221, 221, 221)',
+                borderRadius: '4px',
+                color: 'rgb(51, 51, 51)',
+                fontFamily: '"Open Sans", sans-serif',
+                fontSize: '13px',
+                fontWeight: '400',
+                height: '45px',
+                outline: '0',
+                padding: '12px 16px',
+            });
+        });
+
+        jest.mocked(getAppliedStyles).mockReturnValue({
+            color: 'rgb(95, 95, 95)',
+            fontFamily: '"Open Sans", sans-serif',
+            fontSize: '13px',
+            fontWeight: '500',
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('maps checkout input styles to Moneris iframe CSS params', async () => {
+        document.body.innerHTML = `
+            <div id="moneris-cc-number"></div>
+            <div id="moneris-cc-expiry"></div>
+            <div id="moneris-cc-cvv"></div>
+        `;
+
+        const styles = await getMonerisIframeStyles({
+            cardNumberContainerId: 'moneris-cc-number',
+            cardExpiryContainerId: 'moneris-cc-expiry',
+            cardCodeContainerId: 'moneris-cc-cvv',
+        });
+
+        expect(styles.cssBody).toContain('font-family: "Open Sans", sans-serif;');
+        expect(styles.cssBody).toContain('background: transparent;');
+        expect(styles.cssTextbox).toContain('border-radius: 4px;');
+        expect(styles.cssTextbox).toContain('width: 100%;');
+        expect(styles.cssTextboxCardNumber).toBe('width: 100%;');
+        expect(styles.cssTextboxExpiryDate).toBe('width: 120px;');
+        expect(styles.cssTextboxCVV).toBe('width: 80px;');
+        expect(styles.cssInputLabel).toContain('font-weight: 500;');
+    });
+});

--- a/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
@@ -81,13 +81,46 @@ describe('getMonerisIframeStyles', () => {
         expect(styles.cssLabelCVV).toBe('grid-column: 2; grid-row: 2;');
     });
 
-    it('throws when style probe elements are missing', () => {
+    it('returns layout-only styles and logs when style probe elements are missing', () => {
+        const onError = jest.fn();
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
         document.body.innerHTML = '';
 
-        expect(() =>
-            getMonerisIframeStyles({
-                cardNumberContainerId: 'moneris-cc-number',
+        const styles = getMonerisIframeStyles({
+            cardNumberContainerId: 'moneris-cc-number',
+        });
+
+        expect(styles.cssBody).toContain('display: grid;');
+        expect(styles.cssBody).toContain('background: transparent;');
+        expect(styles.cssBody).not.toContain('font-family:');
+
+        expect(styles.cssTextbox).toContain('padding: 0 12px;');
+        expect(styles.cssTextbox).not.toContain('border-radius:');
+
+        expect(styles.cssInputLabel).toContain('font-size: 0.75rem;');
+        expect(styles.cssInputLabel).not.toContain('font-weight:');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message:
+                    'Unable to retrieve input styles as the provided container ID is not valid.',
             }),
-        ).toThrow('Unable to retrieve input styles as the provided container ID is not valid.');
+            { containerId: 'moneris-cc-number' },
+        );
+
+        getMonerisIframeStyles({
+            cardNumberContainerId: 'moneris-cc-number',
+            onError,
+        });
+
+        expect(onError).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message:
+                    'Unable to retrieve input styles as the provided container ID is not valid.',
+            }),
+        );
+
+        consoleErrorSpy.mockRestore();
     });
 });

--- a/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
@@ -82,7 +82,6 @@ describe('getMonerisIframeStyles', () => {
     });
 
     it('returns layout-only styles and logs when style probe elements are missing', () => {
-        const onError = jest.fn();
         const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
         document.body.innerHTML = '';
@@ -102,23 +101,8 @@ describe('getMonerisIframeStyles', () => {
         expect(styles.cssInputLabel).not.toContain('font-weight:');
 
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message:
-                    'Unable to retrieve input styles as the provided container ID is not valid.',
-            }),
+            'Unable to retrieve input styles as the provided container ID is not valid.',
             { containerId: 'moneris-cc-number' },
-        );
-
-        getMonerisIframeStyles({
-            cardNumberContainerId: 'moneris-cc-number',
-            onError,
-        });
-
-        expect(onError).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message:
-                    'Unable to retrieve input styles as the provided container ID is not valid.',
-            }),
         );
 
         consoleErrorSpy.mockRestore();

--- a/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.test.ts
@@ -1,14 +1,6 @@
 import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
-import { getCreditCardInputStyles } from '@bigcommerce/checkout/instrument-utils';
 
 import getMonerisIframeStyles from './getMonerisIframeStyles';
-
-jest.mock('@bigcommerce/checkout/instrument-utils', () => ({
-    ...jest.requireActual<typeof import('@bigcommerce/checkout/instrument-utils')>(
-        '@bigcommerce/checkout/instrument-utils',
-    ),
-    getCreditCardInputStyles: jest.fn(),
-}));
 
 jest.mock('@bigcommerce/checkout/dom-utils', () => ({
     getAppliedStyles: jest.fn(),
@@ -16,34 +8,40 @@ jest.mock('@bigcommerce/checkout/dom-utils', () => ({
 
 describe('getMonerisIframeStyles', () => {
     beforeEach(() => {
-        jest.mocked(getCreditCardInputStyles).mockImplementation((containerId: string) => {
-            if (containerId.includes('cc-expiry')) {
-                return Promise.resolve({ width: '120px' });
+        document.body.innerHTML = `
+            <div id="moneris-cc-number"></div>
+        `;
+
+        jest.mocked(getAppliedStyles).mockImplementation((element, properties) => {
+            if (element.classList.contains('optimizedCheckout-form-label')) {
+                return {
+                    color: 'rgb(95, 95, 95)',
+                    fontFamily: '"Open Sans", sans-serif',
+                    fontSize: '13px',
+                    fontWeight: '500',
+                };
             }
 
-            if (containerId.includes('cc-cvv') || containerId.includes('ccCvv')) {
-                return Promise.resolve({ width: '80px' });
-            }
+            return properties.reduce<{ [key: string]: string }>((result, property) => {
+                const inputStyles: Record<string, string> = {
+                    backgroundColor: 'rgb(255, 255, 255)',
+                    border: '1px solid rgb(221, 221, 221)',
+                    borderRadius: '4px',
+                    color: 'rgb(51, 51, 51)',
+                    fontFamily: '"Open Sans", sans-serif',
+                    fontSize: '13px',
+                    fontWeight: '400',
+                    height: '45px',
+                    outline: '0',
+                    padding: '12px 16px',
+                };
 
-            return Promise.resolve({
-                backgroundColor: 'rgb(255, 255, 255)',
-                border: '1px solid rgb(221, 221, 221)',
-                borderRadius: '4px',
-                color: 'rgb(51, 51, 51)',
-                fontFamily: '"Open Sans", sans-serif',
-                fontSize: '13px',
-                fontWeight: '400',
-                height: '45px',
-                outline: '0',
-                padding: '12px 16px',
-            });
-        });
+                if (inputStyles[property]) {
+                    result[property] = inputStyles[property];
+                }
 
-        jest.mocked(getAppliedStyles).mockReturnValue({
-            color: 'rgb(95, 95, 95)',
-            fontFamily: '"Open Sans", sans-serif',
-            fontSize: '13px',
-            fontWeight: '500',
+                return result;
+            }, {});
         });
     });
 
@@ -51,26 +49,44 @@ describe('getMonerisIframeStyles', () => {
         jest.clearAllMocks();
     });
 
-    it('maps checkout input styles to Moneris iframe CSS params', async () => {
-        document.body.innerHTML = `
-            <div id="moneris-cc-number"></div>
-            <div id="moneris-cc-expiry"></div>
-            <div id="moneris-cc-cvv"></div>
-        `;
-
-        const styles = await getMonerisIframeStyles({
+    it('maps checkout input styles to Moneris iframe CSS params', () => {
+        const styles = getMonerisIframeStyles({
             cardNumberContainerId: 'moneris-cc-number',
-            cardExpiryContainerId: 'moneris-cc-expiry',
-            cardCodeContainerId: 'moneris-cc-cvv',
         });
 
+        expect(styles.cssBody).toContain('display: grid;');
+        expect(styles.cssBody).toContain('grid-template-columns: 1fr 1fr;');
+        expect(styles.cssBody).not.toContain('grid-template-areas');
         expect(styles.cssBody).toContain('font-family: "Open Sans", sans-serif;');
         expect(styles.cssBody).toContain('background: transparent;');
+
+        expect(styles.cssTextbox).toContain('justify-self: stretch;');
+        expect(styles.cssTextbox).toContain('padding-top: 1.3em;');
         expect(styles.cssTextbox).toContain('border-radius: 4px;');
-        expect(styles.cssTextbox).toContain('width: 100%;');
-        expect(styles.cssTextboxCardNumber).toBe('width: 100%;');
-        expect(styles.cssTextboxExpiryDate).toBe('width: 120px;');
-        expect(styles.cssTextboxCVV).toBe('width: 80px;');
+        expect(styles.cssTextbox).not.toContain('padding: 12px 16px;');
+
+        expect(styles.cssTextboxCardNumber).toBe('grid-column: 1 / 3; grid-row: 1;');
+        expect(styles.cssTextboxExpiryDate).toBe('grid-column: 1; grid-row: 2;');
+        expect(styles.cssTextboxCVV).toBe('grid-column: 2; grid-row: 2;');
+
+        expect(styles.cssInputLabel).toContain('font-size: 0.75rem;');
+        expect(styles.cssInputLabel).toContain('justify-self: start;');
         expect(styles.cssInputLabel).toContain('font-weight: 500;');
+        expect(styles.cssInputLabel).toContain('font-family: Open Sans, sans-serif;');
+        expect(styles.cssInputLabel).not.toContain('font-size: 13px;');
+
+        expect(styles.cssLabelCardNumber).toBe('grid-column: 1 / 3; grid-row: 1;');
+        expect(styles.cssLabelExpiryDate).toBe('grid-column: 1; grid-row: 2;');
+        expect(styles.cssLabelCVV).toBe('grid-column: 2; grid-row: 2;');
+    });
+
+    it('throws when style probe elements are missing', () => {
+        document.body.innerHTML = '';
+
+        expect(() =>
+            getMonerisIframeStyles({
+                cardNumberContainerId: 'moneris-cc-number',
+            }),
+        ).toThrow('Unable to retrieve input styles as the provided container ID is not valid.');
     });
 });

--- a/packages/moneris-integration/src/getMonerisIframeStyles.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.ts
@@ -1,7 +1,6 @@
 import { kebabCase } from 'lodash';
 
 import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
-import { getCreditCardInputStyles } from '@bigcommerce/checkout/instrument-utils';
 
 export interface MonerisIframeStyles {
     cssBody?: string;
@@ -10,11 +9,12 @@ export interface MonerisIframeStyles {
     cssTextboxExpiryDate?: string;
     cssTextboxCVV?: string;
     cssInputLabel?: string;
+    cssLabelCardNumber?: string;
+    cssLabelExpiryDate?: string;
+    cssLabelCVV?: string;
 }
 
 export interface GetMonerisIframeStylesOptions {
-    cardCodeContainerId?: string;
-    cardExpiryContainerId: string;
     cardNumberContainerId: string;
 }
 
@@ -25,17 +25,96 @@ const INPUT_STYLE_PROPERTIES = [
     'borderRadius',
     'borderStyle',
     'borderWidth',
-    'boxSizing',
     'color',
     'fontFamily',
     'fontSize',
     'fontWeight',
     'height',
     'outline',
-    'padding',
 ];
 
-const LABEL_STYLE_PROPERTIES = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
+const LABEL_STYLE_PROPERTIES = ['color', 'fontFamily', 'fontWeight'];
+
+const CSS_BODY_LAYOUT =
+    'margin: 0; padding: 24px 0; box-sizing: border-box; display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: auto auto; row-gap: 24px; column-gap: 8px;';
+
+const CSS_INPUT_LABEL_LAYOUT =
+    'justify-self: start; align-self: start; font-size: 0.75rem; line-height: 1; pointer-events: none; z-index: 1; transform: translateY(-100%);';
+
+const CSS_TEXTBOX_LAYOUT =
+    'justify-self: stretch; align-self: stretch; width: 100%; box-sizing: border-box;';
+
+const CSS_GRID_PLACEMENT = {
+    cardNumberLabel: 'grid-column: 1 / 3; grid-row: 1;',
+    cardNumberInput: 'grid-column: 1 / 3; grid-row: 1;',
+    expiryDateLabel: 'grid-column: 1; grid-row: 2;',
+    expiryDateInput: 'grid-column: 1; grid-row: 2;',
+    cvvLabel: 'grid-column: 2; grid-row: 2;',
+    cvvInput: 'grid-column: 2; grid-row: 2;',
+} as const;
+
+function getStylesFromElement(element: HTMLElement, properties: string[]): Record<string, string> {
+    return getAppliedStyles(element, properties);
+}
+
+function getStylesFromContainer(
+    containerId: string,
+    properties: string[],
+    className = 'form-input optimizedCheckout-form-input',
+): Record<string, string> {
+    const container = document.getElementById(containerId);
+
+    if (!container) {
+        throw new Error(
+            'Unable to retrieve input styles as the provided container ID is not valid.',
+        );
+    }
+
+    const probe = document.createElement('div');
+
+    probe.className = className;
+    container.appendChild(probe);
+
+    const styles = getStylesFromElement(probe, properties);
+
+    container.removeChild(probe);
+
+    return styles;
+}
+
+function getLabelStyles(containerId: string): Record<string, string> {
+    const container = document.getElementById(containerId);
+
+    if (!container) {
+        throw new Error(
+            'Unable to retrieve input styles as the provided container ID is not valid.',
+        );
+    }
+
+    const field = document.createElement('div');
+    const label = document.createElement('label');
+
+    field.className = 'form-field form-field--ccNumber';
+    label.className = 'form-label optimizedCheckout-form-label';
+    field.appendChild(label);
+    container.appendChild(field);
+
+    const styles = getStylesFromElement(label, LABEL_STYLE_PROPERTIES);
+
+    container.removeChild(field);
+
+    return styles;
+}
+
+function sanitizeLabelStyles(styles: Record<string, string>): Record<string, string> {
+    const sanitizedStyles = { ...styles };
+
+    if (sanitizedStyles.fontFamily) {
+        sanitizedStyles.fontFamily = sanitizedStyles.fontFamily.replace(/"/g, '');
+    }
+
+    return sanitizedStyles;
+}
 
 function toCssString(styles: Record<string, string>, properties: string[]): string {
     return properties
@@ -51,86 +130,33 @@ function toCssString(styles: Record<string, string>, properties: string[]): stri
         .join('');
 }
 
-function getLabelStyles(containerId: string): Record<string, string> {
-    const container = document.getElementById(containerId);
-
-    if (!container) {
-        return {};
-    }
-
-    const field = document.createElement('div');
-    const label = document.createElement('label');
-
-    field.className = 'form-field form-field--ccNumber';
-    label.className = 'form-label';
-    field.appendChild(label);
-    container.appendChild(field);
-
-    const styles = getAppliedStyles(label, LABEL_STYLE_PROPERTIES);
-
-    container.removeChild(field);
-
-    return styles;
-}
-
-export default async function getMonerisIframeStyles({
-    cardCodeContainerId,
-    cardExpiryContainerId,
+export default function getMonerisIframeStyles({
     cardNumberContainerId,
-}: GetMonerisIframeStylesOptions): Promise<MonerisIframeStyles> {
-    const defaultInputStyles = await getCreditCardInputStyles(
-        cardNumberContainerId,
-        INPUT_STYLE_PROPERTIES,
-    );
+}: GetMonerisIframeStylesOptions): MonerisIframeStyles {
+    const inputStyles = getStylesFromContainer(cardNumberContainerId, INPUT_STYLE_PROPERTIES);
 
-    const cssTextbox = toCssString(
+    const cssTextbox = `${CSS_TEXTBOX_LAYOUT}${toCssString(
         {
-            ...defaultInputStyles,
-            outline: defaultInputStyles.outline || '0',
-            width: '100%',
+            ...inputStyles,
+            outline: inputStyles.outline || '0',
         },
-        [...INPUT_STYLE_PROPERTIES, 'outline', 'width'],
-    );
+        INPUT_STYLE_PROPERTIES.concat('outline'),
+    )}`;
 
-    const cssBody = toCssString(defaultInputStyles, ['fontFamily']);
+    const cssBody = `${CSS_BODY_LAYOUT}${toCssString(inputStyles, ['fontFamily'])}background: transparent;`;
 
-    const expiryStyles = await getCreditCardInputStyles(cardExpiryContainerId, [
-        'width',
-        ...INPUT_STYLE_PROPERTIES,
-    ]);
-
-    const cssTextboxExpiryDate = expiryStyles.width
-        ? `width: ${expiryStyles.width};`
-        : 'margin-bottom: 0;width: calc(50% - 12px);';
-
-    let cssTextboxCVV = 'margin-bottom: 0;width: calc(50% - 12px);';
-
-    if (cardCodeContainerId) {
-        const cvvStyles = await getCreditCardInputStyles(cardCodeContainerId, ['width']);
-
-        if (cvvStyles.width) {
-            cssTextboxCVV = `width: ${cvvStyles.width};`;
-        }
-    }
-
-    const labelStyles = getLabelStyles(cardNumberContainerId);
-    const cssInputLabel = toCssString(labelStyles, LABEL_STYLE_PROPERTIES);
-
-    console.log({
-        cssBody: cssBody ? `${cssBody}background: transparent;` : undefined,
-        cssTextbox: cssTextbox || undefined,
-        cssTextboxCardNumber: 'width: 100%;',
-        cssTextboxExpiryDate,
-        cssTextboxCVV,
-        cssInputLabel: cssInputLabel || undefined,
-    });
+    const labelStyles = sanitizeLabelStyles(getLabelStyles(cardNumberContainerId));
+    const cssInputLabel = `${CSS_INPUT_LABEL_LAYOUT}${toCssString(labelStyles, LABEL_STYLE_PROPERTIES)}`;
 
     return {
-        cssBody: cssBody ? `${cssBody}background: transparent;` : undefined,
-        cssTextbox: cssTextbox || undefined,
-        cssTextboxCardNumber: 'width: 100%;',
-        cssTextboxExpiryDate,
-        cssTextboxCVV,
-        cssInputLabel: cssInputLabel || undefined,
+        cssBody,
+        cssTextbox,
+        cssTextboxCardNumber: CSS_GRID_PLACEMENT.cardNumberInput,
+        cssTextboxExpiryDate: CSS_GRID_PLACEMENT.expiryDateInput,
+        cssTextboxCVV: CSS_GRID_PLACEMENT.cvvInput,
+        cssInputLabel,
+        cssLabelCardNumber: CSS_GRID_PLACEMENT.cardNumberLabel,
+        cssLabelExpiryDate: CSS_GRID_PLACEMENT.expiryDateLabel,
+        cssLabelCVV: CSS_GRID_PLACEMENT.cvvLabel,
     };
 }

--- a/packages/moneris-integration/src/getMonerisIframeStyles.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.ts
@@ -157,6 +157,8 @@ export default function getMonerisIframeStyles({
 
         if (onError) {
             onError(error);
+        } else {
+            console.error(error, { containerId: cardNumberContainerId });
         }
 
         return buildMonerisIframeStyles({}, {});

--- a/packages/moneris-integration/src/getMonerisIframeStyles.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.ts
@@ -16,7 +16,6 @@ export interface MonerisIframeStyles {
 
 export interface GetMonerisIframeStylesOptions {
     cardNumberContainerId: string;
-    onError?: (error: Error) => void;
 }
 
 const INPUT_STYLE_PROPERTIES = [
@@ -146,20 +145,14 @@ function buildMonerisIframeStyles(
 
 export default function getMonerisIframeStyles({
     cardNumberContainerId,
-    onError,
 }: GetMonerisIframeStylesOptions): MonerisIframeStyles {
     const container = document.getElementById(cardNumberContainerId);
 
     if (!container) {
-        const error = new Error(
+        console.error(
             'Unable to retrieve input styles as the provided container ID is not valid.',
+            { containerId: cardNumberContainerId },
         );
-
-        if (onError) {
-            onError(error);
-        } else {
-            console.error(error, { containerId: cardNumberContainerId });
-        }
 
         return buildMonerisIframeStyles({}, {});
     }

--- a/packages/moneris-integration/src/getMonerisIframeStyles.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.ts
@@ -1,0 +1,136 @@
+import { kebabCase } from 'lodash';
+
+import { getAppliedStyles } from '@bigcommerce/checkout/dom-utils';
+import { getCreditCardInputStyles } from '@bigcommerce/checkout/instrument-utils';
+
+export interface MonerisIframeStyles {
+    cssBody?: string;
+    cssTextbox?: string;
+    cssTextboxCardNumber?: string;
+    cssTextboxExpiryDate?: string;
+    cssTextboxCVV?: string;
+    cssInputLabel?: string;
+}
+
+export interface GetMonerisIframeStylesOptions {
+    cardCodeContainerId?: string;
+    cardExpiryContainerId: string;
+    cardNumberContainerId: string;
+}
+
+const INPUT_STYLE_PROPERTIES = [
+    'backgroundColor',
+    'border',
+    'borderColor',
+    'borderRadius',
+    'borderStyle',
+    'borderWidth',
+    'boxSizing',
+    'color',
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'height',
+    'outline',
+    'padding',
+];
+
+const LABEL_STYLE_PROPERTIES = ['color', 'fontFamily', 'fontSize', 'fontWeight'];
+
+function toCssString(styles: Record<string, string>, properties: string[]): string {
+    return properties
+        .map((property) => {
+            const value = styles[property];
+
+            if (!value) {
+                return '';
+            }
+
+            return `${kebabCase(property)}: ${value};`;
+        })
+        .join('');
+}
+
+function getLabelStyles(containerId: string): Record<string, string> {
+    const container = document.getElementById(containerId);
+
+    if (!container) {
+        return {};
+    }
+
+    const field = document.createElement('div');
+    const label = document.createElement('label');
+
+    field.className = 'form-field form-field--ccNumber';
+    label.className = 'form-label';
+    field.appendChild(label);
+    container.appendChild(field);
+
+    const styles = getAppliedStyles(label, LABEL_STYLE_PROPERTIES);
+
+    container.removeChild(field);
+
+    return styles;
+}
+
+export default async function getMonerisIframeStyles({
+    cardCodeContainerId,
+    cardExpiryContainerId,
+    cardNumberContainerId,
+}: GetMonerisIframeStylesOptions): Promise<MonerisIframeStyles> {
+    const defaultInputStyles = await getCreditCardInputStyles(
+        cardNumberContainerId,
+        INPUT_STYLE_PROPERTIES,
+    );
+
+    const cssTextbox = toCssString(
+        {
+            ...defaultInputStyles,
+            outline: defaultInputStyles.outline || '0',
+            width: '100%',
+        },
+        [...INPUT_STYLE_PROPERTIES, 'outline', 'width'],
+    );
+
+    const cssBody = toCssString(defaultInputStyles, ['fontFamily']);
+
+    const expiryStyles = await getCreditCardInputStyles(cardExpiryContainerId, [
+        'width',
+        ...INPUT_STYLE_PROPERTIES,
+    ]);
+
+    const cssTextboxExpiryDate = expiryStyles.width
+        ? `width: ${expiryStyles.width};`
+        : 'margin-bottom: 0;width: calc(50% - 12px);';
+
+    let cssTextboxCVV = 'margin-bottom: 0;width: calc(50% - 12px);';
+
+    if (cardCodeContainerId) {
+        const cvvStyles = await getCreditCardInputStyles(cardCodeContainerId, ['width']);
+
+        if (cvvStyles.width) {
+            cssTextboxCVV = `width: ${cvvStyles.width};`;
+        }
+    }
+
+    const labelStyles = getLabelStyles(cardNumberContainerId);
+    const cssInputLabel = toCssString(labelStyles, LABEL_STYLE_PROPERTIES);
+
+    console.log({
+        cssBody: cssBody ? `${cssBody}background: transparent;` : undefined,
+        cssTextbox: cssTextbox || undefined,
+        cssTextboxCardNumber: 'width: 100%;',
+        cssTextboxExpiryDate,
+        cssTextboxCVV,
+        cssInputLabel: cssInputLabel || undefined,
+    });
+
+    return {
+        cssBody: cssBody ? `${cssBody}background: transparent;` : undefined,
+        cssTextbox: cssTextbox || undefined,
+        cssTextboxCardNumber: 'width: 100%;',
+        cssTextboxExpiryDate,
+        cssTextboxCVV,
+        cssInputLabel: cssInputLabel || undefined,
+    };
+}

--- a/packages/moneris-integration/src/getMonerisIframeStyles.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.ts
@@ -16,6 +16,7 @@ export interface MonerisIframeStyles {
 
 export interface GetMonerisIframeStylesOptions {
     cardNumberContainerId: string;
+    onMissingStyleContainer?: (error: Error) => void;
 }
 
 const INPUT_STYLE_PROPERTIES = [
@@ -145,14 +146,20 @@ function buildMonerisIframeStyles(
 
 export default function getMonerisIframeStyles({
     cardNumberContainerId,
+    onMissingStyleContainer,
 }: GetMonerisIframeStylesOptions): MonerisIframeStyles {
     const container = document.getElementById(cardNumberContainerId);
 
     if (!container) {
-        console.error(
+        const error = new Error(
             'Unable to retrieve input styles as the provided container ID is not valid.',
-            { containerId: cardNumberContainerId },
         );
+
+        if (onMissingStyleContainer) {
+            onMissingStyleContainer(error);
+        } else {
+            console.error(error, { containerId: cardNumberContainerId });
+        }
 
         return buildMonerisIframeStyles({}, {});
     }

--- a/packages/moneris-integration/src/getMonerisIframeStyles.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.ts
@@ -16,6 +16,7 @@ export interface MonerisIframeStyles {
 
 export interface GetMonerisIframeStylesOptions {
     cardNumberContainerId: string;
+    onError?: (error: Error) => void;
 }
 
 const INPUT_STYLE_PROPERTIES = [
@@ -58,18 +59,10 @@ function getStylesFromElement(element: HTMLElement, properties: string[]): Recor
 }
 
 function getStylesFromContainer(
-    containerId: string,
+    container: HTMLElement,
     properties: string[],
     className = 'form-input optimizedCheckout-form-input',
 ): Record<string, string> {
-    const container = document.getElementById(containerId);
-
-    if (!container) {
-        throw new Error(
-            'Unable to retrieve input styles as the provided container ID is not valid.',
-        );
-    }
-
     const probe = document.createElement('div');
 
     probe.className = className;
@@ -82,15 +75,7 @@ function getStylesFromContainer(
     return styles;
 }
 
-function getLabelStyles(containerId: string): Record<string, string> {
-    const container = document.getElementById(containerId);
-
-    if (!container) {
-        throw new Error(
-            'Unable to retrieve input styles as the provided container ID is not valid.',
-        );
-    }
-
+function getLabelStyles(container: HTMLElement): Record<string, string> {
     const field = document.createElement('div');
     const label = document.createElement('label');
 
@@ -130,11 +115,10 @@ function toCssString(styles: Record<string, string>, properties: string[]): stri
         .join('');
 }
 
-export default function getMonerisIframeStyles({
-    cardNumberContainerId,
-}: GetMonerisIframeStylesOptions): MonerisIframeStyles {
-    const inputStyles = getStylesFromContainer(cardNumberContainerId, INPUT_STYLE_PROPERTIES);
-
+function buildMonerisIframeStyles(
+    inputStyles: Record<string, string>,
+    labelStyles: Record<string, string>,
+): MonerisIframeStyles {
     const cssTextbox = `${CSS_TEXTBOX_LAYOUT}${toCssString(
         {
             ...inputStyles,
@@ -145,7 +129,6 @@ export default function getMonerisIframeStyles({
 
     const cssBody = `${CSS_BODY_LAYOUT}${toCssString(inputStyles, ['fontFamily'])}background: transparent;`;
 
-    const labelStyles = sanitizeLabelStyles(getLabelStyles(cardNumberContainerId));
     const cssInputLabel = `${CSS_INPUT_LABEL_LAYOUT}${toCssString(labelStyles, LABEL_STYLE_PROPERTIES)}`;
 
     return {
@@ -159,4 +142,28 @@ export default function getMonerisIframeStyles({
         cssLabelExpiryDate: CSS_GRID_PLACEMENT.expiryDateLabel,
         cssLabelCVV: CSS_GRID_PLACEMENT.cvvLabel,
     };
+}
+
+export default function getMonerisIframeStyles({
+    cardNumberContainerId,
+    onError,
+}: GetMonerisIframeStylesOptions): MonerisIframeStyles {
+    const container = document.getElementById(cardNumberContainerId);
+
+    if (!container) {
+        const error = new Error(
+            'Unable to retrieve input styles as the provided container ID is not valid.',
+        );
+
+        if (onError) {
+            onError(error);
+        }
+
+        return buildMonerisIframeStyles({}, {});
+    }
+
+    const inputStyles = getStylesFromContainer(container, INPUT_STYLE_PROPERTIES);
+    const labelStyles = sanitizeLabelStyles(getLabelStyles(container));
+
+    return buildMonerisIframeStyles(inputStyles, labelStyles);
 }

--- a/packages/moneris-integration/src/getMonerisIframeStyles.ts
+++ b/packages/moneris-integration/src/getMonerisIframeStyles.ts
@@ -36,13 +36,13 @@ const INPUT_STYLE_PROPERTIES = [
 const LABEL_STYLE_PROPERTIES = ['color', 'fontFamily', 'fontWeight'];
 
 const CSS_BODY_LAYOUT =
-    'margin: 0; padding: 24px 0; box-sizing: border-box; display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: auto auto; row-gap: 24px; column-gap: 8px;';
+    'margin: 0; padding: 20px 0 0; box-sizing: border-box; display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: auto auto; row-gap: 30px; column-gap: 20px;';
 
 const CSS_INPUT_LABEL_LAYOUT =
-    'justify-self: start; align-self: start; font-size: 0.75rem; line-height: 1; pointer-events: none; z-index: 1; transform: translateY(-100%);';
+    'justify-self: start; align-self: start; font-size: 0.75rem; line-height: 1; pointer-events: none; z-index: 1; transform: translateY(-160%);';
 
 const CSS_TEXTBOX_LAYOUT =
-    'justify-self: stretch; align-self: stretch; width: 100%; box-sizing: border-box;';
+    'justify-self: stretch; align-self: stretch; width: 100%; box-sizing: border-box; padding: 0 12px;';
 
 const CSS_GRID_PLACEMENT = {
     cardNumberLabel: 'grid-column: 1 / 3; grid-row: 1;',


### PR DESCRIPTION
## What/Why?

- get CSS styles from the sample default BC fields
- pass the styles to `checkout-sdk`

`checkout-sdk-js` part: https://github.com/bigcommerce/checkout-sdk-js/pull/3333

## Rollout/Rollback

Revert

## Testing
Before:
<img width="591" height="239" alt="Screenshot 2026-08-03 at 11 45 39" src="https://github.com/user-attachments/assets/b076c0b4-e0f0-4e98-8fb0-05a937766cdd" />

After:
<img width="591" height="240" alt="Screenshot 2026-08-03 at 11 48 04" src="https://github.com/user-attachments/assets/7d402f9e-9237-403c-94d2-f19cc4d6ab2d" />

E2E:
<img width="826" height="99" alt="Screenshot 2026-08-03 at 11 58 34" src="https://github.com/user-attachments/assets/b656468b-00d0-46be-9735-736f771979ff" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Payment UI styling only; no auth or payment data handling changes. Missing style probes degrade to layout defaults with warning logs.
> 
> **Overview**
> **Moneris hosted card fields** now receive CSS derived from the checkout theme so the iframe matches default BigCommerce credit-card inputs (layout grid, borders, fonts, labels).
> 
> A new **`getMonerisIframeStyles`** helper probes DOM styles via hidden sample markup (`optimizedCheckout-form-input` / labels), maps them to Moneris SDK params (`cssBody`, `cssTextbox`, per-field grid placement), and passes the result on **`moneris.style`** during `initializePayment`. **`MonerisPaymentMethod`** renders a visually hidden style sampler and wires **`onUnhandledError`** through the hosted widget.
> 
> If the probe container is missing, checkout still initializes with layout-only styles; the issue is logged as a **warning** (`monerisStyleProbe`) via **`errorLogger`** instead of blocking payment setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40881a1632974c3590cc9b0d862a1e924ff07a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->