### PR TITLE
chore(payment): bump checkout-sdk-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.971.1",
+        "@bigcommerce/checkout-sdk": "^1.974.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.971.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.1.tgz",
-      "integrity": "sha512-SqBfTj9pY36vX8G5igbTKejkUcEICEFUZOcREO76DV2V4ugOFzIk6+zMmtzl+6Rrwc1cIgmfVdYS4GOuEW/htg==",
+      "version": "1.974.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.974.0.tgz",
+      "integrity": "sha512-eI8j/cTGnylF9ZP6x0t0sMpY7cp0rcq7wy7hTzgVrFFyOQt478GnCFIurq0TXtXz8IY+s7JbkX4DAsrOPpuORQ==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -29352,9 +29352,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.971.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.971.1.tgz",
-      "integrity": "sha512-SqBfTj9pY36vX8G5igbTKejkUcEICEFUZOcREO76DV2V4ugOFzIk6+zMmtzl+6Rrwc1cIgmfVdYS4GOuEW/htg==",
+      "version": "1.974.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.974.0.tgz",
+      "integrity": "sha512-eI8j/cTGnylF9ZP6x0t0sMpY7cp0rcq7wy7hTzgVrFFyOQt478GnCFIurq0TXtXz8IY+s7JbkX4DAsrOPpuORQ==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.971.1",
+    "@bigcommerce/checkout-sdk": "^1.974.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What/Why?
Bump checkout-sdk-js version to deploy PRs:
[https://github.com/bigcommerce/checkout-sdk-js/pull/3395](https://github.com/bigcommerce/checkout-sdk-js/pull/3395)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3393](https://github.com/bigcommerce/checkout-sdk-js/pull/3393)
[https://github.com/bigcommerce/checkout-sdk-js/pull/3396](https://github.com/bigcommerce/checkout-sdk-js/pull/3396)

## Rollout/Rollback
Rollback related SDK PR

## Testing
In checkout-sdk-js PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment/checkout behavior can change with SDK releases even when checkout-js is untouched; validate checkout and payment flows against the linked SDK PRs before rollout.
> 
> **Overview**
> **Dependency-only update:** bumps `@bigcommerce/checkout-sdk` from **^1.971.1** to **^1.974.0** in `package.json` and refreshes `package-lock.json` so checkout-js ships the newer SDK.
> 
> This wires in upstream checkout-sdk-js work referenced in the PR (PRs 3393, 3395, 3396); there are **no application code changes** in this repo—behavior changes come entirely from the SDK release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d09dfb94a23c4f12a8c6a13f2ad32ff50e4682b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->