### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.950.3",
+        "@bigcommerce/checkout-sdk": "^1.950.4",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.950.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.3.tgz",
-      "integrity": "sha512-7ndx6lrLrSI+gBtrGEHAydkKYIculC+FD16ozg4CKo1sjZJYGm47i/tgtLPP0/0Uv4u7VhJDUPUNnm4mWqMBVw==",
+      "version": "1.950.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.4.tgz",
+      "integrity": "sha512-V/FsILPH27V7UP+DMMVWeSzmrRM2OVLn/u9yQ2We0rsvqyE433DB04rtUAdvamGv7MwuH44HxgTTvPRjtHJdFA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.950.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.3.tgz",
-      "integrity": "sha512-7ndx6lrLrSI+gBtrGEHAydkKYIculC+FD16ozg4CKo1sjZJYGm47i/tgtLPP0/0Uv4u7VhJDUPUNnm4mWqMBVw==",
+      "version": "1.950.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.4.tgz",
+      "integrity": "sha512-V/FsILPH27V7UP+DMMVWeSzmrRM2OVLn/u9yQ2We0rsvqyE433DB04rtUAdvamGv7MwuH44HxgTTvPRjtHJdFA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.950.3",
+    "@bigcommerce/checkout-sdk": "^1.950.4",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdl version
To deploy PR: [https://github.com/bigcommerce/checkout-sdk-js/pull/3335](https://github.com/bigcommerce/checkout-sdk-js/pull/3335)

## Rollout/Rollback
Rollback this PR and all related

## Testing
In checkout-sdk-js PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the core checkout/payment SDK, so behavior changes ride entirely in 1.950.4 even though this repo diff is only dependency metadata.
> 
> **Overview**
> Updates the **`@bigcommerce/checkout-sdk`** dependency from **`^1.950.3`** to **`^1.950.4`** in **`package.json`**, with the matching lockfile resolution and integrity hash in **`package-lock.json`**.
> 
> This is a version-only change in checkout-js to pick up the corresponding checkout-sdk-js release (linked PR **#3335**); no checkout UI or application source files are modified here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f840edd6635f61a7170e97ccbf6110cb40fa059c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->