### PR TITLE
CHECKOUT-10378: Fix Dependabot lockfile pruning that breaks npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8129,15 +8129,19 @@
       }
     },
     "node_modules/babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -10268,20 +10272,20 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/create-jest": {
@@ -17277,43 +17281,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/jest-circus/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jest-circus/node_modules/dedent": {
@@ -27771,9 +27738,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -30807,7 +30774,7 @@
         "@nx/devkit": "19.8.9",
         "@nx/workspace": "19.8.9",
         "babel-plugin-const-enum": "^1.0.1",
-        "babel-plugin-macros": "^2.8.0",
+        "babel-plugin-macros": "3.1.0",
         "babel-plugin-transform-typescript-metadata": "^0.3.1",
         "chalk": "^4.1.0",
         "columnify": "^1.6.0",
@@ -33248,14 +33215,14 @@
       }
     },
     "babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -34779,16 +34746,16 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       }
     },
     "create-jest": {
@@ -39609,34 +39576,6 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
-        },
-        "babel-plugin-macros": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-          "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "cosmiconfig": "^7.0.0",
-            "resolve": "^1.19.0"
-          }
-        },
-        "cosmiconfig": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-          "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@types/parse-json": "^4.0.0",
-            "import-fresh": "^3.2.1",
-            "parse-json": "^5.0.0",
-            "path-type": "^4.0.0",
-            "yaml": "^1.10.0"
-          }
         },
         "dedent": {
           "version": "1.6.0",
@@ -46805,9 +46744,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,8 @@
     },
     "@bigcommerce/eslint-config": {
       "typescript": "$typescript"
-    }
+    },
+    "babel-plugin-macros": "3.1.0"
   },
   "sideEffects": [
     "**/wdyr.ts",


### PR DESCRIPTION
Jira: [CHECKOUT-10378](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10378)

## What/Why?

Fix the issue where dependabot re-resolves the whole tree when it only updates the lockfile, and prunes optional peer dependencies, for example, https://github.com/bigcommerce/checkout-js/pull/3303.

We had exactly two — `babel-plugin-macros@3.1.0` and `cosmiconfig@7.1.0`, nested under `jest-circus` because `dedent` optionally peers on `^3.1.0` while `@nx/js` holds root at `2.8.0`. Dependabot deletes both, and `npm ci` — which requires a complete lockfile, unlike `npm install` — then aborts:

```
npm error code EUSAGE
npm error Missing: babel-plugin-macros@3.1.0 from lock file
npm error Missing: cosmiconfig@7.1.0 from lock file
```

## Rollout/Rollback

No experiment and no runtime code change — this only affects dev-dependency resolution. Rollback is a straight revert of this commit; nothing depends on it.

## Testing

Local, Node 22 / npm 10.9.2:

- `npm ci` installs cleanly — this is the step that was failing on Dependabot branches
- optional+peer entries in the lockfile: 2 → 0
- lockfile delta is exactly 2 removals and 3 version bumps, no additions:
  ```
  babel-plugin-macros  2.8.0  -> 3.1.0
  cosmiconfig          6.0.0  -> 7.1.0
  yaml                 1.10.2 -> 1.10.3
  ```
- `npm run nx:prerelease-build` — webpack compiled successfully
- `nx test instrument-utils` — 37 suites, 174 passed
- `nx lint instrument-utils,payment-integration-api` — 0 errors

To confirm it works end to end, comment `@dependabot recreate` on #3303 once this lands. The diff should come back a clean `+6 −6`, matching #3215 — the last Dependabot PR that merged green.


[CHECKOUT-10378]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only lockfile and npm override changes with no production runtime impact; main risk is build/test tooling resolving Babel macros differently after the version bump.
> 
> **Overview**
> Fixes **Dependabot lockfile pruning** that made `npm ci` fail with missing `babel-plugin-macros@3.1.0` and `cosmiconfig@7.1.0` entries.
> 
> Adds an npm **`overrides`** entry pinning **`babel-plugin-macros`** to **`3.1.0`**, resolving the conflict where `@nx/js` pulled **2.8.0** while **`jest-circus` → `dedent`** optionally peers on **^3.1.0**, which previously forced duplicate nested lockfile packages. The lockfile now **hoists** `babel-plugin-macros@3.1.0` and **`cosmiconfig@7.1.0`** at the root and **drops** the nested `jest-circus` copies; **`yaml`** bumps **1.10.2 → 1.10.3** as part of that resolution.
> 
> No application or runtime code changes—only dev dependency resolution and `package-lock.json` consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a57d1d09da32e40f7a76023a3f9bfa5cabdabe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->