### PR TITLE
feat(payment): PI-5218 [FE] Remove experiment PI-5111.google_pay_direct_pay_on_click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.974.0",
+        "@bigcommerce/checkout-sdk": "^1.975.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.974.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.974.0.tgz",
-      "integrity": "sha512-eI8j/cTGnylF9ZP6x0t0sMpY7cp0rcq7wy7hTzgVrFFyOQt478GnCFIurq0TXtXz8IY+s7JbkX4DAsrOPpuORQ==",
+      "version": "1.975.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.975.0.tgz",
+      "integrity": "sha512-u8qIAGwkTMgg7a76vThZyLhz8DBjxpXGvi0vBzxJit821j3FBvgWNQHIQgCnSHHozoUVW70YSM6j6czmFI3LXw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -2258,9 +2258,6 @@
       "engines": {
         "node": "22",
         "npm": "10"
-      },
-      "optionalDependencies": {
-        "@swc/core-linux-x64-gnu": "^1.5.29"
       }
     },
     "node_modules/@bigcommerce/checkout-sdk/node_modules/type-fest": {
@@ -5483,22 +5480,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
-      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
-      "cpu": [
-        "x64"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -29137,9 +29118,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.974.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.974.0.tgz",
-      "integrity": "sha512-eI8j/cTGnylF9ZP6x0t0sMpY7cp0rcq7wy7hTzgVrFFyOQt478GnCFIurq0TXtXz8IY+s7JbkX4DAsrOPpuORQ==",
+      "version": "1.975.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.975.0.tgz",
+      "integrity": "sha512-u8qIAGwkTMgg7a76vThZyLhz8DBjxpXGvi0vBzxJit821j3FBvgWNQHIQgCnSHHozoUVW70YSM6j6czmFI3LXw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",
@@ -29148,7 +29129,6 @@
         "@bigcommerce/request-sender": "^1.2.4",
         "@bigcommerce/script-loader": "^2.2.2",
         "@braintree/browser-detection": "^1.16.0",
-        "@swc/core-linux-x64-gnu": "^1.5.29",
         "@types/card-validator": "^4.1.0",
         "@types/iframe-resizer": "^3.5.13",
         "@types/reselect": "^2.2.0",
@@ -31167,12 +31147,6 @@
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.7.tgz",
       "integrity": "sha512-+NDhK+IFTiVK1/o7EXdCeF2hEzCiaRSrb9zD7X2Z7inwWlxAntcSuzZW7Y6BRqGQH89KA91qYgwbnjgTQ22PiQ==",
       "dev": true,
-      "optional": true
-    },
-    "@swc/core-linux-x64-gnu": {
-      "version": "1.15.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
-      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
       "optional": true
     },
     "@swc/core-linux-x64-musl": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.974.0",
+    "@bigcommerce/checkout-sdk": "^1.975.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -66,28 +66,6 @@ describe('when using Google Pay payment', () => {
     };
     const onUnhandledError = jest.fn();
 
-    const storeConfigWithDirectPayDisabled = {
-        ...getStoreConfig(),
-        checkoutSettings: {
-            ...getStoreConfig().checkoutSettings,
-            features: {
-                ...getStoreConfig().checkoutSettings.features,
-                'PI-5111.google_pay_direct_pay_on_click': false,
-            },
-        },
-    };
-
-    const storeConfigWithDirectPayEnabled = {
-        ...getStoreConfig(),
-        checkoutSettings: {
-            ...getStoreConfig().checkoutSettings,
-            features: {
-                ...getStoreConfig().checkoutSettings.features,
-                'PI-5111.google_pay_direct_pay_on_click': true,
-            },
-        },
-    };
-
     beforeEach(() => {
         checkoutService = createCheckoutService();
         checkoutState = checkoutService.getState();
@@ -111,9 +89,7 @@ describe('when using Google Pay payment', () => {
             language: localeContext.language,
         };
 
-        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
-            storeConfigWithDirectPayDisabled,
-        );
+        jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(getStoreConfig());
 
         jest.spyOn(checkoutService, 'deinitializePayment').mockResolvedValue(checkoutState);
 
@@ -132,7 +108,16 @@ describe('when using Google Pay payment', () => {
         );
     });
 
-    describe('when Direct Pay is disabled', () => {
+    describe('when payment is already selected at mount (wallet button flow)', () => {
+        beforeEach(() => {
+            // The wallet button branch only renders when Google Pay was already
+            // selected at mount time, so reflect the current method id in checkout.
+            jest.spyOn(checkoutState.data, 'getCheckout').mockImplementation(() => ({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: method.id }],
+            }));
+        });
+
         it('initializes payment method when component mounts', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
@@ -161,7 +146,7 @@ describe('when using Google Pay payment', () => {
 
             expect(
                 screen.getByText(
-                    defaultProps.language.translate('remote.sign_in_action', {
+                    defaultProps.language.translate('remote.sign_out_action', {
                         providerName: getPaymentMethodName(defaultProps.language)(
                             defaultProps.method,
                         ),
@@ -293,13 +278,7 @@ describe('when using Google Pay payment', () => {
         });
     });
 
-    describe('when Direct Pay is enabled', () => {
-        beforeEach(() => {
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
-                storeConfigWithDirectPayEnabled,
-            );
-        });
-
+    describe('when payment is not selected at mount (Direct Pay flow)', () => {
         it('does not render the wallet button', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
@@ -356,11 +335,7 @@ describe('when using Google Pay payment', () => {
             });
         });
 
-        it('renders the wallet UI with a sign-out option regardless of the feature flag', () => {
-            jest.spyOn(checkoutState.data, 'getConfig').mockReturnValue(
-                storeConfigWithDirectPayEnabled,
-            );
-
+        it('renders the wallet UI with a sign-out option', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
 
             expect(

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -23,7 +23,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
 }) => {
     const {
         checkoutState: {
-            data: { getCheckout, getConfig },
+            data: { getCheckout },
         },
     } = useCheckout();
 
@@ -33,9 +33,6 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     // Capture whether Google Pay was already selected at mount time
     // (PDP/Cart/Customer step button)
     const wasPaymentSelectedAtMountRef = useRef(isPaymentSelected);
-
-    const features = getConfig()?.checkoutSettings.features ?? {};
-    const isDirectPayEnabled = features['PI-5111.google_pay_direct_pay_on_click'] ?? false;
 
     const initializeGooglePayPayment = useCallback(
         (defaultOptions: PaymentInitializeOptions) => {
@@ -159,7 +156,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
         [checkoutService, method, onUnhandledError],
     );
 
-    if (isDirectPayEnabled && !wasPaymentSelectedAtMountRef.current) {
+    if (!wasPaymentSelectedAtMountRef.current) {
         return (
             <GooglePayPaymentMethodComponent
                 {...rest}

--- a/packages/offline-payment-integration/e2e/OfflinePaymentMethod.spec.ts
+++ b/packages/offline-payment-integration/e2e/OfflinePaymentMethod.spec.ts
@@ -1,10 +1,13 @@
 import { PaymentStepAsGuestPreset, test } from '@bigcommerce/checkout/test-framework';
 
+import { mockGooglePayStripeUpeConfig } from './support/googlePayStripeUpeMock';
+
 test.describe('Offline payment method', () => {
-    test('`Pay in Store` payment method is working', async ({ assertions, checkout }) => {
+    test('`Pay in Store` payment method is working', async ({ assertions, checkout, page }) => {
         // Testing environment setup
         await checkout.use(new PaymentStepAsGuestPreset());
         await checkout.start('Pay in Store');
+        await mockGooglePayStripeUpeConfig(page);
 
         // Playwright actions
         await checkout.goto();
@@ -15,10 +18,11 @@ test.describe('Offline payment method', () => {
         await assertions.shouldSeeOrderConfirmation();
     });
 
-    test('`Cash on Delivery` payment method is working', async ({ assertions, checkout }) => {
+    test('`Cash on Delivery` payment method is working', async ({ assertions, checkout, page }) => {
         // Testing environment setup
         await checkout.use(new PaymentStepAsGuestPreset());
         await checkout.start('Cash on Delivery');
+        await mockGooglePayStripeUpeConfig(page);
 
         // Playwright actions
         await checkout.goto();

--- a/packages/offline-payment-integration/e2e/support/googlePayStripeUpeMock.ts
+++ b/packages/offline-payment-integration/e2e/support/googlePayStripeUpeMock.ts
@@ -1,0 +1,14 @@
+import { type Page } from '@playwright/test';
+
+const googlePayStripeUpeConfig =
+    '{"id":"googlepaystripeupe","gateway":null,"logoUrl":"","method":"googlepay","supportedCards":["VISA","AMEX","MC"],"providesShippingAddress":true,"config":{"displayName":"Google Pay","cardCode":null,"helpText":"","enablePaypal":null,"merchantId":null,"is3dsEnabled":null,"testMode":true,"isVisaCheckoutEnabled":null,"requireCustomerCode":false,"isVaultingEnabled":false,"isVaultingCvvEnabled":null,"hasDefaultStoredInstrument":false,"isHostedFormEnabled":false,"logo":null,"showCardHolderName":null},"type":"PAYMENT_TYPE_API","initializationStrategy":{"type":"not_applicable"},"nonce":null,"initializationData":{"gateway":"stripeupe","platformToken":"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjaGFudE9yaWdpbiI6Im15a29sYWRyb25vdjE3MjMxOTg0OTAtdGVzdGluZ3Rvbi5teS1pbnRlZ3JhdGlvbi56b25lIiwibWVyY2hhbnRJZCI6IjE1NTQwMTY4MDUxNzM2ODE3MjEwIiwiaWF0IjoxNzIzMjE1NzQ5fQ.GsVxYNipo71vru4dSPhsCzKr-a78bLfQfjJD1H0iADUkopLniwi-Idq5L2gPL8zMtxJ1hmBSMVXT7Tq73gHoeg","googleMerchantId":"15540168051736817210","googleMerchantName":"mykola.dronov+1723198490 testington","isThreeDSecureEnabled":false,"isShippingOptionsEnabled":true,"stripePublishableKey":"pk_test_bPqA9wSB7spHCx5B3MvPi6L0","stripeVersion":"2017-02-14","stripeConnectedAccount":"acct_1GnvZvFYHgt19eoy"},"clientToken":null,"returnUrl":null}';
+
+export async function mockGooglePayStripeUpeConfig(page: Page): Promise<void> {
+    await page.route(/\/api\/storefront\/payments\/googlepaystripeupe\?cartId=.*/, (route) => {
+        void route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: googlePayStripeUpeConfig,
+        });
+    });
+}


### PR DESCRIPTION
…

## What/Why?

Remove experiment PI-5111.google_pay_direct_pay_on_click, after all the tickets will be done in this project PROJECT-7945: GooglePay: Remove Sign In Button and Streamline the Flow
Closed


## Rollout/Rollback

rollback this commit

## Testing
<img width="2311" height="1069" alt="image" src="https://github.com/user-attachments/assets/83530284-8de1-498e-9ba9-2ebf0c733d9c" />

https://github.com/user-attachments/assets/44cc0891-f8a2-4bb6-a4dc-5d798c8bf194



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Google Pay checkout UI branching for all merchants by removing a feature flag, though behavior matches the previously enabled experiment path.
> 
> **Overview**
> Removes the **`PI-5111.google_pay_direct_pay_on_click`** checkout feature flag and makes the streamlined Google Pay flow the default behavior.
> 
> **`GooglePayPaymentMethod`** no longer reads store config for that experiment. When Google Pay was **not** already selected at mount, it always uses the Direct Pay path (`GooglePayPaymentMethodComponent` / SDK-injected button). When it **was** selected at mount (express entry), it still uses the wallet UI with sign-out. Unit tests are reorganized around those mount-time branches instead of flag on/off cases.
> 
> Also bumps **`@bigcommerce/checkout-sdk`** to `^1.975.0` (lockfile updated). Offline payment e2e tests call a new **`mockGooglePayStripeUpeConfig`** Playwright route so unrelated Google Pay Stripe UPE storefront calls do not break Pay in Store / COD scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eebfe4c1e2857eaee7eddea87af2ee6c06bc286e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->