### PR TITLE
fix(checkout): CHECKOUT-10310 Exclude stores with phone placeholders …

### DIFF
--- a/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormField.test.tsx
@@ -188,6 +188,7 @@ describe('DynamicFormField Component', () => {
         const renderMockFormField = (overrides: {
             field: FormFieldType;
             isNewPhoneValidationExperimentEnabled: boolean;
+            placeholder?: string;
         }) =>
             render(
                 <LocaleContext.Provider value={localeContextMock}>
@@ -199,6 +200,7 @@ describe('DynamicFormField Component', () => {
                                     isNewPhoneValidationExperimentEnabled={
                                         overrides.isNewPhoneValidationExperimentEnabled
                                     }
+                                    placeholder={overrides.placeholder}
                                 />
                                 <button onClick={submitForm} type="button">
                                     Submit
@@ -299,6 +301,31 @@ describe('DynamicFormField Component', () => {
 
             expect(input).toHaveAttribute('type', 'tel');
             expect(input).toHaveAttribute('maxlength', '10');
+            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+            expect(container.querySelector('.iti-wrapper')).not.toBeInTheDocument();
+
+            // The legacy input does not apply IntlTelInput phone validation
+            fireEvent.change(input, { target: { value: '123' } });
+            await userEvent.click(screen.getByText('Submit'));
+
+            await waitFor(() => {
+                expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+            });
+        });
+
+        it('renders the legacy phone input when the field has a placeholder, even when the experiment is enabled', async () => {
+            mockIsValidNumber.mockReturnValue(false);
+
+            const { container } = renderMockFormField({
+                field: { ...phoneFieldMock, default: '1231232' },
+                isNewPhoneValidationExperimentEnabled: true,
+                placeholder: '1231232',
+            });
+
+            const input = screen.getByTestId('phone-text');
+
+            expect(input).toHaveAttribute('type', 'tel');
+            expect(input).toHaveAttribute('placeholder', '1231232');
             // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
             expect(container.querySelector('.iti-wrapper')).not.toBeInTheDocument();
 

--- a/packages/ui/src/form/DynamicFormField/DynamicFormFieldSelector.tsx
+++ b/packages/ui/src/form/DynamicFormField/DynamicFormFieldSelector.tsx
@@ -46,9 +46,11 @@ export const DynamicFormFieldSelector: FunctionComponent<DynamicFormFieldSelecto
         onChange,
     }) => {
         // skipped for stores with maxLength as it caused formatting issues
+        // and for stores with a default value placeholder (to de-risk)
         const isNewPhoneFieldWithValidation =
             isNewPhoneValidationExperimentEnabled &&
             !maxLength &&
+            !placeholder &&
             dynamicFormFieldType === DynamicFormFieldType.TELEPHONE;
 
         const renderInput = useCallback(


### PR DESCRIPTION
…from feature rollout

## What/Why?

To de-risk feature rollout, exclude the sotres with Default Value setting from new phone validation rollout.

<img width="551" height="532" alt="Screenshot 2026-08-10 at 2 00 56 PM" src="https://github.com/user-attachments/assets/d8945c5f-863b-41c7-adb3-5c1caf9e095d" />

When default value is set we will render a default phone field without IntlTelInput validation.


## Rollout/Rollback

Revert the PR.

## Testing

CI + manual:

<img width="704" height="244" alt="Screenshot 2026-08-10 at 3 41 23 PM" src="https://github.com/user-attachments/assets/1dc83de1-9644-406e-b248-635e8775d5fc" />

<img width="705" height="562" alt="Screenshot 2026-08-10 at 3 42 11 PM" src="https://github.com/user-attachments/assets/0b14f9fe-396e-4567-a829-74f0d2893d15" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard on an existing experiment gate; reduces rollout scope without changing validation for stores already on the new path.
> 
> **Overview**
> Narrows the new IntlTelInput phone validation rollout so stores that show a **default value placeholder** on the phone field keep the legacy `tel` input, same as fields with `maxLength`.
> 
> `DynamicFormFieldSelector` now requires no `placeholder` (in addition to no `maxLength`) before routing telephone fields to `PhoneFormField`. Tests cover that the experiment flag alone no longer forces IntlTelInput when a placeholder is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9efdec232dbee0e7a58e2e6b21e13e184465491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->