### PR TITLE
feat(checkout): CHECKOUT-10286 Prevent iOS auto-zoom on mobile form fields

### DIFF
--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -56,18 +56,26 @@
 
         .floating-input,
         .floating-select {
-            font-size: $floating-label-font-size--default;
+            font-size: 16px;
             height: $floating-label-input-height;
             padding-bottom: 0;
             padding-left: $input-horizontalPadding;
             padding-right: $input-horizontalPadding;
             padding-top: $input-verticalPadding * 1.5;
 
+            @include breakpoint("small") {
+                font-size: $floating-label-font-size--default;
+            }
+
             &.floating-form-field-input {
                 color: $color-black;
                 font-family: $fontFamily-montserrat;
-                font-size: $fontSize-smallest;
+                font-size: 16px;
                 font-weight: $fontWeight-normal;
+
+                @include breakpoint("small") {
+                    font-size: $fontSize-smallest;
+                }
             }
         }
 
@@ -161,6 +169,12 @@
     }
 
     .form-input {
+        font-size: 16px;
+
+        @include breakpoint("small") {
+            font-size: $input-font-size;
+        }
+
         &:focus,
         &--focus {
             box-shadow: $input-focus-boxShadow, $input-box-shadow;
@@ -248,7 +262,12 @@
         -webkit-appearance: none; // 2
         background-image: none;
         border-radius: $input-border-radius;
+        font-size: 16px;
         padding: $input-verticalPadding $select-paddingRight $input-verticalPadding $input-horizontalPadding;
+
+        @include breakpoint("small") {
+            font-size: $input-font-size;
+        }
     }
     // scss-lint:enable ImportantRule
 }

--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -56,7 +56,7 @@
 
         .floating-input,
         .floating-select {
-            font-size: 16px;
+            font-size: $input-font-size--mobile-min;
             height: $floating-label-input-height;
             padding-bottom: 0;
             padding-left: $input-horizontalPadding;
@@ -70,7 +70,7 @@
             &.floating-form-field-input {
                 color: $color-black;
                 font-family: $fontFamily-montserrat;
-                font-size: 16px;
+                font-size: $input-font-size--mobile-min;
                 font-weight: $fontWeight-normal;
 
                 @include breakpoint("small") {
@@ -169,7 +169,7 @@
     }
 
     .form-input {
-        font-size: 16px;
+        font-size: $input-font-size--mobile-min;
 
         @include breakpoint("small") {
             font-size: $input-font-size;
@@ -262,7 +262,7 @@
         -webkit-appearance: none; // 2
         background-image: none;
         border-radius: $input-border-radius;
-        font-size: 16px;
+        font-size: $input-font-size--mobile-min;
         padding: $input-verticalPadding $select-paddingRight $input-verticalPadding $input-horizontalPadding;
 
         @include breakpoint("small") {

--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -63,7 +63,7 @@
             padding-right: $input-horizontalPadding;
             padding-top: $input-verticalPadding * 1.5;
 
-            @include breakpoint("small") {
+            @media (min-width: $screen-small) and (min-height: $screen-small-landscape-height) {
                 font-size: $floating-label-font-size--default;
             }
 
@@ -73,7 +73,7 @@
                 font-size: $input-font-size--mobile-min;
                 font-weight: $fontWeight-normal;
 
-                @include breakpoint("small") {
+                @media (min-width: $screen-small) and (min-height: $screen-small-landscape-height) {
                     font-size: $fontSize-smallest;
                 }
             }
@@ -171,7 +171,7 @@
     .form-input {
         font-size: $input-font-size--mobile-min;
 
-        @include breakpoint("small") {
+        @media (min-width: $screen-small) and (min-height: $screen-small-landscape-height) {
             font-size: $input-font-size;
         }
 
@@ -182,6 +182,14 @@
 
         &.form-input--withIcon {
             padding-right: #{$input-formIcon-width + spacing("single")};
+        }
+    }
+
+    .themeV2 .form-input.body-regular {
+        font-size: $input-font-size--mobile-min;
+
+        @media (min-width: $screen-small) and (min-height: $screen-small-landscape-height) {
+            font-size: $fontSize-base;
         }
     }
 
@@ -265,7 +273,7 @@
         font-size: $input-font-size--mobile-min;
         padding: $input-verticalPadding $select-paddingRight $input-verticalPadding $input-horizontalPadding;
 
-        @include breakpoint("small") {
+        @media (min-width: $screen-small) and (min-height: $screen-small-landscape-height) {
             font-size: $input-font-size;
         }
     }

--- a/packages/core/src/scss/settings/foundation/forms/_settings.scss
+++ b/packages/core/src/scss/settings/foundation/forms/_settings.scss
@@ -49,6 +49,11 @@ $floating-label-transition:          all 0.15s cubic-bezier(0.13, 0.615, 0.315, 
 // $input-font-family:               inherit;
 $input-font-color:                   $body-font-color;
 $input-font-size:                    fontSize("base");
+
+// Minimum font-size required on mobile to prevent browsers on iOS 
+// from auto-zooming the viewport when a form field is focused 
+$input-font-size--mobile-min:        16px;
+
 $input-bg-color:                     color("whites", "bright");
 $input-focus-bg-color:               color("whites", "bright");
 $input-border-color:                 container("borderColor", "dark");

--- a/packages/core/src/scss/settings/global/screensizes/_screensizes.scss
+++ b/packages/core/src/scss/settings/global/screensizes/_screensizes.scss
@@ -16,3 +16,5 @@ $screen-xxsmall:                320px;
 
 $screen-large-iPhone:           414px;
 $screen-medium-iPhone:          375px;
+
+$screen-small-landscape-height: 551px;


### PR DESCRIPTION

## What/Why?

### What ### 
Adds a mobile-only font-size override (`< 551px` viewport) that forces checkout form controls — `.form-input`, `.form-select`, `.floating-input`, `.floating-select`, and `.floating-form-field-input` — to render at `16px`, while preserving the original desktop sizes (`1rem`/`1.077rem`) via `@include breakpoint("small")` at `≥551px`. Single file changed: `packages/core/src/scss/components/foundation/forms/_forms.scss`.

### Why ### 
The root font-size is pinned to `13px` at every breakpoint, so checkout form fields (address, login, payment) compute to ~13-14px on all devices, including mobile. iOS Safari automatically zooms the viewport in whenever a focused input has a computed font-size below 16px, so tapping into any checkout field on an iPhone triggered an unwanted zoom-in. Rather than raising the global root font-size (which would resize desktop typography/spacing sitewide), this targets only the actual trigger condition on mobile and leaves desktop untouched.


## Rollout/Rollback

Revert the PR.

## Testing
- Tested live in Chrome DevTools device-emulation mode at **375×667** (mobile viewport): confirmed computed `font-size` on shipping/billing address fields, the login/email field, and payment fields is `16px`.
- Confirmed at desktop widths (≥551px) the font-size correctly reverts to the original ~13-14px values — no visual regression on desktop.
- Confirmed on a real iOS device that checkout fields no longer trigger the browser auto-zoom on focus.

### Before ### 
https://github.com/user-attachments/assets/18b5eff7-0a3c-4389-9560-708a642273d3

<img width="1187" height="698" alt="Screenshot 2026-08-01 at 10 58 00 pm" src="https://github.com/user-attachments/assets/7e97645a-0e96-494c-981b-52a3cc205626" />

<img width="1177" height="685" alt="Screenshot 2026-08-01 at 10 56 47 pm" src="https://github.com/user-attachments/assets/03b7bd81-ad8a-430a-a1aa-7a2afb106828" />


### After ###
https://github.com/user-attachments/assets/ccbf0e9f-cc84-4981-9a65-c080aaa840ed

<img width="1192" height="705" alt="Screenshot 2026-08-01 at 10 53 30 pm" src="https://github.com/user-attachments/assets/d5b0fb95-47e4-4f10-938e-aa104c7ca5f8" />

<img width="1184" height="696" alt="Screenshot 2026-08-01 at 10 55 31 pm" src="https://github.com/user-attachments/assets/90f511f6-89e4-4f8f-9bea-c00a5467e459" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped SCSS typography overrides on form components with no logic or data changes; main review point is minor mobile visual shift vs desktop parity.
> 
> **Overview**
> Checkout form controls now use **16px** text on small viewports so iOS Safari does not zoom when a field is focused, instead of the previous ~13–14px computed sizes from the global root.
> 
> A new **`$input-font-size--mobile-min`** setting drives this on `.form-input`, `.form-select`, floating inputs/selects, and theme V2 `.body-regular` inputs. Original sizes are restored when **width ≥ 551px** and **height ≥ 551px** via **`$screen-small-landscape-height`**, so portrait phones stay at 16px while wider or landscape layouts keep existing typography.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee7538399f2c8689b6e8fb34d0c99afc657b047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->