### PR TITLE
fix(checkout): CHECKOUT-10328 Google Autocomplete dropping suffix from AU addresses

### DIFF
--- a/packages/core/src/app/address/AddressForm.tsx
+++ b/packages/core/src/app/address/AddressForm.tsx
@@ -126,7 +126,7 @@ const AddressForm: React.FC<AddressFormProps> = ({
         (place: google.maps.places.PlaceResult, item: AutocompleteItem) => {
             const { value: autocompleteValue } = item;
 
-            const address = mapToAddress(place, countries);
+            const address = mapToAddress(place, countries, autocompleteValue);
 
             forIn(address, (value, fieldName) => {
                 if (fieldName === AUTOCOMPLETE_FIELD_NAME && value === undefined) {

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.test.ts
@@ -24,4 +24,54 @@ describe('AddressSelectorAU', () => {
 
         expect(selector.getStreet2()).toBe('');
     });
+
+    it('upper-cases lowercase letter suffixes on the street number and subpremise per Australia Post', () => {
+        const selector = new AddressSelectorAU({
+            ...googleAutocompletePlaceMock,
+            address_components: [
+                {
+                    long_name: 'unit 2a',
+                    short_name: 'unit 2a',
+                    types: ['subpremise'],
+                },
+                {
+                    long_name: '34b',
+                    short_name: '34b',
+                    types: ['street_number'],
+                },
+                {
+                    long_name: 'Bayford Street',
+                    short_name: 'Bayford St',
+                    types: ['route'],
+                },
+            ],
+        });
+
+        expect(selector.getStreet()).toBe('unit 2A/34B Bayford Street');
+    });
+
+    it('leaves ordinals and multi-letter endings in the subpremise unchanged', () => {
+        const selector = new AddressSelectorAU({
+            ...googleAutocompletePlaceMock,
+            address_components: [
+                {
+                    long_name: '3rd floor',
+                    short_name: '3rd floor',
+                    types: ['subpremise'],
+                },
+                {
+                    long_name: '34',
+                    short_name: '34',
+                    types: ['street_number'],
+                },
+                {
+                    long_name: 'Bayford Street',
+                    short_name: 'Bayford St',
+                    types: ['route'],
+                },
+            ],
+        });
+
+        expect(selector.getStreet()).toBe('3rd floor/34 Bayford Street');
+    });
 });

--- a/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.ts
+++ b/packages/core/src/app/address/googleAutocomplete/AddressSelectorAU.ts
@@ -1,11 +1,19 @@
 import AddressSelector from './AddressSelector';
 
+// Australia Post requires alphanumeric unit number suffixes to be upper-case
+const uppercaseUnitSuffix = (value: string): string =>
+    value.replace(
+        /\b(\d+)([a-z])\b/gi,
+        (_, digits: string, letter: string) => `${digits}${letter.toUpperCase()}`,
+    );
+
 export default class AddressSelectorAU extends AddressSelector {
     getStreet(): string {
-        const subpremise = this._get('subpremise', 'short_name');
+        const subpremise = uppercaseUnitSuffix(this._get('subpremise', 'short_name'));
         const subpremisePart = subpremise ? `${subpremise}/` : '';
+        const streetNumber = uppercaseUnitSuffix(this._get('street_number', 'long_name'));
 
-        return `${subpremisePart}${this._get('street_number', 'long_name')} ${this._get('route', 'long_name')}`;
+        return `${subpremisePart}${streetNumber} ${this._get('route', 'long_name')}`;
     }
 
     getStreet2(): string {

--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
@@ -56,6 +56,44 @@ export function getGoogleAutocompletePlaceMock(): google.maps.places.PlaceResult
     } as google.maps.places.PlaceResult;
 }
 
+export function getGoogleAutocompleteAUPlaceMock(): google.maps.places.PlaceResult {
+    return {
+        name: '34 Bayford St',
+        address_components: [
+            {
+                long_name: '34',
+                short_name: '34',
+                types: ['street_number'],
+            },
+            {
+                long_name: 'Bayford Street',
+                short_name: 'Bayford St',
+                types: ['route'],
+            },
+            {
+                long_name: 'Birkdale',
+                short_name: 'Birkdale',
+                types: ['locality', 'political'],
+            },
+            {
+                long_name: 'Queensland',
+                short_name: 'QLD',
+                types: ['administrative_area_level_1', 'political'],
+            },
+            {
+                long_name: 'Australia',
+                short_name: 'AU',
+                types: ['country', 'political'],
+            },
+            {
+                long_name: '4159',
+                short_name: '4159',
+                types: ['postal_code'],
+            },
+        ],
+    } as google.maps.places.PlaceResult;
+}
+
 export function getGoogleAutocompleteNZPlaceMock(): google.maps.places.PlaceResult {
     return {
         name: '6d/17 Alberton Avenue',

--- a/packages/core/src/app/address/googleAutocomplete/mapToAddress.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/mapToAddress.test.ts
@@ -22,14 +22,29 @@ describe('mapToAddress()', () => {
         });
     });
 
-    it('restores a street number suffix stripped by place details for AU addresses', () => {
+    it('restores a street number suffix stripped by place details for AU addresses, upper-cased per Australia Post', () => {
         const address = mapToAddress(
             getGoogleAutocompleteAUPlaceMock(),
             getCountries(),
             '34a Bayford Street',
         );
 
-        expect(address.address1).toBe('34a Bayford Street');
+        expect(address.address1).toBe('34A Bayford Street');
+    });
+
+    it('upper-cases a lowercase street number suffix returned by place details for AU addresses', () => {
+        const mockGooglePlace = getGoogleAutocompleteAUPlaceMock();
+
+        mockGooglePlace.address_components = (mockGooglePlace.address_components ?? []).map(
+            (component) =>
+                component.types.includes('street_number')
+                    ? { ...component, long_name: '34b', short_name: '34b' }
+                    : component,
+        );
+
+        const address = mapToAddress(mockGooglePlace, getCountries(), '34b Bayford Street');
+
+        expect(address.address1).toBe('34B Bayford Street');
     });
 
     it('keeps the place details street when the prediction has no extra suffix', () => {

--- a/packages/core/src/app/address/googleAutocomplete/mapToAddress.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/mapToAddress.test.ts
@@ -1,6 +1,9 @@
 import { getCountries } from '../../geography/countries.mock';
 
-import { getGoogleAutocompletePlaceMock } from './googleAutocompleteResult.mock';
+import {
+    getGoogleAutocompleteAUPlaceMock,
+    getGoogleAutocompletePlaceMock,
+} from './googleAutocompleteResult.mock';
 import mapToAddress from './mapToAddress';
 
 describe('mapToAddress()', () => {
@@ -17,6 +20,24 @@ describe('mapToAddress()', () => {
             stateOrProvince: 'New South Wales',
             stateOrProvinceCode: 'NSW',
         });
+    });
+
+    it('restores a street number suffix stripped by place details for AU addresses', () => {
+        const address = mapToAddress(
+            getGoogleAutocompleteAUPlaceMock(),
+            getCountries(),
+            '34a Bayford Street',
+        );
+
+        expect(address.address1).toBe('34a Bayford Street');
+    });
+
+    it('keeps the place details street when the prediction has no extra suffix', () => {
+        const googlePlace = getGoogleAutocompletePlaceMock();
+
+        const address = mapToAddress(googlePlace, getCountries(), 'unit 6/1-3 Smail St');
+
+        expect(address.address1).toBe('unit 6/1-3 (l) Smail Street');
     });
 
     it('returns a partial address with province code when no countries are passed', () => {

--- a/packages/core/src/app/address/googleAutocomplete/mapToAddress.ts
+++ b/packages/core/src/app/address/googleAutocomplete/mapToAddress.ts
@@ -1,10 +1,12 @@
 import { type Address, type Country, type Region } from '@bigcommerce/checkout-sdk';
 
 import AddressSelectorFactory from './AddressSelectorFactory';
+import { restoreStreetNumberSuffix } from './utils';
 
 export default function mapToAddress(
     autocompleteData: google.maps.places.PlaceResult,
     countries: Country[] = [],
+    autocompleteValue?: string,
 ): Partial<Address> {
     if (!autocompleteData || !autocompleteData.address_components) {
         return {};
@@ -17,10 +19,13 @@ export default function mapToAddress(
     const street2 = accessor.getStreet2();
 
     // TODO: Apply this fix for US, UK and CA addresses too.
-    const steet1 = countryCode === 'AU' ? accessor.getStreet() : undefined;
+    const street1 =
+        countryCode === 'AU'
+            ? restoreStreetNumberSuffix(accessor.getStreet(), autocompleteValue)
+            : undefined;
 
     return {
-        address1: steet1,
+        address1: street1,
         address2: street2,
         city: accessor.getCity(),
         countryCode,

--- a/packages/core/src/app/address/googleAutocomplete/utils.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.test.ts
@@ -19,6 +19,24 @@ describe('restoreStreetNumberSuffix()', () => {
         );
     });
 
+    it('returns the street unchanged when the prediction has a "unit" prefix and no extra suffix', () => {
+        expect(restoreStreetNumberSuffix('4/28 Beach Street', 'unit 4/28 Beach Street')).toBe(
+            '4/28 Beach Street',
+        );
+    });
+
+    it('restores a letter suffix when the prediction has a "unit" prefix', () => {
+        expect(restoreStreetNumberSuffix('4/28 Beach Street', 'unit 4/28a Beach St')).toBe(
+            '4/28a Beach Street',
+        );
+    });
+
+    it('restores a letter suffix when the subpremise contains a space', () => {
+        expect(restoreStreetNumberSuffix('shop 2/34 Bayford Street', 'shop 2/34a Bayford St')).toBe(
+            'shop 2/34a Bayford Street',
+        );
+    });
+
     it('returns the street unchanged when the street numbers already match', () => {
         expect(restoreStreetNumberSuffix('34 Bayford Street', '34 Bayford St')).toBe(
             '34 Bayford Street',

--- a/packages/core/src/app/address/googleAutocomplete/utils.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.test.ts
@@ -1,0 +1,47 @@
+import { restoreStreetNumberSuffix } from './utils';
+
+describe('restoreStreetNumberSuffix()', () => {
+    it('restores a letter suffix dropped by place details', () => {
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '34a Bayford Street')).toBe(
+            '34a Bayford Street',
+        );
+    });
+
+    it('restores a letter suffix while keeping the long route name from place details', () => {
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '34a Bayford St')).toBe(
+            '34a Bayford Street',
+        );
+    });
+
+    it('restores a letter suffix on a subpremise street number', () => {
+        expect(restoreStreetNumberSuffix('2/34 Bayford Street', '2/34a Bayford St')).toBe(
+            '2/34a Bayford Street',
+        );
+    });
+
+    it('returns the street unchanged when the street numbers already match', () => {
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '34 Bayford St')).toBe(
+            '34 Bayford Street',
+        );
+    });
+
+    it('returns the street unchanged when the prediction number does not extend the street number', () => {
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '345 Bayford St')).toBe(
+            '34 Bayford Street',
+        );
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '12a Bayford St')).toBe(
+            '34 Bayford Street',
+        );
+    });
+
+    it('returns the street unchanged when the suffix is longer than two letters', () => {
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '34abc Bayford St')).toBe(
+            '34 Bayford Street',
+        );
+    });
+
+    it('returns the street unchanged when no prediction text is provided', () => {
+        expect(restoreStreetNumberSuffix('34 Bayford Street')).toBe('34 Bayford Street');
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '')).toBe('34 Bayford Street');
+    });
+});

--- a/packages/core/src/app/address/googleAutocomplete/utils.test.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.test.ts
@@ -1,21 +1,21 @@
 import { restoreStreetNumberSuffix } from './utils';
 
 describe('restoreStreetNumberSuffix()', () => {
-    it('restores a letter suffix dropped by place details', () => {
+    it('restores a letter suffix dropped by place details, upper-cased per Australia Post', () => {
         expect(restoreStreetNumberSuffix('34 Bayford Street', '34a Bayford Street')).toBe(
-            '34a Bayford Street',
+            '34A Bayford Street',
         );
     });
 
     it('restores a letter suffix while keeping the long route name from place details', () => {
         expect(restoreStreetNumberSuffix('34 Bayford Street', '34a Bayford St')).toBe(
-            '34a Bayford Street',
+            '34A Bayford Street',
         );
     });
 
     it('restores a letter suffix on a subpremise street number', () => {
         expect(restoreStreetNumberSuffix('2/34 Bayford Street', '2/34a Bayford St')).toBe(
-            '2/34a Bayford Street',
+            '2/34A Bayford Street',
         );
     });
 
@@ -27,13 +27,13 @@ describe('restoreStreetNumberSuffix()', () => {
 
     it('restores a letter suffix when the prediction has a "unit" prefix', () => {
         expect(restoreStreetNumberSuffix('4/28 Beach Street', 'unit 4/28a Beach St')).toBe(
-            '4/28a Beach Street',
+            '4/28A Beach Street',
         );
     });
 
     it('restores a letter suffix when the subpremise contains a space', () => {
         expect(restoreStreetNumberSuffix('shop 2/34 Bayford Street', 'shop 2/34a Bayford St')).toBe(
-            'shop 2/34a Bayford Street',
+            'shop 2/34A Bayford Street',
         );
     });
 
@@ -52,10 +52,17 @@ describe('restoreStreetNumberSuffix()', () => {
         );
     });
 
-    it('returns the street unchanged when the suffix is longer than two letters', () => {
+    it('returns the street unchanged when the suffix is longer than a single letter', () => {
+        expect(restoreStreetNumberSuffix('34 Bayford Street', '34ab Bayford St')).toBe(
+            '34 Bayford Street',
+        );
         expect(restoreStreetNumberSuffix('34 Bayford Street', '34abc Bayford St')).toBe(
             '34 Bayford Street',
         );
+    });
+
+    it('returns the street unchanged when the prediction number is an ordinal', () => {
+        expect(restoreStreetNumberSuffix('34 34th Avenue', '34th Avenue')).toBe('34 34th Avenue');
     });
 
     it('returns the street unchanged when no prediction text is provided', () => {

--- a/packages/core/src/app/address/googleAutocomplete/utils.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.ts
@@ -45,11 +45,12 @@ export const restoreStreetNumberSuffix = (
 
     const lostLetterSuffix = autocompleteStreetNumber.slice(placeDetailsStreetNumber.length);
 
-    if (!/^[a-z]{1,2}$/i.test(lostLetterSuffix)) {
+    if (!/^[a-z]$/i.test(lostLetterSuffix)) {
         return placeDetailsAddress;
     }
 
-    placeDetailsTokens[placeDetailsStreetNumberIndex] = autocompleteStreetNumber;
+    placeDetailsTokens[placeDetailsStreetNumberIndex] =
+        `${placeDetailsStreetNumber}${lostLetterSuffix.toUpperCase()}`;
 
     return placeDetailsTokens.join(' ');
 };

--- a/packages/core/src/app/address/googleAutocomplete/utils.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.ts
@@ -10,3 +10,32 @@ export const toAutocompleteItems = (
         id: result.place_id,
     }));
 };
+
+export const restoreStreetNumberSuffix = (
+    placeDetailsStreet: string,
+    selectedAutocompleteText?: string,
+): string => {
+    if (!placeDetailsStreet || !selectedAutocompleteText) {
+        return placeDetailsStreet;
+    }
+
+    const [streetNumber, ...rest] = placeDetailsStreet.split(' ');
+    const [autocompleteNumber] = selectedAutocompleteText.split(' ');
+
+    if (
+        !streetNumber ||
+        !autocompleteNumber ||
+        autocompleteNumber.length <= streetNumber.length ||
+        !autocompleteNumber.toLowerCase().startsWith(streetNumber.toLowerCase())
+    ) {
+        return placeDetailsStreet;
+    }
+
+    const suffix = autocompleteNumber.slice(streetNumber.length);
+
+    if (!/^[a-z]{1,2}$/i.test(suffix)) {
+        return placeDetailsStreet;
+    }
+
+    return [autocompleteNumber, ...rest].join(' ');
+};

--- a/packages/core/src/app/address/googleAutocomplete/utils.ts
+++ b/packages/core/src/app/address/googleAutocomplete/utils.ts
@@ -11,31 +11,45 @@ export const toAutocompleteItems = (
     }));
 };
 
+const hasDigits = (token: string): boolean => {
+    return /\d/.test(token);
+};
+
 export const restoreStreetNumberSuffix = (
-    placeDetailsStreet: string,
-    selectedAutocompleteText?: string,
+    placeDetailsAddress: string,
+    selectedAutocompleteAddress?: string,
 ): string => {
-    if (!placeDetailsStreet || !selectedAutocompleteText) {
-        return placeDetailsStreet;
+    if (!placeDetailsAddress || !selectedAutocompleteAddress) {
+        return placeDetailsAddress;
     }
 
-    const [streetNumber, ...rest] = placeDetailsStreet.split(' ');
-    const [autocompleteNumber] = selectedAutocompleteText.split(' ');
+    const placeDetailsTokens = placeDetailsAddress.split(' ');
+    const selectedAutocompleteTokens = selectedAutocompleteAddress.split(' ');
 
-    if (
-        !streetNumber ||
-        !autocompleteNumber ||
-        autocompleteNumber.length <= streetNumber.length ||
-        !autocompleteNumber.toLowerCase().startsWith(streetNumber.toLowerCase())
-    ) {
-        return placeDetailsStreet;
+    const placeDetailsStreetNumberIndex = placeDetailsTokens.findIndex(hasDigits);
+    const autocompleteStreetNumber = selectedAutocompleteTokens.find(hasDigits);
+
+    if (placeDetailsStreetNumberIndex === -1 || !autocompleteStreetNumber) {
+        return placeDetailsAddress;
     }
 
-    const suffix = autocompleteNumber.slice(streetNumber.length);
+    const placeDetailsStreetNumber = placeDetailsTokens[placeDetailsStreetNumberIndex];
 
-    if (!/^[a-z]{1,2}$/i.test(suffix)) {
-        return placeDetailsStreet;
+    const extendsPlaceDetailsStreetNumber = autocompleteStreetNumber
+        .toLowerCase()
+        .startsWith(placeDetailsStreetNumber.toLowerCase());
+
+    if (!extendsPlaceDetailsStreetNumber) {
+        return placeDetailsAddress;
     }
 
-    return [autocompleteNumber, ...rest].join(' ');
+    const lostLetterSuffix = autocompleteStreetNumber.slice(placeDetailsStreetNumber.length);
+
+    if (!/^[a-z]{1,2}$/i.test(lostLetterSuffix)) {
+        return placeDetailsAddress;
+    }
+
+    placeDetailsTokens[placeDetailsStreetNumberIndex] = autocompleteStreetNumber;
+
+    return placeDetailsTokens.join(' ');
 };


### PR DESCRIPTION
## What/Why?

Fixes 2 bug: 
1. When a shopper selects an Australian address with a letter suffix on the street number (e.g. **34A Bayford St, Birkdale QLD 4159**) from Google Autocomplete, the address line 1 field is populated without the suffix (**34 Bayford St**), producing an undeliverable address.
2. Sometimes Google is returning lower case e.g. "b" instead of "B" for addresses like "12B George Street Burwood NSW 2134". Whereas per Australia Post alphanumeric house numbers must always use an **uppercase single letter**.

For AU addresses only, mapToAddress builds address line 1 from the Place Details API response (via AddressSelectorAU) rather than the Google Autocomplete suggestion. This was done because of the following issue:
https://github.com/bigcommerce/checkout-js/pull/2313 (The implementation was slightly changed in https://github.com/bigcommerce/checkout-js/pull/2431 and https://github.com/bigcommerce/checkout-js/pull/2450)

All other countries use the Autocomplete suggestion for address line 1, and only use Place Details for other fields like city and postcode.

I added a function that compares the Autocomplete suggestion with the Place Details result and restores a letter suffix lost from the street number. In every other case it keeps the Place Details result unchanged, so we don't reintroduce the bugs from the tickets above.

To fix issue number 2 I directly apply uppercase transformation to AddressSelectorAU.ts since this is AU-specific rule.

## Rollout/Rollback

Revert.

## Testing

You can test this PR on this store: https://maxteststore.mybigcommerce.com/ (currently deployed via webdav)

CI + manual test.

Before:


https://github.com/user-attachments/assets/7ff09495-78ca-47d6-9e90-b32cd581bfd1


After:

https://github.com/user-attachments/assets/f8c9b966-3e1d-4b9a-b01b-1556aa0a83bf

And then after also correcting lowercase letters:

https://github.com/user-attachments/assets/afa3be9a-9b1e-4b36-8567-095e37b25b16


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how AU checkout address line 1 is built at autocomplete time; scope is AU-only and defaults to existing Place Details when suffix rules don’t apply.
> 
> **Overview**
> Fixes Australian checkout addresses where Google Place Details drops a **single-letter street number suffix** (e.g. `34a` → `34`) or returns it lowercase, which breaks Australia Post formatting.
> 
> **Address line 1 for AU** still comes from Place Details via `AddressSelectorAU`, but `mapToAddress` now accepts the shopper’s autocomplete main text and runs **`restoreStreetNumberSuffix`** so a suffix present only on the prediction is merged back (uppercased) without replacing the long route name. **`AddressSelectorAU`** also uppercases digit+letter patterns on subpremise and street number. **`AddressForm`** passes the selected autocomplete value into `mapToAddress`.
> 
> Behavior is unchanged when the prediction doesn’t extend the street number, when suffixes aren’t a single letter, or when no prediction text is passed; tests cover AU selector, mapping, and suffix restoration edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb51015d8b44d84463b74c8d6b8845898c9f7d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->