### PR TITLE
feat(payment): PAYPAL-6856 added error callback for BT FL

### DIFF
--- a/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.test.tsx
+++ b/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.test.tsx
@@ -56,6 +56,7 @@ describe('BraintreeFastlanePaymentMethod', () => {
                 onInit: expect.any(Function),
                 onChange: expect.any(Function),
                 onError: expect.any(Function),
+                onErrorLog: expect.any(Function),
             },
         });
     });

--- a/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.tsx
@@ -12,6 +12,7 @@ import { FormContext, LoadingOverlay } from '@bigcommerce/checkout/ui';
 import BraintreeFastlaneForm from './components/BraintreeFastlaneForm';
 
 import './BraintreeFastlanePaymentMethod.scss';
+import { useCheckout } from '@bigcommerce/checkout/contexts';
 
 export interface BraintreeFastlaneComponentRef {
     renderPayPalCardComponent?: (container: string) => void;
@@ -28,25 +29,29 @@ const BraintreeFastlanePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const paypalFastlaneComponentRef = useRef<BraintreeFastlaneComponentRef>({});
 
     const { isLoadingPaymentMethod, isInitializingPayment } = checkoutState.statuses;
+    const { errorLogger } = useCheckout(() => undefined);
 
     const initializePaymentOrThrow = async () => {
         try {
             await checkoutService.initializePayment({
-                methodId: method.id,
-                integrations: [createBraintreeFastlanePaymentStrategy],
-                braintreefastlane: {
-                    onInit: (renderPayPalCardComponent) => {
-                        paypalFastlaneComponentRef.current.renderPayPalCardComponent =
-                            renderPayPalCardComponent;
-                    },
-                    onChange: (showPayPalCardSelector) => {
-                        paypalFastlaneComponentRef.current.showPayPalCardSelector =
-                            showPayPalCardSelector;
-                    },
-                    onError: (error: Error) => {
-                        onUnhandledError(error);
-                    },
+              methodId: method.id,
+              integrations: [createBraintreeFastlanePaymentStrategy],
+              braintreefastlane: {
+                onInit: (renderPayPalCardComponent) => {
+                  paypalFastlaneComponentRef.current.renderPayPalCardComponent =
+                    renderPayPalCardComponent;
                 },
+                onChange: (showPayPalCardSelector) => {
+                  paypalFastlaneComponentRef.current.showPayPalCardSelector =
+                    showPayPalCardSelector;
+                },
+                onError: (error: Error) => {
+                  onUnhandledError(error);
+                },
+                onErrorLog: (error: unknown) => {
+                  errorLogger?.log(error instanceof Error ? error : new Error(String(error)));
+                },
+              },
             });
         } catch (error) {
             if (error instanceof Error) {

--- a/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreeFastlane/BraintreeFastlanePaymentMethod.tsx
@@ -2,6 +2,7 @@ import { type CardInstrument } from '@bigcommerce/checkout-sdk';
 import { createBraintreeFastlanePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useEffect, useRef } from 'react';
 
+import { useCheckout } from '@bigcommerce/checkout/contexts';
 import {
     type PaymentMethodProps,
     type PaymentMethodResolveId,
@@ -12,7 +13,6 @@ import { FormContext, LoadingOverlay } from '@bigcommerce/checkout/ui';
 import BraintreeFastlaneForm from './components/BraintreeFastlaneForm';
 
 import './BraintreeFastlanePaymentMethod.scss';
-import { useCheckout } from '@bigcommerce/checkout/contexts';
 
 export interface BraintreeFastlaneComponentRef {
     renderPayPalCardComponent?: (container: string) => void;
@@ -34,24 +34,24 @@ const BraintreeFastlanePaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const initializePaymentOrThrow = async () => {
         try {
             await checkoutService.initializePayment({
-              methodId: method.id,
-              integrations: [createBraintreeFastlanePaymentStrategy],
-              braintreefastlane: {
-                onInit: (renderPayPalCardComponent) => {
-                  paypalFastlaneComponentRef.current.renderPayPalCardComponent =
-                    renderPayPalCardComponent;
+                methodId: method.id,
+                integrations: [createBraintreeFastlanePaymentStrategy],
+                braintreefastlane: {
+                    onInit: (renderPayPalCardComponent) => {
+                        paypalFastlaneComponentRef.current.renderPayPalCardComponent =
+                            renderPayPalCardComponent;
+                    },
+                    onChange: (showPayPalCardSelector) => {
+                        paypalFastlaneComponentRef.current.showPayPalCardSelector =
+                            showPayPalCardSelector;
+                    },
+                    onError: (error: Error) => {
+                        onUnhandledError(error);
+                    },
+                    onErrorLog: (error: unknown) => {
+                        errorLogger?.log(error instanceof Error ? error : new Error(String(error)));
+                    },
                 },
-                onChange: (showPayPalCardSelector) => {
-                  paypalFastlaneComponentRef.current.showPayPalCardSelector =
-                    showPayPalCardSelector;
-                },
-                onError: (error: Error) => {
-                  onUnhandledError(error);
-                },
-                onErrorLog: (error: unknown) => {
-                  errorLogger?.log(error instanceof Error ? error : new Error(String(error)));
-                },
-              },
             });
         } catch (error) {
             if (error instanceof Error) {

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -49,41 +49,41 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             const { onUnhandledError, method, paymentForm } = rest;
 
             return checkoutService.initializePayment({
-              ...defaultOptions,
-              integrations: [createBraintreePaypalPaymentStrategy],
-              braintree: {
-                containerId: '#checkout-payment-continue',
-                submitForm: () => {
-                  paymentForm.setSubmitted(true);
-                  paymentForm.submitForm();
-                },
-                onError: (error: Error) => {
-                  if (error.message === 'INSTRUMENT_DECLINED') {
-                    onUnhandledError?.(new InstrumentDeclinedError());
-                  } else {
-                    onUnhandledError?.(error);
-                  }
-                },
-                onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
-                  const keysValidation = await validateForm();
+                ...defaultOptions,
+                integrations: [createBraintreePaypalPaymentStrategy],
+                braintree: {
+                    containerId: '#checkout-payment-continue',
+                    submitForm: () => {
+                        paymentForm.setSubmitted(true);
+                        paymentForm.submitForm();
+                    },
+                    onError: (error: Error) => {
+                        if (error.message === 'INSTRUMENT_DECLINED') {
+                            onUnhandledError?.(new InstrumentDeclinedError());
+                        } else {
+                            onUnhandledError?.(error);
+                        }
+                    },
+                    onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
+                        const keysValidation = await validateForm();
 
-                  if (keysValidation.length) {
-                    paymentForm.setSubmitted(true);
-                    keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
+                        if (keysValidation.length) {
+                            paymentForm.setSubmitted(true);
+                            keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
 
-                    return reject();
-                  }
+                            return reject();
+                        }
 
-                  return resolve();
+                        return resolve();
+                    },
+                    onInitButton: async (actions: ButtonActions) => {
+                        buttonActionsRef.current = actions;
+                        await validateButton();
+                    },
+                    onRenderButton: () => {
+                        paymentForm.hidePaymentSubmitButton(method, true);
+                    },
                 },
-                onInitButton: async (actions: ButtonActions) => {
-                  buttonActionsRef.current = actions;
-                  await validateButton();
-                },
-                onRenderButton: () => {
-                  paymentForm.hidePaymentSubmitButton(method, true);
-                },
-              },
             });
         },
         [rest, checkoutService],

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -1,8 +1,8 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { createBraintreePaypalPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
-import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 
+import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
 import {
     type PaymentMethodProps,
@@ -49,41 +49,41 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             const { onUnhandledError, method, paymentForm } = rest;
 
             return checkoutService.initializePayment({
-              ...defaultOptions,
-              integrations: [createBraintreePaypalPaymentStrategy],
-              braintree: {
-                containerId: '#checkout-payment-continue',
-                submitForm: () => {
-                  paymentForm.setSubmitted(true);
-                  paymentForm.submitForm();
-                },
-                onError: (error: Error) => {
-                  if (error.message === 'INSTRUMENT_DECLINED') {
-                    onUnhandledError?.(new InstrumentDeclinedError());
-                  } else {
-                    onUnhandledError?.(error);
-                  }
-                },
-                onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
-                  const keysValidation = await validateForm();
+                ...defaultOptions,
+                integrations: [createBraintreePaypalPaymentStrategy],
+                braintree: {
+                    containerId: '#checkout-payment-continue',
+                    submitForm: () => {
+                        paymentForm.setSubmitted(true);
+                        paymentForm.submitForm();
+                    },
+                    onError: (error: Error) => {
+                        if (error.message === 'INSTRUMENT_DECLINED') {
+                            onUnhandledError?.(new InstrumentDeclinedError());
+                        } else {
+                            onUnhandledError?.(error);
+                        }
+                    },
+                    onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
+                        const keysValidation = await validateForm();
 
-                  if (keysValidation.length) {
-                    paymentForm.setSubmitted(true);
-                    keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
+                        if (keysValidation.length) {
+                            paymentForm.setSubmitted(true);
+                            keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
 
-                    return reject();
-                  }
+                            return reject();
+                        }
 
-                  return resolve();
+                        return resolve();
+                    },
+                    onInitButton: async (actions: ButtonActions) => {
+                        buttonActionsRef.current = actions;
+                        await validateButton();
+                    },
+                    onRenderButton: () => {
+                        paymentForm.hidePaymentSubmitButton(method, true);
+                    },
                 },
-                onInitButton: async (actions: ButtonActions) => {
-                  buttonActionsRef.current = actions;
-                  await validateButton();
-                },
-                onRenderButton: () => {
-                  paymentForm.hidePaymentSubmitButton(method, true);
-                },
-              },
             });
         },
         [rest, checkoutService],

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -49,41 +49,41 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             const { onUnhandledError, method, paymentForm } = rest;
 
             return checkoutService.initializePayment({
-                ...defaultOptions,
-                integrations: [createBraintreePaypalPaymentStrategy],
-                braintree: {
-                    containerId: '#checkout-payment-continue',
-                    submitForm: () => {
-                        paymentForm.setSubmitted(true);
-                        paymentForm.submitForm();
-                    },
-                    onError: (error: Error) => {
-                        if (error.message === 'INSTRUMENT_DECLINED') {
-                            onUnhandledError?.(new InstrumentDeclinedError());
-                        } else {
-                            onUnhandledError?.(error);
-                        }
-                    },
-                    onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
-                        const keysValidation = await validateForm();
-
-                        if (keysValidation.length) {
-                            paymentForm.setSubmitted(true);
-                            keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
-
-                            return reject();
-                        }
-
-                        return resolve();
-                    },
-                    onInitButton: async (actions: ButtonActions) => {
-                        buttonActionsRef.current = actions;
-                        await validateButton();
-                    },
-                    onRenderButton: () => {
-                        paymentForm.hidePaymentSubmitButton(method, true);
-                    },
+              ...defaultOptions,
+              integrations: [createBraintreePaypalPaymentStrategy],
+              braintree: {
+                containerId: '#checkout-payment-continue',
+                submitForm: () => {
+                  paymentForm.setSubmitted(true);
+                  paymentForm.submitForm();
                 },
+                onError: (error: Error) => {
+                  if (error.message === 'INSTRUMENT_DECLINED') {
+                    onUnhandledError?.(new InstrumentDeclinedError());
+                  } else {
+                    onUnhandledError?.(error);
+                  }
+                },
+                onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
+                  const keysValidation = await validateForm();
+
+                  if (keysValidation.length) {
+                    paymentForm.setSubmitted(true);
+                    keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
+
+                    return reject();
+                  }
+
+                  return resolve();
+                },
+                onInitButton: async (actions: ButtonActions) => {
+                  buttonActionsRef.current = actions;
+                  await validateButton();
+                },
+                onRenderButton: () => {
+                  paymentForm.hidePaymentSubmitButton(method, true);
+                },
+              },
             });
         },
         [rest, checkoutService],

--- a/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
+++ b/packages/braintree-integration/src/BraintreePaypalPaymentMethod.tsx
@@ -1,8 +1,8 @@
 import { type PaymentInitializeOptions } from '@bigcommerce/checkout-sdk';
 import { createBraintreePaypalPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/braintree';
 import React, { type FunctionComponent, useCallback, useEffect, useRef } from 'react';
-
 import { InstrumentDeclinedError } from '@bigcommerce/checkout/error-handling-utils';
+
 import { HostedPaymentComponent } from '@bigcommerce/checkout/hosted-payment-integration';
 import {
     type PaymentMethodProps,
@@ -49,41 +49,41 @@ const BraintreePaypalPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
             const { onUnhandledError, method, paymentForm } = rest;
 
             return checkoutService.initializePayment({
-                ...defaultOptions,
-                integrations: [createBraintreePaypalPaymentStrategy],
-                braintree: {
-                    containerId: '#checkout-payment-continue',
-                    submitForm: () => {
-                        paymentForm.setSubmitted(true);
-                        paymentForm.submitForm();
-                    },
-                    onError: (error: Error) => {
-                        if (error.message === 'INSTRUMENT_DECLINED') {
-                            onUnhandledError?.(new InstrumentDeclinedError());
-                        } else {
-                            onUnhandledError?.(error);
-                        }
-                    },
-                    onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
-                        const keysValidation = await validateForm();
-
-                        if (keysValidation.length) {
-                            paymentForm.setSubmitted(true);
-                            keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
-
-                            return reject();
-                        }
-
-                        return resolve();
-                    },
-                    onInitButton: async (actions: ButtonActions) => {
-                        buttonActionsRef.current = actions;
-                        await validateButton();
-                    },
-                    onRenderButton: () => {
-                        paymentForm.hidePaymentSubmitButton(method, true);
-                    },
+              ...defaultOptions,
+              integrations: [createBraintreePaypalPaymentStrategy],
+              braintree: {
+                containerId: '#checkout-payment-continue',
+                submitForm: () => {
+                  paymentForm.setSubmitted(true);
+                  paymentForm.submitForm();
                 },
+                onError: (error: Error) => {
+                  if (error.message === 'INSTRUMENT_DECLINED') {
+                    onUnhandledError?.(new InstrumentDeclinedError());
+                  } else {
+                    onUnhandledError?.(error);
+                  }
+                },
+                onValidate: async (resolve: () => void, reject: () => void): Promise<void> => {
+                  const keysValidation = await validateForm();
+
+                  if (keysValidation.length) {
+                    paymentForm.setSubmitted(true);
+                    keysValidation.forEach((key) => paymentForm.setFieldTouched(key));
+
+                    return reject();
+                  }
+
+                  return resolve();
+                },
+                onInitButton: async (actions: ButtonActions) => {
+                  buttonActionsRef.current = actions;
+                  await validateButton();
+                },
+                onRenderButton: () => {
+                  paymentForm.hidePaymentSubmitButton(method, true);
+                },
+              },
             });
         },
         [rest, checkoutService],


### PR DESCRIPTION
## What/Why?
Added error callback for Braintree Fastlane

## Rollout/Rollback
Revert

## Testing
Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional error logging alongside existing onError handling; no changes to payment submission or auth.
> 
> **Overview**
> Braintree Fastlane payment initialization now passes an **`onErrorLog`** callback to the Fastlane integration options, in addition to the existing **`onError`** handler.
> 
> **`onError`** still forwards errors to **`onUnhandledError`** for user-facing handling. **`onErrorLog`** sends errors to the checkout **`errorLogger`** (normalizing non-`Error` values to `Error`) so Fastlane issues can be recorded without changing the unhandled-error flow.
> 
> The unit test for **`initializePayment`** was updated to expect **`onErrorLog`** in the init payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cc1d59e40853ce94bc3489a4bc0c79629ef14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->