### PR TITLE
feat(payment): PAYPAL-6634 Improve Error Messaging for Bank-Declined 3DS Authentication (PayPal PPCP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.970.0",
+        "@bigcommerce/checkout-sdk": "^1.971.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.970.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.970.0.tgz",
-      "integrity": "sha512-QNnLK+9Ir2LAYXH4HMfeMJEk55gODj2gZOXHzXdhhLlXn1U02wVjyHuaQ8mNlHKygIdXXWRphqMSZYG23O3g6Q==",
+      "version": "1.971.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.0.tgz",
+      "integrity": "sha512-PASiDkUi2AqsfJ4rMkLPoNIy3H333PzYcRN7qaN1J2MioxaYBDBuWEmt8QDFxATkT3e+O6wL4P3LQtYOJf4W2w==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29391,9 +29391,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.970.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.970.0.tgz",
-      "integrity": "sha512-QNnLK+9Ir2LAYXH4HMfeMJEk55gODj2gZOXHzXdhhLlXn1U02wVjyHuaQ8mNlHKygIdXXWRphqMSZYG23O3g6Q==",
+      "version": "1.971.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.0.tgz",
+      "integrity": "sha512-PASiDkUi2AqsfJ4rMkLPoNIy3H333PzYcRN7qaN1J2MioxaYBDBuWEmt8QDFxATkT3e+O6wL4P3LQtYOJf4W2w==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.970.0",
+    "@bigcommerce/checkout-sdk": "^1.971.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.test.ts
@@ -27,6 +27,16 @@ describe('mapSubmitOrderErrorMessage()', () => {
         expect(message).toEqual(translate('payment.payment_method_disabled_error'));
     });
 
+    it('returns correct message when bank declined authentication', () => {
+        const message = mapSubmitOrderErrorMessage(
+            { type: 'bank_declined_authentication' },
+            translate,
+            false,
+        );
+
+        expect(message).toEqual(translate('payment.errors.bank_declined_authentication'));
+    });
+
     it('returns correct message when shopping cart changed', () => {
         const message = mapSubmitOrderErrorMessage({ type: 'cart_changed' }, translate, false);
 

--- a/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
+++ b/packages/core/src/app/payment/mapSubmitOrderErrorMessage.ts
@@ -19,6 +19,9 @@ export default function mapSubmitOrderErrorMessage(
         case 'payment_method_invalid':
             return translate('payment.payment_method_disabled_error');
 
+        case 'bank_declined_authentication':
+            return translate('payment.errors.bank_declined_authentication');
+
         case 'tax_provider_unavailable':
             return translate('payment.tax_provider_unavailable');
 

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -494,7 +494,8 @@
                 "unsupported_request": "Unable to process the payment because invalid data was supplied with the transaction.",
                 "user_authorization_error": "There was an error while processing your payment. Please contact us.",
                 "vaulting_service_unavailable": "Vaulting service is currently not available.",
-                "voided_transaction": "Unable to process your payment because the transaction has already been voided. Please try again or contact us."
+                "voided_transaction": "Unable to process your payment because the transaction has already been voided. Please try again or contact us.",
+                "bank_declined_authentication": "Your bank declined authentication, please use a different card."
             },
             "ratepay": {
                 "payment_method_title": "Pay upon Invoice",


### PR DESCRIPTION
## What/Why?

Improve Error Messaging for Bank-Declined 3DS Authentication (PayPal PPCP)

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/6840220b-95d6-477b-bd29-dd7510a0236e

https://github.com/user-attachments/assets/fcdf6006-4ff2-4a64-956f-4d9b8a47f40b



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized checkout error copy and mapping only; no auth or payment execution logic changes beyond the SDK patch bump.
> 
> **Overview**
> Shows a **specific shopper message** when place-order fails with `bank_declined_authentication` (PayPal PPCP / bank-declined 3DS), instead of a generic payment error.
> 
> `mapSubmitOrderErrorMessage` now handles that error type via `payment.errors.bank_declined_authentication`, with matching English copy and a unit test. **`@bigcommerce/checkout-sdk`** is bumped to **^1.971.0** (lockfile updated) so the new error type can surface from the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec42511d37363116dfd4efe9fc3627238737aa2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->