### PR TITLE
feat(checkout): CHECKOUT-10303 Fix `Same as shipping address` checkbox to be accurate

### DIFF
--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -10,6 +10,7 @@ export { default as StaticAddress } from './StaticAddress';
 export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';
+export { default as isEmptyAddress } from './isEmptyAddress';
 export { default as getAddressExtraFields } from './getAddressExtraFields';
 export { default as setDefaultAddress } from './setDefaultAddress';
 export { default as getShouldSaveAddress } from './getShouldSaveAddress';

--- a/packages/core/src/app/address/index.ts
+++ b/packages/core/src/app/address/index.ts
@@ -10,7 +10,7 @@ export { default as StaticAddress } from './StaticAddress';
 export { default as isValidAddress } from './isValidAddress';
 export { default as isValidCustomerAddress } from './isValidCustomerAddress';
 export { default as isEqualAddress } from './isEqualAddress';
-export { default as isEmptyAddress } from './isEmptyAddress';
+export { isEmptyAddress } from './isEmptyAddress';
 export { default as getAddressExtraFields } from './getAddressExtraFields';
 export { default as setDefaultAddress } from './setDefaultAddress';
 export { default as getShouldSaveAddress } from './getShouldSaveAddress';

--- a/packages/core/src/app/address/isEmptyAddress.test.ts
+++ b/packages/core/src/app/address/isEmptyAddress.test.ts
@@ -1,0 +1,63 @@
+import { getEmptyBillingAddress } from '../billing/billingAddresses.mock';
+
+import { getAddress } from './address.mock';
+import isEmptyAddress from './isEmptyAddress';
+
+describe('isEmptyAddress', () => {
+    it('returns true when the address is undefined', () => {
+        expect(isEmptyAddress(undefined)).toBe(true);
+    });
+
+    it('returns true for a guest billing address that only carries an email', () => {
+        expect(isEmptyAddress(getEmptyBillingAddress())).toBe(true);
+    });
+
+    it('returns true when only ignored or geo-prefilled fields are set', () => {
+        expect(
+            isEmptyAddress({
+                ...getEmptyBillingAddress(),
+                id: 'x',
+                email: 'test@bigcommerce.com',
+                shouldSaveAddress: true,
+                country: 'Australia',
+                countryCode: 'AU',
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false when any address field is set', () => {
+        expect(
+            isEmptyAddress({
+                ...getEmptyBillingAddress(),
+                address1: '12345 Testing Way',
+            }),
+        ).toBe(false);
+
+        expect(
+            isEmptyAddress({
+                ...getEmptyBillingAddress(),
+                firstName: 'Test',
+            }),
+        ).toBe(false);
+
+        expect(
+            isEmptyAddress({
+                ...getEmptyBillingAddress(),
+                stateOrProvince: 'California',
+            }),
+        ).toBe(false);
+    });
+
+    it('returns false when only a non-empty custom field is set', () => {
+        expect(
+            isEmptyAddress({
+                ...getEmptyBillingAddress(),
+                customFields: [{ fieldId: 'field_25', fieldValue: 'foo' }],
+            }),
+        ).toBe(false);
+    });
+
+    it('returns false for a complete address', () => {
+        expect(isEmptyAddress(getAddress())).toBe(false);
+    });
+});

--- a/packages/core/src/app/address/isEmptyAddress.test.ts
+++ b/packages/core/src/app/address/isEmptyAddress.test.ts
@@ -1,7 +1,7 @@
 import { getEmptyBillingAddress } from '../billing/billingAddresses.mock';
 
 import { getAddress } from './address.mock';
-import isEmptyAddress from './isEmptyAddress';
+import { isEmptyAddress } from './isEmptyAddress';
 
 describe('isEmptyAddress', () => {
     it('returns true when the address is undefined', () => {

--- a/packages/core/src/app/address/isEmptyAddress.ts
+++ b/packages/core/src/app/address/isEmptyAddress.ts
@@ -1,0 +1,23 @@
+import { type ComparableAddress, normalizeAddress } from './isEqualAddress';
+
+// Empty = no shopper-entered content, e.g. a guest billing address holding only an email.
+export default function isEmptyAddress(address?: ComparableAddress): boolean {
+    if (!address) {
+        return true;
+    }
+
+    const {
+        customFields = [],
+        extraFields = [],
+        countryCode: _countryCode,
+        ...fields
+    } = normalizeAddress(address);
+
+    return (
+        Object.values(fields).every((value) => !value) &&
+        customFields.length === 0 &&
+        extraFields.length === 0 &&
+        !address.stateOrProvince &&
+        !address.stateOrProvinceCode
+    );
+}

--- a/packages/core/src/app/address/isEmptyAddress.ts
+++ b/packages/core/src/app/address/isEmptyAddress.ts
@@ -1,7 +1,7 @@
 import { type ComparableAddress, normalizeAddress } from './isEqualAddress';
 
 // Empty = no shopper-entered content, e.g. a guest billing address holding only an email.
-export default function isEmptyAddress(address?: ComparableAddress): boolean {
+export function isEmptyAddress(address?: ComparableAddress): boolean {
     if (!address) {
         return true;
     }

--- a/packages/core/src/app/address/isEqualAddress.ts
+++ b/packages/core/src/app/address/isEqualAddress.ts
@@ -8,7 +8,7 @@ import { isEqual, omit } from 'lodash';
 
 import getAddressExtraFields from './getAddressExtraFields';
 
-type ComparableAddress = CustomerAddress | Address | BillingAddress | AddressRequestBody;
+export type ComparableAddress = CustomerAddress | Address | BillingAddress | AddressRequestBody;
 type ComparableAddressFields = keyof CustomerAddress | keyof Address | keyof BillingAddress;
 
 export default function isEqualAddress(
@@ -43,7 +43,7 @@ function isSameState(address1: ComparableAddress, address2: ComparableAddress): 
     );
 }
 
-function normalizeAddress(address: ComparableAddress) {
+export function normalizeAddress(address: ComparableAddress) {
     const ignoredFields: ComparableAddressFields[] = [
         'id',
         'shouldSaveAddress',

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -28,6 +28,7 @@ import {
     CheckoutPreset,
     checkoutSettings,
     checkoutWithBillingEmail,
+    checkoutWithShipping,
     checkoutWithShippingAndBilling,
     checkoutWithShippingDiscount,
     consignmentAutomaticDiscount,
@@ -791,6 +792,74 @@ describe('Checkout', () => {
                     .queryByLabelText('My billing address is the same as my shipping address.')
                     ?.hasAttribute('checked'),
             ).toBeFalsy();
+        });
+
+        it('unchecks the checkbox after the billing step saves an address that differs from shipping', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShipping);
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForBillingStep();
+            await checkout.fillAddressForm();
+
+            checkout.updateCheckout(
+                'put',
+                '/checkouts/xxxxxxxxxx-xxxx-xxax-xxxx-xxxxxx/billing-address/billing-address-id*',
+                {
+                    ...checkoutWithShippingAndBilling,
+                },
+            );
+
+            await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+            await checkout.waitForPaymentStep();
+
+            await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
+            await checkout.waitForShippingStep();
+
+            expect(
+                screen
+                    .queryByLabelText('My billing address is the same as my shipping address.')
+                    ?.hasAttribute('checked'),
+            ).toBeFalsy();
+        });
+
+        it('rechecks the checkbox after the billing step saves an address that matches shipping', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[2]);
+            await checkout.waitForBillingStep();
+            await checkout.fillAddressForm();
+
+            checkout.updateCheckout(
+                'put',
+                '/checkouts/xxxxxxxxxx-xxxx-xxax-xxxx-xxxxxx/billing-address/billing-address-id*',
+                {
+                    ...checkoutWithShipping,
+                    billingAddress: {
+                        id: 'billing-address-id',
+                        email: 'test@example.com',
+                        shouldSaveAddress: true,
+                        ...shippingAddress,
+                    },
+                },
+            );
+
+            await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+            await checkout.waitForPaymentStep();
+
+            await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
+            await checkout.waitForShippingStep();
+
+            // eslint-disable-next-line jest-dom/prefer-to-have-attribute
+            expect(
+                screen
+                    .getByLabelText('My billing address is the same as my shipping address.')
+                    .hasAttribute('checked'),
+            ).toBeTruthy();
         });
     });
 

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -4,6 +4,7 @@ import {
     createEmbeddedCheckoutMessenger,
     type EmbeddedCheckoutMessenger,
 } from '@bigcommerce/checkout-sdk';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
 import React, { act, type FunctionComponent } from 'react';
@@ -46,6 +47,10 @@ import {
 import { getCountries } from '../geography/countries.mock';
 
 import Checkout, { type CheckoutProps } from './Checkout';
+
+// The test-framework import above loads Playwright's expect, whose Locator-only matchers
+// (e.g. toBeChecked) shadow jest-dom's in the shared matcher registry; restore jest-dom's.
+expect.extend(jestDomMatchers);
 
 describe('Checkout', () => {
     let checkout: CheckoutPageNodeObject;
@@ -735,10 +740,8 @@ describe('Checkout', () => {
             await checkout.waitForShippingStep();
 
             expect(
-                screen
-                    .queryByLabelText('My billing address is the same as my shipping address.')
-                    ?.hasAttribute('checked'),
-            ).toBeFalsy();
+                screen.getByLabelText('My billing address is the same as my shipping address.'),
+            ).not.toBeChecked();
         });
 
         it('keeps the checkbox checked on reload when the saved billing address matches shipping', async () => {
@@ -761,12 +764,9 @@ describe('Checkout', () => {
             await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
             await checkout.waitForShippingStep();
 
-            // eslint-disable-next-line jest-dom/prefer-to-have-attribute
             expect(
-                screen
-                    .getByLabelText('My billing address is the same as my shipping address.')
-                    .hasAttribute('checked'),
-            ).toBeTruthy();
+                screen.getByLabelText('My billing address is the same as my shipping address.'),
+            ).toBeChecked();
         });
 
         it('seeds the checkbox from the store setting when the billing address is not set yet', async () => {
@@ -788,10 +788,8 @@ describe('Checkout', () => {
             await checkout.waitForShippingStep();
 
             expect(
-                screen
-                    .queryByLabelText('My billing address is the same as my shipping address.')
-                    ?.hasAttribute('checked'),
-            ).toBeFalsy();
+                screen.getByLabelText('My billing address is the same as my shipping address.'),
+            ).not.toBeChecked();
         });
 
         it('unchecks the checkbox after the billing step saves an address that differs from shipping', async () => {
@@ -817,10 +815,8 @@ describe('Checkout', () => {
             await checkout.waitForShippingStep();
 
             expect(
-                screen
-                    .queryByLabelText('My billing address is the same as my shipping address.')
-                    ?.hasAttribute('checked'),
-            ).toBeFalsy();
+                screen.getByLabelText('My billing address is the same as my shipping address.'),
+            ).not.toBeChecked();
         });
 
         it('rechecks the checkbox after the billing step saves an address that matches shipping', async () => {
@@ -854,12 +850,9 @@ describe('Checkout', () => {
             await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
             await checkout.waitForShippingStep();
 
-            // eslint-disable-next-line jest-dom/prefer-to-have-attribute
             expect(
-                screen
-                    .getByLabelText('My billing address is the same as my shipping address.')
-                    .hasAttribute('checked'),
-            ).toBeTruthy();
+                screen.getByLabelText('My billing address is the same as my shipping address.'),
+            ).toBeChecked();
         });
     });
 

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -26,10 +26,13 @@ import { CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration
 import {
     CheckoutPageNodeObject,
     CheckoutPreset,
+    checkoutSettings,
     checkoutWithBillingEmail,
+    checkoutWithShippingAndBilling,
     checkoutWithShippingDiscount,
     consignmentAutomaticDiscount,
     consignmentCouponDiscount,
+    shippingAddress,
 } from '@bigcommerce/checkout/test-framework';
 import { renderWithoutWrapper as render, screen, waitFor } from '@bigcommerce/checkout/test-utils';
 import { CannotCreatePersonalAccountSessionStorage } from '@bigcommerce/checkout/utility';
@@ -716,6 +719,78 @@ describe('Checkout', () => {
                     writable: true,
                 });
             }
+        });
+    });
+
+    describe('billing same as shipping checkbox', () => {
+        it('unchecks the checkbox on reload when the saved billing address differs from shipping', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling);
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
+            await checkout.waitForShippingStep();
+
+            expect(
+                screen
+                    .queryByLabelText('My billing address is the same as my shipping address.')
+                    ?.hasAttribute('checked'),
+            ).toBeFalsy();
+        });
+
+        it('keeps the checkbox checked on reload when the saved billing address matches shipping', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithShippingAndBilling, {
+                checkout: {
+                    ...checkoutWithShippingAndBilling,
+                    billingAddress: {
+                        id: 'billing-address-id',
+                        email: 'test@example.com',
+                        shouldSaveAddress: true,
+                        ...shippingAddress,
+                    },
+                },
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForPaymentStep();
+
+            await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
+            await checkout.waitForShippingStep();
+
+            // eslint-disable-next-line jest-dom/prefer-to-have-attribute
+            expect(
+                screen
+                    .getByLabelText('My billing address is the same as my shipping address.')
+                    .hasAttribute('checked'),
+            ).toBeTruthy();
+        });
+
+        it('seeds the checkbox from the store setting when the billing address is not set yet', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithBillingEmail, {
+                config: {
+                    ...checkoutSettings,
+                    storeConfig: {
+                        ...checkoutSettings.storeConfig,
+                        checkoutSettings: {
+                            ...checkoutSettings.storeConfig.checkoutSettings,
+                            checkoutBillingSameAsShippingEnabled: false,
+                        },
+                    },
+                },
+            });
+
+            render(<CheckoutTest {...defaultProps} />);
+
+            await checkout.waitForShippingStep();
+
+            expect(
+                screen
+                    .queryByLabelText('My billing address is the same as my shipping address.')
+                    ?.hasAttribute('checked'),
+            ).toBeFalsy();
         });
     });
 

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -61,6 +61,7 @@ import {
     ShippingStep,
 } from './components';
 import { deleteCartOnExit } from './deleteCartOnExit';
+import getInitialBillingSameAsShipping from './getInitialBillingSameAsShipping';
 import useB2BToken from './hooks/useB2BToken';
 import { mapCheckoutComponentErrorMessage } from './mapErrorMessage';
 import mapToCheckoutProps from './mapToCheckoutProps';
@@ -645,6 +646,8 @@ const Checkout = ({
 
                 const consignments = data.getConsignments();
                 const cart = data.getCart();
+                const initialBillingAddress = data.getBillingAddress();
+                const initialShippingAddress = data.getShippingAddress();
 
                 const hasMultiShippingEnabled =
                     data.getConfig()?.checkoutSettings.hasMultiShippingEnabled;
@@ -660,7 +663,11 @@ const Checkout = ({
 
                 setState((prevState) => ({
                     ...prevState,
-                    isBillingSameAsShipping: checkoutBillingSameAsShippingEnabled,
+                    isBillingSameAsShipping: getInitialBillingSameAsShipping({
+                        billingAddress: initialBillingAddress,
+                        shippingAddress: initialShippingAddress,
+                        defaultValue: checkoutBillingSameAsShippingEnabled,
+                    }),
                     isSubscribed: defaultNewsletterSignupOption,
                 }));
 

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -445,6 +445,24 @@ const Checkout = ({
         [],
     );
 
+    // The billing step has no same-as-shipping checkbox, so re-derive the flag
+    // from the just-saved addresses; read them at call time as the props
+    // captured before the billing update are stale.
+    const handleBillingNextStep = useCallback((): void => {
+        const { data: currentData } = checkoutService.getState();
+
+        setState((prev) => ({
+            ...prev,
+            isBillingSameAsShipping: getInitialBillingSameAsShipping({
+                billingAddress: currentData.getBillingAddress(),
+                shippingAddress: currentData.getShippingAddress(),
+                defaultValue: prev.isBillingSameAsShipping,
+            }),
+        }));
+
+        navigateToNextIncompleteStep();
+    }, [checkoutService, navigateToNextIncompleteStep]);
+
     const handleShippingSignIn = useCallback((): void => {
         setCustomerViewType(CustomerViewType.Login);
     }, [setCustomerViewType]);
@@ -530,7 +548,7 @@ const Checkout = ({
                 return (
                     <BillingStep
                         billingAddress={billingAddress}
-                        navigateNextStep={navigateToNextIncompleteStep}
+                        navigateNextStep={handleBillingNextStep}
                         onEdit={handleEditStep}
                         onExpanded={handleExpanded}
                         onReady={handleReady}

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -61,7 +61,7 @@ import {
     ShippingStep,
 } from './components';
 import { deleteCartOnExit } from './deleteCartOnExit';
-import getInitialBillingSameAsShipping from './getInitialBillingSameAsShipping';
+import { getInitialBillingSameAsShipping } from './getInitialBillingSameAsShipping';
 import useB2BToken from './hooks/useB2BToken';
 import { mapCheckoutComponentErrorMessage } from './mapErrorMessage';
 import mapToCheckoutProps from './mapToCheckoutProps';

--- a/packages/core/src/app/checkout/getInitialBillingSameAsShipping.test.ts
+++ b/packages/core/src/app/checkout/getInitialBillingSameAsShipping.test.ts
@@ -1,0 +1,70 @@
+import { getAddress } from '../address/address.mock';
+import { getBillingAddress, getEmptyBillingAddress } from '../billing/billingAddresses.mock';
+
+import getInitialBillingSameAsShipping from './getInitialBillingSameAsShipping';
+
+describe('getInitialBillingSameAsShipping', () => {
+    it('returns the store default when there is no shipping address', () => {
+        expect(
+            getInitialBillingSameAsShipping({
+                billingAddress: getBillingAddress(),
+                shippingAddress: undefined,
+                defaultValue: true,
+            }),
+        ).toBe(true);
+
+        expect(
+            getInitialBillingSameAsShipping({
+                billingAddress: getBillingAddress(),
+                shippingAddress: undefined,
+                defaultValue: false,
+            }),
+        ).toBe(false);
+    });
+
+    it('returns the store default when the billing address is empty', () => {
+        expect(
+            getInitialBillingSameAsShipping({
+                billingAddress: getEmptyBillingAddress(),
+                shippingAddress: getAddress(),
+                defaultValue: true,
+            }),
+        ).toBe(true);
+
+        expect(
+            getInitialBillingSameAsShipping({
+                billingAddress: getEmptyBillingAddress(),
+                shippingAddress: getAddress(),
+                defaultValue: false,
+            }),
+        ).toBe(false);
+
+        expect(
+            getInitialBillingSameAsShipping({
+                billingAddress: undefined,
+                shippingAddress: getAddress(),
+                defaultValue: true,
+            }),
+        ).toBe(true);
+    });
+
+    it('returns true when the billing address equals the shipping address, ignoring noise fields', () => {
+        expect(
+            getInitialBillingSameAsShipping({
+                billingAddress: { ...getBillingAddress(), ...getAddress(), id: 'billing-id' },
+                shippingAddress: getAddress(),
+                defaultValue: false,
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false when the billing address differs from the shipping address', () => {
+        expect(
+            getInitialBillingSameAsShipping({
+                billingAddress: { ...getBillingAddress(), address1: '130 Pitt St' },
+                shippingAddress: getAddress(),
+                defaultValue: true,
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/core/src/app/checkout/getInitialBillingSameAsShipping.test.ts
+++ b/packages/core/src/app/checkout/getInitialBillingSameAsShipping.test.ts
@@ -1,7 +1,7 @@
 import { getAddress } from '../address/address.mock';
 import { getBillingAddress, getEmptyBillingAddress } from '../billing/billingAddresses.mock';
 
-import getInitialBillingSameAsShipping from './getInitialBillingSameAsShipping';
+import { getInitialBillingSameAsShipping } from './getInitialBillingSameAsShipping';
 
 describe('getInitialBillingSameAsShipping', () => {
     it('returns the store default when there is no shipping address', () => {

--- a/packages/core/src/app/checkout/getInitialBillingSameAsShipping.ts
+++ b/packages/core/src/app/checkout/getInitialBillingSameAsShipping.ts
@@ -2,14 +2,14 @@ import { type Address, type BillingAddress } from '@bigcommerce/checkout-sdk/ess
 
 import { isEmptyAddress, isEqualAddress } from '../address';
 
-export interface GetInitialBillingSameAsShippingOptions {
+interface GetInitialBillingSameAsShippingOptions {
     billingAddress?: BillingAddress;
     shippingAddress?: Address;
     defaultValue: boolean;
 }
 
 // Seed from the persisted addresses when they exist; fresh checkouts fall back to the store setting.
-export default function getInitialBillingSameAsShipping({
+export function getInitialBillingSameAsShipping({
     billingAddress,
     shippingAddress,
     defaultValue,

--- a/packages/core/src/app/checkout/getInitialBillingSameAsShipping.ts
+++ b/packages/core/src/app/checkout/getInitialBillingSameAsShipping.ts
@@ -1,0 +1,22 @@
+import { type Address, type BillingAddress } from '@bigcommerce/checkout-sdk/essential';
+
+import { isEmptyAddress, isEqualAddress } from '../address';
+
+export interface GetInitialBillingSameAsShippingOptions {
+    billingAddress?: BillingAddress;
+    shippingAddress?: Address;
+    defaultValue: boolean;
+}
+
+// Seed from the persisted addresses when they exist; fresh checkouts fall back to the store setting.
+export default function getInitialBillingSameAsShipping({
+    billingAddress,
+    shippingAddress,
+    defaultValue,
+}: GetInitialBillingSameAsShippingOptions): boolean {
+    if (!shippingAddress || isEmptyAddress(billingAddress)) {
+        return defaultValue;
+    }
+
+    return isEqualAddress(billingAddress, shippingAddress);
+}


### PR DESCRIPTION
## What/Why?

- Fix `Same as shipping address` or `My billing address is same as shipping` checkbox state to honour the latest stae and not only the default checkout setting.
- If the addresses are not same on the stored checkout object the checkbox should not be enabled even if the default setting is set to `true`.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**BEFORE**
- Existing theme 

https://github.com/user-attachments/assets/72e7bd49-cced-4a7c-979f-206499cd22ef


- New theme 

https://github.com/user-attachments/assets/a4625e13-a987-40a8-a2b5-1886697a5d93



**AFTER**
- Existing theme 

https://github.com/user-attachments/assets/516900fb-0593-408a-8cd6-e75280bcddc6


- New theme 

https://github.com/user-attachments/assets/94ecea0c-6b49-44da-8727-35a1eee927c4


- B2B - QuoteToCheckout

https://github.com/user-attachments/assets/60db9ace-14ac-4d1b-ad10-f34c86224653




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout billing/shipping state derivation on load and after billing save; incorrect logic could mislead shoppers about billing address, but scope is limited and covered by new tests.
> 
> **Overview**
> Fixes the **“My billing address is the same as my shipping address”** checkbox so it reflects persisted billing/shipping data, not only the store default `checkoutBillingSameAsShippingEnabled`.
> 
> On checkout load, `CheckoutPage` now seeds `isBillingSameAsShipping` via **`getInitialBillingSameAsShipping`**, which falls back to the store setting when shipping is missing or billing is “empty” (new **`isEmptyAddress`**, e.g. guest billing with only email), otherwise uses **`isEqualAddress`**.
> 
> After the billing step saves (no checkbox there), **`handleBillingNextStep`** re-reads addresses from the checkout service and updates the flag before advancing, so returning to shipping shows the correct checked state.
> 
> Exports **`normalizeAddress`** / **`ComparableAddress`** from `isEqualAddress` for shared comparison logic. Adds unit and Checkout integration tests; restores jest-dom matchers shadowed by Playwright in `Checkout.test.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9b8a7bc64866cb108fd87ae9c022ab305228ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->