### PR TITLE
feat(payment): CHECKOUT-10242 Update log message

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -59,7 +59,11 @@ const PaymentMethodComponent: FunctionComponent<
     const { method } = props;
 
     if (method.id === PaymentMethodId.Humm || method.type === PaymentMethodProviderType.Hosted) {
-        const sentryMessage = `DataHostedPaymentMethod Hosted/Humm ${JSON.stringify(method)}`;
+        const sentryMessage = `DataHostedPaymentMethod Hosted/Humm ${JSON.stringify({
+            gateway: method.gateway,
+            id: method.id,
+            type: method.type,
+        })}`;
 
         return (
             <>
@@ -78,7 +82,11 @@ const PaymentMethodComponent: FunctionComponent<
         method.method === PaymentMethodType.CreditCard ||
         method.type === PaymentMethodProviderType.Api
     ) {
-        const sentryMessage = `DataHostedCreditCardPaymentMethod ${JSON.stringify(method)}`;
+        const sentryMessage = `DataHostedCreditCardPaymentMethod ${JSON.stringify({
+            gateway: method.gateway,
+            id: method.id,
+            type: method.type,
+        })}`;
 
         return (
             <>

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -366,7 +366,13 @@ export const CreditCardPaymentMethodComponent = (
 
     const storeConfig = getStoreConfig();
 
-    const SentryMessage = methodProp ? `DataCreditCardFieldset ${JSON.stringify(methodProp)}` : '';
+    const SentryMessage = methodProp
+        ? `DataCreditCardFieldset component ${JSON.stringify({
+              gateway: methodProp.gateway,
+              id: methodProp.id,
+              type: methodProp.type,
+          })}`
+        : '';
 
     if (!storeConfig) {
         throw Error('Unable to get config or customer');


### PR DESCRIPTION
## What/Why?
Update log message

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes with smaller log payloads; no payment initialization or UI behavior changes.
> 
> **Overview**
> Payment routing diagnostics sent through `CaptureMessageComponent` no longer stringify the full `PaymentMethod` object.
> 
> In `PaymentMethod.tsx`, hosted/Humm and hosted credit-card branches now log only `gateway`, `id`, and `type` instead of the entire `method`. In `CreditCardPaymentMethodComponent.tsx`, the credit-card fieldset message prefix is clarified to **DataCreditCardFieldset component** and uses the same three-field payload instead of full `methodProp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633a18d340c67271492c99a04dd9b0e43e2e94f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->