### PR TITLE
fix(checkout): CHECKOUT-10288 Add role="img" to credit card SVG icons

### DIFF
--- a/packages/ui/src/icon/CreditCardIconList.test.tsx
+++ b/packages/ui/src/icon/CreditCardIconList.test.tsx
@@ -13,6 +13,32 @@ describe('CreditCardIconList', () => {
         expect(screen.getAllByRole('listitem')).toHaveLength(2);
     });
 
+    it('exposes each icon as an image with an accessible name', async () => {
+        render(<CreditCardIconList cardTypes={['visa', 'mastercard']} />);
+
+        expect(await screen.findAllByRole('img')).toHaveLength(2);
+        expect(await screen.findByRole('img', { name: 'Visa' })).toBeInTheDocument();
+        expect(await screen.findByRole('img', { name: 'Master' })).toBeInTheDocument();
+    });
+
+    // dom-accessibility-api falls back to an SVG's <title> when aria-labelledby dangles,
+    // so getByRole({ name }) passes under jsdom on markup that fails on real AT.
+    it('points every aria-labelledby at a title that exists and is unique', async () => {
+        render(<CreditCardIconList cardTypes={['discover', 'electron', 'troy']} />);
+
+        const icons = await screen.findAllByRole('img');
+
+        expect(icons).toHaveLength(3);
+
+        icons.forEach((icon) => {
+            const titleId = icon.getAttribute('aria-labelledby') ?? '';
+            const titles = document.querySelectorAll(`[id="${titleId}"]`);
+
+            expect(titles).toHaveLength(1);
+            expect(icon.contains(titles[0])).toBe(true);
+        });
+    });
+
     it('renders nothing if no cards have icon', () => {
         render(<CreditCardIconList cardTypes={['foo', 'bar']} />);
 

--- a/packages/ui/src/icon/IconBitCoin.tsx
+++ b/packages/ui/src/icon/IconBitCoin.tsx
@@ -7,6 +7,7 @@ const IconBitCoinSvg: FunctionComponent = () => (
         aria-labelledby="iconBitCoinTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconBitCoinCash.tsx
+++ b/packages/ui/src/icon/IconBitCoinCash.tsx
@@ -7,6 +7,7 @@ const IconBitCoinCashSvg: FunctionComponent = () => (
         aria-labelledby="iconBitCoinCashTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardAmex.tsx
+++ b/packages/ui/src/icon/IconCardAmex.tsx
@@ -7,6 +7,7 @@ const IconCardAmexSvg: FunctionComponent = () => (
         aria-labelledby="iconCardAmexTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardBancontact.tsx
+++ b/packages/ui/src/icon/IconCardBancontact.tsx
@@ -7,6 +7,7 @@ const IconCardBancontactSvg: FunctionComponent = () => (
         aria-labelledby="iconCardBancontactTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardCB.tsx
+++ b/packages/ui/src/icon/IconCardCB.tsx
@@ -7,6 +7,7 @@ const IconCardCBSvg: FunctionComponent = () => (
         aria-labelledby="iconCardCBTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardDankort.tsx
+++ b/packages/ui/src/icon/IconCardDankort.tsx
@@ -7,6 +7,7 @@ const IconCardDankortSvg: FunctionComponent = () => (
         aria-labelledby="iconCardDankortTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardDinersClub.tsx
+++ b/packages/ui/src/icon/IconCardDinersClub.tsx
@@ -7,6 +7,7 @@ const IconCardDinersClubSvg: FunctionComponent = () => (
         aria-labelledby="iconCardDinersClubTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardDiscover.tsx
+++ b/packages/ui/src/icon/IconCardDiscover.tsx
@@ -7,6 +7,7 @@ const IconCardDiscoverSvg: FunctionComponent = () => (
         aria-labelledby="iconCardDiscoverTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardElectron.tsx
+++ b/packages/ui/src/icon/IconCardElectron.tsx
@@ -7,11 +7,12 @@ const IconCardElectronSvg: FunctionComponent = () => (
         aria-labelledby="iconCardElectronTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"
     >
-        <title id="iconCardDiscoverTitle">Electron</title>
+        <title id="iconCardElectronTitle">Electron</title>
         <rect fill="#293381" height="47" rx="5.5" stroke="#D9D9D9" width="69" x="0.5" y="0.5" />
         <path
             clipRule="evenodd"

--- a/packages/ui/src/icon/IconCardElo.tsx
+++ b/packages/ui/src/icon/IconCardElo.tsx
@@ -7,6 +7,7 @@ const IconCardEloSvg: FunctionComponent = () => (
         aria-labelledby="iconCardEloTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardHipercard.tsx
+++ b/packages/ui/src/icon/IconCardHipercard.tsx
@@ -7,6 +7,7 @@ const IconCardHipercardSvg: FunctionComponent = () => (
         aria-labelledby="iconCardHiperTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardJCB.tsx
+++ b/packages/ui/src/icon/IconCardJCB.tsx
@@ -7,6 +7,7 @@ const IconCardJCBSvg: FunctionComponent = () => (
         aria-labelledby="iconCardJCBTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardMada.tsx
+++ b/packages/ui/src/icon/IconCardMada.tsx
@@ -7,6 +7,7 @@ const IconCardMadaSvg: FunctionComponent = () => (
         aria-labelledby="iconCardMadaTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardMaestro.tsx
+++ b/packages/ui/src/icon/IconCardMaestro.tsx
@@ -7,6 +7,7 @@ const IconCardMaestroSvg: FunctionComponent = () => (
         aria-labelledby="iconCardMaestroTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardMastercard.tsx
+++ b/packages/ui/src/icon/IconCardMastercard.tsx
@@ -7,6 +7,7 @@ const IconCardMastercardSvg: FunctionComponent = () => (
         aria-labelledby="iconCardMasterTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardTroy.tsx
+++ b/packages/ui/src/icon/IconCardTroy.tsx
@@ -4,9 +4,10 @@ import IconContainer, { type IconProps } from './IconContainer';
 
 const IconCardTroySvg: FunctionComponent = () => (
     <svg
-        aria-labelledby="iconCardToryTitle"
+        aria-labelledby="iconCardTroyTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardUnionPay.tsx
+++ b/packages/ui/src/icon/IconCardUnionPay.tsx
@@ -7,6 +7,7 @@ const IconCardUnionPaySvg: FunctionComponent = () => (
         aria-labelledby="iconCardUnionPayTitle"
         fill="none"
         height="24"
+        role="img"
         viewBox="0 0 35 24"
         width="35"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconCardVisa.tsx
+++ b/packages/ui/src/icon/IconCardVisa.tsx
@@ -7,6 +7,7 @@ const IconCardVisaSvg: FunctionComponent = () => (
         aria-labelledby="iconCardVisaTitle"
         fill="none"
         height="24"
+        role="img"
         viewBox="0 0 35 24"
         width="35"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconDogeCoin.tsx
+++ b/packages/ui/src/icon/IconDogeCoin.tsx
@@ -7,6 +7,7 @@ const IconDogeCoinSvg: FunctionComponent = () => (
         aria-labelledby="iconDogeCoinTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconEthereum.tsx
+++ b/packages/ui/src/icon/IconEthereum.tsx
@@ -7,6 +7,7 @@ const IconEthereumSvg: FunctionComponent = () => (
         aria-labelledby="iconEthereumTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconLiteCoin.tsx
+++ b/packages/ui/src/icon/IconLiteCoin.tsx
@@ -7,6 +7,7 @@ const IconLiteCoinSvg: FunctionComponent = () => (
         aria-labelledby="iconLiteCoinTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconShibaInu.tsx
+++ b/packages/ui/src/icon/IconShibaInu.tsx
@@ -7,6 +7,7 @@ const IconShibaInuSvg: FunctionComponent = () => (
         aria-labelledby="iconShibaInuTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/ui/src/icon/IconUsdCoin.tsx
+++ b/packages/ui/src/icon/IconUsdCoin.tsx
@@ -7,6 +7,7 @@ const IconUsdCoinSvg: FunctionComponent = () => (
         aria-labelledby="iconUsdCoinTitle"
         fill="none"
         height="48"
+        role="img"
         viewBox="0 0 70 48"
         width="70"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## What/Why?

###  What?
Adds an explicit `role="img"` to the payment icon SVGs in `packages/ui/src/icon/` (16 card brands and 7 crypto icons), and repairs two broken `aria-labelledby` references found along the way.

###  Why?
Card and crypto icons already used `aria-labelledby` pointing at an internal `<title>`, which is spec-compliant and works with modern screen readers. Adding an explicit role="img" maps them to the image role for older assistive technology versions that only expose an accessible name when the role is set.

While investigating, two icons turned out to have `aria-labelledby` pointing at ids that don't exist:

- `IconCardElectron` — its `<title>` carried Discover's id (`iconCardDiscoverTitle`). This both broke Electron's own reference *and* made `iconCardDiscoverTitle` the only duplicated id in the package, so with both brands rendered the name resolves to whichever is first in document order — Discover's icon could be announced as "Electron".
- `IconCardTroy` — referenced `iconCardToryTitle` ("Tory") while the title is `iconCardTroyTitle`.

These had to be fixed in the same change rather than deferred. Without the repair, adding `role="img"` would have made both icons *worse*: today assistive tech largely skips them, but with the role set and a dangling reference they'd be exposed as images with no accessible name.


## Rollout/Rollback
Revert the PR.

## Testing

Verified in Chrome DevTools on the payment step: each `<svg>` under `ul.creditCardTypes-list` now carries `role="img"`.

### Before
<img width="1010" height="527" alt="Before" src="https://github.com/user-attachments/assets/a562112a-8ab5-4e54-9f0c-8e4ffb76a87d" />

### After
<img width="1050" height="492" alt="After" src="https://github.com/user-attachments/assets/efc8ba60-1b59-4240-98cc-4f3357652d8b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only accessibility markup and tests on icon components; no payment processing or auth logic changes.
> 
> **Overview**
> Payment and crypto SVG icons in `packages/ui/src/icon/` now include **`role="img"`** so assistive technology consistently treats them as images with names from existing `aria-labelledby` + internal `<title>` elements.
> 
> **Accessibility fixes bundled with that change:** `IconCardElectron`’s `<title>` id was corrected from Discover’s id to `iconCardElectronTitle` (removing a duplicate-id clash with Discover). `IconCardTroy`’s `aria-labelledby` now matches `iconCardTroyTitle` instead of the dangling `iconCardToryTitle`.
> 
> **Tests:** `CreditCardIconList.test.tsx` adds coverage for named `img` roles and asserts each icon’s `aria-labelledby` references exactly one in-SVG title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a44eacc922cadc1021d5a2372e972729f7ccc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->