### PR TITLE
feat(checkout): Add version to Cart and Checkout interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.969.0",
+        "@bigcommerce/checkout-sdk": "^1.970.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2238,9 +2238,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.969.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.969.0.tgz",
-      "integrity": "sha512-hMOXvnp8GqC+L7JrQNgTi/UBOXNckZFdi6BSkgeqm9d3r2WgO4NJCDT947BOHlhn5CMJsqqDd41KCR5g3wIkcA==",
+      "version": "1.970.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.970.0.tgz",
+      "integrity": "sha512-QNnLK+9Ir2LAYXH4HMfeMJEk55gODj2gZOXHzXdhhLlXn1U02wVjyHuaQ8mNlHKygIdXXWRphqMSZYG23O3g6Q==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29391,9 +29391,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.969.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.969.0.tgz",
-      "integrity": "sha512-hMOXvnp8GqC+L7JrQNgTi/UBOXNckZFdi6BSkgeqm9d3r2WgO4NJCDT947BOHlhn5CMJsqqDd41KCR5g3wIkcA==",
+      "version": "1.970.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.970.0.tgz",
+      "integrity": "sha512-QNnLK+9Ir2LAYXH4HMfeMJEk55gODj2gZOXHzXdhhLlXn1U02wVjyHuaQ8mNlHKygIdXXWRphqMSZYG23O3g6Q==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.969.0",
+    "@bigcommerce/checkout-sdk": "^1.970.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/app/cart/carts.mock.ts
+++ b/packages/core/src/app/cart/carts.mock.ts
@@ -31,5 +31,6 @@ export function getCart(): Cart {
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
         locale: 'en',
+        version: 1,
     };
 }

--- a/packages/core/src/app/checkout/checkouts.mock.ts
+++ b/packages/core/src/app/checkout/checkouts.mock.ts
@@ -43,6 +43,7 @@ export function getCheckout(): Checkout {
         totalDiscount: 0,
         comparisonShippingCost: 20,
         fees: [],
+        version: 0,
     };
 }
 

--- a/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
+++ b/packages/test-framework/src/react-testing-library-support/mocks/checkout.mock.ts
@@ -223,6 +223,7 @@ const checkout: Checkout = {
         createdTime: timeString,
         updatedTime: timeString,
         locale: 'en',
+        version: 0,
     },
     consignments: [],
     orderId: undefined,

--- a/packages/test-mocks/src/cart.mock.ts
+++ b/packages/test-mocks/src/cart.mock.ts
@@ -31,5 +31,6 @@ export function getCart(): Cart {
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
         locale: 'en',
+        version: 1,
     };
 }


### PR DESCRIPTION
## What/Why?
Mock data update after changes in [https://github.com/bigcommerce/checkout-sdk-js/pull/3394](https://github.com/bigcommerce/checkout-sdk-js/pull/3394)

## Rollout/Rollback
Rollback this PR and checkout-sdk-js

## Testing
In CircleCI results

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and mock-only TypeScript shape updates; no checkout runtime behavior changes in this diff.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from `^1.969.0` to **`^1.970.0`** in `package.json` and the lockfile, aligning checkout-js with SDK changes that add a **`version`** field on **Cart** and **Checkout**.
> 
> Test and fixture mocks are updated so typed objects stay valid: cart mocks set **`version: 1`**, checkout and RTL checkout fixtures set **`version: 0`** on the nested cart/checkout shapes. No application logic in this repo consumes `version` yet—only dependency and mock alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a74453e160e7d8d73743ad2de44985c8b61f5da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->