### PR TITLE
feat(payment): PAYPAL-7017 add BigCommerce Payments Invoices display name and title support

### DIFF
--- a/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
+++ b/packages/core/src/app/payment/paymentMethod/PaymentMethodTitle.tsx
@@ -137,6 +137,10 @@ export function getPaymentMethodTitle(
                 logoUrl: method.logoUrl || '',
                 titleText: method.logoUrl ? '' : methodDisplayName,
             },
+            [PaymentMethodId.BigCommercePaymentsInvoices]: {
+                logoUrl: method.logoUrl || '',
+                titleText: methodDisplayName,
+            },
             [PaymentMethodId.PaypalCommerce]: {
                 logoUrl: cdnPath('/img/payment-providers/paypal_commerce_logo.svg'),
                 titleText: '',

--- a/packages/core/src/app/payment/paymentMethod/getPaymentMethodDisplayName.test.ts
+++ b/packages/core/src/app/payment/paymentMethod/getPaymentMethodDisplayName.test.ts
@@ -60,4 +60,15 @@ describe('getPaymentMethodDisplayName()', () => {
             language.translate('payment.open_banking_display_name_text'),
         );
     });
+
+    it('returns translated "Pay by Invoice" display name for BigCommerce Payments Invoices', () => {
+        const method = {
+            ...getPaymentMethod(),
+            id: PaymentMethodId.BigCommercePaymentsInvoices,
+        };
+
+        expect(getPaymentMethodDisplayName(language)(method)).toEqual(
+            language.translate('payment.invoices_display_name_text'),
+        );
+    });
 });

--- a/packages/core/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
+++ b/packages/core/src/app/payment/paymentMethod/getPaymentMethodDisplayName.tsx
@@ -31,6 +31,10 @@ export default function getPaymentMethodDisplayName(
             return language.translate('payment.open_banking_display_name_text');
         }
 
+        if (method.id === PaymentMethodId.BigCommercePaymentsInvoices) {
+            return language.translate('payment.invoices_display_name_text');
+        }
+
         if (
             (isCreditCard && method.id === PaymentMethodId.AdyenV2) ||
             method.id === PaymentMethodId.AdyenV3

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -309,6 +309,7 @@
             "credit_card_number_mismatch_error": "The card number entered does not match the card stored in your account",
             "credit_debit_card_text": "Credit/Debit Card",
             "open_banking_display_name_text": "Open Banking",
+            "invoices_display_name_text": "Pay by Invoice",
             "invoice_payment_comment_label": "Payment comment",
             "payment_methods_text": "Payment Methods",
             "redeemable_payments_text": "Redeemable Payments",


### PR DESCRIPTION
Jira: [PAYPAL-7017](https://bigcommercecloud.atlassian.net/browse/PAYPAL-7017)

## What/Why?

change Display name for BigCommerce Payments Invoices to "Pay by invoice"

## Rollout/Rollback

Rollout

## Testing
<img width="2030" height="1005" alt="Screenshot 2026-08-21 at 13 40 54" src="https://github.com/user-attachments/assets/b6668bb2-efcf-4823-84d3-e66ba2731b8f" />





[PAYPAL-7017]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-7017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-name and title mapping only; no payment processing, auth, or data-handling changes.
> 
> **Overview**
> Checkout now labels **BigCommerce Payments Invoices** as **Pay by Invoice** instead of the provider-configured display name.
> 
> `getPaymentMethodDisplayName` translates `payment.invoices_display_name_text` for that method id, and `PaymentMethodTitle` always shows that title (plus any method logo). English copy is added in `en.json`, with a unit test covering the translation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b075c5f17af8b14255479a440f887c569951407d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->