### PR TITLE
fix(checkout): CHECKOUT-10328 Resolve lint issue related to autocomplete

### DIFF
--- a/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
+++ b/packages/core/src/app/address/googleAutocomplete/googleAutocompleteResult.mock.ts
@@ -91,7 +91,7 @@ export function getGoogleAutocompleteAUPlaceMock(): google.maps.places.PlaceResu
                 types: ['postal_code'],
             },
         ],
-    } as google.maps.places.PlaceResult;
+    };
 }
 
 export function getGoogleAutocompleteNZPlaceMock(): google.maps.places.PlaceResult {


### PR DESCRIPTION
## What/Why?

There is a lint error currently on master that blocks releases.

## Rollout/Rollback

Revert

## Testing

Make sure that lint on CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock typing cleanup with no production or behavioral changes.
> 
> **Overview**
> Fixes a **lint failure** on master by updating the Google autocomplete AU place mock in `googleAutocompleteResult.mock.ts`.
> 
> The mock return value no longer uses `as google.maps.places.PlaceResult` at the end of the object literal; it matches the other mocks in that file, which rely on the function’s declared return type instead of a trailing assertion. **No runtime or test data changes**—only how the mock is typed for the linter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e661eb629d75556761146cd76ea70ef519fb6481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->