### PR TITLE
chore(other): CHECKOUT-10370 bump citadel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/checkout-sdk": "^1.964.2",
-        "@bigcommerce/citadel": "^2.15.1",
+        "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
         "@bigcommerce/request-sender": "^1.2.4",
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/@bigcommerce/citadel": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/citadel/-/citadel-2.15.1.tgz",
-      "integrity": "sha512-br/e8zrb7y0/ixdqpTYr4F+3TD/S/zj+XSzx8rVCKAlmYEF0RJE8/fvjGzfqbG9cFEpLD+zeo2IBSKMsc2LyCQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/citadel/-/citadel-2.16.1.tgz",
+      "integrity": "sha512-CK0Lxk6SEoFw8XnuFaSUFhNoGlS760angOahQ71/SJZIWEx9qSzoZ2He69cVnnmjDk597IUcSs0ylw2eYfgZwA==",
       "license": "BSD-4-Clause",
       "engines": {
         "node": ">= 0.10.0"
@@ -29431,9 +29431,9 @@
       }
     },
     "@bigcommerce/citadel": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/citadel/-/citadel-2.15.1.tgz",
-      "integrity": "sha512-br/e8zrb7y0/ixdqpTYr4F+3TD/S/zj+XSzx8rVCKAlmYEF0RJE8/fvjGzfqbG9cFEpLD+zeo2IBSKMsc2LyCQ=="
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/citadel/-/citadel-2.16.1.tgz",
+      "integrity": "sha512-CK0Lxk6SEoFw8XnuFaSUFhNoGlS760angOahQ71/SJZIWEx9qSzoZ2He69cVnnmjDk597IUcSs0ylw2eYfgZwA=="
     },
     "@bigcommerce/data-store": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
     "@bigcommerce/checkout-sdk": "^1.964.2",
-    "@bigcommerce/citadel": "^2.15.1",
+    "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",
     "@bigcommerce/request-sender": "^1.2.4",


### PR DESCRIPTION
## What/Why?
We have a new version of citadel published after 9 years. It reduces build time on cold start by 15ms on average.

## Rollout/Rollback
- revert this PR

## Testing
- CI

#### Before 
<img width="711" height="444" alt="Screenshot 2026-08-31 at 3 18 29 pm" src="https://github.com/user-attachments/assets/30a80eea-c3e3-417f-a7b6-1a929671071f" />


#### After
<img width="711" height="444" alt="Screenshot 2026-08-31 at 3 21 30 pm" src="https://github.com/user-attachments/assets/4bff8803-2120-4107-a41e-a761bd02c2cb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no application logic changes; rollback is reverting the PR.
> 
> **Overview**
> Upgrades **`@bigcommerce/citadel`** from **2.15.1** to **2.16.1** in `package.json` and refreshes the lockfile. This is the only functional change in the PR—no checkout source updates.
> 
> Citadel remains the SCSS toolkit consumed by checkout (e.g. `App.scss` imports `dist/tools/toolkit`). The bump is intended to shave roughly **15ms** off average **cold-start build** time per the ticket description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53423795802dd3367060a4cbf60e662b4c1a1c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->