### PR TITLE
chore(checkout): CHECKOUT-10378 Upgrade faker

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -5,7 +5,7 @@ module.exports = {
   ...nxPreset,
   testPathIgnorePatterns: ['<rootDir>/e2e/'],
   transformIgnorePatterns: [
-    '/node_modules/(?!@intl-tel-input)',
+    '/node_modules/(?!(@intl-tel-input|@faker-js))',
     '\\.pnp\\.[^\\/]+$',
   ],
   moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@babel/preset-env": "^7.9.0",
         "@bigcommerce/eslint-config": "^2.6.1",
         "@bigcommerce/eslint-plugin": "^1.4.0",
-        "@faker-js/faker": "^7.6.0",
+        "@faker-js/faker": "^10.6.0",
         "@nx/devkit": "19.8.9",
         "@nx/eslint": "19.8.9",
         "@nx/eslint-plugin": "19.8.9",
@@ -3333,13 +3333,20 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.6.0.tgz",
+      "integrity": "sha512-3RQHgEtvL1Frl/d1cSreo7qhJ3Gk1OdNUai/CtZ8G+wYeRQnJih3s9xJ9/kgYekPQRdwgh0HXRPqMlzWGwivIQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -29984,9 +29991,9 @@
       "dev": true
     },
     "@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.6.0.tgz",
+      "integrity": "sha512-3RQHgEtvL1Frl/d1cSreo7qhJ3Gk1OdNUai/CtZ8G+wYeRQnJih3s9xJ9/kgYekPQRdwgh0HXRPqMlzWGwivIQ==",
       "dev": true
     },
     "@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@babel/preset-env": "^7.9.0",
     "@bigcommerce/eslint-config": "^2.6.1",
     "@bigcommerce/eslint-plugin": "^1.4.0",
-    "@faker-js/faker": "^7.6.0",
+    "@faker-js/faker": "^10.6.0",
     "@nx/devkit": "19.8.9",
     "@nx/eslint": "19.8.9",
     "@nx/eslint-plugin": "19.8.9",

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,6 +6,9 @@ module.exports = {
             tsconfig: '<rootDir>/tsconfig.spec.json',
             diagnostics: false,
         }],
+        '^.+\\.js$': ['babel-jest', {
+            presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+        }],
         '\\.(gif|png|jpe?g|svg)$': '../../scripts/jest/file-transformer',
         '\\.scss$': '../../scripts/jest/style-transformer',
     },

--- a/packages/core/src/app/address/AddressFormModal.test.tsx
+++ b/packages/core/src/app/address/AddressFormModal.test.tsx
@@ -139,9 +139,9 @@ describe('AddressFormModal Component', () => {
     it('renders prefilled address form in the modal when selectedAddress is present', () => {
         const address = JSON.parse(
             JSON.stringify({
-                firstName: faker.name.firstName(),
-                lastName: faker.name.lastName(),
-                address1: faker.address.streetAddress(),
+                firstName: faker.person.firstName(),
+                lastName: faker.person.lastName(),
+                address1: faker.location.streetAddress(),
             }),
         );
 

--- a/packages/core/src/app/customer/Customer.test.tsx
+++ b/packages/core/src/app/customer/Customer.test.tsx
@@ -189,8 +189,8 @@ describe('Customer Component', () => {
         await userEvent.click(screen.getByText('Create an account'));
         await userEvent.click(screen.getByText('Cancel'));
         await userEvent.click(screen.getByText('Create an account'));
-        await userEvent.type(await screen.findByLabelText('First Name'), faker.name.firstName());
-        await userEvent.type(await screen.findByLabelText('Last Name'), faker.name.lastName());
+        await userEvent.type(await screen.findByLabelText('First Name'), faker.person.firstName());
+        await userEvent.type(await screen.findByLabelText('Last Name'), faker.person.lastName());
         await userEvent.type(await screen.findByLabelText('Email'), customerEmail);
         await userEvent.type(await screen.findByLabelText('Password'), 'abc');
         await userEvent.click(screen.getByText('Create Account'));

--- a/packages/core/src/app/shipping/MultiShipping.test.tsx
+++ b/packages/core/src/app/shipping/MultiShipping.test.tsx
@@ -427,13 +427,13 @@ describe('Multi-shipping', () => {
 
         const address = JSON.parse(
             JSON.stringify({
-                firstName: faker.name.firstName(),
-                lastName: faker.name.lastName(),
-                address1: faker.address.streetAddress(),
-                city: faker.address.city(),
+                firstName: faker.person.firstName(),
+                lastName: faker.person.lastName(),
+                address1: faker.location.streetAddress(),
+                city: faker.location.city(),
                 countryCode: 'AU',
                 stateOrProvinceCode: faker.helpers.arrayElement(['NSW', 'VIC', 'QLD', 'TAS']),
-                postalCode: faker.address.zipCode(),
+                postalCode: faker.location.zipCode(),
             }),
         );
 

--- a/packages/test-framework/src/fixture/pagePreset/ApiRequestsSender.ts
+++ b/packages/test-framework/src/fixture/pagePreset/ApiRequestsSender.ts
@@ -1,5 +1,5 @@
 import { type Cart, type Checkout } from '@bigcommerce/checkout-sdk';
-import { faker } from '@faker-js/faker';
+import { en, en_AU, en_US, Faker } from '@faker-js/faker';
 import { type Page } from '@playwright/test';
 
 import { getStoreUrl } from '../';
@@ -7,11 +7,17 @@ import { getStoreUrl } from '../';
 import { ApiContextFactory } from './ApiContextFactory';
 import { Locales } from './types';
 
+const fakerByLocale: Record<Locales, Faker> = {
+    [Locales.US]: new Faker({ locale: [en_US, en] }),
+    [Locales.AU]: new Faker({ locale: [en_AU, en] }),
+};
+
 /**
  * @internal
  */
 export class ApiRequestsSender {
     private readonly apiContextFactory: ApiContextFactory;
+    private readonly faker: Faker;
     private readonly page: Page;
     private readonly storeUrl: string;
     private readonly startTime: number;
@@ -21,8 +27,7 @@ export class ApiRequestsSender {
         this.page = page;
         this.storeUrl = getStoreUrl();
         this.apiContextFactory = new ApiContextFactory();
-
-        faker.setLocale(fakerLocale);
+        this.faker = fakerByLocale[fakerLocale];
 
         // hack for BC dev store's root certificate issue during recording HAR
         // https://stackoverflow.com/questions/31673587/error-unable-to-verify-the-first-certificate-in-nodejs
@@ -56,7 +61,7 @@ export class ApiRequestsSender {
 
         const apiContext = await this.apiContextFactory.create(this.page, this.storeUrl);
         const checkout = await this.getCheckoutOrThrow();
-        const email = faker.internet.email('checkout');
+        const email = this.faker.internet.email({ firstName: 'checkout' });
 
         await apiContext.post(`./checkouts/${checkout.id}/billing-address`, {
             data: { email },
@@ -83,18 +88,18 @@ export class ApiRequestsSender {
         // Set shipping address
         console.log(`  - Setting shipping address`);
 
-        const stateCode = faker.address.stateAbbr();
+        const stateCode = this.faker.location.state({ abbreviated: true });
         const address = {
-            firstName: faker.name.firstName(),
-            lastName: faker.name.lastName(),
-            company: faker.company.companyName(),
-            phone: faker.phone.phoneNumber('##########'),
-            address1: faker.address.streetName(),
-            address2: faker.address.secondaryAddress(),
-            city: faker.address.cityName(),
+            firstName: this.faker.person.firstName(),
+            lastName: this.faker.person.lastName(),
+            company: this.faker.company.name(),
+            phone: this.faker.string.numeric(10),
+            address1: this.faker.location.street(),
+            address2: this.faker.location.secondaryAddress(),
+            city: this.faker.location.city(),
             countryCode,
             stateOrProvince: '',
-            postalCode: faker.address.zipCodeByState(stateCode),
+            postalCode: this.getZipCodeByState(stateCode),
             shouldSaveAddress: true,
             stateOrProvinceCode: stateCode,
             customFields: [],
@@ -148,17 +153,17 @@ export class ApiRequestsSender {
             `./checkouts/${checkout.id}/billing-address/${billingAddressId ?? ''}`,
             {
                 data: {
-                    firstName: faker.name.firstName(),
-                    lastName: faker.name.lastName(),
-                    email: faker.internet.email('checkout'),
-                    company: faker.company.companyName(),
-                    address1: faker.address.streetName(),
-                    address2: faker.address.secondaryAddress(),
-                    phone: faker.phone.phoneNumber('##########'),
-                    city: faker.address.cityName(),
+                    firstName: this.faker.person.firstName(),
+                    lastName: this.faker.person.lastName(),
+                    email: this.faker.internet.email({ firstName: 'checkout' }),
+                    company: this.faker.company.name(),
+                    address1: this.faker.location.street(),
+                    address2: this.faker.location.secondaryAddress(),
+                    phone: this.faker.string.numeric(10),
+                    city: this.faker.location.city(),
                     stateOrProvinceCode: stateCode,
                     countryCode,
-                    postalCode: faker.address.zipCodeByState(stateCode),
+                    postalCode: this.getZipCodeByState(stateCode),
                 },
             },
         );
@@ -174,6 +179,12 @@ export class ApiRequestsSender {
         const time = Math.ceil((Date.now() - this.startTime) / 1000);
 
         console.log(`\x1b[32m\n  ${message} \x1b[0m\x1b[2m(${time}s)\x1b[0m`);
+    }
+
+    private getZipCodeByState(state: string): string {
+        return this.faker.rawDefinitions.location?.postcode_by_state
+            ? this.faker.location.zipCode({ state })
+            : this.faker.location.zipCode();
     }
 
     private async getCheckoutIdOrThrow(): Promise<string> {

--- a/packages/test-framework/src/fixture/pagePreset/PaymentStepAsGuest.ts
+++ b/packages/test-framework/src/fixture/pagePreset/PaymentStepAsGuest.ts
@@ -8,7 +8,7 @@ export class PaymentStepAsGuest implements CheckoutPagePreset {
     constructor(
         private currency = 'USD',
         private countryCode?: string,
-        private locale: string = Locales.US,
+        private locale: Locales = Locales.US,
     ) {}
     async apply(page: Page): Promise<void> {
         const api = new ApiRequestsSender(page, this.locale);


### PR DESCRIPTION
Jira: [CHECKOUT-10378](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10378)

## What/Why?

Bumps `@faker-js/faker` from `^7.6.0` to `^10.6.0`. 

Three jumps' worth of breaking changes, most of which are mechanical renames (`name` → `person`, `address` → `location`, `company.companyName()` → `company.name()`).


## Rollout/Rollback

Test-only change — `@faker-js/faker` is a `devDependency` and is not part of the shipped checkout bundle, so there is no shopper-facing impact and nothing to flag or ramp. No migrations.

Rollback is a straight revert of the commit; the `package-lock.json` change reverts with it.

## Testing

No new tests — existing suites cover the migrated call sites. Full local run on Node 22.14:

```
npm run test:core       # 228 suites, 1545 passed, 2 skipped
npm run test:others     # 44/45 projects pass
npm run test:extension  # 2/2 projects, 13 tests
```

`test:others` reports `test-framework` as failed; that is pre-existing and unrelated — the package has no `jest.config.js`, so `scripts/nx/run-tests.js` always fails to resolve a config for it. Reproduces on a clean tree.

Also verified directly, since these paths are not covered by unit tests:

- `npx tsc -p packages/test-framework/tsconfig.json --noEmit` — no faker-related errors remain.
- `MODE=test PORT=8080 npx playwright test --config=playwright.config.ts --list packages/hosted-payment-integration/e2e/humm.spec.ts` — confirms Playwright can load the ESM-only faker through its CJS transform.
- Generated the full US and AU address payloads across repeated runs to confirm the AU zip fallback produces valid 4-digit postcodes and the US path still uses state-correct zips.


[CHECKOUT-10378]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to devDependencies, Jest config, and test/e2e fixture data generation with no production checkout bundle impact.
> 
> **Overview**
> Upgrades **`@faker-js/faker`** from **7.6.0** to **10.6.0** (devDependency only). Test and Playwright fixture code is updated for v10 APIs: **`person`** / **`location`** namespaces, updated **`internet.email`**, **`company.name`**, **`string.numeric`**, and similar renames.
> 
> **Jest** is adjusted so v10’s ESM package runs in tests: root **`transformIgnorePatterns`** whitelists **`@faker-js`**, and **`packages/core/jest.config.js`** adds **babel-jest** for **`.js`** transforms.
> 
> **`ApiRequestsSender`** drops global **`setLocale`** in favor of per-locale **`Faker`** instances (US/AU) and adds **`getZipCodeByState`** so US state-specific zips still work when locale data supports it, with a generic zip fallback for AU.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe4fe40c701193e456831e1ea5d330af0bb5b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->