### PR TITLE
feat(payment): PAYPAL-6696 add BigCommerce Payments Invoices payment method

### DIFF
--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.test.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.test.tsx
@@ -16,6 +16,8 @@ describe('BigCommercePaymentsInvoicesPaymentMethod', () => {
     beforeEach(() => {
         checkoutService = createCheckoutService();
 
+        jest.spyOn(checkoutService.getState().data, 'isPaymentDataRequired').mockReturnValue(true);
+
         defaultProps = {
             method: getBigCommercePaymentsInvoicesMethod(),
             checkoutService,
@@ -47,7 +49,9 @@ describe('BigCommercePaymentsInvoicesPaymentMethod', () => {
 
         render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
 
-        await expect(checkoutService.initializePayment).rejects.toThrow('test error');
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalled();
     });
 
     it('deinitializes payment method when component unmounts', () => {
@@ -72,8 +76,36 @@ describe('BigCommercePaymentsInvoicesPaymentMethod', () => {
 
         const { unmount } = render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
 
+        await new Promise((resolve) => process.nextTick(resolve));
+
         unmount();
 
-        await expect(checkoutService.deinitializePayment).rejects.toThrow('test error');
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+    });
+
+    it('does not initialize payment method when payment data is not required', () => {
+        jest.spyOn(defaultProps.checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
+        jest.spyOn(checkoutService, 'initializePayment').mockResolvedValue(
+            checkoutService.getState(),
+        );
+
+        render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
+
+        expect(checkoutService.initializePayment).not.toHaveBeenCalled();
+    });
+
+    it('does not deinitialize payment method on unmount when payment data is not required', () => {
+        jest.spyOn(defaultProps.checkoutState.data, 'isPaymentDataRequired').mockReturnValue(false);
+        jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(
+            checkoutService.getState(),
+        );
+
+        const { unmount } = render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
+
+        unmount();
+
+        expect(checkoutService.deinitializePayment).not.toHaveBeenCalled();
     });
 });

--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.test.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.test.tsx
@@ -1,0 +1,79 @@
+import { createCheckoutService, createLanguageService } from '@bigcommerce/checkout-sdk';
+import { createBigCommercePaymentsInvoicesPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bigcommerce-payments';
+import React from 'react';
+
+import { type PaymentMethodProps } from '@bigcommerce/checkout/payment-integration-api';
+import { render } from '@bigcommerce/checkout/test-utils';
+
+import { getBigCommercePaymentsInvoicesMethod } from '../mocks/paymentMethods.mock';
+
+import BigCommercePaymentsInvoicesPaymentMethod from './BigCommercePaymentsInvoicesPaymentMethod';
+
+describe('BigCommercePaymentsInvoicesPaymentMethod', () => {
+    let checkoutService: ReturnType<typeof createCheckoutService>;
+    let defaultProps: PaymentMethodProps;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+
+        defaultProps = {
+            method: getBigCommercePaymentsInvoicesMethod(),
+            checkoutService,
+            checkoutState: checkoutService.getState(),
+
+            paymentForm: jest.fn() as unknown as PaymentMethodProps['paymentForm'],
+
+            language: createLanguageService(),
+            onUnhandledError: jest.fn(),
+        };
+    });
+
+    it('initializes payment method when component mounts', () => {
+        jest.spyOn(checkoutService, 'initializePayment').mockResolvedValue(
+            checkoutService.getState(),
+        );
+
+        render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
+
+        expect(checkoutService.initializePayment).toHaveBeenCalledWith({
+            gatewayId: defaultProps.method.gateway,
+            methodId: defaultProps.method.id,
+            integrations: [createBigCommercePaymentsInvoicesPaymentStrategy],
+        });
+    });
+
+    it('catches error during initialization', async () => {
+        jest.spyOn(checkoutService, 'initializePayment').mockRejectedValue(new Error('test error'));
+
+        render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
+
+        await expect(checkoutService.initializePayment).rejects.toThrow('test error');
+    });
+
+    it('deinitializes payment method when component unmounts', () => {
+        jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(
+            checkoutService.getState(),
+        );
+
+        const { unmount } = render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
+
+        unmount();
+
+        expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+            gatewayId: defaultProps.method.gateway,
+            methodId: defaultProps.method.id,
+        });
+    });
+
+    it('catches error during deinitialization', async () => {
+        jest.spyOn(checkoutService, 'deinitializePayment').mockRejectedValue(
+            new Error('test error'),
+        );
+
+        const { unmount } = render(<BigCommercePaymentsInvoicesPaymentMethod {...defaultProps} />);
+
+        unmount();
+
+        await expect(checkoutService.deinitializePayment).rejects.toThrow('test error');
+    });
+});

--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.tsx
@@ -10,9 +10,16 @@ import {
 const BigCommercePaymentsInvoicesPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     method,
     checkoutService,
+    checkoutState,
     onUnhandledError,
 }) => {
+    const isPaymentDataRequired = checkoutState.data.isPaymentDataRequired();
+
     useEffect(() => {
+        if (!isPaymentDataRequired) {
+            return;
+        }
+
         const initializePayment = async () => {
             try {
                 await checkoutService.initializePayment({
@@ -45,7 +52,7 @@ const BigCommercePaymentsInvoicesPaymentMethod: FunctionComponent<PaymentMethodP
 
             void deinitializePayment();
         };
-    }, [checkoutService, method.gateway, method.id, onUnhandledError]);
+    }, [checkoutService, method.gateway, method.id, onUnhandledError, isPaymentDataRequired]);
 
     return null;
 };

--- a/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.tsx
+++ b/packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod.tsx
@@ -1,0 +1,56 @@
+import { createBigCommercePaymentsInvoicesPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bigcommerce-payments';
+import { type FunctionComponent, useEffect } from 'react';
+
+import {
+    type PaymentMethodProps,
+    type PaymentMethodResolveId,
+    toResolvableComponent,
+} from '@bigcommerce/checkout/payment-integration-api';
+
+const BigCommercePaymentsInvoicesPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
+    method,
+    checkoutService,
+    onUnhandledError,
+}) => {
+    useEffect(() => {
+        const initializePayment = async () => {
+            try {
+                await checkoutService.initializePayment({
+                    gatewayId: method.gateway,
+                    methodId: method.id,
+                    integrations: [createBigCommercePaymentsInvoicesPaymentStrategy],
+                });
+            } catch (error) {
+                if (error instanceof Error) {
+                    onUnhandledError(error);
+                }
+            }
+        };
+
+        void initializePayment();
+
+        return () => {
+            const deinitializePayment = async () => {
+                try {
+                    await checkoutService.deinitializePayment({
+                        gatewayId: method.gateway,
+                        methodId: method.id,
+                    });
+                } catch (error) {
+                    if (error instanceof Error) {
+                        onUnhandledError(error);
+                    }
+                }
+            };
+
+            void deinitializePayment();
+        };
+    }, [checkoutService, method.gateway, method.id, onUnhandledError]);
+
+    return null;
+};
+
+export default toResolvableComponent<PaymentMethodProps, PaymentMethodResolveId>(
+    BigCommercePaymentsInvoicesPaymentMethod,
+    [{ id: 'bigcommerce_payments_invoices' }],
+);

--- a/packages/bigcommerce-payments-integration/src/index.ts
+++ b/packages/bigcommerce-payments-integration/src/index.ts
@@ -48,3 +48,10 @@ export { default as BigCommercePaymentsVenmoPaymentMethod } from './BigCommerceP
  *
  * */
 export { default as BigCommercePaymentsRatePayPaymentMethod } from './BigCommercePaymentsRatePay/BigCommercePaymentsRatePayPaymentMethod';
+
+/**
+ *
+ * BigCommerce Payments Invoices
+ *
+ * */
+export { default as BigCommercePaymentsInvoicesPaymentMethod } from './BigCommercePaymentsInvoices/BigCommercePaymentsInvoicesPaymentMethod';

--- a/packages/bigcommerce-payments-integration/src/mocks/paymentMethods.mock.ts
+++ b/packages/bigcommerce-payments-integration/src/mocks/paymentMethods.mock.ts
@@ -90,6 +90,16 @@ export function getBigCommercePaymentsVenmoMethod() {
     };
 }
 
+export function getBigCommercePaymentsInvoicesMethod() {
+    const bigCommercePayments = getBigCommercePaymentsMethod();
+
+    return {
+        ...bigCommercePayments,
+        id: 'bigcommerce_payments_invoices',
+        method: 'bigcommerce_payments_invoices',
+    };
+}
+
 export function getBigCommercePaymentsAPMsMethod() {
     const bigcommercePayments = getBigCommercePaymentsMethod();
 

--- a/packages/payment-integration-api/src/PaymentMethodId.ts
+++ b/packages/payment-integration-api/src/PaymentMethodId.ts
@@ -53,6 +53,7 @@ enum PaymentMethodId {
     BigCommercePaymentsVenmo = 'bigcommerce_payments_venmo',
     BigCommercePaymentsFastLane = 'bigcommerce_payments_fastlane',
     BigCommercePaymentsGooglePay = 'googlepay_bigcommerce_payments',
+    BigCommercePaymentsInvoices = 'bigcommerce_payments_invoices',
     Qpay = 'qpay',
     Quadpay = 'quadpay',
     Ratepay = 'ratepay',


### PR DESCRIPTION
Jira: [PAYPAL-6696](https://bigcommercecloud.atlassian.net/browse/PAYPAL-6696)

## What/Why?

Adds support for a new BigCommerce Payments Invoices payment method so merchants can
offer invoice-based payments through BigCommerce Payments at checkout. The component
initializes/deinitializes the strategy via the checkout SDK on mount/unmount, following
the same pattern as the existing BigCommerce Payments sub-methods (Venmo, RatePay, etc.).

### Changes
- Added `BigCommercePaymentsInvoicesPaymentMethod` component with unit tests (`packages/bigcommerce-payments-integration/src/BigCommercePaymentsInvoices/`)
- Exported the new component from `bigcommerce-payments-integration`'s package `index.ts`
- Added `BigCommercePaymentsInvoices = 'bigcommerce_payments_invoices'` to `PaymentMethodId` enum
- Added `getBigCommercePaymentsInvoicesMethod` mock helper for tests

## Rollout/Rollback
Rollout

## Testing

**checkout-sdk-js:** - https://github.com/bigcommerce/checkout-sdk-js/pull/3355

**Enable experiment `PROJECT-8681.bcp_invoices_checkout_implementation`**

**Enable Invoices in BCP CP**

<img width="1197" height="196" alt="Screenshot 2026-08-13 at 15 24 30" src="https://github.com/user-attachments/assets/5322991b-d8ac-45cf-a6c5-a8ad66e23e26" />


**Invoices for guest shopper**

https://github.com/user-attachments/assets/ef57add3-bac1-44e6-93c4-715e49c81e65

**Invoices for member shopper**

https://github.com/user-attachments/assets/a9f51bc6-1036-4ae5-8ec8-53c574ea9397

**Invoices with promotions**

https://github.com/user-attachments/assets/7c953582-d794-428b-9996-0a313d14783e

**Invoices with enabled stored instruments**

https://github.com/user-attachments/assets/d292b8cb-50f2-4f5a-bee9-04cdf595f7e8




[PAYPAL-6696]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-6696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated payment method registration and lifecycle hooks mirroring other BCP sub-methods; no changes to shared payment processing beyond a new enum ID and export.
> 
> **Overview**
> Adds checkout support for **BigCommerce Payments Invoices** (`bigcommerce_payments_invoices`) so invoice payments can be wired through the existing checkout SDK integration layer.
> 
> A new **headless** payment method component registers for that ID and, when payment data is required, **initializes** checkout payment with `createBigCommercePaymentsInvoicesPaymentStrategy` on mount and **deinitializes** on unmount, forwarding errors to `onUnhandledError`. The package export, `PaymentMethodId` enum entry, and a mock helper for tests are included; unit tests cover init/deinit, error paths, and skipping lifecycle when payment data is not required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d35b2ca28a57fba7c946def86531a3cc7b58ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->