### PR TITLE
chore(payment): PAYPAL-5799 bump checkout-sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.971.1",
+        "@bigcommerce/checkout-sdk": "^1.972.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.971.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.1.tgz",
-      "integrity": "sha512-SqBfTj9pY36vX8G5igbTKejkUcEICEFUZOcREO76DV2V4ugOFzIk6+zMmtzl+6Rrwc1cIgmfVdYS4GOuEW/htg==",
+      "version": "1.972.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.972.0.tgz",
+      "integrity": "sha512-EldpyfVNPNt9dFcZFupKEhxGuXpGdilUsa2UkTCC2AokJ+IzwSPVBHL70iq3TUzF5Ws4e9jDyc9WCmbiTDJVxw==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29352,9 +29352,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.971.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.1.tgz",
-      "integrity": "sha512-SqBfTj9pY36vX8G5igbTKejkUcEICEFUZOcREO76DV2V4ugOFzIk6+zMmtzl+6Rrwc1cIgmfVdYS4GOuEW/htg==",
+      "version": "1.972.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.972.0.tgz",
+      "integrity": "sha512-EldpyfVNPNt9dFcZFupKEhxGuXpGdilUsa2UkTCC2AokJ+IzwSPVBHL70iq3TUzF5Ws4e9jDyc9WCmbiTDJVxw==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.971.1",
+    "@bigcommerce/checkout-sdk": "^1.972.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?

Bump checkout-sdk version

https://github.com/bigcommerce/checkout-sdk-js/pull/3396

## Rollout/Rollback

Revert

## Testing

Manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumping the core checkout SDK can affect payment and checkout flows across integrations; risk depends on what changed in 1.972.0, not on edits in this PR.
> 
> **Overview**
> Updates **`@bigcommerce/checkout-sdk`** from **^1.971.1** to **^1.972.0** in `package.json` and the matching lockfile entries so checkout-js picks up the SDK release tied to [checkout-sdk-js#3396](https://github.com/bigcommerce/checkout-sdk-js/pull/3396) (PAYPAL-5799).
> 
> No application source changes in this repo—behavior shifts come entirely from the new SDK version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c95d6c902da5bb51655632b0f3d74d765211e3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->