### PR TITLE
refactor(checkout): CHECKOUT-10329 Remove isShippingDiscountDisplayEnabled

### DIFF
--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -106,7 +106,6 @@ export interface WithCheckoutProps {
     isPersistingB2BMetadata: boolean;
     isPriceHiddenFromGuests: boolean;
     isShowingWalletButtonsOnTop: boolean;
-    isShippingDiscountDisplayEnabled: boolean;
     loginUrl: string;
     cartUrl: string;
     createAccountUrl: string;
@@ -136,7 +135,6 @@ const Checkout = ({
     isGuestEnabled,
     isShowingWalletButtonsOnTop,
     hasCartChanged,
-    isShippingDiscountDisplayEnabled,
     clearError,
     error,
     steps,
@@ -514,7 +512,6 @@ const Checkout = ({
                         consignments={consignments || []}
                         isBillingSameAsShipping={isBillingSameAsShipping}
                         isMultiShippingMode={isMultiShippingMode}
-                        isShippingDiscountDisplayEnabled={isShippingDiscountDisplayEnabled}
                         navigateNextStep={handleShippingNextStep}
                         onCreateAccount={handleShippingCreateAccount}
                         onEdit={handleEditStep}

--- a/packages/core/src/app/checkout/components/ShippingStep.tsx
+++ b/packages/core/src/app/checkout/components/ShippingStep.tsx
@@ -24,7 +24,6 @@ const Shipping = lazy(() =>
 export interface ShippingStepProps extends ShippingProps {
     cart?: Cart;
     consignments: Consignment[];
-    isShippingDiscountDisplayEnabled: boolean;
     onEdit(type: CheckoutStepType): void;
     onExpanded(type: CheckoutStepType): void;
 }
@@ -36,7 +35,6 @@ const ShippingStep: React.FC<ShippingStepProps> = ({
     consignments,
     isBillingSameAsShipping,
     isMultiShippingMode,
-    isShippingDiscountDisplayEnabled,
     onEdit,
     onExpanded,
     navigateNextStep,
@@ -86,7 +84,6 @@ const ShippingStep: React.FC<ShippingStepProps> = ({
                     cart={cart}
                     consignments={consignments}
                     isMultiShippingMode={isMultiShippingMode}
-                    isShippingDiscountDisplayEnabled={isShippingDiscountDisplayEnabled}
                 />
             }
         >

--- a/packages/core/src/app/checkout/mapToCheckoutProps.ts
+++ b/packages/core/src/app/checkout/mapToCheckoutProps.ts
@@ -2,7 +2,6 @@ import { type CheckoutSelectors, type CustomError } from '@bigcommerce/checkout-
 import { createSelector } from 'reselect';
 
 import { type CheckoutContextProps } from '@bigcommerce/checkout/contexts';
-import { isExperimentEnabled } from '@bigcommerce/checkout/utility';
 
 import { EMPTY_ARRAY } from '../common/utility';
 
@@ -40,10 +39,6 @@ export default function mapToCheckoutProps({
     );
 
     const walletButtonsOnTopFlag = Boolean(checkoutUserExperienceSettings.walletButtonsOnTop);
-    const isShippingDiscountDisplayEnabled = isExperimentEnabled(
-        data.getConfig()?.checkoutSettings,
-        'PROJECT-6643.enable_shipping_discounts_in_orders',
-    );
 
     return {
         billingAddress: data.getBillingAddress(),
@@ -54,7 +49,6 @@ export default function mapToCheckoutProps({
         hasCartChanged: submitOrderError && submitOrderError.type === 'cart_changed', // TODO: Need to clear the error once it's displayed
         isGuestEnabled,
         isLoadingCheckout: statuses.isLoadingCheckout(),
-        isShippingDiscountDisplayEnabled,
         isPending: statuses.isPending(),
         isPersistingB2BMetadata: statuses.isPersistingB2BMetadata(),
         isPriceHiddenFromGuests,

--- a/packages/core/src/app/shipping/ShippingSummary.tsx
+++ b/packages/core/src/app/shipping/ShippingSummary.tsx
@@ -8,14 +8,12 @@ import StaticConsignmentV2 from './StaticConsignmentV2';
 import StaticMultiConsignment from './StaticMultiConsignment';
 
 interface ShippingSummaryProps {
-    isShippingDiscountDisplayEnabled: boolean;
     isMultiShippingMode: boolean;
     consignments: Consignment[];
     cart: Cart;
 }
 
 const ShippingSummary: FunctionComponent<ShippingSummaryProps> = ({
-    isShippingDiscountDisplayEnabled,
     isMultiShippingMode,
     consignments,
     cart,
@@ -31,7 +29,6 @@ const ShippingSummary: FunctionComponent<ShippingSummaryProps> = ({
                             cart={cart}
                             consignment={consignment}
                             consignmentNumber={index + 1}
-                            isShippingDiscountDisplayEnabled={isShippingDiscountDisplayEnabled}
                         />
                     </div>
                 ))}
@@ -44,15 +41,9 @@ const ShippingSummary: FunctionComponent<ShippingSummaryProps> = ({
             {consignments.map((consignment) => (
                 <div className="staticConsignmentContainer" key={consignment.id}>
                     {enhancedThemeV1 ? (
-                        <StaticConsignmentV2
-                            consignment={consignment}
-                            isShippingDiscountDisplayEnabled={isShippingDiscountDisplayEnabled}
-                        />
+                        <StaticConsignmentV2 consignment={consignment} />
                     ) : (
-                        <StaticConsignment
-                            consignment={consignment}
-                            isShippingDiscountDisplayEnabled={isShippingDiscountDisplayEnabled}
-                        />
+                        <StaticConsignment consignment={consignment} />
                     )}
                 </div>
             ))}

--- a/packages/core/src/app/shipping/StaticConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticConsignment.tsx
@@ -14,13 +14,9 @@ import './StaticConsignment.scss';
 
 interface StaticConsignmentProps {
     consignment: Consignment;
-    isShippingDiscountDisplayEnabled: boolean;
 }
 
-const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
-    consignment,
-    isShippingDiscountDisplayEnabled,
-}) => {
+const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({ consignment }) => {
     const { paypalFastlaneAddresses } = usePayPalFastlaneAddress();
 
     const {
@@ -45,11 +41,7 @@ const StaticConsignment: FunctionComponent<StaticConsignmentProps> = ({
                         <StaticShippingOption
                             displayAdditionalInformation={false}
                             method={selectedShippingOption}
-                            shippingCostAfterDiscount={
-                                isShippingDiscountDisplayEnabled
-                                    ? comparisonShippingCost
-                                    : undefined
-                            }
+                            shippingCostAfterDiscount={comparisonShippingCost}
                         />
                     </div>
                 </div>

--- a/packages/core/src/app/shipping/StaticConsignmentV2.tsx
+++ b/packages/core/src/app/shipping/StaticConsignmentV2.tsx
@@ -17,13 +17,9 @@ import './StaticConsignment.scss';
 
 interface StaticConsignmentV2Props {
     consignment: Consignment;
-    isShippingDiscountDisplayEnabled: boolean;
 }
 
-const StaticConsignmentV2: FunctionComponent<StaticConsignmentV2Props> = ({
-    consignment,
-    isShippingDiscountDisplayEnabled,
-}) => {
+const StaticConsignmentV2: FunctionComponent<StaticConsignmentV2Props> = ({ consignment }) => {
     const { paypalFastlaneAddresses } = usePayPalFastlaneAddress();
     const isMobile = isMobileView();
 
@@ -56,11 +52,7 @@ const StaticConsignmentV2: FunctionComponent<StaticConsignmentV2Props> = ({
                         <StaticShippingOption
                             displayAdditionalInformation={false}
                             method={selectedShippingOption}
-                            shippingCostAfterDiscount={
-                                isShippingDiscountDisplayEnabled
-                                    ? comparisonShippingCost
-                                    : undefined
-                            }
+                            shippingCostAfterDiscount={comparisonShippingCost}
                         />
                     </div>
                 </div>

--- a/packages/core/src/app/shipping/StaticMultiConsignment.tsx
+++ b/packages/core/src/app/shipping/StaticMultiConsignment.tsx
@@ -20,14 +20,12 @@ interface StaticMultiConsignmentProps {
     consignment: Consignment;
     cart: Cart;
     consignmentNumber: number;
-    isShippingDiscountDisplayEnabled: boolean;
 }
 
 const StaticMultiConsignment: FunctionComponent<StaticMultiConsignmentProps> = ({
     consignment,
     cart,
     consignmentNumber,
-    isShippingDiscountDisplayEnabled,
 }) => {
     const { selectedState: shippingCountries } = useCheckout(({ data }) =>
         data.getShippingCountries(),
@@ -103,11 +101,7 @@ const StaticMultiConsignment: FunctionComponent<StaticMultiConsignmentProps> = (
                         <StaticShippingOption
                             displayAdditionalInformation={false}
                             method={selectedShippingOption}
-                            shippingCostAfterDiscount={
-                                isShippingDiscountDisplayEnabled
-                                    ? comparisonShippingCost
-                                    : undefined
-                            }
+                            shippingCostAfterDiscount={comparisonShippingCost}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
## What/Why?

Remove the experiment, `PROJECT-6643.enable_shipping_discounts_in_orders`.

## Rollout/Rollback

Revert.

## Testing

CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cleanup after experiment rollout; behavior change is limited to always-on display of existing comparison shipping cost in checkout shipping summaries.
> 
> **Overview**
> Removes the **`PROJECT-6643.enable_shipping_discounts_in_orders`** experiment and the **`isShippingDiscountDisplayEnabled`** prop that was threaded from checkout through shipping summary components.
> 
> **`mapToCheckoutProps`** no longer reads the experiment via `isExperimentEnabled` or passes the flag into checkout props. **`StaticConsignment`**, **`StaticConsignmentV2`**, and **`StaticMultiConsignment`** always pass **`comparisonShippingCost`** into **`StaticShippingOption`** as **`shippingCostAfterDiscount`** instead of only when the flag was on.
> 
> Shipping discount pricing in the collapsed shipping step summary is now always shown when comparison cost data exists, with no experiment gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c6534652c95d5e02971b3129de90e9714f6298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->