### PR TITLE
CHECKOUT-10368: Update Company GQL Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.964.3",
+        "@bigcommerce/checkout-sdk": "^1.965.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.964.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.3.tgz",
-      "integrity": "sha512-Bz2CJh2BxtLtuM/4Z0rUX1tiTwq3ZpOozUCwJmJ+bhtGi2GGzQ7792fmixj3Dkp/KqYJQZETo/raKzRhgjTIPg==",
+      "version": "1.965.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.965.0.tgz",
+      "integrity": "sha512-baL9RKHeptYZcr8ZgG2aw+pJ/AqACUwuwOSScd8xp2zCLWC0z4EHRj5lNcBp9+7ye+i0UzicFtbyrNDY0NOi+A==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29380,9 +29380,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.964.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.964.3.tgz",
-      "integrity": "sha512-Bz2CJh2BxtLtuM/4Z0rUX1tiTwq3ZpOozUCwJmJ+bhtGi2GGzQ7792fmixj3Dkp/KqYJQZETo/raKzRhgjTIPg==",
+      "version": "1.965.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.965.0.tgz",
+      "integrity": "sha512-baL9RKHeptYZcr8ZgG2aw+pJ/AqACUwuwOSScd8xp2zCLWC0z4EHRj5lNcBp9+7ye+i0UzicFtbyrNDY0NOi+A==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.964.3",
+    "@bigcommerce/checkout-sdk": "^1.965.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/address/useCompanyAddressSearch.test.ts
+++ b/packages/core/src/app/address/useCompanyAddressSearch.test.ts
@@ -55,10 +55,12 @@ describe('useCompanyAddressSearch', () => {
     });
 
     const createSearchResult = (nodes: CompanyAddress[]): CompanyAddressSearchResult => ({
-        company: {
-            addresses: {
-                edges: nodes.map((node) => ({ node })),
-                pageInfo: { hasNextPage: false },
+        customer: {
+            activeCompany: {
+                addresses: {
+                    edges: nodes.map((node) => ({ node })),
+                    pageInfo: { hasNextPage: false },
+                },
             },
         },
     });

--- a/packages/core/src/app/address/useCompanyAddressSearch.ts
+++ b/packages/core/src/app/address/useCompanyAddressSearch.ts
@@ -82,7 +82,7 @@ export function useCompanyAddressSearch({
                     await checkoutService.getB2BToken();
                 }
 
-                const { company } = await checkoutService.searchCompanyAddresses(query, {
+                const { customer } = await checkoutService.searchCompanyAddresses(query, {
                     first: COMPANY_ADDRESS_SEARCH_LIMIT,
                     ...(propsRef.current.type === AddressType.Shipping
                         ? { isShipping: true }
@@ -93,7 +93,9 @@ export function useCompanyAddressSearch({
                     return;
                 }
 
-                if (!company) {
+                const activeCompany = customer?.activeCompany;
+
+                if (!activeCompany) {
                     setSearchResults(undefined);
 
                     return;
@@ -104,7 +106,7 @@ export function useCompanyAddressSearch({
                 );
 
                 setSearchResults(
-                    (company.addresses.edges ?? []).map(
+                    (activeCompany.addresses.edges ?? []).map(
                         ({ node }) =>
                             addressesById.get(node.entityId) ?? mapToCustomerAddress(node),
                     ),


### PR DESCRIPTION
Jira: [CHECKOUT-10368](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10368)

## What/Why?

The checkout SDK's `searchCompanyAddresses` GraphQL response shape changed: company addresses are now returned under `customer.activeCompany` instead of a top-level `company` field. 

This bumps `@bigcommerce/checkout-sdk` to `^1.965.0` and updates `useCompanyAddressSearch` to read the new shape.

A missing `activeCompany` is treated the same as the previous missing `company` (search results cleared, falls back to local filtering).

## Rollout/Rollback

Ships with the regular checkout-js release. Company address search is only exercised for B2B shoppers behind the existing gating, so the blast radius is limited. Rollback is a simple code revert — no migrations or experiment changes required.

## Testing
GQL is returning the new shape.
<img width="1510" height="829" alt="image" src="https://github.com/user-attachments/assets/f43b1e53-eb1d-4543-9e3d-43da7b0a90a9" />


[CHECKOUT-10368]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to B2B company address search behind existing gating; behavior on missing company data is preserved.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** to **`^1.965.0`** so checkout-js matches the SDK’s updated company-address GraphQL payload.
> 
> **`useCompanyAddressSearch`** now reads search hits from **`customer.activeCompany.addresses`** instead of a top-level **`company`** field. If **`activeCompany`** is missing, behavior is unchanged: remote results are cleared and the hook keeps using local address filtering. Unit test mocks were updated to the new **`customer.activeCompany`** structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608ad47c02823577c57e3623817531b0743c5c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->