### PR TITLE
feat(checkout): CHECKOUT-10304 UI-UX changes for customer login form for enhancedThemeV1

### DIFF
--- a/packages/core/src/app/customer/LoginForm.tsx
+++ b/packages/core/src/app/customer/LoginForm.tsx
@@ -1,9 +1,13 @@
 import { type FormikProps, withFormik } from 'formik';
 import { noop } from 'lodash';
-import React, { type FunctionComponent, memo, useCallback } from 'react';
+import React, { type FunctionComponent, memo, useCallback, useEffect } from 'react';
 import { object, string } from 'yup';
 
-import { useCheckout } from '@bigcommerce/checkout/contexts';
+import {
+    useCheckout,
+    useSetCheckoutStepHeaderAction,
+    useThemeContext,
+} from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import {
     TranslatedHtml,
@@ -65,6 +69,8 @@ const LoginForm: FunctionComponent<
     isFloatingLabelEnabled,
     viewType = CustomerViewType.Login,
 }) => {
+    const { enhancedThemeV1 } = useThemeContext();
+    const setHeaderAction = useSetCheckoutStepHeaderAction();
     const { checkoutState } = useCheckout(
         ({
             data: { getCart, getConfig },
@@ -99,6 +105,31 @@ const LoginForm: FunctionComponent<
     } = config;
 
     const isBuyNowCart = cart.source === 'BUY_NOW';
+
+    const showContinueAsGuestHeaderAction =
+        enhancedThemeV1 && canCancel && viewType === CustomerViewType.Login;
+
+    useEffect(() => {
+        if (!showContinueAsGuestHeaderAction) {
+            setHeaderAction(null);
+
+            return;
+        }
+
+        setHeaderAction(
+            <a
+                className="body-cta"
+                data-test="customer-continue-as-guest-link"
+                href="#"
+                id="checkout-customer-continue-as-guest"
+                onClick={preventDefault(onCancel)}
+            >
+                <TranslatedString id="customer.continue_checkout_as_guest_action" />
+            </a>,
+        );
+
+        return () => setHeaderAction(null);
+    }, [showContinueAsGuestHeaderAction, onCancel, setHeaderAction]);
 
     const changeEmailLink = useCallback(() => {
         if (!email) {
@@ -191,14 +222,16 @@ const LoginForm: FunctionComponent<
                                 </a>
                             )}
                     </span>
-                    {viewType === CustomerViewType.Login && shouldShowCreateAccountLink && (
-                        <span>
-                            <TranslatedLink
-                                id="customer.create_account_to_continue_text"
-                                onClick={onCreateAccount}
-                            />
-                        </span>
-                    )}
+                    {!enhancedThemeV1 &&
+                        viewType === CustomerViewType.Login &&
+                        shouldShowCreateAccountLink && (
+                            <span>
+                                <TranslatedLink
+                                    id="customer.create_account_to_continue_text"
+                                    onClick={onCreateAccount}
+                                />
+                            </span>
+                        )}
                 </p>
 
                 <div className="form-actions">
@@ -219,7 +252,13 @@ const LoginForm: FunctionComponent<
                             type="submit"
                             variant={ButtonVariant.Primary}
                         >
-                            <TranslatedString id="customer.sign_in_action" />
+                            <TranslatedString
+                                id={
+                                    enhancedThemeV1
+                                        ? 'customer.sign_in_action_v2'
+                                        : 'customer.sign_in_action'
+                                }
+                            />
                         </Button>
                     )}
 
@@ -235,9 +274,24 @@ const LoginForm: FunctionComponent<
                         </a>
                     )}
 
+                    {enhancedThemeV1 &&
+                        viewType === CustomerViewType.Login &&
+                        shouldShowCreateAccountLink && (
+                            <a
+                                className="button optimizedCheckout-buttonSecondary body-bold"
+                                data-test="customer-create-account-button"
+                                href="#"
+                                id="checkout-customer-create-account"
+                                onClick={preventDefault(onCreateAccount)}
+                            >
+                                <TranslatedString id="customer.create_account_instead_action" />
+                            </a>
+                        )}
+
                     {canCancel &&
                         viewType !== CustomerViewType.EnforcedLogin &&
-                        viewType !== CustomerViewType.SuggestedLogin && (
+                        viewType !== CustomerViewType.SuggestedLogin &&
+                        !(enhancedThemeV1 && viewType === CustomerViewType.Login) && (
                             <a
                                 className="button optimizedCheckout-buttonSecondary body-bold"
                                 data-test="customer-cancel-button"

--- a/packages/core/src/scss/enhancedThemeV1/font/_font.scss
+++ b/packages/core/src/scss/enhancedThemeV1/font/_font.scss
@@ -52,7 +52,10 @@
 
     #checkout-customer-continue,
     #stripe-checkout-customer-continue,
-    #checkout-shipping-continue {
+    #checkout-shipping-continue,
+    #checkout-customer-create-account,
+    #checkout-customer-create,
+    #checkout-customer-cancel {
         text-transform: none;
     }
 

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -137,7 +137,9 @@
         "customer": {
             "continue_as_guest_action": "Continue as guest",
             "continue_as_stripe_customer_action": "Continue with Link",
+            "continue_checkout_as_guest_action": "Continue checkout as a guest",
             "create_account_action": "Create Account",
+            "create_account_instead_action": "Create an account instead",
             "continue": "Continue",
             "continue_to_shipping_action": "Continue to Shipping",
             "set_password_action": "Save Password",
@@ -183,6 +185,7 @@
             "reset_password_before_login_error": "Sign-in is currently unavailable. You will receive an e-mail in the next 5 minutes with instructions for resetting your password. If you don't receive this e-mail, please check your junk mail folder or contact us for further assistance.",
             "returning_customer_text": "Returning Customer",
             "sign_in_action": "Sign In",
+            "sign_in_action_v2": "Sign in",
             "sign_in_error": "The email or password you entered is not valid.",
             "sign_in_throttled_error": "Due to excessive login attempts, please wait 10 seconds before attempting to log in again.",
             "sign_out_action": "Sign Out",


### PR DESCRIPTION
## What/Why?

Login Form CTA changes for enhancedThemeV1
- Move 'Continue checkout as a guest' to the Customer header row
- Move 'Create an account instead' to secondary button

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**BEFORE**
<img width="765" height="386" alt="Screenshot 2026-08-19 at 6 31 30 pm" src="https://github.com/user-attachments/assets/06fd706d-c308-4bfa-9f88-69648aa67f0b" />
<img width="741" height="360" alt="Screenshot 2026-08-19 at 6 31 48 pm" src="https://github.com/user-attachments/assets/363bb78f-5c9a-4450-b63b-d15ec6336b9f" />
<img width="743" height="375" alt="Screenshot 2026-08-19 at 6 32 16 pm" src="https://github.com/user-attachments/assets/5f7b8638-08b8-4dc3-b6d8-47040d6b4a8c" />



**AFTER**
<img width="768" height="358" alt="Screenshot 2026-08-19 at 6 30 28 pm" src="https://github.com/user-attachments/assets/7f19c54e-aa74-4702-b2a1-64cc84464227" />
<img width="798" height="373" alt="Screenshot 2026-08-19 at 6 30 46 pm" src="https://github.com/user-attachments/assets/7b387eb5-b140-4007-8322-a2b7354b7116" />
<img width="769" height="390" alt="Screenshot 2026-08-19 at 6 31 10 pm" src="https://github.com/user-attachments/assets/7ead5b07-7a8b-4804-a997-f7779e19fa76" />
<img width="735" height="376" alt="Screenshot 2026-08-19 at 6 33 43 pm" src="https://github.com/user-attachments/assets/2577d55b-736b-4025-a936-82603feeffb7" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme-gated checkout UI and copy only; existing handlers and non-enhancedThemeV1 layouts stay unchanged.
> 
> **Overview**
> For **enhancedThemeV1**, the returning-customer login step changes how guest checkout and account creation are surfaced.
> 
> **Continue as guest** moves from a secondary form button into the **Customer step header** via `useSetCheckoutStepHeaderAction`, with cleanup on unmount when guest checkout is allowed on the standard login view.
> 
> **Create account** shifts from inline text in the legend row to a **secondary button** (`Create an account instead`), and that inline create-account link is hidden under enhancedThemeV1. The footer **Cancel / continue as guest** button is suppressed on login when enhancedThemeV1 would show the header link instead.
> 
> The primary sign-in button uses the new **`sign_in_action_v2`** label (“Sign in”), and **en.json** adds strings for the header link and secondary button. **enhancedThemeV1** font SCSS disables uppercase on the new create-account and cancel button IDs alongside existing continue buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27c584d89101dc25fdd759aa36e02dc4fed97c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->