### PR TITLE
feat(payment): CHECKOUT-10242 Add logging to capture fallback method usage

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -10,6 +10,7 @@ import { createNoPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/
 import React, { type FunctionComponent, lazy, memo, Suspense } from 'react';
 
 import { type CheckoutContextProps } from '@bigcommerce/checkout/contexts';
+import { CaptureMessageComponent } from '@bigcommerce/checkout/payment-integration-api';
 
 import { withCheckout } from '../../checkout';
 
@@ -58,10 +59,15 @@ const PaymentMethodComponent: FunctionComponent<
     const { method } = props;
 
     if (method.id === PaymentMethodId.Humm || method.type === PaymentMethodProviderType.Hosted) {
+        const sentryMessage = `DataHostedPaymentMethod Hosted/Humm ${JSON.stringify(method)}`;
+
         return (
-            <Suspense>
-                <HostedPaymentMethod {...props} />
-            </Suspense>
+            <>
+                <CaptureMessageComponent message={sentryMessage} />
+                <Suspense>
+                    <HostedPaymentMethod {...props} />
+                </Suspense>
+            </>
         );
     }
 
@@ -72,10 +78,15 @@ const PaymentMethodComponent: FunctionComponent<
         method.method === PaymentMethodType.CreditCard ||
         method.type === PaymentMethodProviderType.Api
     ) {
+        const sentryMessage = `DataHostedCreditCardPaymentMethod ${JSON.stringify(method)}`;
+
         return (
-            <Suspense>
-                <HostedCreditCardPaymentMethod {...props} />
-            </Suspense>
+            <>
+                <CaptureMessageComponent message={sentryMessage} />
+                <Suspense>
+                    <HostedCreditCardPaymentMethod {...props} />
+                </Suspense>
+            </>
         );
     }
 

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -31,6 +31,7 @@ import {
     StoreInstrumentFieldset,
 } from '@bigcommerce/checkout/instrument-utils';
 import {
+    CaptureMessageComponent,
     type CardInstrumentFieldsetValues,
     type PaymentMethodProps,
 } from '@bigcommerce/checkout/payment-integration-api';
@@ -365,6 +366,8 @@ export const CreditCardPaymentMethodComponent = (
 
     const storeConfig = getStoreConfig();
 
+    const SentryMessage = methodProp ? `DataCreditCardFieldset ${JSON.stringify(methodProp)}` : '';
+
     if (!storeConfig) {
         throw Error('Unable to get config or customer');
     }
@@ -396,12 +399,15 @@ export const CreditCardPaymentMethodComponent = (
                 )}
 
                 {shouldShowCreditCardFieldset && !cardFieldset && (
-                    <CreditCardFieldset
-                        shouldShowCardCodeField={
-                            methodProp.config.cardCode || methodProp.config.cardCode === null
-                        }
-                        shouldShowCustomerCodeField={methodProp.config.requireCustomerCode}
-                    />
+                    <>
+                        <CaptureMessageComponent message={SentryMessage} />
+                        <CreditCardFieldset
+                            shouldShowCardCodeField={
+                                methodProp.config.cardCode || methodProp.config.cardCode === null
+                            }
+                            shouldShowCustomerCodeField={methodProp.config.requireCustomerCode}
+                        />
+                    </>
                 )}
 
                 {shouldShowCreditCardFieldset && cardFieldset}


### PR DESCRIPTION
## What/Why?
Add logging to capture fallback method usage

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live payment-method render paths and logs full payment method objects to the error logger, which may increase observability noise or expose method metadata in Sentry without changing payment processing logic.
> 
> **Overview**
> Adds **diagnostic logging** when checkout renders generic/fallback payment UI instead of integration-specific components, to measure fallback usage (CHECKOUT-10242).
> 
> In **`PaymentMethod.tsx`**, **`CaptureMessageComponent`** runs before lazy-loaded **`HostedPaymentMethod`** (Humm or hosted type) and **`HostedCreditCardPaymentMethod`** (credit-card method or API provider type), with tagged messages that include **`JSON.stringify(method)`**.
> 
> In **`CreditCardPaymentMethodComponent`**, the same component logs when the default **`CreditCardFieldset`** is shown (no custom `cardFieldset`), with a `DataCreditCardFieldset` prefix and serialized method payload.
> 
> Payment behavior and rendering are unchanged aside from these **`errorLogger.logMessage`** calls on mount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0b7b6da51a4bf639a8f0b7825e4033b8d12e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->