### PR TITLE
feat(checkout): CHECKOUT-10232 Do not render wallet buttons if disableWalletButtons is true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.960.0",
+        "@bigcommerce/checkout-sdk": "^1.961.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.960.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.960.0.tgz",
-      "integrity": "sha512-RyibHXWvBS3H4kwhC0HaTl8K8mV5j/RarrO+cA0rIJZ9bVo6lP2lKatbv7a57ziDCyJxU0ADoUiWgPN++ve4Og==",
+      "version": "1.961.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.961.0.tgz",
+      "integrity": "sha512-xt8B8QFgL75+9tk0vbc+KI47g6JwAQGU6HZBwIHsmGrmMSZr0HK92ShB4bygThMsp+JU7cMDH2xDtLG9Z2Cepg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.960.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.960.0.tgz",
-      "integrity": "sha512-RyibHXWvBS3H4kwhC0HaTl8K8mV5j/RarrO+cA0rIJZ9bVo6lP2lKatbv7a57ziDCyJxU0ADoUiWgPN++ve4Og==",
+      "version": "1.961.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.961.0.tgz",
+      "integrity": "sha512-xt8B8QFgL75+9tk0vbc+KI47g6JwAQGU6HZBwIHsmGrmMSZr0HK92ShB4bygThMsp+JU7cMDH2xDtLG9Z2Cepg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.960.0",
+    "@bigcommerce/checkout-sdk": "^1.961.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -6,6 +6,7 @@ export const defaultCapabilities: Capabilities = {
         disableEditCart: false,
         disableGiftCertificate: false,
         disableStoreCredit: false,
+        disableWalletButtons: false,
         hasCompanyAddressBook: false,
         hasAddressExtraFields: false,
         hasOrderExtraFields: false,

--- a/packages/core/src/app/customer/CheckoutButtonContainer.test.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.test.tsx
@@ -6,7 +6,11 @@ import {
 import { noop } from 'lodash';
 import React, { type FunctionComponent } from 'react';
 
-import { CheckoutProvider, LocaleProvider } from '@bigcommerce/checkout/contexts';
+import {
+    CheckoutProvider,
+    defaultCapabilities,
+    LocaleProvider,
+} from '@bigcommerce/checkout/contexts';
 import { getLanguageService } from '@bigcommerce/checkout/locale';
 import { type CheckoutButtonProps } from '@bigcommerce/checkout/payment-integration-api';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
@@ -107,6 +111,33 @@ describe('CheckoutButtonContainer', () => {
         const { container } = renderCheckoutButtonContainer();
 
         expect(container).toBeEmptyDOMElement();
+    });
+
+    it('does not render when the disableWalletButtons capability is enabled', () => {
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                remoteCheckoutProviders: ['applepay'],
+                capabilities: {
+                    ...defaultCapabilities,
+                    userJourney: {
+                        ...defaultCapabilities.userJourney,
+                        disableWalletButtons: true,
+                    },
+                },
+            },
+        });
+
+        const { container } = renderCheckoutButtonContainer();
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders wallet buttons when disableWalletButtons capability is absent', async () => {
+        renderCheckoutButtonContainer();
+
+        expect(await screen.findByTestId('applepayCheckoutButton')).toBeInTheDocument();
     });
 
     it('does not render when payment data is not required', () => {

--- a/packages/core/src/app/customer/CheckoutButtonContainer.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonContainer.tsx
@@ -1,7 +1,11 @@
 import { type CheckoutSelectors, type CheckoutService } from '@bigcommerce/checkout-sdk';
 import React, { type FunctionComponent, lazy, memo, Suspense } from 'react';
 
-import { type CheckoutContextProps, useLocale } from '@bigcommerce/checkout/contexts';
+import {
+    type CheckoutContextProps,
+    useCapabilities,
+    useLocale,
+} from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { WalletButtonsContainerSkeleton } from '@bigcommerce/checkout/ui';
 import { isExperimentEnabled } from '@bigcommerce/checkout/utility';
@@ -46,6 +50,13 @@ const CheckoutButtonContainer: FunctionComponent<
     onWalletButtonClick,
 }) => {
     const { language } = useLocale();
+    const {
+        userJourney: { disableWalletButtons },
+    } = useCapabilities();
+
+    if (disableWalletButtons) {
+        return null;
+    }
 
     try {
         checkEmbeddedSupport(availableMethodIds);

--- a/packages/core/src/app/customer/CheckoutButtonList.test.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.test.tsx
@@ -1,24 +1,40 @@
+import {
+    type CheckoutSelectors,
+    type CheckoutService,
+    createCheckoutService,
+} from '@bigcommerce/checkout-sdk';
 import { noop } from 'lodash';
 import React from 'react';
 
+import { CheckoutProvider, defaultCapabilities } from '@bigcommerce/checkout/contexts';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
 import { getStoreConfig } from '../config/config.mock';
 
-import CheckoutButtonList from './CheckoutButtonList';
+import CheckoutButtonList, { type CheckoutButtonListProps } from './CheckoutButtonList';
 
 describe('CheckoutButtonList', () => {
-    const checkoutSettings = getStoreConfig().checkoutSettings;
+    let checkoutService: CheckoutService;
+    let checkoutState: CheckoutSelectors;
+
+    const renderCheckoutButtonList = (props: Partial<CheckoutButtonListProps> = {}) =>
+        render(
+            <CheckoutProvider checkoutService={checkoutService}>
+                <CheckoutButtonList deinitialize={noop} initialize={noop} {...props} />
+            </CheckoutProvider>,
+        );
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+        checkoutState = checkoutService.getState();
+
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
+    });
 
     it('filters out unsupported methods', async () => {
-        render(
-            <CheckoutButtonList
-                checkoutSettings={checkoutSettings}
-                deinitialize={noop}
-                initialize={noop}
-                methodIds={['applepay', 'amazonpay', 'braintreevisacheckout']}
-            />,
-        );
+        renderCheckoutButtonList({
+            methodIds: ['applepay', 'amazonpay', 'braintreevisacheckout'],
+        });
 
         expect(await screen.findByTestId('applepayCheckoutButton')).toBeInTheDocument();
         expect(
@@ -28,42 +44,50 @@ describe('CheckoutButtonList', () => {
     });
 
     it('does not crash when no methods are passed', () => {
-        render(
-            <CheckoutButtonList
-                checkoutSettings={checkoutSettings}
-                deinitialize={noop}
-                initialize={noop}
-            />,
-        );
+        renderCheckoutButtonList();
 
         expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
     });
 
     it('does not render if there are no supported methods', () => {
-        render(
-            <CheckoutButtonList
-                checkoutSettings={checkoutSettings}
-                deinitialize={noop}
-                initialize={noop}
-                methodIds={['foobar']}
-            />,
-        );
+        renderCheckoutButtonList({ methodIds: ['foobar'] });
 
         expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
     });
 
     it('does not render the translated string when initializing', () => {
-        render(
-            <CheckoutButtonList
-                checkoutSettings={checkoutSettings}
-                deinitialize={noop}
-                initialize={noop}
-                isInitializing={true}
-                methodIds={['amazonpay', 'braintreevisacheckout']}
-            />,
-        );
+        renderCheckoutButtonList({
+            isInitializing: true,
+            methodIds: ['amazonpay', 'braintreevisacheckout'],
+        });
 
         expect(screen.queryByText('Or continue with')).not.toBeInTheDocument();
+    });
+
+    it('does not render wallet buttons when the disableWalletButtons capability is true', () => {
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue({
+            ...getStoreConfig(),
+            checkoutSettings: {
+                ...getStoreConfig().checkoutSettings,
+                capabilities: {
+                    ...defaultCapabilities,
+                    userJourney: {
+                        ...defaultCapabilities.userJourney,
+                        disableWalletButtons: true,
+                    },
+                },
+            },
+        });
+
+        const { container } = renderCheckoutButtonList({ methodIds: ['applepay'] });
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders wallet buttons when the disableWalletButtons capability is absent', async () => {
+        renderCheckoutButtonList({ methodIds: ['applepay'] });
+
+        expect(await screen.findByTestId('applepayCheckoutButton')).toBeInTheDocument();
     });
 
     it('notifies parent if methods are incompatible with Embedded Checkout', () => {
@@ -73,16 +97,11 @@ describe('CheckoutButtonList', () => {
             throw new Error();
         });
 
-        render(
-            <CheckoutButtonList
-                checkEmbeddedSupport={checkEmbeddedSupport}
-                checkoutSettings={checkoutSettings}
-                deinitialize={noop}
-                initialize={noop}
-                methodIds={methodIds}
-                onError={onError}
-            />,
-        );
+        renderCheckoutButtonList({
+            checkEmbeddedSupport,
+            methodIds,
+            onError,
+        });
 
         expect(checkEmbeddedSupport).toHaveBeenCalledWith(methodIds);
 

--- a/packages/core/src/app/customer/CheckoutButtonList.tsx
+++ b/packages/core/src/app/customer/CheckoutButtonList.tsx
@@ -7,7 +7,11 @@ import {
 import { noop } from 'lodash';
 import React, { type FunctionComponent, lazy, memo } from 'react';
 
-import { type CheckoutContextProps, useLocale } from '@bigcommerce/checkout/contexts';
+import {
+    type CheckoutContextProps,
+    useCapabilities,
+    useLocale,
+} from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { LazyContainer } from '@bigcommerce/checkout/ui';
 
@@ -51,7 +55,15 @@ const CheckoutButtonList: FunctionComponent<
     onError,
 }) => {
     const { language } = useLocale();
+    const {
+        userJourney: { disableWalletButtons },
+    } = useCapabilities();
     const paymentMethods = checkoutState.data.getPaymentMethods();
+
+    if (disableWalletButtons) {
+        return null;
+    }
+
     const supportedMethodIds = getSupportedMethodIds(methodIds, paymentMethods);
 
     if (supportedMethodIds.length === 0) {


### PR DESCRIPTION
## What/Why?

We added a new disableWalletButtons capability in these PRs: 
https://github.com/bigcommerce/bigcommerce/pull/69687
https://github.com/bigcommerce/checkout-sdk-js/pull/3362

This PR uses the capability to control wallet buttons behavior. If this capability is set to `true`, then we do not render wallet buttons. In all other scenarios the behavior should stay the same.

## Rollout/Rollback

Revert the PR.

## Testing

New CI tests + manual testing that wallet buttons still render as usual when the capability is not set:

<img width="1491" height="758" alt="Screenshot 2026-08-19 at 12 27 02 PM" src="https://github.com/user-attachments/assets/57fc80da-66ee-47c7-a8ba-095cfd5a6935" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating of wallet buttons behind a checkout capability with a safe default; no auth or payment flow changes.
> 
> **Overview**
> When checkout settings expose **`userJourney.disableWalletButtons`**, wallet / express checkout buttons no longer render in **`CheckoutButtonContainer`** and **`CheckoutButtonList`** (early `return null` via `useCapabilities()`).
> 
> **`defaultCapabilities`** now includes **`disableWalletButtons: false`** so behavior stays unchanged when the flag is unset. **`@bigcommerce/checkout-sdk`** is bumped to **^1.961.0** for the capability definition. Tests cover both the disabled and default paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 757d47a541357acee1ba3e76ce9acf7eee12f720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->