### PR TITLE
chore(checkout): CHECKOUT-10347 Add Claude.md file with repo rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# checkout-js — project conventions
+
+## Exports
+
+**Always use named exports. Never add new default exports.**
+
+Much of the existing codebase uses default exports — do NOT copy that pattern.
+It is legacy; the team has standardized on named exports for all new code.
+
+```ts
+// ✅ Correct
+export const CustomerInfo = () => { ... };
+export { CustomerInfo } from './CustomerInfo';
+
+// ❌ Wrong — do not do this, even though existing files do
+export default CustomerInfo;
+```
+
+- New files: named exports only, including React components.
+- When editing an existing file that has a default export, leave the existing
+  export as-is unless the task is specifically to refactor it — but any new
+  symbol you export must be a named export.
+- Barrel files (`index.ts`): re-export by name (`export { X } from './X'`),
+  not `export { default as X }` for new modules.
+
+## useCheckout
+
+**Avoid bare `useCheckout()`.** Calling it with no selector subscribes the
+component to the entire checkout state, so it re-renders on every state change.
+Always pass a selector, or a no-op selector if you don't need reactive state.
+
+```ts
+// ✅ Need state — pass a selector returning an object, and destructure
+// `selectedState` inline so values are ready to use directly
+const {
+    selectedState: {
+        config,
+        checkout,
+        order,
+    },
+} = useCheckout(({ data }) => ({
+    config: data.getConfig(),
+    checkout: data.getCheckout(),
+    order: data.getOrder(),
+}));
+
+// ✅ Only need non-reactive context (checkoutService, errorLogger, etc.) —
+// pass a no-op selector so the component never re-renders on state changes
+const { checkoutService } = useCheckout(() => undefined);
+
+// ❌ Wrong — bare call subscribes to ALL state changes
+const { checkoutState } = useCheckout();
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,10 @@ const {
     order: data.getOrder(),
 }));
 
-// ✅ Only need non-reactive context (checkoutService, errorLogger, etc.) —
-// pass a no-op selector so the component never re-renders on state changes
+// ✅ No-op selector — only for two cases where subscribing adds nothing:
+//    1. Calling service methods only (checkoutService, errorLogger).
+//    2. Reading state once on mount for initial local state (see useLoadCheckout).
+// NOT an escape hatch: if the component renders from checkout state, use a real selector
 const { checkoutService } = useCheckout(() => undefined);
 
 // ❌ Wrong — bare call subscribes to ALL state changes


### PR DESCRIPTION
## What/Why?

We have made a decision on some things like using named exports or not using bare useCheckout, but they are not documented for Claude so all new PRs created by Claude rely on existing conventions. Fix it by adding an explicit Claude file that defines the repo rules.

## Rollout/Rollback

Revert

## Testing

No app changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application or runtime behavior changes.
> 
> **Overview**
> Adds **`CLAUDE.md`** so AI-assisted PRs follow documented checkout-js rules instead of copying legacy patterns from the repo.
> 
> The file requires **named exports only** for new code (including React components and barrel re-exports), while leaving existing default exports untouched unless refactoring. It also documents **`useCheckout` usage**: always pass a selector (or `() => undefined` only for service calls or one-time mount reads), and never call bare `useCheckout()` because it subscribes to all checkout state and causes unnecessary re-renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f235199e91f2ef17443cb53ddb71feee5f1d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->