### PR TITLE
feat(checkout): CHECKOUT-10216 show the alert on payment options reload

### DIFF
--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -34,7 +34,12 @@ import {
     orderResponse,
     payments,
 } from '@bigcommerce/checkout/test-framework';
-import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
+import {
+    renderWithoutWrapper as render,
+    screen,
+    waitFor,
+    within,
+} from '@bigcommerce/checkout/test-utils';
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import Checkout, { type CheckoutProps } from '../checkout/Checkout';
@@ -328,7 +333,7 @@ describe('Payment step', () => {
             mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
         });
 
-        it('does not reload payment methods on initial load', async () => {
+        it('does not reload payment methods or show the refresh note on initial load', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
                 config: themeV2Config,
             });
@@ -340,6 +345,7 @@ describe('Payment step', () => {
             await checkout.waitForPaymentStep();
 
             expect(loadPaymentMethodsSpy).toHaveBeenCalledTimes(1);
+            expect(screen.queryByTestId('payment-methods-refresh-alert')).not.toBeInTheDocument();
         });
 
         it('reloads payment methods in place when the billing country changes', async () => {
@@ -439,6 +445,171 @@ describe('Payment step', () => {
             });
 
             expect(loadPaymentMethodsSpy).toHaveBeenCalledTimes(initialCalls);
+        });
+
+        it('shows a dismissible note when the list refreshes and the selection survives', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            mockBillingAddressPut('US', 'United States');
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            expect(
+                await screen.findByText(
+                    'Payment options updated for United States as the billing country.',
+                ),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole('radio', { name: 'Pay in Store', checked: true }),
+            ).toBeInTheDocument();
+
+            await act(async () =>
+                userEvent.click(
+                    within(screen.getByTestId('payment-methods-refresh-alert')).getByRole(
+                        'button',
+                        { name: 'Close' },
+                    ),
+                ),
+            );
+
+            expect(screen.queryByTestId('payment-methods-refresh-alert')).not.toBeInTheDocument();
+        });
+
+        it('prompts to select another method when the selection is gone after the refresh', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            mockBillingAddressPut('US', 'United States');
+            // The refreshed list no longer contains the selected Pay in Store.
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/payments', (_, res, ctx) =>
+                    res(ctx.json(payments.filter(({ id }) => id !== 'instore'))),
+                ),
+            );
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            expect(
+                await screen.findByText(
+                    "Payment options reloaded for United States as the billing country. Pay in Store isn't available in this country, please select another payment method.",
+                ),
+            ).toBeInTheDocument();
+            // Focus lands on the alert unless CheckoutStep's own focus
+            // management moves it to the first method input — both are fine.
+            await waitFor(() => {
+                // eslint-disable-next-line testing-library/no-node-access
+                const activeElement = document.activeElement;
+
+                expect(
+                    activeElement === screen.getByTestId('payment-methods-refresh-alert') ||
+                        activeElement === screen.getByRole('radio', { name: 'Cash on Delivery' }),
+                ).toBe(true);
+            });
+        });
+
+        it('re-tracks the shopper selection, not the default method, after a country reload', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () =>
+                userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
+            );
+
+            mockBillingAddressPut('US', 'United States');
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            await waitFor(() =>
+                expect(analyticsTracker.selectedPaymentMethod).toHaveBeenLastCalledWith(
+                    'Cash on Delivery',
+                    'cod',
+                ),
+            );
+        });
+
+        it('clears the refresh note when the methods reload for a cart total change', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            mockBillingAddressPut('US', 'United States');
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            await screen.findByTestId('payment-methods-refresh-alert');
+
+            // Grand-total change, same billing country — only the cart-total reload fires.
+            checkout.updateCheckout('put', '/checkout/*', {
+                ...checkoutWithShippingAndBilling,
+                billingAddress: {
+                    ...checkoutWithShippingAndBilling.billingAddress,
+                    country: 'United States',
+                    countryCode: 'US',
+                } as BillingAddress,
+                grandTotal: checkoutWithShippingAndBilling.grandTotal + 1,
+            });
+
+            await act(async () => {
+                await checkoutService.updateCheckout({ customerMessage: 'gift wrap please' });
+            });
+
+            await waitFor(() =>
+                expect(
+                    screen.queryByTestId('payment-methods-refresh-alert'),
+                ).not.toBeInTheDocument(),
+            );
+        });
+
+        it('dismisses the refresh note once the shopper selects a payment method', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            mockBillingAddressPut('US', 'United States');
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            await screen.findByTestId('payment-methods-refresh-alert');
+
+            await act(async () =>
+                userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
+            );
+
+            expect(screen.queryByTestId('payment-methods-refresh-alert')).not.toBeInTheDocument();
         });
 
         it('stops watching the billing country after unmount', async () => {

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -312,6 +312,12 @@ describe('Payment step', () => {
     });
 
     describe('billing country change (themeV2)', () => {
+        const scrollIntoViewMock = jest.fn();
+
+        beforeAll(() => {
+            window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+        });
+
         const mockBillingAddressPut = (countryCode: string, country: string) => {
             checkout.updateCheckout('put', '/checkouts/*/billing-address/*', {
                 ...checkoutWithShippingAndBilling,
@@ -326,6 +332,7 @@ describe('Payment step', () => {
         };
 
         beforeEach(() => {
+            scrollIntoViewMock.mockClear();
             mockEnsureBillingAddressSaved = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
         });
 
@@ -410,6 +417,7 @@ describe('Payment step', () => {
             });
 
             expect(placeOrderButton.disabled).toBe(true);
+            expect(scrollIntoViewMock).toHaveBeenCalled();
 
             await act(async () => {
                 resolvePaymentsResponse();
@@ -488,6 +496,10 @@ describe('Payment step', () => {
 
             await checkout.waitForPaymentStep();
 
+            await waitFor(() => {
+                expect(screen.getByRole('radio', { name: 'Pay in Store' })).toHaveFocus();
+            });
+
             mockBillingAddressPut('US', 'United States');
             checkout.setRequestHandler(
                 rest.get('/api/storefront/payments', (_, res, ctx) =>
@@ -505,13 +517,7 @@ describe('Payment step', () => {
                 ),
             ).toBeInTheDocument();
             await waitFor(() => {
-                // eslint-disable-next-line testing-library/no-node-access
-                const activeElement = document.activeElement;
-
-                expect(
-                    activeElement === screen.getByTestId('payment-methods-refresh-alert') ||
-                        activeElement === screen.getByRole('radio', { name: 'Cash on Delivery' }),
-                ).toBe(true);
+                expect(screen.getByTestId('payment-methods-refresh-alert')).toHaveFocus();
             });
         });
 

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -69,8 +69,6 @@ jest.mock('./billingForm', () => {
                 context?.setEnsureBillingAddressSaved(mockEnsureBillingAddressSaved);
             }, [context]);
 
-            // Uncontrolled probe input: its DOM value survives only if this
-            // subtree is never unmounted.
             return ReactActual.createElement(
                 'div',
                 { 'data-test': 'payment-billing-block' },
@@ -314,8 +312,6 @@ describe('Payment step', () => {
     });
 
     describe('billing country change (themeV2)', () => {
-        // The fixture billing address is AU; the countryCode subscription only
-        // sees a change if the PUT response carries the new country.
         const mockBillingAddressPut = (countryCode: string, country: string) => {
             checkout.updateCheckout('put', '/checkouts/*/billing-address/*', {
                 ...checkoutWithShippingAndBilling,
@@ -493,7 +489,6 @@ describe('Payment step', () => {
             await checkout.waitForPaymentStep();
 
             mockBillingAddressPut('US', 'United States');
-            // The refreshed list no longer contains the selected Pay in Store.
             checkout.setRequestHandler(
                 rest.get('/api/storefront/payments', (_, res, ctx) =>
                     res(ctx.json(payments.filter(({ id }) => id !== 'instore'))),
@@ -509,8 +504,6 @@ describe('Payment step', () => {
                     "Payment options reloaded for United States as the billing country. Pay in Store isn't available in this country, please select another payment method.",
                 ),
             ).toBeInTheDocument();
-            // Focus lands on the alert unless CheckoutStep's own focus
-            // management moves it to the first method input — both are fine.
             await waitFor(() => {
                 // eslint-disable-next-line testing-library/no-node-access
                 const activeElement = document.activeElement;
@@ -566,7 +559,6 @@ describe('Payment step', () => {
 
             await screen.findByTestId('payment-methods-refresh-alert');
 
-            // Grand-total change, same billing country — only the cart-total reload fires.
             checkout.updateCheckout('put', '/checkout/*', {
                 ...checkoutWithShippingAndBilling,
                 billingAddress: {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -70,12 +70,14 @@ import {
 import { getB2BMetadataPayload } from './b2bMetadataForPostOrder';
 import { mapToB2BOrderRequestBody } from './b2bMetadataForSubmitOrder';
 import CartStockPositionsChangedModal from './CartStockPositionsChangedModal';
+import getPaymentMethodsRefreshAlert from './getPaymentMethodsRefreshAlert';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
 import PaymentContext, { type EnsureBillingAddressSaved } from './PaymentContext';
 import PaymentForm from './PaymentForm';
 import { getUniquePaymentMethodId, PaymentMethodProviderType } from './paymentMethod';
 import { getFilteredPaymentMethodsWithDefault } from './paymentMethodFilters';
+import { type PaymentMethodsRefreshAlertData } from './PaymentMethodsRefreshAlert';
 
 export interface PaymentProps {
     capabilities: Capabilities;
@@ -159,10 +161,20 @@ const Payment = (
     });
 
     const [isCartStockRefreshComplete, setIsCartStockRefreshComplete] = useState(false);
+    const [methodsRefreshAlert, setMethodsRefreshAlert] = useState<
+        PaymentMethodsRefreshAlertData | undefined
+    >();
 
     const isReadyRef = useRef(state.isReady);
     const grandTotalChangeUnsubscribe = useRef<() => void>();
     const billingAddressChangeUnsubscribe = useRef<() => void>();
+    // Live selection for the mount-effect subscription, whose closures are stale.
+    const selectedMethodRef = useRef<PaymentMethod | undefined>();
+    // TODO: CHECKOUT-10199 remove this temporary fix. A removed method's unmount
+    // deinitialize rejects with missing_data (its data is already gone);
+    // handleError swallows those inside this window — a timestamp, because the
+    // rejection can land before or after the reload's continuation.
+    const suppressMethodRemovedErrorUntilRef = useRef(0);
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
     // Set by the themeV2 billing form. Awaited before submitOrder so the order
@@ -396,6 +408,13 @@ const Payment = (
             return;
         }
 
+        // TODO: CHECKOUT-10199 remove this temporary fix
+        if (type === 'missing_data' && Date.now() < suppressMethodRemovedErrorUntilRef.current) {
+            errorLogger.log(error);
+
+            return;
+        }
+
         return onUnhandledError(error);
     }, []);
 
@@ -559,6 +578,8 @@ const Payment = (
         analyticsTracker.selectedPaymentMethod(methodName, methodId);
     };
 
+    const dismissMethodsRefreshAlert = useCallback(() => setMethodsRefreshAlert(undefined), []);
+
     const setSelectedMethod = useCallback((method?: PaymentMethod): void => {
         const { selectedMethod } = state;
 
@@ -572,6 +593,14 @@ const Payment = (
 
         setState((prevState) => ({ ...prevState, selectedMethod: method }));
     }, []);
+
+    const handleMethodSelect = useCallback(
+        (method: PaymentMethod): void => {
+            dismissMethodsRefreshAlert();
+            setSelectedMethod(method);
+        },
+        [dismissMethodsRefreshAlert, setSelectedMethod],
+    );
 
     const setSubmit = (
         method: PaymentMethod,
@@ -613,15 +642,22 @@ const Payment = (
         [],
     );
 
-    const loadPaymentMethodsOrThrow = async (): Promise<void> => {
+    const loadPaymentMethodsOrThrow = async (billingCountryChange?: {
+        previousSelectedMethod?: PaymentMethod;
+    }): Promise<void> => {
         const { loadPaymentMethods, onUnhandledError = noop } = props;
+
+        // The rejection can beat the await, so arm before the fetch; disarmed below.
+        if (billingCountryChange) {
+            suppressMethodRemovedErrorUntilRef.current = Date.now() + 5000;
+        }
 
         try {
             const updatedState = await loadPaymentMethods();
             const checkout = updatedState.data.getCheckout();
             const config = updatedState.data.getConfig();
             const methods = updatedState.data.getPaymentMethods() || EMPTY_ARRAY;
-            const defaultMethod =
+            const filteredMethodsWithDefault =
                 checkout && config
                     ? getFilteredPaymentMethodsWithDefault({
                           checkout,
@@ -630,12 +666,30 @@ const Payment = (
                           methods,
                           paymentProviderCustomer: updatedState.data.getPaymentProviderCustomer(),
                           capabilities: props.capabilities,
-                      }).defaultMethod
+                      })
                     : undefined;
-            const selectedMethod = state.selectedMethod || defaultMethod;
+            const defaultMethod = filteredMethodsWithDefault?.defaultMethod;
+            // state.selectedMethod is stale in the mount-effect closures.
+            const selectedMethod = selectedMethodRef.current || defaultMethod;
 
             if (selectedMethod) {
                 trackSelectedPaymentMethod(selectedMethod);
+            }
+
+            // Derived from the resolved state so it can't race prop updates.
+            if (billingCountryChange) {
+                const refreshAlert = getPaymentMethodsRefreshAlert({
+                    billingAddress: updatedState.data.getBillingAddress(),
+                    language: props.language,
+                    previousSelectedMethod: billingCountryChange.previousSelectedMethod,
+                    refreshedMethods: filteredMethodsWithDefault?.filteredMethods ?? [],
+                });
+
+                if (!refreshAlert.removedMethodName) {
+                    suppressMethodRemovedErrorUntilRef.current = 0;
+                }
+
+                setMethodsRefreshAlert(refreshAlert);
             }
         } catch (error) {
             onUnhandledError(error);
@@ -648,6 +702,9 @@ const Payment = (
         if (!isReady) {
             return;
         }
+
+        // Any refresh note on display describes a list this reload replaces.
+        dismissMethodsRefreshAlert();
 
         setState((prevState) => ({ ...prevState, isReady: false }));
 
@@ -669,6 +726,10 @@ const Payment = (
     useEffect(() => {
         isReadyRef.current = state.isReady;
     }, [state.isReady]);
+
+    useEffect(() => {
+        selectedMethodRef.current = state.selectedMethod || props.defaultMethod;
+    }, [state.selectedMethod, props.defaultMethod]);
 
     useEffect(() => {
         const init = async () => {
@@ -750,7 +811,10 @@ const Payment = (
 
                         lastCountryCode = countryCode;
 
-                        void loadPaymentMethodsOrThrow();
+                        // Snapshot now — defaultMethod re-derives before the reload lands.
+                        void loadPaymentMethodsOrThrow({
+                            previousSelectedMethod: selectedMethodRef.current,
+                        });
                     },
                     ({ data }) => data.getBillingAddress()?.countryCode,
                 );
@@ -824,8 +888,10 @@ const Payment = (
                     isTermsConditionsRequired={props.isTermsConditionsRequired}
                     isUsingMultiShipping={props.isUsingMultiShipping}
                     methods={props.methods}
+                    methodsRefreshAlert={methodsRefreshAlert}
                     onBillingSameAsShippingChange={props.onBillingSameAsShippingChange}
-                    onMethodSelect={setSelectedMethod}
+                    onMethodSelect={handleMethodSelect}
+                    onMethodsRefreshAlertDismiss={dismissMethodsRefreshAlert}
                     onStoreCreditChange={handleStoreCreditChange}
                     onSubmit={handleSubmit}
                     onUnhandledError={handleError}

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -47,7 +47,7 @@ import {
 import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
-import { ChecklistSkeleton } from '@bigcommerce/checkout/ui';
+import { ChecklistSkeleton, LoadingOverlay } from '@bigcommerce/checkout/ui';
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { withAnalytics } from '../analytics';
@@ -862,54 +862,56 @@ const Payment = (
     return (
         <PaymentContext.Provider value={getContextValue()}>
             <ChecklistSkeleton isLoading={!state.isReady}>
-                <PaymentForm
-                    additionalField={props.capabilities.payment.additionalField}
-                    availableStoreCredit={props.availableStoreCredit}
-                    defaultGatewayId={props.defaultMethod?.gateway}
-                    defaultMethodId={props.defaultMethod?.id || ''}
-                    didExceedSpamLimit={state.didExceedSpamLimit}
-                    disableStoreCredit={disableStoreCredit}
-                    isBillingSameAsShipping={props.isBillingSameAsShipping}
-                    isEmbedded={props.isEmbedded}
-                    isInitializingPayment={props.isInitializingPayment}
-                    isPaymentDataRequired={props.isPaymentDataRequired}
-                    isReloadingPaymentMethods={isReloadingPaymentMethods}
-                    isStoreCreditApplied={props.isStoreCreditApplied}
-                    isTermsConditionsRequired={props.isTermsConditionsRequired}
-                    isUsingMultiShipping={props.isUsingMultiShipping}
-                    methods={props.methods}
-                    methodsRefreshAlert={methodsRefreshAlert}
-                    onBillingSameAsShippingChange={props.onBillingSameAsShippingChange}
-                    onMethodSelect={handleMethodSelect}
-                    onMethodsRefreshAlertDismiss={dismissMethodsRefreshAlert}
-                    onStoreCreditChange={handleStoreCreditChange}
-                    onSubmit={handleSubmit}
-                    onUnhandledError={handleError}
-                    orderExtraFields={props.orderExtraFields}
-                    selectedMethod={state.selectedMethod || props.defaultMethod}
-                    shouldDisableSubmit={
-                        (uniqueSelectedMethodId &&
-                            state.shouldDisableSubmit[uniqueSelectedMethodId]) ||
-                        isBillingFormBusy ||
-                        isReloadingPaymentMethods ||
-                        undefined
-                    }
-                    shouldExecuteSpamCheck={props.shouldExecuteSpamCheck}
-                    shouldHidePaymentSubmitButton={
-                        (uniqueSelectedMethodId &&
-                            props.isPaymentDataRequired() &&
-                            state.shouldHidePaymentSubmitButton[uniqueSelectedMethodId]) ||
-                        undefined
-                    }
-                    termsConditionsText={props.termsConditionsText}
-                    termsConditionsUrl={props.termsConditionsUrl}
-                    usableStoreCredit={props.usableStoreCredit}
-                    validationSchema={
-                        (uniqueSelectedMethodId &&
-                            validationSchemasRef.current[uniqueSelectedMethodId]) ||
-                        undefined
-                    }
-                />
+                <LoadingOverlay isLoading={isBillingFormBusy || isReloadingPaymentMethods}>
+                    <PaymentForm
+                        additionalField={props.capabilities.payment.additionalField}
+                        availableStoreCredit={props.availableStoreCredit}
+                        defaultGatewayId={props.defaultMethod?.gateway}
+                        defaultMethodId={props.defaultMethod?.id || ''}
+                        didExceedSpamLimit={state.didExceedSpamLimit}
+                        disableStoreCredit={disableStoreCredit}
+                        isBillingSameAsShipping={props.isBillingSameAsShipping}
+                        isEmbedded={props.isEmbedded}
+                        isInitializingPayment={props.isInitializingPayment}
+                        isPaymentDataRequired={props.isPaymentDataRequired}
+                        isReloadingPaymentMethods={isReloadingPaymentMethods}
+                        isStoreCreditApplied={props.isStoreCreditApplied}
+                        isTermsConditionsRequired={props.isTermsConditionsRequired}
+                        isUsingMultiShipping={props.isUsingMultiShipping}
+                        methods={props.methods}
+                        methodsRefreshAlert={methodsRefreshAlert}
+                        onBillingSameAsShippingChange={props.onBillingSameAsShippingChange}
+                        onMethodSelect={handleMethodSelect}
+                        onMethodsRefreshAlertDismiss={dismissMethodsRefreshAlert}
+                        onStoreCreditChange={handleStoreCreditChange}
+                        onSubmit={handleSubmit}
+                        onUnhandledError={handleError}
+                        orderExtraFields={props.orderExtraFields}
+                        selectedMethod={state.selectedMethod || props.defaultMethod}
+                        shouldDisableSubmit={
+                            (uniqueSelectedMethodId &&
+                                state.shouldDisableSubmit[uniqueSelectedMethodId]) ||
+                            isBillingFormBusy ||
+                            isReloadingPaymentMethods ||
+                            undefined
+                        }
+                        shouldExecuteSpamCheck={props.shouldExecuteSpamCheck}
+                        shouldHidePaymentSubmitButton={
+                            (uniqueSelectedMethodId &&
+                                props.isPaymentDataRequired() &&
+                                state.shouldHidePaymentSubmitButton[uniqueSelectedMethodId]) ||
+                            undefined
+                        }
+                        termsConditionsText={props.termsConditionsText}
+                        termsConditionsUrl={props.termsConditionsUrl}
+                        usableStoreCredit={props.usableStoreCredit}
+                        validationSchema={
+                            (uniqueSelectedMethodId &&
+                                validationSchemasRef.current[uniqueSelectedMethodId]) ||
+                            undefined
+                        }
+                    />
+                </LoadingOverlay>
             </ChecklistSkeleton>
 
             {renderOrderErrorModal()}

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -168,12 +168,8 @@ const Payment = (
     const isReadyRef = useRef(state.isReady);
     const grandTotalChangeUnsubscribe = useRef<() => void>();
     const billingAddressChangeUnsubscribe = useRef<() => void>();
-    // Live selection for the mount-effect subscription, whose closures are stale.
     const selectedMethodRef = useRef<PaymentMethod | undefined>();
-    // TODO: CHECKOUT-10199 remove this temporary fix. A removed method's unmount
-    // deinitialize rejects with missing_data (its data is already gone);
-    // handleError swallows those inside this window — a timestamp, because the
-    // rejection can land before or after the reload's continuation.
+    // TODO: CHECKOUT-10199 remove this temporary fix
     const suppressMethodRemovedErrorUntilRef = useRef(0);
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
@@ -647,7 +643,6 @@ const Payment = (
     }): Promise<void> => {
         const { loadPaymentMethods, onUnhandledError = noop } = props;
 
-        // The rejection can beat the await, so arm before the fetch; disarmed below.
         if (billingCountryChange) {
             suppressMethodRemovedErrorUntilRef.current = Date.now() + 5000;
         }
@@ -669,14 +664,12 @@ const Payment = (
                       })
                     : undefined;
             const defaultMethod = filteredMethodsWithDefault?.defaultMethod;
-            // state.selectedMethod is stale in the mount-effect closures.
             const selectedMethod = selectedMethodRef.current || defaultMethod;
 
             if (selectedMethod) {
                 trackSelectedPaymentMethod(selectedMethod);
             }
 
-            // Derived from the resolved state so it can't race prop updates.
             if (billingCountryChange) {
                 const refreshAlert = getPaymentMethodsRefreshAlert({
                     billingAddress: updatedState.data.getBillingAddress(),
@@ -692,6 +685,10 @@ const Payment = (
                 setMethodsRefreshAlert(refreshAlert);
             }
         } catch (error) {
+            if (billingCountryChange) {
+                suppressMethodRemovedErrorUntilRef.current = 0;
+            }
+
             onUnhandledError(error);
         }
     };
@@ -703,7 +700,6 @@ const Payment = (
             return;
         }
 
-        // Any refresh note on display describes a list this reload replaces.
         dismissMethodsRefreshAlert();
 
         setState((prevState) => ({ ...prevState, isReady: false }));
@@ -795,10 +791,7 @@ const Payment = (
                 ({ data }) => data.getCheckout()?.outstandingBalance,
             );
 
-            // Reload the server-filtered method list when the billing country changes.
             if (themeV2) {
-                // subscribe() also fires immediately and on unfiltered store
-                // notifications, so only react to a real country change.
                 let lastCountryCode = props.billingAddress?.countryCode;
 
                 billingAddressChangeUnsubscribe.current = checkoutServiceSubscribe(
@@ -811,7 +804,6 @@ const Payment = (
 
                         lastCountryCode = countryCode;
 
-                        // Snapshot now — defaultMethod re-derives before the reload lands.
                         void loadPaymentMethodsOrThrow({
                             previousSelectedMethod: selectedMethodRef.current,
                         });
@@ -865,8 +857,6 @@ const Payment = (
         (props.isLoadingBillingCountries ||
             props.isUpdatingBillingAddress ||
             props.isUpdatingCheckout);
-    // The in-place reload keeps the form mounted, so block submit and overlay
-    // the method list until the refreshed, country-filtered methods land.
     const isReloadingPaymentMethods = themeV2 && props.isLoadingPaymentMethods;
 
     return (

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -6,7 +6,15 @@ import {
 } from '@bigcommerce/checkout-sdk/essential';
 import { type FormikProps, type FormikState, withFormik, type WithFormikConfig } from 'formik';
 import { isEmpty, noop, omitBy } from 'lodash';
-import React, { type FunctionComponent, memo, useCallback, useContext, useMemo } from 'react';
+import React, {
+    type FunctionComponent,
+    memo,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+} from 'react';
 import { object, type ObjectSchema, string } from 'yup';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
@@ -162,6 +170,20 @@ const PaymentForm: FunctionComponent<
     const hideSubmitPaymentButton =
         shouldHidePaymentSubmitButton || (isPaymentDataRequired() && isEmpty(methods));
 
+    const methodListRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!isReloadingPaymentMethods) {
+            return;
+        }
+
+        try {
+            methodListRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } catch {
+            methodListRef.current?.scrollIntoView();
+        }
+    }, [isReloadingPaymentMethods]);
+
     if (shouldExecuteSpamCheck) {
         return (
             <SpamProtectionField
@@ -183,12 +205,14 @@ const PaymentForm: FunctionComponent<
                 />
             )}
 
-            {methodsRefreshAlert && (
-                <PaymentMethodsRefreshAlert
-                    alert={methodsRefreshAlert}
-                    onDismiss={onMethodsRefreshAlertDismiss ?? noop}
-                />
-            )}
+            <div ref={methodListRef}>
+                {methodsRefreshAlert && (
+                    <PaymentMethodsRefreshAlert
+                        alert={methodsRefreshAlert}
+                        onDismiss={onMethodsRefreshAlertDismiss ?? noop}
+                    />
+                )}
+            </div>
 
             {isEmpty(methods) &&
                 (isPaymentDataRequired() ? (

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -204,8 +204,6 @@ const PaymentForm: FunctionComponent<
                 ))}
 
             {!isEmpty(methods) && (
-                // Default LoadingOverlay mode keeps the list mounted, so typed
-                // payment details and hosted-field iframes survive the reload.
                 <LoadingOverlay isLoading={isReloadingPaymentMethods ?? false}>
                     <PaymentMethodListFieldset
                         isEmbedded={isEmbedded}

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -25,7 +25,7 @@ import {
     type WithLanguageProps,
 } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
-import { Fieldset, Form, FormContext, Legend, LoadingOverlay } from '@bigcommerce/checkout/ui';
+import { Fieldset, Form, FormContext, Legend } from '@bigcommerce/checkout/ui';
 import { B2BSessionStorage } from '@bigcommerce/checkout/utility';
 
 import { getTranslateAddressError } from '../address';
@@ -228,19 +228,17 @@ const PaymentForm: FunctionComponent<
                 ))}
 
             {!isEmpty(methods) && (
-                <LoadingOverlay isLoading={isReloadingPaymentMethods ?? false}>
-                    <PaymentMethodListFieldset
-                        isEmbedded={isEmbedded}
-                        isInitializingPayment={isInitializingPayment}
-                        isPaymentDataRequired={isPaymentDataRequired}
-                        isUsingMultiShipping={isUsingMultiShipping}
-                        methods={methods}
-                        onMethodSelect={onMethodSelect}
-                        onUnhandledError={onUnhandledError}
-                        resetForm={resetForm}
-                        values={values}
-                    />
-                </LoadingOverlay>
+                <PaymentMethodListFieldset
+                    isEmbedded={isEmbedded}
+                    isInitializingPayment={isInitializingPayment}
+                    isPaymentDataRequired={isPaymentDataRequired}
+                    isUsingMultiShipping={isUsingMultiShipping}
+                    methods={methods}
+                    onMethodSelect={onMethodSelect}
+                    onUnhandledError={onUnhandledError}
+                    resetForm={resetForm}
+                    values={values}
+                />
             )}
 
             {themeV2 && (

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -38,6 +38,10 @@ import {
     PaymentMethodList,
     usePoMethodDisabledReason,
 } from './paymentMethod';
+import {
+    PaymentMethodsRefreshAlert,
+    type PaymentMethodsRefreshAlertData,
+} from './PaymentMethodsRefreshAlert';
 import PaymentRedeemables from './PaymentRedeemables';
 import PaymentSubmitButton from './PaymentSubmitButton';
 import { ProvidersSectionOnTopOfPaymentsList } from './ProvidersSectionOnTopOfPaymentsList';
@@ -61,6 +65,7 @@ export interface PaymentFormProps {
     isUsingMultiShipping?: boolean;
     isStoreCreditApplied: boolean;
     methods: PaymentMethod[];
+    methodsRefreshAlert?: PaymentMethodsRefreshAlertData;
     orderExtraFields?: FormField[];
     selectedMethod?: PaymentMethod;
     shouldShowStoreCredit?: boolean;
@@ -74,6 +79,7 @@ export interface PaymentFormProps {
     isPaymentDataRequired(): boolean;
     onBillingSameAsShippingChange?(isBillingSameAsShipping: boolean): void;
     onMethodSelect?(method: PaymentMethod): void;
+    onMethodsRefreshAlertDismiss?(): void;
     onStoreCreditChange?(useStoreCredit?: boolean): void;
     onSubmit?(values: PaymentFormValues): void;
     onUnhandledError?(error: Error): void;
@@ -96,8 +102,10 @@ const PaymentForm: FunctionComponent<
     isUsingMultiShipping,
     language,
     methods,
+    methodsRefreshAlert,
     onBillingSameAsShippingChange,
     onMethodSelect,
+    onMethodsRefreshAlertDismiss,
     onStoreCreditChange,
     onUnhandledError,
     orderExtraFields,
@@ -172,6 +180,13 @@ const PaymentForm: FunctionComponent<
                     name="useStoreCredit"
                     onChange={onStoreCreditChange}
                     usableStoreCredit={usableStoreCredit}
+                />
+            )}
+
+            {methodsRefreshAlert && (
+                <PaymentMethodsRefreshAlert
+                    alert={methodsRefreshAlert}
+                    onDismiss={onMethodsRefreshAlertDismiss ?? noop}
                 />
             )}
 

--- a/packages/core/src/app/payment/PaymentMethodsRefreshAlert.scss
+++ b/packages/core/src/app/payment/PaymentMethodsRefreshAlert.scss
@@ -1,8 +1,10 @@
+@import "../../scss/Base";
+
 .paymentMethodsRefreshAlert {
     outline: none;
 
     .alertBox {
-        padding-right: 3rem;
+        padding-right: spacing("double");
         position: relative;
     }
 
@@ -13,7 +15,7 @@
         line-height: 0;
         padding: 0;
         position: absolute;
-        right: 0.75rem;
-        top: 0.75rem;
+        right: spacing("half");
+        top: spacing("half");
     }
 }

--- a/packages/core/src/app/payment/PaymentMethodsRefreshAlert.scss
+++ b/packages/core/src/app/payment/PaymentMethodsRefreshAlert.scss
@@ -1,0 +1,18 @@
+.paymentMethodsRefreshAlert {
+    outline: none;
+
+    .alertBox {
+        position: relative;
+    }
+
+    &-closeButton {
+        background: none;
+        border: 0;
+        cursor: pointer;
+        line-height: 0;
+        padding: 0;
+        position: absolute;
+        right: 0.75rem;
+        top: 0.75rem;
+    }
+}

--- a/packages/core/src/app/payment/PaymentMethodsRefreshAlert.scss
+++ b/packages/core/src/app/payment/PaymentMethodsRefreshAlert.scss
@@ -2,6 +2,7 @@
     outline: none;
 
     .alertBox {
+        padding-right: 3rem;
         position: relative;
     }
 

--- a/packages/core/src/app/payment/PaymentMethodsRefreshAlert.tsx
+++ b/packages/core/src/app/payment/PaymentMethodsRefreshAlert.tsx
@@ -8,7 +8,6 @@ import './PaymentMethodsRefreshAlert.scss';
 
 export interface PaymentMethodsRefreshAlertData {
     countryName: string;
-    // Set when the refresh dropped the selection; switches the message variant.
     removedMethodName?: string;
 }
 
@@ -30,7 +29,6 @@ export const PaymentMethodsRefreshAlert: FunctionComponent<PaymentMethodsRefresh
 
     useEffect(() => {
         if (removedMethodName) {
-            // The shopper must act, so move focus (and the viewport) here.
             containerRef.current?.focus();
 
             return;

--- a/packages/core/src/app/payment/PaymentMethodsRefreshAlert.tsx
+++ b/packages/core/src/app/payment/PaymentMethodsRefreshAlert.tsx
@@ -1,0 +1,77 @@
+import React, { type FunctionComponent, useEffect, useRef } from 'react';
+
+import { useLocale } from '@bigcommerce/checkout/contexts';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
+import { Alert, AlertType, IconClose } from '@bigcommerce/checkout/ui';
+
+import './PaymentMethodsRefreshAlert.scss';
+
+export interface PaymentMethodsRefreshAlertData {
+    countryName: string;
+    // Set when the refresh dropped the selection; switches the message variant.
+    removedMethodName?: string;
+}
+
+export interface PaymentMethodsRefreshAlertProps {
+    alert: PaymentMethodsRefreshAlertData;
+    onDismiss(): void;
+}
+
+const AUTO_DISMISS_TIMEOUT = 5000;
+
+export const PaymentMethodsRefreshAlert: FunctionComponent<PaymentMethodsRefreshAlertProps> = ({
+    alert: { countryName, removedMethodName },
+    onDismiss,
+}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const onDismissRef = useRef(onDismiss);
+
+    onDismissRef.current = onDismiss;
+
+    useEffect(() => {
+        if (removedMethodName) {
+            // The shopper must act, so move focus (and the viewport) here.
+            containerRef.current?.focus();
+
+            return;
+        }
+
+        const timeoutId = window.setTimeout(() => onDismissRef.current(), AUTO_DISMISS_TIMEOUT);
+
+        return () => window.clearTimeout(timeoutId);
+    }, [countryName, removedMethodName]);
+
+    const { language } = useLocale();
+
+    return (
+        <div
+            className="paymentMethodsRefreshAlert"
+            data-test="payment-methods-refresh-alert"
+            ref={containerRef}
+            tabIndex={-1}
+        >
+            <Alert type={AlertType.Info}>
+                {removedMethodName ? (
+                    <TranslatedString
+                        data={{ countryName, methodName: removedMethodName }}
+                        id="payment.payment_methods_reloaded_method_unavailable_text"
+                    />
+                ) : (
+                    <TranslatedString
+                        data={{ countryName }}
+                        id="payment.payment_methods_updated_for_country_text"
+                    />
+                )}
+
+                <button
+                    aria-label={language.translate('common.close_action')}
+                    className="paymentMethodsRefreshAlert-closeButton"
+                    onClick={onDismiss}
+                    type="button"
+                >
+                    <IconClose />
+                </button>
+            </Alert>
+        </div>
+    );
+};

--- a/packages/core/src/app/payment/PaymentMethodsRefreshAlert.tsx
+++ b/packages/core/src/app/payment/PaymentMethodsRefreshAlert.tsx
@@ -28,8 +28,16 @@ export const PaymentMethodsRefreshAlert: FunctionComponent<PaymentMethodsRefresh
     onDismissRef.current = onDismiss;
 
     useEffect(() => {
+        const container = containerRef.current;
+
+        try {
+            container?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        } catch {
+            container?.scrollIntoView();
+        }
+
         if (removedMethodName) {
-            containerRef.current?.focus();
+            container?.focus({ preventScroll: true });
 
             return;
         }

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -324,7 +324,6 @@ describe('PaymentBillingBlock', () => {
             jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
                 getBillingAddress(),
             );
-            // Keep the first update in flight so the store still has 'US'.
             jest.spyOn(checkoutService, 'updateBillingAddress').mockReturnValue(
                 new Promise(() => undefined),
             );
@@ -349,8 +348,6 @@ describe('PaymentBillingBlock', () => {
         });
 
         it('persists a change back to a previously requested country once the first persist settles', async () => {
-            // Store stays US throughout, as if an external update (address book,
-            // same as shipping) reverted the country after the first persist.
             jest.spyOn(checkoutState.data, 'getBillingAddress').mockReturnValue(
                 getBillingAddress(),
             );

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.test.tsx
@@ -139,7 +139,13 @@ describe('PaymentBillingBlock', () => {
         expect(mockCapturedProps.isBillingSameAsShipping).toBe(true);
     });
 
-    it('copies the shipping address to billing when the toggle is checked', async () => {
+    it('copies the shipping address to billing without its empty email when the toggle is checked', async () => {
+        const shippingAddressWithEmptyEmail = { ...getShippingAddress(), email: '' };
+
+        jest.spyOn(checkoutState.data, 'getShippingAddress').mockReturnValue(
+            shippingAddressWithEmptyEmail,
+        );
+
         render(<PaymentBillingBlockTest />);
 
         await screen.findByTestId('trigger-persist');

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -1,4 +1,5 @@
 import type { CheckoutSelectors } from '@bigcommerce/checkout-sdk';
+import { omit } from 'lodash';
 import React, { type FunctionComponent, useRef } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
@@ -48,7 +49,9 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
         const shippingAddress = getShippingAddress();
 
         if (shippingAddress && !isEqualAddress(shippingAddress, getBillingAddress())) {
-            updateBillingAddress(shippingAddress).catch((error) => {
+            // The consignment address carries email: '' — sent as-is it overwrites
+            // the guest email; omitted, the SDK falls back to the stored one.
+            updateBillingAddress(omit(shippingAddress, 'email')).catch((error) => {
                 onBillingSameAsShippingChange(false);
 
                 if (error instanceof Error) {

--- a/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingBlock.tsx
@@ -58,12 +58,8 @@ export const PaymentBillingBlock: FunctionComponent<PaymentBillingBlockProps> = 
         }
     };
 
-    // The store's countryCode lags while an update is in flight, so guard on
-    // the pending request instead; cleared on settle so it can't go stale.
     const lastRequestedCountryCodeRef = useRef<string | undefined>();
 
-    // Persist the form values (not the store address) so typed fields survive
-    // the Formik reinitialize; stateOrProvince is country-specific, so clear it.
     const handleBillingCountryChange = (countryCode: string, addressValues: AddressFormValues) => {
         const lastCountryCode =
             lastRequestedCountryCodeRef.current ?? getBillingAddress()?.countryCode;

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
@@ -104,15 +104,6 @@ describe('PaymentBillingForm', () => {
         expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
     });
 
-    it('overlays the address form while the billing address is being updated', () => {
-        jest.spyOn(checkoutState.statuses, 'isUpdatingBillingAddress').mockReturnValue(true);
-
-        renderForm(defaultProps);
-
-        expect(screen.getByTestId('loading-overlay')).toBeInTheDocument();
-        expect(screen.getByText('First Name')).toBeInTheDocument();
-    });
-
     it('does not render its own <form> element', () => {
         renderForm(defaultProps);
 

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
@@ -104,6 +104,15 @@ describe('PaymentBillingForm', () => {
         expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
     });
 
+    it('overlays the address form while the billing address is being updated', () => {
+        jest.spyOn(checkoutState.statuses, 'isUpdatingBillingAddress').mockReturnValue(true);
+
+        renderForm(defaultProps);
+
+        expect(screen.getByTestId('loading-overlay')).toBeInTheDocument();
+        expect(screen.getByText('First Name')).toBeInTheDocument();
+    });
+
     it('does not render its own <form> element', () => {
         renderForm(defaultProps);
 

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.test.tsx
@@ -208,8 +208,6 @@ describe('PaymentBillingForm', () => {
     });
 
     describe('billing country change', () => {
-        // getFormFields() has no countryCode field; AddressForm needs a dropdown
-        // one to render a country select.
         const getFieldsWithCountry = (): FormField[] => [
             ...getFormFields(),
             {

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -39,7 +39,6 @@ export interface PaymentBillingFormProps {
     // so the pre-submit ensureBillingAddressSaved can block the order.
     onPersist(values: BillingFormValues): Promise<void>;
     onBillingSameAsShippingChange(isBillingSameAsShipping: boolean): void;
-    // Let the block persist the new country so payment methods re-filter.
     onBillingCountryChange(countryCode: string, addressValues: AddressFormValues): void;
     onUnhandledError(error: Error): void;
     updateBillingAddress(address: Partial<Address>): Promise<unknown>;
@@ -189,8 +188,6 @@ const PaymentBillingFormComponent = ({
         void handleSelectAddress({});
     };
 
-    // `values.countryCode` may still hold the previous country when onChange
-    // fires, so the new country travels as the first argument.
     const handleAddressFieldChange = useCallback(
         (fieldName: string, value: string | string[]) => {
             if (fieldName === 'countryCode' && typeof value === 'string' && value) {

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -240,14 +240,16 @@ const PaymentBillingFormComponent = ({
 
                         {!restrictManualAddressEntry && !hasValidCustomerAddress && (
                             <AddressFormSkeleton isLoading={isResettingAddress}>
-                                <AddressForm
-                                    countryCode={values.countryCode}
-                                    formFields={editableFormFields}
-                                    onChange={handleAddressFieldChange}
-                                    setFieldValue={setFieldValue}
-                                    shouldShowSaveAddress={shouldShowSaveAddress}
-                                    type={AddressType.Billing}
-                                />
+                                <LoadingOverlay isLoading={isUpdatingBillingAddress}>
+                                    <AddressForm
+                                        countryCode={values.countryCode}
+                                        formFields={editableFormFields}
+                                        onChange={handleAddressFieldChange}
+                                        setFieldValue={setFieldValue}
+                                        shouldShowSaveAddress={shouldShowSaveAddress}
+                                        type={AddressType.Billing}
+                                    />
+                                </LoadingOverlay>
                             </AddressFormSkeleton>
                         )}
                     </Fieldset>

--- a/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
+++ b/packages/core/src/app/payment/billingForm/PaymentBillingForm.tsx
@@ -240,16 +240,14 @@ const PaymentBillingFormComponent = ({
 
                         {!restrictManualAddressEntry && !hasValidCustomerAddress && (
                             <AddressFormSkeleton isLoading={isResettingAddress}>
-                                <LoadingOverlay isLoading={isUpdatingBillingAddress}>
-                                    <AddressForm
-                                        countryCode={values.countryCode}
-                                        formFields={editableFormFields}
-                                        onChange={handleAddressFieldChange}
-                                        setFieldValue={setFieldValue}
-                                        shouldShowSaveAddress={shouldShowSaveAddress}
-                                        type={AddressType.Billing}
-                                    />
-                                </LoadingOverlay>
+                                <AddressForm
+                                    countryCode={values.countryCode}
+                                    formFields={editableFormFields}
+                                    onChange={handleAddressFieldChange}
+                                    setFieldValue={setFieldValue}
+                                    shouldShowSaveAddress={shouldShowSaveAddress}
+                                    type={AddressType.Billing}
+                                />
                             </AddressFormSkeleton>
                         )}
                     </Fieldset>

--- a/packages/core/src/app/payment/getPaymentMethodsRefreshAlert.ts
+++ b/packages/core/src/app/payment/getPaymentMethodsRefreshAlert.ts
@@ -1,0 +1,34 @@
+import { type Address, type LanguageService, type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import {
+    getPaymentMethodName,
+    getUniquePaymentMethodId,
+    hasPaymentMethodWithId,
+} from './paymentMethod';
+import { type PaymentMethodsRefreshAlertData } from './PaymentMethodsRefreshAlert';
+
+export default function getPaymentMethodsRefreshAlert({
+    billingAddress,
+    language,
+    previousSelectedMethod,
+    refreshedMethods,
+}: {
+    billingAddress?: Address;
+    language: LanguageService;
+    previousSelectedMethod?: PaymentMethod;
+    refreshedMethods: PaymentMethod[];
+}): PaymentMethodsRefreshAlertData {
+    const isPreviousSelectedRemoved =
+        previousSelectedMethod &&
+        !hasPaymentMethodWithId(
+            refreshedMethods,
+            getUniquePaymentMethodId(previousSelectedMethod.id, previousSelectedMethod.gateway),
+        );
+
+    return {
+        countryName: billingAddress?.country || billingAddress?.countryCode || '',
+        removedMethodName: isPreviousSelectedRemoved
+            ? getPaymentMethodName(language)(previousSelectedMethod)
+            : undefined,
+    };
+}

--- a/packages/core/src/app/payment/paymentMethod/hasPaymentMethodWithId.ts
+++ b/packages/core/src/app/payment/paymentMethod/hasPaymentMethodWithId.ts
@@ -1,0 +1,12 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import getUniquePaymentMethodId from './getUniquePaymentMethodId';
+
+export default function hasPaymentMethodWithId(
+    methods: PaymentMethod[],
+    uniquePaymentMethodId: string,
+): boolean {
+    return methods.some(
+        (method) => getUniquePaymentMethodId(method.id, method.gateway) === uniquePaymentMethodId,
+    );
+}

--- a/packages/core/src/app/payment/paymentMethod/index.ts
+++ b/packages/core/src/app/payment/paymentMethod/index.ts
@@ -9,6 +9,7 @@ export {
     parseUniquePaymentMethodId,
 } from './getUniquePaymentMethodId';
 export { default as getPaymentMethodName } from './getPaymentMethodName';
+export { default as hasPaymentMethodWithId } from './hasPaymentMethodWithId';
 export { usePoMethodDisabledReason } from './usePoMethodDisabledReason';
 export { isHostedCreditCardFieldsetValues } from './HostedCreditCardFieldsetValues';
 export {

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -330,6 +330,8 @@
             "payment_method_unavailable_error": "This payment provider is temporarily unavailable. Please try again later.",
             "payment_not_required_text": "Payment is not required for this order.",
             "payment_methods_unavailable_error": "We're unable to load payment methods at the moment. Please try again later or contact the store for assistance.",
+            "payment_methods_reloaded_method_unavailable_text": "Payment options reloaded for {countryName} as the billing country. {methodName} isn't available in this country, please select another payment method.",
+            "payment_methods_updated_for_country_text": "Payment options updated for {countryName} as the billing country.",
             "paypal_complete_action": "Complete order",
             "paypal_continue_action": "Continue with PayPal",
             "paypal_pay_later_complete_action": "Complete order",


### PR DESCRIPTION
## What/Why?

- Add the alerting above payment method list to indicate the list has been refreshed after the billing country change. There are 2 variants, one with normal country change and the selected payment as is; and another one when the selected payment method is lost on country change.
- TODO's added for supressing or handling the error of lost payment method and to select the default payment method from the new list automatically if the selected payment method is no longer available. https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10199
- Solved the issue of billing email address being wiped OFF when chcking `Same as shipping address` on payment step checkbox. This happens only in themeV2 because in shipping step the payload is generated using form fields which do not have email field so it never gets passed in payload.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

1. Payment step alert

https://github.com/user-attachments/assets/10a32ceb-d314-4708-b731-4878ccc8b230



2. Guest email wipe off issue

**BEFORE**

https://github.com/user-attachments/assets/a2b72c5a-6c9e-4d4d-8c74-739a6f6d8359


**AFTER**

https://github.com/user-attachments/assets/b6080747-41f0-4762-acdf-1693d35cc4c6






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment method reload, selection tracking, and billing address sync on the critical payment step; error suppression for removed methods is temporary and could mask real issues if mis-timed.
> 
> **Overview**
> Adds **themeV2** UX when billing country changes reload payment methods: an info alert above the method list (updated options vs. selected method no longer available), dismissible or auto-dismissed, cleared on cart total reload or when the shopper picks another method. **LoadingOverlay** now wraps the whole payment form during billing/reload busy states; the method list overlay is removed so hosted fields stay mounted.
> 
> Country-change reloads pass the **prior selection** into analytics tracking and alert copy via `selectedMethodRef` and `getPaymentMethodsRefreshAlert` / `hasPaymentMethodWithId`. A temporary **5s suppression** of `missing_data` errors during reload when the selection is removed is marked TODO CHECKOUT-10199.
> 
> Fixes guest **email wiped** when “Same as shipping” is checked on payment: `PaymentBillingBlock` omits empty `email` from the shipping copy so the SDK keeps the stored guest email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5768ebd513e9035e51588ff69b310596d56f99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->