### PR TITLE
chore(checkout): bump checkout-sdk-js to 1.968.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.967.0",
+        "@bigcommerce/checkout-sdk": "^1.968.2",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.967.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.967.0.tgz",
-      "integrity": "sha512-0cQFoW8b2j37tVZC44uoBgDq4TnrVw8ca0zwO/7a6ROB5KV/B8PE+5poueGE+tA3T1wtNvYxPd234gGM4XQ4vw==",
+      "version": "1.968.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.968.2.tgz",
+      "integrity": "sha512-ivsg4KosgUKdyZNTccGWUqGuXjXzGThoZ2FqPxvn4WMKgEmHB5YV/WZVWZjITVYvoxsr1OqjzVEAMw738kAD6g==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29390,9 +29390,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.967.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.967.0.tgz",
-      "integrity": "sha512-0cQFoW8b2j37tVZC44uoBgDq4TnrVw8ca0zwO/7a6ROB5KV/B8PE+5poueGE+tA3T1wtNvYxPd234gGM4XQ4vw==",
+      "version": "1.968.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.968.2.tgz",
+      "integrity": "sha512-ivsg4KosgUKdyZNTccGWUqGuXjXzGThoZ2FqPxvn4WMKgEmHB5YV/WZVWZjITVYvoxsr1OqjzVEAMw738kAD6g==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.967.0",
+    "@bigcommerce/checkout-sdk": "^1.968.2",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk to version 1.968.2 (released to prod this time 🎉 ). The release includes:
[chore(deps-dev): bump fast-uri from 3.1.5 to 3.1.7](https://github.com/bigcommerce/checkout-sdk-js/pull/3391)
[fix(checkout): CHECKOUT-10379 Export enums explicitly](https://github.com/bigcommerce/checkout-sdk-js/pull/3386)
[feat(checkout): CHECKOUT-10352 Add support for isPhoneNumberValidation setting](https://github.com/bigcommerce/checkout-sdk-js/pull/3380)
[chore(common): CHECKOUT-10379 Update all types to be exported as types for transpileOnly](https://github.com/bigcommerce/checkout-sdk-js/pull/3384)

## Rollout/Rollback

Revert

## Testing

Should be a no-op, make sure CI and functional tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SDK bumps can affect checkout flows, payment integrations, and TypeScript/build compatibility via export and enum changes, even when this PR only touches lockfiles.
> 
> **Overview**
> Bumps `@bigcommerce/checkout-sdk` from **^1.967.0** to **^1.968.2** in `package.json` and `package-lock.json`. There are no other changes in this repo—checkout-js picks up the new SDK release at install/build time.
> 
> The **1.968.2** SDK line includes explicit enum exports and type-only export adjustments for `transpileOnly`, plus **`isPhoneNumberValidation`** checkout setting support in the SDK itself. Checkout-js does not add new code here to wire that setting; behavior changes come from the upgraded dependency unless follow-up UI work lands separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0a47742b2f63d8888eb59965ade27699cdeb35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
