### PR TITLE
fix(checkout): CHECKOUT-10410 Use amount and not displayAmount for price comparison

### DIFF
--- a/packages/core/src/app/order/OrderSummaryPrice.test.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.test.tsx
@@ -190,6 +190,27 @@ describe('OrderSummaryPrice', () => {
             expect(screen.getByTestId('cart-price-value-superscript')).toHaveTextContent('*');
         });
 
+        it('does not strike through an undiscounted price while the old one slides out', () => {
+            const props = { ...initialProps, amountBeforeDiscount: 10 };
+            const { rerender } = renderTestComponent(props, { enhancedThemeV1: true });
+
+            rerender(
+                buildTestComponent(
+                    { ...props, amount: 15, amountBeforeDiscount: 15 },
+                    { enhancedThemeV1: true },
+                ),
+            );
+
+            expect(screen.getByTestId('price-ticker')).toHaveClass('priceTicker-exit');
+            expect(screen.getByTestId('ShopperCurrency')).toHaveTextContent('10');
+
+            act(() => {
+                jest.advanceTimersByTime(1600);
+            });
+
+            expect(screen.getByTestId('ShopperCurrency')).toHaveTextContent('15');
+        });
+
         it('recovers to the new price when the amount becomes unavailable mid-animation', () => {
             const { rerender } = renderTestComponent(initialProps, { enhancedThemeV1: true });
 

--- a/packages/core/src/app/order/OrderSummaryPrice.tsx
+++ b/packages/core/src/app/order/OrderSummaryPrice.tsx
@@ -139,7 +139,7 @@ const OrderSummaryPrice: FC<OrderSummaryPriceProps> = ({
             >
                 {!showDots &&
                     isNumberValue(amountBeforeDiscount) &&
-                    amountBeforeDiscount !== displayAmount && (
+                    amountBeforeDiscount !== amount && (
                         <span className="cart-priceItem-before-value">
                             <ShopperCurrency amount={amountBeforeDiscount} />
                         </span>


### PR DESCRIPTION
## What/Why?

For shipping price for enhancedThemeV1 we used displayAmount for price comparison. However that displayAmount is a presentational value and not the actual price - it is used for animation to be smooth and delayed by 200ms slide duration.

During the animation delays the price would not match and we see the strikethrough price text.

The bug is fixed by using amount and not displayAmount so it compares real values, not the animation's display text.

## Rollout/Rollback

Revert the PR.

## Testing

New CI tests + manual testing.

### Before

https://github.com/user-attachments/assets/48a9bd9b-8f01-4a76-ab89-2e926a5d4b6c

### After

https://github.com/user-attachments/assets/ac7c7a7a-c729-4e9d-999b-ac01d98e1539


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in checkout order summary UI with a focused unit test; no auth, payment, or data-layer impact.
> 
> **Overview**
> Fixes a visual bug in **enhancedThemeV1** order summary pricing where a strikethrough “before” price could appear when there was no discount.
> 
> The strikethrough visibility check now compares `amountBeforeDiscount` to the real **`amount`** instead of **`displayAmount`** from `usePriceChangeTicker`. `displayAmount` still reflects the animated value (e.g. the previous price during exit), so the old comparison could treat a mid-animation mismatch as a discount.
> 
> A regression test covers updating from equal before/after amounts (e.g. 10 → 15 with `amountBeforeDiscount` 15) and asserts no incorrect strikethrough behavior through the slide-out animation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc78a1ed9c2840533f12c9f2184cbfd6274e594e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->