### PR TITLE
feat(checkout): CHECKOUT-10304 ui-ux changes for order summary for enhancedThemeV1

### DIFF
--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -7,16 +7,18 @@ import {
 import React, { type FunctionComponent, type ReactNode } from 'react';
 
 import { Extension } from '@bigcommerce/checkout/checkout-extension';
-import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useLocale, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { TranslatedHtml, TranslatedString } from '@bigcommerce/checkout/locale';
 
 import { OrderSummarySubtotals, type OrderSummarySubtotalsProps } from '../coupon';
 
+import getItemsCount from './getItemsCount';
 import OrderSummaryHeader from './OrderSummaryHeader';
 import OrderSummaryItems from './OrderSummaryItems';
 import OrderSummaryPrice from './OrderSummaryPrice';
 import OrderSummarySection from './OrderSummarySection';
 import OrderSummaryTotal from './OrderSummaryTotal';
+import { getNonBundledItems } from './removeBundledItems';
 
 export interface OrderSummaryProps {
     lineItems: LineItemMap;
@@ -41,6 +43,7 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
     const displayInclusiveTax = isTaxIncluded && taxes && taxes.length > 0;
 
     const { currency } = useLocale();
+    const { enhancedThemeV1 } = useThemeContext();
 
     const {
         selectedState: { checkout, order },
@@ -58,12 +61,21 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
 
     const isTotalDiscountVisible = Boolean(totalDiscount && totalDiscount > 0);
 
+    // Must match the de-bundling in OrderSummaryItems so the header count equals the item list.
+    const { nonBundledItems } = getNonBundledItems(lineItems, order?.bundledItems);
+
     return (
         <article className="cart optimizedCheckout-orderSummary" data-test="cart">
-            {showHeader && <OrderSummaryHeader>{headerLink}</OrderSummaryHeader>}
+            {showHeader && (
+                <OrderSummaryHeader
+                    itemsCount={enhancedThemeV1 ? getItemsCount(nonBundledItems) : undefined}
+                >
+                    {headerLink}
+                </OrderSummaryHeader>
+            )}
 
             <OrderSummarySection>
-                <OrderSummaryItems displayLineItemsCount items={lineItems} />
+                <OrderSummaryItems displayLineItemsCount={!enhancedThemeV1} items={lineItems} />
             </OrderSummarySection>
 
             <Extension region={ExtensionRegion.SummaryLastItemAfter} />
@@ -92,26 +104,26 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
                         />
                     </div>
                 )}
-            </OrderSummarySection>
 
-            {displayInclusiveTax && (
-                <OrderSummarySection>
-                    <h5
-                        className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary body-regular"
-                        data-test="tax-text"
-                    >
-                        <TranslatedString id="tax.inclusive_label" />
-                    </h5>
-                    {(taxes || []).map((tax, index) => (
-                        <OrderSummaryPrice
-                            amount={tax.amount}
-                            key={index}
-                            label={tax.name}
-                            testId="cart-taxes"
-                        />
-                    ))}
-                </OrderSummarySection>
-            )}
+                {displayInclusiveTax && (
+                    <>
+                        <h5
+                            className="cart-taxItem cart-taxItem--subtotal optimizedCheckout-contentPrimary body-regular"
+                            data-test="tax-text"
+                        >
+                            <TranslatedString id="tax.inclusive_label" />
+                        </h5>
+                        {(taxes || []).map((tax, index) => (
+                            <OrderSummaryPrice
+                                amount={tax.amount}
+                                key={index}
+                                label={tax.name}
+                                testId="cart-taxes"
+                            />
+                        ))}
+                    </>
+                )}
+            </OrderSummarySection>
         </article>
     );
 };

--- a/packages/core/src/app/order/OrderSummaryHeader.tsx
+++ b/packages/core/src/app/order/OrderSummaryHeader.tsx
@@ -2,11 +2,28 @@ import React, { type FunctionComponent } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 
-const OrderSummaryHeader: FunctionComponent<{ children?: React.ReactNode }> = ({ children }) => {
+interface OrderSummaryHeaderProps {
+    children?: React.ReactNode;
+    itemsCount?: number;
+}
+
+const OrderSummaryHeader: FunctionComponent<OrderSummaryHeaderProps> = ({
+    children,
+    itemsCount,
+}) => {
+    const showItemsCount = itemsCount !== undefined;
+
     return (
         <header className="cart-header">
-            <h3 className="cart-title optimizedCheckout-headingSecondary sub-header">
-                <TranslatedString id="cart.cart_heading" />
+            <h3
+                className="cart-title optimizedCheckout-headingSecondary sub-header"
+                data-test={showItemsCount ? 'cart-count-total' : undefined}
+            >
+                {showItemsCount ? (
+                    <TranslatedString data={{ count: itemsCount }} id="cart.item_count_text" />
+                ) : (
+                    <TranslatedString id="cart.cart_heading" />
+                )}
             </h3>
             {children}
         </header>

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -27,7 +27,7 @@ import mapFromDigital from './mapFromDigital';
 import mapFromGiftCertificate from './mapFromGiftCertificate';
 import mapFromPhysical from './mapFromPhysical';
 import OrderSummaryItem from './OrderSummaryItem';
-import { buildBundleItemsMapFromOrder, removeAndBundleItemsTogether } from './removeBundledItems';
+import { getNonBundledItems } from './removeBundledItems';
 
 // Module-scoped to survive the responsive remount. Safe as MobileView mounts only one instance at a time.
 let backorderDetailsExpanded = false;
@@ -214,9 +214,7 @@ const OrderSummaryItems = ({
 
     const expandBackorderDetails = showBackorderSwitch && showBackorderDetails;
 
-    const { nonBundledItems, bundleItemsMap } = order?.bundledItems
-        ? buildBundleItemsMapFromOrder(items, order.bundledItems)
-        : removeAndBundleItemsTogether(items);
+    const { nonBundledItems, bundleItemsMap } = getNonBundledItems(items, order?.bundledItems);
 
     const collapsedLimit = isSmallScreen()
         ? COLLAPSED_ITEMS_LIMIT_SMALL_SCREEN

--- a/packages/core/src/app/order/removeBundledItems.ts
+++ b/packages/core/src/app/order/removeBundledItems.ts
@@ -62,6 +62,18 @@ export function removeBundledItems(lineItems: LineItemMap): LineItemMap {
     };
 }
 
+export function getNonBundledItems(
+    items: LineItemMap,
+    orderBundledItems?: Pick<LineItemMap, 'physicalItems' | 'digitalItems'>,
+): {
+    nonBundledItems: LineItemMap;
+    bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>>;
+} {
+    return orderBundledItems
+        ? buildBundleItemsMapFromOrder(items, orderBundledItems)
+        : removeAndBundleItemsTogether(items);
+}
+
 export function removeAndBundleItemsTogether(items: LineItemMap): {
     nonBundledItems: LineItemMap;
     bundleItemsMap: Map<string | number, Array<PhysicalItem | DigitalItem>>;

--- a/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
+++ b/packages/core/src/app/shipping/hooks/useMultishippingConsignmentItems.ts
@@ -2,6 +2,7 @@ import { type Consignment, type LineItemMap } from '@bigcommerce/checkout-sdk';
 
 import { useCheckout } from '@bigcommerce/checkout/contexts';
 
+import { removeBundledItems } from '../../order/removeBundledItems';
 import {
     LineItemType,
     type MultiShippingConsignmentData,
@@ -13,15 +14,6 @@ import { generateItemHash } from '../utils';
 interface MultiShippingConsignmentItemsHook {
     unassignedItems: MultiShippingTableData;
     consignmentList: MultiShippingConsignmentData[];
-}
-
-// TODO: consolidate this from /app/order/removeBundledItems
-function removeBundledItems(lineItems: LineItemMap): LineItemMap {
-    return {
-        ...lineItems,
-        physicalItems: lineItems.physicalItems.filter((item) => typeof item.parentId !== 'string'),
-        digitalItems: lineItems.digitalItems.filter((item) => typeof item.parentId !== 'string'),
-    };
 }
 
 const calculateShippableItemsCount = (items: MultiShippingTableItemWithType[]): number => {


### PR DESCRIPTION
## What/Why?

- Update order summary to remove `Order Summary` title and moving 'x item' to where 'Order Summary' is today,
- Remove the divider line above tax total for a more unified look.  (done in general and not only for enhancedThemeV1).
- Also consolidate `removeBundledItems` in `useMultiShippingConsignmentItems`

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**BEFORE**
<img width="476" height="673" alt="Screenshot 2026-08-19 at 4 48 04 pm" src="https://github.com/user-attachments/assets/5ca4a0e7-27bc-43f3-a104-2a5e430beaa4" />


**AFTER**
<img width="425" height="635" alt="Screenshot 2026-08-19 at 4 48 19 pm" src="https://github.com/user-attachments/assets/050369f4-675d-4d4b-994b-e84ff843f429" />
<img width="354" height="725" alt="Screenshot 2026-08-19 at 4 48 55 pm" src="https://github.com/user-attachments/assets/dbd01460-2a47-403c-9128-5567b628d6f7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Most changes are presentation and theme-gated; inclusive tax markup is a small layout change with no payment or data logic.
> 
> **Overview**
> For **enhancedThemeV1**, the order summary header now shows the **item count** (`cart.item_count_text`) instead of the “Order Summary” title, using the same de-bundled line items as the list so counts stay aligned. The duplicate count above the product list is turned off when that theme flag is on.
> 
> **Inclusive tax** rows are rendered inside the same totals section as the order total (for all themes), which removes the extra divider between total and tax.
> 
> Bundling logic is centralized via **`getNonBundledItems`**, and multishipping reuses the shared **`removeBundledItems`** export instead of a local copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548d5f229f68b6f53d39e7198234554515964c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->