### PR TITLE
chore(checkout): SHIPPING-4147 Bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.945.0",
+        "@bigcommerce/checkout-sdk": "^1.948.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2230,9 +2230,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.945.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.945.0.tgz",
-      "integrity": "sha512-vXqE/W6RU1pQlIi/le0auaZ4gzHh/yWJNGXLwzRhq9eepgDYHg6/+vOsPQ4N3XtAGGhlLOTBox4K3STw1pycBw==",
+      "version": "1.948.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.948.1.tgz",
+      "integrity": "sha512-Q5MOZInu0XqzAXAzc0RVm0GC66DJuSLKakDaDmwFT6TRTE1wiEOb0Vh01G9f8cA1t2BVowugl57qJoevFVqAoQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.28.1",
@@ -29814,9 +29814,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.945.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.945.0.tgz",
-      "integrity": "sha512-vXqE/W6RU1pQlIi/le0auaZ4gzHh/yWJNGXLwzRhq9eepgDYHg6/+vOsPQ4N3XtAGGhlLOTBox4K3STw1pycBw==",
+      "version": "1.948.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.948.1.tgz",
+      "integrity": "sha512-Q5MOZInu0XqzAXAzc0RVm0GC66DJuSLKakDaDmwFT6TRTE1wiEOb0Vh01G9f8cA1t2BVowugl57qJoevFVqAoQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.28.1",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.945.0",
+    "@bigcommerce/checkout-sdk": "^1.948.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk to release:
- https://github.com/bigcommerce/checkout-sdk-js/pull/3332
- https://github.com/bigcommerce/checkout-sdk-js/pull/3323

## Rollout/Rollback
Revert.

## Testing
CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but checkout-sdk drives checkout payment and shipping behavior; regressions would surface at runtime without local code review in this repo.
> 
> **Overview**
> Updates the **`@bigcommerce/checkout-sdk`** dependency from **^1.945.0** to **^1.948.1** in `package.json` and `package-lock.json`. There are **no other code changes** in checkout-js; behavior comes from the published SDK releases referenced in the ticket (including checkout-sdk-js PRs **#3332** and **#3323** for SHIPPING-4147).
> 
> After merge, installs resolve to SDK **1.948.1** and the checkout UI uses that SDK build for payment/shipping flows wired through the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba0265ec701c311b147e295828a0857abd318c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->