### PR TITLE
feat(payment): PI-5626 Enable cybersource test url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.961.0",
+        "@bigcommerce/checkout-sdk": "^1.963.2",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.961.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.961.0.tgz",
-      "integrity": "sha512-xt8B8QFgL75+9tk0vbc+KI47g6JwAQGU6HZBwIHsmGrmMSZr0HK92ShB4bygThMsp+JU7cMDH2xDtLG9Z2Cepg==",
+      "version": "1.963.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.963.2.tgz",
+      "integrity": "sha512-Pd2FeGwKI+E/gzIkzfp8uu/wHVEvJW0rdTcrs76fRul77nW+LaIOB6RzOIA9P8OOzK5bhXaQdfkxcbT4alBY/g==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.961.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.961.0.tgz",
-      "integrity": "sha512-xt8B8QFgL75+9tk0vbc+KI47g6JwAQGU6HZBwIHsmGrmMSZr0HK92ShB4bygThMsp+JU7cMDH2xDtLG9Z2Cepg==",
+      "version": "1.963.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.963.2.tgz",
+      "integrity": "sha512-Pd2FeGwKI+E/gzIkzfp8uu/wHVEvJW0rdTcrs76fRul77nW+LaIOB6RzOIA9P8OOzK5bhXaQdfkxcbT4alBY/g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.961.0",
+    "@bigcommerce/checkout-sdk": "^1.963.2",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

fix cybersource 3ds flow 

## Rollout/Rollback

rollback this commit 

## Testing
<img width="1505" height="242" alt="Screenshot 2026-08-25 at 13 29 25" src="https://github.com/user-attachments/assets/b13ab276-449b-4e42-ac1a-db6bfa24a46f" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the payment SDK used for checkout, including CyberSource 3DS flows; risk is limited to what changed in checkout-sdk 1.961.0→1.963.2, but payment paths warrant careful regression testing.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **^1.961.0** to **^1.963.2** in `package.json` and `package-lock.json` so checkout-js picks up SDK changes for **PI-5626** (CyberSource test URL / 3DS flow fix). There are **no application source changes** in this repo—the behavior change ships in the SDK release consumed by this dependency update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb475a102d7d75e7dda3aabaf7056b33dc8e7c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->