### PR TITLE
chore(checkout): CHECKOUT-10281 Bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.950.2",
+        "@bigcommerce/checkout-sdk": "^1.950.3",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.950.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.2.tgz",
-      "integrity": "sha512-uF1a9VOctv1sRdBLs9vv5TslO+BDs0l09cTeHRL90WkqkZEkTDk0MLWSgfdX1b5nzlBSiw+4L3xKx9jw1rVL6g==",
+      "version": "1.950.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.3.tgz",
+      "integrity": "sha512-7ndx6lrLrSI+gBtrGEHAydkKYIculC+FD16ozg4CKo1sjZJYGm47i/tgtLPP0/0Uv4u7VhJDUPUNnm4mWqMBVw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.950.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.2.tgz",
-      "integrity": "sha512-uF1a9VOctv1sRdBLs9vv5TslO+BDs0l09cTeHRL90WkqkZEkTDk0MLWSgfdX1b5nzlBSiw+4L3xKx9jw1rVL6g==",
+      "version": "1.950.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.3.tgz",
+      "integrity": "sha512-7ndx6lrLrSI+gBtrGEHAydkKYIculC+FD16ozg4CKo1sjZJYGm47i/tgtLPP0/0Uv4u7VhJDUPUNnm4mWqMBVw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.950.2",
+    "@bigcommerce/checkout-sdk": "^1.950.3",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump SDK version.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine SDK patch bump with no checkout-js code changes; behavior shifts depend on what shipped in checkout-sdk 1.950.3 and should be covered by CI.
> 
> **Overview**
> Bumps `@bigcommerce/checkout-sdk` from **^1.950.2** to **^1.950.3** in `package.json`, with matching updates in `package-lock.json`. No application source changes in this PR—only the dependency version and lockfile entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b40f786920f42a089f3843ba17df744c331bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->