### PR TITLE
feat(checkout): CHECKOUT-10308 rename checkoutV2Theme to enhancedCheckoutThemeV1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.963.2",
+        "@bigcommerce/checkout-sdk": "^1.964.0",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.963.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.963.2.tgz",
-      "integrity": "sha512-Pd2FeGwKI+E/gzIkzfp8uu/wHVEvJW0rdTcrs76fRul77nW+LaIOB6RzOIA9P8OOzK5bhXaQdfkxcbT4alBY/g==",
+      "version": "1.964.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.0.tgz",
+      "integrity": "sha512-LWHvf+D79F3zJVz126VcmNCpe28t/9S91aHjVyha8RhldrCtJIXQw7g5kDxte9o82+HggT/elUlDrK/E+5vCKg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.963.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.963.2.tgz",
-      "integrity": "sha512-Pd2FeGwKI+E/gzIkzfp8uu/wHVEvJW0rdTcrs76fRul77nW+LaIOB6RzOIA9P8OOzK5bhXaQdfkxcbT4alBY/g==",
+      "version": "1.964.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.0.tgz",
+      "integrity": "sha512-LWHvf+D79F3zJVz126VcmNCpe28t/9S91aHjVyha8RhldrCtJIXQw7g5kDxte9o82+HggT/elUlDrK/E+5vCKg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.963.2",
+    "@bigcommerce/checkout-sdk": "^1.964.0",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/contexts/src/theme/isEnhancedThemeV1Enabled.ts
+++ b/packages/contexts/src/theme/isEnhancedThemeV1Enabled.ts
@@ -12,7 +12,7 @@ export const isEnhancedThemeV1Enabled = (config?: StoreConfig): boolean => {
         'CHECKOUT-7962.update_font_style_on_checkout_page',
     );
     const newThemeSettingEnabled = Boolean(
-        config.checkoutSettings.checkoutUserExperienceSettings.checkoutV2Theme ?? false,
+        config.checkoutSettings.checkoutUserExperienceSettings.enhancedCheckoutThemeV1 ?? false,
     );
 
     return newThemeSettingEnabled && newThemeExperimentEnabled;

--- a/packages/core/src/app/checkout/getCheckoutStepStatuses.test.ts
+++ b/packages/core/src/app/checkout/getCheckoutStepStatuses.test.ts
@@ -491,7 +491,7 @@ describe('getCheckoutStepStatuses()', () => {
                 },
                 checkoutUserExperienceSettings: {
                     ...getStoreConfig().checkoutSettings.checkoutUserExperienceSettings,
-                    checkoutV2Theme: true,
+                    enhancedCheckoutThemeV1: true,
                 },
             },
         });

--- a/packages/core/src/app/config/config.mock.ts
+++ b/packages/core/src/app/config/config.mock.ts
@@ -15,7 +15,7 @@ export function getStoreConfig(): StoreConfig {
             checkoutUserExperienceSettings: {
                 walletButtonsOnTop: false,
                 floatingLabelEnabled: false,
-                checkoutV2Theme: false,
+                enhancedCheckoutThemeV1: false,
             },
             enableOrderComments: true,
             enableTermsAndConditions: false,

--- a/packages/core/src/app/payment/Payment.test.tsx
+++ b/packages/core/src/app/payment/Payment.test.tsx
@@ -118,7 +118,7 @@ describe('Payment step', () => {
                 ...checkoutSettings.storeConfig.checkoutSettings,
                 checkoutUserExperienceSettings: {
                     ...checkoutSettings.storeConfig.checkoutSettings.checkoutUserExperienceSettings,
-                    checkoutV2Theme: true,
+                    enhancedCheckoutThemeV1: true,
                 },
             },
         },
@@ -258,7 +258,7 @@ describe('Payment step', () => {
                     checkoutUserExperienceSettings: {
                         ...checkoutSettings.storeConfig.checkoutSettings
                             .checkoutUserExperienceSettings,
-                        checkoutV2Theme: true,
+                        enhancedCheckoutThemeV1: true,
                     },
                 },
             },
@@ -304,7 +304,7 @@ describe('Payment step', () => {
                     checkoutUserExperienceSettings: {
                         ...checkoutSettings.storeConfig.checkoutSettings
                             .checkoutUserExperienceSettings,
-                        checkoutV2Theme: true,
+                        enhancedCheckoutThemeV1: true,
                     },
                 },
             },

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout-settings.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout-settings.mock.ts
@@ -52,7 +52,7 @@ const checkoutSettings: Config = {
             checkoutUserExperienceSettings: {
                 walletButtonsOnTop: true,
                 floatingLabelEnabled: true,
-                checkoutV2Theme: false,
+                enhancedCheckoutThemeV1: false,
             },
             shouldRedirectToStorefrontForAuth: false,
         },

--- a/packages/test-mocks/src/config.mock.ts
+++ b/packages/test-mocks/src/config.mock.ts
@@ -16,7 +16,7 @@ export function getStoreConfig(): StoreConfig {
             checkoutUserExperienceSettings: {
                 walletButtonsOnTop: false,
                 floatingLabelEnabled: false,
-                checkoutV2Theme: false,
+                enhancedCheckoutThemeV1: false,
             },
             enableOrderComments: true,
             enableTermsAndConditions: false,


### PR DESCRIPTION
## What/Why?

Rename checkoutV2Theme to enhancedCheckoutThemeV1.

Depends on: https://github.com/bigcommerce/checkout-sdk-js/pull/3366

## Rollout/Rollback

Revert this PR

## Testing

- CI checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming a store-config flag requires coordinated SDK/backend rollout; mismatched deploys could leave enhanced theme v1 disabled until config uses the new property name.
> 
> **Overview**
> Aligns checkout-js with the checkout-sdk rename of the enhanced checkout theme flag from **`checkoutV2Theme`** to **`enhancedCheckoutThemeV1`** under `checkoutUserExperienceSettings`.
> 
> **`isEnhancedThemeV1Enabled`** now reads **`enhancedCheckoutThemeV1`** (still gated by the same `CHECKOUT-7962.update_font_style_on_checkout_page` experiment). Tests and shared config mocks were updated to use the new key.
> 
> **`@bigcommerce/checkout-sdk`** is bumped from **1.963.2** to **1.964.0** so types and store config match the SDK change (depends on checkout-sdk-js PR 3366).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e1488c78c823336f54bd6ba4c48c8d715def3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->