### PR TITLE
fix(checkout): CHECKOUT-10281 Fetch Shipping Options when Changing Extra Field

### DIFF
--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -10,6 +10,7 @@ export { default as StaticAddress } from './StaticAddress';
 export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';
+export { default as getAddressExtraFields } from './getAddressExtraFields';
 export { default as setDefaultAddress } from './setDefaultAddress';
 export { default as getShouldSaveAddress } from './getShouldSaveAddress';
 export { reorderAddressFormFields } from './reorderAddressFormFields';

--- a/packages/core/src/app/shipping/SingleShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.test.tsx
@@ -1,4 +1,4 @@
-import { createCheckoutService } from '@bigcommerce/checkout-sdk';
+import { type Address, createCheckoutService, type FormField } from '@bigcommerce/checkout-sdk';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -27,6 +27,28 @@ describe('SingleShippingForm', () => {
     const checkoutService = createCheckoutService();
     const extensionService = new ExtensionService(checkoutService, createErrorLogger());
     const addressFormFields = getAddressFormFields().filter(({ custom }) => !custom);
+
+    const extraFormField: FormField = {
+        custom: false,
+        default: '',
+        fieldType: 'dropdown',
+        id: 'b2bExtraField_11',
+        label: 'Dropdown extra field',
+        name: 'b2bExtraField_11',
+        options: {
+            items: [
+                { label: 'a', value: 'a' },
+                { label: 'b', value: 'b' },
+            ],
+        },
+        required: true,
+        type: 'array',
+    };
+
+    const shippingAddressWithExtraFields: Address = {
+        ...getShippingAddress(),
+        extraFields: [{ fieldId: '11', fieldValue: 'a' }],
+    };
 
     const mockUseShipping = useShipping as jest.MockedFunction<typeof useShipping>;
 
@@ -200,6 +222,76 @@ describe('SingleShippingForm', () => {
                 params: {
                     include: {
                         'consignments.availableShippingOptions': true,
+                    },
+                },
+            },
+        );
+    });
+
+    it('calls updateAddress including shipping options if extra fields are updated and shipping options have already been requested', async () => {
+        const updateShippingAddress = jest.fn();
+
+        mockUseShipping.mockReturnValue({ ...defaultUseShippingValues, updateShippingAddress });
+        renderSingleShippingFormComponent({
+            shippingAddress: shippingAddressWithExtraFields,
+            getFields: () => [...addressFormFields, extraFormField],
+        });
+
+        await userEvent.clear(screen.getByTestId('addressLine2Input-text'));
+        await userEvent.keyboard('foo 1');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        await userEvent.selectOptions(screen.getByTestId('b2bExtraField_11Input-select'), 'b');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateShippingAddress).toHaveBeenCalledTimes(2);
+        expect(updateShippingAddress).toHaveBeenLastCalledWith(
+            {
+                ...getShippingAddress(),
+                address2: 'foo 1',
+                extraFields: [{ fieldId: '11', fieldValue: 'b' }],
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': true,
+                    },
+                },
+            },
+        );
+    });
+
+    it('calls updateAddress without shipping options if extra fields are unchanged and shipping options have already been requested', async () => {
+        const updateShippingAddress = jest.fn();
+
+        mockUseShipping.mockReturnValue({ ...defaultUseShippingValues, updateShippingAddress });
+        renderSingleShippingFormComponent({
+            shippingAddress: shippingAddressWithExtraFields,
+            getFields: () => [...addressFormFields, extraFormField],
+        });
+
+        await userEvent.clear(screen.getByTestId('addressLine2Input-text'));
+        await userEvent.keyboard('foo1');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        await userEvent.clear(screen.getByTestId('addressLine2Input-text'));
+        await userEvent.keyboard('foo2');
+
+        await new Promise((resolve) => setTimeout(resolve, waitingDelay));
+
+        expect(updateShippingAddress).toHaveBeenLastCalledWith(
+            {
+                ...getShippingAddress(),
+                address2: 'foo2',
+                extraFields: [{ fieldId: '11', fieldValue: 'a' }],
+            },
+            {
+                params: {
+                    include: {
+                        'consignments.availableShippingOptions': false,
                     },
                 },
             },

--- a/packages/core/src/app/shipping/SingleShippingForm.tsx
+++ b/packages/core/src/app/shipping/SingleShippingForm.tsx
@@ -11,6 +11,7 @@ import { Fieldset, Form } from '@bigcommerce/checkout/ui';
 import {
     type AddressFormValues,
     decodeAddressLabel,
+    getAddressExtraFields,
     getAddressFormFieldsValidationSchema,
     getTranslateAddressError,
     isEqualAddress,
@@ -202,6 +203,12 @@ const SingleShippingForm: React.FC<
                     updatedShippingAddress?.customFields,
                 ) || includeShippingOptions;
         }
+
+        newIncludeShippingOptions =
+            !isEqual(
+                getAddressExtraFields(currentShippingAddress),
+                getAddressExtraFields(updatedShippingAddress),
+            ) || newIncludeShippingOptions;
 
         if (
             !updatedShippingAddress ||


### PR DESCRIPTION
## What/Why?

This PR enables an extra-field change to trigger a shipping-option PUT call.

Currently, after the first shipping-options call, `checkout-js` calls consignment API without requesting shipping options for non-address-field or non-custom-field changes.
- This breaks a checkout flow when an  extra field is edited.

No checkout-sdk dependency.

## Rollout/Rollback
Revert.

## Testing
### Manual Testing
#### Before
Changing B2B extra fields the second time triggers a PUT call.

https://github.com/user-attachments/assets/6bf499e6-0645-4d49-a108-ee5232a59a5c

#### After

https://github.com/user-attachments/assets/7870a62b-8ea3-4e8c-9947-c3252f502a11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to shipping autosave include flags plus tests; no auth or payment impact.
> 
> **Overview**
> Fixes stale shipping options when shoppers change **B2B extra fields** on the single-shipping form after shipping options were already loaded.
> 
> Autosave already re-fetches shipping options when **custom fields** change, but **extra fields** were treated like ordinary non-shipping fields, so later PUTs omitted `consignments.availableShippingOptions`. **`SingleShippingForm`** now compares extra fields via **`getAddressExtraFields`** (exported from the address module) and requests shipping options when they differ, matching custom-field behavior.
> 
> Tests cover an extra-field change forcing a refresh and unchanged extra fields skipping an unnecessary options fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ea7bff87a8f6169102894194f0095b5bfe3567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->