### PR TITLE
PI-5491: Add error message for payment methods that are no longer available

### DIFF
--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -467,6 +467,7 @@
                 "not_found": "We're experiencing difficulty processing your transaction. Please try again later.",
                 "payment_config_error": "Something went wrong on the server. Please try again at a later time.",
                 "payment_config_not_found": "Something went wrong on the server. Please try again at a later time.",
+                "payment_method_no_longer_available": "This payment method is no longer available. Please choose another payment method.",
                 "pending_review": "Your transaction was authorized, but is being held for review by the merchant.",
                 "pickup_card": "Your card cannot be used to make this payment. Please contact your card issuer, or try using a different card.",
                 "processing_error": "We're experiencing difficulty processing your transaction. Please try again later.",


### PR DESCRIPTION
Jira: [PI-5491](https://bigcommercecloud.atlassian.net/browse/PI-5491), [PI-5096](https://bigcommercecloud.atlassian.net/browse/PI-5096)

## What/Why?

Securenet and Mollie are being deprecated. BigPay is gaining a gate that refuses new payments for a sunset gateway (bigcommerce/bigpay#11198) and emits a new error code, `payment_method_no_longer_available`. This adds the matching shopper-facing string.

The key is required, not optional. `mapSubmitOrderErrorMessage` resolves the message from our own locale file rather than from the API response:

```ts
if (shouldLocalise && error.body?.errors?.length) {
    const messages = error.body.errors.map((err) => translate(`payment.errors.${err.code}`));

    return messages.join(' ');
}
```

Wording avoids implying the shopper did something wrong or that retrying will help — the gateway is gone, so the only useful instruction is to pick a different method. Compare `unsupported_request`, whose existing string ("invalid data was supplied with the transaction") is what a sunset gateway would otherwise surface; that text would send shoppers off to re-check their card details for no reason.

## Rollout/Rollback

No feature flag needed here — an unused locale key is inert. It only becomes visible once the BigPay gate is switched on for a gateway via its own flag (`PI-5491.deprecate_securenet`, `PI-5096.stop_mollie_transactions`).

Ordering: this should merge before those flags are enabled, otherwise shoppers hitting the gate see a missing-translation string. Rollback is reverting this commit.

## Testing
<img width="1442" height="1044" alt="image" src="https://github.com/user-attachments/assets/ae396cdc-bb9e-471d-a23a-0b0cc6a2d227" />

[PI-5491]: https://bigcommercecloud.atlassian.net/browse/PI-5491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-5096]: https://bigcommercecloud.atlassian.net/browse/PI-5096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single English locale string; unused until BigPay emits the new error code. No payment logic or security changes.
> 
> **Overview**
> Adds a shopper-facing string for the new BigPay error code `payment_method_no_longer_available`, used when a sunset gateway (e.g. SecureNet, Mollie) refuses new payments.
> 
> Checkout already maps API error codes through `mapSubmitOrderErrorMessage` to `payment.errors.*` locale keys, so this key is required to avoid a missing-translation fallback. The copy tells shoppers to pick another method rather than implying a retry or invalid card data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbfe4cdb7642d1dc79544ac2fcdd7fb5a8171a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->