### PR TITLE
feat(checkout): CHECKOUT-10353 show loading dots animation for price updates in mobile view order summary

### DIFF
--- a/packages/core/src/app/cart/CartOutstandingBalance.tsx
+++ b/packages/core/src/app/cart/CartOutstandingBalance.tsx
@@ -2,7 +2,7 @@ import React, { type FunctionComponent } from 'react';
 
 import { ShopperCurrency } from '../currency';
 import { PriceTicker } from '../order/PriceTicker';
-import { usePriceChangeTicker } from '../order/usePriceChangeTicker';
+import { PriceTickerPhase, usePriceChangeTicker } from '../order/usePriceChangeTicker';
 
 export interface CartOutstandingBalanceProps {
     amount: number;
@@ -14,17 +14,17 @@ export const CartOutstandingBalance: FunctionComponent<CartOutstandingBalancePro
     amount,
     currencyCode,
 }) => {
-    const ticker = usePriceChangeTicker(amount);
+    const { phase, displayAmount } = usePriceChangeTicker(amount);
 
     return (
         <span
-            aria-busy={ticker.phase !== 'idle' || undefined}
+            aria-busy={phase !== PriceTickerPhase.Idle || undefined}
             aria-live="polite"
             className="sub-header"
             data-test="cart-outstanding-balance"
         >
-            <PriceTicker ticker={ticker}>
-                <ShopperCurrency amount={ticker.displayAmount ?? amount} /> ({currencyCode})
+            <PriceTicker phase={phase}>
+                <ShopperCurrency amount={displayAmount ?? amount} /> ({currencyCode})
             </PriceTicker>
         </span>
     );

--- a/packages/core/src/app/cart/CartOutstandingBalance.tsx
+++ b/packages/core/src/app/cart/CartOutstandingBalance.tsx
@@ -4,21 +4,22 @@ import { ShopperCurrency } from '../currency';
 import { PriceTicker } from '../order/PriceTicker';
 import { PriceTickerPhase, usePriceChangeTicker } from '../order/usePriceChangeTicker';
 
-export interface CartOutstandingBalanceProps {
+interface CartOutstandingBalanceProps {
     amount: number;
     currencyCode: string;
 }
 
-// Owns the ticker state so phase changes re-render only this span, not the drawer.
 export const CartOutstandingBalance: FunctionComponent<CartOutstandingBalanceProps> = ({
     amount,
     currencyCode,
 }) => {
+    // Keep the ticker state here so phase changes re-render only this span, not the drawer.
     const { phase, displayAmount } = usePriceChangeTicker(amount);
+    const isPriceUpdating = phase !== PriceTickerPhase.Idle || undefined;
 
     return (
         <span
-            aria-busy={phase !== PriceTickerPhase.Idle || undefined}
+            aria-busy={isPriceUpdating}
             aria-live="polite"
             className="sub-header"
             data-test="cart-outstanding-balance"

--- a/packages/core/src/app/cart/CartOutstandingBalance.tsx
+++ b/packages/core/src/app/cart/CartOutstandingBalance.tsx
@@ -1,0 +1,31 @@
+import React, { type FunctionComponent } from 'react';
+
+import { ShopperCurrency } from '../currency';
+import { PriceTicker } from '../order/PriceTicker';
+import { usePriceChangeTicker } from '../order/usePriceChangeTicker';
+
+export interface CartOutstandingBalanceProps {
+    amount: number;
+    currencyCode: string;
+}
+
+// Owns the ticker state so phase changes re-render only this span, not the drawer.
+export const CartOutstandingBalance: FunctionComponent<CartOutstandingBalanceProps> = ({
+    amount,
+    currencyCode,
+}) => {
+    const ticker = usePriceChangeTicker(amount);
+
+    return (
+        <span
+            aria-busy={ticker.phase !== 'idle' || undefined}
+            aria-live="polite"
+            className="sub-header"
+            data-test="cart-outstanding-balance"
+        >
+            <PriceTicker ticker={ticker}>
+                <ShopperCurrency amount={ticker.displayAmount ?? amount} /> ({currencyCode})
+            </PriceTicker>
+        </span>
+    );
+};

--- a/packages/core/src/app/cart/CartSummaryDrawerV2.test.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
 import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
-import { configure, render, screen, waitFor, within } from '@bigcommerce/checkout/test-utils';
+import { act, configure, render, screen, waitFor, within } from '@bigcommerce/checkout/test-utils';
 
 import { getCheckout } from '../checkout/checkouts.mock';
 import { createErrorLogger } from '../common/error';
@@ -25,18 +25,25 @@ describe('CartSummaryDrawerV2 Component', () => {
         const extensionService = new ExtensionService(checkoutService, createErrorLogger());
 
         jest.spyOn(checkoutService.getState().data, 'getCustomer').mockReturnValue(getCustomer());
-        jest.spyOn(checkoutService.getState().data, 'getCheckout').mockReturnValue(checkout);
         jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(getStoreConfig());
 
-        return render(
+        const getCheckoutMock = jest
+            .spyOn(checkoutService.getState().data, 'getCheckout')
+            .mockReturnValue(checkout);
+
+        const buildUi = () => (
             <CheckoutProvider checkoutService={checkoutService}>
                 <LocaleContext.Provider value={localeContext}>
                     <ExtensionProvider extensionService={extensionService}>
                         <CartSummaryDrawerV2 isMultiShippingMode={false} />
                     </ExtensionProvider>
                 </LocaleContext.Provider>
-            </CheckoutProvider>,
+            </CheckoutProvider>
         );
+
+        const view = render(buildUi());
+
+        return { ...view, getCheckoutMock, rerenderComponent: () => view.rerender(buildUi()) };
     };
 
     const getCollapsedBar = () => screen.getByTestId('cart-summary-collapsed-bar');
@@ -161,5 +168,42 @@ describe('CartSummaryDrawerV2 Component', () => {
         await userEvent.click(screen.getByTestId('cart-summary-backdrop'));
 
         await expectSheetClosed();
+    });
+
+    it('slides the old balance out, shows dots, then slides the new balance in', () => {
+        jest.useFakeTimers();
+
+        try {
+            const checkout = getCheckout();
+            const { getCheckoutMock, rerenderComponent } = renderComponent(checkout);
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+
+            getCheckoutMock.mockReturnValue({ ...checkout, outstandingBalance: 300 });
+            rerenderComponent();
+
+            const balance = screen.getByTestId('cart-outstanding-balance');
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(balance).toHaveTextContent('$212.80 (USD)');
+
+            act(() => {
+                jest.advanceTimersByTime(200);
+            });
+
+            expect(within(balance).getByTestId('loading-dots')).toBeInTheDocument();
+            expect(balance).toHaveAttribute('aria-busy', 'true');
+            expect(balance).not.toHaveTextContent('$');
+            expect(balance).not.toHaveTextContent('(USD)');
+
+            act(() => {
+                jest.advanceTimersByTime(1200);
+            });
+
+            expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument();
+            expect(balance).toHaveTextContent('$336.00 (USD)');
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
@@ -6,13 +6,13 @@ import { useCheckout, useLocale } from '@bigcommerce/checkout/contexts';
 import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { IconChevronDown, IconChevronUp } from '@bigcommerce/checkout/ui';
 
-import { ShopperCurrency } from '../currency';
 import getItemsCount from '../order/getItemsCount';
 import getLineItemsCount from '../order/getLineItemsCount';
 import OrderSummary from '../order/OrderSummary';
 import { removeBundledItems } from '../order/removeBundledItems';
 
 import { CartHeaderLink } from './CartHeaderLink';
+import { CartOutstandingBalance } from './CartOutstandingBalance';
 import { CartSummaryItemImage } from './CartSummaryItemImage';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
 import withRedeemable from './withRedeemable';
@@ -86,10 +86,10 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
                             id="cart.item_count_text"
                         />
                     </span>
-                    <span className="sub-header" data-test="cart-outstanding-balance">
-                        <ShopperCurrency amount={checkout.outstandingBalance} /> (
-                        {shopperCurrency.code})
-                    </span>
+                    <CartOutstandingBalance
+                        amount={checkout.outstandingBalance}
+                        currencyCode={shopperCurrency.code}
+                    />
                 </div>
                 <span className="cart-summary-bar-toggle-label body-regular optimizedCheckout-orderSummary-toggle">
                     <TranslatedString


### PR DESCRIPTION
## What/Why?

- For enhancedThemeV1, add the highlight notification style for price updates in the mobile view order summary footer.
- Along with the loader we also add animation on price, which is sliding up old price -> showing loading dots -> sliding up the new price.

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**BEFORE**

https://github.com/user-attachments/assets/b1787215-5302-49d3-81c5-b9ea20bad2bb



**AFTER**

https://github.com/user-attachments/assets/d02f9f9f-d38b-4e95-851e-affdfd18c9a1



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to mobile cart summary display and tests; reuses existing price ticker hooks with no auth or payment logic changes.
> 
> **Overview**
> The mobile **CartSummaryDrawerV2** collapsed bar no longer renders a static outstanding balance. It now uses a new **`CartOutstandingBalance`** component that wires **`usePriceChangeTicker`** and **`PriceTicker`** (same pattern as order summary prices) so when **`checkout.outstandingBalance`** changes, users see the old amount slide out, loading dots, then the new amount slide in.
> 
> The component keeps ticker state local so animation phases only re-render the balance span (not the whole drawer), and exposes **`aria-busy`** / **`aria-live="polite"`** while the price is updating. Tests were extended to assert the timed animation sequence and updated checkout mocks via rerender.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d61e83847b20a2c184d40fdf642ff48305aa68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->