### PR TITLE
feat(payment): PI-5626 Enable cybersource test url up sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.958.1",
+        "@bigcommerce/checkout-sdk": "^1.960.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.958.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.958.1.tgz",
-      "integrity": "sha512-hGJU12j1uPnfoH5OcMFSda2YAVWU/FiQIRttmFELg2Fo2WWdlogVuHG+NGI1+TSRjL5/DGXL/PNuLdzdhMs37Q==",
+      "version": "1.960.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.960.0.tgz",
+      "integrity": "sha512-RyibHXWvBS3H4kwhC0HaTl8K8mV5j/RarrO+cA0rIJZ9bVo6lP2lKatbv7a57ziDCyJxU0ADoUiWgPN++ve4Og==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.958.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.958.1.tgz",
-      "integrity": "sha512-hGJU12j1uPnfoH5OcMFSda2YAVWU/FiQIRttmFELg2Fo2WWdlogVuHG+NGI1+TSRjL5/DGXL/PNuLdzdhMs37Q==",
+      "version": "1.960.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.960.0.tgz",
+      "integrity": "sha512-RyibHXWvBS3H4kwhC0HaTl8K8mV5j/RarrO+cA0rIJZ9bVo6lP2lKatbv7a57ziDCyJxU0ADoUiWgPN++ve4Og==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.958.1",
+    "@bigcommerce/checkout-sdk": "^1.960.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Enable cybersource test url up sdk version

## Rollout/Rollback

roll back this commit
-->

## Testing

<!--
Provide as much information as you can about how you tested and how another
Engineer can test your change. Include screenshots, or test run output
where appropriate.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment SDK upgrades can change CyberSource behavior in checkout even without local code edits; scope is limited to a minor version bump for a targeted test-URL fix.
> 
> **Overview**
> Bumps `@bigcommerce/checkout-sdk` from **^1.958.1** to **^1.960.0** in `package.json` and `package-lock.json` only—no checkout-js source changes.
> 
> This pulls in SDK-side work (PI-5626) to **enable the CyberSource test URL** for payment flows that depend on the SDK’s CyberSource integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d472af41e2b7c4d42f83a6452bce276376c25c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->