### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.961.0",
+        "@bigcommerce/checkout-sdk": "^1.963.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.961.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.961.0.tgz",
-      "integrity": "sha512-xt8B8QFgL75+9tk0vbc+KI47g6JwAQGU6HZBwIHsmGrmMSZr0HK92ShB4bygThMsp+JU7cMDH2xDtLG9Z2Cepg==",
+      "version": "1.963.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.963.2.tgz",
+      "integrity": "sha512-Pd2FeGwKI+E/gzIkzfp8uu/wHVEvJW0rdTcrs76fRul77nW+LaIOB6RzOIA9P8OOzK5bhXaQdfkxcbT4alBY/g==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.961.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.961.0.tgz",
-      "integrity": "sha512-xt8B8QFgL75+9tk0vbc+KI47g6JwAQGU6HZBwIHsmGrmMSZr0HK92ShB4bygThMsp+JU7cMDH2xDtLG9Z2Cepg==",
+      "version": "1.963.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.963.2.tgz",
+      "integrity": "sha512-Pd2FeGwKI+E/gzIkzfp8uu/wHVEvJW0rdTcrs76fRul77nW+LaIOB6RzOIA9P8OOzK5bhXaQdfkxcbT4alBY/g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.961.0",
+    "@bigcommerce/checkout-sdk": "^1.963.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version to deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3364](https://github.com/bigcommerce/checkout-sdk-js/pull/3364)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3365](https://github.com/bigcommerce/checkout-sdk-js/pull/3365)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3363](https://github.com/bigcommerce/checkout-sdk-js/pull/3363)

## Rollout/Rollback
Rollback related PR

## Testing
In checkout-sdk-js PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment and checkout behavior can change via the SDK upgrade even though this repo only updates dependencies; validate against the linked checkout-sdk-js PRs before release.
> 
> **Overview**
> Bumps the **`@bigcommerce/checkout-sdk`** dependency from **`^1.961.0`** to **`^1.963.2`** in **`package.json`** and the lockfile so checkout-js ships the newer SDK build.
> 
> There are **no changes to checkout-js source** in this PR—behavior updates come entirely from the linked **checkout-sdk-js** releases (PRs **3363**, **3364**, **3365**). Rollback is reverting this bump if needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61fde43aef01b57ae17cde63d250a6b0f9229687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->