### PR TITLE
chore(checkout): CHECKOUT-9979 Bump SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.964.0",
+        "@bigcommerce/checkout-sdk": "^1.964.1",
         "@bigcommerce/citadel": "^2.15.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.964.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.0.tgz",
-      "integrity": "sha512-LWHvf+D79F3zJVz126VcmNCpe28t/9S91aHjVyha8RhldrCtJIXQw7g5kDxte9o82+HggT/elUlDrK/E+5vCKg==",
+      "version": "1.964.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.1.tgz",
+      "integrity": "sha512-1TN+4QxzZojCHYXpILz7JGvLXh2eAtvEsWl2a36WNSVIR8hCIGDwETO4SLCdX02eftBQqFXKvxvMZCz79e2ILw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29808,9 +29808,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.964.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.0.tgz",
-      "integrity": "sha512-LWHvf+D79F3zJVz126VcmNCpe28t/9S91aHjVyha8RhldrCtJIXQw7g5kDxte9o82+HggT/elUlDrK/E+5vCKg==",
+      "version": "1.964.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.1.tgz",
+      "integrity": "sha512-1TN+4QxzZojCHYXpILz7JGvLXh2eAtvEsWl2a36WNSVIR8hCIGDwETO4SLCdX02eftBQqFXKvxvMZCz79e2ILw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.964.0",
+    "@bigcommerce/checkout-sdk": "^1.964.1",
     "@bigcommerce/citadel": "^2.15.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
Refs [CHECKOUT-9979](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-9979)

## What/Why?

Bumps `@bigcommerce/checkout-sdk` from 1.964.0 to 1.964.1 to pick up the SDK-side change for this ticket: 
- [removal of the `b2b-dev-tools` testing helpers](https://github.com/bigcommerce/checkout-sdk-js/pull/3376), which were only meant to exist during development and must be removed before project delivery.

## Rollout/Rollback

Rolls out with the standard checkout-js release process; no feature flag or experiment involved. Rollback is a simple revert of this version bump.

## Testing
Dependency-only change — verified by CI (build, lint, unit tests). The removed `b2b-dev-tools` module was a dev-only helper with no production usage, so no behavioural change is expected in checkout.

[CHECKOUT-9979]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-9979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump; the SDK change removes dev-only tooling with no expected production behavior change in checkout-js.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **1.964.0** to **1.964.1** in `package.json` and `package-lock.json`, with no other checkout-js code changes.
> 
> This aligns checkout-js with the SDK release that **removes the `b2b-dev-tools` testing helpers** (dev-only utilities that should not ship). Expect **no production checkout behavior change** from this repo’s side—only the resolved SDK tarball and integrity hash update in the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb63afcf3ec6d622f8abc72dcf153228e4db4d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->