### PR TITLE
feat(payment): hide billing same as shipping toggle in Stripe UPE shipping form under enhanced theme

### DIFF
--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.test.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.test.tsx
@@ -3,7 +3,12 @@ import userEvent from '@testing-library/user-event';
 import React, { act } from 'react';
 
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
-import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
+import {
+    CheckoutProvider,
+    ExtensionProvider,
+    LocaleContext,
+    ThemeContext,
+} from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
 import { render, screen } from '@bigcommerce/checkout/test-utils';
 
@@ -65,16 +70,17 @@ describe('StripeShippingForm', () => {
         deleteConsignments: jest.fn(),
     };
 
-    const renderContainer = (props = {}) =>
-        render(
-            <CheckoutProvider checkoutService={checkoutService}>
-                <LocaleContext.Provider value={localeContext}>
-                    <ExtensionProvider extensionService={extensionService}>
-                        <StripeShippingForm {...defaultProps} {...props} />
-                    </ExtensionProvider>
-                </LocaleContext.Provider>
-            </CheckoutProvider>,
-        );
+    const createContainer = (props = {}) => (
+        <CheckoutProvider checkoutService={checkoutService}>
+            <LocaleContext.Provider value={localeContext}>
+                <ExtensionProvider extensionService={extensionService}>
+                    <StripeShippingForm {...defaultProps} {...props} />
+                </ExtensionProvider>
+            </LocaleContext.Provider>
+        </CheckoutProvider>
+    );
+
+    const renderContainer = (props = {}) => render(createContainer(props));
 
     beforeEach(() => {
         checkoutState = checkoutService.getState();
@@ -99,6 +105,23 @@ describe('StripeShippingForm', () => {
         expect(defaultProps.getFields).toHaveBeenCalledWith('US');
         // eslint-disable-next-line testing-library/no-node-access,testing-library/no-container
         expect(container.querySelector('#StripeUpeShipping')).toBeInTheDocument();
+    });
+
+    it('renders billing same as shipping checkbox', async () => {
+        renderContainer({ isLoading: false });
+
+        expect(screen.getByTestId('billingSameAsShipping')).toBeInTheDocument();
+    });
+
+    it('does not render billing same as shipping checkbox under enhancedThemeV1', async () => {
+        // Under enhancedThemeV1 the toggle moves to the payment step's billing block.
+        render(
+            <ThemeContext.Provider value={{ enhancedThemeV1: true }}>
+                {createContainer({ isLoading: false })}
+            </ThemeContext.Provider>,
+        );
+
+        expect(screen.queryByTestId('billingSameAsShipping')).not.toBeInTheDocument();
     });
 
     it('disables submit button when loading', async () => {

--- a/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
+++ b/packages/core/src/app/shipping/stripeUPE/StripeShippingForm.tsx
@@ -4,7 +4,7 @@ import { noop } from 'lodash';
 import React, { useCallback, useState } from 'react';
 import { lazy, object } from 'yup';
 
-import { useCapabilities } from '@bigcommerce/checkout/contexts';
+import { useCapabilities, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { withLanguage, type WithLanguageProps } from '@bigcommerce/checkout/locale';
 import { Fieldset, Form } from '@bigcommerce/checkout/ui';
 
@@ -62,6 +62,7 @@ const StripeShippingForm: React.FC<
         shouldShowOrderComments,
         updateShippingAddress: updateAddress,
     } = useShipping();
+    const { enhancedThemeV1 } = useThemeContext();
 
     const [isUpdatingShippingData] = useState(false);
 
@@ -108,6 +109,8 @@ const StripeShippingForm: React.FC<
         [values, setValues, onUnhandledError],
     );
 
+    const shouldShowBillingSameAsShipping = !hideBillingSameAsShippingCheck && !enhancedThemeV1;
+
     return (
         <Form autoComplete="on">
             <Fieldset>
@@ -126,9 +129,11 @@ const StripeShippingForm: React.FC<
                     step={step}
                 />
 
-                <div className="form-body">
-                    {!hideBillingSameAsShippingCheck && <BillingSameAsShippingField />}
-                </div>
+                {shouldShowBillingSameAsShipping && (
+                    <div className="form-body">
+                        <BillingSameAsShippingField />
+                    </div>
+                )}
             </Fieldset>
 
             <ShippingFormFooter


### PR DESCRIPTION
## What/Why?
The Stripe UPE shipping form rendered the "My billing address is the same as my
shipping address" toggle whenever the `hideBillingSameAsShippingCheck` capability
was off, without accounting for the enhanced checkout theme.

Under the enhanced theme the toggle is intentionally relocated to the payment
step's billing block, and the default (non-Stripe) shipping form has already been
gated accordingly in `SingleShippingForm`. Because `PaymentBillingForm` renders
the toggle unconditionally with respect to the theme, stores on Stripe UPE **and**
the enhanced theme saw the toggle twice — once in the shipping step and again in
the billing block.

This change brings `StripeShippingForm` in line with `SingleShippingForm`:
No behaviour change for stores that are not on the enhanced theme.

## Rollout/Rollback
Rollback this PR

## Testing
Before:

https://github.com/user-attachments/assets/f86069fa-d88f-4f23-8975-4b8cc6423de6

After:
theme V1

https://github.com/user-attachments/assets/91d4e6c9-4f27-44c8-9ee9-21da7fa9a762

Theme V2

https://github.com/user-attachments/assets/046b411e-9206-424f-9e13-7a47081d8dcb


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility gate for an existing checkbox; no checkout, payment, or address-submission logic changes.
> 
> **Overview**
> Hides the “billing same as shipping” checkbox on the Stripe UPE shipping form when `enhancedThemeV1` is on, matching `SingleShippingForm`. The toggle already lives in the payment billing block under that theme, so Stripe UPE stores were seeing it twice.
> 
> Non-enhanced theme behavior is unchanged. Tests cover both the default and enhanced-theme cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb31457ce572ec29362c1a54a01336caeb12f3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->