### PR TITLE
fix(checkout): CHECKOUT-10344 Add object has own polyfill

### DIFF
--- a/packages/core/src/app/polyfill.ts
+++ b/packages/core/src/app/polyfill.ts
@@ -1,1 +1,4 @@
+// Needed by intl-tel-input on Chrome/WebView < 93 (CHECKOUT-10344).
+import 'core-js/modules/es.object.has-own';
+
 import './generated/polyfill';


### PR DESCRIPTION
## What/Why?

I noticed that we have a few more cases of old browsers using checkout: https://bigcommerce.sentry.io/issues/7651086999/?notification_uuid=238496f2-1bfe-4e0f-bb67-d172f7fa10e3&project=1542560&referrer=activity_notification

So I think it is worth adding a polyfill for Object.hasOwn.

## Rollout/Rollback

Revert the PR.

## Testing

Tested on my store + tested with WebDav and BrowserStack for Chrome 87 - it does not crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single early polyfill import in the existing polyfill entrypoint; no auth, payment, or business-logic changes.
> 
> **Overview**
> Adds **`core-js/modules/es.object.has-own`** at the top of `polyfill.ts` (before the generated polyfill) so checkout does not throw on browsers that lack native `Object.hasOwn`—notably **Chrome/WebView &lt; 93**, where **intl-tel-input** and code such as `isOrderFee` (`Object.hasOwn(fee, 'customerDisplayName')`) were failing per Sentry.
> 
> No other logic changes; rollback is revert-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0b536efdcef06b74f7736614f3e8a3f97f5a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->