### PR TITLE
chore(checkout): CHECKOUT-10115 Remove rolled out CHECKOUT-10115 flag

### DIFF
--- a/packages/core/src/app/auto-loader.ts
+++ b/packages/core/src/app/auto-loader.ts
@@ -16,7 +16,6 @@ export interface CustomCheckoutWindow extends Window {
         publicPath?: string;
         sentryConfig?: BrowserOptions;
         permalinkStatus?: OrderPermalinkStatus | null;
-        isConsistentCrossOriginFixEnabled?: boolean;
     };
 }
 
@@ -31,18 +30,9 @@ function isCustomCheckoutWindow(window: Window): window is CustomCheckoutWindow 
         throw new Error('Checkout config is missing.');
     }
 
-    const { renderOrderConfirmation, renderCheckout } = await loadFiles({
-        isConsistentCrossOriginFixEnabled: Boolean(
-            window.checkoutConfig.isConsistentCrossOriginFixEnabled,
-        ),
-    });
+    const { renderOrderConfirmation, renderCheckout } = await loadFiles();
 
-    const {
-        orderId,
-        checkoutId,
-        isConsistentCrossOriginFixEnabled: _isConsistentCrossOriginFixEnabled,
-        ...appProps
-    } = window.checkoutConfig;
+    const { orderId, checkoutId, ...appProps } = window.checkoutConfig;
 
     if (orderId) {
         renderOrderConfirmation({ ...appProps, orderId });

--- a/packages/core/src/app/loader.test.ts
+++ b/packages/core/src/app/loader.test.ts
@@ -119,42 +119,22 @@ describe('loadFiles', () => {
         );
     });
 
-    it('prefetches dynamic JS chunks listed in manifest', async () => {
+    it('prefetches dynamic JS chunks with crossorigin matching the real chunk requests', async () => {
         await loadFiles(options);
 
         expect(getScriptLoader().preloadScripts).toHaveBeenCalledWith(
             ['https://cdn.foo.bar/step-a.js', 'https://cdn.foo.bar/step-b.js'],
-            { prefetch: true },
+            { prefetch: true, crossOrigin: 'anonymous' },
         );
     });
 
-    it('prefetches dynamic CSS chunks listed in manifest', async () => {
+    it('prefetches dynamic CSS chunks with crossorigin matching the real chunk requests', async () => {
         await loadFiles(options);
 
         expect(getStylesheetLoader().preloadStylesheets).toHaveBeenCalledWith(
             ['https://cdn.foo.bar/step-a.css', 'https://cdn.foo.bar/step-b.css'],
-            { prefetch: true },
+            { prefetch: true, crossOrigin: 'anonymous' },
         );
-    });
-
-    describe('when isConsistentCrossOriginFixEnabled is true', () => {
-        it('prefetches dynamic JS chunks with crossorigin matching the real chunk requests', async () => {
-            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
-
-            expect(getScriptLoader().preloadScripts).toHaveBeenCalledWith(
-                ['https://cdn.foo.bar/step-a.js', 'https://cdn.foo.bar/step-b.js'],
-                { prefetch: true, crossOrigin: 'anonymous' },
-            );
-        });
-
-        it('prefetches dynamic CSS chunks with crossorigin matching the real chunk requests', async () => {
-            await loadFiles({ ...options, isConsistentCrossOriginFixEnabled: true });
-
-            expect(getStylesheetLoader().preloadStylesheets).toHaveBeenCalledWith(
-                ['https://cdn.foo.bar/step-a.css', 'https://cdn.foo.bar/step-b.css'],
-                { prefetch: true, crossOrigin: 'anonymous' },
-            );
-        });
     });
 
     it('resolves with app version', async () => {

--- a/packages/core/src/app/loader.ts
+++ b/packages/core/src/app/loader.ts
@@ -21,7 +21,6 @@ export interface AssetManifest {
 
 export interface LoadFilesOptions {
     publicPath?: string;
-    isConsistentCrossOriginFixEnabled?: boolean;
 }
 
 export interface LoadFilesResult {
@@ -32,7 +31,6 @@ export interface LoadFilesResult {
 
 export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> {
     const publicPath = configurePublicPath(options && options.publicPath);
-    const isConsistentCrossOriginFixEnabled = Boolean(options?.isConsistentCrossOriginFixEnabled);
 
     const {
         appVersion,
@@ -74,7 +72,7 @@ export function loadFiles(options?: LoadFilesOptions): Promise<LoadFilesResult> 
 
     const preloadOptions = {
         prefetch: true,
-        ...(isConsistentCrossOriginFixEnabled && { crossOrigin: 'anonymous' as const }),
+        crossOrigin: 'anonymous' as const,
     };
 
     getScriptLoader().preloadScripts(


### PR DESCRIPTION
## What/Why?

The flag is now fully rolled out across all tiers: https://app.launchdarkly.com/projects/default/flags/CHECKOUT-10115.consistent_crossorigin_prefetch_fix so we can remove the references from checkout-js.

It is passed from bigcommerce side through a variable, see here: https://github.com/bigcommerce/bigcommerce/blob/149504273c74b1b175e0c9e02929c1d825b239b0/config/Experiments/CheckoutExperiments.php#L61

## Rollout/Rollback

Revert the PR

## Testing

Passing CI, functional tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cleanup only; prefetch crossorigin behavior was already the default via the rolled-out flag. Revert restores the flag gate if needed.
> 
> **Overview**
> Removes the fully rolled-out **CHECKOUT-10115** experiment flag (`isConsistentCrossOriginFixEnabled`) from checkout-js after LaunchDarkly rollout.
> 
> **Behavior is unchanged for production:** dynamic JS/CSS chunk prefetches in `loadFiles` now always use `crossOrigin: 'anonymous'`, matching what the flag already enforced everywhere. The option is dropped from `LoadFilesOptions`, `checkoutConfig` on the custom checkout window, and the `auto-loader` no longer reads or forwards it.
> 
> Tests are simplified so prefetch expectations always include `crossOrigin: 'anonymous'` instead of duplicating cases behind the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016a53c9eb0445da9578a22dae1950bed7cf19c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->