### PR TITLE
feat(checkout): CHECKOUT-10304 Minor ui-ux fixes for enhancedThemeV1

### DIFF
--- a/packages/core/src/app/payment/PaymentSubmitButton.tsx
+++ b/packages/core/src/app/payment/PaymentSubmitButton.tsx
@@ -162,7 +162,7 @@ const PaymentSubmitButton: FunctionComponent<
                         methodId as PaymentMethodId,
                     ),
                 },
-                enhancedThemeV1 ? 'header' : 'sub-header',
+                'sub-header',
             )}
             data-test="payment-submit-button"
             disabled={isInitializing || isSubmitting || isDisabled}

--- a/packages/core/src/scss/enhancedThemeV1/common/_common.scss
+++ b/packages/core/src/scss/enhancedThemeV1/common/_common.scss
@@ -4,6 +4,7 @@ $element-border-radius: remCalc(12px);
     .button,
     .shippingOptions-panel,
     .alertBox,
+    .discountBanner .alertBox,
     .applied-coupons-list ul,
     &.modal {
         border-radius: $element-border-radius;

--- a/packages/core/src/scss/enhancedThemeV1/components/checkout/_checklist.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/checkout/_checklist.scss
@@ -65,7 +65,7 @@
         }
 
         &:focus ~ .form-label {
-            box-shadow: $checklist-focus-boxShadow;
+            box-shadow: none;
         }
 
         & ~ .form-label::before {

--- a/packages/core/src/scss/enhancedThemeV1/components/checkout/_checkout.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/checkout/_checkout.scss
@@ -88,6 +88,11 @@
         .checkout-button-container {
             padding: 0 #{spacing("base") + spacing("base")};
             margin-top: spacing("single");
+            text-align: center;
+
+            .checkoutRemote {
+                place-items: center;
+            }
         }
     }
 

--- a/packages/core/src/scss/enhancedThemeV1/components/checkout/_payment-billing.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/checkout/_payment-billing.scss
@@ -1,5 +1,5 @@
 .checkout-billing {
     @include enhancedThemeV1 {
-        margin-block: spacing("single");
+        margin-block: spacing("half");
     }
 }

--- a/packages/core/src/scss/enhancedThemeV1/font/_font.scss
+++ b/packages/core/src/scss/enhancedThemeV1/font/_font.scss
@@ -44,7 +44,7 @@
         font-weight: $fontWeight-bold;
     }
 
-    .header {
+    .sub-header {
         &.button--primary {
             text-transform: none;
         }

--- a/packages/core/src/scss/enhancedThemeV1/form/_form.scss
+++ b/packages/core/src/scss/enhancedThemeV1/form/_form.scss
@@ -54,4 +54,8 @@
     .checkout-step--payment .form-field .form-label.body-medium {
         font-size: $fontSize-tiny;
     }
+
+    .form-legend.sub-header {
+        margin-bottom: 0;
+    }
 }


### PR DESCRIPTION
## What/Why?

- Reduce `Place order` button text size to be same as other buttons.
- Use the same radius for Promotion banner too.
- Center align the wallet button and 'Checkout faster with' so the layout is not awkward when there's one wallet button only. 
- Remove the extra padding in between labels and their objects. e.g. padding between "Billing address" and the checkbox, and "Terms and conditions" and the field.
- Remove the blue container box on payment selection.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

https://github.com/user-attachments/assets/4667e052-ef0d-4c55-ad68-71008b7a6afc

<img width="583" height="206" alt="Screenshot 2026-08-19 at 4 43 14 pm" src="https://github.com/user-attachments/assets/668a3527-b93c-42fc-8d9f-652fc9266180" />
<img width="563" height="153" alt="Screenshot 2026-08-19 at 4 43 42 pm" src="https://github.com/user-attachments/assets/2a1e6b85-a90c-4c83-b29a-a46e49747f06" />
<img width="546" height="232" alt="Screenshot 2026-08-19 at 4 44 01 pm" src="https://github.com/user-attachments/assets/095953f1-0002-4df3-8ddd-442e4d6631c2" />
<img width="594" height="425" alt="Screenshot 2026-08-19 at 4 44 14 pm" src="https://github.com/user-attachments/assets/8d84db82-b481-410b-aadf-68a8ab8e3554" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SCSS and a single button className change for theme styling only; no auth, payment processing, or data flow changes.
> 
> **Overview**
> Polishes **enhancedThemeV1** checkout spacing, typography, and alignment without changing payment or checkout logic.
> 
> The **Place order** button in `PaymentSubmitButton` always uses the `sub-header` class (instead of `header` when enhanced theme is on), matching other primary continue buttons. Font rules target `.sub-header.button--primary` for the same sizing behavior.
> 
> **Promotion / discount** banners get the shared 12px border radius via `.discountBanner .alertBox`. **Wallet / remote checkout** rows are centered in `.checkout-button-container` (`text-align` and `place-items` on `.checkoutRemote`).
> 
> **Payment method checklist** focus no longer applies the blue focus box-shadow on labels. **Billing** block vertical margin is halved. **Form legends** with `sub-header` drop extra bottom margin to tighten label-to-control gaps (e.g. billing checkbox, terms).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b0f0a05de5885553ff3da0e502c1b8a8a9b4bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->