### PR TITLE
fix(checkout): CHECKOUT-10306 Rely on 403 error type to render customer login

### DIFF
--- a/packages/core/src/app/customer/Customer.test.tsx
+++ b/packages/core/src/app/customer/Customer.test.tsx
@@ -379,7 +379,7 @@ describe('Customer Component', () => {
                 res(
                     ctx.status(403),
                     ctx.json({
-                        type: 'about:blank',
+                        type: 'existing_customer_require_login',
                         title: 'Sign in to Your Account',
                         detail: 'This email is already associated to an account. Please login to continue.',
                     }),

--- a/packages/core/src/app/customer/Customer.tsx
+++ b/packages/core/src/app/customer/Customer.tsx
@@ -238,7 +238,11 @@ const Customer: React.FC<CustomerProps> = ({
                     return onChangeViewType(CustomerViewType.EnforcedLogin);
                 }
 
-                if (isErrorWithType(error) && error.status === 403) {
+                if (
+                    isErrorWithType(error) &&
+                    error.status === 403 &&
+                    error.body?.type === 'existing_customer_require_login'
+                ) {
                     return onChangeViewType(CustomerViewType.CancellableEnforcedLogin);
                 }
 

--- a/packages/core/src/app/customer/CustomerGuest.test.tsx
+++ b/packages/core/src/app/customer/CustomerGuest.test.tsx
@@ -542,13 +542,16 @@ describe('Customer Guest', () => {
         expect(onChangeViewType).not.toHaveBeenCalled();
     });
 
-    it('shows cancellable enforced login if API returns 403 error', async () => {
-        const email = faker.internet.email();
+    it('shows cancellable enforced login if API returns 403 error for an existing customer', async () => {
+        const mockEmail = faker.internet.email();
         const onChangeViewType = jest.fn();
 
         jest.spyOn(checkoutService, 'continueAsGuest').mockRejectedValue({
             type: 'error',
             status: 403,
+            body: {
+                type: 'existing_customer_require_login',
+            },
         });
 
         const { rerender } = render(
@@ -563,12 +566,12 @@ describe('Customer Guest', () => {
             localeContext.language.translate('customer.email_label'),
         );
 
-        await userEvent.type(emailField, email);
-        await userEvent.click(
-            screen.getByRole('button', {
-                name: localeContext.language.translate('customer.continue'),
-            }),
-        );
+        const continueButton = screen.getByRole('button', {
+            name: localeContext.language.translate('customer.continue'),
+        });
+
+        await userEvent.type(emailField, mockEmail);
+        await userEvent.click(continueButton);
 
         expect(onChangeViewType).toHaveBeenCalledWith(CustomerViewType.CancellableEnforcedLogin);
 
@@ -578,8 +581,45 @@ describe('Customer Guest', () => {
 
         expect(
             screen.getByText(
-                `Looks like you have an account. Please sign in to proceed with ${email}, or use another email.`,
+                `Looks like you have an account. Please sign in to proceed with ${mockEmail}, or use another email.`,
             ),
         ).toBeInTheDocument();
+    });
+
+    it('triggers generic error callback instead of enforcing login 403 response does not have a specific type', async () => {
+        const mockEmail = faker.internet.email();
+        const onChangeViewType = jest.fn();
+        const handleError = jest.fn();
+
+        jest.spyOn(checkoutService, 'continueAsGuest').mockRejectedValue({
+            type: 'error',
+            status: 403,
+            body: {
+                type: 'about:blank',
+            },
+        });
+
+        render(
+            <CustomerTest
+                onChangeViewType={onChangeViewType}
+                onContinueAsGuestError={handleError}
+                viewType={CustomerViewType.Guest}
+                {...defaultProps}
+            />,
+        );
+
+        const emailField = screen.getByLabelText(
+            localeContext.language.translate('customer.email_label'),
+        );
+
+        const continueButton = screen.getByRole('button', {
+            name: localeContext.language.translate('customer.continue'),
+        });
+
+        await userEvent.type(emailField, mockEmail);
+        await userEvent.click(continueButton);
+
+        expect(onChangeViewType).not.toHaveBeenCalled();
+        expect(handleError).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## What/Why?

When a user types their email at checkout, we first check if they are an existing customer or not. 

If they are an existing customer, we ask them to log in. 

This login form is triggered based on the 403 endpoint response. Previously, any 403 error would bring up the login form. Now we have an exact error type for this situation, in addition to the 403 code, introduced here: https://github.com/bigcommerce/bigcommerce/pull/69597.

This PR uses this new error type on the frontend to be more precise about rendering the login form.

## Rollout/Rollback

Revert the PR.

## Testing

New CI test + manual check that it still works as expected:

<img width="714" height="368" alt="Screenshot 2026-08-14 at 2 34 10 PM" src="https://github.com/user-attachments/assets/3a511208-a53c-46df-881c-1eeeb62ed56e" />

<img width="714" height="368" alt="Screenshot 2026-08-14 at 2 34 43 PM" src="https://github.com/user-attachments/assets/894910d7-48cb-47a2-b122-5ce198a194db" />



**NOTE: we should only merge this PR once the backend change propagates to all Tiers.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout guest-flow error handling tied to auth UX; wrong deployment order (frontend before backend on all tiers) could briefly stop showing login for existing customers until types align.
> 
> **Overview**
> **Guest checkout** no longer treats every **403** from `continueAsGuest` as “existing customer—please sign in.” The **cancellable enforced login** view only opens when the response is **403** and `error.body.type` is **`existing_customer_require_login`**, matching the new backend error contract.
> 
> Other **403** responses (e.g. `about:blank`) now follow the generic **`onContinueAsGuestError`** path instead of forcing the login UI.
> 
> Tests were updated to use the new error type in mocks and a new case confirms non-specific **403** errors do not switch view type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da82a08f1de45deafd1f5a527eb7bf2f00fb158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->