### PR TITLE
fix(checkout): CHECKOUT-10297 Adjust styling so that phone input flag is centered

### DIFF
--- a/packages/core/src/scss/components/foundation/forms/_forms.scss
+++ b/packages/core/src/scss/components/foundation/forms/_forms.scss
@@ -89,6 +89,10 @@
             position: relative;
             width: 100%;
 
+            input.iti__tel-input {
+                float: none;
+            }
+
             .iti__selected-country-primary {
                 // remove default background to align with out form style
                 background-color: transparent !important;
@@ -102,7 +106,7 @@
         .iti-wrapper {
             display: block;
 
-            .iti__country-container {
+            .iti__country-container:has(+ input.floating-input) {
                 top: $input-verticalPadding * 1.5;
                 bottom: auto;
                 height: $floating-label-input-height - $input-verticalPadding * 1.5;


### PR DESCRIPTION
## What/Why?

There is an issue with phone input flag alignment when "Display labels inside input fields" is off in Checkout settings (as reported by http://mody.com.au/ 😄 ). This PR fixes the issue.

## Rollout/Rollback

Revert the PR.

## Testing

Manual.
Before:

<img width="1492" height="816" alt="Screenshot 2026-08-05 at 11 46 46 AM" src="https://github.com/user-attachments/assets/7e642d87-3162-4412-9a89-1f85ee5e0804" />

After:

<img width="921" height="515" alt="Screenshot 2026-08-05 at 12 13 26 PM" src="https://github.com/user-attachments/assets/724e19c2-f391-490d-af89-cf0a3cc272a1" />

Still works fine for floating labels:

<img width="921" height="515" alt="Screenshot 2026-08-05 at 12 38 19 PM" src="https://github.com/user-attachments/assets/43b8ce8d-867c-4b44-bb8c-1e155a8a7a5b" />

Still works fin for themeEnhanced (v2) with both setting options:

<img width="921" height="515" alt="Screenshot 2026-08-05 at 12 47 50 PM" src="https://github.com/user-attachments/assets/7da9af49-1281-499b-b610-fc989ddd6f4f" />


<img width="921" height="515" alt="Screenshot 2026-08-05 at 12 46 27 PM" src="https://github.com/user-attachments/assets/87b39f09-6e90-4f13-b17a-454d33b310e6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout form SCSS only; no logic or data changes. Risk is limited to phone field appearance across label modes.
> 
> **Overview**
> Fixes **intl-tel-input** flag/country selector alignment on checkout when **“Display labels inside input fields”** is turned off.
> 
> Sets `float: none` on `input.iti__tel-input` so the tel field doesn’t fight layout from floating styles. **Country container** vertical offsets (top, height, padding) now apply only when the input uses floating labels, via `:has(+ input.floating-input)`, so non-floating phone fields keep default flag positioning while floating-label checkout still gets the centered flag treatment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e7a9ec94848e0521993de5cc209a717810eb13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->