### PR TITLE
PHPMNT-395 Fix cart items sorting

### DIFF
--- a/packages/core/src/app/order/OrderSummaryItems.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.test.tsx
@@ -343,6 +343,39 @@ describe('OrderSummaryItems', () => {
         });
     });
 
+    describe('line item ordering', () => {
+        it('renders physical items sorted by variantId ascending', () => {
+            renderOrderSummaryItems({
+                displayLineItemsCount: true,
+                items: {
+                    customItems: [],
+                    physicalItems: [
+                        {
+                            ...getPhysicalItem(),
+                            id: '1',
+                            name: 'High Variant Item',
+                            variantId: 71,
+                        },
+                        {
+                            ...getPhysicalItem(),
+                            id: '2',
+                            name: 'Low Variant Item',
+                            variantId: 5,
+                        },
+                    ],
+                    digitalItems: [],
+                    giftCertificates: [],
+                },
+            });
+
+            const headings = screen.getAllByRole('heading').map((heading) => heading.textContent);
+
+            expect(headings.indexOf('1 x Low Variant Item')).toBeLessThan(
+                headings.indexOf('1 x High Variant Item'),
+            );
+        });
+    });
+
     describe('when it has 5 line items or more', () => {
         const fiveOrMoreItemsProps: OrderSummaryItemsProps = {
             displayLineItemsCount: true,

--- a/packages/core/src/app/order/OrderSummaryItems.tsx
+++ b/packages/core/src/app/order/OrderSummaryItems.tsx
@@ -130,12 +130,12 @@ const ProductList = ({
     const summaryItems = [
         ...items.physicalItems
             .slice()
-            .sort((item) => item.variantId)
+            .sort((a, b) => a.variantId - b.variantId)
             .map((item) => mapFromPhysical(item, bundleItemsMap)),
         ...items.giftCertificates.slice().map(mapFromGiftCertificate),
         ...items.digitalItems
             .slice()
-            .sort((item) => item.variantId)
+            .sort((a, b) => a.variantId - b.variantId)
             .map((item) => mapFromDigital(item, bundleItemsMap)),
         ...(items.customItems || []).map(mapFromCustom),
     ].slice(0, isExpanded ? undefined : collapsedLimit);


### PR DESCRIPTION
## What/Why?
Line items in the order summary weren't being sorted by variant ID as intended, because .sort() was called with a single argument callback instead of the valid (a, b) comparator. So this never actually compared anything and left them in the order returned by the checkout (the items array)

## Rollout/Rollback
Merge / revert

## Testing
Checkout line items:
<img width="292" height="650" alt="checkout_line_items" src="https://github.com/user-attachments/assets/96929923-4e7c-4787-b178-a1682183cb12" />

Before
<img width="1049" height="751" alt="before" src="https://github.com/user-attachments/assets/50deed43-5281-4e91-bac1-f5f4deb4c0ca" />

After
<img width="927" height="668" alt="after" src="https://github.com/user-attachments/assets/70d580c5-7df7-451d-b296-4c8ce1d6399f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only ordering change in order summary UI with a focused regression test; no payment, auth, or data persistence impact.
> 
> **Overview**
> Fixes **incorrect line item order** in the checkout order summary by replacing invalid `Array.sort` comparators on physical and digital items with `(a, b) => a.variantId - b.variantId`, so items render in **ascending `variantId`** instead of effectively unsorted behavior from the previous single-argument callback.
> 
> Adds a **`line item ordering`** test that asserts lower `variantId` physical items appear before higher ones in the rendered headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed268f725f62afca2b1a9797db3bbaad679ad9ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->