### PR TITLE
fix(checkout): CHECKOUT-10282 Send Empty Order Extra Fields

### DIFF
--- a/packages/core/src/app/payment/b2bMetadata.ts
+++ b/packages/core/src/app/payment/b2bMetadata.ts
@@ -15,12 +15,12 @@ export const getRecordValue = (value: unknown): Record<string, unknown> | undefi
         ? (value as Record<string, unknown>)
         : undefined;
 
-export const hasNonEmptyExtraFieldValue = (
+export const hasValidOrderExtraFieldValue = (
     entry: [string, unknown],
 ): entry is [string, string | number] => {
     const value = entry[1];
 
-    return typeof value === 'number' || (typeof value === 'string' && value !== '');
+    return typeof value === 'number' || typeof value === 'string';
 };
 
 export const storeB2BPaymentValues = ({

--- a/packages/core/src/app/payment/b2bMetadataForPostOrder.test.ts
+++ b/packages/core/src/app/payment/b2bMetadataForPostOrder.test.ts
@@ -38,10 +38,13 @@ describe('b2bMetadataForPostOrder', () => {
             ]);
         });
 
-        it('omits fields with empty values', () => {
+        it('keeps fields with empty values', () => {
             expect(
                 getOrderExtraFieldsValues({ field_25: '', field_26: 'Finance' }, orderExtraFields),
-            ).toEqual([{ fieldName: 'Department', fieldValue: 'Finance' }]);
+            ).toEqual([
+                { fieldName: 'Cost Centre', fieldValue: '' },
+                { fieldName: 'Department', fieldValue: 'Finance' },
+            ]);
         });
 
         it('returns an empty array when there are no form values', () => {

--- a/packages/core/src/app/payment/b2bMetadataForPostOrder.ts
+++ b/packages/core/src/app/payment/b2bMetadataForPostOrder.ts
@@ -11,7 +11,7 @@ import {
     type B2BPaymentFormValues,
     getRecordValue,
     getStringValue,
-    hasNonEmptyExtraFieldValue,
+    hasValidOrderExtraFieldValue,
 } from './b2bMetadata';
 
 type B2BMetadataExtraField = NonNullable<PersistB2BMetadataOptions['extraFields']>[number];
@@ -37,7 +37,7 @@ const mapOrderExtraFieldsValues = (
     fieldLabels: FieldLabelLookup,
 ): B2BMetadataExtraField[] =>
     Object.entries(formExtraFields)
-        .filter(hasNonEmptyExtraFieldValue)
+        .filter(hasValidOrderExtraFieldValue)
         .map(([fieldName, fieldValue]) => ({
             // The API expects the field label, but form values are keyed by field name (id).
             fieldName: getExtraFieldLabel(fieldName, fieldLabels),

--- a/packages/core/src/app/payment/b2bMetadataForSubmitOrder.test.ts
+++ b/packages/core/src/app/payment/b2bMetadataForSubmitOrder.test.ts
@@ -24,7 +24,7 @@ describe('b2bMetadataForSubmitOrder', () => {
             });
         });
 
-        it('omits empty and non-scalar extra field values', () => {
+        it('omits values that are not strings or numbers but keeps empty strings', () => {
             expect(
                 mapToB2BOrderRequestBody({
                     orderExtraFields: {
@@ -34,7 +34,12 @@ describe('b2bMetadataForSubmitOrder', () => {
                         filled: 'value',
                     },
                 }),
-            ).toEqual({ orderExtraFields: [{ fieldId: 'filled', fieldValue: 'value' }] });
+            ).toEqual({
+                orderExtraFields: [
+                    { fieldId: 'empty', fieldValue: '' },
+                    { fieldId: 'filled', fieldValue: 'value' },
+                ],
+            });
         });
 
         it('omits the keys when the values are empty or missing', () => {

--- a/packages/core/src/app/payment/b2bMetadataForSubmitOrder.ts
+++ b/packages/core/src/app/payment/b2bMetadataForSubmitOrder.ts
@@ -4,7 +4,7 @@ import {
     type B2BPaymentFormValues,
     getRecordValue,
     getStringValue,
-    hasNonEmptyExtraFieldValue,
+    hasValidOrderExtraFieldValue,
 } from './b2bMetadata';
 
 type B2BOrderRequestExtraField = NonNullable<OrderRequestBody['orderExtraFields']>[number];
@@ -21,7 +21,7 @@ const toRawExtraFieldId = (fieldName: string): string =>
 
 const getOrderExtraFieldValues = (value: unknown): B2BOrderRequestExtraField[] =>
     Object.entries(getRecordValue(value) ?? {})
-        .filter(hasNonEmptyExtraFieldValue)
+        .filter(hasValidOrderExtraFieldValue)
         .map(([fieldName, fieldValue]) => ({
             fieldId: toRawExtraFieldId(fieldName),
             fieldValue,


### PR DESCRIPTION
## What/Why?

Update the order extra field filter to allow empty string values.

We allow empty shipping extra fields now.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to B2B extra-field filtering with updated tests; no auth or payment processing logic touched.
> 
> **Overview**
> B2B checkout now **includes order extra fields whose value is an empty string** when building post-order metadata and submit-order payloads, instead of dropping them.
> 
> The shared filter in `b2bMetadata` is renamed to `hasValidOrderExtraFieldValue` and only excludes non-string/non-number values; **empty strings are treated as valid**. `poNumber` and `additionalText` still omit empty strings via separate `getStringValue` checks—only `orderExtraFields` behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf36f8c2d974fc934a1e42dcbc42a6158c311ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->