### PR TITLE
CHECKOUT-9630 Remove no countries error on checkout experiment

### DIFF
--- a/packages/core/src/app/shipping/Shipping.test.tsx
+++ b/packages/core/src/app/shipping/Shipping.test.tsx
@@ -980,21 +980,8 @@ describe('Shipping step', () => {
     });
 
     describe('No countries available error handling', () => {
-        it('calls onUnhandledError when no countries are available and experiment is enabled', async () => {
-            const config = {
-                ...checkoutSettings,
-                storeConfig: {
-                    ...checkoutSettings.storeConfig,
-                    checkoutSettings: {
-                        ...checkoutSettings.storeConfig.checkoutSettings,
-                        features: {
-                            'CHECKOUT-9630.no_countries_error_on_checkout': true,
-                        },
-                    },
-                },
-            };
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithBillingEmail, { config });
+        it('calls onUnhandledError when no countries are available', async () => {
+            checkoutService = checkout.use(CheckoutPreset.CheckoutWithBillingEmail);
 
             jest.spyOn(checkoutService.getState().data, 'getShippingCountries').mockReturnValue([]);
 
@@ -1021,41 +1008,6 @@ describe('Shipping step', () => {
                     }),
                 );
             });
-        });
-
-        it('does not call onUnhandledError when no countries are available but experiment is disabled', async () => {
-            const config = {
-                ...checkoutSettings,
-                storeConfig: {
-                    ...checkoutSettings.storeConfig,
-                    checkoutSettings: {
-                        ...checkoutSettings.storeConfig.checkoutSettings,
-                        features: {
-                            'CHECKOUT-9630.no_countries_error_on_checkout': false,
-                        },
-                    },
-                },
-            };
-
-            checkoutService = checkout.use(CheckoutPreset.CheckoutWithBillingEmail, { config });
-
-            // Mock getShippingCountries to return empty array
-            jest.spyOn(checkoutService.getState().data, 'getShippingCountries').mockReturnValue([]);
-
-            // Spy on errorLogger to verify error handling
-            jest.spyOn(defaultProps.errorLogger, 'log');
-
-            render(<CheckoutTest {...defaultProps} />);
-
-            await checkout.waitForShippingStep();
-
-            // Verify that error was NOT logged when experiment is disabled
-            expect(defaultProps.errorLogger.log).not.toHaveBeenCalledWith(
-                expect.objectContaining({
-                    name: 'no_countries_available',
-                    type: 'custom',
-                }),
-            );
         });
     });
 

--- a/packages/core/src/app/shipping/ShippingForm.tsx
+++ b/packages/core/src/app/shipping/ShippingForm.tsx
@@ -40,7 +40,6 @@ const ShippingForm = ({
         customerMessage,
         getFields,
         hasMultiShippingEnabled,
-        isNoCountriesErrorOnCheckoutEnabled,
         methodId,
         shippingAddress,
     } = useShipping();
@@ -64,7 +63,7 @@ const ShippingForm = ({
     }, [shippingFormRenderTimestamp]);
 
     useEffect(() => {
-        if (isInitialValueLoaded && countries.length === 0 && isNoCountriesErrorOnCheckoutEnabled) {
+        if (isInitialValueLoaded && countries.length === 0) {
             onUnhandledError(
                 new CustomError({
                     name: 'no_countries_available',
@@ -91,7 +90,7 @@ const ShippingForm = ({
         );
     };
 
-    if (isInitialValueLoaded && countries.length === 0 && isNoCountriesErrorOnCheckoutEnabled) {
+    if (isInitialValueLoaded && countries.length === 0) {
         return null;
     }
 

--- a/packages/core/src/app/shipping/hooks/useShipping.mock.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.mock.ts
@@ -24,7 +24,6 @@ export const getUseShippingTestMock: () => ReturnType<typeof useShipping> = () =
     isGuest: false,
     isInitializing: false,
     isLoading: false,
-    isNoCountriesErrorOnCheckoutEnabled: false,
     isShippingStepPending: false,
     loadBillingAddressFields: jest.fn(),
     loadShippingAddressFields: jest.fn(),

--- a/packages/core/src/app/shipping/hooks/useShipping.ts
+++ b/packages/core/src/app/shipping/hooks/useShipping.ts
@@ -9,7 +9,6 @@ import {
 } from '@bigcommerce/checkout/contexts';
 import { shouldUseStripeLinkByMinimumAmount } from '@bigcommerce/checkout/instrument-utils';
 import { PaymentMethodId } from '@bigcommerce/checkout/payment-integration-api';
-import { isExperimentEnabled } from '@bigcommerce/checkout/utility';
 
 import { encodeAddressForWrite } from '../../address';
 import { EMPTY_ARRAY } from '../../common/utility';
@@ -248,11 +247,6 @@ export const useShipping = () => {
         isGuest: customer.isGuest,
         isInitializing: isLoadingShippingCountries() || isLoadingShippingOptions(),
         isLoading,
-        isNoCountriesErrorOnCheckoutEnabled: isExperimentEnabled(
-            config.checkoutSettings,
-            'CHECKOUT-9630.no_countries_error_on_checkout',
-            true,
-        ),
         isShippingStepPending: isShippingStepPending(),
         loadShippingAddressFields: checkoutService.loadShippingAddressFields,
         loadBillingAddressFields: checkoutService.loadBillingAddressFields,


### PR DESCRIPTION
## What/Why?

Removes the rolled-out `CHECKOUT-9630.no_countries_error_on_checkout` LaunchDarkly experiment and its dead code path. The experiment's fallback value was already `true` (enabled), so the "on" behavior — logging an `no_countries_available` unhandled error and rendering nothing when the shipping step has no countries available — becomes the permanent, unconditional behavior in [ShippingForm.tsx](packages/core/src/app/shipping/ShippingForm.tsx).

Changes:
- [useShipping.ts](packages/core/src/app/shipping/hooks/useShipping.ts): removed `isNoCountriesErrorOnCheckoutEnabled` (and the now-unused `isExperimentEnabled` import).
- [ShippingForm.tsx](packages/core/src/app/shipping/ShippingForm.tsx): removed the experiment guard from both the error-reporting effect and the early `return null`.
- [useShipping.mock.ts](packages/core/src/app/shipping/hooks/useShipping.mock.ts): removed the corresponding mock field.
- [Shipping.test.tsx](packages/core/src/app/shipping/Shipping.test.tsx): dropped the "experiment disabled" test and the experiment-flag setup from the "experiment enabled" test, since the behavior is now unconditional.

## Rollout/Rollback

No rollout needed — the experiment was already defaulting to enabled, so this only removes the flag check; runtime behavior is unchanged. Rollback is a straight revert of this PR.

Note: the LaunchDarkly Terraform module (`bigcommerce/terraform-launchdarkly`) and the backend constant (`bigcommerce/bigcommerce: config/Experiments/CheckoutExperiments.php`) still reference this flag and are intentionally left in place — those should be removed in a follow-up PR after this one merges, per team convention (keep the flag alive in LD while the code cleanup is in flight).

## Testing

Ran the updated `Shipping.test.tsx` suite locally — all 20 tests pass, including the simplified "No countries available error handling" test. `tsc --noEmit` shows no new type errors versus the pre-existing baseline.