### PR TITLE
feat(checkout): CHECKOUT-10353 add loading dots animation for price updates in enhancedThemeV1

### DIFF
--- a/packages/core/src/app/order/PriceTicker.tsx
+++ b/packages/core/src/app/order/PriceTicker.tsx
@@ -1,0 +1,31 @@
+import React, { type FunctionComponent, type ReactNode } from 'react';
+
+import { LoadingDots } from '@bigcommerce/checkout/ui';
+
+import { type PriceChangeTicker } from './usePriceChangeTicker';
+
+export interface PriceTickerProps {
+    ticker: PriceChangeTicker;
+    children: ReactNode;
+}
+
+export const PriceTicker: FunctionComponent<PriceTickerProps> = ({ ticker, children }) => {
+    const { phase } = ticker;
+
+    if (phase === 'idle') {
+        return <>{children}</>;
+    }
+
+    if (phase === 'dots') {
+        return <LoadingDots />;
+    }
+
+    return (
+        <span
+            className={phase === 'exiting' ? 'priceTicker-exit' : 'priceTicker-enter'}
+            data-test="price-ticker"
+        >
+            {children}
+        </span>
+    );
+};

--- a/packages/core/src/app/order/PriceTicker.tsx
+++ b/packages/core/src/app/order/PriceTicker.tsx
@@ -2,7 +2,7 @@ import React, { type FunctionComponent, type ReactNode } from 'react';
 
 import { LoadingDots } from '@bigcommerce/checkout/ui';
 
-import { type PriceChangeTicker } from './usePriceChangeTicker';
+import { type PriceChangeTicker, PriceTickerPhase } from './usePriceChangeTicker';
 
 export interface PriceTickerProps {
     ticker: PriceChangeTicker;
@@ -12,17 +12,19 @@ export interface PriceTickerProps {
 export const PriceTicker: FunctionComponent<PriceTickerProps> = ({ ticker, children }) => {
     const { phase } = ticker;
 
-    if (phase === 'idle') {
+    if (phase === PriceTickerPhase.Idle) {
         return <>{children}</>;
     }
 
-    if (phase === 'dots') {
+    if (phase === PriceTickerPhase.Dots) {
         return <LoadingDots />;
     }
 
     return (
         <span
-            className={phase === 'exiting' ? 'priceTicker-exit' : 'priceTicker-enter'}
+            className={
+                phase === PriceTickerPhase.Exiting ? 'priceTicker-exit' : 'priceTicker-enter'
+            }
             data-test="price-ticker"
         >
             {children}

--- a/packages/core/src/app/order/usePriceChangeTicker.ts
+++ b/packages/core/src/app/order/usePriceChangeTicker.ts
@@ -1,0 +1,57 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { prefersReducedMotion } from '@bigcommerce/checkout/ui';
+
+export type PriceTickerPhase = 'idle' | 'exiting' | 'dots' | 'entering';
+
+export interface PriceChangeTicker {
+    phase: PriceTickerPhase;
+    displayAmount: number | null | undefined;
+}
+
+// Must match the $animation-priceTicker-* / $animation-loadingDots-* settings
+// in scss/settings/checkout/animation/_settings.scss.
+const SLIDE_DURATION = 200;
+const DOT_PULSE_DURATION = 900;
+const DOT_STAGGER = 150;
+
+// One full pulse cycle for all three staggered dots.
+const DOTS_DURATION = DOT_PULSE_DURATION + DOT_STAGGER * 2;
+
+export const usePriceChangeTicker = (
+    amount: number | null | undefined,
+    isEnabled = true,
+): PriceChangeTicker => {
+    const [phase, setPhase] = useState<PriceTickerPhase>('idle');
+    const previousAmount = useRef(amount);
+    const exitingAmount = useRef(amount);
+
+    useLayoutEffect(() => {
+        const oldAmount = previousAmount.current;
+        const hasAmountChanged = amount !== oldAmount;
+
+        previousAmount.current = amount;
+
+        if (isEnabled && hasAmountChanged && oldAmount != null && !prefersReducedMotion()) {
+            exitingAmount.current = oldAmount;
+            setPhase('exiting');
+
+            const timers = [
+                setTimeout(() => setPhase('dots'), SLIDE_DURATION),
+                setTimeout(() => setPhase('entering'), SLIDE_DURATION + DOTS_DURATION),
+                setTimeout(() => setPhase('idle'), SLIDE_DURATION + DOTS_DURATION + SLIDE_DURATION),
+            ];
+
+            return () => timers.forEach((timer) => clearTimeout(timer));
+        }
+
+        // A non-animating change must still reset a phase left over from a
+        // cancelled in-flight animation, or the ticker wedges showing dots.
+        setPhase('idle');
+    }, [amount, isEnabled]);
+
+    return {
+        phase,
+        displayAmount: phase === 'exiting' ? exitingAmount.current : amount,
+    };
+};

--- a/packages/core/src/app/order/usePriceChangeTicker.ts
+++ b/packages/core/src/app/order/usePriceChangeTicker.ts
@@ -2,7 +2,12 @@ import { useLayoutEffect, useRef, useState } from 'react';
 
 import { prefersReducedMotion } from '@bigcommerce/checkout/ui';
 
-export type PriceTickerPhase = 'idle' | 'exiting' | 'dots' | 'entering';
+export enum PriceTickerPhase {
+    Idle = 'idle',
+    Exiting = 'exiting',
+    Dots = 'dots',
+    Entering = 'entering',
+}
 
 export interface PriceChangeTicker {
     phase: PriceTickerPhase;
@@ -22,7 +27,7 @@ export const usePriceChangeTicker = (
     amount: number | null | undefined,
     isEnabled = true,
 ): PriceChangeTicker => {
-    const [phase, setPhase] = useState<PriceTickerPhase>('idle');
+    const [phase, setPhase] = useState(PriceTickerPhase.Idle);
     const previousAmount = useRef(amount);
     const exitingAmount = useRef(amount);
 
@@ -34,12 +39,18 @@ export const usePriceChangeTicker = (
 
         if (isEnabled && hasAmountChanged && oldAmount != null && !prefersReducedMotion()) {
             exitingAmount.current = oldAmount;
-            setPhase('exiting');
+            setPhase(PriceTickerPhase.Exiting);
 
             const timers = [
-                setTimeout(() => setPhase('dots'), SLIDE_DURATION),
-                setTimeout(() => setPhase('entering'), SLIDE_DURATION + DOTS_DURATION),
-                setTimeout(() => setPhase('idle'), SLIDE_DURATION + DOTS_DURATION + SLIDE_DURATION),
+                setTimeout(() => setPhase(PriceTickerPhase.Dots), SLIDE_DURATION),
+                setTimeout(
+                    () => setPhase(PriceTickerPhase.Entering),
+                    SLIDE_DURATION + DOTS_DURATION,
+                ),
+                setTimeout(
+                    () => setPhase(PriceTickerPhase.Idle),
+                    SLIDE_DURATION + DOTS_DURATION + SLIDE_DURATION,
+                ),
             ];
 
             return () => timers.forEach((timer) => clearTimeout(timer));
@@ -47,11 +58,11 @@ export const usePriceChangeTicker = (
 
         // A non-animating change must still reset a phase left over from a
         // cancelled in-flight animation, or the ticker wedges showing dots.
-        setPhase('idle');
+        setPhase(PriceTickerPhase.Idle);
     }, [amount, isEnabled]);
 
     return {
         phase,
-        displayAmount: phase === 'exiting' ? exitingAmount.current : amount,
+        displayAmount: phase === PriceTickerPhase.Exiting ? exitingAmount.current : amount,
     };
 };

--- a/packages/core/src/scss/enhancedThemeV1/components/_components.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/_components.scss
@@ -10,3 +10,4 @@
 @import "checkout/products-list";
 @import "checkout/payment-billing";
 @import "checkout/paymentProvider";
+@import "checkout/loading-dots";

--- a/packages/core/src/scss/enhancedThemeV1/components/checkout/_loading-dots.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/checkout/_loading-dots.scss
@@ -1,0 +1,88 @@
+.loadingDots {
+    @include enhancedThemeV1 {
+        align-items: baseline;
+        display: inline-flex;
+        gap: remCalc(2px);
+
+        .loadingDots-dot {
+            animation: loadingDotsPulse $animation-loadingDots-pulseSpeed ease-in-out infinite;
+            opacity: 0.25;
+
+            &:nth-child(2) {
+                animation-delay: $animation-loadingDots-stagger;
+            }
+
+            &:nth-child(3) {
+                animation-delay: $animation-loadingDots-stagger * 2;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .loadingDots-dot {
+                animation: none;
+                opacity: 1;
+            }
+        }
+    }
+}
+
+.priceTicker-exit {
+    @include enhancedThemeV1 {
+        animation: priceTickerSlideOut $animation-priceTicker-slideSpeed ease-in both;
+        display: inline-block;
+
+        @media (prefers-reduced-motion: reduce) {
+            animation: none;
+        }
+    }
+}
+
+.priceTicker-enter {
+    @include enhancedThemeV1 {
+        animation: priceTickerSlideIn $animation-priceTicker-slideSpeed ease-out both;
+        display: inline-block;
+
+        @media (prefers-reduced-motion: reduce) {
+            animation: none;
+        }
+    }
+}
+
+// Keyframes must stay outside the enhancedThemeV1 mixin: Sass does not hoist
+// them out of the generated `.enhancedThemeV1 …` selector.
+@keyframes loadingDotsPulse {
+    0%,
+    100% {
+        opacity: 0.25;
+        transform: translateY(0);
+    }
+
+    40% {
+        opacity: 1;
+        transform: translateY(remCalc(-2px));
+    }
+}
+
+@keyframes priceTickerSlideOut {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    to {
+        opacity: 0;
+        transform: translateY(-0.6em);
+    }
+}
+
+@keyframes priceTickerSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(0.6em);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/packages/core/src/scss/settings/checkout/animation/_settings.scss
+++ b/packages/core/src/scss/settings/checkout/animation/_settings.scss
@@ -9,3 +9,8 @@ $animation-collapse-transitionProperty: max-height;
 $animation-collapse-transitionSpeed: 600ms;
 $animation-collapse-transition: $animation-collapse-transitionProperty $animation-collapse-transitionSpeed $animation-collapse-transitionCurve;
 
+// Must match SLIDE_DURATION / DOT_PULSE_DURATION / DOT_STAGGER in usePriceChangeTicker.ts
+$animation-priceTicker-slideSpeed: 200ms;
+$animation-loadingDots-pulseSpeed: 900ms;
+$animation-loadingDots-stagger: 150ms;
+

--- a/packages/ui/src/animation/index.ts
+++ b/packages/ui/src/animation/index.ts
@@ -1,1 +1,2 @@
 export { CollapseCSSTransition } from './collapse';
+export { prefersReducedMotion } from './prefersReducedMotion';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-export { CollapseCSSTransition } from './animation';
+export { CollapseCSSTransition, prefersReducedMotion } from './animation';
 export { Alert, AlertType } from './alert';
 export {
     Accordion,
@@ -105,7 +105,13 @@ export {
     IconChevronUp,
     IconArrowLeft,
 } from './icon';
-export { LazyContainer, LoadingNotification, LoadingOverlay, LoadingSpinner } from './loading';
+export {
+    LazyContainer,
+    LoadingDots,
+    LoadingNotification,
+    LoadingOverlay,
+    LoadingSpinner,
+} from './loading';
 export {
     ConfirmationModal,
     Modal,

--- a/packages/ui/src/loading/LoadingDots.test.tsx
+++ b/packages/ui/src/loading/LoadingDots.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { LoadingDots } from './LoadingDots';
+
+describe('LoadingDots', () => {
+    it('renders three dots hidden from assistive technology', () => {
+        const { container } = render(<LoadingDots />);
+
+        expect(screen.getByTestId('loading-dots')).toHaveAttribute('aria-hidden', 'true');
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        expect(container.querySelectorAll('.loadingDots-dot')).toHaveLength(3);
+    });
+});

--- a/packages/ui/src/loading/LoadingDots.tsx
+++ b/packages/ui/src/loading/LoadingDots.tsx
@@ -1,0 +1,11 @@
+import React, { type FunctionComponent, memo } from 'react';
+
+const LoadingDotsComponent: FunctionComponent = () => (
+    <span aria-hidden="true" className="loadingDots" data-test="loading-dots">
+        <span className="loadingDots-dot">&bull;</span>
+        <span className="loadingDots-dot">&bull;</span>
+        <span className="loadingDots-dot">&bull;</span>
+    </span>
+);
+
+export const LoadingDots = memo(LoadingDotsComponent);

--- a/packages/ui/src/loading/index.ts
+++ b/packages/ui/src/loading/index.ts
@@ -1,4 +1,5 @@
 export { default as LazyContainer } from './LazyContainer';
+export { LoadingDots } from './LoadingDots';
 export { default as LoadingNotification } from './LoadingNotification';
 export { default as LoadingOverlay } from './LoadingOverlay';
 export { default as LoadingSpinner } from './LoadingSpinner';


### PR DESCRIPTION
## What/Why?

**Part 1 of 3:** adds the building blocks for a scoreboard-style
price-change animation in enhancedThemeV1, without wiring them into any UI.

**No behavior or visual change ships in this PR.**

- `LoadingDots` — pulsing `•••` indicator in `@bigcommerce/checkout/ui`
- `usePriceChangeTicker` — phase machine (`idle → exiting → dots → entering`)
  that detects amount changes and exposes which value to display; skips
  animation for initial population, when disabled, and under
  `prefers-reduced-motion`
- `PriceTicker` — renders the dots/slide markup for a given phase
- SCSS: slide + pulse keyframes (enhancedThemeV1-scoped), with durations as
  named variables in the animation settings paired to the hook's constants
- Exports the existing `prefersReducedMotion` helper from the ui package

Follow-ups consume these: PR [#2 ](https://github.com/bigcommerce/checkout-js/pull/3285)wires the order-summary price rows,
PR [#3](https://github.com/bigcommerce/checkout-js/pull/3286) the mobile drawer's outstanding-balance bar. Behavior tests live with
the consumers; `LoadingDots` has unit tests here.
## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing (After PR [#2](https://github.com/bigcommerce/checkout-js/pull/3285))

**BEFORE**


https://github.com/user-attachments/assets/686b2ae3-2f1c-497d-a1ef-2886ccfca558




**AFTER**


https://github.com/user-attachments/assets/3c4b8aab-cd1c-4ada-888a-46f13e700583







<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive APIs, styles, and tests only; no checkout surfaces consume the ticker yet, so runtime behavior is unchanged.
> 
> **Overview**
> **Part 1 of a multi-PR effort:** introduces reusable pieces for a scoreboard-style price update animation in enhancedThemeV1. **Nothing in checkout UI uses them yet**, so shoppers should see no change until follow-up PRs wire order summary / mobile balance.
> 
> Adds **`LoadingDots`** in `@bigcommerce/checkout/ui` (three `aria-hidden` bullets) plus a unit test, and **`usePriceChangeTicker`** / **`PriceTicker`** in core order code. The hook runs an `idle → exiting → dots → entering` sequence when a numeric amount changes (skipping first paint, disabled mode, and `prefers-reduced-motion`), keeps the prior value visible during exit, and clears timers so a fast follow-up change cannot leave the UI stuck on dots.
> 
> SCSS adds enhancedThemeV1-scoped slide/pulse keyframes and animation timing variables aligned with the hook constants, and **`prefersReducedMotion`** is newly exported from the UI package for the hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99cf3f1111d037ddc35ea9f1685f3adc6879481d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->