### PR TITLE
feat(payment): PI-5532 [Afterpay] [FE] Create logs for tracking post-redirect actions

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -3,6 +3,7 @@ import {
     type Capabilities,
     type Cart,
     type CartStockPositionsChangedError,
+    type CheckoutPayment,
     type CheckoutSelectors,
     type CheckoutService,
     type Consignment,
@@ -44,7 +45,7 @@ import {
     useCapabilities,
     useThemeContext,
 } from '@bigcommerce/checkout/contexts';
-import { type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
+import { ErrorLevelType, type ErrorLogger } from '@bigcommerce/checkout/error-handling-utils';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { type PaymentFormValues } from '@bigcommerce/checkout/payment-integration-api';
 import { ChecklistSkeleton } from '@bigcommerce/checkout/ui';
@@ -115,6 +116,7 @@ interface WithCheckoutPaymentProps {
     methods: PaymentMethod[];
     orderExtraFields?: FormField[];
     orderId?: number;
+    payments?: CheckoutPayment[];
     shouldExecuteSpamCheck: boolean;
     shouldLocaliseErrorMessages: boolean;
     submitOrderError?: Error;
@@ -671,16 +673,60 @@ const Payment = (
     useEffect(() => {
         const init = async () => {
             const {
+                cart,
+                errorLogger,
                 finalizeOrderIfNeeded,
                 onFinalize = noop,
                 onFinalizeError = noop,
                 onReady = noop,
                 onUnhandledError = noop,
                 orderId,
+                payments,
                 refreshB2BPaymentMethods,
                 usableStoreCredit,
                 checkoutServiceSubscribe,
             } = props;
+
+            // Diagnostic logging: shoppers redirected back from
+            // Afterpay sometimes land with no order created and no server-side trace.
+            const isReturningFromAfterpay = () =>
+                typeof document !== 'undefined' && /afterpay\.com/i.test(document.referrer || '');
+
+            const logAfterpayRedirectOutcome = (error?: unknown) => {
+                if (!isReturningFromAfterpay()) {
+                    return;
+                }
+
+                const isExpectedSkip =
+                    isErrorWithType(error) && error.type === 'order_finalization_not_required';
+                const outcome = !error ? 'success' : isExpectedSkip ? 'skipped' : 'failure';
+
+                // `payments` (checkout.payments) is already loaded by the time Payment mounts,
+                // unlike the payment methods list, so read the attempted method straight off the
+                // HOSTED payment record rather than off `defaultMethod`, which is still empty at
+                // this point (loadPaymentMethodsOrThrow hasn't resolved yet).
+                const hostedPayment = (payments || []).find(
+                    (payment) => payment.providerType === 'PAYMENT_TYPE_HOSTED',
+                );
+
+                const meta = {
+                    stage: 'afterpay-redirect-finalize',
+                    outcome,
+                    errorType: isErrorWithType(error) ? error.type : undefined,
+                    methodId: hostedPayment?.providerId,
+                    gatewayId: hostedPayment?.gatewayId,
+                    cartId: cart?.id,
+                    hasHostedPayment: Boolean(hostedPayment),
+                };
+
+                if (outcome === 'failure' && error instanceof Error) {
+                    errorLogger.log(error, undefined, ErrorLevelType.Warning, meta);
+                } else {
+                    errorLogger.logMessage?.(
+                        `Afterpay redirect-back finalize: ${JSON.stringify(meta)}`,
+                    );
+                }
+            };
 
             if (!disableStoreCredit && usableStoreCredit) {
                 await handleStoreCreditChange(true);
@@ -719,8 +765,11 @@ const Payment = (
 
                 await persistB2BMetadataIfNeeded();
 
+                logAfterpayRedirectOutcome();
                 onFinalize(order?.orderId);
             } catch (error) {
+                logAfterpayRedirectOutcome(error);
+
                 if (isErrorWithType(error) && error.type !== 'order_finalization_not_required') {
                     onFinalizeError(error);
                 }
@@ -928,6 +977,7 @@ export function mapToPaymentProps(
         methods: filteredMethods,
         orderExtraFields,
         orderId: checkout.orderId,
+        payments: checkout.payments,
         refreshB2BPaymentMethods: checkoutService.refreshB2BPaymentMethods,
         submitB2BMetadata: checkoutService.persistB2BMetadata,
         shouldExecuteSpamCheck: checkout.shouldExecuteSpamCheck,


### PR DESCRIPTION
## What/Why?
Create FE logs to check what happens when the shopper gets redirected from Afterpay back to BC store. We could use the logs as we don't have enough information to successfully debug the issue raised by one of the merchants.

## Rollout/Rollback

Revert this PR

## Testing
TBA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes gated on Afterpay referrer; no payment or order logic is altered beyond existing finalize behavior.
> 
> **Overview**
> Adds **diagnostic logging** when checkout detects a return from Afterpay (`document.referrer`) during Payment mount, around **`finalizeOrderIfNeeded`**.
> 
> On redirect-back, the init flow records outcome (`success`, `skipped` for `order_finalization_not_required`, or `failure`) with metadata such as hosted payment `methodId`/`gatewayId`, `cartId`, and `hasHostedPayment`. Failures go to **`errorLogger.log`** at warning level; other outcomes use **`logMessage`**.
> 
> **`checkout.payments`** is passed into Payment props so the hosted payment record can be read before payment methods finish loading (when `defaultMethod` is still unset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aca9a846ce00d8a9818a8f22e6685d8b4ad4360f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->