### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.956.0",
+        "@bigcommerce/checkout-sdk": "^1.958.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.956.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.956.0.tgz",
-      "integrity": "sha512-EzoAf1ybDzp6VsH4xzvC9kLAKFJyrUe+a8BsRwKeA3rNts/Q1kmopZ/7pNd1D7EAngmegcw6SjszFDPkKvCSyA==",
+      "version": "1.958.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.958.1.tgz",
+      "integrity": "sha512-hGJU12j1uPnfoH5OcMFSda2YAVWU/FiQIRttmFELg2Fo2WWdlogVuHG+NGI1+TSRjL5/DGXL/PNuLdzdhMs37Q==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.956.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.956.0.tgz",
-      "integrity": "sha512-EzoAf1ybDzp6VsH4xzvC9kLAKFJyrUe+a8BsRwKeA3rNts/Q1kmopZ/7pNd1D7EAngmegcw6SjszFDPkKvCSyA==",
+      "version": "1.958.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.958.1.tgz",
+      "integrity": "sha512-hGJU12j1uPnfoH5OcMFSda2YAVWU/FiQIRttmFELg2Fo2WWdlogVuHG+NGI1+TSRjL5/DGXL/PNuLdzdhMs37Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.956.0",
+    "@bigcommerce/checkout-sdk": "^1.958.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version
to deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3359](https://github.com/bigcommerce/checkout-sdk-js/pull/3359)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3357](https://github.com/bigcommerce/checkout-sdk-js/pull/3357)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3358](https://github.com/bigcommerce/checkout-sdk-js/pull/3358)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3352](https://github.com/bigcommerce/checkout-sdk-js/pull/3352)

## Rollout/Rollback
Rollback this PR and related in Checkout-sdk

## Testing
In checkout-sdk-js PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkout SDK updates can change payment and checkout behavior across integrations; risk depends on the linked SDK PRs, not on code changed here.
> 
> **Overview**
> Bumps the **`@bigcommerce/checkout-sdk`** dependency from **^1.956.0** to **^1.958.1** in `package.json` and `package-lock.json`. There are no application source changes in this repo—the checkout UI will pick up whatever payment/checkout behavior ships in that SDK release.
> 
> This bump is intended to deploy related work in **checkout-sdk-js** (linked PRs in the description). Rollback is reverting this PR and the corresponding SDK release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff4cccac3a57392a77636d4214d3720adb518c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->