### PR TITLE
feat(checkout): CHECKOUT-10351 update order summary padding and white background backdrop issue

### DIFF
--- a/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
@@ -103,7 +103,7 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
                     ariaHideApp={false}
                     bodyOpenClassName="has-activeCartSummarySheet"
                     className={{
-                        base: 'cart-summary-sheet',
+                        base: 'cart-summary-sheet optimizedCheckout-orderSummary',
                         afterOpen: 'cart-summary-sheet--afterOpen',
                         beforeClose: 'cart-summary-sheet--beforeClose',
                     }}
@@ -118,7 +118,7 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
                     isOpen={isExpanded}
                     onRequestClose={closeSheet}
                     overlayClassName={{
-                        base: 'cart-summary-backdrop optimizedCheckout-orderSummary',
+                        base: 'cart-summary-backdrop',
                         afterOpen: 'cart-summary-backdrop--afterOpen',
                         beforeClose: 'cart-summary-backdrop--beforeClose',
                     }}

--- a/packages/core/src/scss/enhancedThemeV1/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/checkout/_cart-summary.scss
@@ -148,7 +148,7 @@
             min-height: 0;
             overflow-y: auto;
             overscroll-behavior: contain;
-            padding: 0 spacing("single") spacing("single");
+            padding-bottom: spacing("single");
         }
 
         @media (prefers-reduced-motion: reduce) {

--- a/packages/core/src/scss/enhancedThemeV1/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/checkout/_cart-summary.scss
@@ -4,6 +4,7 @@
         order: -1;
 
         .cart-summary-drawer {
+            background: none;
             border: none;
             box-shadow: none;
             bottom: 0;


### PR DESCRIPTION
## What/Why?

- Fix the padding on order summary content to be same as the sticky summary footer.
- Fix the white/dark background color visible on backdrop when summary sheet opens or closes.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**BEFORE**

https://github.com/user-attachments/assets/85fb2ae9-c079-454a-8505-35e5dd6517a2

<img width="316" height="525" alt="Screenshot 2026-08-24 at 3 24 47 pm" src="https://github.com/user-attachments/assets/1785d7da-ad52-49d3-8611-fe75906bbd6b" />



**AFTER**

https://github.com/user-attachments/assets/2a3c8175-bf2b-4978-b22e-188862686fdb

<img width="321" height="524" alt="Screenshot 2026-08-24 at 3 22 24 pm" src="https://github.com/user-attachments/assets/ef95bf3b-0316-43ab-ad01-2c973ee52fea" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class and SCSS tweaks to checkout cart UI only; no logic, auth, or data-handling changes.
> 
> **Overview**
> Fixes visual glitches in the enhanced-theme cart summary sheet: mismatched content padding and a themed background flashing on the backdrop during open/close.
> 
> Moves `optimizedCheckout-orderSummary` from the modal overlay to the sheet so theme background applies only to the panel. Clears the drawer background and drops horizontal padding on `.cart-summary-sheet-content` so it matches the sticky footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4869d497b118399a19b8aab3abf09de063afa7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->