### PR TITLE
chore(payment): PAYPAL-6634 Upgrade @bigcommerce/checkout-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.971.0",
+        "@bigcommerce/checkout-sdk": "^1.971.1",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.971.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.0.tgz",
-      "integrity": "sha512-PASiDkUi2AqsfJ4rMkLPoNIy3H333PzYcRN7qaN1J2MioxaYBDBuWEmt8QDFxATkT3e+O6wL4P3LQtYOJf4W2w==",
+      "version": "1.971.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.1.tgz",
+      "integrity": "sha512-SqBfTj9pY36vX8G5igbTKejkUcEICEFUZOcREO76DV2V4ugOFzIk6+zMmtzl+6Rrwc1cIgmfVdYS4GOuEW/htg==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29352,9 +29352,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.971.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.0.tgz",
-      "integrity": "sha512-PASiDkUi2AqsfJ4rMkLPoNIy3H333PzYcRN7qaN1J2MioxaYBDBuWEmt8QDFxATkT3e+O6wL4P3LQtYOJf4W2w==",
+      "version": "1.971.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.1.tgz",
+      "integrity": "sha512-SqBfTj9pY36vX8G5igbTKejkUcEICEFUZOcREO76DV2V4ugOFzIk6+zMmtzl+6Rrwc1cIgmfVdYS4GOuEW/htg==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.971.0",
+    "@bigcommerce/checkout-sdk": "^1.971.1",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

This PR is created to use the latest version for `@bigcommerce/checkout-sdk` dependency.
Update for https://github.com/bigcommerce/checkout-js/pull/3284

## Rollout/Rollback

Revert

## Testing

https://github.com/user-attachments/assets/6840220b-95d6-477b-bd29-dd7510a0236e

https://github.com/user-attachments/assets/fcdf6006-4ff2-4a64-956f-4d9b8a47f40b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-only dependency bump with no local code edits; any behavior change is confined to the SDK release and can be rolled back by reverting the version pins.
> 
> **Overview**
> Bumps **`@bigcommerce/checkout-sdk`** from **^1.971.0** to **^1.971.1** in `package.json` and `package-lock.json`. There are no other source changes in this repo—the checkout UI picks up SDK behavior from the new release.
> 
> Per the linked work (**PAYPAL-6634**), that SDK patch is intended to **improve shopper-facing error messaging when PayPal PPCP 3DS authentication is declined by the bank**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff225c728c4cc2f05e6af89efdd3e005d89159b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->