### PR TITLE
feat(checkout): CHECKOUT-10327 Link email validation error to its input

### DIFF
--- a/packages/core/src/app/customer/CustomerGuest.test.tsx
+++ b/packages/core/src/app/customer/CustomerGuest.test.tsx
@@ -126,6 +126,8 @@ describe('Customer Guest', () => {
         );
 
         expect(emailField).toBeInTheDocument();
+        expect(emailField).toHaveAttribute('aria-invalid', 'false');
+
         await userEvent.type(emailField, invalidEmail);
 
         await userEvent.click(
@@ -137,6 +139,11 @@ describe('Customer Guest', () => {
         expect(
             screen.getByLabelText(localeContext.language.translate('customer.email_invalid_error')),
         ).toBeInTheDocument();
+
+        expect(emailField).toHaveAttribute('aria-invalid', 'true');
+        expect(emailField).toHaveAccessibleDescription(
+            localeContext.language.translate('customer.email_invalid_error'),
+        );
 
         expect(checkoutService.continueAsGuest).not.toHaveBeenCalled();
 

--- a/packages/core/src/app/customer/EmailField.tsx
+++ b/packages/core/src/app/customer/EmailField.tsx
@@ -1,26 +1,33 @@
 import { type FieldProps } from 'formik';
-import React, { type FunctionComponent, memo, useCallback, useMemo } from 'react';
+import React, { type FunctionComponent, memo, useCallback, useContext, useMemo } from 'react';
 
 import { TranslatedString } from '@bigcommerce/checkout/locale';
-import { FormField, TextInput } from '@bigcommerce/checkout/ui';
+import { FormContext, FormField, TextInput } from '@bigcommerce/checkout/ui';
 
 export interface EmailFieldProps {
     isFloatingLabelEnabled?: boolean;
     onChange?(value: string): void;
 }
 
+const FIELD_NAME = 'email';
+
 const EmailField: FunctionComponent<EmailFieldProps> = ({ onChange, isFloatingLabelEnabled }) => {
+    const { isSubmitted } = useContext(FormContext);
+    const errorId = `${FIELD_NAME}-field-error-message`;
+
     const renderInput = useCallback(
-        (props: FieldProps) => (
+        ({ field, meta }: FieldProps) => (
             <TextInput
-                {...props.field}
-                autoComplete={props.field.name}
-                id={props.field.name}
+                {...field}
+                aria-describedby={errorId}
+                aria-invalid={Boolean(meta.error && meta.touched && isSubmitted)}
+                autoComplete={field.name}
+                id={field.name}
                 isFloatingLabelEnabled={isFloatingLabelEnabled}
                 type="email"
             />
         ),
-        [isFloatingLabelEnabled],
+        [isFloatingLabelEnabled, isSubmitted],
     );
 
     const labelContent = useMemo(() => <TranslatedString id="customer.email_label" />, []);
@@ -30,7 +37,7 @@ const EmailField: FunctionComponent<EmailFieldProps> = ({ onChange, isFloatingLa
             input={renderInput}
             isFloatingLabelEnabled={isFloatingLabelEnabled}
             labelContent={labelContent}
-            name="email"
+            name={FIELD_NAME}
             onChange={onChange}
         />
     );


### PR DESCRIPTION
## What/Why?
### What
Email field now sets:
- `aria-invalid` to `true` for an invalid email
- `aria-describedby` pointing to the error label

## Rollout/Rollback
Revert the PR.

## Testing
- Manually verified in Chrome dev tools that the email field attributes are correctly linked up.
- Manually verified with a screen reader (VoiceOver): Submit `not-an-email`, tab away and back - the field is announced as invalid and the error is read. 

### Before
<img width="1104" height="621" alt="Before" src="https://github.com/user-attachments/assets/bfb9ff19-10b7-472f-b6bb-1386b092f92f" />

### After
<img width="1104" height="627" alt="After" src="https://github.com/user-attachments/assets/a71b743b-e518-46d8-b3b8-6252e6b642fb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized accessibility attributes on the guest email field with no changes to validation or submit behavior.
> 
> **Overview**
> Guest checkout **email** input now exposes validation state to assistive tech: **`aria-invalid`** reflects invalid email after submit (when the field is touched), and **`aria-describedby`** points at the existing `email-field-error-message` element so the error text is announced with the field.
> 
> `EmailField` reads **`FormContext.isSubmitted`** so invalid state only applies after a submit attempt, not while the user is still typing.
> 
> **Customer guest** tests assert initial `aria-invalid="false"`, then `true` plus accessible description after an invalid continue, alongside the existing error message checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df667c9436d0a19d74164c30f461c9064ef83292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->