### PR TITLE
feat(payment): PAYPAL-6933 fix to the implementation of the isComplete

### DIFF
--- a/packages/bigcommerce-payments-integration/src/BigCommercePayments/BigCommercePaymentsPaymentMethod.test.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePayments/BigCommercePaymentsPaymentMethod.test.tsx
@@ -144,5 +144,13 @@ describe('BigCommercePaymentsPaymentMethod', () => {
 
             expect(checkoutService.loadInstruments).not.toHaveBeenCalled();
         });
+
+        it('should load instruments if isComplete is false', () => {
+            props.method.initializationData.isComplete = false;
+
+            render(<BigCommercePaymentsPaymentMethodMock {...props} />);
+
+            expect(checkoutService.loadInstruments).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/bigcommerce-payments-integration/src/BigCommercePayments/BigCommercePaymentsPaymentMethod.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePayments/BigCommercePaymentsPaymentMethod.tsx
@@ -23,7 +23,7 @@ const BigCommercePaymentsPaymentMethod: FunctionComponent<PaymentMethodProps> = 
         },
         method: {
             config: { isVaultingEnabled },
-            initializationData: { ...isComplete },
+            initializationData: { isComplete },
         },
         method,
         checkoutService,
@@ -58,7 +58,7 @@ const BigCommercePaymentsPaymentMethod: FunctionComponent<PaymentMethodProps> = 
         if (shouldLoadInstruments) {
             void loadInstrumentsOrThrow();
         }
-    });
+    }, []);
 
     if (!isPaymentDataRequired()) {
         return null;


### PR DESCRIPTION
## What/Why?

isComplete does not work properly because it is taken wrong. This PR fixes it in a way of how it should work.

## Rollout/Rollback

Revert

## Testing

Verified via local store

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small payment-method bugfix with targeted tests; no auth or data-model changes beyond correct gating of instrument loading.
> 
> **Overview**
> Fixes **`isComplete`** handling in `BigCommercePaymentsPaymentMethod` so vaulted instrument loading and UI respect checkout completion state.
> 
> **`initializationData`** was destructured as `{ ...isComplete }`, which did not read the boolean **`isComplete`** flag correctly. It now uses **`{ isComplete }`**, aligning with **`useBigCommercePaymentsInstruments`**, which already gates vaulting UI on **`!method.initializationData.isComplete`**.
> 
> The **`useEffect`** that calls **`loadInstruments`** now uses an empty dependency array **`[]`**, so instrument loading runs once on mount when **`shouldLoadInstruments`** is true (**registered customer**, vaulting enabled, **`!isComplete`**).
> 
> Tests add coverage that **`loadInstruments`** is invoked when **`isComplete`** is **`false`**, complementing the existing case when it is **`true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b17b05a9ffc256c3bcc6f91dacac0e32b1512e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->