### PR TITLE
fix(checkout): CHECKOUT-10316 Resolve WebDav issues

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethod.tsx
@@ -44,6 +44,26 @@ export interface WithCheckoutPaymentMethodProps {
     initializePayment(options: PaymentInitializeOptions): Promise<CheckoutSelectors>;
 }
 
+const KNOWN_API_METHOD_IDS = new Set([
+    'authorizenet',
+    'cybersourcev2',
+    'ewayrapid',
+    'nmi',
+    'bigpaypay',
+    'usaepay',
+    'googlepay',
+    'quickbooks',
+    'orbital',
+    'stripe',
+    'firstdatae4v14',
+    'cybersource',
+    'hps',
+    'clover',
+    'elavon',
+    'bnz',
+    'vantivcore',
+]);
+
 /**
  * If possible, try to avoid having components that are specific to a specific
  * payment provider or method. Instead, try to generalise the requirements and
@@ -59,11 +79,7 @@ const PaymentMethodComponent: FunctionComponent<
     const { method } = props;
 
     if (method.id === PaymentMethodId.Humm || method.type === PaymentMethodProviderType.Hosted) {
-        const sentryMessage = `DataHostedPaymentMethod Hosted/Humm ${JSON.stringify({
-            gateway: method.gateway,
-            id: method.id,
-            type: method.type,
-        })}`;
+        const sentryMessage = `DataHostedPaymentMethod Hosted/Humm gateway=${method.gateway} id=${method.id} type=${method.type}`;
 
         return (
             <>
@@ -82,40 +98,14 @@ const PaymentMethodComponent: FunctionComponent<
         method.method === PaymentMethodType.CreditCard ||
         method.type === PaymentMethodProviderType.Api
     ) {
-        const knownMethods: Array<{ gateway: string | null; id: string; type: string }> = [
-            { gateway: null, id: 'authorizenet', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'cybersourcev2', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'ewayrapid', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'nmi', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'bigpaypay', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'usaepay', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'googlepay', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'quickbooks', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'orbital', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'stripe', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'firstdatae4v14', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'cybersource', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'hps', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'clover', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'elavon', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'bnz', type: PaymentMethodProviderType.Api },
-            { gateway: null, id: 'vantivcore', type: PaymentMethodProviderType.Api },
-        ];
-
-        const isKnownMethod = knownMethods.some(
-            (knownMethod) =>
-                knownMethod.gateway === method.gateway &&
-                knownMethod.id === method.id &&
-                knownMethod.type === method.type,
-        );
+        const isKnownMethod =
+            method.gateway === null &&
+            method.type === PaymentMethodProviderType.Api &&
+            KNOWN_API_METHOD_IDS.has(method.id);
 
         const sentryMessage = isKnownMethod
             ? ''
-            : `DataHostedCreditCardPaymentMethod ${JSON.stringify({
-                  gateway: method.gateway,
-                  id: method.id,
-                  type: method.type,
-              })}`;
+            : `DataHostedCreditCardPaymentMethod gateway=${method.gateway} id=${method.id} type=${method.type}`;
 
         return (
             <>

--- a/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
+++ b/packages/credit-card-integration/src/CreditCardPaymentMethodComponent.tsx
@@ -367,11 +367,7 @@ export const CreditCardPaymentMethodComponent = (
     const storeConfig = getStoreConfig();
 
     const SentryMessage = methodProp
-        ? `DataCreditCardFieldset component ${JSON.stringify({
-              gateway: methodProp.gateway,
-              id: methodProp.id,
-              type: methodProp.type,
-          })}`
+        ? `DataCreditCardFieldset component gateway=${methodProp.gateway} id=${methodProp.id} type=${methodProp.type}`
         : '';
 
     if (!storeConfig) {


### PR DESCRIPTION
## What/Why?

Resolves this reported issue: https://github.com/bigcommerce/checkout-js/issues/3238

Sentry diagnostic messages fired via CaptureMessageComponent for unrecognized/hosted payment methods were built with JSON.stringify({ gateway, id, type }) embedded directly into the message string. 

It looks like something in this JSON string matched a WAF/CDN rule which caused any uploads to WebDav to be blocked with a 403.

This PR replaces JSON.stringify approach.

Note: this might cause slight change in Sentry messages and start new groups of events for logged items.

## Rollout/Rollback

Revert the PR.

## Testing

No app behavior difference expected, so check for existing tests pass.

Test WebDav upload. Before:

<img width="253" height="302" alt="image" src="https://github.com/user-attachments/assets/ef377249-339d-486a-9d4b-1f6916104bfb" />


After:

<img width="415" height="63" alt="image" src="https://github.com/user-attachments/assets/5e9cfcca-3f17-499b-a5eb-f084d0907911" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only string formatting and a small refactor of known-method IDs; no payment initialization or WebDAV upload logic changes.
> 
> **Overview**
> Sentry diagnostic strings sent through `CaptureMessageComponent` for hosted and credit-card payment routing no longer embed `JSON.stringify({ gateway, id, type })`. They now use plain `gateway=… id=… type=…` text so upload traffic is less likely to trip WAF/CDN rules that were blocking WebDAV with 403 (CHECKOUT-10316 / checkout-js #3238).
> 
> In `PaymentMethod.tsx`, the inline list of known API methods is consolidated into a `KNOWN_API_METHOD_IDS` set; “known method” detection still requires `gateway === null`, API type, and membership in that set—only the representation and Sentry formatting change. `CreditCardPaymentMethodComponent.tsx` uses the same message format for the credit-card fieldset capture.
> 
> **Note:** Sentry grouping may shift slightly because message text changed; checkout payment UI behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aaa10e94fa606a0a47caa3986bf216f6bbbee9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->