### PR TITLE
feat(checkout): CHECKOUT-10198 add fallback colors for new theme

### DIFF
--- a/packages/core/src/scss/enhancedThemeV1/color/_color.scss
+++ b/packages/core/src/scss/enhancedThemeV1/color/_color.scss
@@ -8,3 +8,4 @@ $color-white:                       #ffffff;
 $color-greyMedium:                  #dddddd;
 $color-greyDark:                    #A9A9A9;
 $color-black:                       #000000;
+$color-background:                  #F2F4F6;

--- a/packages/core/src/scss/enhancedThemeV1/common/_common.scss
+++ b/packages/core/src/scss/enhancedThemeV1/common/_common.scss
@@ -7,4 +7,50 @@ $element-border-radius: remCalc(12px);
     .applied-coupons-list ul {
         border-radius: $element-border-radius;
     }
+
+    // Optimized Checkout fallback styles
+    background-color: $color-background;
+
+    .optimizedCheckout-form-checklist-checkbox:checked ~ .optimizedCheckout-form-label::before {
+        background-color: $color-black;
+        border-color: $color-black;
+    }
+
+    .optimizedCheckout-form-checklist-checkbox:checked ~ .optimizedCheckout-form-label::after {
+        background-color: $color-white;
+    }
+
+    .optimizedCheckout-form-checklist {
+        .optimizedCheckout-form-checklist-item {
+            border-color: $color-greyMedium;
+        }
+
+        .optimizedCheckout-form-checklist-item--selected {
+            border-color: $color-black;
+        }
+    }
+
+    .optimizedCheckout-contentPrimary {
+        .optimizedCheckout-checkoutStep {
+            background-color: transparentize($color-white, 0.5);
+
+            &.checkout-step--current {
+                background-color: $color-white;
+            }
+
+            &:not(.checkout-step--current) .optimizedCheckout-buttonSecondary {
+                background-color: transparent;
+            }
+        }
+    }
+
+    .optimizedCheckout-orderSummary {
+        .optimizedCheckout-orderSummary-toggle {
+            color: $color-highlightDarkest;
+        }
+
+        svg {
+            fill: $color-highlightDarkest;
+        }
+    }
 }

--- a/packages/core/src/scss/enhancedThemeV1/common/_common.scss
+++ b/packages/core/src/scss/enhancedThemeV1/common/_common.scss
@@ -47,10 +47,10 @@ $element-border-radius: remCalc(12px);
     .optimizedCheckout-orderSummary {
         .optimizedCheckout-orderSummary-toggle {
             color: $color-highlightDarkest;
-        }
 
-        svg {
-            fill: $color-highlightDarkest;
+            svg {
+                fill: $color-highlightDarkest;
+            }
         }
     }
 }


### PR DESCRIPTION
## What/Why?

- Add fallback styles/colors for enhanced Theme 

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing


https://github.com/user-attachments/assets/18c99b81-49ff-4183-974e-2a4fef7d06a6



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure SCSS theming/fallback styles with no logic, auth, or data-handling changes.
> 
> **Overview**
> Adds **Optimized Checkout fallback styles** for `enhancedThemeV1`, so checklist items, checkout steps, and the order summary render with consistent colors when theme-specific styles are missing.
> 
> Introduces a new `$color-background` token and applies it as the theme background, along with black/white/grey borders and fills for selected checkboxes, step panels, and the order summary toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981531103f7d14f03daf77a1a4a443343cdcfd91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->