### PR TITLE
feat(payment): PI-5384 [AdyenV3] [FE] Disable Place order button when Adyen script is not loaded

### DIFF
--- a/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
@@ -173,6 +173,37 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         ],
     );
 
+    // HostedWidgetPaymentComponent calls `initializePayment` from a few places (mount, switching
+    // instruments, adding a new card) that can race each other, so this token makes sure only
+    // the most recent attempt's outcome ends up touching disableSubmit.
+    const activeInitAttemptRef = useRef<object>();
+
+    const initializeAdyenPaymentWithSubmitGuard: HostedWidgetComponentProps['initializePayment'] =
+        useCallback(
+            async (options, selectedInstrument) => {
+                const token = {};
+
+                activeInitAttemptRef.current = token;
+
+                try {
+                    const result = await initializeAdyenPayment(options, selectedInstrument);
+
+                    if (activeInitAttemptRef.current === token) {
+                        paymentForm.disableSubmit(method, false);
+                    }
+
+                    return result;
+                } catch (error) {
+                    if (activeInitAttemptRef.current === token) {
+                        paymentForm.disableSubmit(method, true);
+                    }
+
+                    throw error;
+                }
+            },
+            [initializeAdyenPayment, method, paymentForm],
+        );
+
     useEffect(() => {
         if (!isGrouped) {
             return;
@@ -292,7 +323,7 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
                         checkoutState={checkoutState}
                         containerId={containerId}
                         hideContentWhenSignedOut
-                        initializePayment={initializeAdyenPayment}
+                        initializePayment={initializeAdyenPaymentWithSubmitGuard}
                         isAccountInstrument={isAccountInstrument()}
                         isModalVisible={isAdditionalActionContentModalVisible}
                         language={language}

--- a/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
+++ b/packages/adyen-integration/src/adyenv3/AdyenV3PaymentMethod.tsx
@@ -178,19 +178,29 @@ const AdyenV3PaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             return;
         }
 
+        let isCurrent = true;
+
         paymentForm.setValidationSchema(method, null);
         paymentForm.setSubmit(method, null);
+        paymentForm.disableSubmit(method, false);
 
         void initializeAdyenPayment({
             methodId: component,
             gatewayId: method.gateway,
         }).catch((error: unknown) => {
+            if (!isCurrent) {
+                return;
+            }
+
+            paymentForm.disableSubmit(method, true);
+
             if (error instanceof Error) {
                 onUnhandledError(error);
             }
         });
 
         return () => {
+            isCurrent = false;
             paymentForm.setValidationSchema(method, null);
             paymentForm.setSubmit(method, null);
 

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
@@ -125,7 +125,6 @@ const HostedWidgetPaymentComponent = ({
     onUnhandledError = noop,
     deinitializeCustomer,
     deinitializePayment,
-    disableSubmit,
     setSubmit,
     initializeCustomer,
     initializePayment,
@@ -148,10 +147,6 @@ const HostedWidgetPaymentComponent = ({
     const [isAddingNewCard, setIsAddingNewCard] = useState(false);
     const [selectedInstrumentId, setSelectedInstrumentId] = useState<string | undefined>(undefined);
     const instrumentsRef = useRef<PaymentInstrument[]>(instruments);
-    // Shared by the mount init effect, the reInit effect, and handleUseNewCard - whichever of
-    // them starts an attempt most recently owns this token, so an older attempt settling later
-    // (from any of the three) can tell it's been superseded and skip touching disableSubmit.
-    const activeInitAttemptRef = useRef<object>();
 
     useEffect(() => {
         instrumentsRef.current = instruments;
@@ -226,13 +221,24 @@ const HostedWidgetPaymentComponent = ({
         [instruments, selectedInstrumentId, getDefaultInstrumentId],
     );
 
-    // Re-initialization (deinitializePayment + initializeMethod, guarded against stale
-    // attempts) is handled by the reInit effect below, which also runs when isAddingNewCard
-    // changes - this just flips the state that effect is watching.
-    const handleUseNewCard = useCallback(() => {
+    const handleUseNewCard = useCallback(async () => {
         setIsAddingNewCard(true);
         setSelectedInstrumentId(undefined);
-    }, []);
+
+        if (deinitializePayment) {
+            await deinitializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+        }
+
+        if (initializePayment) {
+            await initializePayment({
+                gatewayId: method.gateway,
+                methodId: method.id,
+            });
+        }
+    }, [method, deinitializePayment, initializePayment]);
 
     const handleSelectInstrument = useCallback((id: string) => {
         setIsAddingNewCard(false);
@@ -333,10 +339,6 @@ const HostedWidgetPaymentComponent = ({
     const shouldShowAccountInstrument = instruments[0] && isBankAccountInstrument(instruments[0]);
 
     useEffect(() => {
-        const token = {};
-
-        activeInitAttemptRef.current = token;
-
         const init = async () => {
             setValidationSchema(method, getValidationSchema());
 
@@ -346,17 +348,7 @@ const HostedWidgetPaymentComponent = ({
                 }
 
                 await initializeMethod();
-
-                if (activeInitAttemptRef.current === token) {
-                    disableSubmit(method, false);
-                }
             } catch (error: unknown) {
-                if (activeInitAttemptRef.current !== token) {
-                    return;
-                }
-
-                disableSubmit(method, true);
-
                 if (error instanceof Error) {
                     onUnhandledError(error);
                 }
@@ -366,10 +358,6 @@ const HostedWidgetPaymentComponent = ({
         void init();
 
         return () => {
-            if (activeInitAttemptRef.current === token) {
-                activeInitAttemptRef.current = undefined;
-            }
-
             const deInit = async () => {
                 setValidationSchema(method, null);
                 setSubmit(method, null);
@@ -400,7 +388,6 @@ const HostedWidgetPaymentComponent = ({
     const instrumentsLength = useRef(instruments.length);
     const isPaymentDataRequiredRef = useRef(isPaymentDataRequired);
     const selectedInstrumentIdRef = useRef(selectedInstrumentId);
-    const isAddingNewCardRef = useRef(isAddingNewCard);
 
     useEffect(() => {
         if (isInitialRenderRef.current) {
@@ -409,26 +396,7 @@ const HostedWidgetPaymentComponent = ({
             return;
         }
 
-        const shouldReInit =
-            selectedInstrumentIdRef.current !== selectedInstrumentId ||
-            (Number(instrumentsLength.current) > 0 && instruments.length === 0) ||
-            isPaymentDataRequiredRef.current !== isPaymentDataRequired ||
-            isAddingNewCardRef.current !== isAddingNewCard;
-
-        selectedInstrumentIdRef.current = selectedInstrumentId;
-        instrumentsLength.current = instruments.length;
-        isPaymentDataRequiredRef.current = isPaymentDataRequired;
-        isAddingNewCardRef.current = isAddingNewCard;
-
-        if (!shouldReInit) {
-            return;
-        }
-
         setValidationSchema(method, getValidationSchema());
-
-        const token = {};
-
-        activeInitAttemptRef.current = token;
 
         const reInit = async () => {
             try {
@@ -440,25 +408,25 @@ const HostedWidgetPaymentComponent = ({
                 }
 
                 await initializeMethod();
-
-                if (activeInitAttemptRef.current === token) {
-                    disableSubmit(method, false);
-                }
             } catch (error: unknown) {
-                if (activeInitAttemptRef.current !== token) {
-                    return;
-                }
-
-                disableSubmit(method, true);
-
                 if (error instanceof Error) {
                     onUnhandledError(error);
                 }
             }
         };
 
-        void reInit();
-    }, [selectedInstrumentId, instruments, isPaymentDataRequired, isAddingNewCard]);
+        if (
+            selectedInstrumentIdRef.current !== selectedInstrumentId ||
+            (Number(instrumentsLength.current) > 0 && instruments.length === 0) ||
+            isPaymentDataRequiredRef.current !== isPaymentDataRequired
+        ) {
+            selectedInstrumentIdRef.current = selectedInstrumentId;
+            instrumentsLength.current = instruments.length;
+            isPaymentDataRequiredRef.current = isPaymentDataRequired;
+
+            void reInit();
+        }
+    }, [selectedInstrumentId, instruments, isPaymentDataRequired]);
 
     if (!shouldShow) {
         return <div style={{ display: 'none' }} />;

--- a/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
+++ b/packages/hosted-widget-integration/src/HostedWidgetPaymentComponent.tsx
@@ -125,6 +125,7 @@ const HostedWidgetPaymentComponent = ({
     onUnhandledError = noop,
     deinitializeCustomer,
     deinitializePayment,
+    disableSubmit,
     setSubmit,
     initializeCustomer,
     initializePayment,
@@ -147,6 +148,10 @@ const HostedWidgetPaymentComponent = ({
     const [isAddingNewCard, setIsAddingNewCard] = useState(false);
     const [selectedInstrumentId, setSelectedInstrumentId] = useState<string | undefined>(undefined);
     const instrumentsRef = useRef<PaymentInstrument[]>(instruments);
+    // Shared by the mount init effect, the reInit effect, and handleUseNewCard - whichever of
+    // them starts an attempt most recently owns this token, so an older attempt settling later
+    // (from any of the three) can tell it's been superseded and skip touching disableSubmit.
+    const activeInitAttemptRef = useRef<object>();
 
     useEffect(() => {
         instrumentsRef.current = instruments;
@@ -221,24 +226,13 @@ const HostedWidgetPaymentComponent = ({
         [instruments, selectedInstrumentId, getDefaultInstrumentId],
     );
 
-    const handleUseNewCard = useCallback(async () => {
+    // Re-initialization (deinitializePayment + initializeMethod, guarded against stale
+    // attempts) is handled by the reInit effect below, which also runs when isAddingNewCard
+    // changes - this just flips the state that effect is watching.
+    const handleUseNewCard = useCallback(() => {
         setIsAddingNewCard(true);
         setSelectedInstrumentId(undefined);
-
-        if (deinitializePayment) {
-            await deinitializePayment({
-                gatewayId: method.gateway,
-                methodId: method.id,
-            });
-        }
-
-        if (initializePayment) {
-            await initializePayment({
-                gatewayId: method.gateway,
-                methodId: method.id,
-            });
-        }
-    }, [method, deinitializePayment, initializePayment]);
+    }, []);
 
     const handleSelectInstrument = useCallback((id: string) => {
         setIsAddingNewCard(false);
@@ -339,6 +333,10 @@ const HostedWidgetPaymentComponent = ({
     const shouldShowAccountInstrument = instruments[0] && isBankAccountInstrument(instruments[0]);
 
     useEffect(() => {
+        const token = {};
+
+        activeInitAttemptRef.current = token;
+
         const init = async () => {
             setValidationSchema(method, getValidationSchema());
 
@@ -348,7 +346,17 @@ const HostedWidgetPaymentComponent = ({
                 }
 
                 await initializeMethod();
+
+                if (activeInitAttemptRef.current === token) {
+                    disableSubmit(method, false);
+                }
             } catch (error: unknown) {
+                if (activeInitAttemptRef.current !== token) {
+                    return;
+                }
+
+                disableSubmit(method, true);
+
                 if (error instanceof Error) {
                     onUnhandledError(error);
                 }
@@ -358,6 +366,10 @@ const HostedWidgetPaymentComponent = ({
         void init();
 
         return () => {
+            if (activeInitAttemptRef.current === token) {
+                activeInitAttemptRef.current = undefined;
+            }
+
             const deInit = async () => {
                 setValidationSchema(method, null);
                 setSubmit(method, null);
@@ -388,6 +400,7 @@ const HostedWidgetPaymentComponent = ({
     const instrumentsLength = useRef(instruments.length);
     const isPaymentDataRequiredRef = useRef(isPaymentDataRequired);
     const selectedInstrumentIdRef = useRef(selectedInstrumentId);
+    const isAddingNewCardRef = useRef(isAddingNewCard);
 
     useEffect(() => {
         if (isInitialRenderRef.current) {
@@ -396,7 +409,26 @@ const HostedWidgetPaymentComponent = ({
             return;
         }
 
+        const shouldReInit =
+            selectedInstrumentIdRef.current !== selectedInstrumentId ||
+            (Number(instrumentsLength.current) > 0 && instruments.length === 0) ||
+            isPaymentDataRequiredRef.current !== isPaymentDataRequired ||
+            isAddingNewCardRef.current !== isAddingNewCard;
+
+        selectedInstrumentIdRef.current = selectedInstrumentId;
+        instrumentsLength.current = instruments.length;
+        isPaymentDataRequiredRef.current = isPaymentDataRequired;
+        isAddingNewCardRef.current = isAddingNewCard;
+
+        if (!shouldReInit) {
+            return;
+        }
+
         setValidationSchema(method, getValidationSchema());
+
+        const token = {};
+
+        activeInitAttemptRef.current = token;
 
         const reInit = async () => {
             try {
@@ -408,25 +440,25 @@ const HostedWidgetPaymentComponent = ({
                 }
 
                 await initializeMethod();
+
+                if (activeInitAttemptRef.current === token) {
+                    disableSubmit(method, false);
+                }
             } catch (error: unknown) {
+                if (activeInitAttemptRef.current !== token) {
+                    return;
+                }
+
+                disableSubmit(method, true);
+
                 if (error instanceof Error) {
                     onUnhandledError(error);
                 }
             }
         };
 
-        if (
-            selectedInstrumentIdRef.current !== selectedInstrumentId ||
-            (Number(instrumentsLength.current) > 0 && instruments.length === 0) ||
-            isPaymentDataRequiredRef.current !== isPaymentDataRequired
-        ) {
-            selectedInstrumentIdRef.current = selectedInstrumentId;
-            instrumentsLength.current = instruments.length;
-            isPaymentDataRequiredRef.current = isPaymentDataRequired;
-
-            void reInit();
-        }
-    }, [selectedInstrumentId, instruments, isPaymentDataRequired]);
+        void reInit();
+    }, [selectedInstrumentId, instruments, isPaymentDataRequired, isAddingNewCard]);
 
     if (!shouldShow) {
         return <div style={{ display: 'none' }} />;


### PR DESCRIPTION
## What/Why?

When Adyen Web Components script fails to load, the shopper can still attempt to place order by clicking Place order button.
Place order button should be disabled when Adyen Web Components script is not loaded.

## Rollout/Rollback

Revert this PR

## Testing

<img width="1418" height="815" alt="Screenshot 2026-08-10 at 09 57 50" src="https://github.com/user-attachments/assets/dbba21ae-7d5e-4fae-9cfe-0c12b55097fc" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout UX only: toggles submit via existing paymentForm APIs when Adyen init succeeds or fails, with race guards; no auth or payment processing logic changes.
> 
> **Overview**
> **Place order** stays disabled when Adyen Web Components fail to load or payment init throws, and is re-enabled only after a successful init.
> 
> A new **`initializeAdyenPaymentWithSubmitGuard`** wraps the existing initializer passed into **`AdyenV3Form`**: on success it calls `paymentForm.disableSubmit(method, false)`; on failure it disables submit and rethrows. An **`activeInitAttemptRef`** token avoids stale concurrent init paths (mount, instrument switch, new card) from flipping submit state incorrectly.
> 
> For **grouped** payment methods, the mount effect now enables submit before init, disables it on init failure (with an **`isCurrent`** flag so cleanup/unmount does not apply stale errors), and clears the flag on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5076d5aac17fbe74d3080a75c61ec1c3bf2bab8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->