### PR TITLE
chore(payment): PAYPAL-6856 bumped checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.954.1",
+        "@bigcommerce/checkout-sdk": "^1.956.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.954.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.954.1.tgz",
-      "integrity": "sha512-dF1HbDZFE8t2IRZ+3QxN9eAP18y74OF7HS1ULVtPSr237kJolW2KwO53T2Mj5A7GcMdjHMDoQtqOin0PKizEuA==",
+      "version": "1.956.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.956.0.tgz",
+      "integrity": "sha512-EzoAf1ybDzp6VsH4xzvC9kLAKFJyrUe+a8BsRwKeA3rNts/Q1kmopZ/7pNd1D7EAngmegcw6SjszFDPkKvCSyA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.954.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.954.1.tgz",
-      "integrity": "sha512-dF1HbDZFE8t2IRZ+3QxN9eAP18y74OF7HS1ULVtPSr237kJolW2KwO53T2Mj5A7GcMdjHMDoQtqOin0PKizEuA==",
+      "version": "1.956.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.956.0.tgz",
+      "integrity": "sha512-EzoAf1ybDzp6VsH4xzvC9kLAKFJyrUe+a8BsRwKeA3rNts/Q1kmopZ/7pNd1D7EAngmegcw6SjszFDPkKvCSyA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.954.1",
+    "@bigcommerce/checkout-sdk": "^1.956.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bumped checkout-sdk-js version

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout SDK upgrades can change payment and checkout behavior at runtime even without local code edits; scope is limited to a minor semver bump with rollback via reverting the dependency change.
> 
> **Overview**
> Bumps the **`@bigcommerce/checkout-sdk`** dependency from **^1.954.1** to **^1.956.0** in `package.json`, with matching updates in `package-lock.json` (resolved tarball and integrity).
> 
> There are **no application source changes** in this PR—only the SDK version pin and lockfile refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28da0936b74d50190a5df6bae2d247f75ebf66c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->