### PR TITLE
chore(others): CHECKOUT-10379 Add symlinking option to fix linked package build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,11 @@ function appConfig(options, argv) {
                     /^(.+?[\\/]node_modules[\\/](?!\.cache)(?!@bigcommerce[\\/]checkout-sdk)(?:@.+?[\\/])?.+?)(?:[\\/].*)?$/,
                 ],
             },
+            // Watchpack only watches a symlinked package's real path when this is on,
+            // so without it edits to a linked checkout-sdk never invalidate the build.
+            watchOptions: {
+                followSymlinks: true,
+            },
             devtool: isProduction ? 'source-map' : 'eval-source-map',
             resolve: {
                 alias,


### PR DESCRIPTION
## What/Why?
Update `followSymlinks` to true, so linked packages builds are picked up by webpack's build watcher correctly.

## Rollout/Rollback
- revert this PR

## Testing
- CI

https://github.com/user-attachments/assets/0b401a29-491d-44be-a3d9-be58e4c533a7


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev/build tooling only; no runtime checkout behavior or security-sensitive logic changes.
> 
> **Overview**
> Fixes local development when `@bigcommerce/checkout-sdk` is **yarn/npm linked**: webpack’s watcher now follows symlinks so edits in the linked package trigger rebuilds.
> 
> Adds **`watchOptions.followSymlinks: true`** to the main app webpack config (with a short comment). **`resolve.symlinks`** stays **`false`**—only file watching behavior changes, not module resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0801851bc0e518f684752eebf29e51ce9c687535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->