### PR TITLE
feat(payment): PI-4870 [FE] Remove experiment PI-4789.afterpay_script_use_https

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.968.2",
+        "@bigcommerce/checkout-sdk": "^1.969.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.968.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.968.2.tgz",
-      "integrity": "sha512-ivsg4KosgUKdyZNTccGWUqGuXjXzGThoZ2FqPxvn4WMKgEmHB5YV/WZVWZjITVYvoxsr1OqjzVEAMw738kAD6g==",
+      "version": "1.969.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.969.0.tgz",
+      "integrity": "sha512-hMOXvnp8GqC+L7JrQNgTi/UBOXNckZFdi6BSkgeqm9d3r2WgO4NJCDT947BOHlhn5CMJsqqDd41KCR5g3wIkcA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29390,9 +29390,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.968.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.968.2.tgz",
-      "integrity": "sha512-ivsg4KosgUKdyZNTccGWUqGuXjXzGThoZ2FqPxvn4WMKgEmHB5YV/WZVWZjITVYvoxsr1OqjzVEAMw738kAD6g==",
+      "version": "1.969.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.969.0.tgz",
+      "integrity": "sha512-hMOXvnp8GqC+L7JrQNgTi/UBOXNckZFdi6BSkgeqm9d3r2WgO4NJCDT947BOHlhn5CMJsqqDd41KCR5g3wIkcA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.968.2",
+    "@bigcommerce/checkout-sdk": "^1.969.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
…
## What/Why?

Remove experiment PI-4789.afterpay_script_use_https

## Rollout/Rollback

rollback this commit

## Testing

<img width="2990" height="792" alt="image" src="https://github.com/user-attachments/assets/dcddd463-1f1f-4f4d-9617-53d87fb76891" />
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Afterpay checkout script URL/protocol behavior changes with the SDK bump; rollback is reverting this commit as noted in the PR description.
> 
> **Overview**
> **Bumps `@bigcommerce/checkout-sdk` from `^1.968.2` to `^1.969.0`** in `package.json` and `package-lock.json`, with no other application source changes in this PR.
> 
> This dependency update is tied to **PI-4870**: adopting the SDK release that **removes the `PI-4789.afterpay_script_use_https` experiment**, so Afterpay script loading behavior is no longer gated behind that flag (the winning path from the experiment is assumed to live in the SDK).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7f15e063b7b3e93fa5ccf586ea8eea26589f9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->