### PR TITLE
feat(checkout): CHECKOUT-10199 select default method on refetch payment list

### DIFF
--- a/packages/core/src/app/customer/getContinueAsGuestButtonLabelId.test.ts
+++ b/packages/core/src/app/customer/getContinueAsGuestButtonLabelId.test.ts
@@ -14,7 +14,7 @@ describe('getContinueAsGuestButtonLabelId()', () => {
         config = getStoreConfig();
     });
 
-    it('returns generic continue label when themeV2 is disabled', () => {
+    it('returns generic continue label when enhancedThemeV1 is disabled', () => {
         expect(getContinueAsGuestButtonLabelId(false, cart, config)).toBe('customer.continue');
     });
 
@@ -39,7 +39,7 @@ describe('getContinueAsGuestButtonLabelId()', () => {
         );
     });
 
-    it('returns generic continue label when themeV2 is disabled even if shipping step is complete', () => {
+    it('returns generic continue label when enhancedThemeV1 is disabled even if shipping step is complete', () => {
         expect(getContinueAsGuestButtonLabelId(false, cart, config, true)).toBe(
             'customer.continue',
         );

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -549,6 +549,146 @@ describe('Payment step', () => {
             await waitFor(() => {
                 expect(screen.getByTestId('payment-methods-refresh-alert')).toHaveFocus();
             });
+
+            expect(
+                await screen.findByRole('radio', { name: 'Cash on Delivery', checked: true }),
+            ).toBeInTheDocument();
+        });
+
+        it('falls back to the default method when the selected method is removed by the refresh', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            // Move off the default method so the fallback is observable.
+            await act(async () =>
+                userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
+            );
+
+            expect(
+                screen.getByRole('radio', { name: 'Cash on Delivery', checked: true }),
+            ).toBeInTheDocument();
+
+            mockBillingAddressPut('US', 'United States');
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/payments', (_, res, ctx) =>
+                    res(ctx.json(payments.filter(({ id }) => id !== 'cod'))),
+                ),
+            );
+
+            await act(async () => {
+                await checkoutService.updateBillingAddress({ countryCode: 'US' });
+            });
+
+            expect(
+                await screen.findByRole('radio', { name: 'Pay in Store', checked: true }),
+            ).toBeInTheDocument();
+            expect(
+                screen.queryByRole('radio', { name: 'Cash on Delivery' }),
+            ).not.toBeInTheDocument();
+
+            // The automatic fallback must not dismiss the refresh alert...
+            expect(screen.getByTestId('payment-methods-refresh-alert')).toBeInTheDocument();
+            // ...nor surface an error modal from deinitializing the removed method.
+            expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
+        });
+
+        // The cart total path unmounts the payment form behind the loading skeleton, so
+        // the fallback here comes from the remount re-seeding Formik rather than from
+        // the effect in PaymentForm.
+        it('falls back to the default method after a cart total reload', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () =>
+                userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
+            );
+
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/payments', (_, res, ctx) =>
+                    res(ctx.json(payments.filter(({ id }) => id !== 'cod'))),
+                ),
+            );
+
+            checkout.updateCheckout('put', '/checkout/*', {
+                ...checkoutWithShippingAndBilling,
+                grandTotal: checkoutWithShippingAndBilling.grandTotal + 1,
+            });
+
+            await act(async () => {
+                await checkoutService.updateCheckout({ customerMessage: 'gift wrap please' });
+            });
+
+            expect(
+                await screen.findByRole('radio', { name: 'Pay in Store', checked: true }),
+            ).toBeInTheDocument();
+            expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
+        });
+
+        it('falls back to the default method when the order is rejected with payment_method_invalid', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                config: themeV2Config,
+            });
+
+            const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await act(async () =>
+                userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
+            );
+
+            const callsBeforeSubmit = loadPaymentMethodsSpy.mock.calls.length;
+
+            checkout.setRequestHandler(
+                // Shaped as an internal error response so the SDK maps it to a
+                // PaymentMethodInvalidError (type: 'payment_method_invalid').
+                rest.post('/internalapi/v1/checkout/order', (_, res, ctx) =>
+                    res(
+                        ctx.status(400),
+                        ctx.json({
+                            errors: {},
+                            status: 400,
+                            title: 'Payment method is invalid.',
+                            type: 'invalid_payment_provider',
+                        }),
+                    ),
+                ),
+            );
+            checkout.setRequestHandler(
+                rest.get('/api/storefront/payments', (_, res, ctx) =>
+                    res(ctx.json(payments.filter(({ id }) => id !== 'cod'))),
+                ),
+            );
+
+            await act(async () => {
+                await userEvent.click(screen.getByText('Place Order'));
+            });
+
+            await waitFor(() =>
+                expect(loadPaymentMethodsSpy.mock.calls.length).toBeGreaterThan(callsBeforeSubmit),
+            );
+
+            expect(
+                await screen.findByRole('radio', { name: 'Pay in Store', checked: true }),
+            ).toBeInTheDocument();
+
+            // Only the intended payment_method_invalid modal - tearing down the removed
+            // method must not add a MissingPaymentMethod error on top of it.
+            expect(screen.getByRole('dialog')).toHaveTextContent(
+                'The selected payment method is no longer valid. Click OK to see the most up-to-date payment methods.',
+            );
         });
 
         it('re-tracks the shopper selection, not the default method, after a country reload', async () => {

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -110,7 +110,7 @@ describe('Payment step', () => {
     let embeddedMessengerMock: EmbeddedCheckoutMessenger;
     let analyticsTracker: Partial<AnalyticsEvents>;
 
-    const themeV2Config = {
+    const enhancedThemeV1Config = {
         ...checkoutSettings,
         storeConfig: {
             ...checkoutSettings.storeConfig,
@@ -341,7 +341,7 @@ describe('Payment step', () => {
         );
     });
 
-    describe('billing country change (themeV2)', () => {
+    describe('billing country change (enhancedThemeV1)', () => {
         const scrollIntoViewMock = jest.fn();
 
         beforeAll(() => {
@@ -368,7 +368,7 @@ describe('Payment step', () => {
 
         it('does not reload payment methods or show the refresh note on initial load', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
@@ -383,7 +383,7 @@ describe('Payment step', () => {
 
         it('reloads payment methods in place when the billing country changes', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
@@ -414,7 +414,7 @@ describe('Payment step', () => {
 
         it('disables Place Order and overlays the method list while the reload is in flight', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -461,7 +461,7 @@ describe('Payment step', () => {
 
         it('does not reload payment methods for a billing update that keeps the same country', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
@@ -483,7 +483,7 @@ describe('Payment step', () => {
 
         it('shows a dismissible note when the list refreshes and the selection survives', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -519,7 +519,7 @@ describe('Payment step', () => {
 
         it('prompts to select another method when the selection is gone after the refresh', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -557,7 +557,7 @@ describe('Payment step', () => {
 
         it('falls back to the default method when the selected method is removed by the refresh', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -572,6 +572,8 @@ describe('Payment step', () => {
             expect(
                 screen.getByRole('radio', { name: 'Cash on Delivery', checked: true }),
             ).toBeInTheDocument();
+
+            jest.mocked(analyticsTracker.selectedPaymentMethod)?.mockClear();
 
             mockBillingAddressPut('US', 'United States');
             checkout.setRequestHandler(
@@ -595,6 +597,13 @@ describe('Payment step', () => {
             expect(screen.getByTestId('payment-methods-refresh-alert')).toBeInTheDocument();
             // ...nor surface an error modal from deinitializing the removed method.
             expect(screen.queryByText("Something's gone wrong")).not.toBeInTheDocument();
+
+            // Exactly one analytics event for the fallback, despite the checklist echo.
+            expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledTimes(1);
+            expect(analyticsTracker.selectedPaymentMethod).toHaveBeenCalledWith(
+                'Pay in Store',
+                'instore',
+            );
         });
 
         // The cart total path unmounts the payment form behind the loading skeleton, so
@@ -602,7 +611,7 @@ describe('Payment step', () => {
         // the effect in PaymentForm.
         it('falls back to the default method after a cart total reload', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -636,7 +645,7 @@ describe('Payment step', () => {
 
         it('falls back to the default method when the order is rejected with payment_method_invalid', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');
@@ -673,7 +682,7 @@ describe('Payment step', () => {
             );
 
             await act(async () => {
-                await userEvent.click(screen.getByText('Place Order'));
+                await userEvent.click(screen.getByText(/place order/i));
             });
 
             await waitFor(() =>
@@ -691,9 +700,9 @@ describe('Payment step', () => {
             );
         });
 
-        it('re-tracks the shopper selection, not the default method, after a country reload', async () => {
+        it('does not re-track the selection when it survives a country reload', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -704,23 +713,22 @@ describe('Payment step', () => {
                 userEvent.click(screen.getByRole('radio', { name: 'Cash on Delivery' })),
             );
 
+            jest.mocked(analyticsTracker.selectedPaymentMethod)?.mockClear();
+
             mockBillingAddressPut('US', 'United States');
 
             await act(async () => {
                 await checkoutService.updateBillingAddress({ countryCode: 'US' });
             });
 
-            await waitFor(() =>
-                expect(analyticsTracker.selectedPaymentMethod).toHaveBeenLastCalledWith(
-                    'Cash on Delivery',
-                    'cod',
-                ),
-            );
+            await screen.findByTestId('payment-methods-refresh-alert');
+
+            expect(analyticsTracker.selectedPaymentMethod).not.toHaveBeenCalled();
         });
 
         it('clears the refresh note when the methods reload for a cart total change', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -758,7 +766,7 @@ describe('Payment step', () => {
 
         it('dismisses the refresh note once the shopper selects a payment method', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             render(<CheckoutTest {...defaultProps} />);
@@ -782,7 +790,7 @@ describe('Payment step', () => {
 
         it('stops watching the billing country after unmount', async () => {
             checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
-                config: themeV2Config,
+                config: enhancedThemeV1Config,
             });
 
             const loadPaymentMethodsSpy = jest.spyOn(checkoutService, 'loadPaymentMethods');

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -75,7 +75,7 @@ import getPaymentMethodsRefreshAlert from './getPaymentMethodsRefreshAlert';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
 import PaymentContext, { type EnsureBillingAddressSaved } from './PaymentContext';
-import PaymentForm, { type PaymentMethodSelectOptions } from './PaymentForm';
+import PaymentForm from './PaymentForm';
 import {
     getUniquePaymentMethodId,
     hasPaymentMethodWithId,
@@ -459,7 +459,6 @@ const Payment = (
         async (values: PaymentFormValues) => {
             const {
                 defaultMethod,
-                loadPaymentMethods,
                 checkoutServiceSubscribe,
                 isPaymentDataRequired,
                 onCartChangedError = noop,
@@ -545,7 +544,7 @@ const Payment = (
                 analyticsTracker.paymentRejected();
 
                 if (isErrorWithType(error) && error.type === 'payment_method_invalid') {
-                    return loadPaymentMethods();
+                    return loadPaymentMethodsOrThrow();
                 }
 
                 if (isCartChangedError(error)) {
@@ -574,23 +573,24 @@ const Payment = (
     const dismissMethodsRefreshAlert = useCallback(() => setMethodsRefreshAlert(undefined), []);
 
     const setSelectedMethod = useCallback((method?: PaymentMethod): void => {
-        setState((prevState) => {
-            if (prevState.selectedMethod === method) {
-                return prevState;
-            }
-
-            if (method) {
-                trackSelectedPaymentMethod(method);
-            }
-
-            return { ...prevState, selectedMethod: method };
-        });
+        setState((prevState) =>
+            prevState.selectedMethod === method
+                ? prevState
+                : { ...prevState, selectedMethod: method },
+        );
     }, []);
 
     const handleMethodSelect = useCallback(
-        (method: PaymentMethod, options?: PaymentMethodSelectOptions): void => {
-            // The alert about a removed method must outlive the automatic fallback selection.
-            if (!options?.isAutomatic) {
+        (method: PaymentMethod): void => {
+            const currentMethod = selectedMethodRef.current;
+            // The fallback echoes back here as a reselection of the already-current
+            // method; only a change of method should dismiss the removed-method alert.
+            const isReselection =
+                !!currentMethod &&
+                getUniquePaymentMethodId(currentMethod.id, currentMethod.gateway) ===
+                    getUniquePaymentMethodId(method.id, method.gateway);
+
+            if (!isReselection) {
                 dismissMethodsRefreshAlert();
             }
 
@@ -660,12 +660,6 @@ const Payment = (
                           capabilities: props.capabilities,
                       })
                     : undefined;
-            const defaultMethod = filteredMethodsWithDefault?.defaultMethod;
-            const selectedMethod = selectedMethodRef.current || defaultMethod;
-
-            if (selectedMethod) {
-                trackSelectedPaymentMethod(selectedMethod);
-            }
 
             if (billingCountryChange) {
                 const refreshAlert = getPaymentMethodsRefreshAlert({
@@ -716,20 +710,41 @@ const Payment = (
         selectedMethodRef.current = state.selectedMethod || props.defaultMethod;
     }, [state.selectedMethod, props.defaultMethod]);
 
-    // Custom checklist items (Stripe OCS) render outside the checklist and never report
-    // a selection change, so PaymentForm's fallback cannot update this on its own.
+    // The only analytics emitter for method selection: keyed on the id string so it
+    // fires exactly when the effective selection changes, never on object identity.
+    const effectiveSelectedMethod = state.selectedMethod || props.defaultMethod;
+    const trackedSelectedMethodId = effectiveSelectedMethod
+        ? getUniquePaymentMethodId(effectiveSelectedMethod.id, effectiveSelectedMethod.gateway)
+        : undefined;
+
+    useEffect(() => {
+        if (effectiveSelectedMethod) {
+            trackSelectedPaymentMethod(effectiveSelectedMethod);
+        }
+    }, [trackedSelectedMethodId]);
+
+    // Owns the fallback when a methods reload drops the selected method; PaymentForm
+    // follows through its selectedMethod prop.
     useEffect(() => {
         const { selectedMethod } = state;
+        const { defaultMethod, methods } = props;
 
         if (
-            selectedMethod &&
-            !hasPaymentMethodWithId(
-                props.methods,
+            !selectedMethod ||
+            hasPaymentMethodWithId(
+                methods,
                 getUniquePaymentMethodId(selectedMethod.id, selectedMethod.gateway),
             )
         ) {
-            setSelectedMethod(props.defaultMethod);
+            return;
         }
+
+        // Keep the selection when a transiently empty list leaves nothing to fall back to.
+        if (!defaultMethod) {
+            return;
+        }
+
+        setSelectedMethod(defaultMethod);
     }, [props.methods, props.defaultMethod, state.selectedMethod, setSelectedMethod]);
 
     useEffect(() => {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -75,8 +75,12 @@ import getPaymentMethodsRefreshAlert from './getPaymentMethodsRefreshAlert';
 import mapSubmitOrderErrorMessage, { mapSubmitOrderErrorTitle } from './mapSubmitOrderErrorMessage';
 import mapToOrderRequestBody from './mapToOrderRequestBody';
 import PaymentContext, { type EnsureBillingAddressSaved } from './PaymentContext';
-import PaymentForm from './PaymentForm';
-import { getUniquePaymentMethodId, PaymentMethodProviderType } from './paymentMethod';
+import PaymentForm, { type PaymentMethodSelectOptions } from './PaymentForm';
+import {
+    getUniquePaymentMethodId,
+    hasPaymentMethodWithId,
+    PaymentMethodProviderType,
+} from './paymentMethod';
 import { getFilteredPaymentMethodsWithDefault } from './paymentMethodFilters';
 import { type PaymentMethodsRefreshAlertData } from './PaymentMethodsRefreshAlert';
 
@@ -171,8 +175,6 @@ const Payment = (
     const grandTotalChangeUnsubscribe = useRef<() => void>();
     const billingAddressChangeUnsubscribe = useRef<() => void>();
     const selectedMethodRef = useRef<PaymentMethod | undefined>();
-    // TODO: CHECKOUT-10199 remove this temporary fix
-    const suppressMethodRemovedErrorUntilRef = useRef(0);
     const validationSchemasRef = useRef<validationSchemas>({});
     const lastFormValuesRef = useRef<PaymentFormValues | null>(null);
     // Set by the enhancedThemeV1 billing form. Awaited before submitOrder so the order
@@ -406,13 +408,6 @@ const Payment = (
             return;
         }
 
-        // TODO: CHECKOUT-10199 remove this temporary fix
-        if (type === 'missing_data' && Date.now() < suppressMethodRemovedErrorUntilRef.current) {
-            errorLogger.log(error);
-
-            return;
-        }
-
         return onUnhandledError(error);
     }, []);
 
@@ -579,22 +574,26 @@ const Payment = (
     const dismissMethodsRefreshAlert = useCallback(() => setMethodsRefreshAlert(undefined), []);
 
     const setSelectedMethod = useCallback((method?: PaymentMethod): void => {
-        const { selectedMethod } = state;
+        setState((prevState) => {
+            if (prevState.selectedMethod === method) {
+                return prevState;
+            }
 
-        if (selectedMethod === method) {
-            return;
-        }
+            if (method) {
+                trackSelectedPaymentMethod(method);
+            }
 
-        if (method) {
-            trackSelectedPaymentMethod(method);
-        }
-
-        setState((prevState) => ({ ...prevState, selectedMethod: method }));
+            return { ...prevState, selectedMethod: method };
+        });
     }, []);
 
     const handleMethodSelect = useCallback(
-        (method: PaymentMethod): void => {
-            dismissMethodsRefreshAlert();
+        (method: PaymentMethod, options?: PaymentMethodSelectOptions): void => {
+            // The alert about a removed method must outlive the automatic fallback selection.
+            if (!options?.isAutomatic) {
+                dismissMethodsRefreshAlert();
+            }
+
             setSelectedMethod(method);
         },
         [dismissMethodsRefreshAlert, setSelectedMethod],
@@ -645,10 +644,6 @@ const Payment = (
     }): Promise<void> => {
         const { loadPaymentMethods, onUnhandledError = noop } = props;
 
-        if (billingCountryChange) {
-            suppressMethodRemovedErrorUntilRef.current = Date.now() + 5000;
-        }
-
         try {
             const updatedState = await loadPaymentMethods();
             const checkout = updatedState.data.getCheckout();
@@ -680,17 +675,9 @@ const Payment = (
                     refreshedMethods: filteredMethodsWithDefault?.filteredMethods ?? [],
                 });
 
-                if (!refreshAlert.removedMethodName) {
-                    suppressMethodRemovedErrorUntilRef.current = 0;
-                }
-
                 setMethodsRefreshAlert(refreshAlert);
             }
         } catch (error) {
-            if (billingCountryChange) {
-                suppressMethodRemovedErrorUntilRef.current = 0;
-            }
-
             onUnhandledError(error);
         }
     };
@@ -728,6 +715,22 @@ const Payment = (
     useEffect(() => {
         selectedMethodRef.current = state.selectedMethod || props.defaultMethod;
     }, [state.selectedMethod, props.defaultMethod]);
+
+    // Custom checklist items (Stripe OCS) render outside the checklist and never report
+    // a selection change, so PaymentForm's fallback cannot update this on its own.
+    useEffect(() => {
+        const { selectedMethod } = state;
+
+        if (
+            selectedMethod &&
+            !hasPaymentMethodWithId(
+                props.methods,
+                getUniquePaymentMethodId(selectedMethod.id, selectedMethod.gateway),
+            )
+        ) {
+            setSelectedMethod(props.defaultMethod);
+        }
+    }, [props.methods, props.defaultMethod, state.selectedMethod, setSelectedMethod]);
 
     useEffect(() => {
         const init = async () => {

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -78,8 +78,9 @@ import PaymentContext, { type EnsureBillingAddressSaved } from './PaymentContext
 import PaymentForm from './PaymentForm';
 import {
     getUniquePaymentMethodId,
-    hasPaymentMethodWithId,
+    isSamePaymentMethod,
     PaymentMethodProviderType,
+    useFallbackWhenMethodRemoved,
 } from './paymentMethod';
 import { getFilteredPaymentMethodsWithDefault } from './paymentMethodFilters';
 import { type PaymentMethodsRefreshAlertData } from './PaymentMethodsRefreshAlert';
@@ -583,12 +584,8 @@ const Payment = (
     const handleMethodSelect = useCallback(
         (method: PaymentMethod): void => {
             const currentMethod = selectedMethodRef.current;
-            // The fallback echoes back here as a reselection of the already-current
-            // method; only a change of method should dismiss the removed-method alert.
-            const isReselection =
-                !!currentMethod &&
-                getUniquePaymentMethodId(currentMethod.id, currentMethod.gateway) ===
-                    getUniquePaymentMethodId(method.id, method.gateway);
+            // The fallback echoes back here as a reselection; it must not dismiss the alert.
+            const isReselection = !!currentMethod && isSamePaymentMethod(currentMethod, method);
 
             if (!isReselection) {
                 dismissMethodsRefreshAlert();
@@ -710,8 +707,7 @@ const Payment = (
         selectedMethodRef.current = state.selectedMethod || props.defaultMethod;
     }, [state.selectedMethod, props.defaultMethod]);
 
-    // The only analytics emitter for method selection: keyed on the id string so it
-    // fires exactly when the effective selection changes, never on object identity.
+    // The only analytics emitter for method selection.
     const effectiveSelectedMethod = state.selectedMethod || props.defaultMethod;
     const trackedSelectedMethodId = effectiveSelectedMethod
         ? getUniquePaymentMethodId(effectiveSelectedMethod.id, effectiveSelectedMethod.gateway)
@@ -723,29 +719,16 @@ const Payment = (
         }
     }, [trackedSelectedMethodId]);
 
-    // Owns the fallback when a methods reload drops the selected method; PaymentForm
-    // follows through its selectedMethod prop.
-    useEffect(() => {
-        const { selectedMethod } = state;
-        const { defaultMethod, methods } = props;
-
-        if (
-            !selectedMethod ||
-            hasPaymentMethodWithId(
-                methods,
-                getUniquePaymentMethodId(selectedMethod.id, selectedMethod.gateway),
-            )
-        ) {
-            return;
-        }
-
-        // Keep the selection when a transiently empty list leaves nothing to fall back to.
-        if (!defaultMethod) {
-            return;
-        }
-
-        setSelectedMethod(defaultMethod);
-    }, [props.methods, props.defaultMethod, state.selectedMethod, setSelectedMethod]);
+    useFallbackWhenMethodRemoved(
+        props.methods,
+        state.selectedMethod
+            ? getUniquePaymentMethodId(state.selectedMethod.id, state.selectedMethod.gateway)
+            : undefined,
+        props.defaultMethod
+            ? getUniquePaymentMethodId(props.defaultMethod.id, props.defaultMethod.gateway)
+            : undefined,
+        () => setSelectedMethod(props.defaultMethod),
+    );
 
     useEffect(() => {
         const init = async () => {

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -541,7 +541,7 @@ describe('PaymentForm', () => {
         const authorizenet = getPaymentMethod();
         const cybersource = { ...getPaymentMethod(), id: 'cybersource' };
 
-        it('falls back to the default method', () => {
+        it('re-points the form at the selection made by the parent', () => {
             const onMethodSelect = jest.fn();
 
             const { rerender } = render(
@@ -549,26 +549,58 @@ describe('PaymentForm', () => {
                     {...defaultProps}
                     methods={[authorizenet, cybersource]}
                     onMethodSelect={onMethodSelect}
+                    selectedMethod={authorizenet}
                 />,
             );
 
             fireEvent.click(screen.getAllByRole('radio')[1]);
 
             expect(screen.getAllByRole('radio')[1]).toBeChecked();
-            expect(onMethodSelect).toHaveBeenCalledWith(cybersource, { isAutomatic: false });
+            expect(onMethodSelect).toHaveBeenCalledWith(cybersource);
 
             onMethodSelect.mockClear();
 
+            // Payment applies the fallback and hands the new selection down.
             rerender(
                 <PaymentFormTest
                     {...defaultProps}
                     methods={[authorizenet]}
                     onMethodSelect={onMethodSelect}
+                    selectedMethod={authorizenet}
                 />,
             );
 
             expect(screen.getByRole('radio')).toBeChecked();
-            expect(onMethodSelect).toHaveBeenCalledWith(authorizenet, { isAutomatic: true });
+            expect(onMethodSelect).toHaveBeenCalledWith(authorizenet);
+        });
+
+        it('stays put while the parent selection is not yet in the list', () => {
+            const onMethodSelect = jest.fn();
+
+            const { rerender } = render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    methods={[authorizenet, cybersource]}
+                    onMethodSelect={onMethodSelect}
+                    selectedMethod={cybersource}
+                />,
+            );
+
+            fireEvent.click(screen.getAllByRole('radio')[1]);
+            onMethodSelect.mockClear();
+
+            // The parent selection is stale for one commit during a removal.
+            rerender(
+                <PaymentFormTest
+                    {...defaultProps}
+                    methods={[authorizenet]}
+                    onMethodSelect={onMethodSelect}
+                    selectedMethod={cybersource}
+                />,
+            );
+
+            expect(screen.getByRole('radio')).not.toBeChecked();
+            expect(onMethodSelect).not.toHaveBeenCalled();
         });
 
         it('leaves the selection alone while it is still in the list', () => {

--- a/packages/core/src/app/payment/PaymentForm.test.tsx
+++ b/packages/core/src/app/payment/PaymentForm.test.tsx
@@ -536,4 +536,65 @@ describe('PaymentForm', () => {
             expect(screen.queryByTestId('payment-billing-block')).not.toBeInTheDocument();
         });
     });
+
+    describe('when the selected method is removed from the list', () => {
+        const authorizenet = getPaymentMethod();
+        const cybersource = { ...getPaymentMethod(), id: 'cybersource' };
+
+        it('falls back to the default method', () => {
+            const onMethodSelect = jest.fn();
+
+            const { rerender } = render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    methods={[authorizenet, cybersource]}
+                    onMethodSelect={onMethodSelect}
+                />,
+            );
+
+            fireEvent.click(screen.getAllByRole('radio')[1]);
+
+            expect(screen.getAllByRole('radio')[1]).toBeChecked();
+            expect(onMethodSelect).toHaveBeenCalledWith(cybersource, { isAutomatic: false });
+
+            onMethodSelect.mockClear();
+
+            rerender(
+                <PaymentFormTest
+                    {...defaultProps}
+                    methods={[authorizenet]}
+                    onMethodSelect={onMethodSelect}
+                />,
+            );
+
+            expect(screen.getByRole('radio')).toBeChecked();
+            expect(onMethodSelect).toHaveBeenCalledWith(authorizenet, { isAutomatic: true });
+        });
+
+        it('leaves the selection alone while it is still in the list', () => {
+            const onMethodSelect = jest.fn();
+
+            const { rerender } = render(
+                <PaymentFormTest
+                    {...defaultProps}
+                    methods={[authorizenet, cybersource]}
+                    onMethodSelect={onMethodSelect}
+                />,
+            );
+
+            fireEvent.click(screen.getAllByRole('radio')[1]);
+            onMethodSelect.mockClear();
+
+            rerender(
+                <PaymentFormTest
+                    {...defaultProps}
+                    methods={[authorizenet, cybersource]}
+                    onMethodSelect={onMethodSelect}
+                />,
+            );
+
+            expect(screen.getAllByRole('radio')[1]).toBeChecked();
+            expect(onMethodSelect).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -42,6 +42,7 @@ import { getInitialOrderExtraFieldsValues, OrderExtraFieldsFieldset } from './or
 import {
     getPaymentMethodName,
     getUniquePaymentMethodId,
+    hasPaymentMethodWithId,
     PaymentMethodId,
     PaymentMethodList,
     usePoMethodDisabledReason,
@@ -57,6 +58,11 @@ import SpamProtectionField from './SpamProtectionField';
 import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
 
 import './PaymentForm.scss';
+
+export interface PaymentMethodSelectOptions {
+    // True when selected by the removed-method fallback rather than the shopper.
+    isAutomatic?: boolean;
+}
 
 export interface PaymentFormProps {
     additionalField?: Capabilities['payment']['additionalField'];
@@ -86,7 +92,7 @@ export interface PaymentFormProps {
     validationSchema?: ObjectSchema<Partial<PaymentFormValues>>;
     isPaymentDataRequired(): boolean;
     onBillingSameAsShippingChange?(isBillingSameAsShipping: boolean): void;
-    onMethodSelect?(method: PaymentMethod): void;
+    onMethodSelect?(method: PaymentMethod, options?: PaymentMethodSelectOptions): void;
     onMethodsRefreshAlertDismiss?(): void;
     onStoreCreditChange?(useStoreCredit?: boolean): void;
     onSubmit?(values: PaymentFormValues): void;
@@ -98,6 +104,8 @@ const PaymentForm: FunctionComponent<
 > = ({
     additionalField,
     availableStoreCredit = 0,
+    defaultGatewayId,
+    defaultMethodId,
     disableStoreCredit = false,
     didExceedSpamLimit,
     isBillingSameAsShipping,
@@ -229,6 +237,8 @@ const PaymentForm: FunctionComponent<
 
             {!isEmpty(methods) && (
                 <PaymentMethodListFieldset
+                    defaultGatewayId={defaultGatewayId}
+                    defaultMethodId={defaultMethodId}
                     isEmbedded={isEmbedded}
                     isInitializingPayment={isInitializingPayment}
                     isPaymentDataRequired={isPaymentDataRequired}
@@ -307,18 +317,22 @@ const PaymentMethodSubmitButtonContainer: FunctionComponent = () => {
 };
 
 interface PaymentMethodListFieldsetProps {
+    defaultGatewayId?: string;
+    defaultMethodId: string;
     isEmbedded?: boolean;
     isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
     values: PaymentFormValues;
     isPaymentDataRequired(): boolean;
-    onMethodSelect?(method: PaymentMethod): void;
+    onMethodSelect?(method: PaymentMethod, options?: PaymentMethodSelectOptions): void;
     onUnhandledError?(error: Error): void;
     resetForm(nextValues?: Partial<FormikState<PaymentFormValues>>): void;
 }
 
 const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProps> = ({
+    defaultGatewayId,
+    defaultMethodId,
     isEmbedded,
     isInitializingPayment,
     isPaymentDataRequired,
@@ -332,30 +346,68 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     const { setSubmitted } = useContext(FormContext);
     const { enhancedThemeV1 } = useThemeContext();
 
+    // The checklist reports fallback and shopper selections through the same callback;
+    // this marks the next arrival of this id as the fallback's.
+    const automaticSelectionIdRef = useRef<string>();
+
+    const selectMethod = useCallback(
+        (uniquePaymentMethodId: string) => {
+            resetForm({
+                values: {
+                    ...values,
+                    ccCustomerCode: '',
+                    ccCvv: '',
+                    ccDocument: '',
+                    customerEmail: '',
+                    customerMobile: '',
+                    ccExpiry: '',
+                    ccName: '',
+                    ccNumber: '',
+                    instrumentId: '',
+                    paymentProviderRadio: uniquePaymentMethodId,
+                    shouldCreateAccount: true,
+                    shouldSaveInstrument: false,
+                },
+            });
+            setSubmitted(false);
+        },
+        [values, resetForm, setSubmitted],
+    );
+
     const handlePaymentMethodSelect = useCallback(
         (method: PaymentMethod) => {
-            const updatedValues = {
-                ...values,
-                ccCustomerCode: '',
-                ccCvv: '',
-                ccDocument: '',
-                customerEmail: '',
-                customerMobile: '',
-                ccExpiry: '',
-                ccName: '',
-                ccNumber: '',
-                instrumentId: '',
-                paymentProviderRadio: getUniquePaymentMethodId(method.id, method.gateway),
-                shouldCreateAccount: true,
-                shouldSaveInstrument: false,
-            };
+            const uniquePaymentMethodId = getUniquePaymentMethodId(method.id, method.gateway);
+            const isAutomatic = automaticSelectionIdRef.current === uniquePaymentMethodId;
 
-            resetForm({ values: updatedValues });
-            setSubmitted(false);
-            onMethodSelect(method);
+            automaticSelectionIdRef.current = undefined;
+
+            selectMethod(uniquePaymentMethodId);
+            onMethodSelect(method, { isAutomatic });
         },
-        [values, onMethodSelect, resetForm, setSubmitted],
+        [selectMethod, onMethodSelect],
     );
+
+    // A payment methods reload can drop the method the shopper had selected; fall back to
+    // the default. The checklist picks the change up and expands the new method's form.
+    useEffect(() => {
+        if (
+            !values.paymentProviderRadio ||
+            hasPaymentMethodWithId(methods, values.paymentProviderRadio)
+        ) {
+            return;
+        }
+
+        const fallbackId = getUniquePaymentMethodId(defaultMethodId, defaultGatewayId);
+
+        // `selectMethod` changes identity on every `values` change, so writing an id that
+        // is not in the list would re-run this effect without end.
+        if (!fallbackId || !hasPaymentMethodWithId(methods, fallbackId)) {
+            return;
+        }
+
+        automaticSelectionIdRef.current = fallbackId;
+        selectMethod(fallbackId);
+    }, [values.paymentProviderRadio, methods, defaultMethodId, defaultGatewayId, selectMethod]);
 
     return (
         <Fieldset

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -42,9 +42,9 @@ import { getInitialOrderExtraFieldsValues, OrderExtraFieldsFieldset } from './or
 import {
     getPaymentMethodName,
     getUniquePaymentMethodId,
-    hasPaymentMethodWithId,
     PaymentMethodId,
     PaymentMethodList,
+    useFallbackWhenMethodRemoved,
     usePoMethodDisabledReason,
 } from './paymentMethod';
 import {
@@ -368,26 +368,12 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
         [values, onMethodSelect, resetForm, setSubmitted],
     );
 
-    // When a reload drops the selected method, re-point the form at the fallback that
-    // Payment decided on; the checklist picks the value change up from there.
-    useEffect(() => {
-        if (
-            !values.paymentProviderRadio ||
-            hasPaymentMethodWithId(methods, values.paymentProviderRadio)
-        ) {
-            return;
-        }
-
-        if (
-            !selectedMethodUniqueId ||
-            selectedMethodUniqueId === values.paymentProviderRadio ||
-            !hasPaymentMethodWithId(methods, selectedMethodUniqueId)
-        ) {
-            return;
-        }
-
-        setFieldValue('paymentProviderRadio', selectedMethodUniqueId);
-    }, [values.paymentProviderRadio, methods, selectedMethodUniqueId, setFieldValue]);
+    useFallbackWhenMethodRemoved(
+        methods,
+        values.paymentProviderRadio,
+        selectedMethodUniqueId,
+        (fallbackUniqueId) => setFieldValue('paymentProviderRadio', fallbackUniqueId),
+    );
 
     return (
         <Fieldset

--- a/packages/core/src/app/payment/PaymentForm.tsx
+++ b/packages/core/src/app/payment/PaymentForm.tsx
@@ -59,11 +59,6 @@ import { StoreCreditField, StoreCreditOverlay } from './storeCredit';
 
 import './PaymentForm.scss';
 
-export interface PaymentMethodSelectOptions {
-    // True when selected by the removed-method fallback rather than the shopper.
-    isAutomatic?: boolean;
-}
-
 export interface PaymentFormProps {
     additionalField?: Capabilities['payment']['additionalField'];
     availableStoreCredit?: number;
@@ -92,7 +87,7 @@ export interface PaymentFormProps {
     validationSchema?: ObjectSchema<Partial<PaymentFormValues>>;
     isPaymentDataRequired(): boolean;
     onBillingSameAsShippingChange?(isBillingSameAsShipping: boolean): void;
-    onMethodSelect?(method: PaymentMethod, options?: PaymentMethodSelectOptions): void;
+    onMethodSelect?(method: PaymentMethod): void;
     onMethodsRefreshAlertDismiss?(): void;
     onStoreCreditChange?(useStoreCredit?: boolean): void;
     onSubmit?(values: PaymentFormValues): void;
@@ -104,8 +99,6 @@ const PaymentForm: FunctionComponent<
 > = ({
     additionalField,
     availableStoreCredit = 0,
-    defaultGatewayId,
-    defaultMethodId,
     disableStoreCredit = false,
     didExceedSpamLimit,
     isBillingSameAsShipping,
@@ -127,6 +120,7 @@ const PaymentForm: FunctionComponent<
     orderExtraFields,
     resetForm,
     selectedMethod,
+    setFieldValue,
     shouldDisableSubmit,
     shouldHidePaymentSubmitButton,
     shouldExecuteSpamCheck,
@@ -237,8 +231,6 @@ const PaymentForm: FunctionComponent<
 
             {!isEmpty(methods) && (
                 <PaymentMethodListFieldset
-                    defaultGatewayId={defaultGatewayId}
-                    defaultMethodId={defaultMethodId}
                     isEmbedded={isEmbedded}
                     isInitializingPayment={isInitializingPayment}
                     isPaymentDataRequired={isPaymentDataRequired}
@@ -247,6 +239,11 @@ const PaymentForm: FunctionComponent<
                     onMethodSelect={onMethodSelect}
                     onUnhandledError={onUnhandledError}
                     resetForm={resetForm}
+                    selectedMethodUniqueId={
+                        selectedMethod &&
+                        getUniquePaymentMethodId(selectedMethod.id, selectedMethod.gateway)
+                    }
+                    setFieldValue={setFieldValue}
                     values={values}
                 />
             )}
@@ -317,22 +314,20 @@ const PaymentMethodSubmitButtonContainer: FunctionComponent = () => {
 };
 
 interface PaymentMethodListFieldsetProps {
-    defaultGatewayId?: string;
-    defaultMethodId: string;
     isEmbedded?: boolean;
     isInitializingPayment?: boolean;
     isUsingMultiShipping?: boolean;
     methods: PaymentMethod[];
+    selectedMethodUniqueId?: string;
     values: PaymentFormValues;
     isPaymentDataRequired(): boolean;
-    onMethodSelect?(method: PaymentMethod, options?: PaymentMethodSelectOptions): void;
+    onMethodSelect?(method: PaymentMethod): void;
     onUnhandledError?(error: Error): void;
     resetForm(nextValues?: Partial<FormikState<PaymentFormValues>>): void;
+    setFieldValue(field: string, value: string): void;
 }
 
 const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProps> = ({
-    defaultGatewayId,
-    defaultMethodId,
     isEmbedded,
     isInitializingPayment,
     isPaymentDataRequired,
@@ -341,54 +336,40 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
     onMethodSelect = noop,
     onUnhandledError,
     resetForm,
+    selectedMethodUniqueId,
     values,
+    setFieldValue,
 }) => {
     const { setSubmitted } = useContext(FormContext);
     const { enhancedThemeV1 } = useThemeContext();
 
-    // The checklist reports fallback and shopper selections through the same callback;
-    // this marks the next arrival of this id as the fallback's.
-    const automaticSelectionIdRef = useRef<string>();
-
-    const selectMethod = useCallback(
-        (uniquePaymentMethodId: string) => {
-            resetForm({
-                values: {
-                    ...values,
-                    ccCustomerCode: '',
-                    ccCvv: '',
-                    ccDocument: '',
-                    customerEmail: '',
-                    customerMobile: '',
-                    ccExpiry: '',
-                    ccName: '',
-                    ccNumber: '',
-                    instrumentId: '',
-                    paymentProviderRadio: uniquePaymentMethodId,
-                    shouldCreateAccount: true,
-                    shouldSaveInstrument: false,
-                },
-            });
-            setSubmitted(false);
-        },
-        [values, resetForm, setSubmitted],
-    );
-
     const handlePaymentMethodSelect = useCallback(
         (method: PaymentMethod) => {
-            const uniquePaymentMethodId = getUniquePaymentMethodId(method.id, method.gateway);
-            const isAutomatic = automaticSelectionIdRef.current === uniquePaymentMethodId;
+            const updatedValues = {
+                ...values,
+                ccCustomerCode: '',
+                ccCvv: '',
+                ccDocument: '',
+                customerEmail: '',
+                customerMobile: '',
+                ccExpiry: '',
+                ccName: '',
+                ccNumber: '',
+                instrumentId: '',
+                paymentProviderRadio: getUniquePaymentMethodId(method.id, method.gateway),
+                shouldCreateAccount: true,
+                shouldSaveInstrument: false,
+            };
 
-            automaticSelectionIdRef.current = undefined;
-
-            selectMethod(uniquePaymentMethodId);
-            onMethodSelect(method, { isAutomatic });
+            resetForm({ values: updatedValues });
+            setSubmitted(false);
+            onMethodSelect(method);
         },
-        [selectMethod, onMethodSelect],
+        [values, onMethodSelect, resetForm, setSubmitted],
     );
 
-    // A payment methods reload can drop the method the shopper had selected; fall back to
-    // the default. The checklist picks the change up and expands the new method's form.
+    // When a reload drops the selected method, re-point the form at the fallback that
+    // Payment decided on; the checklist picks the value change up from there.
     useEffect(() => {
         if (
             !values.paymentProviderRadio ||
@@ -397,17 +378,16 @@ const PaymentMethodListFieldset: FunctionComponent<PaymentMethodListFieldsetProp
             return;
         }
 
-        const fallbackId = getUniquePaymentMethodId(defaultMethodId, defaultGatewayId);
-
-        // `selectMethod` changes identity on every `values` change, so writing an id that
-        // is not in the list would re-run this effect without end.
-        if (!fallbackId || !hasPaymentMethodWithId(methods, fallbackId)) {
+        if (
+            !selectedMethodUniqueId ||
+            selectedMethodUniqueId === values.paymentProviderRadio ||
+            !hasPaymentMethodWithId(methods, selectedMethodUniqueId)
+        ) {
             return;
         }
 
-        automaticSelectionIdRef.current = fallbackId;
-        selectMethod(fallbackId);
-    }, [values.paymentProviderRadio, methods, defaultMethodId, defaultGatewayId, selectMethod]);
+        setFieldValue('paymentProviderRadio', selectedMethodUniqueId);
+    }, [values.paymentProviderRadio, methods, selectedMethodUniqueId, setFieldValue]);
 
     return (
         <Fieldset

--- a/packages/core/src/app/payment/payment-methods.mock.ts
+++ b/packages/core/src/app/payment/payment-methods.mock.ts
@@ -42,8 +42,6 @@ export function getPaypalCreditPaymentMethod(): PaymentMethod {
     };
 }
 
-// TODO: CHECKOUT-9010 Clean up this mock if it's not used
-/* istanbul ignore next */
 export function getMobilePaymentMethod(): PaymentMethod {
     return {
         id: 'authorizenetMobile',

--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodList.tsx
@@ -1,12 +1,11 @@
 import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
-import { find, get, noop } from 'lodash';
+import { find, noop } from 'lodash';
 import React, { type FunctionComponent, memo, useCallback, useMemo } from 'react';
 
 import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 import { Checklist, ChecklistItem, LoadingOverlay } from '@bigcommerce/checkout/ui';
 
 import { connectFormik, type ConnectFormikProps } from '../../common/form';
-import { isMobile } from '../../common/utility';
 
 import CustomChecklistItem from './CustomChecklistItem';
 import getPaymentMethodName from './getPaymentMethodName';
@@ -95,15 +94,6 @@ const PaymentMethodList: FunctionComponent<
                 >
                     {methods.map((method) => {
                         const value = getUniquePaymentMethodId(method.id, method.gateway);
-                        const showOnlyOnMobileDevices = get(
-                            method,
-                            'initializationData.showOnlyOnMobileDevices',
-                            false,
-                        );
-
-                        if (showOnlyOnMobileDevices && !isMobile()) {
-                            return;
-                        }
 
                         return (
                             <PaymentMethodListItem

--- a/packages/core/src/app/payment/paymentMethod/index.ts
+++ b/packages/core/src/app/payment/paymentMethod/index.ts
@@ -10,6 +10,8 @@ export {
 } from './getUniquePaymentMethodId';
 export { default as getPaymentMethodName } from './getPaymentMethodName';
 export { default as hasPaymentMethodWithId } from './hasPaymentMethodWithId';
+export { default as isSamePaymentMethod } from './isSamePaymentMethod';
+export { default as useFallbackWhenMethodRemoved } from './useFallbackWhenMethodRemoved';
 export { usePoMethodDisabledReason } from './usePoMethodDisabledReason';
 export { isHostedCreditCardFieldsetValues } from './HostedCreditCardFieldsetValues';
 export {

--- a/packages/core/src/app/payment/paymentMethod/isSamePaymentMethod.test.ts
+++ b/packages/core/src/app/payment/paymentMethod/isSamePaymentMethod.test.ts
@@ -1,0 +1,25 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { getPaymentMethod } from '../payment-methods.mock';
+
+import isSamePaymentMethod from './isSamePaymentMethod';
+
+describe('isSamePaymentMethod', () => {
+    it('returns true when methods share the same id and gateway', () => {
+        const method: PaymentMethod = getPaymentMethod();
+
+        expect(isSamePaymentMethod(method, { ...method })).toBe(true);
+    });
+
+    it('returns false when methods have different ids', () => {
+        const method: PaymentMethod = getPaymentMethod();
+
+        expect(isSamePaymentMethod(method, { ...method, id: 'braintree' })).toBe(false);
+    });
+
+    it('returns false when methods have different gateways', () => {
+        const method: PaymentMethod = getPaymentMethod();
+
+        expect(isSamePaymentMethod(method, { ...method, gateway: 'adyen' })).toBe(false);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethod/isSamePaymentMethod.ts
+++ b/packages/core/src/app/payment/paymentMethod/isSamePaymentMethod.ts
@@ -1,0 +1,7 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import getUniquePaymentMethodId from './getUniquePaymentMethodId';
+
+export default function isSamePaymentMethod(a: PaymentMethod, b: PaymentMethod): boolean {
+    return getUniquePaymentMethodId(a.id, a.gateway) === getUniquePaymentMethodId(b.id, b.gateway);
+}

--- a/packages/core/src/app/payment/paymentMethod/useFallbackWhenMethodRemoved.test.ts
+++ b/packages/core/src/app/payment/paymentMethod/useFallbackWhenMethodRemoved.test.ts
@@ -1,0 +1,51 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { renderHook } from '@testing-library/react';
+
+import { getPaymentMethod } from '../payment-methods.mock';
+
+import getUniquePaymentMethodId from './getUniquePaymentMethodId';
+import useFallbackWhenMethodRemoved from './useFallbackWhenMethodRemoved';
+
+describe('useFallbackWhenMethodRemoved', () => {
+    const removedMethod: PaymentMethod = getPaymentMethod();
+    const fallbackMethod: PaymentMethod = { ...getPaymentMethod(), id: 'braintree' };
+    const removedMethodId = getUniquePaymentMethodId(removedMethod.id, removedMethod.gateway);
+    const fallbackMethodId = getUniquePaymentMethodId(fallbackMethod.id, fallbackMethod.gateway);
+
+    const renderFallbackHook = (methods: PaymentMethod[]) => {
+        const onFallback = jest.fn();
+        const { rerender } = renderHook(
+            (props: { methods: PaymentMethod[] }) =>
+                useFallbackWhenMethodRemoved(
+                    props.methods,
+                    removedMethodId,
+                    fallbackMethodId,
+                    onFallback,
+                ),
+            { initialProps: { methods } },
+        );
+
+        return { onFallback, rerender };
+    };
+
+    it('falls back when the current method was removed from the list', () => {
+        const { onFallback } = renderFallbackHook([fallbackMethod]);
+
+        expect(onFallback).toHaveBeenCalledTimes(1);
+        expect(onFallback).toHaveBeenCalledWith(fallbackMethodId);
+    });
+
+    it('does not fall back when the current method is still in the list', () => {
+        const { onFallback } = renderFallbackHook([removedMethod, fallbackMethod]);
+
+        expect(onFallback).not.toHaveBeenCalled();
+    });
+
+    it('does not fall back again when the list is rebuilt with the same method ids', () => {
+        const { onFallback, rerender } = renderFallbackHook([fallbackMethod]);
+
+        rerender({ methods: [{ ...fallbackMethod }] });
+
+        expect(onFallback).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethod/useFallbackWhenMethodRemoved.ts
+++ b/packages/core/src/app/payment/paymentMethod/useFallbackWhenMethodRemoved.ts
@@ -1,0 +1,30 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+import { useEffect } from 'react';
+
+import getUniquePaymentMethodId from './getUniquePaymentMethodId';
+import hasPaymentMethodWithId from './hasPaymentMethodWithId';
+
+export default function useFallbackWhenMethodRemoved(
+    methods: PaymentMethod[],
+    currentUniqueId: string | undefined,
+    fallbackUniqueId: string | undefined,
+    onFallback: (fallbackUniqueId: string) => void,
+): void {
+    // Keyed on id strings because callers rebuild `methods` on every render.
+    const methodIdsKey = methods
+        .map((method) => getUniquePaymentMethodId(method.id, method.gateway))
+        .join(',');
+
+    useEffect(() => {
+        if (!currentUniqueId || hasPaymentMethodWithId(methods, currentUniqueId)) {
+            return;
+        }
+
+        // A transiently empty list has no valid fallback; keep the current selection.
+        if (!fallbackUniqueId || !hasPaymentMethodWithId(methods, fallbackUniqueId)) {
+            return;
+        }
+
+        onFallback(fallbackUniqueId);
+    }, [methodIdsKey, currentUniqueId, fallbackUniqueId]);
+}

--- a/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/applyPaymentMethodFilters.ts
@@ -8,6 +8,7 @@ import { stripeMethodsFiltering } from '@bigcommerce/checkout/stripe-utils';
 
 import { boltAndBraintreeFilter } from './boltAndBraintreeFilter';
 import { checkPaymentMethodFilter } from './checkPaymentMethodFilter';
+import { mobileOnlyMethodFilter } from './mobileOnlyMethodFilter';
 import { multiShippingFilter } from './multiShippingFilter';
 import { selectedHostedPaymentFilter } from './selectedHostedPaymentFilter';
 
@@ -15,6 +16,7 @@ import { selectedHostedPaymentFilter } from './selectedHostedPaymentFilter';
 // collapse the list to a single method when a hosted payment is already in flight.
 const FILTERS: PaymentMethodFilter[] = [
     checkPaymentMethodFilter,
+    mobileOnlyMethodFilter,
     stripeMethodsFiltering,
     boltAndBraintreeFilter,
     multiShippingFilter,

--- a/packages/core/src/app/payment/paymentMethodFilters/mobileOnlyMethodFilter.test.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/mobileOnlyMethodFilter.test.ts
@@ -1,0 +1,53 @@
+import { type PaymentMethod } from '@bigcommerce/checkout-sdk';
+
+import { defaultCapabilities } from '@bigcommerce/checkout/contexts';
+import { type PaymentMethodFilterContext } from '@bigcommerce/checkout/payment-integration-api';
+
+import { getCheckout } from '../../checkout/checkouts.mock';
+import { isMobile } from '../../common/utility';
+import { getStoreConfig } from '../../config/config.mock';
+import { getMobilePaymentMethod, getPaymentMethod } from '../payment-methods.mock';
+
+import { mobileOnlyMethodFilter } from './mobileOnlyMethodFilter';
+
+jest.mock('../../common/utility', () => ({
+    ...jest.requireActual('../../common/utility'),
+    isMobile: jest.fn(),
+}));
+
+describe('mobileOnlyMethodFilter', () => {
+    const mobileOnlyMethod: PaymentMethod = getMobilePaymentMethod();
+    const otherMethod: PaymentMethod = { ...getPaymentMethod(), id: 'authorizenet' };
+
+    const buildContext = (): PaymentMethodFilterContext => ({
+        capabilities: defaultCapabilities,
+        checkout: getCheckout(),
+        checkoutSettings: getStoreConfig().checkoutSettings,
+        getPaymentMethod: jest.fn(),
+        paymentProviderCustomer: undefined,
+    });
+
+    it('removes mobile-only methods on desktop', () => {
+        jest.mocked(isMobile).mockReturnValue(false);
+
+        expect(
+            mobileOnlyMethodFilter.apply([mobileOnlyMethod, otherMethod], buildContext()),
+        ).toEqual([otherMethod]);
+    });
+
+    it('keeps mobile-only methods on mobile devices', () => {
+        jest.mocked(isMobile).mockReturnValue(true);
+
+        const methods = [mobileOnlyMethod, otherMethod];
+
+        expect(mobileOnlyMethodFilter.apply(methods, buildContext())).toEqual(methods);
+    });
+
+    it('keeps methods without the flag regardless of device', () => {
+        jest.mocked(isMobile).mockReturnValue(false);
+
+        const methods = [otherMethod];
+
+        expect(mobileOnlyMethodFilter.apply(methods, buildContext())).toEqual(methods);
+    });
+});

--- a/packages/core/src/app/payment/paymentMethodFilters/mobileOnlyMethodFilter.ts
+++ b/packages/core/src/app/payment/paymentMethodFilters/mobileOnlyMethodFilter.ts
@@ -1,0 +1,14 @@
+import { type PaymentMethodFilter } from '@bigcommerce/checkout/payment-integration-api';
+
+import { isMobile } from '../../common/utility';
+
+export const mobileOnlyMethodFilter: PaymentMethodFilter = {
+    name: 'mobileOnly',
+    apply(methods) {
+        if (isMobile()) {
+            return methods;
+        }
+
+        return methods.filter((method) => !method.initializationData?.showOnlyOnMobileDevices);
+    },
+};


### PR DESCRIPTION
## What/Why?

- Select default payment method on refetching payment methods after billing country update, if the previously selected method is not in the new list.
- Also remove the temporary error suppress logic that was added to suppress the method not available error and deinitialize that method from checkout-sdk instead.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**BEFORE**

https://github.com/user-attachments/assets/be4feb48-aba0-4254-bf28-409c511a46c7



**AFTER**

https://github.com/user-attachments/assets/5650c964-5315-4eaa-b62c-3db4c2c29391



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core payment selection, analytics, and error handling when methods refresh; scope is checkout payment step with substantial test coverage but real shopper impact on billing-country and invalid-method flows.
> 
> **Overview**
> When payment methods reload and the shopper’s selection is no longer available, checkout **automatically selects the default method** instead of leaving a stale choice or surfacing SDK “missing method” errors.
> 
> **`useFallbackWhenMethodRemoved`** drives this in **`Payment`** (parent selection state) and **`PaymentForm`** (Formik `paymentProviderRadio`). The temporary **`suppressMethodRemovedErrorUntilRef`** workaround and related **`missing_data`** suppression are removed. **`isSamePaymentMethod`** keeps automatic fallback from dismissing the payment-methods refresh alert, and payment-method analytics are centralized in a single effect keyed on the effective selection id (no duplicate events on reload when the selection survives).
> 
> **Mobile-only methods** are filtered in **`mobileOnlyMethodFilter`** (part of **`applyPaymentMethodFilters`**) instead of being skipped inline in **`PaymentMethodList`**. Tests are updated for **`enhancedThemeV1`** naming and expanded coverage for country change, cart total reload, and **`payment_method_invalid`** submit paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756a0a00fc7fcb3fda981640e01725c568d069dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->