### PR TITLE
fix(checkout): CHECKOUT-10299 Get gift certificates from payments for order page

### DIFF
--- a/packages/core/src/app/coupon/useMultiCoupon.test.ts
+++ b/packages/core/src/app/coupon/useMultiCoupon.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@bigcommerce/checkout/test-mocks';
 
 import { getCheckout } from '../checkout/checkouts.mock';
+import { getGatewayOrderPayment, getOrder } from '../order/orders.mock';
 
 import { useMultiCoupon } from './useMultiCoupon';
 
@@ -186,6 +187,42 @@ describe('useMultiCoupon', () => {
             const { result } = renderHook(() => useMultiCoupon());
 
             expect(result.current.appliedGiftCertificates).toEqual([]);
+        });
+
+        describe('on order confirmation page', () => {
+            beforeEach(() => {
+                checkoutState.data.getCheckout.mockReturnValue(undefined);
+                checkoutState.data.getGiftCertificates.mockReturnValue(undefined);
+                checkoutState.data.getOrder.mockReturnValue(getOrder());
+            });
+
+            it('returns gift certificates mapped from order payments', () => {
+                const { result } = renderHook(() => useMultiCoupon());
+
+                expect(result.current.appliedGiftCertificates).toEqual([{ code: 'gc', amount: 7 }]);
+            });
+
+            it('ignores non gift certificate payments', () => {
+                const order = getOrder();
+
+                order.payments = [getGatewayOrderPayment()];
+                checkoutState.data.getOrder.mockReturnValue(order);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                expect(result.current.appliedGiftCertificates).toEqual([]);
+            });
+
+            it('returns empty array when order has no payments', () => {
+                const order = getOrder();
+
+                order.payments = undefined;
+                checkoutState.data.getOrder.mockReturnValue(order);
+
+                const { result } = renderHook(() => useMultiCoupon());
+
+                expect(result.current.appliedGiftCertificates).toEqual([]);
+            });
         });
     });
 

--- a/packages/core/src/app/coupon/useMultiCoupon.ts
+++ b/packages/core/src/app/coupon/useMultiCoupon.ts
@@ -81,11 +81,12 @@ export const useMultiCoupon = (): UseMultiCouponValues => {
 
     const appliedCoupons = coupons ?? EMPTY_ARRAY;
 
-    const giftCertificatesFromCorrectSource =
-        !checkout && order ? mapFromPayments(order.payments ?? []) : giftCertificates;
+    const giftCertificatesFromCheckoutOrOrder = checkout
+        ? giftCertificates
+        : mapFromPayments(order?.payments ?? []);
 
     const appliedGiftCertificates =
-        giftCertificatesFromCorrectSource?.map(({ code, used }) => ({
+        giftCertificatesFromCheckoutOrOrder?.map(({ code, used }) => ({
             code,
             amount: used,
         })) ?? EMPTY_ARRAY;

--- a/packages/core/src/app/coupon/useMultiCoupon.ts
+++ b/packages/core/src/app/coupon/useMultiCoupon.ts
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useCapabilities, useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 
 import { EMPTY_ARRAY } from '../common/utility';
+import { mapFromPayments } from '../giftCertificate';
 import { hasSelectedShippingOptions } from '../shipping';
 
 import { type AppliedGiftCertificateInfo } from './components';
@@ -80,8 +81,11 @@ export const useMultiCoupon = (): UseMultiCouponValues => {
 
     const appliedCoupons = coupons ?? EMPTY_ARRAY;
 
+    const giftCertificatesFromCorrectSource =
+        !checkout && order ? mapFromPayments(order.payments ?? []) : giftCertificates;
+
     const appliedGiftCertificates =
-        giftCertificates?.map(({ code, used }) => ({
+        giftCertificatesFromCorrectSource?.map(({ code, used }) => ({
             code,
             amount: used,
         })) ?? EMPTY_ARRAY;


### PR DESCRIPTION
## What/Why?

GIft certificates are not shown on Order Confirmation page when `CHECKOUT-9674.multi_coupon_cart_checkout` flag is `true`. It works fine when the flag is `false`.

I changed the useMultiCoupon implementation to get giftCertificates from order.payments using an existing mapFromPayments helper.

## Rollout/Rollback

Revert the PR.

## Testing

New CI tests + manual testing.

### Before the change

When the flag is `false` it renders correctly:

<img width="581" height="635" alt="Screenshot 2026-08-12 at 4 20 25 PM" src="https://github.com/user-attachments/assets/3d25d33f-060d-440d-8ce7-eddb8197f2a2" />

When the flag is `true` it does not show gift certificates (even though they are applied):

<img width="1507" height="833" alt="Screenshot 2026-08-12 at 4 13 56 PM" src="https://github.com/user-attachments/assets/f1d84558-65ad-48c8-b86e-f8760fcc8217" />

### After the change

Gift certificates are visible:

<img width="488" height="620" alt="Screenshot 2026-08-12 at 4 48 48 PM" src="https://github.com/user-attachments/assets/cc8373e6-89b5-4276-8ba4-223e34a2cba1" />

Also consistent with checkout page for multi-coupon scenario:

<img width="406" height="797" alt="Screenshot 2026-08-12 at 4 58 16 PM" src="https://github.com/user-attachments/assets/147b5752-5c4c-4656-aef0-3c0414d68bcd" />

<img width="406" height="797" alt="Screenshot 2026-08-12 at 4 59 19 PM" src="https://github.com/user-attachments/assets/ec728611-fa20-4f3c-808d-b2503f190641" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display logic in `useMultiCoupon` with an existing mapper; checkout path unchanged and new tests cover order confirmation cases.
> 
> **Overview**
> Fixes **missing gift certificates on the order confirmation page** when multi-coupon checkout is enabled (`CHECKOUT-9674.multi_coupon_cart_checkout`).
> 
> `useMultiCoupon` now builds `appliedGiftCertificates` from checkout gift-certificate data when a checkout is present, and from **`order.payments`** via the existing `mapFromPayments` helper when only an order is available (confirmation). Checkout behavior is unchanged.
> 
> Tests cover mapping from order payments, filtering non–gift-certificate payments, and empty/missing payments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda6b7f773ea33a77f0d47c2e1f19e08cafc5942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->