### PR TITLE
BACK-879: Use showQuantityOnHand setting for on-hand quantity display

### DIFF
--- a/packages/core/src/app/order/OrderSummaryItem.tsx
+++ b/packages/core/src/app/order/OrderSummaryItem.tsx
@@ -64,6 +64,7 @@ const OrderSummaryItemBackorderDetails = ({
 
     const inventorySettings = config?.inventorySettings;
     const showQuantityOnBackorder = !!inventorySettings?.showQuantityOnBackorder;
+    const showQuantityOnHand = !!inventorySettings?.showQuantityOnHand;
     const showBackorderMessage = !!inventorySettings?.showBackorderMessage;
     const shouldDisplayBackorderMessagesOnStorefront =
         !!inventorySettings?.shouldDisplayBackorderMessagesOnStorefront;
@@ -75,7 +76,7 @@ const OrderSummaryItemBackorderDetails = ({
         return null;
     }
 
-    const shouldDisplayQuantityOnHand = showQuantityOnBackorder && !!quantityOnHand;
+    const shouldDisplayQuantityOnHand = showQuantityOnHand && !!quantityOnHand;
     const shouldDisplayQuantityOnBackorder = showQuantityOnBackorder && !!quantityBackordered;
     const shouldDisplayBackorderMessage =
         showBackorderMessage && !!backorderMessage && !!quantityBackordered;


### PR DESCRIPTION
Jira: [BACK-879](https://bigcommercecloud.atlassian.net/browse/BACK-879)

## What/Why?

Bug on the PR (https://github.com/bigcommerce/checkout-js/pull/2844/changes#diff-163a009279ce910b130e8f5201b138f849a270467af39d517f75c5da9255f731R49): `shouldDisplayQuantityOnHand` in `OrderSummaryItemBackorderDetails` (`packages/core/src/app/order/OrderSummaryItem.tsx`) was gated on `inventorySettings.showQuantityOnBackorder` instead of the dedicated `inventorySettings.showQuantityOnHand` flag. This meant the on-hand quantity line followed the backorder toggle rather than its own setting.

This PR is to fix this. 

## Rollout/Rollback

Standard deploy, no feature flag or migration involved. Revert the commit to roll back.

## Testing

Verified the settings check now reads `showQuantityOnHand` for the on-hand quantity line, and `showQuantityOnBackorder` still gates the backorder quantity line independently.

Fixes BACK-879

[BACK-879]: https://bigcommercecloud.atlassian.net/browse/BACK-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small display-logic fix in storefront checkout UI with no auth, payment, or data-persistence changes.
> 
> **Overview**
> Fixes **on-hand quantity** visibility in checkout order summary backorder details so it respects **`inventorySettings.showQuantityOnHand`** instead of incorrectly using **`showQuantityOnBackorder`**.
> 
> Merchants can now show ready-to-ship counts independently of backorder quantity toggles; backorder quantity and message behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d1df6c0b0f97781b359617a838ee46a613a321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->