### PR TITLE
feat(checkout): CHECKOUT-10216 reload payment method list on billing country change

### DIFF
--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -1,4 +1,5 @@
 import {
+    type BillingAddress,
     type CheckoutService,
     createCheckoutService,
     createEmbeddedCheckoutMessenger,
@@ -63,7 +64,13 @@ jest.mock('./billingForm', () => {
                 context?.setEnsureBillingAddressSaved(mockEnsureBillingAddressSaved);
             }, [context]);
 
-            return ReactActual.createElement('div', { 'data-test': 'payment-billing-block' });
+            // Uncontrolled probe input: its DOM value survives only if this
+            // subtree is never unmounted.
+            return ReactActual.createElement(
+                'div',
+                { 'data-test': 'payment-billing-block' },
+                ReactActual.createElement('input', { 'data-test': 'billing-block-probe' }),
+            );
         },
     };
 });
@@ -99,6 +106,20 @@ describe('Payment step', () => {
     let defaultProps: CheckoutProps;
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
     let analyticsTracker: Partial<AnalyticsEvents>;
+
+    const themeV2Config = {
+        ...checkoutSettings,
+        storeConfig: {
+            ...checkoutSettings.storeConfig,
+            checkoutSettings: {
+                ...checkoutSettings.storeConfig.checkoutSettings,
+                checkoutUserExperienceSettings: {
+                    ...checkoutSettings.storeConfig.checkoutSettings.checkoutUserExperienceSettings,
+                    checkoutV2Theme: true,
+                },
+            },
+        },
+    };
 
     beforeAll(() => {
         checkout = new CheckoutPageNodeObject();
@@ -225,21 +246,6 @@ describe('Payment step', () => {
     });
 
     it('does not place the order when embedded billing (themeV2) is invalid', async () => {
-        const themeV2Config = {
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    checkoutUserExperienceSettings: {
-                        ...checkoutSettings.storeConfig.checkoutSettings
-                            .checkoutUserExperienceSettings,
-                        checkoutV2Theme: true,
-                    },
-                },
-            },
-        };
-
         mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(false);
 
         const location = window.location;
@@ -271,21 +277,6 @@ describe('Payment step', () => {
     });
 
     it('disables Place Order while the embedded billing (themeV2) address is being persisted', async () => {
-        const themeV2Config = {
-            ...checkoutSettings,
-            storeConfig: {
-                ...checkoutSettings.storeConfig,
-                checkoutSettings: {
-                    ...checkoutSettings.storeConfig.checkoutSettings,
-                    checkoutUserExperienceSettings: {
-                        ...checkoutSettings.storeConfig.checkoutSettings
-                            .checkoutUserExperienceSettings,
-                        checkoutV2Theme: true,
-                    },
-                },
-            },
-        };
-
         mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
 
         checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
@@ -315,6 +306,164 @@ describe('Payment step', () => {
                 screen.getByRole('button', { name: /place order/i }).hasAttribute('disabled'),
             ).toBeTruthy(),
         );
+    });
+
+    describe('billing country change (themeV2)', () => {
+        // The fixture billing address is AU; the countryCode subscription only
+        // sees a change if the PUT response carries the new country.
+        const mockBillingAddressPut = (countryCode: string, country: string) => {
+            checkout.updateCheckout('put', '/checkouts/*/billing-address/*', {
+                ...checkoutWithShippingAndBilling,
+                billingAddress: {
+                    ...checkoutWithShippingAndBilling.billingAddress,
+                    country,
+                    countryCode,
+                    stateOrProvince: '',
+                    stateOrProvinceCode: '',
+                } as BillingAddress,
+            });
+        };
+
+        beforeEach(() => {
+            mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
+        });
+
+        it('does not reload payment methods on initial load', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            expect(loadPaymentMethodsSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('reloads payment methods in place when the billing country changes', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            const initialCalls = loadPaymentMethodsSpy.mock.calls.length;
+
+            await userEvent.type(screen.getByTestId('billing-block-probe'), 'still-mounted');
+
+            mockBillingAddressPut('US', 'United States');
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            await waitFor(() =>
+                expect(loadPaymentMethodsSpy).toHaveBeenCalledTimes(initialCalls + 1),
+            );
+
+            expect(screen.getByTestId<HTMLInputElement>('billing-block-probe').value).toBe(
+                'still-mounted',
+            );
+            expect(screen.getByRole('radio', { name: 'Pay in Store' })).toBeInTheDocument();
+        });
+
+        it('disables Place Order and overlays the method list while the reload is in flight', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            mockBillingAddressPut('US', 'United States');
+
+            let resolvePaymentsResponse!: () => void;
+            const paymentsResponseBlocker = new Promise<void>((resolve) => {
+                resolvePaymentsResponse = resolve;
+            });
+
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/payments', async (_, res, ctx) => {
+                    await paymentsResponseBlocker;
+
+                    return res(ctx.json(payments));
+                }),
+            );
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            await screen.findByTestId('loading-overlay');
+
+            const placeOrderButton = screen.getByRole<HTMLButtonElement>('button', {
+                name: /place order/i,
+            });
+
+            expect(placeOrderButton.disabled).toBe(true);
+
+            await act(async () => {
+                resolvePaymentsResponse();
+            });
+
+            await waitFor(() =>
+                expect(screen.queryByTestId('loading-overlay')).not.toBeInTheDocument(),
+            );
+            expect(placeOrderButton.disabled).toBe(false);
+        });
+
+        it('does not reload payment methods for a billing update that keeps the same country', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            const initialCalls = loadPaymentMethodsSpy.mock.calls.length;
+
+            mockBillingAddressPut('AU', 'Australia');
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({});
+            });
+
+            expect(loadPaymentMethodsSpy).toHaveBeenCalledTimes(initialCalls);
+        });
+
+        it('stops watching the billing country after unmount', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
+
+            const { unmount } = render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            const initialCalls = loadPaymentMethodsSpy.mock.calls.length;
+
+            unmount();
+
+            mockBillingAddressPut('US', 'United States');
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            expect(loadPaymentMethodsSpy).toHaveBeenCalledTimes(initialCalls);
+        });
     });
 
     it('does not submit the order when disableSubmit is called for another method right after the selected one', async () => {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -107,6 +107,7 @@ interface WithCheckoutPaymentProps {
     finalizeOrderError?: Error;
     isInitializingPayment: boolean;
     isLoadingBillingCountries: boolean;
+    isLoadingPaymentMethods: boolean;
     isSubmittingOrder: boolean;
     isStoreCreditApplied: boolean;
     isTermsConditionsRequired: boolean;
@@ -161,6 +162,7 @@ const Payment = (
 
     const isReadyRef = useRef(state.isReady);
     const grandTotalChangeUnsubscribe = useRef<() => void>();
+    const billingAddressChangeUnsubscribe = useRef<() => void>();
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
     // Set by the themeV2 billing form. Awaited before submitOrder so the order
@@ -732,6 +734,28 @@ const Payment = (
                 ({ data }) => data.getCheckout()?.outstandingBalance,
             );
 
+            // Reload the server-filtered method list when the billing country changes.
+            if (themeV2) {
+                // subscribe() also fires immediately and on unfiltered store
+                // notifications, so only react to a real country change.
+                let lastCountryCode = props.billingAddress?.countryCode;
+
+                billingAddressChangeUnsubscribe.current = checkoutServiceSubscribe(
+                    ({ data }) => {
+                        const countryCode = data.getBillingAddress()?.countryCode;
+
+                        if (countryCode === lastCountryCode) {
+                            return;
+                        }
+
+                        lastCountryCode = countryCode;
+
+                        void loadPaymentMethodsOrThrow();
+                    },
+                    ({ data }) => data.getBillingAddress()?.countryCode,
+                );
+            }
+
             window.addEventListener('beforeunload', handleBeforeUnload);
             setState((prevState) => ({ ...prevState, isReady: true }));
             onReady();
@@ -744,6 +768,11 @@ const Payment = (
                 if (grandTotalChangeUnsubscribe.current) {
                     grandTotalChangeUnsubscribe.current();
                     grandTotalChangeUnsubscribe.current = undefined;
+                }
+
+                if (billingAddressChangeUnsubscribe.current) {
+                    billingAddressChangeUnsubscribe.current();
+                    billingAddressChangeUnsubscribe.current = undefined;
                 }
 
                 window.removeEventListener('beforeunload', handleBeforeUnload);
@@ -772,6 +801,9 @@ const Payment = (
         (props.isLoadingBillingCountries ||
             props.isUpdatingBillingAddress ||
             props.isUpdatingCheckout);
+    // The in-place reload keeps the form mounted, so block submit and overlay
+    // the method list until the refreshed, country-filtered methods land.
+    const isReloadingPaymentMethods = themeV2 && props.isLoadingPaymentMethods;
 
     return (
         <PaymentContext.Provider value={getContextValue()}>
@@ -787,6 +819,7 @@ const Payment = (
                     isEmbedded={props.isEmbedded}
                     isInitializingPayment={props.isInitializingPayment}
                     isPaymentDataRequired={props.isPaymentDataRequired}
+                    isReloadingPaymentMethods={isReloadingPaymentMethods}
                     isStoreCreditApplied={props.isStoreCreditApplied}
                     isTermsConditionsRequired={props.isTermsConditionsRequired}
                     isUsingMultiShipping={props.isUsingMultiShipping}
@@ -802,6 +835,7 @@ const Payment = (
                         (uniqueSelectedMethodId &&
                             state.shouldDisableSubmit[uniqueSelectedMethodId]) ||
                         isBillingFormBusy ||
+                        isReloadingPaymentMethods ||
                         undefined
                     }
                     shouldExecuteSpamCheck={props.shouldExecuteSpamCheck}
@@ -853,6 +887,7 @@ export function mapToPaymentProps(
         statuses: {
             isInitializingPayment,
             isLoadingBillingCountries,
+            isLoadingPaymentMethods,
             isSubmittingOrder,
             isUpdatingBillingAddress,
             isUpdatingCheckout,
@@ -918,6 +953,7 @@ export function mapToPaymentProps(
         loadCheckout: checkoutService.loadCheckout,
         isInitializingPayment: isInitializingPayment(),
         isLoadingBillingCountries: isLoadingBillingCountries(),
+        isLoadingPaymentMethods: isLoadingPaymentMethods(),
         isPaymentDataRequired,
         isStoreCreditApplied,
         isSubmittingOrder: isSubmittingOrder(),

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -17,7 +17,7 @@ import {
     type WithLanguageProps,
 } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
-import { Fieldset, Form, FormContext, Legend } from '@bigcommerce/checkout/ui';
+import { Fieldset, Form, FormContext, Legend, LoadingOverlay } from '@bigcommerce/checkout/ui';
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { getTranslateAddressError } from '../address';
@@ -56,6 +56,7 @@ export interface PaymentFormProps {
     isBillingSameAsShipping?: boolean;
     isEmbedded?: boolean;
     isInitializingPayment?: boolean;
+    isReloadingPaymentMethods?: boolean;
     isTermsConditionsRequired?: boolean;
     isUsingMultiShipping?: boolean;
     isStoreCreditApplied: boolean;
@@ -89,6 +90,7 @@ const PaymentForm: FunctionComponent<
     isEmbedded,
     isInitializingPayment,
     isPaymentDataRequired,
+    isReloadingPaymentMethods,
     isTermsConditionsRequired,
     isStoreCreditApplied,
     isUsingMultiShipping,
@@ -187,17 +189,21 @@ const PaymentForm: FunctionComponent<
                 ))}
 
             {!isEmpty(methods) && (
-                <PaymentMethodListFieldset
-                    isEmbedded={isEmbedded}
-                    isInitializingPayment={isInitializingPayment}
-                    isPaymentDataRequired={isPaymentDataRequired}
-                    isUsingMultiShipping={isUsingMultiShipping}
-                    methods={methods}
-                    onMethodSelect={onMethodSelect}
-                    onUnhandledError={onUnhandledError}
-                    resetForm={resetForm}
-                    values={values}
-                />
+                // Default LoadingOverlay mode keeps the list mounted, so typed
+                // payment details and hosted-field iframes survive the reload.
+                <LoadingOverlay isLoading={isReloadingPaymentMethods ?? false}>
+                    <PaymentMethodListFieldset
+                        isEmbedded={isEmbedded}
+                        isInitializingPayment={isInitializingPayment}
+                        isPaymentDataRequired={isPaymentDataRequired}
+                        isUsingMultiShipping={isUsingMultiShipping}
+                        methods={methods}
+                        onMethodSelect={onMethodSelect}
+                        onUnhandledError={onUnhandledError}
+                        resetForm={resetForm}
+                        values={values}
+                    />
+                </LoadingOverlay>
             )}
 
             {themeV2 && (

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -348,6 +348,34 @@ describe('PaymentBillingBlock', () => {
             );
         });
 
+        it('persists a change back to a previously requested country once the first persist settles', async () => {
+            // Store stays US throughout, as if an external update (address book,
+            // same as shipping) reverted the country after the first persist.
+            jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
+                getBillingAddress(),
+            );
+
+            render(<PaymentBillingBlockTest />);
+
+            await screen.findByTestId('trigger-persist');
+
+            const { orderComment: _orderComment, ...addressValues } = mockPersistValues;
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('CA', addressValues);
+            });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('CA', addressValues);
+            });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.updateBillingAddress).toHaveBeenCalledTimes(2);
+        });
+
         it('allows retrying the same country after a failed persist', async () => {
             const error = new Error('update failed');
 

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -272,6 +272,131 @@ describe('PaymentBillingBlock', () => {
         });
     });
 
+    describe('billing country change', () => {
+        it('persists the current form values with the new country and cleared state', async () => {
+            jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
+                getBillingAddress(),
+            );
+
+            render(<PaymentBillingBlockTest />);
+
+            await screen.findByTestId('trigger-persist');
+
+            const { orderComment: _orderComment, ...addressValues } = mockPersistValues;
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('CA', addressValues);
+            });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.updateBillingAddress).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    firstName: getBillingAddress().firstName,
+                    countryCode: 'CA',
+                    stateOrProvince: '',
+                    stateOrProvinceCode: '',
+                }),
+            );
+        });
+
+        it('does not persist when the billing country is unchanged', async () => {
+            jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
+                getBillingAddress(),
+            );
+
+            render(<PaymentBillingBlockTest />);
+
+            await screen.findByTestId('trigger-persist');
+
+            const { orderComment: _orderComment, ...addressValues } = mockPersistValues;
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('US', addressValues);
+            });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.updateBillingAddress).not.toHaveBeenCalled();
+        });
+
+        it('persists a flip back to the original country while the first update is in flight', async () => {
+            jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
+                getBillingAddress(),
+            );
+            // Keep the first update in flight so the store still has 'US'.
+            jest.spyOn(checkoutService, 'updateBillingAddress').mockReturnValue(
+                new Promise(() => undefined),
+            );
+
+            render(<PaymentBillingBlockTest />);
+
+            await screen.findByTestId('trigger-persist');
+
+            const { orderComment: _orderComment, ...addressValues } = mockPersistValues;
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('CA', addressValues);
+            });
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('US', addressValues);
+            });
+
+            expect(checkoutService.updateBillingAddress).toHaveBeenCalledTimes(2);
+            expect(checkoutService.updateBillingAddress).toHaveBeenLastCalledWith(
+                expect.objectContaining({ countryCode: 'US' }),
+            );
+        });
+
+        it('allows retrying the same country after a failed persist', async () => {
+            const error = new Error('update failed');
+
+            jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
+                getBillingAddress(),
+            );
+            jest.spyOn(checkoutService, 'updateBillingAddress').mockRejectedValueOnce(error);
+
+            render(<PaymentBillingBlockTest />);
+
+            await screen.findByTestId('trigger-persist');
+
+            const { orderComment: _orderComment, ...addressValues } = mockPersistValues;
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('CA', addressValues);
+            });
+
+            await waitFor(() => expect(onUnhandledError).toHaveBeenCalledWith(error));
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('CA', addressValues);
+            });
+
+            expect(checkoutService.updateBillingAddress).toHaveBeenCalledTimes(2);
+        });
+
+        it('reports a failed country-change persist via onUnhandledError', async () => {
+            const error = new Error('update failed');
+
+            jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
+                getBillingAddress(),
+            );
+            jest.spyOn(checkoutService, 'updateBillingAddress').mockRejectedValue(error);
+
+            render(<PaymentBillingBlockTest />);
+
+            await screen.findByTestId('trigger-persist');
+
+            const { orderComment: _orderComment, ...addressValues } = mockPersistValues;
+
+            act(() => {
+                mockCapturedProps.onBillingCountryChange('CA', addressValues);
+            });
+
+            await waitFor(() => expect(onUnhandledError).toHaveBeenCalledWith(error));
+        });
+    });
+
     it('keeps the billing form mounted (with isLoading) while billing is still loading', async () => {
         jest.spyOn(checkoutService, 'loadBillingAddressFields').mockReturnValue(
             new Promise(() => undefined),

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -58,15 +58,12 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
         }
     };
 
-    // The store's countryCode is stale while an update is in flight; guarding
-    // on it would drop a quick flip back to the original country. Only
-    // meaningful while a request is pending — it is cleared once it settles,
-    // so billing changes made via other paths aren't wrongly vetoed.
+    // The store's countryCode lags while an update is in flight, so guard on
+    // the pending request instead; cleared on settle so it can't go stale.
     const lastRequestedCountryCodeRef = useRef<string | undefined>();
 
-    // Persisting the form values (not the store address) keeps typed fields
-    // alive through the Formik reinitialize that follows; stateOrProvince is
-    // country-specific so it must be cleared.
+    // Persist the form values (not the store address) so typed fields survive
+    // the Formik reinitialize; stateOrProvince is country-specific, so clear it.
     const handleBillingCountryChange = (countryCode: string, addressValues: AddressFormValues) => {
         const lastCountryCode =
             lastRequestedCountryCodeRef.current ?? getBillingAddress()?.countryCode;
@@ -79,7 +76,6 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
 
         updateBillingAddress({
             ...mapAddressFromFormValues(addressValues),
-            // Must win — addressValues may still carry the old country.
             countryCode,
             stateOrProvince: '',
             stateOrProvinceCode: '',
@@ -90,7 +86,6 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
                 }
             })
             .finally(() => {
-                // Unless a newer request has taken over the ref.
                 if (lastRequestedCountryCodeRef.current === countryCode) {
                     lastRequestedCountryCodeRef.current = undefined;
                 }

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -1,10 +1,10 @@
 import type { CheckoutSelectors } from '@bigcommerce/checkout-sdk';
-import React, { type FunctionComponent } from 'react';
+import React, { type FunctionComponent, useRef } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { AddressFormSkeleton, Legend } from '@bigcommerce/checkout/ui';
 
-import { isEqualAddress, mapAddressFromFormValues } from '../../address';
+import { type AddressFormValues, isEqualAddress, mapAddressFromFormValues } from '../../address';
 import { type BillingFormValues } from '../../billing/billingFormConfig';
 import { useBilling } from '../../billing/hooks/useBilling';
 
@@ -58,6 +58,39 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
         }
     };
 
+    // The store's countryCode is stale while an update is in flight; guarding
+    // on it would drop a quick flip back to the original country.
+    const lastRequestedCountryCodeRef = useRef<string | undefined>();
+
+    // Persisting the form values (not the store address) keeps typed fields
+    // alive through the Formik reinitialize that follows; stateOrProvince is
+    // country-specific so it must be cleared.
+    const handleBillingCountryChange = (countryCode: string, addressValues: AddressFormValues) => {
+        const lastCountryCode =
+            lastRequestedCountryCodeRef.current ?? getBillingAddress()?.countryCode;
+
+        if (lastCountryCode === countryCode) {
+            return;
+        }
+
+        lastRequestedCountryCodeRef.current = countryCode;
+
+        updateBillingAddress({
+            ...mapAddressFromFormValues(addressValues),
+            // Must win — addressValues may still carry the old country.
+            countryCode,
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+        }).catch((error) => {
+            // Fall back to the store's country so a retry isn't skipped.
+            lastRequestedCountryCodeRef.current = undefined;
+
+            if (error instanceof Error) {
+                onUnhandledError(error);
+            }
+        });
+    };
+
     // Persist without navigating — the payment step's "Place Order" is the only
     // submit. Called by PaymentBillingForm's pre-submit save;
     const handlePersist = async ({
@@ -102,6 +135,7 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
                     isBillingSameAsShipping={isBillingSameAsShipping}
                     isLoading={isInitializing}
                     methodId={methodId}
+                    onBillingCountryChange={handleBillingCountryChange}
                     onBillingSameAsShippingChange={handleBillingSameAsShippingChange}
                     onPersist={handlePersist}
                     onUnhandledError={onUnhandledError}

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -59,7 +59,9 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
     };
 
     // The store's countryCode is stale while an update is in flight; guarding
-    // on it would drop a quick flip back to the original country.
+    // on it would drop a quick flip back to the original country. Only
+    // meaningful while a request is pending — it is cleared once it settles,
+    // so billing changes made via other paths aren't wrongly vetoed.
     const lastRequestedCountryCodeRef = useRef<string | undefined>();
 
     // Persisting the form values (not the store address) keeps typed fields
@@ -81,14 +83,18 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
             countryCode,
             stateOrProvince: '',
             stateOrProvinceCode: '',
-        }).catch((error) => {
-            // Fall back to the store's country so a retry isn't skipped.
-            lastRequestedCountryCodeRef.current = undefined;
-
-            if (error instanceof Error) {
-                onUnhandledError(error);
-            }
-        });
+        })
+            .catch((error) => {
+                if (error instanceof Error) {
+                    onUnhandledError(error);
+                }
+            })
+            .finally(() => {
+                // Unless a newer request has taken over the ref.
+                if (lastRequestedCountryCodeRef.current === countryCode) {
+                    lastRequestedCountryCodeRef.current = undefined;
+                }
+            });
     };
 
     // Persist without navigating — the payment step's "Place Order" is the only

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
@@ -2,7 +2,9 @@ import {
     type CheckoutSelectors,
     type CheckoutService,
     createCheckoutService,
+    type FormField,
 } from '@bigcommerce/checkout-sdk';
+import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
 import React, { type FunctionComponent } from 'react';
 
@@ -86,6 +88,7 @@ describe('PaymentBillingForm', () => {
             getFields: () => getFormFields(),
             isBillingSameAsShipping: false,
             isLoading: false,
+            onBillingCountryChange: jest.fn(),
             onBillingSameAsShippingChange: jest.fn(),
             onPersist,
             onUnhandledError: noop,
@@ -104,6 +107,7 @@ describe('PaymentBillingForm', () => {
     it('does not render its own <form> element', () => {
         renderForm(defaultProps);
 
+        // eslint-disable-next-line testing-library/no-node-access
         expect(document.querySelector('form')).not.toBeInTheDocument();
     });
 
@@ -132,6 +136,7 @@ describe('PaymentBillingForm', () => {
             ...getCustomer(),
             isGuest: false,
         });
+
         // Keep updateBillingAddress in flight so isResettingAddress stays true.
         const updateBillingAddress = jest.fn().mockReturnValue(new Promise(() => undefined));
 
@@ -200,6 +205,59 @@ describe('PaymentBillingForm', () => {
 
         await expect(capturedEnsureBillingAddressSaved?.()).resolves.toBe(false);
         expect(onUnhandledError).toHaveBeenCalledWith(error);
+    });
+
+    describe('billing country change', () => {
+        // getFormFields() has no countryCode field; AddressForm needs a dropdown
+        // one to render a country select.
+        const getFieldsWithCountry = (): FormField[] => [
+            ...getFormFields(),
+            {
+                custom: false,
+                default: '',
+                fieldType: 'dropdown',
+                id: 'field_country',
+                label: 'Country',
+                name: 'countryCode',
+                options: {
+                    helperLabel: 'Choose a Country',
+                    items: [
+                        { label: 'United States', value: 'US' },
+                        { label: 'Canada', value: 'CA' },
+                    ],
+                },
+                required: true,
+                type: 'array',
+            },
+        ];
+
+        it('notifies onBillingCountryChange with the new country and the current form values', async () => {
+            renderForm({ ...defaultProps, getFields: getFieldsWithCountry });
+
+            await userEvent.clear(screen.getByTestId('firstNameInput-text'));
+            await userEvent.type(screen.getByTestId('firstNameInput-text'), 'Jane');
+
+            await userEvent.selectOptions(screen.getByTestId('countryCodeInput-select'), 'CA');
+
+            expect(defaultProps.onBillingCountryChange).toHaveBeenCalledWith(
+                'CA',
+                expect.objectContaining({ firstName: 'Jane' }),
+            );
+
+            const [, addressValues] = (defaultProps.onBillingCountryChange as jest.Mock).mock
+                .calls[0];
+
+            expect(addressValues).not.toHaveProperty('billingSameAsShipping');
+            expect(addressValues).not.toHaveProperty('orderComment');
+        });
+
+        it('does not notify onBillingCountryChange when a non-country field changes', async () => {
+            renderForm({ ...defaultProps, getFields: getFieldsWithCountry });
+
+            await userEvent.type(screen.getByTestId('firstNameInput-text'), 'Jane');
+
+            expect(defaultProps.onBillingCountryChange).not.toHaveBeenCalled();
+        });
     });
 
     describe('billing same as shipping toggle', () => {

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -39,7 +39,7 @@ export interface PaymentBillingFormProps {
     // so the pre-submit ensureBillingAddressSaved can block the order.
     onPersist(values: BillingFormValues): Promise<void>;
     onBillingSameAsShippingChange(isBillingSameAsShipping: boolean): void;
-    // Lets the block persist the new country so payment methods re-filter.
+    // Let the block persist the new country so payment methods re-filter.
     onBillingCountryChange(countryCode: string, addressValues: AddressFormValues): void;
     onUnhandledError(error: Error): void;
     updateBillingAddress(address: Partial<Address>): Promise<unknown>;

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -9,6 +9,7 @@ import { AddressFormSkeleton, Fieldset, LoadingOverlay } from '@bigcommerce/chec
 
 import {
     AddressForm,
+    type AddressFormValues,
     AddressSelect,
     AddressType,
     decodeAddressLabel,
@@ -38,6 +39,8 @@ export interface PaymentBillingFormProps {
     // so the pre-submit ensureBillingAddressSaved can block the order.
     onPersist(values: BillingFormValues): Promise<void>;
     onBillingSameAsShippingChange(isBillingSameAsShipping: boolean): void;
+    // Lets the block persist the new country so payment methods re-filter.
+    onBillingCountryChange(countryCode: string, addressValues: AddressFormValues): void;
     onUnhandledError(error: Error): void;
     updateBillingAddress(address: Partial<Address>): Promise<unknown>;
 }
@@ -53,6 +56,7 @@ const PaymentBillingFormComponent = ({
     values,
     onPersist,
     onBillingSameAsShippingChange,
+    onBillingCountryChange,
     onUnhandledError,
     updateBillingAddress,
 }: PaymentBillingFormProps & WithLanguageProps & FormikProps<PaymentBillingFormValues>) => {
@@ -185,6 +189,23 @@ const PaymentBillingFormComponent = ({
         void handleSelectAddress({});
     };
 
+    // `values.countryCode` may still hold the previous country when onChange
+    // fires, so the new country travels as the first argument.
+    const handleAddressFieldChange = useCallback(
+        (fieldName: string, value: string | string[]) => {
+            if (fieldName === 'countryCode' && typeof value === 'string' && value) {
+                const {
+                    billingSameAsShipping: _billingSameAsShipping,
+                    orderComment: _orderComment,
+                    ...addressValues
+                } = values;
+
+                onBillingCountryChange(value, addressValues);
+            }
+        },
+        [onBillingCountryChange, values],
+    );
+
     return (
         <div className="checkout-billing-form" data-test="checkout-billing-form">
             {shouldShowBillingSameAsShipping && (
@@ -225,6 +246,7 @@ const PaymentBillingFormComponent = ({
                                 <AddressForm
                                     countryCode={values.countryCode}
                                     formFields={editableFormFields}
+                                    onChange={handleAddressFieldChange}
                                     setFieldValue={setFieldValue}
                                     shouldShowSaveAddress={shouldShowSaveAddress}
                                     type={AddressType.Billing}

--- a/packages/core/src/scss/themeV2/components/_components.scss
+++ b/packages/core/src/scss/themeV2/components/_components.scss
@@ -8,3 +8,4 @@
 @import "checkout/cart-summary";
 @import "checkout/staticConsignment";
 @import "checkout/products-list";
+@import "checkout/payment-billing";

--- a/packages/core/src/scss/themeV2/components/checkout/_payment-billing.scss
+++ b/packages/core/src/scss/themeV2/components/checkout/_payment-billing.scss
@@ -1,0 +1,5 @@
+.checkout-billing {
+    @include themeV2 {
+        margin-block: spacing("single");
+    }
+}


### PR DESCRIPTION
## What/Why?

Refetch payment methods list when billing country changes in themeV2.

There will be a follow up PR to show the alerting once the list is refreshed.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

https://github.com/user-attachments/assets/e233dc61-bb5d-48ad-8bf7-c9489ab01910




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment method loading and submit gating when billing country changes on the payment step, which can affect which methods appear and whether orders can be placed mid-update.
> 
> **Overview**
> For **themeV2**, changing the embedded payment-step billing country now **persists** the shopper’s current form values (with state cleared), then **refetches** the server-filtered payment method list **without unmounting** the list or billing block.
> 
> `Payment` subscribes to billing `countryCode` changes (ignoring duplicates and initial noise), calls `loadPaymentMethods`, and tears down the subscription on unmount. While methods are loading, **Place Order** stays disabled and the method list shows a **loading overlay** so hosted fields and typed details are not lost.
> 
> `PaymentBillingBlock` / `PaymentBillingForm` wire country dropdown changes through `onBillingCountryChange`, with guards for in-flight updates, same-country skips, and retries after failures. Tests cover the full flow; themeV2 adds minor spacing for `.checkout-billing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73887cac20ef019d87092e3d6351637a868bdfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->