### PR TITLE
feat(payment): PAYPAL-6856 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.950.4",
+        "@bigcommerce/checkout-sdk": "^1.952.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,10 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.950.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.4.tgz",
-      "integrity": "sha512-V/FsILPH27V7UP+DMMVWeSzmrRM2OVLn/u9yQ2We0rsvqyE433DB04rtUAdvamGv7MwuH44HxgTTvPRjtHJdFA==",
-      "license": "MIT",
+      "version": "1.952.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.952.0.tgz",
+      "integrity": "sha512-Yi6GahXmSmcKV9Ueoqce+QZofnHxIrR0G/FWZd6R7dxSCA5Rb1pQ0T9bEHjGGWYrjFeChDEAxguq8Py217aH8g==",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",
@@ -29808,9 +29807,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.950.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.950.4.tgz",
-      "integrity": "sha512-V/FsILPH27V7UP+DMMVWeSzmrRM2OVLn/u9yQ2We0rsvqyE433DB04rtUAdvamGv7MwuH44HxgTTvPRjtHJdFA==",
+      "version": "1.952.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.952.0.tgz",
+      "integrity": "sha512-Yi6GahXmSmcKV9Ueoqce+QZofnHxIrR0G/FWZd6R7dxSCA5Rb1pQ0T9bEHjGGWYrjFeChDEAxguq8Py217aH8g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.950.4",
+    "@bigcommerce/checkout-sdk": "^1.952.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bumped checkout-sdk-js version

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change but targets the checkout SDK, which drives payment and checkout behavior; regressions would show up at integration/runtime rather than in this diff.
> 
> **Overview**
> Updates the **`@bigcommerce/checkout-sdk`** dependency from **^1.950.4** to **^1.952.0** in `package.json` and `package-lock.json`. There are no application source changes in this repo—the checkout UI will run against the newer SDK release (aligned with PAYPAL-6856).
> 
> Reviewers should treat this as consuming whatever fixes or payment-related changes ship in checkout-sdk **1.952.0**; validate checkout and PayPal flows after install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bb1a4b0b5d32649b5dcf1820cd4da4d89bf95b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->