### PR TITLE
feat(checkout): CHECKOUT-10407 Support reloadPageAfterSignIn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/checkout-sdk": "^1.975.0",
+        "@bigcommerce/checkout-sdk": "^1.976.0",
         "@bigcommerce/citadel": "^2.16.1",
         "@bigcommerce/form-poster": "^1.2.2",
         "@bigcommerce/memoize": "^1.0.0",
@@ -2340,9 +2340,9 @@
       }
     },
     "node_modules/@bigcommerce/checkout-sdk": {
-      "version": "1.975.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.975.0.tgz",
-      "integrity": "sha512-u8qIAGwkTMgg7a76vThZyLhz8DBjxpXGvi0vBzxJit821j3FBvgWNQHIQgCnSHHozoUVW70YSM6j6czmFI3LXw==",
+      "version": "1.976.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.976.0.tgz",
+      "integrity": "sha512-atKlDNwPhzucjSJP4ztHCZ7ZrW8tJMrS+BUAdKLZNg6Pr+lV0URTfBo84XJEYlL1Ot/cYkq7P25001TNa/gckA==",
       "license": "MIT",
       "dependencies": {
         "@bigcommerce/bigpay-client": "^5.31.0",
@@ -33177,9 +33177,9 @@
       }
     },
     "@bigcommerce/checkout-sdk": {
-      "version": "1.975.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.975.0.tgz",
-      "integrity": "sha512-u8qIAGwkTMgg7a76vThZyLhz8DBjxpXGvi0vBzxJit821j3FBvgWNQHIQgCnSHHozoUVW70YSM6j6czmFI3LXw==",
+      "version": "1.976.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/checkout-sdk/-/checkout-sdk-1.976.0.tgz",
+      "integrity": "sha512-atKlDNwPhzucjSJP4ztHCZ7ZrW8tJMrS+BUAdKLZNg6Pr+lV0URTfBo84XJEYlL1Ot/cYkq7P25001TNa/gckA==",
       "requires": {
         "@bigcommerce/bigpay-client": "^5.31.0",
         "@bigcommerce/data-store": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "prettier": "@bigcommerce/eslint-config/prettier",
   "homepage": "https://github.com/bigcommerce/checkout-js#readme",
   "dependencies": {
-    "@bigcommerce/checkout-sdk": "^1.975.0",
+    "@bigcommerce/checkout-sdk": "^1.976.0",
     "@bigcommerce/citadel": "^2.16.1",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/contexts/src/capabilities/Capability.ts
+++ b/packages/contexts/src/capabilities/Capability.ts
@@ -15,6 +15,7 @@ export const defaultCapabilities: Capabilities = {
         quoteConfig: null,
     },
     customer: {
+        reloadPageAfterSignIn: false,
         superAdminCompanySelector: false,
     },
     shipping: {

--- a/packages/core/src/app/checkout/Checkout.test.tsx
+++ b/packages/core/src/app/checkout/Checkout.test.tsx
@@ -22,7 +22,7 @@ import {
     LocaleProvider,
     ThemeProvider,
 } from '@bigcommerce/checkout/contexts';
-import { replaceLocation } from '@bigcommerce/checkout/dom-utils';
+import { reloadLocation, replaceLocation } from '@bigcommerce/checkout/dom-utils';
 import { getLanguageService } from '@bigcommerce/checkout/locale';
 import { CHECKOUT_ROOT_NODE_ID } from '@bigcommerce/checkout/payment-integration-api';
 import {
@@ -55,6 +55,7 @@ expect.extend(jestDomMatchers);
 
 jest.mock('@bigcommerce/checkout/dom-utils', () => ({
     ...jest.requireActual('@bigcommerce/checkout/dom-utils'),
+    reloadLocation: jest.fn(),
     replaceLocation: jest.fn(),
 }));
 
@@ -86,6 +87,7 @@ describe('Checkout', () => {
         window.scrollTo = jest.fn();
 
         (replaceLocation as jest.Mock).mockClear();
+        (reloadLocation as jest.Mock).mockClear();
 
         checkoutService = createCheckoutService();
         extensionService = new ExtensionService(checkoutService, createErrorLogger());
@@ -357,6 +359,133 @@ describe('Checkout', () => {
             await screen.findByText('test@example.com');
 
             expect(screen.getByText('test@example.com')).toBeInTheDocument();
+        });
+
+        describe('reloadPageAfterSignIn capability', () => {
+            const reloadCapabilities = {
+                ...defaultCapabilities,
+                customer: {
+                    ...defaultCapabilities.customer,
+                    reloadPageAfterSignIn: true,
+                },
+            };
+
+            const showLoginForm = async () => {
+                await act(async () => {
+                    await userEvent.click(await screen.findByText('Sign in now'));
+                });
+            };
+
+            const submitLoginForm = async () => {
+                await act(async () => {
+                    await userEvent.type(screen.getByLabelText('Email'), 'test@example.com');
+                    await userEvent.type(screen.getByLabelText('Password'), 'Password123');
+                    await userEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+                });
+            };
+
+            const submitCreateAccountForm = async () => {
+                await act(async () => {
+                    await userEvent.click(await screen.findByText('Create an account'));
+                });
+
+                await act(async () => {
+                    await userEvent.type(screen.getByLabelText('First Name'), 'Foo');
+                    await userEvent.type(screen.getByLabelText('Last Name'), 'Bar');
+                    await userEvent.type(screen.getByLabelText('Email'), 'test@example.com');
+                    await userEvent.type(screen.getByLabelText('Password'), 'Password123');
+                    await userEvent.type(screen.getByLabelText('Referral Code'), 'ABC');
+                    await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+                });
+            };
+
+            const stepCompletedCount = () =>
+                (analyticsTracker.trackStepCompleted as jest.Mock).mock.calls.length;
+
+            beforeEach(() => {
+                jest.spyOn(checkoutService, 'signInCustomer').mockResolvedValue(
+                    checkoutService.getState(),
+                );
+                jest.spyOn(checkoutService, 'createCustomerAccount').mockResolvedValue(
+                    checkoutService.getState(),
+                );
+            });
+
+            it('reloads the page after signing in when the capability is enabled', async () => {
+                render(<CheckoutTest {...defaultProps} capabilities={reloadCapabilities} />);
+
+                await checkout.waitForCustomerStep();
+                await showLoginForm();
+
+                const stepsCompleted = stepCompletedCount();
+
+                await submitLoginForm();
+
+                expect(checkoutService.signInCustomer).toHaveBeenCalled();
+                expect(reloadLocation).toHaveBeenCalled();
+                expect(stepCompletedCount()).toBe(stepsCompleted);
+            });
+
+            it('navigates to the next step after signing in when the capability is disabled', async () => {
+                render(<CheckoutTest {...defaultProps} />);
+
+                await checkout.waitForCustomerStep();
+                await showLoginForm();
+
+                const stepsCompleted = stepCompletedCount();
+
+                await submitLoginForm();
+
+                expect(checkoutService.signInCustomer).toHaveBeenCalled();
+                expect(reloadLocation).not.toHaveBeenCalled();
+                expect(stepCompletedCount()).toBeGreaterThan(stepsCompleted);
+            });
+
+            it('reloads the page after creating an account when the capability is enabled', async () => {
+                render(<CheckoutTest {...defaultProps} capabilities={reloadCapabilities} />);
+
+                await checkout.waitForCustomerStep();
+                await showLoginForm();
+
+                const stepsCompleted = stepCompletedCount();
+
+                await submitCreateAccountForm();
+
+                expect(checkoutService.createCustomerAccount).toHaveBeenCalled();
+                expect(reloadLocation).toHaveBeenCalled();
+                expect(stepCompletedCount()).toBe(stepsCompleted);
+            });
+
+            it('navigates to the next step after creating an account when the capability is disabled', async () => {
+                render(<CheckoutTest {...defaultProps} />);
+
+                await checkout.waitForCustomerStep();
+                await showLoginForm();
+
+                const stepsCompleted = stepCompletedCount();
+
+                await submitCreateAccountForm();
+
+                expect(checkoutService.createCustomerAccount).toHaveBeenCalled();
+                expect(reloadLocation).not.toHaveBeenCalled();
+                expect(stepCompletedCount()).toBeGreaterThan(stepsCompleted);
+            });
+
+            it('does not reload the page when the shopper continues as a guest', async () => {
+                render(<CheckoutTest {...defaultProps} capabilities={reloadCapabilities} />);
+
+                await checkout.waitForCustomerStep();
+
+                const stepsCompleted = stepCompletedCount();
+
+                await act(async () => {
+                    await userEvent.type(screen.getByLabelText('Email'), 'test@example.com');
+                    await userEvent.click(screen.getByText('Continue'));
+                });
+
+                expect(reloadLocation).not.toHaveBeenCalled();
+                expect(stepCompletedCount()).toBeGreaterThan(stepsCompleted);
+            });
         });
 
         it('renders checkout button container with ApplePay', async () => {

--- a/packages/core/src/app/checkout/CheckoutPage.tsx
+++ b/packages/core/src/app/checkout/CheckoutPage.tsx
@@ -32,6 +32,7 @@ import {
 } from '@bigcommerce/checkout/contexts';
 import {
     assignTopLocation,
+    reloadLocation,
     replaceLocation,
     replaceTopLocation,
     setTopLocationHref,
@@ -469,6 +470,16 @@ const Checkout = ({
         navigateToNextIncompleteStep();
     }, [checkoutService, navigateToNextIncompleteStep]);
 
+    const handleCustomerAuthenticated = useCallback((): void => {
+        if (capabilities.customer.reloadPageAfterSignIn) {
+            reloadLocation();
+
+            return;
+        }
+
+        navigateToNextIncompleteStep();
+    }, [navigateToNextIncompleteStep]);
+
     const handleShippingSignIn = useCallback((): void => {
         setCustomerViewType(CustomerViewType.Login);
     }, [setCustomerViewType]);
@@ -510,14 +521,14 @@ const Checkout = ({
                         checkEmbeddedSupport={checkEmbeddedSupport}
                         isSubscribed={isSubscribed}
                         isWalletButtonsOnTop={isShowingWalletButtonsOnTop}
-                        onAccountCreated={navigateToNextIncompleteStep}
+                        onAccountCreated={handleCustomerAuthenticated}
                         onChangeViewType={setCustomerViewType}
                         onContinueAsGuest={navigateToNextIncompleteStep}
                         onContinueAsGuestError={handleError}
                         onEdit={handleEditStep}
                         onExpanded={handleExpanded}
                         onReady={handleReady}
-                        onSignIn={navigateToNextIncompleteStep}
+                        onSignIn={handleCustomerAuthenticated}
                         onSignInError={handleError}
                         onSignOut={handleSignOut}
                         onSignOutError={handleError}

--- a/packages/dom-utils/src/index.ts
+++ b/packages/dom-utils/src/index.ts
@@ -3,6 +3,7 @@ export { isTopWindow } from './isTopWindow';
 export {
     assignLocation,
     assignTopLocation,
+    reloadLocation,
     replaceLocation,
     replaceTopLocation,
     setTopLocationHref,

--- a/packages/dom-utils/src/navigation.ts
+++ b/packages/dom-utils/src/navigation.ts
@@ -6,6 +6,10 @@ export function replaceLocation(url: string): void {
     window.location.replace(url);
 }
 
+export function reloadLocation(): void {
+    window.location.reload();
+}
+
 export function assignTopLocation(url: string): void {
     window.top?.location.assign(url);
 }


### PR DESCRIPTION
Jira: [CHECKOUT-10407](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10407)

## What/Why?

Adds support for the new `customer.reloadPageAfterSignIn` capability ([checkout-sdk-js](https://github.com/bigcommerce/checkout-sdk-js) `1.976.0` + [bcapp](https://github.com/bigcommerce/bigcommerce/pull/70074)). 

When it is on, a successful in-line sign-in on the checkout page triggers a hard page refresh instead of advancing to the next incomplete step.

## Rollout/Rollback

No feature flag or experiment. The behaviour is gated entirely by the `customer.reloadPageAfterSignIn` capability, which defaults to `false` in `defaultCapabilities`, so stores that do not opt in are unaffected.

Rollback is a code revert. Alternatively, turning the capability off for the affected merchants restores the previous navigation behaviour without a deploy.

## Testing

Unit tests added in `packages/core/src/app/checkout/Checkout.test.tsx` under `customer step > reloadPageAfterSignIn capability`, driving the real customer-step UI:

- reloads after sign-in when the capability is enabled
- navigates to the next step (no reload) when disabled
- reloads after account creation when enabled
- navigates to the next step (no reload) when disabled
- does not reload when the shopper continues as a guest

```
npx jest --config packages/core/jest.config.js --rootDir packages/core --testPathPatterns "app/checkout/Checkout.test.tsx"

Test Suites: 1 passed, 1 total
Tests:       42 passed, 42 total
```

Manual check: on a store with `reloadPageAfterSignIn` enabled, sign in from the customer step and confirm the page hard-refreshes rather than expanding the shipping step; repeat with "Create an account". With the capability off, both should advance the step as before.


[CHECKOUT-10407]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-10407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-authentication navigation on the customer step for merchants that opt in via capability; default behavior is unchanged, but a full page reload can affect session/checkout state for those stores.
> 
> **Overview**
> Adds **`customer.reloadPageAfterSignIn`** (default `false` in `defaultCapabilities`) and bumps **`@bigcommerce/checkout-sdk`** to `^1.976.0` so checkout-js can honor the SDK capability.
> 
> After a successful **sign-in** or **account creation** on the customer step, checkout now runs **`handleCustomerAuthenticated`**: when the capability is enabled it calls new **`reloadLocation()`** (`window.location.reload()` via `dom-utils`) instead of advancing to the next incomplete step; guest continue and the disabled-capability path are unchanged.
> 
> Unit tests in **`Checkout.test.tsx`** cover reload vs step navigation for sign-in, create account, and guest checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0947266444a8e30347992035c4b836c15c3026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->