### PR TITLE
feat(other): CHECKOUT-10272 Make corners rounded for various UI elements

### DIFF
--- a/packages/core/src/app/coupon/components/CouponForm.tsx
+++ b/packages/core/src/app/coupon/components/CouponForm.tsx
@@ -1,6 +1,6 @@
 import React, { type FunctionComponent, useState } from 'react';
 
-import { useLocale } from '@bigcommerce/checkout/contexts';
+import { useLocale, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import {
     Alert,
@@ -17,6 +17,7 @@ import { ManageCouponsAndGiftCertificates } from './ManageCouponsAndGiftCertific
 
 export const CouponForm: FunctionComponent = () => {
     const [code, setCode] = useState<string>('');
+    const { themeV2 } = useThemeContext();
 
     const { language } = useLocale();
     const {
@@ -89,7 +90,7 @@ export const CouponForm: FunctionComponent = () => {
             </div>
             <div className="applied-coupons-list">
                 {Boolean(couponError) && (
-                    <Alert additionalClassName="no-padding" type={AlertType.Error}>
+                    <Alert additionalClassName={themeV2 ? '' : 'no-padding'} type={AlertType.Error}>
                         <ul className="applied-coupon-error-message">
                             <li>
                                 <span>{couponError}</span>

--- a/packages/core/src/app/shipping/MultiShippingForm.scss
+++ b/packages/core/src/app/shipping/MultiShippingForm.scss
@@ -21,6 +21,7 @@ $allocate-items-table-image-width-small-screen: 40%;
 .consignment-header {
     display: flex;
     justify-content: space-between;
+    margin-bottom: 0;
 
     h3 {
         font-size: fontSize("small");

--- a/packages/core/src/scss/themeV2/_themeV2.scss
+++ b/packages/core/src/scss/themeV2/_themeV2.scss
@@ -8,6 +8,9 @@
 // Color
 @import "color/color";
 
+// Common
+@import "common/common";
+
 // Font
 @import "font/font";
 
@@ -22,6 +25,3 @@
 
 // Utilities
 @import "utils/utils";
-
-// Common
-@import "common/common";

--- a/packages/core/src/scss/themeV2/_themeV2.scss
+++ b/packages/core/src/scss/themeV2/_themeV2.scss
@@ -22,3 +22,6 @@
 
 // Utilities
 @import "utils/utils";
+
+// Common
+@import "common/common";

--- a/packages/core/src/scss/themeV2/_themeV2.scss
+++ b/packages/core/src/scss/themeV2/_themeV2.scss
@@ -25,3 +25,6 @@
 
 // Utilities
 @import "utils/utils";
+
+// Multi Shipping
+@import "multiShipping/multiShipping";

--- a/packages/core/src/scss/themeV2/color/_color.scss
+++ b/packages/core/src/scss/themeV2/color/_color.scss
@@ -1,6 +1,7 @@
 $color-secondaryDark:               #fcfcfc;
 $color-secondaryDarker:             #f5f5f5;
 $color-secondaryDarkest:            #757575;
+$color-highlightLightest:            #f4f6ff;
 $color-highlight:                   #4496f6;
 $color-highlightDarkest:            #476BEF;
 $color-white:                       #ffffff;

--- a/packages/core/src/scss/themeV2/color/_color.scss
+++ b/packages/core/src/scss/themeV2/color/_color.scss
@@ -5,4 +5,5 @@ $color-highlight:                   #4496f6;
 $color-highlightDarkest:            #476BEF;
 $color-white:                       #ffffff;
 $color-greyMedium:                  #dddddd;
+$color-greyDark:                    #A9A9A9;
 $color-black:                       #000000;

--- a/packages/core/src/scss/themeV2/common/_common.scss
+++ b/packages/core/src/scss/themeV2/common/_common.scss
@@ -1,0 +1,5 @@
+@include themeV2 {
+    .button, .shippingOptions-panel {
+        border-radius: remCalc(12px);
+    }
+}

--- a/packages/core/src/scss/themeV2/common/_common.scss
+++ b/packages/core/src/scss/themeV2/common/_common.scss
@@ -1,5 +1,7 @@
+$element-border-radius: remCalc(12px);
+
 @include themeV2 {
     .button, .shippingOptions-panel {
-        border-radius: remCalc(12px);
+        border-radius: $element-border-radius;
     }
 }

--- a/packages/core/src/scss/themeV2/common/_common.scss
+++ b/packages/core/src/scss/themeV2/common/_common.scss
@@ -1,7 +1,10 @@
 $element-border-radius: remCalc(12px);
 
 @include themeV2 {
-    .button, .shippingOptions-panel {
+    .button,
+    .shippingOptions-panel,
+    .alertBox,
+    .modal {
         border-radius: $element-border-radius;
     }
 }

--- a/packages/core/src/scss/themeV2/common/_common.scss
+++ b/packages/core/src/scss/themeV2/common/_common.scss
@@ -1,6 +1,8 @@
 $element-border-radius: remCalc(12px);
 
 @include themeV2 {
+    background-color: $color-secondaryDarker;
+
     .button,
     .shippingOptions-panel,
     .alertBox,

--- a/packages/core/src/scss/themeV2/common/_common.scss
+++ b/packages/core/src/scss/themeV2/common/_common.scss
@@ -7,8 +7,4 @@ $element-border-radius: remCalc(12px);
     .modal {
         border-radius: $element-border-radius;
     }
-
-    .alertBox.alertBox--error {
-        padding: 0 spacing("quarter");
-    }
 }

--- a/packages/core/src/scss/themeV2/common/_common.scss
+++ b/packages/core/src/scss/themeV2/common/_common.scss
@@ -5,8 +5,7 @@ $element-border-radius: remCalc(12px);
 
     .button,
     .shippingOptions-panel,
-    .alertBox,
-    .modal {
+    .alertBox{
         border-radius: $element-border-radius;
     }
 }

--- a/packages/core/src/scss/themeV2/common/_common.scss
+++ b/packages/core/src/scss/themeV2/common/_common.scss
@@ -7,4 +7,8 @@ $element-border-radius: remCalc(12px);
     .modal {
         border-radius: $element-border-radius;
     }
+
+    .alertBox.alertBox--error {
+        padding: 0 spacing("quarter");
+    }
 }

--- a/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
@@ -22,7 +22,7 @@
             display: block;
             margin-top: 0;
             margin-bottom: 0;
-            border-radius: remCalc(12px);
+            border-radius: $element-border-radius;
         }
 
         .cart-priceItem:last-child {

--- a/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
@@ -36,6 +36,10 @@
             justify-content: space-between;
             padding: spacing("base") #{spacing("base") + spacing("base")};
             width: 100%;
+
+            .sub-header {
+                margin-bottom: 0;
+            }
         }
 
         .cart-summary-header {

--- a/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_cart-summary.scss
@@ -22,6 +22,7 @@
             display: block;
             margin-top: 0;
             margin-bottom: 0;
+            border-radius: remCalc(12px);
         }
 
         .cart-priceItem:last-child {

--- a/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
@@ -6,15 +6,18 @@
 
         .form-checklist-item {
             border: 1px solid $color-greyMedium;
-            border-radius: spacing("sixth");
             margin: spacing("sixth") 0;
 
             &:first-child {
                 margin-top: 0;
+                border-top-right-radius: remCalc(12px);
+                border-top-left-radius: remCalc(12px);
             }
 
             &:last-child {
                 margin-bottom: 0;
+                border-bottom-right-radius: remCalc(12px);
+                border-bottom-left-radius: remCalc(12px);
             }         
         }
 

--- a/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checklist.scss
@@ -7,22 +7,20 @@
         .form-checklist-item {
             border: 1px solid $color-greyMedium;
             margin: spacing("sixth") 0;
+            border-radius: $element-border-radius;
 
             &:first-child {
                 margin-top: 0;
-                border-top-right-radius: remCalc(12px);
-                border-top-left-radius: remCalc(12px);
             }
 
             &:last-child {
                 margin-bottom: 0;
-                border-bottom-right-radius: remCalc(12px);
-                border-bottom-left-radius: remCalc(12px);
             }         
         }
 
         .form-checklist-item--selected {
             border: $input-border-width $input-border-style $color-black;
+            background-color: $color-highlightLightest;
         }
 
         .form-checklist-header {

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -11,10 +11,17 @@
         .layout-main {
             padding: 0;
         }
+        
+        .checkout-separator {
+            .sub-header {
+                color: $color-greyDark;
+                margin-top: #{spacing("half")};
+            }
+        }
 
         .checkout-separator::before,
         .checkout-separator::after {
-            background-color: $color-black;
+            background-color: $color-greyDark;
         }
         
         .checkout-steps {
@@ -30,6 +37,7 @@
             border-bottom: none;
             padding: #{spacing("base")} #{spacing("base") + spacing("base")};
             margin: spacing("single") 0;
+            border-radius: remCalc(12px);
         }
         
         // :not(:last-child) keeps collapsed steps unaffected
@@ -67,6 +75,7 @@
 
         .checkout-button-container {
             padding: 0 #{spacing("base") + spacing("base")};
+            margin-top: #{spacing("single")};
         }
     }
 
@@ -78,7 +87,7 @@
         }
 
         .checkout-button-container {
-            padding: 0 #{spacing('double') + spacing('double')} 0 0;
+            padding: 0;
         }
     }
 

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -16,6 +16,7 @@
             .sub-header {
                 color: $color-greyDark;
                 margin-top: spacing("half");
+                margin-bottom: 0;
             }
         }
 
@@ -69,7 +70,7 @@
             }
 
             .stepHeader-figure {
-                align-items: flex-end;
+                align-items: center;
             }
         }
 

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -15,7 +15,7 @@
         .checkout-separator {
             .sub-header {
                 color: $color-greyDark;
-                margin-top: #{spacing("half")};
+                margin-top: spacing("half");
             }
         }
 
@@ -37,7 +37,7 @@
             border-bottom: none;
             padding: #{spacing("base")} #{spacing("base") + spacing("base")};
             margin: spacing("single") 0;
-            border-radius: remCalc(12px);
+            border-radius: $element-border-radius;
         }
         
         // :not(:last-child) keeps collapsed steps unaffected
@@ -75,7 +75,7 @@
 
         .checkout-button-container {
             padding: 0 #{spacing("base") + spacing("base")};
-            margin-top: #{spacing("single")};
+            margin-top: spacing("single");
         }
     }
 

--- a/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_checkout.scss
@@ -15,8 +15,7 @@
         .checkout-separator {
             .sub-header {
                 color: $color-greyDark;
-                margin-top: spacing("half");
-                margin-bottom: 0;
+                margin: 0;
             }
         }
 

--- a/packages/core/src/scss/themeV2/components/checkout/_products-list.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_products-list.scss
@@ -20,6 +20,12 @@
     @include themeV2-desktop {
         .product-figure {
             max-width: none;
+            width: 20%;
+            padding-right: spacing("single");
+
+            img {
+                border-radius: $element-border-radius;
+            }
         }
     }
 }

--- a/packages/core/src/scss/themeV2/font/_font.scss
+++ b/packages/core/src/scss/themeV2/font/_font.scss
@@ -14,6 +14,7 @@
     // optimizedCheckout-headingSecondary
     .sub-header {
         font-size: $fontSize-smaller;
+        margin-bottom: spacing("half");
     }
 
     // optimizedCheckout-contentPrimary

--- a/packages/core/src/scss/themeV2/font/_font.scss
+++ b/packages/core/src/scss/themeV2/font/_font.scss
@@ -11,13 +11,11 @@
         color: $color-secondaryDarkest;
     }
 
-    // optimizedCheckout-headingSecondary
     .sub-header {
         font-size: $fontSize-smaller;
         margin-bottom: spacing("half");
     }
 
-    // optimizedCheckout-contentPrimary
     .body-regular, .body-cta, .body-thin, .body-medium, .body-bold {
         color: $color-black;
         font-family: $fontFamily-montserrat;

--- a/packages/core/src/scss/themeV2/form/_form.scss
+++ b/packages/core/src/scss/themeV2/form/_form.scss
@@ -3,7 +3,7 @@
 // =============================================================================
 
 @include themeV2 {
-    .form-input {
+    .form-input, .form-select {
         border-radius: $element-border-radius;
     }
 

--- a/packages/core/src/scss/themeV2/form/_form.scss
+++ b/packages/core/src/scss/themeV2/form/_form.scss
@@ -4,13 +4,13 @@
 
 @include themeV2 {
     .form-input {
-        border-radius: remCalc(12px);
+        border-radius: $element-border-radius;
     }
 
     .floating-select,
     .floating-input {
         background-color: $color-secondaryDark;
-        border-radius: remCalc(12px);
+        border-radius: $element-border-radius;
     }
 
     .form-field:not(.form-field--error) .floating-input:not(:focus),

--- a/packages/core/src/scss/themeV2/form/_form.scss
+++ b/packages/core/src/scss/themeV2/form/_form.scss
@@ -3,9 +3,14 @@
 // =============================================================================
 
 @include themeV2 {
+    .form-input {
+        border-radius: remCalc(12px);
+    }
+
     .floating-select,
     .floating-input {
         background-color: $color-secondaryDark;
+        border-radius: remCalc(12px);
     }
 
     .form-field:not(.form-field--error) .floating-input:not(:focus),

--- a/packages/core/src/scss/themeV2/multiShipping/_multiShipping.scss
+++ b/packages/core/src/scss/themeV2/multiShipping/_multiShipping.scss
@@ -1,0 +1,5 @@
+@include themeV2 {
+    .consignment-container {
+        border-radius: $element-border-radius;
+    }
+}


### PR DESCRIPTION
## What/Why?
Make corners rounded for various UI elements. Walled buttons out of scope, they need to be handed separately.

## Rollout/Rollback
- revert this PR

## Testing
- CI 
- screencast


https://github.com/user-attachments/assets/df562956-9f38-4efc-8fe4-21e6f1888d18





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Theme V2 SCSS and one conditional class in CouponForm; no auth, payment, or data logic changes.
> 
> **Overview**
> Introduces a shared **12px** corner radius (`$element-border-radius`) for Theme V2 and applies it across checkout surfaces—steps, cart, form controls, checklist options, buttons, alerts, shipping panels, and multi-shipping consignment blocks.
> 
> **Visual polish** includes a light blue background on selected checklist items, grey separator lines and sub-headers, adjusted step header alignment, and rounded product images on desktop. **CouponForm** drops the `no-padding` class on coupon error alerts when Theme V2 is active so alert padding matches the new rounded alert styling.
> 
> A small non-theme tweak sets `consignment-header` margin-bottom to **0** in `MultiShippingForm.scss`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39dfd6b8e44694e8cc101ab0d0deb808023be328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->