### PR TITLE
feat(checkout): CHECKOUT-10348 make the grey bar on order summary slidable

### DIFF
--- a/packages/core/src/app/cart/CartSummaryDrawerV2.test.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.test.tsx
@@ -186,6 +186,29 @@ describe('CartSummaryDrawerV2 Component', () => {
         await expectSheetClosed();
     });
 
+    it('reopens the sheet when toggled during the close transition after a swipe dismiss', async () => {
+        renderComponent();
+
+        await userEvent.click(getCollapsedBar());
+
+        expectSheetOpen();
+
+        const handle = screen.getByTestId('cart-summary-sheet-handle');
+
+        fireEvent.pointerDown(handle, { pointerId: 1, clientY: 100 });
+        fireEvent.pointerUp(handle, { pointerId: 1, clientY: 200 });
+
+        expect(getCollapsedBar()).toHaveAttribute('aria-expanded', 'false');
+        expect(getSheet()).toHaveStyle({ transform: 'translateY(100%)' });
+
+        await userEvent.click(getCollapsedBar());
+
+        expectSheetOpen();
+
+        expect(getSheet()).not.toHaveStyle({ transform: 'translateY(100%)' });
+        expect(getSheet()).toHaveClass('cart-summary-sheet--afterOpen');
+    });
+
     it('keeps the sheet open when the handle swipe is too short', async () => {
         renderComponent();
 

--- a/packages/core/src/app/cart/CartSummaryDrawerV2.test.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.test.tsx
@@ -5,7 +5,15 @@ import React from 'react';
 import { ExtensionService } from '@bigcommerce/checkout/checkout-extension';
 import { CheckoutProvider, ExtensionProvider, LocaleContext } from '@bigcommerce/checkout/contexts';
 import { createLocaleContext } from '@bigcommerce/checkout/locale';
-import { act, configure, render, screen, waitFor, within } from '@bigcommerce/checkout/test-utils';
+import {
+    act,
+    configure,
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    within,
+} from '@bigcommerce/checkout/test-utils';
 
 import { getCheckout } from '../checkout/checkouts.mock';
 import { createErrorLogger } from '../common/error';
@@ -19,6 +27,11 @@ configure({ testIdAttribute: 'data-test' });
 
 describe('CartSummaryDrawerV2 Component', () => {
     const localeContext = createLocaleContext(getStoreConfig());
+
+    beforeAll(() => {
+        // jsdom lacks PointerEvent; a MouseEvent stand-in lets fireEvent carry clientY
+        window.PointerEvent = MouseEvent as unknown as typeof PointerEvent;
+    });
 
     const renderComponent = (checkout: Checkout = getCheckout()) => {
         const checkoutService = createCheckoutService();
@@ -156,6 +169,36 @@ describe('CartSummaryDrawerV2 Component', () => {
         await userEvent.keyboard('{Escape}');
 
         await expectSheetClosed();
+    });
+
+    it('closes the sheet when the handle is swiped down', async () => {
+        renderComponent();
+
+        await userEvent.click(getCollapsedBar());
+
+        expectSheetOpen();
+
+        const handle = screen.getByTestId('cart-summary-sheet-handle');
+
+        fireEvent.pointerDown(handle, { pointerId: 1, clientY: 100 });
+        fireEvent.pointerUp(handle, { pointerId: 1, clientY: 200 });
+
+        await expectSheetClosed();
+    });
+
+    it('keeps the sheet open when the handle swipe is too short', async () => {
+        renderComponent();
+
+        await userEvent.click(getCollapsedBar());
+
+        expectSheetOpen();
+
+        const handle = screen.getByTestId('cart-summary-sheet-handle');
+
+        fireEvent.pointerDown(handle, { pointerId: 1, clientY: 100 });
+        fireEvent.pointerUp(handle, { pointerId: 1, clientY: 120 });
+
+        expectSheetOpen();
     });
 
     it('closes the sheet when the backdrop is clicked', async () => {

--- a/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
@@ -35,7 +35,10 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
         setIsExpanded(false);
     };
 
-    const { setSheetElement, handleProps: sheetHandleProps } = useSheetDismissDrag(closeSheet);
+    const { setSheetElement, handleProps: sheetHandleProps } = useSheetDismissDrag(
+        isExpanded,
+        closeSheet,
+    );
 
     const { language } = useLocale();
     const checkoutContext = useCheckout();

--- a/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
+++ b/packages/core/src/app/cart/CartSummaryDrawerV2.tsx
@@ -15,6 +15,7 @@ import { CartHeaderLink } from './CartHeaderLink';
 import { CartOutstandingBalance } from './CartOutstandingBalance';
 import { CartSummaryItemImage } from './CartSummaryItemImage';
 import mapToCartSummaryProps from './mapToCartSummaryProps';
+import { useSheetDismissDrag } from './useSheetDismissDrag';
 import withRedeemable from './withRedeemable';
 
 // Must match $animation-collapse-transitionSpeed in scss settings
@@ -30,6 +31,12 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
     const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null);
     const [isExpanded, setIsExpanded] = useState(false);
 
+    const closeSheet = () => {
+        setIsExpanded(false);
+    };
+
+    const { setSheetElement, handleProps: sheetHandleProps } = useSheetDismissDrag(closeSheet);
+
     const { language } = useLocale();
     const checkoutContext = useCheckout();
     const props = mapToCartSummaryProps(checkoutContext);
@@ -44,10 +51,6 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
 
     const toggleSheet = () => {
         setIsExpanded((currentState) => !currentState);
-    };
-
-    const closeSheet = () => {
-        setIsExpanded(false);
     };
 
     const handleBarKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -114,6 +117,7 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
                         </div>
                     )}
                     contentLabel={cartHeading}
+                    contentRef={setSheetElement}
                     id="cart-summary-sheet"
                     isOpen={isExpanded}
                     onRequestClose={closeSheet}
@@ -129,7 +133,13 @@ const CartSummaryDrawerV2: FunctionComponent<CartSummaryDrawerV2Props> = ({
                     )}
                     parentSelector={() => rootElement}
                 >
-                    <div className="cart-summary-sheet-handle" />
+                    <div
+                        className="cart-summary-sheet-handle-region"
+                        data-test="cart-summary-sheet-handle"
+                        {...sheetHandleProps}
+                    >
+                        <div className="cart-summary-sheet-handle" />
+                    </div>
                     <div className="cart-summary-sheet-content">
                         {withRedeemable(OrderSummary)({
                             ...props,

--- a/packages/core/src/app/cart/useSheetDismissDrag.ts
+++ b/packages/core/src/app/cart/useSheetDismissDrag.ts
@@ -1,4 +1,4 @@
-import { type PointerEvent as ReactPointerEvent, useRef } from 'react';
+import { type PointerEvent as ReactPointerEvent, useEffect, useRef } from 'react';
 
 const DRAG_CLOSE_DISTANCE = 40;
 
@@ -14,9 +14,20 @@ interface SheetDismissDrag {
     };
 }
 
-export const useSheetDismissDrag = (onDismiss: () => void): SheetDismissDrag => {
+export const useSheetDismissDrag = (isOpen: boolean, onDismiss: () => void): SheetDismissDrag => {
     const sheetRef = useRef<HTMLDivElement | null>(null);
     const dragStartY = useRef<number | null>(null);
+
+    // react-modal reuses the sheet node when reopened during the close transition,
+    // so the swipe dismiss's inline styles must be cleared to let the classes apply
+    useEffect(() => {
+        const sheet = sheetRef.current;
+
+        if (isOpen && sheet) {
+            sheet.style.transition = '';
+            sheet.style.transform = '';
+        }
+    }, [isOpen]);
 
     const setSheetElement = (element: HTMLDivElement | null) => {
         sheetRef.current = element;

--- a/packages/core/src/app/cart/useSheetDismissDrag.ts
+++ b/packages/core/src/app/cart/useSheetDismissDrag.ts
@@ -1,0 +1,75 @@
+import { type PointerEvent as ReactPointerEvent, useRef } from 'react';
+
+const DRAG_CLOSE_DISTANCE = 40;
+
+type SheetPointerHandler = (event: ReactPointerEvent<HTMLDivElement>) => void;
+
+interface SheetDismissDrag {
+    setSheetElement: (element: HTMLDivElement | null) => void;
+    handleProps: {
+        onPointerCancel: SheetPointerHandler;
+        onPointerDown: SheetPointerHandler;
+        onPointerMove: SheetPointerHandler;
+        onPointerUp: SheetPointerHandler;
+    };
+}
+
+export const useSheetDismissDrag = (onDismiss: () => void): SheetDismissDrag => {
+    const sheetRef = useRef<HTMLDivElement | null>(null);
+    const dragStartY = useRef<number | null>(null);
+
+    const setSheetElement = (element: HTMLDivElement | null) => {
+        sheetRef.current = element;
+    };
+
+    const handlePointerDown: SheetPointerHandler = (event) => {
+        dragStartY.current = event.clientY;
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+
+        if (sheetRef.current) {
+            sheetRef.current.style.transition = 'none';
+        }
+    };
+
+    const handlePointerMove: SheetPointerHandler = (event) => {
+        const sheet = sheetRef.current;
+
+        if (dragStartY.current === null || !sheet) {
+            return;
+        }
+
+        const offset = Math.max(0, event.clientY - dragStartY.current);
+
+        sheet.style.transform = `translateY(${offset}px)`;
+    };
+
+    const handlePointerUp: SheetPointerHandler = (event) => {
+        const sheet = sheetRef.current;
+
+        if (dragStartY.current === null || !sheet) {
+            return;
+        }
+
+        sheet.style.transition = '';
+
+        if (event.clientY - dragStartY.current > DRAG_CLOSE_DISTANCE) {
+            // Must match the sheet's closing transform so the slide continues from the drop position
+            sheet.style.transform = 'translateY(100%)';
+            onDismiss();
+        } else {
+            sheet.style.transform = '';
+        }
+
+        dragStartY.current = null;
+    };
+
+    return {
+        setSheetElement,
+        handleProps: {
+            onPointerCancel: handlePointerUp,
+            onPointerDown: handlePointerDown,
+            onPointerMove: handlePointerMove,
+            onPointerUp: handlePointerUp,
+        },
+    };
+};

--- a/packages/core/src/app/cart/useSheetDismissDrag.ts
+++ b/packages/core/src/app/cart/useSheetDismissDrag.ts
@@ -49,7 +49,8 @@ export const useSheetDismissDrag = (isOpen: boolean, onDismiss: () => void): She
             return;
         }
 
-        const offset = Math.max(0, event.clientY - dragStartY.current);
+        const dragDistance = event.clientY - dragStartY.current;
+        const offset = Math.max(0, dragDistance);
 
         sheet.style.transform = `translateY(${offset}px)`;
     };
@@ -61,9 +62,11 @@ export const useSheetDismissDrag = (isOpen: boolean, onDismiss: () => void): She
             return;
         }
 
+        const dragDistance = event.clientY - dragStartY.current;
+
         sheet.style.transition = '';
 
-        if (event.clientY - dragStartY.current > DRAG_CLOSE_DISTANCE) {
+        if (dragDistance > DRAG_CLOSE_DISTANCE) {
             // Must match the sheet's closing transform so the slide continues from the drop position
             sheet.style.transform = 'translateY(100%)';
             onDismiss();

--- a/packages/core/src/scss/enhancedThemeV1/components/checkout/_cart-summary.scss
+++ b/packages/core/src/scss/enhancedThemeV1/components/checkout/_cart-summary.scss
@@ -135,12 +135,18 @@
             transform: translateY(100%);
         }
 
+        .cart-summary-sheet-handle-region {
+            cursor: grab;
+            flex-shrink: 0;
+            padding: spacing("half") 0;
+            touch-action: none;
+        }
+
         .cart-summary-sheet-handle {
             background-color: $color-greyMedium;
             border-radius: remCalc(2px);
-            flex-shrink: 0;
             height: remCalc(4px);
-            margin: spacing("half") auto;
+            margin: 0 auto;
             width: remCalc(40px);
         }
 


### PR DESCRIPTION
## What/Why?

Make the grey bar on order summary slidable similar to mobile app or iOS system patterns for enhancedThemeV1

## Rollout/Rollback

Revert this PR.

## Testing

- CI checks
- Manual testing

**BEFORE**

https://github.com/user-attachments/assets/23b4bc73-66b1-44a8-a8bb-183a202ee345



**AFTER**

https://github.com/user-attachments/assets/8e125744-3118-4f67-ba44-2e0705483836


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Checkout UI-only interaction change with unit tests; no payment, auth, or data-path changes.
> 
> **Overview**
> Adds **swipe-down on the grey handle** to dismiss the enhancedThemeV1 cart order-summary bottom sheet, matching common mobile sheet patterns.
> 
> A new `useSheetDismissDrag` hook tracks pointer drag on the handle, moves the sheet with `translateY` while dragging, and closes when the downward distance exceeds **40px**; shorter swipes snap back. It wires into `CartSummaryDrawerV2` via `contentRef` and pointer handlers on a new `cart-summary-sheet-handle-region`, and clears inline transform/transition when the sheet reopens so **react-modal** can reuse the node during close/reopen transitions.
> 
> SCSS gives the handle region grab styling, padding, and `touch-action: none`. Tests cover dismiss, insufficient swipe, and reopening mid-close after a swipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c86fb025aa07eaebf5ec4a4a60e1fda5cd067a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->