### PR TITLE
feat(payment): add shipping options filtering callback for Apple Pay and Google Pay

### DIFF
--- a/packages/apple-pay-integration/src/ApplePayButton.test.tsx
+++ b/packages/apple-pay-integration/src/ApplePayButton.test.tsx
@@ -61,6 +61,7 @@ describe('ApplePayButton', () => {
                     subtotalLabel: defaultProps.language.translate('cart.subtotal_text'),
                     onPaymentAuthorize: navigateToOrderConfirmation,
                     onError: defaultProps.onUnhandledError,
+                    filterAvailableShippingOptions: expect.any(Function),
                 },
             }),
             {},

--- a/packages/apple-pay-integration/src/ApplePayButton.tsx
+++ b/packages/apple-pay-integration/src/ApplePayButton.tsx
@@ -1,3 +1,4 @@
+import { type ShippingOption } from '@bigcommerce/checkout-sdk';
 import { createApplePayCustomerStrategy } from '@bigcommerce/checkout-sdk/integrations/apple-pay';
 import React, { type FunctionComponent } from 'react';
 
@@ -14,11 +15,17 @@ const ApplePayButton: FunctionComponent<CheckoutButtonProps> = (props) => {
 
     const integrations = [createApplePayCustomerStrategy];
 
+    const filterAvailableShippingOptions = (shippingOptions: ShippingOption[]) =>
+        Promise.resolve(
+            shippingOptions.filter((option) => option.type !== 'shipping_pickupinstore'),
+        );
+
     const additionalInitializationOptions = {
         shippingLabel: language.translate('cart.shipping_text'),
         subtotalLabel: language.translate('cart.subtotal_text'),
         onPaymentAuthorize: navigateToOrderConfirmation,
         onError: onUnhandledError,
+        filterAvailableShippingOptions,
     };
 
     return (

--- a/packages/google-pay-integration/src/GooglePayButton.tsx
+++ b/packages/google-pay-integration/src/GooglePayButton.tsx
@@ -1,3 +1,4 @@
+import { type ShippingOption } from '@bigcommerce/checkout-sdk';
 import {
     createGooglePayAdyenV2CustomerStrategy,
     createGooglePayAdyenV3CustomerStrategy,
@@ -59,8 +60,14 @@ const GooglePayButton: FunctionComponent<CheckoutButtonProps> = (props) => {
         createGooglePayTdOnlineMartCustomerStrategy,
     ];
 
+    const filterAvailableShippingOptions = (shippingOptions: ShippingOption[]) =>
+        Promise.resolve(
+            shippingOptions.filter((option) => option.type !== 'shipping_pickupinstore'),
+        );
+
     return (
         <CheckoutButton
+            additionalInitializationOptions={{ filterAvailableShippingOptions }}
             checkoutButtonContainerClass="google-pay-top-button"
             integrations={integrations}
             {...props}


### PR DESCRIPTION
## What/Why?
Example how to add custom filtering for wallet buttons on checkout

## Rollout/Rollback
Do not merge

## Testing
In checkout sdk PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to wallet button initialization and shipping option presentation; no auth or payment capture changes, though shoppers using Apple/Google Pay will no longer see in-store pickup in those flows.
> 
> **Overview**
> Apple Pay and Google Pay checkout buttons now pass a **`filterAvailableShippingOptions`** callback through **`additionalInitializationOptions`** so wallet shipping sheets only show methods the integration supports.
> 
> Both buttons use the same logic: async filter that drops options whose **`type`** is **`shipping_pickupinstore`**. Apple Pay keeps existing label, authorize, and error options and adds this filter; Google Pay adds the filter via **`additionalInitializationOptions`** on **`CheckoutButton`**.
> 
> The Apple Pay unit test is updated to assert **`filterAvailableShippingOptions`** is passed to **`CheckoutButton`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6309cf2b571106cf01e1d56d9686e25ff4411d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->