### PR TITLE
feat(checkout): CHECKOUT-10353 show loading dots animation for price updates in desktop view order summary

### DIFF
--- a/packages/core/src/app/coupon/OrderSummarySubtotals.tsx
+++ b/packages/core/src/app/coupon/OrderSummarySubtotals.tsx
@@ -71,20 +71,20 @@ const OrderSummarySubtotals: FunctionComponent<OrderSummarySubtotalsProps> = ({
                     />
                 )}
 
-                {fees?.map((fee, index) => (
+                {fees?.map((fee) => (
                     <OrderSummaryPrice
                         amount={fee.cost}
-                        key={index}
+                        key={fee.id}
                         label={isOrderFee(fee) ? fee.customerDisplayName : fee.displayName}
                         testId="cart-fees"
                     />
                 ))}
 
                 {!isTaxIncluded &&
-                    (taxes || []).map((tax, index) => (
+                    (taxes || []).map((tax) => (
                         <OrderSummaryPrice
                             amount={tax.amount}
-                            key={index}
+                            key={tax.name}
                             label={tax.name}
                             testId="cart-taxes"
                         />

--- a/packages/core/src/app/order/OrderSummary.tsx
+++ b/packages/core/src/app/order/OrderSummary.tsx
@@ -113,10 +113,10 @@ const OrderSummary: FunctionComponent<OrderSummaryProps & OrderSummarySubtotalsP
                         >
                             <TranslatedString id="tax.inclusive_label" />
                         </h5>
-                        {(taxes || []).map((tax, index) => (
+                        {(taxes || []).map((tax) => (
                             <OrderSummaryPrice
                                 amount={tax.amount}
-                                key={index}
+                                key={tax.name}
                                 label={tax.name}
                                 testId="cart-taxes"
                             />

--- a/packages/core/src/app/order/OrderSummaryModal.tsx
+++ b/packages/core/src/app/order/OrderSummaryModal.tsx
@@ -148,10 +148,10 @@ const OrderSummaryModal: FunctionComponent<
                     >
                         <TranslatedString id="tax.inclusive_label" />
                     </h5>
-                    {(taxes || []).map((tax, index) => (
+                    {(taxes || []).map((tax) => (
                         <OrderSummaryPrice
                             amount={tax.amount}
-                            key={index}
+                            key={tax.name}
                             label={tax.name}
                             testId="cart-taxes"
                         />

--- a/packages/core/src/app/order/OrderSummaryPrice.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.test.tsx
@@ -224,7 +224,7 @@ describe('OrderSummaryPrice', () => {
                 addEventListener: noop,
                 removeListener: noop,
                 removeEventListener: noop,
-            } as unknown as MediaQueryList);
+            });
 
             const { rerender } = renderTestComponent(initialProps, { enhancedThemeV1: true });
 

--- a/packages/core/src/app/order/OrderSummaryPrice.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.test.tsx
@@ -2,7 +2,7 @@ import { noop } from 'lodash';
 import React, { type ReactNode } from 'react';
 
 import * as contexts from '@bigcommerce/checkout/contexts';
-import { fireEvent, render, screen } from '@bigcommerce/checkout/test-utils';
+import { act, fireEvent, render, screen, within } from '@bigcommerce/checkout/test-utils';
 
 jest.mock('react-transition-group', () => ({
     CSSTransition: ({ children }: { children: React.ReactNode }) => children,
@@ -31,8 +31,20 @@ describe('OrderSummaryPrice', () => {
         );
     };
 
-    const renderTestComponent = (props: OrderSummaryPriceProps & { children?: ReactNode }) => {
-        return render(<OrderSummaryPrice {...props} />);
+    const buildTestComponent = (
+        props: OrderSummaryPriceProps & { children?: ReactNode },
+        { enhancedThemeV1 = false }: { enhancedThemeV1?: boolean } = {},
+    ) => (
+        <contexts.ThemeContext.Provider value={{ enhancedThemeV1 }}>
+            <OrderSummaryPrice {...props} />
+        </contexts.ThemeContext.Provider>
+    );
+
+    const renderTestComponent = (
+        props: OrderSummaryPriceProps & { children?: ReactNode },
+        options: { enhancedThemeV1?: boolean } = {},
+    ) => {
+        return render(buildTestComponent(props, options));
     };
 
     describe('when has non-zero amount', () => {
@@ -114,6 +126,168 @@ describe('OrderSummaryPrice', () => {
 
                 expect(screen.getByTestId('cart-price-value')).toHaveTextContent('Free');
             });
+        });
+    });
+
+    describe('when amount changes', () => {
+        const initialProps: OrderSummaryPriceProps = {
+            amount: 10,
+            label: 'Label',
+            superscript: '*',
+            testId: 'test-id',
+        };
+
+        beforeEach(() => {
+            useCheckoutMock(false);
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('slides the old price out, shows dots, then slides the new price in', () => {
+            const props = { ...initialProps, amountBeforeDiscount: 20 };
+            const { rerender } = renderTestComponent(props, { enhancedThemeV1: true });
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+
+            rerender(buildTestComponent({ ...props, amount: 15 }, { enhancedThemeV1: true }));
+
+            const priceValue = screen.getByTestId('cart-price-value');
+            const priceRow = priceValue.closest('.cart-priceItem');
+
+            expect(screen.getByTestId('price-ticker')).toHaveClass('priceTicker-exit');
+            expect(within(priceValue).getByTestId('ShopperCurrency')).toHaveTextContent('10');
+            expect(screen.getByTestId('cart-price-value-superscript')).toBeInTheDocument();
+            expect(priceRow).toHaveAttribute('aria-busy', 'true');
+
+            act(() => {
+                jest.advanceTimersByTime(200);
+            });
+
+            expect(screen.getByTestId('loading-dots')).toBeInTheDocument();
+            expect(priceValue).toContainElement(screen.getByTestId('loading-dots'));
+            expect(screen.queryByTestId('ShopperCurrency')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('cart-price-value-superscript')).not.toBeInTheDocument();
+            expect(priceRow).toHaveAttribute('aria-busy', 'true');
+
+            act(() => {
+                jest.advanceTimersByTime(1200);
+            });
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(screen.getByTestId('price-ticker')).toHaveClass('priceTicker-enter');
+            expect(within(priceValue).getByTestId('ShopperCurrency')).toHaveTextContent('15');
+            expect(screen.getByTestId('cart-price-value-superscript')).toBeInTheDocument();
+
+            act(() => {
+                jest.advanceTimersByTime(200);
+            });
+
+            expect(screen.queryByTestId('price-ticker')).not.toBeInTheDocument();
+            expect(priceRow).not.toHaveAttribute('aria-busy');
+            expect(screen.getByTestId('cart-price-value-superscript')).toHaveTextContent('*');
+        });
+
+        it('recovers to the new price when the amount becomes unavailable mid-animation', () => {
+            const { rerender } = renderTestComponent(initialProps, { enhancedThemeV1: true });
+
+            rerender(
+                buildTestComponent({ ...initialProps, amount: null }, { enhancedThemeV1: true }),
+            );
+
+            act(() => {
+                jest.advanceTimersByTime(600);
+            });
+
+            expect(screen.getByTestId('loading-dots')).toBeInTheDocument();
+
+            rerender(
+                buildTestComponent({ ...initialProps, amount: 25 }, { enhancedThemeV1: true }),
+            );
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(screen.getByTestId('ShopperCurrency')).toHaveTextContent('25');
+
+            act(() => {
+                jest.advanceTimersByTime(5000);
+            });
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+        });
+
+        it('skips the animation when the user prefers reduced motion', () => {
+            (window.matchMedia as jest.Mock).mockReturnValueOnce({
+                matches: true,
+                addListener: noop,
+                addEventListener: noop,
+                removeListener: noop,
+                removeEventListener: noop,
+            } as unknown as MediaQueryList);
+
+            const { rerender } = renderTestComponent(initialProps, { enhancedThemeV1: true });
+
+            rerender(
+                buildTestComponent({ ...initialProps, amount: 15 }, { enhancedThemeV1: true }),
+            );
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('price-ticker')).not.toBeInTheDocument();
+            expect(screen.getByTestId('ShopperCurrency')).toHaveTextContent('15');
+        });
+
+        it('does not animate the initial amount population', () => {
+            const { rerender } = renderTestComponent(
+                { ...initialProps, amount: null },
+                { enhancedThemeV1: true },
+            );
+
+            rerender(
+                buildTestComponent({ ...initialProps, amount: 10 }, { enhancedThemeV1: true }),
+            );
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('price-ticker')).not.toBeInTheDocument();
+            expect(screen.getByTestId('ShopperCurrency')).toHaveTextContent('10');
+        });
+
+        it('restarts the animation when the amount changes again mid-animation', () => {
+            const { rerender } = renderTestComponent(initialProps, { enhancedThemeV1: true });
+
+            rerender(
+                buildTestComponent({ ...initialProps, amount: 15 }, { enhancedThemeV1: true }),
+            );
+
+            act(() => {
+                jest.advanceTimersByTime(800);
+            });
+
+            expect(screen.getByTestId('loading-dots')).toBeInTheDocument();
+
+            rerender(
+                buildTestComponent({ ...initialProps, amount: 25 }, { enhancedThemeV1: true }),
+            );
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(screen.getByTestId('price-ticker')).toHaveClass('priceTicker-exit');
+
+            act(() => {
+                jest.advanceTimersByTime(1600);
+            });
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('price-ticker')).not.toBeInTheDocument();
+            expect(screen.getByTestId('ShopperCurrency')).toHaveTextContent('25');
+        });
+
+        it('renders the price without dots in non-enhanced theme', () => {
+            const { rerender } = renderTestComponent(initialProps);
+
+            rerender(buildTestComponent({ ...initialProps, amount: 15 }));
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(screen.getByTestId('ShopperCurrency')).toHaveTextContent('15');
         });
     });
 

--- a/packages/core/src/app/order/OrderSummaryPrice.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.tsx
@@ -2,10 +2,13 @@ import classNames from 'classnames';
 import React, { type FC, type ReactNode, useCallback, useEffect, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
 
-import { useCheckout } from '@bigcommerce/checkout/contexts';
+import { useCheckout, useThemeContext } from '@bigcommerce/checkout/contexts';
 import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 
 import { ShopperCurrency } from '../currency';
+
+import { PriceTicker } from './PriceTicker';
+import { usePriceChangeTicker } from './usePriceChangeTicker';
 
 export interface OrderSummaryPriceProps {
     children?: ReactNode;
@@ -20,11 +23,6 @@ export interface OrderSummaryPriceProps {
     actionLabel?: ReactNode;
     onActionTriggered?(): void;
     isOrderTotal?: boolean;
-}
-
-export interface OrderSummaryPriceState {
-    highlight: boolean;
-    previousAmount?: number;
 }
 
 function getDisplayValue(amount?: number | null, zeroLabel?: ReactNode): ReactNode | number {
@@ -64,12 +62,18 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
     const { selectedState: isActionDisabled } = useCheckout(({ statuses }) =>
         statuses.isSubmittingOrder(),
     );
+    const { enhancedThemeV1 } = useThemeContext();
 
-    const displayValue = getDisplayValue(amount, zeroLabel);
+    const ticker = usePriceChangeTicker(amount, enhancedThemeV1);
+    const { phase, displayAmount } = ticker;
+    const showDots = phase === 'dots';
+    const displayValue = getDisplayValue(displayAmount, zeroLabel);
 
     useEffect(() => {
-        setHighlight(amount !== previousAmount);
-        setPreviousAmount(amount);
+        if (!enhancedThemeV1) {
+            setHighlight(amount !== previousAmount);
+            setPreviousAmount(amount);
+        }
     }, [amount]);
 
     const handleTransitionEnd: (node: HTMLElement, done: () => void) => void = useCallback(
@@ -92,6 +96,79 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
         onActionTriggered();
     };
 
+    const priceRow = (
+        <div
+            aria-busy={phase !== 'idle' || undefined}
+            aria-live="polite"
+            className={classNames('cart-priceItem', 'optimizedCheckout-contentPrimary', className)}
+        >
+            <span
+                className={classNames('cart-priceItem-label', {
+                    'body-regular optimizedCheckout-contentPrimary': !isOrderTotal,
+                    'sub-header optimizedCheckout-headingSecondary': isOrderTotal,
+                })}
+            >
+                <span data-test="cart-price-label">
+                    {label}
+                    {'  '}
+                </span>
+                {currencyCode && (
+                    <span className="cart-priceItem-currencyCode">{`(${currencyCode}) `}</span>
+                )}
+                {onActionTriggered && actionLabel && (
+                    <span className="cart-priceItem-link">
+                        <a
+                            className={classNames({
+                                'link--disabled': isActionDisabled,
+                                'body-cta': !isOrderTotal,
+                            })}
+                            data-test="cart-price-callback"
+                            href="#"
+                            onClick={preventDefault(handleActionTrigger)}
+                        >
+                            {actionLabel}
+                        </a>
+                    </span>
+                )}
+            </span>
+
+            <span
+                className={classNames('cart-priceItem-value', {
+                    'body-medium optimizedCheckout-contentPrimary': !isOrderTotal,
+                    'header optimizedCheckout-headingPrimary': isOrderTotal,
+                })}
+            >
+                {!showDots &&
+                    isNumberValue(amountBeforeDiscount) &&
+                    amountBeforeDiscount !== displayAmount && (
+                        <span className="cart-priceItem-before-value">
+                            <ShopperCurrency amount={amountBeforeDiscount} />
+                        </span>
+                    )}
+
+                <span data-test="cart-price-value">
+                    <PriceTicker ticker={ticker}>
+                        {isNumberValue(displayValue) ? (
+                            <ShopperCurrency amount={displayValue} />
+                        ) : (
+                            displayValue
+                        )}
+                    </PriceTicker>
+                </span>
+
+                {superscript && !showDots && (
+                    <sup data-test="cart-price-value-superscript">{superscript}</sup>
+                )}
+            </span>
+
+            {children}
+        </div>
+    );
+
+    if (enhancedThemeV1) {
+        return <div data-test={testId}>{priceRow}</div>;
+    }
+
     return (
         <div data-test={testId}>
             <CSSTransition
@@ -100,73 +177,7 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
                 in={highlight}
                 timeout={{}}
             >
-                <div
-                    aria-live="polite"
-                    className={classNames(
-                        'cart-priceItem',
-                        'optimizedCheckout-contentPrimary',
-                        className,
-                    )}
-                >
-                    <span
-                        className={classNames('cart-priceItem-label', {
-                            'body-regular optimizedCheckout-contentPrimary': !isOrderTotal,
-                            'sub-header optimizedCheckout-headingSecondary': isOrderTotal,
-                        })}
-                    >
-                        <span data-test="cart-price-label">
-                            {label}
-                            {'  '}
-                        </span>
-                        {currencyCode && (
-                            <span className="cart-priceItem-currencyCode">
-                                {`(${currencyCode}) `}
-                            </span>
-                        )}
-                        {onActionTriggered && actionLabel && (
-                            <span className="cart-priceItem-link">
-                                <a
-                                    className={classNames({
-                                        'link--disabled': isActionDisabled,
-                                        'body-cta': !isOrderTotal,
-                                    })}
-                                    data-test="cart-price-callback"
-                                    href="#"
-                                    onClick={preventDefault(handleActionTrigger)}
-                                >
-                                    {actionLabel}
-                                </a>
-                            </span>
-                        )}
-                    </span>
-
-                    <span
-                        className={classNames('cart-priceItem-value', {
-                            'body-medium optimizedCheckout-contentPrimary': !isOrderTotal,
-                            'header optimizedCheckout-headingPrimary': isOrderTotal,
-                        })}
-                    >
-                        {isNumberValue(amountBeforeDiscount) && amountBeforeDiscount !== amount && (
-                            <span className="cart-priceItem-before-value">
-                                <ShopperCurrency amount={amountBeforeDiscount} />
-                            </span>
-                        )}
-
-                        <span data-test="cart-price-value">
-                            {isNumberValue(displayValue) ? (
-                                <ShopperCurrency amount={displayValue} />
-                            ) : (
-                                displayValue
-                            )}
-                        </span>
-
-                        {superscript && (
-                            <sup data-test="cart-price-value-superscript">{superscript}</sup>
-                        )}
-                    </span>
-
-                    {children}
-                </div>
+                {priceRow}
             </CSSTransition>
         </div>
     );

--- a/packages/core/src/app/order/OrderSummaryPrice.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.tsx
@@ -8,7 +8,7 @@ import { preventDefault } from '@bigcommerce/checkout/dom-utils';
 import { ShopperCurrency } from '../currency';
 
 import { PriceTicker } from './PriceTicker';
-import { usePriceChangeTicker } from './usePriceChangeTicker';
+import { PriceTickerPhase, usePriceChangeTicker } from './usePriceChangeTicker';
 
 export interface OrderSummaryPriceProps {
     children?: ReactNode;
@@ -64,9 +64,8 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
     );
     const { enhancedThemeV1 } = useThemeContext();
 
-    const ticker = usePriceChangeTicker(amount, enhancedThemeV1);
-    const { phase, displayAmount } = ticker;
-    const showDots = phase === 'dots';
+    const { phase, displayAmount } = usePriceChangeTicker(amount, enhancedThemeV1);
+    const showDots = phase === PriceTickerPhase.Dots;
     const displayValue = getDisplayValue(displayAmount, zeroLabel);
 
     useEffect(() => {
@@ -98,7 +97,7 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
 
     const priceRow = (
         <div
-            aria-busy={phase !== 'idle' || undefined}
+            aria-busy={phase !== PriceTickerPhase.Idle || undefined}
             aria-live="polite"
             className={classNames('cart-priceItem', 'optimizedCheckout-contentPrimary', className)}
         >
@@ -147,7 +146,7 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
                     )}
 
                 <span data-test="cart-price-value">
-                    <PriceTicker ticker={ticker}>
+                    <PriceTicker phase={phase}>
                         {isNumberValue(displayValue) ? (
                             <ShopperCurrency amount={displayValue} />
                         ) : (

--- a/packages/core/src/app/order/PriceTicker.tsx
+++ b/packages/core/src/app/order/PriceTicker.tsx
@@ -2,16 +2,14 @@ import React, { type FunctionComponent, type ReactNode } from 'react';
 
 import { LoadingDots } from '@bigcommerce/checkout/ui';
 
-import { type PriceChangeTicker, PriceTickerPhase } from './usePriceChangeTicker';
+import { PriceTickerPhase } from './usePriceChangeTicker';
 
 export interface PriceTickerProps {
-    ticker: PriceChangeTicker;
+    phase: PriceTickerPhase;
     children: ReactNode;
 }
 
-export const PriceTicker: FunctionComponent<PriceTickerProps> = ({ ticker, children }) => {
-    const { phase } = ticker;
-
+export const PriceTicker: FunctionComponent<PriceTickerProps> = ({ phase, children }) => {
     if (phase === PriceTickerPhase.Idle) {
         return <>{children}</>;
     }


### PR DESCRIPTION
## What/Why?

- For enhancedThemeV1, update the highlight notification style for price updates. Instead of a blue background highlight show `...` dotted loader on price.
- Along with the loader we also add animation on price, which is sliding up old price -> showing loading dots -> sliding up the new price.

## Rollout/Rollback

Revert this PR.

## Testing

 - CI checks
 - Manual testing

**BEFORE**

https://github.com/user-attachments/assets/94151040-d2fc-4c45-b528-6a461882ebd7



**AFTER**

https://github.com/user-attachments/assets/dc2107f2-737f-4ea0-aff1-56b9d5f1b018



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout UI-only behavior gated on enhancedThemeV1; non-enhanced checkout keeps existing highlight behavior with added test coverage.
> 
> **Overview**
> For **`enhancedThemeV1`**, order summary line prices no longer use the blue **changeHighlight** flash when amounts update. **`OrderSummaryPrice`** now drives updates through **`usePriceChangeTicker`** and **`PriceTicker`**: slide the previous value out, show **`LoadingDots`**, then slide the new value in. The row sets **`aria-busy`** during the sequence; superscript and strikethrough “before discount” values are hidden while dots show. **`prefers-reduced-motion`**, first paint, and rapid mid-animation amount changes are handled in the hook; the legacy theme path still uses **`CSSTransition`** highlight only.
> 
> **`PriceTicker`** now takes **`phase`** directly instead of a full ticker object. Fee and tax rows in **`OrderSummarySubtotals`**, **`OrderSummary`**, and **`OrderSummaryModal`** use stable React **`key`**s (`fee.id`, `tax.name`) instead of array index so list re-renders don’t break the animation. Tests in **`OrderSummaryPrice.test.tsx`** cover the full ticker timeline and theme branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825c06f911b5842faad6caec6a3b8d5c1abd606e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->