### PR TITLE
test(checkout): BACK-729 Add data-test to make checkout more resilient to changes

### DIFF
--- a/packages/core/src/app/shipping/ShippingFormFooter.tsx
+++ b/packages/core/src/app/shipping/ShippingFormFooter.tsx
@@ -50,7 +50,7 @@ const ShippingFormFooter: FunctionComponent<ShippingFormFooterProps> = ({
                             <TranslatedString id="shipping.shipping_method_label" />
                         </Legend>
                         {defaultShippingExpectationMessage && (
-                            <p className="shipping-ExpectationMessage">
+                            <p className="shipping-ExpectationMessage" data-test="shipping-expectation-message">
                                 {defaultShippingExpectationMessage}
                             </p>
                         )}


### PR DESCRIPTION
## What/Why?
- Add data-test to the shipping expectation message. This is to make the test more resilient to future refactors.

## Rollout/Rollback
Revert

## Testing
N/A. Adding a data-test value
