### PR TITLE
fix(checkout): add check for globalHandlersIntegration method on sentry object

### DIFF
--- a/packages/core/src/app/common/error/SentryErrorLogger.ts
+++ b/packages/core/src/app/common/error/SentryErrorLogger.ts
@@ -53,16 +53,21 @@ export default class SentryErrorLogger implements ErrorLogger {
         this.dsn = config.dsn || '';
 
         window.sentryOnLoad = async () => {
+            const integrations =
+                typeof Sentry.globalHandlersIntegration === 'function'
+                    ? [
+                          Sentry.globalHandlersIntegration({
+                              onerror: false,
+                              onunhandledrejection: true,
+                          }),
+                      ]
+                    : [];
+
             Sentry.init({
                 sampleRate,
                 beforeSend: this.handleBeforeSend.bind(this),
                 denyUrls: [...(config.denyUrls || []), 'polyfill~checkout'],
-                integrations: [
-                    Sentry.globalHandlersIntegration({
-                        onerror: false,
-                        onunhandledrejection: true,
-                    }),
-                ],
+                integrations,
                 ...config,
             });
 


### PR DESCRIPTION
## What/Why?
Add check for globalHandlersIntegration method on sentry object

## Rollout/Rollback
- revert PR

## Testing
- CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guard around Sentry init. Worst case is missing the global handlers integration on incompatible SDKs, not a security or data-handling change.
> 
> **Overview**
> Prevents Sentry init from throwing when the CDN-loaded SDK does not expose `globalHandlersIntegration`.
> 
> `SentryErrorLogger` now only registers that integration if it is a function; otherwise it initializes with an empty integrations list. Unhandled-rejection handling is skipped on older/incompatible Sentry builds instead of breaking error logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 306507a97b5a740a88e1774f85a91d0a7554c698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->