### PR TITLE
fix(checkout): CHECKOUT-10300 Render legacy component for phone fields with maxLength

### DIFF
--- a/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
@@ -287,6 +287,30 @@ describe('DynamicFormField Component', () => {
             });
         });
 
+        it('renders the legacy phone input when the field has a max length, even when the experiment is enabled', async () => {
+            mockIsValidNumber.mockReturnValue(false);
+
+            const { container } = renderMockFormField({
+                field: { ...phoneFieldMock, maxLength: 10 },
+                isNewPhoneValidationExperimentEnabled: true,
+            });
+
+            const input = screen.getByTestId('phone-text');
+
+            expect(input).toHaveAttribute('type', 'tel');
+            expect(input).toHaveAttribute('maxlength', '10');
+            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+            expect(container.querySelector('.iti-wrapper')).not.toBeInTheDocument();
+
+            // The legacy input does not apply IntlTelInput phone validation
+            fireEvent.change(input, { target: { value: '123' } });
+            await userEvent.click(screen.getByText('Submit'));
+
+            await waitFor(() => {
+                expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+            });
+        });
+
         it('does not validate phone for non-telephone fields even when experiment is enabled', async () => {
             mockIsValidNumber.mockReturnValue(false);
 

--- a/packages/ui/src/form/DynamicFormField/DynamicFormFieldSelector.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormFieldSelector.tsx
@@ -45,8 +45,10 @@ export const DynamicFormFieldSelector: FunctionComponent<DynamicFormFieldSelecto
         selectedCountry,
         onChange,
     }) => {
+        // skipped for stores with maxLength as it caused formatting issues
         const isNewPhoneFieldWithValidation =
             isNewPhoneValidationExperimentEnabled &&
+            !maxLength &&
             dynamicFormFieldType === DynamicFormFieldType.TELEPHONE;
 
         const renderInput = useCallback(


### PR DESCRIPTION
## What/Why?

The new IntlTelInput phone component formats values (e.g. `3188675309` → `(318) 867-5309`), so on stores where the merchant has set a max length on the phone field, valid numbers fail max-length validation and block checkout.

This PR keeps the legacy phone input for stores with a phone max length set, so the existing max-length validation applies as-is. Stores without a max length are unaffected and continue to get the new component.

## Rollout/Rollback

Revert the PR.

## Testing

New CI test + manual testing:


https://github.com/user-attachments/assets/b667d92c-ac6e-4a83-8147-ef66175463e1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped checkout form routing for phone fields with maxLength; no auth or payment changes, and behavior reverts by disabling the experiment or reverting the PR.
> 
> **Overview**
> Fixes checkout blocking when merchants set a **max length** on the phone field: **IntlTelInput** formatting (e.g. digits → `(318) 867-5309`) made valid numbers fail max-length checks.
> 
> **`DynamicFormFieldSelector`** now only routes to **`PhoneFormField`** when the new phone validation experiment is on, the field is telephone, and **`maxLength` is not set**; fields with **`maxLength`** keep the legacy **`tel`** **`DynamicInput`** so merchant max-length rules apply to raw input.
> 
> Adds a test confirming the legacy input ( **`maxlength`**, no **`.iti-wrapper`** ) and that IntlTel validity is not applied on submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40f59c0d74c05f0b1db6428a3e02743bef6c9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->