### PR TITLE
refactor(checkout): CHECKOUT-10325 Fix Flaky Test

### DIFF
--- a/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
+++ b/packages/test-framework/src/react-testing-library-support/CheckoutPageNodeObject.ts
@@ -388,7 +388,7 @@ export class CheckoutPageNodeObject {
     }
 
     async waitForCustomerStep(): Promise<void> {
-        await waitFor(() => screen.getByRole('textbox', { name: /email/i }));
+        await waitFor(() => screen.getByRole('textbox', { name: /email/i }), { timeout: 20000 });
     }
 
     async waitForShippingStep(): Promise<void> {
@@ -396,7 +396,7 @@ export class CheckoutPageNodeObject {
     }
 
     async waitForBillingStep(): Promise<void> {
-        await waitFor(() => screen.getByText(/billing address/i));
+        await waitFor(() => screen.getByText(/billing address/i), { timeout: 20000 });
     }
 
     async waitForPaymentStep(): Promise<void> {


### PR DESCRIPTION
## What/Why?

Add `20s` timeout to all checkout steps to avoid flaky tests.
We have `20s` timeout for payment and shipping steps already.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout changes in shared checkout test helpers; no production behavior changes.
> 
> **Overview**
> Adds a **20 second** `waitFor` timeout to `waitForCustomerStep` and `waitForBillingStep` in `CheckoutPageNodeObject`, matching `waitForShippingStep` and `waitForPaymentStep`.
> 
> This reduces flaky checkout RTL tests that sometimes fail before the customer email field or billing address UI appears under slower CI loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bb51a86ea65f20bfbdc0400f9a3bf4fd27a7b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->