### PR TITLE
feat(payment): PI-5643 [Google Pay] show error on 3ds challenge failure

### DIFF
--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -12,7 +12,6 @@ import {
     type OrderRequestBody,
     type PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
-// import { createAdyenV3PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/adyen';
 import { createAfterpayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/afterpay';
 import { createBlueSnapV2PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
 import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
@@ -823,7 +822,6 @@ const Payment = (
             try {
                 const state = await finalizeOrderIfNeeded({
                     integrations: [
-                        // createAdyenV3PaymentStrategy,
                         createAfterpayPaymentStrategy,
                         createBlueSnapV2PaymentStrategy,
                         createCBAMPGSPaymentStrategy,

--- a/packages/core/src/app/payment/Payment.tsx
+++ b/packages/core/src/app/payment/Payment.tsx
@@ -12,6 +12,7 @@ import {
     type OrderRequestBody,
     type PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
+// import { createAdyenV3PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/adyen';
 import { createAfterpayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/afterpay';
 import { createBlueSnapV2PaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/bluesnap-direct';
 import { createCBAMPGSPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/cba-mpgs';
@@ -23,6 +24,20 @@ import {
     createCheckoutComSepaPaymentStrategy,
 } from '@bigcommerce/checkout-sdk/integrations/checkoutcom-custom';
 import { createClearpayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/clearpay';
+import {
+    createGooglePayAdyenV2PaymentStrategy,
+    createGooglePayAdyenV3PaymentStrategy,
+    createGooglePayAuthorizeNetPaymentStrategy,
+    createGooglePayBigCommercePaymentsPaymentStrategy,
+    createGooglePayBraintreePaymentStrategy,
+    createGooglePayCheckoutComPaymentStrategy,
+    createGooglePayCybersourcePaymentStrategy,
+    createGooglePayOrbitalPaymentStrategy,
+    createGooglePayPPCPPaymentStrategy,
+    createGooglePayStripePaymentStrategy,
+    createGooglePayTdOnlineMartPaymentStrategy,
+    createGooglePayWorldpayAccessPaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/google-pay';
 import { createOffsitePaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/offsite';
 import { createPaypalExpressPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/paypal-express';
 import { createSagePayPaymentStrategy } from '@bigcommerce/checkout-sdk/integrations/sagepay';
@@ -808,6 +823,7 @@ const Payment = (
             try {
                 const state = await finalizeOrderIfNeeded({
                     integrations: [
+                        // createAdyenV3PaymentStrategy,
                         createAfterpayPaymentStrategy,
                         createBlueSnapV2PaymentStrategy,
                         createCBAMPGSPaymentStrategy,
@@ -817,6 +833,18 @@ const Payment = (
                         createCheckoutComIdealPaymentStrategy,
                         createCheckoutComSepaPaymentStrategy,
                         createClearpayPaymentStrategy,
+                        createGooglePayAdyenV2PaymentStrategy,
+                        createGooglePayAdyenV3PaymentStrategy,
+                        createGooglePayAuthorizeNetPaymentStrategy,
+                        createGooglePayBigCommercePaymentsPaymentStrategy,
+                        createGooglePayBraintreePaymentStrategy,
+                        createGooglePayCheckoutComPaymentStrategy,
+                        createGooglePayCybersourcePaymentStrategy,
+                        createGooglePayOrbitalPaymentStrategy,
+                        createGooglePayPPCPPaymentStrategy,
+                        createGooglePayStripePaymentStrategy,
+                        createGooglePayTdOnlineMartPaymentStrategy,
+                        createGooglePayWorldpayAccessPaymentStrategy,
                         createOffsitePaymentStrategy,
                         createPaypalExpressPaymentStrategy,
                         createSagePayPaymentStrategy,

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -6,20 +6,6 @@ import {
     type PaymentInitializeOptions,
     type PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
-import {
-    createGooglePayAdyenV2PaymentStrategy,
-    createGooglePayAdyenV3PaymentStrategy,
-    createGooglePayAuthorizeNetPaymentStrategy,
-    createGooglePayBigCommercePaymentsPaymentStrategy,
-    createGooglePayBraintreePaymentStrategy,
-    createGooglePayCheckoutComPaymentStrategy,
-    createGooglePayCybersourcePaymentStrategy,
-    createGooglePayOrbitalPaymentStrategy,
-    createGooglePayPPCPPaymentStrategy,
-    createGooglePayStripePaymentStrategy,
-    createGooglePayTdOnlineMartPaymentStrategy,
-    createGooglePayWorldpayAccessPaymentStrategy,
-} from '@bigcommerce/checkout-sdk/integrations/google-pay';
 import { Formik } from 'formik';
 import each from 'jest-each';
 import { noop } from 'lodash';
@@ -327,7 +313,12 @@ describe('when using Google Pay payment', () => {
         });
     });
 
-    describe('when payment is already selected (Express Entry flow)', () => {
+    // If the shopper already picked Google Pay before reaching checkout
+    // (e.g. a Buy Now/Express button on PDP or Cart), `checkout.payments`
+    // already lists it as selected the moment this component mounts. That
+    // case keeps the wallet-button UI (with its sign-out option), since the
+    // shopper has already completed a wallet interaction elsewhere.
+    describe('when payment is already selected at mount (Express Entry flow)', () => {
         beforeEach(() => {
             jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
                 ...getCheckout(),
@@ -347,6 +338,143 @@ describe('when using Google Pay payment', () => {
                     }),
                 ),
             ).toBeInTheDocument();
+        });
+
+        each([
+            PaymentMethodId.AdyenV2GooglePay,
+            PaymentMethodId.AdyenV3GooglePay,
+            PaymentMethodId.AuthorizeNetGooglePay,
+            PaymentMethodId.BNZGooglePay,
+            PaymentMethodId.BraintreeGooglePay,
+            PaymentMethodId.PayPalCommerceGooglePay,
+            PaymentMethodId.CheckoutcomGooglePay,
+            PaymentMethodId.CybersourceV2GooglePay,
+            PaymentMethodId.OrbitalGooglePay,
+            PaymentMethodId.StripeGooglePay,
+            PaymentMethodId.StripeUPEGooglePay,
+            PaymentMethodId.WorldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('initializes with required config', (id: PaymentMethodId) => {
+            method.id = id;
+
+            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: id }],
+            });
+
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: id,
+                    gatewayId: method.gateway,
+                    [id]: {
+                        walletButton: 'walletButton',
+                        onError: defaultProps.onUnhandledError,
+                        loadingContainerId: 'checkout-app',
+                        onPaymentSelect: expect.any(Function),
+                    },
+                }),
+            );
+        });
+
+        each([
+            GooglePayPaymentMethodId.adyenV2GooglePay,
+            GooglePayPaymentMethodId.adyenV3GooglePay,
+            GooglePayPaymentMethodId.authorizeNetGooglePay,
+            GooglePayPaymentMethodId.bnzGooglePay,
+            GooglePayPaymentMethodId.braintreeGooglePay,
+            GooglePayPaymentMethodId.payPalCommerceGooglePay,
+            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
+            GooglePayPaymentMethodId.checkoutcomGooglePay,
+            GooglePayPaymentMethodId.cybersourceV2GooglePay,
+            GooglePayPaymentMethodId.orbitalGooglePay,
+            GooglePayPaymentMethodId.stripeGooglePay,
+            GooglePayPaymentMethodId.stripeUPEGooglePay,
+            GooglePayPaymentMethodId.worldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('reinitializes method once payment option is selected', async (id: string) => {
+            method.id = id;
+
+            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: id }],
+            });
+
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            const options: PaymentInitializeOptions = (
+                checkoutService.initializePayment as jest.Mock
+            ).mock.calls[0][0];
+
+            (checkoutService.initializePayment as jest.Mock).mockReset();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (options as Record<string, any>)[id]!.onPaymentSelect!();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+                methodId: method.id,
+            });
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+
+                    [method.id]: expect.any(Object),
+                }),
+            );
+        });
+
+        each([
+            GooglePayPaymentMethodId.adyenV2GooglePay,
+            GooglePayPaymentMethodId.adyenV3GooglePay,
+            GooglePayPaymentMethodId.authorizeNetGooglePay,
+            GooglePayPaymentMethodId.bnzGooglePay,
+            GooglePayPaymentMethodId.braintreeGooglePay,
+            GooglePayPaymentMethodId.payPalCommerceGooglePay,
+            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
+            GooglePayPaymentMethodId.checkoutcomGooglePay,
+            GooglePayPaymentMethodId.cybersourceV2GooglePay,
+            GooglePayPaymentMethodId.orbitalGooglePay,
+            GooglePayPaymentMethodId.stripeGooglePay,
+            GooglePayPaymentMethodId.stripeUPEGooglePay,
+            GooglePayPaymentMethodId.worldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('catches error during component reinitialization', async (id: string) => {
+            method.id = id;
+
+            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: id }],
+            });
+
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(() =>
+                Promise.reject(new Error('test error')),
+            );
+
+            const options: PaymentInitializeOptions = (
+                checkoutService.initializePayment as jest.Mock
+            ).mock.calls[0][0];
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (options as Record<string, any>)[id]!.onPaymentSelect!();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+                methodId: method.id,
+            });
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+
+                    [method.id]: expect.any(Object),
+                }),
+            );
+
+            expect(defaultProps.onUnhandledError).toHaveBeenCalled();
         });
     });
 });

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -6,6 +6,20 @@ import {
     type PaymentInitializeOptions,
     type PaymentMethod,
 } from '@bigcommerce/checkout-sdk';
+import {
+    createGooglePayAdyenV2PaymentStrategy,
+    createGooglePayAdyenV3PaymentStrategy,
+    createGooglePayAuthorizeNetPaymentStrategy,
+    createGooglePayBigCommercePaymentsPaymentStrategy,
+    createGooglePayBraintreePaymentStrategy,
+    createGooglePayCheckoutComPaymentStrategy,
+    createGooglePayCybersourcePaymentStrategy,
+    createGooglePayOrbitalPaymentStrategy,
+    createGooglePayPPCPPaymentStrategy,
+    createGooglePayStripePaymentStrategy,
+    createGooglePayTdOnlineMartPaymentStrategy,
+    createGooglePayWorldpayAccessPaymentStrategy,
+} from '@bigcommerce/checkout-sdk/integrations/google-pay';
 import { Formik } from 'formik';
 import each from 'jest-each';
 import { noop } from 'lodash';
@@ -94,176 +108,6 @@ describe('when using Google Pay payment', () => {
         );
     });
 
-    describe('when payment is already selected at mount (wallet button flow)', () => {
-        beforeEach(() => {
-            // The wallet button branch only renders when Google Pay was already
-            // selected at mount time, so reflect the current method id in checkout.
-            jest.spyOn(checkoutState.data, 'getCheckout').mockImplementation(() => ({
-                ...getCheckout(),
-                payments: [{ ...getCheckoutPayment(), providerId: method.id }],
-            }));
-        });
-
-        it('initializes payment method when component mounts', () => {
-            render(<GooglePayPaymentMethodTest {...defaultProps} />);
-
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    integrations: [
-                        createGooglePayAdyenV2PaymentStrategy,
-                        createGooglePayAdyenV3PaymentStrategy,
-                        createGooglePayAuthorizeNetPaymentStrategy,
-                        createGooglePayCheckoutComPaymentStrategy,
-                        createGooglePayCybersourcePaymentStrategy,
-                        createGooglePayOrbitalPaymentStrategy,
-                        createGooglePayStripePaymentStrategy,
-                        createGooglePayWorldpayAccessPaymentStrategy,
-                        createGooglePayBraintreePaymentStrategy,
-                        createGooglePayPPCPPaymentStrategy,
-                        createGooglePayBigCommercePaymentsPaymentStrategy,
-                        createGooglePayTdOnlineMartPaymentStrategy,
-                    ],
-                }),
-            );
-        });
-
-        it('renders Google Pay as a wallet button method', () => {
-            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-            expect(
-                screen.getByText(
-                    defaultProps.language.translate('remote.sign_out_action', {
-                        providerName: getPaymentMethodName(defaultProps.language)(
-                            defaultProps.method,
-                        ),
-                    }),
-                ),
-            ).toBeInTheDocument();
-        });
-
-        each([
-            PaymentMethodId.AdyenV2GooglePay,
-            PaymentMethodId.AdyenV3GooglePay,
-            PaymentMethodId.AuthorizeNetGooglePay,
-            PaymentMethodId.BNZGooglePay,
-            PaymentMethodId.BraintreeGooglePay,
-            PaymentMethodId.PayPalCommerceGooglePay,
-            PaymentMethodId.CheckoutcomGooglePay,
-            PaymentMethodId.CybersourceV2GooglePay,
-            PaymentMethodId.OrbitalGooglePay,
-            PaymentMethodId.StripeGooglePay,
-            PaymentMethodId.StripeUPEGooglePay,
-            PaymentMethodId.WorldpayAccessGooglePay,
-            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-        ]).it('initializes with required config', (id: PaymentMethodId) => {
-            method.id = id;
-
-            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    methodId: id,
-                    gatewayId: method.gateway,
-                    [id]: {
-                        walletButton: 'walletButton',
-                        onError: defaultProps.onUnhandledError,
-                        loadingContainerId: 'checkout-app',
-                        onPaymentSelect: expect.any(Function),
-                    },
-                }),
-            );
-        });
-
-        each([
-            GooglePayPaymentMethodId.adyenV2GooglePay,
-            GooglePayPaymentMethodId.adyenV3GooglePay,
-            GooglePayPaymentMethodId.authorizeNetGooglePay,
-            GooglePayPaymentMethodId.bnzGooglePay,
-            GooglePayPaymentMethodId.braintreeGooglePay,
-            GooglePayPaymentMethodId.payPalCommerceGooglePay,
-            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
-            GooglePayPaymentMethodId.checkoutcomGooglePay,
-            GooglePayPaymentMethodId.cybersourceV2GooglePay,
-            GooglePayPaymentMethodId.orbitalGooglePay,
-            GooglePayPaymentMethodId.stripeGooglePay,
-            GooglePayPaymentMethodId.stripeUPEGooglePay,
-            GooglePayPaymentMethodId.worldpayAccessGooglePay,
-            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-        ]).it('reinitializes method once payment option is selected', async (id: string) => {
-            method.id = id;
-            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-            const options: PaymentInitializeOptions = (
-                checkoutService.initializePayment as jest.Mock
-            ).mock.calls[0][0];
-
-            (checkoutService.initializePayment as jest.Mock).mockReset();
-
-            options.googlepaybraintree!.onPaymentSelect!();
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (options as Record<string, any>)[id]!.onPaymentSelect!();
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
-                methodId: method.id,
-            });
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    methodId: method.id,
-
-                    [method.id]: expect.any(Object),
-                }),
-            );
-        });
-
-        each([
-            GooglePayPaymentMethodId.adyenV2GooglePay,
-            GooglePayPaymentMethodId.adyenV3GooglePay,
-            GooglePayPaymentMethodId.authorizeNetGooglePay,
-            GooglePayPaymentMethodId.bnzGooglePay,
-            GooglePayPaymentMethodId.braintreeGooglePay,
-            GooglePayPaymentMethodId.payPalCommerceGooglePay,
-            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
-            GooglePayPaymentMethodId.checkoutcomGooglePay,
-            GooglePayPaymentMethodId.cybersourceV2GooglePay,
-            GooglePayPaymentMethodId.orbitalGooglePay,
-            GooglePayPaymentMethodId.stripeGooglePay,
-            GooglePayPaymentMethodId.stripeUPEGooglePay,
-            GooglePayPaymentMethodId.worldpayAccessGooglePay,
-            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-        ]).it('catches error during component reinitialization', async (id: string) => {
-            method.id = id;
-            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(() =>
-                Promise.reject(new Error('test error')),
-            );
-
-            const options: PaymentInitializeOptions = (
-                checkoutService.initializePayment as jest.Mock
-            ).mock.calls[0][0];
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (options as Record<string, any>)[id]!.onPaymentSelect!();
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
-                methodId: method.id,
-            });
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    methodId: method.id,
-
-                    [method.id]: expect.any(Object),
-                }),
-            );
-
-            expect(defaultProps.onUnhandledError).toHaveBeenCalled();
-        });
-    });
-
     describe('when payment is not selected at mount (Direct Pay flow)', () => {
         it('does not render the wallet button', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
@@ -338,6 +182,29 @@ describe('when using Google Pay payment', () => {
                     }),
                 ),
             ).toBeInTheDocument();
+        });
+
+        it('initializes payment method with the full set of Google Pay integrations', () => {
+            render(<GooglePayPaymentMethodTest {...defaultProps} />);
+
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    integrations: [
+                        createGooglePayAdyenV2PaymentStrategy,
+                        createGooglePayAdyenV3PaymentStrategy,
+                        createGooglePayAuthorizeNetPaymentStrategy,
+                        createGooglePayCheckoutComPaymentStrategy,
+                        createGooglePayCybersourcePaymentStrategy,
+                        createGooglePayOrbitalPaymentStrategy,
+                        createGooglePayStripePaymentStrategy,
+                        createGooglePayWorldpayAccessPaymentStrategy,
+                        createGooglePayBraintreePaymentStrategy,
+                        createGooglePayPPCPPaymentStrategy,
+                        createGooglePayBigCommercePaymentsPaymentStrategy,
+                        createGooglePayTdOnlineMartPaymentStrategy,
+                    ],
+                }),
+            );
         });
 
         each([

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.test.tsx
@@ -108,6 +108,176 @@ describe('when using Google Pay payment', () => {
         );
     });
 
+    describe('when payment is already selected at mount (wallet button flow)', () => {
+        beforeEach(() => {
+            // The wallet button branch only renders when Google Pay was already
+            // selected at mount time, so reflect the current method id in checkout.
+            jest.spyOn(checkoutState.data, 'getCheckout').mockImplementation(() => ({
+                ...getCheckout(),
+                payments: [{ ...getCheckoutPayment(), providerId: method.id }],
+            }));
+        });
+
+        it('initializes payment method when component mounts', () => {
+            render(<GooglePayPaymentMethodTest {...defaultProps} />);
+
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    integrations: [
+                        createGooglePayAdyenV2PaymentStrategy,
+                        createGooglePayAdyenV3PaymentStrategy,
+                        createGooglePayAuthorizeNetPaymentStrategy,
+                        createGooglePayCheckoutComPaymentStrategy,
+                        createGooglePayCybersourcePaymentStrategy,
+                        createGooglePayOrbitalPaymentStrategy,
+                        createGooglePayStripePaymentStrategy,
+                        createGooglePayWorldpayAccessPaymentStrategy,
+                        createGooglePayBraintreePaymentStrategy,
+                        createGooglePayPPCPPaymentStrategy,
+                        createGooglePayBigCommercePaymentsPaymentStrategy,
+                        createGooglePayTdOnlineMartPaymentStrategy,
+                    ],
+                }),
+            );
+        });
+
+        it('renders Google Pay as a wallet button method', () => {
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(
+                screen.getByText(
+                    defaultProps.language.translate('remote.sign_out_action', {
+                        providerName: getPaymentMethodName(defaultProps.language)(
+                            defaultProps.method,
+                        ),
+                    }),
+                ),
+            ).toBeInTheDocument();
+        });
+
+        each([
+            PaymentMethodId.AdyenV2GooglePay,
+            PaymentMethodId.AdyenV3GooglePay,
+            PaymentMethodId.AuthorizeNetGooglePay,
+            PaymentMethodId.BNZGooglePay,
+            PaymentMethodId.BraintreeGooglePay,
+            PaymentMethodId.PayPalCommerceGooglePay,
+            PaymentMethodId.CheckoutcomGooglePay,
+            PaymentMethodId.CybersourceV2GooglePay,
+            PaymentMethodId.OrbitalGooglePay,
+            PaymentMethodId.StripeGooglePay,
+            PaymentMethodId.StripeUPEGooglePay,
+            PaymentMethodId.WorldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('initializes with required config', (id: PaymentMethodId) => {
+            method.id = id;
+
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: id,
+                    gatewayId: method.gateway,
+                    [id]: {
+                        walletButton: 'walletButton',
+                        onError: defaultProps.onUnhandledError,
+                        loadingContainerId: 'checkout-app',
+                        onPaymentSelect: expect.any(Function),
+                    },
+                }),
+            );
+        });
+
+        each([
+            GooglePayPaymentMethodId.adyenV2GooglePay,
+            GooglePayPaymentMethodId.adyenV3GooglePay,
+            GooglePayPaymentMethodId.authorizeNetGooglePay,
+            GooglePayPaymentMethodId.bnzGooglePay,
+            GooglePayPaymentMethodId.braintreeGooglePay,
+            GooglePayPaymentMethodId.payPalCommerceGooglePay,
+            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
+            GooglePayPaymentMethodId.checkoutcomGooglePay,
+            GooglePayPaymentMethodId.cybersourceV2GooglePay,
+            GooglePayPaymentMethodId.orbitalGooglePay,
+            GooglePayPaymentMethodId.stripeGooglePay,
+            GooglePayPaymentMethodId.stripeUPEGooglePay,
+            GooglePayPaymentMethodId.worldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('reinitializes method once payment option is selected', async (id: string) => {
+            method.id = id;
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+
+            const options: PaymentInitializeOptions = (
+                checkoutService.initializePayment as jest.Mock
+            ).mock.calls[0][0];
+
+            (checkoutService.initializePayment as jest.Mock).mockReset();
+
+            options.googlepaybraintree!.onPaymentSelect!();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (options as Record<string, any>)[id]!.onPaymentSelect!();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+                methodId: method.id,
+            });
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+
+                    [method.id]: expect.any(Object),
+                }),
+            );
+        });
+
+        each([
+            GooglePayPaymentMethodId.adyenV2GooglePay,
+            GooglePayPaymentMethodId.adyenV3GooglePay,
+            GooglePayPaymentMethodId.authorizeNetGooglePay,
+            GooglePayPaymentMethodId.bnzGooglePay,
+            GooglePayPaymentMethodId.braintreeGooglePay,
+            GooglePayPaymentMethodId.payPalCommerceGooglePay,
+            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
+            GooglePayPaymentMethodId.checkoutcomGooglePay,
+            GooglePayPaymentMethodId.cybersourceV2GooglePay,
+            GooglePayPaymentMethodId.orbitalGooglePay,
+            GooglePayPaymentMethodId.stripeGooglePay,
+            GooglePayPaymentMethodId.stripeUPEGooglePay,
+            GooglePayPaymentMethodId.worldpayAccessGooglePay,
+            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
+        ]).it('catches error during component reinitialization', async (id: string) => {
+            method.id = id;
+            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
+            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(() =>
+                Promise.reject(new Error('test error')),
+            );
+
+            const options: PaymentInitializeOptions = (
+                checkoutService.initializePayment as jest.Mock
+            ).mock.calls[0][0];
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (options as Record<string, any>)[id]!.onPaymentSelect!();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
+                methodId: method.id,
+            });
+            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    methodId: method.id,
+
+                    [method.id]: expect.any(Object),
+                }),
+            );
+
+            expect(defaultProps.onUnhandledError).toHaveBeenCalled();
+        });
+    });
+
     describe('when payment is not selected at mount (Direct Pay flow)', () => {
         it('does not render the wallet button', () => {
             render(<GooglePayPaymentMethodTest {...defaultProps} />);
@@ -157,12 +327,7 @@ describe('when using Google Pay payment', () => {
         });
     });
 
-    // If the shopper already picked Google Pay before reaching checkout
-    // (e.g. a Buy Now/Express button on PDP or Cart), `checkout.payments`
-    // already lists it as selected the moment this component mounts. That
-    // case keeps the wallet-button UI (with its sign-out option), since the
-    // shopper has already completed a wallet interaction elsewhere.
-    describe('when payment is already selected at mount (Express Entry flow)', () => {
+    describe('when payment is already selected (Express Entry flow)', () => {
         beforeEach(() => {
             jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
                 ...getCheckout(),
@@ -182,166 +347,6 @@ describe('when using Google Pay payment', () => {
                     }),
                 ),
             ).toBeInTheDocument();
-        });
-
-        it('initializes payment method with the full set of Google Pay integrations', () => {
-            render(<GooglePayPaymentMethodTest {...defaultProps} />);
-
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    integrations: [
-                        createGooglePayAdyenV2PaymentStrategy,
-                        createGooglePayAdyenV3PaymentStrategy,
-                        createGooglePayAuthorizeNetPaymentStrategy,
-                        createGooglePayCheckoutComPaymentStrategy,
-                        createGooglePayCybersourcePaymentStrategy,
-                        createGooglePayOrbitalPaymentStrategy,
-                        createGooglePayStripePaymentStrategy,
-                        createGooglePayWorldpayAccessPaymentStrategy,
-                        createGooglePayBraintreePaymentStrategy,
-                        createGooglePayPPCPPaymentStrategy,
-                        createGooglePayBigCommercePaymentsPaymentStrategy,
-                        createGooglePayTdOnlineMartPaymentStrategy,
-                    ],
-                }),
-            );
-        });
-
-        each([
-            PaymentMethodId.AdyenV2GooglePay,
-            PaymentMethodId.AdyenV3GooglePay,
-            PaymentMethodId.AuthorizeNetGooglePay,
-            PaymentMethodId.BNZGooglePay,
-            PaymentMethodId.BraintreeGooglePay,
-            PaymentMethodId.PayPalCommerceGooglePay,
-            PaymentMethodId.CheckoutcomGooglePay,
-            PaymentMethodId.CybersourceV2GooglePay,
-            PaymentMethodId.OrbitalGooglePay,
-            PaymentMethodId.StripeGooglePay,
-            PaymentMethodId.StripeUPEGooglePay,
-            PaymentMethodId.WorldpayAccessGooglePay,
-            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-        ]).it('initializes with required config', (id: PaymentMethodId) => {
-            method.id = id;
-
-            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
-                ...getCheckout(),
-                payments: [{ ...getCheckoutPayment(), providerId: id }],
-            });
-
-            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    methodId: id,
-                    gatewayId: method.gateway,
-                    [id]: {
-                        walletButton: 'walletButton',
-                        onError: defaultProps.onUnhandledError,
-                        loadingContainerId: 'checkout-app',
-                        onPaymentSelect: expect.any(Function),
-                    },
-                }),
-            );
-        });
-
-        each([
-            GooglePayPaymentMethodId.adyenV2GooglePay,
-            GooglePayPaymentMethodId.adyenV3GooglePay,
-            GooglePayPaymentMethodId.authorizeNetGooglePay,
-            GooglePayPaymentMethodId.bnzGooglePay,
-            GooglePayPaymentMethodId.braintreeGooglePay,
-            GooglePayPaymentMethodId.payPalCommerceGooglePay,
-            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
-            GooglePayPaymentMethodId.checkoutcomGooglePay,
-            GooglePayPaymentMethodId.cybersourceV2GooglePay,
-            GooglePayPaymentMethodId.orbitalGooglePay,
-            GooglePayPaymentMethodId.stripeGooglePay,
-            GooglePayPaymentMethodId.stripeUPEGooglePay,
-            GooglePayPaymentMethodId.worldpayAccessGooglePay,
-            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-        ]).it('reinitializes method once payment option is selected', async (id: string) => {
-            method.id = id;
-
-            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
-                ...getCheckout(),
-                payments: [{ ...getCheckoutPayment(), providerId: id }],
-            });
-
-            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-
-            const options: PaymentInitializeOptions = (
-                checkoutService.initializePayment as jest.Mock
-            ).mock.calls[0][0];
-
-            (checkoutService.initializePayment as jest.Mock).mockReset();
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (options as Record<string, any>)[id]!.onPaymentSelect!();
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
-                methodId: method.id,
-            });
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    methodId: method.id,
-
-                    [method.id]: expect.any(Object),
-                }),
-            );
-        });
-
-        each([
-            GooglePayPaymentMethodId.adyenV2GooglePay,
-            GooglePayPaymentMethodId.adyenV3GooglePay,
-            GooglePayPaymentMethodId.authorizeNetGooglePay,
-            GooglePayPaymentMethodId.bnzGooglePay,
-            GooglePayPaymentMethodId.braintreeGooglePay,
-            GooglePayPaymentMethodId.payPalCommerceGooglePay,
-            GooglePayPaymentMethodId.bigcommercePaymentsGooglePay,
-            GooglePayPaymentMethodId.checkoutcomGooglePay,
-            GooglePayPaymentMethodId.cybersourceV2GooglePay,
-            GooglePayPaymentMethodId.orbitalGooglePay,
-            GooglePayPaymentMethodId.stripeGooglePay,
-            GooglePayPaymentMethodId.stripeUPEGooglePay,
-            GooglePayPaymentMethodId.worldpayAccessGooglePay,
-            GooglePayPaymentMethodId.tdOnlineMartGooglePay,
-        ]).it('catches error during component reinitialization', async (id: string) => {
-            method.id = id;
-
-            jest.spyOn(checkoutState.data, 'getCheckout').mockReturnValue({
-                ...getCheckout(),
-                payments: [{ ...getCheckoutPayment(), providerId: id }],
-            });
-
-            render(<GooglePayPaymentMethodTest {...defaultProps} method={method} />);
-            jest.spyOn(checkoutService, 'initializePayment').mockImplementation(() =>
-                Promise.reject(new Error('test error')),
-            );
-
-            const options: PaymentInitializeOptions = (
-                checkoutService.initializePayment as jest.Mock
-            ).mock.calls[0][0];
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (options as Record<string, any>)[id]!.onPaymentSelect!();
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(checkoutService.deinitializePayment).toHaveBeenCalledWith({
-                methodId: method.id,
-            });
-            expect(checkoutService.initializePayment).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    methodId: method.id,
-
-                    [method.id]: expect.any(Object),
-                }),
-            );
-
-            expect(defaultProps.onUnhandledError).toHaveBeenCalled();
         });
     });
 });

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -31,11 +31,6 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const isPaymentSelected = checkout ? some(checkout.payments, { providerId: method.id }) : false;
 
     // Capture whether Google Pay was already selected at mount time
-    // (PDP/Cart/Customer step button). The wallet-button UI (with its
-    // sign-out option) is only kept for that Express Entry case - everywhere
-    // else, Google Pay should only ever show its own branded button, never
-    // hand off to the generic "Place Order" button. The wallet-button
-    // approach is deprecated for the regular (non-Express-Entry) flow.
     const wasPaymentSelectedAtMountRef = useRef(isPaymentSelected);
 
     const initializeGooglePayPayment = useCallback(

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -31,7 +31,11 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const isPaymentSelected = checkout ? some(checkout.payments, { providerId: method.id }) : false;
 
     // Capture whether Google Pay was already selected at mount time
-    // (PDP/Cart/Customer step button)
+    // (PDP/Cart/Customer step button). The wallet-button UI (with its
+    // sign-out option) is only kept for that Express Entry case - everywhere
+    // else, Google Pay should only ever show its own branded button, never
+    // hand off to the generic "Place Order" button. The wallet-button
+    // approach is deprecated for the regular (non-Express-Entry) flow.
     const wasPaymentSelectedAtMountRef = useRef(isPaymentSelected);
 
     const initializeGooglePayPayment = useCallback(

--- a/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
+++ b/packages/google-pay-integration/src/GooglePayPaymentMethod.tsx
@@ -31,6 +31,7 @@ const GooglePayPaymentMethod: FunctionComponent<PaymentMethodProps> = ({
     const isPaymentSelected = checkout ? some(checkout.payments, { providerId: method.id }) : false;
 
     // Capture whether Google Pay was already selected at mount time
+    // (PDP/Cart/Customer step button)
     const wasPaymentSelectedAtMountRef = useRef(isPaymentSelected);
 
     const initializeGooglePayPayment = useCallback(

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -540,6 +540,7 @@
             "continue_with_text": "Or continue with",
             "or_text": "OR",
             "payment_method_error": "There was an error retrieving your remote payment method. Please try again.",
+            "retry_same_card_action": "Try again",
             "select_different_card_action": "Select a different card",
             "session_error": "Your remote session has expired. Please log in again.",
             "shipping_address_error": "There was an error retrieving your remote shipping address. Please try again.",

--- a/packages/locale/src/translations/en.json
+++ b/packages/locale/src/translations/en.json
@@ -540,7 +540,7 @@
             "continue_with_text": "Or continue with",
             "or_text": "OR",
             "payment_method_error": "There was an error retrieving your remote payment method. Please try again.",
-            "retry_same_card_action": "Try again",
+            "retry_same_card_action": "Try again or select a different card",
             "select_different_card_action": "Select a different card",
             "session_error": "Your remote session has expired. Please log in again.",
             "shipping_address_error": "There was an error retrieving your remote shipping address. Please try again.",

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
@@ -457,6 +457,64 @@ describe('WalletButtonPaymentMethod', () => {
 
                 expect(disableSubmit).toHaveBeenLastCalledWith(freshMethod, false);
             });
+
+            it('relabels the edit action as "try again" instead of "select a different card"', () => {
+                jest.spyOn(checkoutState.errors, 'getSubmitOrderError').mockReturnValue(
+                    new Error('Payment was declined'),
+                );
+
+                render(<WalletButtonPaymentMethodTest {...defaultProps} shouldShowEditButton />);
+
+                expect(
+                    screen.getByText(
+                        localeContext.language.translate('remote.retry_same_card_action'),
+                    ),
+                ).toBeInTheDocument();
+                expect(
+                    screen.queryByText(
+                        localeContext.language.translate('remote.select_different_card_action'),
+                    ),
+                ).not.toBeInTheDocument();
+            });
+
+            it('reverts the edit action back to its default label once a fresh token is available', () => {
+                jest.spyOn(checkoutState.errors, 'getSubmitOrderError').mockReturnValue(
+                    new Error('Payment was declined'),
+                );
+
+                const { rerender } = render(
+                    <WalletButtonPaymentMethodTest {...defaultProps} shouldShowEditButton />,
+                );
+
+                expect(
+                    screen.getByText(
+                        localeContext.language.translate('remote.retry_same_card_action'),
+                    ),
+                ).toBeInTheDocument();
+
+                const freshMethod = merge({}, defaultProps.method, {
+                    initializationData: { nonce: 'nonce-2' },
+                });
+
+                rerender(
+                    <WalletButtonPaymentMethodTest
+                        {...defaultProps}
+                        method={freshMethod}
+                        shouldShowEditButton
+                    />,
+                );
+
+                expect(
+                    screen.getByText(
+                        localeContext.language.translate('remote.select_different_card_action'),
+                    ),
+                ).toBeInTheDocument();
+                expect(
+                    screen.queryByText(
+                        localeContext.language.translate('remote.retry_same_card_action'),
+                    ),
+                ).not.toBeInTheDocument();
+            });
         });
     });
 });

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.test.tsx
@@ -380,5 +380,83 @@ describe('WalletButtonPaymentMethod', () => {
 
             expect(handleSignOutError).toHaveBeenCalledWith(expect.any(Error));
         });
+
+        describe('when a payment attempt using the current token was declined', () => {
+            beforeEach(() => {
+                defaultProps = merge({}, defaultProps, {
+                    method: {
+                        initializationData: {
+                            nonce: 'nonce-1',
+                        },
+                    },
+                });
+            });
+
+            it('disables submit button when a submit order error is present', () => {
+                jest.spyOn(checkoutState.errors, 'getSubmitOrderError').mockReturnValue(
+                    new Error('Payment was declined'),
+                );
+
+                render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+                const {
+                    paymentForm: { disableSubmit },
+                } = defaultProps;
+
+                expect(disableSubmit).toHaveBeenLastCalledWith(defaultProps.method, true);
+            });
+
+            it('disables submit button when a finalize order error is present', () => {
+                jest.spyOn(checkoutState.errors, 'getFinalizeOrderError').mockReturnValue(
+                    new Error('Payment was declined'),
+                );
+
+                render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+                const {
+                    paymentForm: { disableSubmit },
+                } = defaultProps;
+
+                expect(disableSubmit).toHaveBeenLastCalledWith(defaultProps.method, true);
+            });
+
+            it('keeps submit button disabled across re-renders while the token has not changed', () => {
+                jest.spyOn(checkoutState.errors, 'getSubmitOrderError').mockReturnValue(
+                    new Error('Payment was declined'),
+                );
+
+                const { rerender } = render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+                rerender(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+                const {
+                    paymentForm: { disableSubmit },
+                } = defaultProps;
+
+                expect(disableSubmit).toHaveBeenLastCalledWith(defaultProps.method, true);
+            });
+
+            it('re-enables submit button once a fresh token is available', () => {
+                jest.spyOn(checkoutState.errors, 'getSubmitOrderError').mockReturnValue(
+                    new Error('Payment was declined'),
+                );
+
+                const { rerender } = render(<WalletButtonPaymentMethodTest {...defaultProps} />);
+
+                const {
+                    paymentForm: { disableSubmit },
+                } = defaultProps;
+
+                expect(disableSubmit).toHaveBeenLastCalledWith(defaultProps.method, true);
+
+                const freshMethod = merge({}, defaultProps.method, {
+                    initializationData: { nonce: 'nonce-2' },
+                });
+
+                rerender(<WalletButtonPaymentMethodTest {...defaultProps} method={freshMethod} />);
+
+                expect(disableSubmit).toHaveBeenLastCalledWith(freshMethod, false);
+            });
+        });
     });
 });

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
@@ -17,8 +17,6 @@ import normalizeWalletPaymentData from './normalizeWalletPaymentData';
 import PaymentView from './PaymentView';
 import SignInView from './SignInView';
 
-// `initializationData` is a schema-less object (see normalizeWalletPaymentData),
-// so guard our way to the `nonce` field rather than casting.
 const getNonce = (initializationData: unknown): string | undefined => {
     if (
         typeof initializationData === 'object' &&
@@ -73,8 +71,6 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
         },
     } = useCheckout();
 
-    // Scoped selector: only re-run when the order/finalize error actually
-    // changes, rather than on every checkout state change.
     const {
         selectedState: { submitOrderError, finalizeOrderError },
     } = useCheckout(({ errors }) => ({
@@ -95,18 +91,6 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
     const cardName =
         walletPaymentData && [billingAddress.firstName, billingAddress.lastName].join(' ');
 
-    // Wallet providers like Google Pay hand out a single-use token/nonce
-    // each time the shopper completes their native payment sheet. Once a
-    // payment attempt using that token has been declined, it's spent -
-    // resubmitting it just fails again with a generic error. The storefront
-    // has no way to invalidate it server-side, so instead remember which
-    // token was declined and keep "Place Order" disabled for it, until the
-    // shopper goes through the wallet button again for a fresh one (the
-    // "Edit"/re-select action already offered below).
-    //
-    // This is state (rather than a ref) deliberately: it also drives the
-    // "Edit"/re-select action's label below, so updating it needs to
-    // trigger a re-render - a ref's mutation wouldn't.
     const currentNonce = getNonce(method.initializationData);
     const [declinedNonce, setDeclinedNonce] = useState<string>();
 
@@ -117,11 +101,6 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [submitOrderError, finalizeOrderError]);
 
-    // Once the current token has been declined, the shopper isn't limited to
-    // picking a different card - going through the wallet button again with
-    // the same card gets them a fresh, usable token just as well - so the
-    // "Edit"/re-select action's label below is adjusted to make that clear
-    // instead of implying only a different card would work.
     const hasDeclinedPaymentData = declinedNonce !== undefined && declinedNonce === currentNonce;
 
     const toggleSubmit = () => {

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
@@ -6,7 +6,7 @@ import {
     type PaymentRequestOptions,
 } from '@bigcommerce/checkout-sdk';
 import { noop, some } from 'lodash';
-import React, { type ReactNode, useCallback, useEffect } from 'react';
+import React, { type ReactNode, useCallback, useEffect, useRef } from 'react';
 
 import { useCheckout } from '@bigcommerce/checkout/contexts';
 import { type PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
@@ -15,6 +15,21 @@ import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 import normalizeWalletPaymentData from './normalizeWalletPaymentData';
 import PaymentView from './PaymentView';
 import SignInView from './SignInView';
+
+// `initializationData` is a schema-less object (see normalizeWalletPaymentData),
+// so guard our way to the `nonce` field rather than casting.
+const getNonce = (initializationData: unknown): string | undefined => {
+    if (
+        typeof initializationData === 'object' &&
+        initializationData !== null &&
+        'nonce' in initializationData &&
+        typeof initializationData.nonce === 'string'
+    ) {
+        return initializationData.nonce;
+    }
+
+    return undefined;
+};
 
 export interface WalletButtonPaymentMethodProps {
     paymentForm: PaymentFormService;
@@ -57,6 +72,15 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
         },
     } = useCheckout();
 
+    // Scoped selector: only re-run when the order/finalize error actually
+    // changes, rather than on every checkout state change.
+    const {
+        selectedState: { submitOrderError, finalizeOrderError },
+    } = useCheckout(({ errors }) => ({
+        submitOrderError: errors.getSubmitOrderError(),
+        finalizeOrderError: errors.getFinalizeOrderError(),
+    }));
+
     const billingAddress = getBillingAddress();
     const checkout = getCheckout();
 
@@ -70,14 +94,33 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
     const cardName =
         walletPaymentData && [billingAddress.firstName, billingAddress.lastName].join(' ');
 
+    // Wallet providers like Google Pay hand out a single-use token/nonce
+    // each time the shopper completes their native payment sheet. Once a
+    // payment attempt using that token has been declined, it's spent -
+    // resubmitting it just fails again with a generic error. The storefront
+    // has no way to invalidate it server-side, so instead remember which
+    // token was declined and keep "Place Order" disabled for it, until the
+    // shopper goes through the wallet button again for a fresh one (the
+    // "Edit"/re-select action already offered below).
+    const currentNonce = getNonce(method.initializationData);
+    const declinedNonceRef = useRef<string>();
+
+    useEffect(() => {
+        if (submitOrderError || finalizeOrderError) {
+            declinedNonceRef.current = currentNonce;
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [submitOrderError, finalizeOrderError]);
+
     const toggleSubmit = () => {
         const { disableSubmit } = paymentForm;
         const currentIsPaymentDataRequired = isPaymentDataRequired();
+        const hasDeclinedPaymentData =
+            declinedNonceRef.current !== undefined && declinedNonceRef.current === currentNonce;
+        const hasValidWalletData =
+            normalizeWalletPaymentData(method.initializationData) || !currentIsPaymentDataRequired;
 
-        if (
-            normalizeWalletPaymentData(method.initializationData) ||
-            !currentIsPaymentDataRequired
-        ) {
+        if (!hasDeclinedPaymentData && hasValidWalletData) {
             disableSubmit(method, false);
         } else {
             disableSubmit(method, true);

--- a/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
+++ b/packages/wallet-button-integration/src/WalletButtonPaymentMethodComponent.tsx
@@ -6,9 +6,10 @@ import {
     type PaymentRequestOptions,
 } from '@bigcommerce/checkout-sdk';
 import { noop, some } from 'lodash';
-import React, { type ReactNode, useCallback, useEffect, useRef } from 'react';
+import React, { type ReactNode, useCallback, useEffect, useState } from 'react';
 
 import { useCheckout } from '@bigcommerce/checkout/contexts';
+import { TranslatedString } from '@bigcommerce/checkout/locale';
 import { type PaymentFormService } from '@bigcommerce/checkout/payment-integration-api';
 import { LoadingOverlay } from '@bigcommerce/checkout/ui';
 
@@ -102,21 +103,30 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
     // token was declined and keep "Place Order" disabled for it, until the
     // shopper goes through the wallet button again for a fresh one (the
     // "Edit"/re-select action already offered below).
+    //
+    // This is state (rather than a ref) deliberately: it also drives the
+    // "Edit"/re-select action's label below, so updating it needs to
+    // trigger a re-render - a ref's mutation wouldn't.
     const currentNonce = getNonce(method.initializationData);
-    const declinedNonceRef = useRef<string>();
+    const [declinedNonce, setDeclinedNonce] = useState<string>();
 
     useEffect(() => {
         if (submitOrderError || finalizeOrderError) {
-            declinedNonceRef.current = currentNonce;
+            setDeclinedNonce(currentNonce);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [submitOrderError, finalizeOrderError]);
 
+    // Once the current token has been declined, the shopper isn't limited to
+    // picking a different card - going through the wallet button again with
+    // the same card gets them a fresh, usable token just as well - so the
+    // "Edit"/re-select action's label below is adjusted to make that clear
+    // instead of implying only a different card would work.
+    const hasDeclinedPaymentData = declinedNonce !== undefined && declinedNonce === currentNonce;
+
     const toggleSubmit = () => {
         const { disableSubmit } = paymentForm;
         const currentIsPaymentDataRequired = isPaymentDataRequired();
-        const hasDeclinedPaymentData =
-            declinedNonceRef.current !== undefined && declinedNonceRef.current === currentNonce;
         const hasValidWalletData =
             normalizeWalletPaymentData(method.initializationData) || !currentIsPaymentDataRequired;
 
@@ -187,7 +197,13 @@ const WalletButtonPaymentMethodComponent: React.FC<WalletButtonPaymentMethodProp
                         buttonId={buttonId}
                         cardName={cardName}
                         editButtonClassName={editButtonClassName}
-                        editButtonLabel={editButtonLabel}
+                        editButtonLabel={
+                            hasDeclinedPaymentData ? (
+                                <TranslatedString id="remote.retry_same_card_action" />
+                            ) : (
+                                editButtonLabel
+                            )
+                        }
                         method={method}
                         onSignOut={handleSignOut}
                         shouldShowEditButton={shouldShowEditButton}


### PR DESCRIPTION
## What/Why?

For Google Pay, when a shopper fails a 3DS challenge and is redirected back to checkout, no error was shown. The order was left silently unfinalized, and the shopper would only see an error when they tried to place an order again.

- Added Google Pay payment methods to `finalizeOrderIfNeeded`, so the strategy resolution wouldn't fail silently.
- Added disabled state for 'Place order' button when shopper gets redirected back to the checkout after failed 3DS attempt. This forces the shopper to either re-select previous card or select a new one, creating new Google Pay session and enabling the shopper to complete the order.
- Small change in copy - shows to the shopper that they do not have to select a entirely new card and can retry with the previous one

checkout-sdk part of the fix: https://github.com/bigcommerce/checkout-sdk-js/pull/3403

## Rollout/Rollback

Revert

## Testing

After failed 3DS, an error is shown after the redirect back to the checkout; previous token is invalidated, so the shopper has to reselect the card (or select a new one) to try to place an order again (tested with Checkout.com)


https://github.com/user-attachments/assets/44c41b6a-8bb2-42bf-86ce-ceac58088e73



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment finalization integration list and Google Pay submit gating behind a feature flag; incorrect error classification could block or allow retries incorrectly.
> 
> **Overview**
> Adds **PI-5643** (`google_pay_handle_unsuccessful_3ds_check`) to improve checkout after a failed Google Pay 3DS redirect.
> 
> When the flag is on, **Payment** passes all Google Pay gateway payment strategies into `finalizeOrderIfNeeded` on load so redirect-back finalization can run instead of failing quietly.
> 
> For **Google Pay** wallet methods with the flag on, **WalletButtonPaymentMethodComponent** tracks submit/finalize errors (excluding cart, spam, cancellation, etc.), ties declines to the wallet **nonce**, and **disables Place order** until the shopper opens Google Pay again and gets a new token. The card edit action uses new copy **“Try again or select a different card”** (`remote.retry_same_card_action`).
> 
> A shared **`isGooglePayHandleUnsuccessful3dsCheckExperimentOn`** helper is exported from `payment-integration-api`. Behavior is covered by Payment and wallet component tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b8e42ad048f1f9a6864ab83dcd92bb1e433ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->