### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.965.0",
+        "@bigcommerce/checkout-sdk": "^1.967.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.965.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.965.0.tgz",
-      "integrity": "sha512-baL9RKHeptYZcr8ZgG2aw+pJ/AqACUwuwOSScd8xp2zCLWC0z4EHRj5lNcBp9+7ye+i0UzicFtbyrNDY0NOi+A==",
+      "version": "1.967.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.967.0.tgz",
+      "integrity": "sha512-0cQFoW8b2j37tVZC44uoBgDq4TnrVw8ca0zwO/7a6ROB5KV/B8PE+5poueGE+tA3T1wtNvYxPd234gGM4XQ4vw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29380,9 +29380,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.965.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.965.0.tgz",
-      "integrity": "sha512-baL9RKHeptYZcr8ZgG2aw+pJ/AqACUwuwOSScd8xp2zCLWC0z4EHRj5lNcBp9+7ye+i0UzicFtbyrNDY0NOi+A==",
+      "version": "1.967.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.967.0.tgz",
+      "integrity": "sha512-0cQFoW8b2j37tVZC44uoBgDq4TnrVw8ca0zwO/7a6ROB5KV/B8PE+5poueGE+tA3T1wtNvYxPd234gGM4XQ4vw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.965.0",
+    "@bigcommerce/checkout-sdk": "^1.967.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk version to deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3381](https://github.com/bigcommerce/checkout-sdk-js/pull/3381)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3382](https://github.com/bigcommerce/checkout-sdk-js/pull/3382)


## Rollout/Rollback
Check in sdk PRs
Rollback related PRs

## Testing
Check in checkout-sdk-js PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change on the core checkout SDK used by payment flows; actual risk depends on what landed in SDK 1.967.0 (payment-related PRs 3381/3382).
> 
> **Overview**
> Bumps the **`@bigcommerce/checkout-sdk`** dependency from **^1.965.0** to **^1.967.0** in `package.json` and `package-lock.json`, with no application code changes in this repo.
> 
> This release is intended to pick up upstream checkout-sdk-js work (referenced SDK PRs **3381** and **3382**). Checkout behavior, payment integrations, and risk should be validated against those SDK changes rather than this bump alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de219af3c4f19ca43e04dcaad75256f23e27e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->