### PR TITLE
fix(checkout): CHECKOUT-10342 Fix multi-shipping modal alignment

### DIFF
--- a/packages/core/src/app/shipping/MultiShippingForm.scss
+++ b/packages/core/src/app/shipping/MultiShippingForm.scss
@@ -93,6 +93,7 @@ $allocate-items-table-image-width-small-screen: 40%;
 .modal.modal--afterOpen.modal.modal--confirm {
     min-height: 0;
     top: 50%;
+    right: auto;
     bottom: auto;
     left: 50%;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
## What/Why?

For bigger screens the "Ship to a Single Address instead" modal is not aligned correctly (for smaller screens it looks ok). This PR fixes it. The behavior is the same for both classic and enhanced theme.

## Rollout/Rollback

Revert the PR.

## Testing

Manual testing.

Before:
<img width="1910" height="1006" alt="Screenshot 2026-08-18 at 1 59 26 PM" src="https://github.com/user-attachments/assets/2be24cb3-719a-47a4-8df8-1ea12a8e13f9" />
<img width="1910" height="1006" alt="Screenshot 2026-08-18 at 1 54 13 PM" src="https://github.com/user-attachments/assets/84099092-25c3-41ff-889a-2f2807dc2329" />

After:

<img width="1910" height="1006" alt="Screenshot 2026-08-18 at 2 33 16 PM" src="https://github.com/user-attachments/assets/f04c1991-093c-4d95-b9f7-3c4770b29bd3" />
<img width="1907" height="963" alt="Screenshot 2026-08-18 at 2 34 42 PM" src="https://github.com/user-attachments/assets/ac79e20d-3d2e-463e-861b-99109a7f66e2" />


Still looks ok for mobile / smaller resolutions:
<img width="771" height="639" alt="Screenshot 2026-08-18 at 2 34 00 PM" src="https://github.com/user-attachments/assets/d6ee1ab0-afe0-41b0-b32d-8aceda53c6b1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS property in checkout shipping modal styling with no logic or data changes.
> 
> **Overview**
> Fixes horizontal misalignment of the **“Ship to a Single Address instead”** confirm modal on large viewports in multi-shipping checkout.
> 
> Adds `right: auto` to the `.modal--confirm` override in `MultiShippingForm.scss`, alongside the existing `left: 50%` and `transform: translate(-50%, -50%)` centering—matching the allocate-items modal pattern so a default `right` value no longer offsets the dialog on wide screens. Classic and enhanced themes share this stylesheet; mobile layout is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a84ef10ae45b643e5167907358018bd36a47813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->