### PR TITLE
feat(payment): CHECKOUT-10242 Filter out known methods in logging

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -82,11 +82,40 @@ const PaymentMethodComponent: FunctionComponent<
         method.method === PaymentMethodType.CreditCard ||
         method.type === PaymentMethodProviderType.Api
     ) {
-        const sentryMessage = `DataHostedCreditCardPaymentMethod ${JSON.stringify({
-            gateway: method.gateway,
-            id: method.id,
-            type: method.type,
-        })}`;
+        const knownMethods: Array<{ gateway: string | null; id: string; type: string }> = [
+            { gateway: null, id: 'authorizenet', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'cybersourcev2', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'ewayrapid', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'nmi', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'bigpaypay', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'usaepay', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'googlepay', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'quickbooks', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'orbital', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'stripe', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'firstdatae4v14', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'cybersource', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'hps', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'clover', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'elavon', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'bnz', type: PaymentMethodProviderType.Api },
+            { gateway: null, id: 'vantivcore', type: PaymentMethodProviderType.Api },
+        ];
+
+        const isKnownMethod = knownMethods.some(
+            (knownMethod) =>
+                knownMethod.gateway === method.gateway &&
+                knownMethod.id === method.id &&
+                knownMethod.type === method.type,
+        );
+
+        const sentryMessage = isKnownMethod
+            ? ''
+            : `DataHostedCreditCardPaymentMethod ${JSON.stringify({
+                  gateway: method.gateway,
+                  id: method.id,
+                  type: method.type,
+              })}`;
 
         return (
             <>


### PR DESCRIPTION
## What/Why?
Filter out known methods that have already been identified via logging.

## Rollout/Rollback
- revert this PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change; payment routing and HostedCreditCardPaymentMethod behavior are unchanged, with slightly less visibility for new unknown methods until they are added to the list.
> 
> **Overview**
> Reduces **Sentry noise** for the hosted credit card / API payment path in `PaymentMethod.tsx` by only emitting `DataHostedCreditCardPaymentMethod` capture messages when the method is **not** on a new allowlist.
> 
> Previously every match on `credit-card` or `Api` type logged to Sentry. The change introduces a `knownMethods` list (Authorize.net, Stripe, NMI, Cybersource, etc.) and sets `sentryMessage` to an empty string when `gateway`, `id`, and `type` match an entry, so `CaptureMessageComponent` no longer reports already-identified integrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ef1f46aa1096544e874d98a218904e79531206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->